### PR TITLE
Allow primary_hash to be 16-32 chars, pad query side with null bytes.

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -67,10 +67,7 @@ def get_key(event):
 
 def extract_required(output, event, data):
     output['event_id'] = event['event_id']
-
-    # TODO: remove splice and rjust once we handle 'checksum' hashes (which are too long)
-    output['primary_hash'] = event['primary_hash'][-16:].rjust(16)
-
+    output['primary_hash'] = event['primary_hash']
     output['project_id'] = event['project_id']
     output['message'] = _unicodify(event['message'])
     output['platform'] = _unicodify(event['platform'])

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -109,8 +109,8 @@ QUERY_SCHEMA = {
         'fingerprint_hash': {
             'type': 'string',
             'minLength': 16,
-            'maxLength': 16,
-            'pattern': '^[0-9a-f]{16}$',
+            'maxLength': 32,
+            'pattern': '^[0-9a-f]{16,32}$',
         },
         'column_name': {
             'anyOf': [

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -109,7 +109,7 @@ SCHEMA_COLUMNS = """
     message String,
 
     -- required and provided by Sentry
-    primary_hash FixedString(16),
+    primary_hash FixedString(32),
     project_id UInt64,
     received DateTime,
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -103,6 +103,10 @@ def raw_query(sql, client):
     return {'data': data, 'meta': meta}
 
 
+def _pad_primary_hash(hash):
+    return hash.ljust(32, '\0')
+
+
 def issue_expr(issues, col='primary_hash', ids=None):
     """
     Takes a list of (issue_id, fingerprint(s)) tuples of the form:
@@ -122,9 +126,10 @@ def issue_expr(issues, col='primary_hash', ids=None):
 
         if ids is None or issue_id in ids:
             if hasattr(hashes, '__iter__'):
-                predicate = "{} IN ('{}')".format(col, "', '".join(hashes))
+                predicate = "{} IN ('{}')".format(
+                    col, "', '".join([_pad_primary_hash(h) for h in hashes]))
             else:
-                predicate = "{} = '{}'".format(col, hashes)
+                predicate = "{} = '{}'".format(col, _pad_primary_hash(hashes))
             return 'if({}, {}, {})'.format(predicate, issue_id,
                                            issue_expr(issues[1:], col=col, ids=ids))
         else:

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,7 +25,7 @@ class BaseTest(object):
         "Wrap a raw event like the Sentry codebase does before sending to Kafka."
 
         unique = "%s:%s" % (str(event['project']), event['id'])
-        primary_hash = md5(unique).hexdigest()[:16]
+        primary_hash = md5(unique).hexdigest()[:32]
 
         return {
             'event_id': event['id'],

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -28,13 +28,6 @@ class TestProcessor(BaseTest):
 
         assert processed['message'] == '{"what": "why is this in the message"}'
 
-    def test_long_hash(self):
-        self.event['primary_hash'] = 'x' * 128
-
-        processed = process_raw_event(self.event)
-
-        assert processed['primary_hash'] == ('x' * 16)
-
     def test_extract_required(self):
         event = {
             'event_id': '1' * 32,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,16 +1,21 @@
+from datetime import date, datetime
+
 from base import BaseTest
 
-from snuba.util import *
+from snuba.util import issue_expr, column_expr, escape_literal
+
+pad = '\x00' * 31
+
 
 class TestUtil(BaseTest):
 
     def test_issue_expr(self):
         assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash') ==\
-            "if(hash IN ('a', 'b'), 1, if(hash = 'c', 2, 0))"
+            "if(hash IN ('a%(pad)s', 'b%(pad)s'), 1, if(hash = 'c%(pad)s', 2, 0))" % {'pad': pad}
         assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash', ids=[1]) ==\
-            "if(hash IN ('a', 'b'), 1, 0)"
+            "if(hash IN ('a%(pad)s', 'b%(pad)s'), 1, 0)" % {'pad': pad}
         assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash', ids=[2]) ==\
-            "if(hash = 'c', 2, 0)"
+            "if(hash = 'c%(pad)s', 2, 0)" % {'pad': pad}
         assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash', ids=[]) == 0
         assert issue_expr([], col='hash', ids=[]) == 0
 
@@ -19,24 +24,24 @@ class TestUtil(BaseTest):
             'issues': [(1, ['a', 'b']), (2, 'c')],
         }
         assert column_expr('issue', body) ==\
-            "if(primary_hash IN ('a', 'b'), 1, if(primary_hash = 'c', 2, 0))"
+            "if(primary_hash IN ('a%(pad)s', 'b%(pad)s'), 1, if(primary_hash = 'c%(pad)s', 2, 0))" % {
+                'pad': pad}
 
         body['conditions'] = [['issue', 'IN', [1]]]
         assert column_expr('issue', body) ==\
-            "if(primary_hash IN ('a', 'b'), 1, 0)"
+            "if(primary_hash IN ('a%(pad)s', 'b%(pad)s'), 1, 0)" % {'pad': pad}
 
         body['conditions'] = [['issue', 'IN', [1]], ['issue', '=', 2]]
         assert column_expr('issue', body) ==\
-            "if(primary_hash IN ('a', 'b'), 1, if(primary_hash = 'c', 2, 0))"
+            "if(primary_hash IN ('a%(pad)s', 'b%(pad)s'), 1, if(primary_hash = 'c%(pad)s', 2, 0))" % {
+                'pad': pad}
 
         body['conditions'] = [['issue', 'IN', []]]
         assert column_expr('issue', body) == 0
-
 
     def test_escape(self):
         assert escape_literal("'") == r"'\''"
         assert escape_literal(date(2001, 1, 1)) == "toDate('2001-01-01')"
         assert escape_literal(datetime(2001, 1, 1, 1, 1, 1)) == "toDateTime('2001-01-01T01:01:01')"
-        assert escape_literal([1,'a', date(2001, 1, 1)]) ==\
+        assert escape_literal([1, 'a', date(2001, 1, 1)]) ==\
             "(1, 'a', toDate('2001-01-01'))"
-


### PR DESCRIPTION
Looks like we should go with 32 byte `primary_hash` because we allow users to provide custom ones up to that size: https://github.com/getsentry/sentry/blob/7f32f95ff34c12307d1369c9d9aeac216dfcedbb/src/sentry/models/grouphash.py#L26

I noticed this when I got the hash `u"'tinymce' \u063a\u064a\u0631 \u0645\u062d"` which encodes to 21 bytes and blew up.

This method in the client already pads with null bytes on the write side, so we're good there: https://github.com/mymarilyn/clickhouse-driver/blob/52a228e56c6dcc0d375ffcc309465276dc5d4783/src/writer.py#L23-L30

But queries don't match unless you send the exact match, so we need to pad the query side:

```
:) select * from t

SELECT *
FROM t 

┌─f──────────────────────────────────────────────────────────────┐
│ hi\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0 │
└────────────────────────────────────────────────────────────────┘
┌─f────────────────────────────────┐
│ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx │
└──────────────────────────────────┘

2 rows in set. Elapsed: 0.003 sec. 
```

```
In [1]: from clickhouse_driver import Client

In [2]: c = Client('localhost')

In [3]: c.execute("select * from t")
Out[3]: [(u'hi',), (u'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',)]

In [4]: c.execute("select * from t where f = %(f)s", {'f': 'hi'})
Out[4]: []

In [5]: c.execute("select * from t where f = %(f)s", {'f': 'hi'.ljust(32, '\0')})
Out[5]: [(u'hi',)]
```

Thankfully, as you can see, the null bytes are trimmed from the results. So the core of this change is the `ljust` I do in utils, and the tweaks to the schema.