### PR TITLE
Expand primary_hash to the proper 32 chars and md5 ones (at write tim…

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -46,7 +46,8 @@ def query():
         ('timestamp', '<', to_date),
         ('project_id', 'IN', util.to_list(body['project'])),
     ])
-    conditions = [(col, op, tuple(lit) if isinstance(lit, list) else lit) for col, op, lit in conditions]
+    conditions = [(col, op, tuple(lit) if isinstance(lit, list) else lit)
+                  for col, op, lit in conditions]
 
     # TODO need more safety, eg if aggregation is 'uniq' then there must be an 'aggregateby'
     aggregate_columns = [(

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -108,9 +108,9 @@ QUERY_SCHEMA = {
     'definitions': {
         'fingerprint_hash': {
             'type': 'string',
-            'minLength': 16,
-            'maxLength': 16,
-            'pattern': '^[0-9a-f]{16}$',
+            'minLength': 32,
+            'maxLength': 32,
+            'pattern': '^[0-9a-f]{32}$',
         },
         'column_name': {
             'anyOf': [

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -109,7 +109,7 @@ SCHEMA_COLUMNS = """
     message String,
 
     -- required and provided by Sentry
-    primary_hash FixedString(16),
+    primary_hash FixedString(32),
     project_id UInt64,
     received DateTime,
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -189,3 +189,9 @@ def get_distributed_engine(cluster, database, local_table, sharding_key='rand()'
         'local_table': local_table,
         'sharding_key': sharding_key,
     }
+
+
+def force_bytes(s):
+    if isinstance(s, bytes):
+        return s
+    return s.encode('utf-8', 'replace')

--- a/tests/base.py
+++ b/tests/base.py
@@ -25,7 +25,7 @@ class BaseTest(object):
         "Wrap a raw event like the Sentry codebase does before sending to Kafka."
 
         unique = "%s:%s" % (str(event['project']), event['id'])
-        primary_hash = md5(unique).hexdigest()[:16]
+        primary_hash = md5(unique).hexdigest()
 
         return {
             'event_id': event['id'],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,7 @@ class TestApi(BaseTest):
         # values for test data
         self.project_ids = [1, 2, 3]  # 3 projects
         self.platforms = ['a', 'b', 'c', 'd', 'e', 'f']  # 6 platforms
-        self.hashes = [x * 16 for x in '0123456789ab']  # 12 hashes
+        self.hashes = [x * 32 for x in '0123456789ab']  # 12 hashes
         self.minutes = 180
 
         self.base_time = datetime.utcnow().replace(minute=0, second=0, microsecond=0) - \

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,5 +1,3 @@
-from pprint import pprint
-
 from base import BaseTest
 
 from snuba import processor
@@ -28,17 +26,17 @@ class TestProcessor(BaseTest):
 
         assert processed['message'] == '{"what": "why is this in the message"}'
 
-    def test_long_hash(self):
-        self.event['primary_hash'] = 'x' * 128
+    def test_hash_invalid_primary_hash(self):
+        self.event['primary_hash'] = "'tinymce' \u063a\u064a\u0631 \u0645\u062d".decode('utf-8')
 
         processed = process_raw_event(self.event)
 
-        assert processed['primary_hash'] == ('x' * 16)
+        assert processed['primary_hash'] == 'ef981cdeac7a4b76bf55f214e1255653'
 
     def test_extract_required(self):
         event = {
             'event_id': '1' * 32,
-            'primary_hash': 'x' * 16,
+            'primary_hash': 'a' * 32,
             'project_id': 100,
             'message': 'the message',
             'platform': 'the_platform',
@@ -54,7 +52,7 @@ class TestProcessor(BaseTest):
             'event_id': '11111111111111111111111111111111',
             'message': u'the message',
             'platform': u'the_platform',
-            'primary_hash': 'xxxxxxxxxxxxxxxx',
+            'primary_hash': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             'project_id': 100,
             'received': 1520971716,
             'timestamp': 1520971716,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ from base import BaseTest
 
 from snuba.util import *
 
+
 class TestUtil(BaseTest):
 
     def test_issue_expr(self):
@@ -32,11 +33,9 @@ class TestUtil(BaseTest):
         body['conditions'] = [['issue', 'IN', []]]
         assert column_expr('issue', body) == 0
 
-
     def test_escape(self):
         assert escape_literal("'") == r"'\''"
         assert escape_literal(date(2001, 1, 1)) == "toDate('2001-01-01')"
         assert escape_literal(datetime(2001, 1, 1, 1, 1, 1)) == "toDateTime('2001-01-01T01:01:01')"
-        assert escape_literal([1,'a', date(2001, 1, 1)]) ==\
+        assert escape_literal([1, 'a', date(2001, 1, 1)]) ==\
             "(1, 'a', toDate('2001-01-01'))"
-


### PR DESCRIPTION
…e) that don't look like hashes.

I don't know why I even had it at 16, that was an error because it didn't contain the full md5 hexdigest.

Related to: https://github.com/getsentry/sentry/pull/7813