### PR TITLE
Load settings based on environment variable.

### DIFF
--- a/snuba/settings_test.py
+++ b/snuba/settings_test.py
@@ -1,0 +1,5 @@
+from snuba.settings import *  # NOQA
+
+
+TESTING = True
+CLICKHOUSE_TABLE = 'test'

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -64,6 +64,7 @@ def column_expr(column_name, body, alias=None):
 
     return (expr, alias)
 
+
 def escape_literal(value):
     """
     Escape a literal value for use in a SQL clause
@@ -209,14 +210,6 @@ def force_bytes(s):
     if isinstance(s, bytes):
         return s
     return s.encode('utf-8', 'replace')
-
-
-def get_clickhouse_server():
-    clickhouse_servers = os.environ.get('CLICKHOUSE_SERVERS')
-    if clickhouse_servers:
-        return clickhouse_servers.split(',')[0].split(':')
-    else:
-        return settings.CLICKHOUSE_SERVER.split(':')
 
 
 def create_metrics(host, port, prefix, tags=None):

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,14 @@
 from hashlib import md5
+import os
 
 from clickhouse_driver import Client
 
 from snuba import settings, util
 from snuba.processor import process_raw_event
 from snuba.writer import row_from_processed_event, write_rows
+
+
+os.environ['SNUBA_SETTINGS'] = 'settings_test.py'
 
 
 class BaseTest(object):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,13 +17,9 @@ class TestApi(BaseTest):
 
     def setup_method(self, test_method):
         super(TestApi, self).setup_method(test_method)
-        from snuba import settings
-        settings.CLICKHOUSE_TABLE = 'test'
-        settings.CLICKHOUSE_PORT = 9000
-        from snuba import api
-        api.app.testing = True
-        api.clickhouse = self.conn
-        self.app = api.app.test_client()
+        from snuba.api import app
+        assert app.testing
+        self.app = app.test_client()
 
         # values for test data
         self.project_ids = [1, 2, 3]  # 3 projects


### PR DESCRIPTION
The real meat here is:

https://github.com/getsentry/snuba/blob/fb3efef135ab37c4003baf6f1b0060ab60b7cddb/snuba/api.py#L15-L17

I think setting all the right state individually via environment is getting burdensome so I wanted to have `settings_test` vs `settings_prod` etc.

So there are a couple of things left:
1. Things like `util` still import and use `snuba.settings` directly. Should we pass every method the necessary config? Otherwise how do we override settings globally across the app in a sane way?
2. Non-flask code like the `processor` and `writer` also use settings, and should probably follow the same convention. Should we just import `snuba.app` in those and use the `app.config` instead of `settings`, that way everything is confused the same way via `SNUBA_SETTINGS` env var?

Or... is there something completely easier? I just went by Flask docs.