### PR TITLE
Allow complex aggregates to be passed in.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -64,7 +64,6 @@ def query():
     if conditions:
         where_clause = 'WHERE {}'.format(util.condition_expr(conditions, body))
 
-
     group_clause = ', '.join(util.column_expr(gb, body) for gb in groupby)
     if group_clause:
         group_clause = 'GROUP BY ({})'.format(group_clause)

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -87,8 +87,7 @@ QUERY_SCHEMA = {
                         # Aggregation function
                         'type': 'string',
                         'anyOf': [
-                            {'enum': ['count', 'uniq', 'min', 'max']},
-                            {'pattern': 'topK\(\d+\)'},
+                            {'type': 'string'},
                         ],
                     }, {
                         # Aggregate column
@@ -106,7 +105,7 @@ QUERY_SCHEMA = {
                 'maxLength': 3,
             },
             'minLength': 1,
-            'default': [['count', '', 'aggregate']],
+            'default': [['count()', '', 'aggregate']],
         },
         'arrayjoin': {
             '$ref': '#/definitions/column_name',
@@ -139,9 +138,10 @@ QUERY_SCHEMA = {
         'column_name': {
             'type': 'string',
             'anyOf': [
-                {'enum': ['issue', '-issue']},  # Special computed column created from `issues` definition
-                {'pattern': '^-?[a-zA-Z0-9_.]+$',},
-                {'pattern': '^-?tags\[[a-zA-Z0-9_.:-]+\]$',},
+                # Special computed column created from `issues` definition
+                {'enum': ['issue', '-issue']},
+                {'pattern': '^-?[a-zA-Z0-9_.]+$', },
+                {'pattern': '^-?tags\[[a-zA-Z0-9_.:-]+\]$', },
             ],
         },
         'column_list': {

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -85,9 +85,13 @@ def column_expr(column_name, body, alias=None, aggregate=None):
         expr = column_name
 
     if aggregate is not None:
-        expr = '{}({})'.format(aggregate, expr)
+        if not expr:
+            expr = aggregate
+        else:
+            expr = '{}({})'.format(aggregate, expr)
 
     return alias_expr(expr, alias, body)
+
 
 def alias_expr(expr, alias, body):
     """
@@ -110,11 +114,14 @@ def alias_expr(expr, alias, body):
         alias_cache[expr] = alias
         return '({} AS `{}`)'.format(expr, alias)
 
+
 def is_condition(cond_or_list):
     return len(cond_or_list) == 3 and isinstance(cond_or_list[0], six.string_types)
 
+
 def flat_conditions(conditions):
     return list(chain(*[[c] if is_condition(c) else c for c in conditions]))
+
 
 def condition_expr(conditions, body, depth=0):
     """
@@ -127,7 +134,7 @@ def condition_expr(conditions, body, depth=0):
         return ''
 
     if depth == 0:
-        sub = (condition_expr(cond, body, depth+1) for cond in conditions)
+        sub = (condition_expr(cond, body, depth + 1) for cond in conditions)
         return ' AND '.join(s for s in sub if s)
     elif is_condition(conditions):
         col, op, lit = conditions
@@ -135,10 +142,11 @@ def condition_expr(conditions, body, depth=0):
         lit = escape_literal(tuple(lit) if isinstance(lit, list) else lit)
         return '{} {} {}'.format(col, op, lit)
     elif depth == 1:
-        sub = (condition_expr(cond, body, depth+1) for cond in conditions)
+        sub = (condition_expr(cond, body, depth + 1) for cond in conditions)
         sub = [s for s in sub if s]
         res = ' OR '.join(sub)
         return '({})'.format(res) if len(sub) > 1 else res
+
 
 def escape_literal(value):
     """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,7 +102,7 @@ class TestApi(BaseTest):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': self.project_ids,
             'groupby': ['project_id'],
-            'aggregations': [['count', '', 'count']],
+            'aggregations': [['count()', '', 'count']],
             'orderby': '-count',
             'offset': 1,
             'limit': 1,
@@ -114,7 +114,7 @@ class TestApi(BaseTest):
         result = self.app.post('/query', data=json.dumps({
             'project': self.project_ids,
             'groupby': ['project_id'],
-            'aggregations': [['count', '', 'count']],
+            'aggregations': [['count()', '', 'count']],
             'orderby': '-count',
             'offset': 1,
         }))
@@ -239,7 +239,7 @@ class TestApi(BaseTest):
             'granularity': 3600,
             'groupby': ['tags_key'],
             'aggregations': [
-                ['count', '', 'count'],
+                ['count()', '', 'count'],
                 ['uniq', 'tags_value', 'uniq'],
                 ['topK(3)', 'tags_value', 'top'],
             ],

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -74,5 +74,5 @@ class TestUtil(BaseTest):
 
         # Test using alias if column has already been expanded in SELECT clause
         conditions = [[['tags[foo]', '=', 1], ['b', '=', 2]]]
-        column_expr('tags[foo]', body) # Expand it once so the next time is aliased
+        column_expr('tags[foo]', body)  # Expand it once so the next time is aliased
         assert condition_expr(conditions, body) == '(`tags[foo]` = 1 OR b = 2)'


### PR DESCRIPTION
The Django search backend sorts by an aggregate like so:

https://github.com/getsentry/sentry/blob/804c85100d0003cfdda91701911f21ed5f66f67c/src/sentry/search/django/backend.py#L121

Which I've translated to:

```
    aggregations = [
        ['count', '', 'times_seen'],
        ['max', 'timestamp', 'last_seen'],
        ['toUInt32(log(times_seen) * 600) + toUInt32(last_seen)', '', 'priority']
    ]
```

So this PR allows that aggregate.

The pattern I match on in the schema is pretty basic, I'm definitely open to other ideas. Also, I've hardcoded the expressions I'm aggregating on in the aggregate string (`times_seen` and `last_seen`) because I can't currently pass a list in the `col` (`[1]`) field. I tried adjusting the code to do that but `column_expr` is pretty tied to the idea of a single `column_name`. So this could break if you tried to pass in like `some_complex_aggregate_on(issues)` since it won't be handled properly.

If anything this is just food for thought, I'm running this local at least to get search working. I'll add a test unless we want to overhaul this to take multiple columns.