### PR TITLE
fix: Date range interval should be right-open

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -51,7 +51,7 @@ def query():
     where_conditions = body['conditions']
     where_conditions.extend([
         ('timestamp', '>=', from_date),
-        ('timestamp', '<=', to_date),
+        ('timestamp', '<', to_date),
         ('project_id', 'IN', util.to_list(body['project'])),
     ])
     having_conditions = body['having']


### PR DESCRIPTION
event_time should be in the interval [start, end) to avoid counting
events in the first second od the next interval