### PR TITLE
fix: Limit issues to 500

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -46,6 +46,7 @@ QUERY_SCHEMA = {
         },
         'issues': {
             'type': 'array',
+            'maxItems': 500,
             'items': {
                 'type': 'array',
                 'minItems': 2,


### PR DESCRIPTION
Because we recursively generate an issue-matching expression, we can't
deal with big lists of issues because of stack depth limits.