### PR TITLE
Yet another way to get issue IDs

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -107,7 +107,10 @@ def query(validated_body, timer):
     select_exprs = group_exprs + aggregate_exprs
     select_clause = u'SELECT {}'.format(', '.join(select_exprs))
     from_clause = u'FROM {}'.format(settings.CLICKHOUSE_TABLE)
-    join_clause = u'ARRAY JOIN {}'.format(body['arrayjoin']) if 'arrayjoin' in body else ''
+    joins = [util.issue_expr(body)]
+    if 'arrayjoin' in body:
+        joins.append(u'ARRAY JOIN {}'.format(body['arrayjoin']))
+    join_clause = ' '.join(joins)
 
     where_clause = ''
     if where_conditions:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -270,8 +270,8 @@ class TestApi(BaseTest):
         })).data)
         # Issue is expanded once, and alias used subsequently
         sql = raw_query.call_args[0][0]
-        assert "`issue` = 0" in sql
-        assert "`issue` = 1" in sql
+        assert "issue = 0" in sql
+        assert "issue = 1" in sql
 
     def test_promoted_expansion(self):
         result = json.loads(self.app.post('/query', data=json.dumps({

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -5,29 +5,15 @@ from snuba.util import *
 
 class TestUtil(BaseTest):
 
-    def test_issue_expr(self):
-        assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash') ==\
-            "[1,1,2][indexOf(CAST(['a','b','c'], 'Array(FixedString(32))'), hash)]"
-        assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash', ids=[1]) ==\
-            "[1,1][indexOf(CAST(['a','b'], 'Array(FixedString(32))'), hash)]"
-        assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash', ids=[2]) ==\
-            "[2][indexOf(CAST(['c'], 'Array(FixedString(32))'), hash)]"
-        assert issue_expr([(1, ['a', 'b']), (2, 'c')], col='hash', ids=[]) == 0
-        assert issue_expr([], col='hash', ids=[]) == 0
-
     def test_column_expr(self):
         body = {
-            'issues': [(1, ['a', 'b']), (2, 'c')],
+            'granularity': 86400
         }
-        assert column_expr('issue', body.copy()) ==\
-            "([1,1,2][indexOf(CAST(['a','b','c'], 'Array(FixedString(32))'), primary_hash)] AS `issue`)"
+        assert column_expr('tags[foo]', body.copy()) ==\
+            "(tags.value[indexOf(tags.key, \'foo\')] AS `tags[foo]`)"
 
-        body['conditions'] = [['issue', 'IN', [1]]]
-        assert column_expr('issue', body.copy()) ==\
-            "([1,1][indexOf(CAST(['a','b'], 'Array(FixedString(32))'), primary_hash)] AS `issue`)"
-
-        body['conditions'] = [['issue', 'IN', []]]
-        assert column_expr('issue', body.copy()) == "(0 AS `issue`)"
+        assert column_expr('time', body.copy()) ==\
+            "(toDate(timestamp) AS `time`)"
 
     def test_escape(self):
         assert escape_literal("'") == r"'\''"


### PR DESCRIPTION
Finally figured out how to make this a JOIN, so the actual SELECT and
WHERE clauses can stay really simple. This should fix the performace
problems with Array lookups, and the stability problems with nested
if()s as well as the fact that it should be very neat to swap this out
for an actual table JOIN if we ever have another table with
(primary_hash, issue) columns to JOIN.