### PR TITLE
fix: make uniq() always return a number

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -63,8 +63,9 @@ def column_expr(column_name, body, alias=None, aggregate=None):
     if aggregate:
         if expr:
             expr = u'{}({})'.format(aggregate, expr)
-        else:
-            # This is the "count()" case where the brackets are already in the aggregate
+            if aggregate == 'uniq': # default uniq() result to 0, not null
+                expr = 'ifNull({}, 0)'.format(expr)
+        else: # This is the "count()" case where the '()' is already provided
             expr = aggregate
 
     alias = escape_col(alias or column_name or aggregate)


### PR DESCRIPTION
By default, uniq() on a column of null values returns null. This
defaults it to 0 instead, so we don't need special case logic upstream
to deal with this case.