### PR TITLE
fix: Expand the issues JOIN if issues are used anywhere.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,6 +127,15 @@ class TestApi(BaseTest):
             issues_expected = set(range(0, len(self.hashes), p))
             assert issues_found - issues_expected == set()
 
+    def test_no_issues(self):
+        result = json.loads(self.app.post('/query', data=json.dumps({
+            'project': 1,
+            'granularity': 3600,
+            'issues': [],
+            'groupby': 'issue',
+        })).data)
+        assert result['error'] is None
+
     def test_offset_limit(self):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': self.project_ids,


### PR DESCRIPTION
Even if a query passes an empty `issues` mapping, we still need
to expand this JOIN if `issue` is referenced in the groupby or
conditions of the query to avoid a syntax error when 'issue' is not
defined.

In cases where `issues` is empty and `issue` is not referenced, we
can continue to just leave it out.