### PR TITLE
fix: Pull Docker image first to fix build caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_install:
 script:
   - make test
 before_deploy:
+  - docker pull "$IMAGE_NAME" || true
   - docker build --pull --cache-from "$IMAGE_NAME" --tag "$IMAGE_NAME" .
   - docker save $IMAGE_NAME | gzip > $CACHE_FILE_SNUBA
   - echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin


### PR DESCRIPTION
I was investigating various CI solutions for Docker automated builds (Docker Cloud, Google Container Registry, etc.), and @JTCunning suggested to take a look at how it's done with Travis in this repo.

The change in this PR should fix the Docker build caching: without it `docker build --cache-from` will just ignore the non-existing `$IMAGE_NAME` image and start the build with empty cache.