### PR TITLE
test: Allow testing with keepalive connections.

### DIFF
--- a/bin/api
+++ b/bin/api
@@ -2,5 +2,7 @@
 
 from snuba import settings
 from snuba.api import application
+from werkzeug.serving import WSGIRequestHandler
 
-application.run(port=settings.PORT)
+WSGIRequestHandler.protocol_version = "HTTP/1.1"
+application.run(port=settings.PORT, threaded=True)


### PR DESCRIPTION
Use HTTP/1.1 and a threaded server so we don't deadlock in tests when
the test clients use keepalive connections.