### PR TITLE
fix: s/CLICKHOUSE_SERVERS/CLICKHOUSE_SERVER/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY setup.py README.md ./
 
 RUN python setup.py install && rm -rf ./build ./dist
 
-ENV CLICKHOUSE_SERVERS clickhouse-server:9000
+ENV CLICKHOUSE_SERVER clickhouse-server:9000
 ENV CLICKHOUSE_TABLE sentry
 ENV FLASK_DEBUG 0
 


### PR DESCRIPTION
Pretty sure this is a typo, the plural version isn't referenced anywhere else.