### PR TITLE
Enable http-keepalive by default in uWSGI.

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -11,7 +11,7 @@ case $1 in
         echo "Running Snuba API server with arguments:" "${@:2}"
         exec uwsgi --master --manage-script-name --pypy-wsgi snuba.api "${@:2}"
     else
-        _default_args="--socket /tmp/snuba.sock --http 0.0.0.0:1218"
+        _default_args="--socket /tmp/snuba.sock --http 0.0.0.0:1218 --http-keepalive"
         echo "Running Snuba API server with default arguments: $_default_args"
         exec uwsgi --master --manage-script-name --pypy-wsgi snuba.api $_default_args
     fi


### PR DESCRIPTION
Before PR:
```
* Connection #0 to host localhost left intact
* Found bundle for host localhost: 0x557b35ce7040 [can pipeline]
* Connection 0 seems to be dead!
* Closing connection 0
* Hostname localhost was found in DNS cache
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 1218 (#1)
```

After PR:
```
* Connection #0 to host localhost left intact
* Found bundle for host localhost: 0x55c93fb78040 [can pipeline]
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (127.0.0.1) port 1218 (#0)
```

Note that I believe we may override the uWSGI args in production. I figured we may as well change the default? And then we'll need to do the same `--http-keepalive` in Chef.