### PR TITLE
Remove default orderby, always attempt to use user-provided orderby.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -182,10 +182,12 @@ def query(validated_body=None, timer=None):
         group_clause = 'GROUP BY ({})'.format(group_clause)
 
     order_clause = ''
-    desc = body['orderby'].startswith('-')
-    orderby = body['orderby'].lstrip('-')
-    if orderby in body.get('alias_cache', {}).values():
-        order_clause = u'ORDER BY `{}` {}'.format(orderby, 'DESC' if desc else 'ASC')
+    if body.get('orderby'):
+        desc = body['orderby'].startswith('-')
+        orderby = body['orderby'].lstrip('-')
+        order_clause = u'ORDER BY {} {}'.format(
+            util.column_expr(orderby, body), 'DESC' if desc else 'ASC'
+        )
 
     limit_clause = ''
     if 'limit' in body:

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -119,7 +119,6 @@ QUERY_SCHEMA = {
         },
         'orderby': {
             '$ref': '#/definitions/column_name',
-            'default': 'time',
         },
         'limit': {
             'type': 'number'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,6 +87,7 @@ class TestApi(BaseTest):
                 'from_date': self.base_time.isoformat(),
                 'to_date': (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
                 'aggregations': [['count()', '', 'aggregate']],
+                'orderby': 'time',
                 'groupby': 'time',
             })).data)
             buckets = self.minutes / rollup_mins
@@ -106,6 +107,7 @@ class TestApi(BaseTest):
                 'to_date': (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
                 'aggregations': [['count()', '', 'aggregate']],
                 'groupby': 'time',
+                'orderby': 'time',
             })).data)
             buckets = self.minutes / rollup_mins
             for b in range(buckets):


### PR DESCRIPTION
We were silently dropping user orderby's because of a bug related to
escaping. It's probably better to throw an error so the user knows their
results are unordered.

Related: Fixes the mysterious test failure here: https://github.com/getsentry/sentry/pull/8632