### PR TITLE
Deduplicate WHERE conditions

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -157,6 +157,10 @@ def is_condition(cond_or_list):
 def flat_conditions(conditions):
     return list(chain(*[[c] if is_condition(c) else c for c in conditions]))
 
+def tuplify(nested):
+    if isinstance(nested, (list, tuple)):
+        return tuple(tuplify(child) for child in nested)
+    return nested
 
 def condition_expr(conditions, body, depth=0):
     """


### PR DESCRIPTION
Only deduplicates conditions at the top level (ie the ones that are ANDed together) and only deduplicates conditions that are identical.

Future improvements could be to deduplicate things like `col = X AND col IN (X)` or reduce overlapping conditions like `col < 1 AND col < 2` but I don't think its really worth the effort.