### PR TITLE
fix: Workaround for CH exception on `issue IN (x)`

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -303,7 +303,7 @@ def issue_expr(body, hash_column='primary_hash'):
     # compare (Nothing, UInt8), but will work on comparing (Null, Uint8) so
     # we need a Null value in the issue expression for the query to work.
     if not issue_ids and used_ids:
-        issue_ids, hashes, tombstones = ['Null'], ['Null'], ['Null']
+        issue_ids, hashes, tombstones = ['0'], ['Null'], ['Null']
 
     return ("""
         ANY INNER JOIN

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,6 +140,24 @@ class TestApi(BaseTest):
         })).data)
         assert result['error'] is None
 
+        result = json.loads(self.app.post('/query', data=json.dumps({
+            'project': 1,
+            'granularity': 3600,
+            'groupby': 'issue',
+            'conditions': [['issue', '=', 100]],
+        })).data)
+        assert result['error'] is None
+        assert result['data'] == []
+
+        result = json.loads(self.app.post('/query', data=json.dumps({
+            'project': 1,
+            'granularity': 3600,
+            'groupby': 'issue',
+            'conditions': [['issue', 'IN', [100,200]]],
+        })).data)
+        assert result['error'] is None
+        assert result['data'] == []
+
     def test_offset_limit(self):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': self.project_ids,


### PR DESCRIPTION
When there are no issues defined, we still need to expand our join
expression so that conditions on `issue` dont become syntax errors.
We did this by joining to a single row of
`(issue, hash, tombstone) = (Null, Null, Null)`

However, for `IN` comparisons, the type of the `issue` column still
needs to be an int to avoid `Exception: Type mismatch in IN or VALUES
section. Expected: Nothing. Got: UInt64.` .

So now the null row in the join table is `(0, Null, Null)`