### PR TITLE
feat: Readonly and Read/Write connection pools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ blinker==1.4
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-clickhouse-driver==0.0.10
+clickhouse-driver==0.0.11
 colorama==0.3.9
 configparser==3.5.0
 confluent-kafka==0.11.4

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -18,11 +18,13 @@ class ClickhousePool(object):
                  connect_timeout=1,
                  send_receive_timeout=300,
                  max_pool_size=settings.CLICKHOUSE_MAX_POOL_SIZE,
+                 client_settings={}
                  ):
         self.host = host
         self.port = port
         self.connect_timeout = connect_timeout
         self.send_receive_timeout = send_receive_timeout
+        self.client_settings = client_settings
 
         self.pool = queue.LifoQueue(max_pool_size)
 
@@ -53,6 +55,7 @@ class ClickhousePool(object):
             port=self.port,
             connect_timeout=self.connect_timeout,
             send_receive_timeout=self.send_receive_timeout,
+            settings=self.client_settings
         )
 
     def close(self):

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -231,10 +231,10 @@ def raw_query(sql, client):
     for col in meta:
         # Convert naive datetime strings back to TZ aware ones, and stringify
         # TODO maybe this should be in the json serializer
-        if col['type'] == "DateTime":
+        if col['type'].startswith('DateTime'):
             for d in data:
                 d[col['name']] = d[col['name']].replace(tzinfo=tz.tzutc()).isoformat()
-        elif col['type'] == "Date":
+        elif col['type'].startswith('Date'):
             for d in data:
                 dt = datetime(*(d[col['name']].timetuple()[:6])).replace(tzinfo=tz.tzutc())
                 d[col['name']] = dt.isoformat()


### PR DESCRIPTION
+ Upgrade clickhouse-driver to 0.0.11 for the settings support.

+ Fix datetime formatting issue caused by 0.0.11 upgrade.

+ Manually tested that the CREATE/INSERT paths fail when using the
readonly pool.