### PR TITLE
Simplify issue tombstones queries by passing down nulls when possible.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -159,7 +159,11 @@ def query(validated_body=None, timer=None):
     issue_expr = util.issue_expr(body)
     if issue_expr:
         joins.append(issue_expr)
-        where_conditions.append(('timestamp', '>', util.ColumnLiteral('hash_timestamp')))
+        where_conditions.append(
+            ('timestamp', '>', util.Literal(
+                'ifNull(hash_timestamp, CAST(\'1970-01-01 00:00:00\', \'DateTime\'))')
+            )
+        )
     if 'arrayjoin' in body:
         joins.append(u'ARRAY JOIN {}'.format(body['arrayjoin']))
     join_clause = ' '.join(joins)


### PR DESCRIPTION
ClickHouse has a bug where you can't CAST an array of Strings and Nulls
to DateTimes, but an array of Integers and Nulls seems to work. So we
convert the stringified dates to unix timestamps before passing them
down.