### PR TITLE
feat: Track global concurrent usage as a gauge

### DIFF
--- a/snuba/state.py
+++ b/snuba/state.py
@@ -61,14 +61,14 @@ def rate_limit(bucket, per_second_limit=None, concurrent_limit=None):
         _, _, rate, concurrent = pipe.execute()
     except Exception as ex:
         logger.error(ex)
-        yield True  # fail open if redis is having issues
+        yield (True, 0, 0) # fail open if redis is having issues
         return
 
     per_second = rate / float(rate_lookback_s)
     allowed = (per_second_limit is None or per_second <= per_second_limit) and\
         (concurrent_limit is None or concurrent <= concurrent_limit)
     try:
-        yield allowed
+        yield (allowed, concurrent, per_second)
     finally:
         try:
             if allowed:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -10,28 +10,28 @@ class TestState(BaseTest):
 
     def test_concurrent_limit(self):
         # No concurrent limit
-        with state.rate_limit('foo', concurrent_limit=None) as allowed:
+        with state.rate_limit('foo', concurrent_limit=None) as (allowed, _, _):
             assert allowed
 
         # 0 concurrent limit
-        with state.rate_limit('foo', concurrent_limit=0) as allowed:
+        with state.rate_limit('foo', concurrent_limit=0) as (allowed, _, _):
             assert not allowed
 
         # Concurrent limit 1 with consecutive  queries
-        with state.rate_limit('foo', concurrent_limit=1) as allowed:
+        with state.rate_limit('foo', concurrent_limit=1) as (allowed, _, _):
             assert allowed
-        with state.rate_limit('foo', concurrent_limit=1) as allowed:
+        with state.rate_limit('foo', concurrent_limit=1) as (allowed, _, _):
             assert allowed
 
         # Concurrent limit with concurrent queries
-        with state.rate_limit('foo', concurrent_limit=1) as allowed1:
-            with state.rate_limit('foo', concurrent_limit=1) as allowed2:
+        with state.rate_limit('foo', concurrent_limit=1) as (allowed1, _, _):
+            with state.rate_limit('foo', concurrent_limit=1) as (allowed2, _, _):
                 assert allowed1
                 assert not allowed2
 
         # Concurrent with different buckets
-        with state.rate_limit('foo', concurrent_limit=1) as foo_allowed:
-            with state.rate_limit('bar', concurrent_limit=1) as bar_allowed:
+        with state.rate_limit('foo', concurrent_limit=1) as (foo_allowed, _, _):
+            with state.rate_limit('bar', concurrent_limit=1) as (bar_allowed, _, _):
                 assert foo_allowed
                 assert bar_allowed
 
@@ -40,29 +40,29 @@ class TestState(BaseTest):
         # Create 30 queries at time 0, should all be allowed
         with patch.object(state.time, 'time', lambda: 0):
             for _ in range(30):
-                with state.rate_limit(bucket, per_second_limit=1) as allowed:
+                with state.rate_limit(bucket, per_second_limit=1) as (allowed, _, _):
                     assert allowed
 
         # Create another 30 queries at time 30, should also be allowed
         with patch.object(state.time, 'time', lambda: 30):
             for _ in range(30):
-                with state.rate_limit(bucket, per_second_limit=1) as allowed:
+                with state.rate_limit(bucket, per_second_limit=1) as (allowed, _, _):
                     assert allowed
 
         with patch.object(state.time, 'time', lambda: 60):
             # 1 more query should be allowed at T60 because it does not make the previous
             # rate exceed 1/sec until it has finished.
-            with state.rate_limit(bucket, per_second_limit=1) as allowed:
+            with state.rate_limit(bucket, per_second_limit=1) as (allowed, _, _):
                 assert allowed
 
             # But the next one should not be allowed
-            with state.rate_limit(bucket, per_second_limit=1) as allowed:
+            with state.rate_limit(bucket, per_second_limit=1) as (allowed, _, _):
                 assert not allowed
 
         # Another query at time 61 should be allowed because the first 30 queries
         # have fallen out of the lookback window
         with patch.object(state.time, 'time', lambda: 61):
-            with state.rate_limit(bucket, per_second_limit=1) as allowed:
+            with state.rate_limit(bucket, per_second_limit=1) as (allowed, _, _):
                 assert allowed
 
     def test_config(self):


### PR DESCRIPTION
Have the rate limiter decorator return the concurrent and
per_second values so they can be reported.