### PR TITLE
feat: Allow changing Clickhouse query settings at runtime.

### DIFF
--- a/snuba/settings_test.py
+++ b/snuba/settings_test.py
@@ -2,3 +2,4 @@ from snuba.settings_base import *  # NOQA
 
 TESTING = True
 CLICKHOUSE_TABLE = 'test'
+REDIS_DB = 2

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -216,9 +216,17 @@ def raw_query(sql, client):
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON
     """
+    query_settings = {}
+    try:
+        query_settings_json = state.get_config('query_settings_json')
+        if query_settings_json:
+            query_settings = json.loads(query_settings_json)
+    except ValueError:
+        pass
+
     try:
         error = None
-        data, meta = client.execute(sql, with_column_types=True)
+        data, meta = client.execute(sql, with_column_types=True, settings=query_settings)
         logger.debug(sql)
     except BaseException as ex:
         data, meta, error = [], [], six.text_type(ex)


### PR DESCRIPTION
Adding a `query_settings_json` config with a valid json string like:
`{"max_bytes_to_read": 1}` will pass those settings down to the query.

This should allow us to play around with things like max_threads and
various other CH settings much more easily