### PR TITLE
Don't attempt to create tables in the writer.

### DIFF
--- a/bin/writer
+++ b/bin/writer
@@ -27,12 +27,8 @@ sentry = RavenClient(dsn=settings.SENTRY_DSN)
               help='Kafka bootstrap server to use (multiple allowed).')
 @click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
               help='Clickhouse server to write to.')
-@click.option('--local-table-name', default=settings.DEFAULT_LOCAL_TABLE,
-              help='Clickhouse table name for the (optionally replicated) local table.')
 @click.option('--distributed-table-name', default=settings.DEFAULT_DIST_TABLE,
               help='Clickhouse table name for the "meta" Distributed table.')
-@click.option('--clickhouse-cluster', default=settings.CLICKHOUSE_CLUSTER,
-              help='Clickhouse cluster name for the "meta" Distributed table.')
 @click.option('--max-batch-size', default=settings.DEFAULT_MAX_BATCH_SIZE,
               help='Max number of messages to batch in memory before writing to Clickhouse.')
 @click.option('--max-batch-time-ms', default=settings.DEFAULT_MAX_BATCH_TIME_MS,
@@ -43,29 +39,14 @@ sentry = RavenClient(dsn=settings.SENTRY_DSN)
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
 def run(processed_topic, consumer_group, bootstrap_server, clickhouse_server,
-        local_table_name, distributed_table_name, clickhouse_cluster, max_batch_size,
-        max_batch_time_ms, auto_offset_reset, log_level, dogstatsd_host, dogstatsd_port):
+        distributed_table_name, max_batch_size, max_batch_time_ms, auto_offset_reset, log_level,
+        dogstatsd_host, dogstatsd_port):
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
     metrics = util.create_metrics(
         dogstatsd_host, dogstatsd_port, 'snuba.writer', tags=["group:%s" % consumer_group]
     )
     clickhouse = ClickhousePool(clickhouse_server.split(':')[0], port=int(clickhouse_server.split(':')[1]))
-
-    # ensure tables exist
-    LOCAL_TABLE_DEFINITION = get_table_definition(
-        local_table_name, get_replicated_engine(name=local_table_name))
-    DIST_TABLE_DEFINITION = get_table_definition(
-        distributed_table_name,
-        get_distributed_engine(
-            cluster=clickhouse_cluster,
-            database='default',
-            local_table=local_table_name,
-        )
-    )
-
-    clickhouse.execute(LOCAL_TABLE_DEFINITION)
-    clickhouse.execute(DIST_TABLE_DEFINITION)
 
     consumer = BatchingKafkaConsumer(
         processed_topic,

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -112,3 +112,15 @@ def get_distributed_engine(cluster, database, local_table,
         'local_table': local_table,
         'sharding_key': sharding_key,
     }
+
+
+LOCAL_TABLE_DEFINITION = get_table_definition(
+    settings.DEFAULT_LOCAL_TABLE, get_replicated_engine(name=settings.DEFAULT_LOCAL_TABLE))
+DIST_TABLE_DEFINITION = get_table_definition(
+    settings.DEFAULT_DIST_TABLE,
+    get_distributed_engine(
+        cluster=settings.CLICKHOUSE_CLUSTER,
+        database='default',
+        local_table=settings.DEFAULT_LOCAL_TABLE,
+    )
+)


### PR DESCRIPTION
Moved to `clickhouse.py` just because they're handy to print out at least.