### PR TITLE
fix: Invert alias cache

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -90,14 +90,14 @@ def alias_expr(expr, alias, body):
        it can be reused later and return `expr AS alias`
     3. If the expression has been aliased before, return the alias
     """
-    alias_cache = body.setdefault('alias_cache', {})
+    alias_cache = body.setdefault('alias_cache', [])
 
     if expr == alias:
         return expr
-    elif expr in alias_cache:
-        return alias_cache[expr]
+    elif alias in alias_cache:
+        return alias
     else:
-        alias_cache[expr] = alias
+        alias_cache.append(alias)
         return u'({} AS {})'.format(expr, alias)
 
 


### PR DESCRIPTION
Instead of re-using an alias when the generated _expression_ is the same
as a previously generated one, simply re-use the alias if we have ever
aliased _any_ expression to that same alias before.

This makes alias reuse simpler, but has the slight pitfall that if you
mess up and try and alias 2 expressions to the same thing, you will
silently get 2 copies of the first thing, rather than a Clickhouse
exception that you are trying to alias different expressions to the
same thing.