### PR TITLE
Add 'type' and 'version' columns.

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -100,6 +100,8 @@ def extract_common(output, message, data):
         primary_hash = md5(force_bytes(primary_hash)).hexdigest()
     output['primary_hash'] = primary_hash
     output['received'] = int(data['received'])
+    output['type'] = _unicodify(data.get('type', None))
+    output['version'] = _unicodify(data.get('version', None))
 
 
 def extract_sdk(output, sdk):

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -118,6 +118,8 @@ WRITER_COLUMNS = [
     'ip_address',
     'sdk_name',
     'sdk_version',
+    'type',
+    'version',
 ] + METADATA_COLUMNS + PROMOTED_CONTEXTS + PROMOTED_TAGS + PROMOTED_CONTEXT_TAGS + [
     'tags.key',
     'tags.value',
@@ -186,6 +188,8 @@ SCHEMA_COLUMNS = [
     # optional misc
     ('sdk_name', 'Nullable(String)'),
     ('sdk_version', 'Nullable(String)'),
+    ('type', 'Nullable(String)'),
+    ('version', 'Nullable(String)'),
 
     # optional stream related data
     ('offset', 'Nullable(UInt64)'),

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -75,7 +75,9 @@ class TestProcessor(BaseTest):
             'platform': 'the_platform',
         }
         data = {
-            'received': 1520971716.0
+            'received': 1520971716.0,
+            'type': 'error',
+            'version': 6,
         }
         output = {}
 
@@ -85,6 +87,8 @@ class TestProcessor(BaseTest):
             'platform': u'the_platform',
             'primary_hash': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
             'received': 1520971716,
+            'type': 'error',
+            'version': '6',
         }
 
     def test_deleted(self):


### PR DESCRIPTION
Right now these are (1) nullable and (2) strings.

If we want them to be required (and/or if we want `version` to be an integer) I think we need to update the Sentry event schema. It currently only requires that `type` is an `object` and it doesn't declare anything about `version` that I see.