### PR TITLE
feat: Query caching and duplicate concurrent query detection

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -232,7 +232,7 @@ def query(validated_body=None, timer=None):
             if not g_allowed or not allowed:
                 status = 429
             else:
-                result = util.raw_query(sql, clickhouse_ro)
+                result = util.raw_query(sql, clickhouse_ro, timer)
                 timer.mark('execute')
 
                 if result.get('error'):

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from datetime import timedelta
 from dateutil.parser import parse as parse_datetime
 from flask import Flask, render_template, request
+from hashlib import md5
 from markdown import markdown
 from raven.contrib.flask import Sentry
 import simplejson as json
@@ -223,41 +224,60 @@ def query(validated_body=None, timer=None):
     timer.mark('prepare_query')
 
     result = {}
+    status = 200
     gpsl = state.get_config('global_per_second_limit', 1000)
     gcl = state.get_config('global_concurrent_limit', 1000)
     ppsl = state.get_config('project_per_second_limit', 1000)
     pcl = state.get_config('project_concurrent_limit', 1000)
-    with state.rate_limit('global', gpsl, gcl) as (g_allowed, g_concurr, g_rate):
-        with state.rate_limit(project_ids[0], ppsl, pcl) as (allowed, concurr, rate):
-            if not g_allowed or not allowed:
-                status = 429
-            else:
-                result = util.raw_query(sql, clickhouse_ro, timer)
-                timer.mark('execute')
+    use_query_id = state.get_config('use_query_id', 0)
+    use_cache = use_query_id and state.get_config('use_cache', 0)
+    query_id = md5(util.force_bytes(sql)).hexdigest() if use_query_id else None
+    cache_hit = use_cache
+    concurr, rate, g_concurr, g_rate = 0, 0, 0, 0
+    with state.deduper(query_id) as is_dupe:
+        timer.mark('dedupe_wait')
+        if use_cache:
+            result = json.loads(state.get_result(query_id) or "{}")
+            timer.mark('cache_get')
 
-                if result.get('error'):
-                    status = 500
-                else:
-                    status = 200
+        if not result:
+            cache_hit = False
+            with state.rate_limit('global', gpsl, gcl) as (g_allowed, g_concurr, g_rate):
+                with state.rate_limit(project_ids[0], ppsl, pcl) as (allowed, concurr, rate):
+                    if not g_allowed or not allowed:
+                        status = 429
+                    else:
+                        result = util.raw_query(sql, clickhouse_ro, query_id)
+                        timer.mark('execute')
+                        if result.get('error'):
+                            status = 500
+                        elif use_cache:
+                            state.set_result(query_id, json.dumps(result))
+                            timer.mark('cache_set')
 
-    result['timing'] = timer
+    stats = {
+        'is_duplicate': is_dupe,
+        'cache_hit': cache_hit,
+        'num_days': (to_date - from_date).days,
+        'num_issues': len(validated_body.get('issues', [])),
+        'num_hashes': sum(len(h) for i, h in validated_body.get('issues', [])),
+        'global_concurrent': g_concurr,
+        'global_rate': g_rate,
+        'project_concurrent': concurr,
+        'project_rate': rate,
+    }
     timer.record(metrics)
-    metrics.gauge('query.global_concurrent', g_concurr)
     state.record_query({
         'request': validated_body,
         'referrer': request.referrer,
         'sql': sql,
-        'timing': result['timing'],
-        'stats': {
-            'num_days': (to_date - from_date).days,
-            'num_issues': len(validated_body.get('issues', [])),
-            'num_hashes': sum(len(h) for i, h in validated_body.get('issues', [])),
-            'global_concurrent': g_concurr,
-            'global_rate': g_rate,
-            'project_concurrent': concurr,
-            'project_rate': rate,
-        }
+        'timing': timer,
+        'stats': stats,
     })
+
+    result['timing'] = timer
+    if settings.STATS_IN_RESPONSE:
+        result['stats'] = stats
 
     return (json.dumps(result, for_json=True), status, {'Content-Type': 'application/json'})
 

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -286,3 +286,5 @@ RETENTION_OVERRIDES = {}
 
 # the list of keys that will upgrade from a WHERE condition to a PREWHERE
 PREWHERE_KEYS = []
+
+STATS_IN_RESPONSE = False

--- a/snuba/settings_test.py
+++ b/snuba/settings_test.py
@@ -3,3 +3,4 @@ from snuba.settings_base import *  # NOQA
 TESTING = True
 CLICKHOUSE_TABLE = 'test'
 REDIS_DB = 2
+STATS_IN_RESPONSE = True

--- a/snuba/state.py
+++ b/snuba/state.py
@@ -202,14 +202,16 @@ def deduper(query_id):
     queries can then use the cached result from the first query.
     """
     if query_id is None:
-        yield
+        yield False
     else:
         lock = '{}{}'.format(query_lock_prefix, query_id)
         nonce = uuid.uuid4()
         timeout = 10
         try:
+            is_dupe = False
             while not rds.set(lock, nonce, nx=True, ex=timeout):
+                is_dupe = True
                 time.sleep(0.01)
-            yield
+            yield is_dupe
         finally:
             unlock_lua(keys=[lock], args=[nonce])

--- a/snuba/state.py
+++ b/snuba/state.py
@@ -25,6 +25,8 @@ rate_history_s = 3600
 
 
 ratelimit_prefix = 'snuba-ratelimit:'
+query_lock_prefix = 'snuba-query-lock:'
+query_cache_prefix = 'snuba-query-cache:'
 config_hash = 'snuba-config'
 queries_list = 'snuba-queries'
 
@@ -169,3 +171,45 @@ def get_queries():
         logger.error(ex)
 
     return queries
+
+def get_result(query_id):
+    key = '{}{}'.format(query_cache_prefix, query_id)
+    result = rds.get(key)
+    return result
+
+def set_result(query_id, result):
+    timeout = 1
+    key = '{}{}'.format(query_cache_prefix, query_id)
+    return rds.set(key, result, ex=timeout)
+
+unlock_lua = rds.register_script('''
+    if redis.call('get', KEYS[1]) == ARGV[1]
+    then
+        return redis.call('del', KEYS[1])
+    else
+        return 0
+    end
+''')
+
+@contextmanager
+def deduper(query_id):
+    """
+    A simple redis distributed lock on a query_id to prevent multiple
+    concurrent queries running with the same id. Blocks subsequent
+    queries until the first is finished.
+
+    When used in conjunction with caching this means that the subsequent
+    queries can then use the cached result from the first query.
+    """
+    if query_id is None:
+        yield
+    else:
+        lock = '{}{}'.format(query_lock_prefix, query_id)
+        nonce = uuid.uuid4()
+        timeout = 10
+        try:
+            while not rds.set(lock, nonce, nx=True, ex=timeout):
+                time.sleep(0.01)
+            yield
+        finally:
+            unlock_lua(keys=[lock], args=[nonce])

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -239,11 +239,15 @@ def raw_query(sql, client, timer=None):
     use_cache = state.get_config('use_cache', 0)
     query_id = md5(force_bytes(sql)).hexdigest() if use_query_id else None
     with state.deduper(query_id):
+        if timer:
+            timer.mark('dedupe_wait')
         if use_query_id and use_cache:
             cached = state.get_result(query_id)
             if cached is not None:
                 cached = json.loads(cached)
                 cached['cache'] = 1
+                if timer:
+                    timer.mark('cache_hit')
                 return cached
 
         try:

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -222,7 +222,7 @@ def escape_literal(value):
         raise ValueError(u'Do not know how to escape {} for SQL'.format(type(value)))
 
 
-def raw_query(sql, client, timer=None):
+def raw_query(sql, client, query_id=None):
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON
@@ -235,55 +235,35 @@ def raw_query(sql, client, timer=None):
     except ValueError:
         pass
 
-    use_query_id = state.get_config('use_query_id', 0)
-    use_cache = state.get_config('use_cache', 0)
-    query_id = md5(force_bytes(sql)).hexdigest() if use_query_id else None
-    with state.deduper(query_id):
-        if timer:
-            timer.mark('dedupe_wait')
-        if use_query_id and use_cache:
-            cached = state.get_result(query_id)
-            if cached is not None:
-                cached = json.loads(cached)
-                cached['cache'] = 1
-                if timer:
-                    timer.mark('cache_hit')
-                return cached
+    try:
+        error = None
+        data, meta = client.execute(
+            sql,
+            with_column_types=True,
+            settings=query_settings,
+            query_id=query_id
+        )
+        logger.debug(sql)
+    except BaseException as ex:
+        data, meta, error = [], [], six.text_type(ex)
+        logger.error("Error running query: %s\nClickhouse error: %s" % (sql, error))
 
-        try:
-            error = None
-            data, meta = client.execute(
-                sql,
-                with_column_types=True,
-                settings=query_settings,
-                query_id=query_id
-            )
-            logger.debug(sql)
-        except BaseException as ex:
-            data, meta, error = [], [], six.text_type(ex)
-            logger.error("Error running query: %s\nClickhouse error: %s" % (sql, error))
+    # for now, convert back to a dict-y format to emulate the json
+    data = [{c[0]: d[i] for i, c in enumerate(meta)} for d in data]
+    meta = [{'name': m[0], 'type': m[1]} for m in meta]
 
-        # for now, convert back to a dict-y format to emulate the json
-        data = [{c[0]: d[i] for i, c in enumerate(meta)} for d in data]
-        meta = [{'name': m[0], 'type': m[1]} for m in meta]
+    for col in meta:
+        # Convert naive datetime strings back to TZ aware ones, and stringify
+        # TODO maybe this should be in the json serializer
+        if col['type'].startswith('DateTime'):
+            for d in data:
+                d[col['name']] = d[col['name']].replace(tzinfo=tz.tzutc()).isoformat()
+        elif col['type'].startswith('Date'):
+            for d in data:
+                dt = datetime(*(d[col['name']].timetuple()[:6])).replace(tzinfo=tz.tzutc())
+                d[col['name']] = dt.isoformat()
 
-        for col in meta:
-            # Convert naive datetime strings back to TZ aware ones, and stringify
-            # TODO maybe this should be in the json serializer
-            if col['type'].startswith('DateTime'):
-                for d in data:
-                    d[col['name']] = d[col['name']].replace(tzinfo=tz.tzutc()).isoformat()
-            elif col['type'].startswith('Date'):
-                for d in data:
-                    dt = datetime(*(d[col['name']].timetuple()[:6])).replace(tzinfo=tz.tzutc())
-                    d[col['name']] = dt.isoformat()
-
-        result = {'data': data, 'meta': meta, 'error': error, 'cache': 0}
-
-        if use_query_id and use_cache and error is None:
-            state.set_result(query_id, json.dumps(result))
-
-        return result
+    return {'data': data, 'meta': meta, 'error': error}
 
 
 def uses_issue(body):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,12 +1,21 @@
 from base import BaseTest
-import time
+from functools import partial
 from mock import patch
+import simplejson as json
+from threading import Thread
+import time
 import uuid
 
 from snuba import state
 
 
 class TestState(BaseTest):
+    def setup_method(self, test_method):
+        super(TestState, self).setup_method(test_method)
+        from snuba.api import application
+        assert application.testing == True
+        self.app = application.test_client()
+        self.app.post = partial(self.app.post, headers={'referer': 'test'})
 
     def test_concurrent_limit(self):
         # No concurrent limit
@@ -74,3 +83,51 @@ class TestState(BaseTest):
 
         state.set_configs({'bar': 'quux'})
         assert state.get_configs() == {b'foo': 1, b'bar': b'quux', b'baz': 3}
+
+    def test_dedupe(self):
+
+        state.set_config('use_query_id', 1)
+        state.set_config('use_cache', 1)
+
+        def do_request(result_container):
+            result = json.loads(self.app.post('/query', data=json.dumps({
+                'project': 1,
+                'granularity': 3600,
+                'aggregations': [['count()', '', 'concurrent_count']],
+            })).data)
+            result_container.append(result)
+
+        # t0 and t1 are exact duplicate queries submitted concurrently
+        # t1 should be held back until t0 finishes, at which point t1
+        # will use the cached result from t0.
+        results = [[] for _ in range(4)]
+        t0 = Thread(target=do_request, args=(results[0],))
+        t1 = Thread(target=do_request, args=(results[1],))
+        t0.start()
+        t1.start()
+        t0.join()
+        t1.join()
+
+        # a subsequent request will also use the cached value as
+        # it is still fresh
+        do_request(results[2])
+
+        # after a second, the cache entry will no longer be fresh
+        # and we will re-query the database.
+        time.sleep(1)
+        do_request(results[3])
+
+        results = [r.pop() for r in results]
+        # The results should all have the same data
+        datas = [r['data'] for r in results]
+        assert datas[0] == [{'concurrent_count': 0}]
+        assert all(d == datas[0] for d in datas)
+
+        # The results should have the right caching flags
+        assert results[0]['cache'] == 0
+        assert results[1]['cache'] == 1
+        assert results[2]['cache'] == 1
+        assert results[3]['cache'] == 0
+
+        state.delete_config('use_query_id')
+        state.delete_config('use_cache')

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -85,52 +85,59 @@ class TestState(BaseTest):
         assert state.get_configs() == {b'foo': 1, b'bar': b'quux', b'baz': 3}
 
     def test_dedupe(self):
+        try:
+            state.set_config('use_query_id', 1)
+            state.set_config('use_cache', 1)
+            uniq_name = uuid.uuid4().hex[:8]
+            def do_request(result_container):
+                result = json.loads(self.app.post('/query', data=json.dumps({
+                    'project': 1,
+                    'granularity': 3600,
+                    'aggregations': [['count()', '', uniq_name]],
+                })).data)
+                result_container.append(result)
 
-        state.set_config('use_query_id', 1)
-        state.set_config('use_cache', 1)
-        uniq_name = uuid.uuid4().hex[:8]
-        def do_request(result_container):
-            result = json.loads(self.app.post('/query', data=json.dumps({
-                'project': 1,
-                'granularity': 3600,
-                'aggregations': [['count()', '', uniq_name]],
-            })).data)
-            result_container.append(result)
+            # t0 and t1 are exact duplicate queries submitted concurrently.  One of
+            # them will execute normally and the other one should be held back by
+            # the deduper, until it can use the cached result from the first.
+            results = [[] for _ in range(4)]
+            t0 = Thread(target=do_request, args=(results[0],))
+            t1 = Thread(target=do_request, args=(results[1],))
+            t0.start()
+            t1.start()
+            t0.join()
+            t1.join()
 
-        # t0 and t1 are exact duplicate queries submitted concurrently.  One of
-        # them will execute normally and the other one should be held back by
-        # the deduper, until it can use the cached result from the first.
-        results = [[] for _ in range(4)]
-        t0 = Thread(target=do_request, args=(results[0],))
-        t1 = Thread(target=do_request, args=(results[1],))
-        t0.start()
-        t1.start()
-        t0.join()
-        t1.join()
+            # a subsequent request will also use the cached value as
+            # it is still fresh
+            do_request(results[2])
 
-        # a subsequent request will also use the cached value as
-        # it is still fresh
-        do_request(results[2])
+            # after a second, the cache entry will no longer be fresh
+            # and we will re-query the database.
+            time.sleep(1)
+            do_request(results[3])
 
-        # after a second, the cache entry will no longer be fresh
-        # and we will re-query the database.
-        time.sleep(1)
-        do_request(results[3])
+            results = [r.pop() for r in results]
+            # The results should all have the same data
+            datas = [r['data'] for r in results]
+            assert datas[0] == [{uniq_name: 0}]
+            assert all(d == datas[0] for d in datas)
 
-        results = [r.pop() for r in results]
-        # The results should all have the same data
-        datas = [r['data'] for r in results]
-        assert datas[0] == [{uniq_name: 0}]
-        assert all(d == datas[0] for d in datas)
+            stats = [r['stats'] for r in results]
+            # we don't know which order these will execute in, but one
+            # of them will be a cached result
+            assert stats[0]['cache_hit'] in (True, False)
+            assert stats[1]['cache_hit'] in (True, False)
+            assert stats[0]['cache_hit'] != stats[1]['cache_hit']
+            # and the cached one should be the one marked as dupe
+            assert stats[0]['cache_hit'] == stats[0]['is_duplicate']
+            assert stats[1]['cache_hit'] == stats[1]['is_duplicate']
 
-        # we don't know which order these will execute in, but one
-        # of them will be a cached result
-        assert results[0]['cache'] in (0, 1)
-        assert results[1]['cache'] in (0, 1)
-        assert results[0]['cache'] != results[1]['cache']
+            assert stats[2]['cache_hit'] == True
+            assert stats[2]['is_duplicate'] == False
+            assert stats[3]['cache_hit'] == False
+            assert stats[3]['is_duplicate'] == False
 
-        assert results[2]['cache'] == 1
-        assert results[3]['cache'] == 0
-
-        state.delete_config('use_query_id')
-        state.delete_config('use_cache')
+        finally:
+            state.delete_config('use_query_id')
+            state.delete_config('use_cache')


### PR DESCRIPTION
A simple 1-second redis cache for clickhouse results and a
distributed lock on query_id that queues subsequent runs of an
exact duplicate query so that they can use the cached result from
the first query.