### PR TITLE
fix: Fix some things about the deduping

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -79,10 +79,17 @@ class TestState(BaseTest):
         state.set_configs({'bar': 2, 'baz': 3})
         assert state.get_config('foo') == 1
         assert state.get_config('bar') == 2
-        assert state.get_configs() == {b'foo': 1, b'bar': 2, b'baz': 3}
+        assert state.get_config('noexist', 4) == 4
+        assert state.get_all_configs() == {b'foo': 1, b'bar': 2, b'baz': 3}
+        assert state.get_configs([
+            ('foo', 100),
+            ('bar', 200),
+            ('noexist', 300)
+        ]) == [1, 2, 300]
+
 
         state.set_configs({'bar': 'quux'})
-        assert state.get_configs() == {b'foo': 1, b'bar': b'quux', b'baz': 3}
+        assert state.get_all_configs() == {b'foo': 1, b'bar': b'quux', b'baz': 3}
 
     def test_dedupe(self):
         try:


### PR DESCRIPTION
- Make the lock timeout as long as the max duration used by the rate
limiter
- Make the deduping happen inside the rate limiter so we don't accept
unbounded duplicate queries.
- Get all query settings in 1 redis call to save time