### PR TITLE
feat: Leave promoted tags in the nested tags list

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -111,42 +111,42 @@ def extract_sdk(output, sdk):
 
 
 def extract_promoted_tags(output, tags):
-    output.update({name: _unicodify(tags.pop(name, None))
+    output.update({name: _unicodify(tags.get(name, None))
         for name in settings.PROMOTED_TAGS
     })
 
 
 def extract_promoted_contexts(output, contexts, tags):
     app_ctx = contexts.get('app', {})
-    output['app_device'] = _unicodify(tags.pop('app.device', None))
+    output['app_device'] = _unicodify(tags.get('app.device', None))
     app_ctx.pop('device_app_hash', None)  # tag=app.device
 
     os_ctx = contexts.get('os', {})
-    output['os'] = _unicodify(tags.pop('os', None))
-    output['os_name'] = _unicodify(tags.pop('os.name', None))
+    output['os'] = _unicodify(tags.get('os', None))
+    output['os_name'] = _unicodify(tags.get('os.name', None))
     os_ctx.pop('name', None)  # tag=os and/or os.name
     os_ctx.pop('version', None)  # tag=os
-    output['os_rooted'] = _boolify(tags.pop('os.rooted', None))
+    output['os_rooted'] = _boolify(tags.get('os.rooted', None))
     os_ctx.pop('rooted', None)  # tag=os.rooted
     output['os_build'] = _unicodify(os_ctx.pop('build', None))
     output['os_kernel_version'] = _unicodify(os_ctx.pop('kernel_version', None))
 
     runtime_ctx = contexts.get('runtime', {})
-    output['runtime'] = _unicodify(tags.pop('runtime', None))
-    output['runtime_name'] = _unicodify(tags.pop('runtime.name', None))
+    output['runtime'] = _unicodify(tags.get('runtime', None))
+    output['runtime_name'] = _unicodify(tags.get('runtime.name', None))
     runtime_ctx.pop('name', None)  # tag=runtime and/or runtime.name
     runtime_ctx.pop('version', None)  # tag=runtime
 
     browser_ctx = contexts.get('browser', {})
-    output['browser'] = _unicodify(tags.pop('browser', None))
-    output['browser_name'] = _unicodify(tags.pop('browser.name', None))
+    output['browser'] = _unicodify(tags.get('browser', None))
+    output['browser_name'] = _unicodify(tags.get('browser.name', None))
     browser_ctx.pop('name', None)  # tag=browser and/or browser.name
     browser_ctx.pop('version', None)  # tag=browser
 
     device_ctx = contexts.get('device', {})
-    output['device'] = _unicodify(tags.pop('device', None))
+    output['device'] = _unicodify(tags.get('device', None))
     device_ctx.pop('model', None)  # tag=device
-    output['device_family'] = _unicodify(tags.pop('device.family', None))
+    output['device_family'] = _unicodify(tags.get('device.family', None))
     device_ctx.pop('family', None)  # tag=device.family
     output['device_name'] = _unicodify(device_ctx.pop('name', None))
     output['device_brand'] = _unicodify(device_ctx.pop('brand', None))
@@ -182,7 +182,7 @@ def extract_extra_contexts(output, contexts):
 def extract_extra_tags(output, tags):
     tag_keys = []
     tag_values = []
-    for tag_key, tag_value in tags.items():
+    for tag_key, tag_value in sorted(tags.items()):
         value = _unicodify(tag_value)
         if value:
             tag_keys.append(_unicodify(tag_key))

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -127,11 +127,8 @@ def tag_expr(column_name):
 
 def tags_expr(column_name, body):
     """
-    Return an expression enumerating all tags as rows
-
-    For special columns `tags_key` and `tags_value` we construct a an interesting
-    arrayjoin that enumerates all promoted and non-promoted keys. This is for
-    cases where we do not have a tag key to filter on (eg top tags).
+    Return an expression that array-joins on tags to produce an output with one
+    row per tag.
     """
     assert column_name in ['tags_key', 'tags_value']
     col, k_or_v = column_name.split('_', 1)

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -121,7 +121,7 @@ class TestProcessor(BaseTest):
         assert output == {'sdk_name': u'sentry-java', 'sdk_version': u'1.6.1-d1e3a'}
 
     def test_extract_tags(self):
-        tags = {
+        orig_tags = {
             'sentry:user': 'the_user',
             'level': 'the_level',
             'logger': 'the_logger',
@@ -135,6 +135,7 @@ class TestProcessor(BaseTest):
             'extra_tag': 'extra_value',
             'null_tag': None,
         }
+        tags = orig_tags.copy()
         output = {}
 
         processor.extract_promoted_tags(output, tags)
@@ -151,15 +152,16 @@ class TestProcessor(BaseTest):
             'url': u'the_url',
             'sentry:user': u'the_user',
         }
-        assert tags == {
-            'extra_tag': 'extra_value',
-            'null_tag': None,
-        }
+        assert tags == orig_tags
 
         extra_output = {}
         processor.extract_extra_tags(extra_output, tags)
 
-        assert extra_output == {'tags.key': [u'extra_tag'], 'tags.value': [u'extra_value']}
+        valid_items = [(k, v) for k, v in sorted(orig_tags.items()) if v]
+        assert extra_output == {
+            'tags.key': [k for k, v in valid_items],
+            'tags.value': [v for k, v in valid_items]
+        }
 
     def test_extract_tags_empty_string(self):
         # verify our text field extraction doesn't coerce '' to None
@@ -217,7 +219,7 @@ class TestProcessor(BaseTest):
                 'str': 'string',
             }
         }
-        tags = {
+        orig_tags = {
             'app.device': 'the_app_device_uuid',
             'os': 'the_os_name the_os_version',
             'os.name': 'the_os_name',
@@ -230,6 +232,7 @@ class TestProcessor(BaseTest):
             'device.family': 'the_device_family',
             'extra_tag': 'extra_value',
         }
+        tags = orig_tags.copy()
         output = {}
 
         processor.extract_promoted_contexts(output, contexts, tags)
@@ -275,7 +278,7 @@ class TestProcessor(BaseTest):
             'os': {},
             'runtime': {},
         }
-        assert tags == {'extra_tag': 'extra_value'}
+        assert tags == orig_tags
 
         extra_output = {}
         processor.extract_extra_contexts(extra_output, contexts)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,9 +26,7 @@ class TestUtil(BaseTest):
         # All tag keys expression
         with patch.object(util.settings, 'PROMOTED_COLS', {'tags': ['level', 'sentry:user']}):
             assert column_expr('tags_key', body.copy()) == (
-                '(((arrayJoin(arrayMap((x,y) -> [x,y], '
-                'arrayConcat([\'level\', \'sentry:user\'], tags.key), '
-                'arrayConcat([level, `sentry:user`], tags.value))) '
+                '(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) '
                 'AS all_tags))[1] AS `tags_key`)'
             )
 
@@ -37,9 +35,7 @@ class TestUtil(BaseTest):
         # uses the actual column name
         with patch.object(util.settings, 'PROMOTED_COLS', {'tags': ['browser_name']}):
             assert column_expr('tags_key', body.copy()) == (
-                '(((arrayJoin(arrayMap((x,y) -> [x,y], '
-                'arrayConcat([\'browser.name\'], tags.key), '
-                'arrayConcat([`browser_name`], tags.value))) '
+                '(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) '
                 'AS all_tags))[1] AS `tags_key`)'
             )
 
@@ -69,9 +65,7 @@ class TestUtil(BaseTest):
         body = {}
         with patch.object(util.settings, 'PROMOTED_COLS', {'tags': ['browser_name']}):
             assert column_expr('tags_key', body) == (
-                '(((arrayJoin(arrayMap((x,y) -> [x,y], '
-                'arrayConcat([\'browser.name\'], tags.key), '
-                'arrayConcat([`browser_name`], tags.value))) '
+                '(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) '
                 'AS all_tags))[1] AS `tags_key`)'
             )
 


### PR DESCRIPTION
Based on the observation that the tags_key expression to grab the union
of promoted and nested tags creates exceptionally slow queries, and
requires a bunch of other translation hacks etc. Instead we can just
leave the promoted tags in the nested tags column, and use only that
column when doing queries for all tags.

Note that queries for specific named tags eg. `tags[environment]` will
still use the promoted column to maintain optimal performance in the
case where we know which tag we are looking for.