### PR TITLE
Allow (but ignore) project_id in  in the schema.

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -48,20 +48,43 @@ QUERY_SCHEMA = {
         'issues': {
             'type': 'array',
             'items': {
-                'type': 'array',
-                'minItems': 2,
-                'maxItems': 2,
-                'items': [
-                    {'type': 'number'},
+                'anyOf': [
                     {
                         'type': 'array',
-                        'items': {
-                            'anyOf': [
-                                {'$ref': '#/definitions/fingerprint_hash'},
-                                {'$ref': '#/definitions/fingerprint_hash_with_tombstone'},
-                            ],
-                        },
-                        'minItems': 1,
+                        'minItems': 2,
+                        'maxItems': 2,
+                        'items': [
+                            {'type': 'number'},
+                            {
+                                'type': 'array',
+                                'items': {
+                                    'anyOf': [
+                                        {'$ref': '#/definitions/fingerprint_hash'},
+                                        {'$ref': '#/definitions/fingerprint_hash_with_tombstone'},
+                                    ],
+                                },
+                                'minItems': 1,
+                            },
+                        ],
+                    },
+                    {
+                        'type': 'array',
+                        'minItems': 3,
+                        'maxItems': 3,
+                        'items': [
+                            {'type': 'number'},
+                            {'type': 'number'},
+                            {
+                                'type': 'array',
+                                'items': {
+                                    'anyOf': [
+                                        {'$ref': '#/definitions/fingerprint_hash'},
+                                        {'$ref': '#/definitions/fingerprint_hash_with_tombstone'},
+                                    ],
+                                },
+                                'minItems': 1,
+                            },
+                        ],
                     },
                 ],
             },

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -315,6 +315,14 @@ def issue_expr(body, hash_column='primary_hash'):
     if max_issues is not None:
         issues = issues[:max_issues]
 
+    if len(issues) > 0 and len(issues[0]) == 3:
+        # HACK: Temporary hack to allow (but not require) Sentry to send
+        # (group_id, project_id, (tombstones, ...)) tuples. Once this is
+        # deployed, Sentry can be upgraded to always send the `project_id`
+        # and *then* Snuba can be upgraded to actually expect/respect that
+        # parameter.
+        issues = [(i[0], i[2]) for i in issues]
+
     for issue_id, issue_hashes in issues:
         if used_ids is None or issue_id in used_ids:
             if max_hashes_per_issue is not None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -177,3 +177,10 @@ class TestUtil(BaseTest):
         }
         assert 'ANY INNER JOIN' in issue_expr(body)
         assert '[Null]' in issue_expr(body)
+
+        # Middle tuple member is ignored -- as a placement for project_id
+        body = {
+            'issues': [(1, 9, ['a', 'b']), (2, 10, 'c')],
+            'conditions': [['issue', '=', 1]]
+        }
+        assert '[1,1]' in issue_expr(body)


### PR DESCRIPTION
Temporary hack to allow (but not require) Sentry to send
(group_id, project_id, (tombstones, ...)) tuples. Once this is
deployed, Sentry can be upgraded to always send the `project_id`
and *then* Snuba can be upgraded to actually expect/respect that
parameter.

---

Multi-step piece to handle SNS-117