### PR TITLE
Respect and prefer new canonical forms of interface keys.

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -316,16 +316,17 @@ def process_insert(message):
     contexts = data.get('contexts', {})
     extract_promoted_contexts(processed, contexts, tags)
 
-    user = data.get('sentry.interfaces.User', {})
+    user = data.get('user', data.get('sentry.interfaces.User', {}))
     extract_user(processed, user)
 
-    http = data.get('sentry.interfaces.Http', {})
+    http = data.get('http', data.get('sentry.interfaces.Http', {}))
     extract_http(processed, http)
 
     extract_extra_contexts(processed, contexts)
     extract_extra_tags(processed, tags)
 
-    stacks = data.get('sentry.interfaces.Exception', {}).get('values', [])
+    exception = data.get('exception', data.get('sentry.interfaces.Exception', {}))
+    stacks = exception.get('values', [])
     extract_stacktraces(processed, stacks)
 
     return processed


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry/pull/8789

This is the bare minimum we need so Snuba is forward-compatible with
events it may see going forward. There may be other coordination work or
schemas we share in the future, but this is here so we don't block
process on canonicalization.