### PR TITLE
fix: Revert clickhouse-driver to master for now

### DIFF
--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -10,7 +10,7 @@ blinker==1.4
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-git+https://github.com/alex-hofsteede/clickhouse-driver.git@total-progress#egg=clickhouse-driver==0.0.12
+clickhouse-driver==0.0.11
 colorama==0.3.9
 configparser==3.5.0
 confluent-kafka==0.11.4

--- a/requirements-py3.txt
+++ b/requirements-py3.txt
@@ -9,7 +9,7 @@ blinker==1.4
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-git+https://github.com/alex-hofsteede/clickhouse-driver.git@total-progress#egg=clickhouse-driver==0.0.12
+clickhouse-driver==0.0.11
 colorama==0.3.9
 configparser==3.5.0
 confluent-kafka==0.11.4

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -230,6 +230,7 @@ def raw_query(sql, client, query_id=None):
     fix some of the formatting issues in the result JSON
     """
     query_settings = {}
+    stats = {}
     try:
         query_settings_json = state.get_config('query_settings_json')
         if query_settings_json:
@@ -247,10 +248,11 @@ def raw_query(sql, client, query_id=None):
         )
         logger.debug(sql)
         data, meta = query.get_result()
-        stats = {
-            'rows_read': query.progress_totals.rows,
-            'bytes_read': query.progress_totals.bytes,
-        }
+        if hasattr(query, 'progress_totals'):
+            stats.update({
+                'rows_read': query.progress_totals.rows,
+                'bytes_read': query.progress_totals.bytes,
+            })
     except BaseException as ex:
         data, meta, error, stats = [], [], six.text_type(ex), {}
         logger.error("Error running query: %s\nClickhouse error: %s" % (sql, error))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -555,6 +555,7 @@ class TestApi(BaseTest):
         })).data)
         assert result['data'] == [{'count': 1, 'issue': 0}]
 
+    @pytest.mark.xfail
     def test_row_stats(self):
         query = {
             'project': 1,


### PR DESCRIPTION
There is some weird behavior around socket closing that I need to figure
out first. Snuba client code can basically remain the same for now, I
have xfailed the test that depends on getting total progress bytes