### PR TITLE
fix: Turn off query recording for non-prod environments

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -35,6 +35,7 @@ REDIS_PORT = 6379
 REDIS_DB = 1
 
 # Query Recording Options
+RECORD_QUERIES = False
 QUERIES_TOPIC = 'snuba-queries'
 
 # Sentry Options

--- a/snuba/state.py
+++ b/snuba/state.py
@@ -159,15 +159,16 @@ def record_query(data):
             .ltrim(queries_list, 0, max_redis_queries - 1)\
             .execute()
 
-        if kfk is None:
-            kfk = Producer({
-                'bootstrap.servers': ','.join(settings.DEFAULT_BROKERS)
-            })
+        if settings.RECORD_QUERIES:
+            if kfk is None:
+                kfk = Producer({
+                    'bootstrap.servers': ','.join(settings.DEFAULT_BROKERS)
+                })
 
-        kfk.produce(
-            settings.QUERIES_TOPIC,
-            data.encode('utf-8'),
-        )
+            kfk.produce(
+                settings.QUERIES_TOPIC,
+                data.encode('utf-8'),
+            )
     except Exception as ex:
         logger.error(ex)
         pass

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -309,7 +309,8 @@ def raw_query(body, sql, client, timer, stats=None):
         'stats': stats,
     })
 
-    timer.record(metrics)
+    if settings.RECORD_QUERIES:
+        timer.record(metrics)
     result['timing'] = timer
 
     if settings.STATS_IN_RESPONSE:


### PR DESCRIPTION
This only counts for services like dogstatsd and kafka reporting,
queries are still added to a local redis instance for the dashboard.

Should eliminate kafka noise in dev