### PR TITLE
Implement support for array indexing in column names

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -165,7 +165,7 @@ QUERY_SCHEMA = {
             'anyOf': [
                 # Special computed column created from `issues` definition
                 {'enum': ['issue', '-issue']},
-                {'pattern': '^-?[a-zA-Z0-9_.]+$', },
+                {'pattern': '^-?[a-zA-Z0-9_.]+(?:\[\d+\])?$', },
                 {'pattern': '^-?tags\[[a-zA-Z0-9_.:-]+\]$', },
             ],
         },

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -19,7 +19,8 @@ from snuba import schemas, settings, state
 logger = logging.getLogger('snuba.util')
 
 
-ESCAPE_RE = re.compile(r'^[a-zA-Z]*$')
+ESCAPE_RE = re.compile(r'^[a-zA-Z]*(?:\[\d+\])?$')
+INDEX_RE = re.compile(r'^.+\[\d+\]$')
 # example partition name: "('2018-03-13 00:00:00', 90)"
 PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2}) 00:00:00', (\d+)\)")
 
@@ -36,8 +37,10 @@ def to_list(value):
 def escape_col(col):
     if ESCAPE_RE.match(col):
         return col
-    else:
-        return '`{}`'.format(col)
+    if INDEX_RE.match(col):
+        idx = col.index('[')
+        return '`{}`{}'.format(col[:idx], col[idx:])
+    return '`{}`'.format(col)
 
 
 def string_col(col):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,6 +50,8 @@ class TestUtil(BaseTest):
 
         # Columns that need escaping
         assert column_expr('sentry:release', body.copy()) == '`sentry:release`'
+        assert column_expr('sentry:release[1]', body.copy()) == '`sentry:release`[1]'
+        assert column_expr('sentry:release[foo]', body.copy()) == '`sentry:release[foo]`'
 
     def test_alias_in_alias(self):
         body = {}
@@ -184,3 +186,9 @@ class TestUtil(BaseTest):
         }
         assert '[1,1,2]' in issue_expr(body)
         assert '[99,99,100]' in issue_expr(body)
+
+    def test_escape_col(self):
+        assert escape_col('foo') == 'foo'
+        assert escape_col('foo.bar') == '`foo.bar`'
+        assert escape_col('foo.bar[1]') == '`foo.bar`[1]'
+        assert escape_col('foo[1]') == 'foo[1]'


### PR DESCRIPTION
Fixes #115 

So this seems to mostly work. What I don't like about it is Clickhouse expands this into `arrayElement(xxx, 1)` for the response.

Which means we end up getting something like this back:

```json
{
    "data": [
        {
            "arrayElement(exception_stacks.type, 1)": "KeyboardInterrupt"
        },
        {
            "arrayElement(exception_stacks.type, 1)": "NameError"
        },
        {
            "arrayElement(exception_stacks.type, 1)": "NameError"
        },
        {
            "arrayElement(exception_stacks.type, 1)": "NameError"
        },
        {
            "arrayElement(exception_stacks.type, 1)": "NameError"
        }
    ],
    "meta": [
        {
            "name": "arrayElement(exception_stacks.type, 1)",
            "type": "Nullable(String)"
        }
    ],
    "timing": {
        "timestamp": 1531251008,
        "duration_ms": 19,
        "marks_ms": {
            "validate_schema": 3,
            "prepare_query": 2,
            "get_configs": 0,
            "rate_limit": 5,
            "dedupe_wait": 0,
            "cache_get": 0,
            "execute": 6
        }
    }
}
```

Which, imo, is probably more confusing. Since the input doesn't match the output. And we have no way of supplying an alias right now.

I think I'd just prefer being able to use `arrayElement(..., 1)` syntax instead of this.