### PR TITLE
Fix primary_hash PREWHERE experiment for new issue format.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -177,7 +177,11 @@ def query(validated_body=None, timer=None):
     prewhere_clause = ''
     prewhere_conditions = []
     # Experiment, if only a single issue with a single hash, add that as a condition in PREWHERE
-    if 'issues' in body and len(body['issues']) == 1 and len(body['issues'][0][2]) == 1:
+    if 'issues' in body \
+        and (len(body['issues']) == 1) \
+        and (len(body['issues'][0][2]) == 1) \
+        and (len(project_ids) == 1):
+
         hash_ = body['issues'][0][2][0]
         hash_ = hash_[0] if isinstance(hash_, (list, tuple)) else hash_  # strip out tombstone
         prewhere_conditions.append(['primary_hash', '=', hash_])


### PR DESCRIPTION
This fixes the PREWHERE "experiment" for the newer issue format `[(group, project, [...hashes...]), ...])`
