### PR TITLE
feat: Allow alignment of from_date, to_date

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -3,7 +3,6 @@ import os
 
 from copy import deepcopy
 from datetime import datetime, timedelta
-from dateutil.parser import parse as parse_datetime
 from flask import Flask, render_template, request
 from hashlib import md5
 from markdown import markdown
@@ -121,14 +120,18 @@ def query(validated_body=None, timer=None):
         template_str = json.dumps(query_template, sort_keys=True, indent=4)
         return render_template('query.html', query_template=template_str)
 
+    max_days, table, date_align = state.get_configs([
+        ('max_days', None),
+        ('clickhouse_table', settings.CLICKHOUSE_TABLE),
+        ('date_align_seconds', 1),
+    ])
     body = deepcopy(validated_body)
     stats = {}
     project_ids = util.to_list(body['project'])
-    to_date = parse_datetime(body['to_date'])
-    from_date = parse_datetime(body['from_date'])
+    to_date = util.parse_datetime(body['to_date'], date_align)
+    from_date = util.parse_datetime(body['from_date'], date_align)
     assert from_date <= to_date
 
-    max_days = state.get_config('max_days', None)
     if max_days is not None and (to_date - from_date).days > max_days:
         from_date = to_date - timedelta(days=max_days)
 
@@ -153,7 +156,6 @@ def query(validated_body=None, timer=None):
     select_exprs = group_exprs + aggregate_exprs + selected_cols
 
     select_clause = u'SELECT {}'.format(', '.join(select_exprs))
-    table = state.get_config('clickhouse_table', settings.CLICKHOUSE_TABLE)
     from_clause = u'FROM {}'.format(table)
 
     joins = []

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -1,6 +1,7 @@
 from flask import request
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
+from dateutil.parser import parse as dateutil_parse
 from dateutil.tz import tz
 from hashlib import md5
 from itertools import chain
@@ -45,6 +46,11 @@ def string_col(col):
         return escape_col(col)
     else:
         return 'toString({})'.format(escape_col(col))
+
+
+def parse_datetime(value, alignment):
+    dt = dateutil_parse(value)
+    return dt - timedelta(seconds=(dt - dt.min).seconds % alignment)
 
 
 def column_expr(column_name, body, alias=None, aggregate=None):


### PR DESCRIPTION
Experiment to improve cache hits for duplicate queries sent/received a
few seconds apart.

Eg the tagstore query to get releases for an issue is repeated 4-5 times
to render a single issue page, but usually there are 1-2 seconds between
requeests so the queries are not identical.