### PR TITLE
Add support for message protocol version 1

### DIFF
--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -37,7 +37,7 @@ class TestProcessor(BaseTest):
 
     def test_invalid_version(self):
         with pytest.raises(InvalidMessageVersion):
-            process_message((sys.maxint, 'insert', self.event))
+            process_message((2 ** 32 - 1, 'insert', self.event))
 
     def test_invalid_format(self):
         with pytest.raises(InvalidMessageVersion):


### PR DESCRIPTION
This will include an extra tuple member, `state`, that will be used for post-processing but ignored by the Snuba consumer/processor. 