### PR TITLE
fix: Parse Nullable(DateTime) columns

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -23,6 +23,8 @@ logger = logging.getLogger('snuba.util')
 ESCAPE_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_\.]*$')
 # example partition name: "('2018-03-13 00:00:00', 90)"
 PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2})', (\d+)\)")
+DATE_TYPE_RE = re.compile(r'(Nullable\()?Date\b')
+DATETIME_TYPE_RE = re.compile(r'(Nullable\()?DateTime\b')
 
 
 class InvalidConditionException(Exception):
@@ -399,10 +401,10 @@ def scrub_ch_data(data, meta):
     for col in meta:
         # Convert naive datetime strings back to TZ aware ones, and stringify
         # TODO maybe this should be in the json serializer
-        if col['type'].startswith('DateTime'):
+        if DATETIME_TYPE_RE.match(col['type']):
             for d in data:
                 d[col['name']] = d[col['name']].replace(tzinfo=tz.tzutc()).isoformat()
-        elif col['type'].startswith('Date'):
+        elif DATE_TYPE_RE.match(col['type']):
             for d in data:
                 dt = datetime(*(d[col['name']].timetuple()[:6])).replace(tzinfo=tz.tzutc())
                 d[col['name']] = dt.isoformat()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -521,6 +521,14 @@ class TestApi(BaseTest):
         assert len(result['data']) == 180
         assert result['data'][0] == {'message': 'a message', 'platform': 'a'}
 
+    def test_nullable_datetime_columns(self):
+        # Test that requesting a Nullable(DateTime) column does not throw
+        query = {
+            'project': 1,
+            'selected_columns': ['received'],
+        }
+        result = json.loads(self.app.post('/query', data=json.dumps(query)).data)
+
     def test_test_endpoints(self):
         project_id = 73
         event = {


### PR DESCRIPTION
This was causing a json.dumps error when serializing datetimes in the result.

An alternative is just to use a JSON serializer that serializes datetimes,
but for now I think we want to retain control over which result columns
we are doing this for, so we don't just blindly jsonify weird objects we're
not expecting to the clients.