### PR TITLE
fix: Prevent unlimited queries with a default and max limit

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -120,7 +120,9 @@ QUERY_SCHEMA = {
             '$ref': '#/definitions/column_name',
         },
         'limit': {
-            'type': 'number'
+            'type': 'number',
+            'default': 1000,
+            'maximum': 10000,
         },
         'offset': {
             'type': 'number',
@@ -138,7 +140,6 @@ QUERY_SCHEMA = {
     'required': ['project'],
     'dependencies': {
         'offset': ['limit'],
-        'limit': ['orderby'],
     },
 
     'definitions': {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -209,13 +209,13 @@ class TestApi(BaseTest):
         assert len(result['data']) == 1
         assert result['data'][0]['project_id'] == 2
 
-        # offset without limit is invalid
+        # limit over max-limit is invalid
         result = self.app.post('/query', data=json.dumps({
             'project': self.project_ids,
             'groupby': ['project_id'],
             'aggregations': [['count()', '', 'count']],
             'orderby': '-count',
-            'offset': 1,
+            'limit': 1000000,
         }))
         assert result.status_code == 400
 


### PR DESCRIPTION
And remove the dependency of limit on orderby