### PR TITLE
fix: Tighten up schema by not allowing extra keys

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -141,6 +141,7 @@ QUERY_SCHEMA = {
     'dependencies': {
         'offset': ['limit'],
     },
+    'additionalProperties': False,
 
     'definitions': {
         'fingerprint_hash': {


### PR DESCRIPTION
This should also help by making it clearer what the issue is if someone
misspells a key or something.