### PR TITLE
feat: Show query and stats in output

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -138,6 +138,9 @@ QUERY_SCHEMA = {
         'sample': {
             'type': 'number',
             'min': 0,
+        },
+        'debug': {
+            'type': 'boolean',
         }
     },
     # Need to select down to the project level for customer isolation and performance

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -385,8 +385,9 @@ def raw_query(body, sql, client, timer, stats=None):
         timer.record(metrics)
     result['timing'] = timer
 
-    if settings.STATS_IN_RESPONSE:
+    if settings.STATS_IN_RESPONSE or body.get('debug', False):
         result['stats'] = stats
+        result['sql'] = sql
 
     return (result, status)
 


### PR DESCRIPTION
If you pass a `"debug": true` flag to the query