### PR TITLE
feat: Allow strings in function calls

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -51,6 +51,12 @@ class TestUtil(BaseTest):
         # Columns that need escaping
         assert column_expr('sentry:release', body.copy()) == '`sentry:release`'
 
+        # A 'column' that is actually a string literal
+        assert column_expr('\'hello world\'', body.copy()) == '\'hello world\''
+
+        # Complex expressions (function calls) involving both string and column arguments
+        assert column_expr(tuplify(['concat', ['a', '\':\'', 'b']]), body.copy()) == 'concat(a, \':\', b)'
+
     def test_alias_in_alias(self):
         body = {}
         assert column_expr('tags_key', body) == (


### PR DESCRIPTION
This introduces a way to distinguish between column names and strings
when constructing an expression that involves both types. eg.
    `concat(column, 'string')`
or
    `ifNull(column, 'value if empty')`

Basically any argument string that starts and ends with a single-quote
character, is serialized as a string literal (with the single quotes), and
any other string is treated as a column name.

There are other places where values are always recognized and serialized
as string literals, by virtue of their position in the query. For
example the 3rd element in a condition tuple is serialized as a quoted
string literal into the expression, and does not need the quotes
provided.

I realize this is probably confusing and should probably be unified a
bit.