### PR TITLE
Add a --debug flag to bin/api

### DIFF
--- a/bin/api
+++ b/bin/api
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 
+import sys
+
 from snuba import settings
 from snuba.api import application
 from werkzeug.serving import WSGIRequestHandler
 
+debug = '--debug' in sys.argv
+
 WSGIRequestHandler.protocol_version = "HTTP/1.1"
-application.run(port=settings.PORT, threaded=True)
+application.run(port=settings.PORT, threaded=True, debug=debug)


### PR DESCRIPTION
Locally, I think the normal behavior, if you're not actively developing
on Snuba, is to just run the api server, and skip the overhead of
filewatching and debugging.

So this makes debug an opt-in through `bin/api --debug`

I'm also open to changing this into an explicit opt-out instead. And do `bin/api --no-debug` or something.