### PR TITLE
Docker: use CPython for everything except the consumer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-ARG PYTHON_VERSION=2
-FROM pypy:${PYTHON_VERSION}-slim
-
-# pypy:2-slim binary: /usr/local/bin/pypy
-# pypy:3-slim binary: /usr/local/bin/pypy3
-ARG PYPY_SUFFIX
-RUN ln -s /usr/local/bin/pypy${PYPY_SUFFIX} /usr/local/bin/python
+FROM python:2-slim
 
 RUN groupadd -r snuba && useradd -r -g snuba snuba
 
@@ -18,9 +12,9 @@ ENV PIP_NO_CACHE_DIR=off \
 RUN set -ex; \
     apt-get update; \
     apt-get install --no-install-recommends -y \
-        gcc \
+        libexpat1 \
+        libffi6 \
         libpcre3 \
-        libpcre3-dev \
         liblz4-1 \
     ; \
     rm -rf /var/lib/apt/lists/*
@@ -28,25 +22,37 @@ RUN set -ex; \
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
 RUN set -ex; \
-    apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/*; \
+    \
+    buildDeps=' \
+        dirmngr \
+        gnupg \
+        wget \
+    '; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends $buildDeps; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
     wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)"; \
     wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc"; \
     export GNUPGHOME="$(mktemp -d)"; \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
     gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
-    rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
     chmod +x /usr/local/bin/gosu; \
     gosu nobody true; \
-    apt-get purge -y --auto-remove wget
+    \
+    apt-get purge -y --auto-remove $buildDeps
 
 RUN set -ex; \
     LIBRDKAFKA_VERSION=0.11.5; \
     \
     buildDeps=' \
-        wget \
         make \
+        gcc \
         g++ \
+        libc6-dev \
         liblz4-dev \
+        wget \
     '; \
     apt-get update; \
     apt-get install -y $buildDeps --no-install-recommends; \
@@ -66,17 +72,55 @@ RUN set -ex; \
 # This is required in addition to the PYTHON_VERSION ARG at the top, because
 # apparently the one before FROM is not in scope here.
 ARG PYTHON_VERSION=2
-COPY requirements-py${PYTHON_VERSION}.txt ./
+COPY requirements-py2.txt ./
+
+# Install PyPy at /pypy, for running the consumer code. Note that PyPy is built
+# against libssl1.0.0, so this is required for using the SSL module, which is
+# required to bootstrap pip. Since this is a short term stopgap it seemed better
+# than building PyPy ourselves.
 RUN set -ex; \
     \
     buildDeps=' \
+        bzip2 \
+        gcc \
+        libc6-dev \
         liblz4-dev \
+        libpcre3-dev \
+        wget \
     '; \
     apt-get update; \
     apt-get install -y $buildDeps --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*; \
     \
-    pip install -r requirements-py${PYTHON_VERSION}.txt; \
+    wget https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2; \
+    [ "$(sha256sum pypy2-v6.0.0-linux64.tar.bz2)" = '6cbf942ba7c90f504d8d6a2e45d4244e3bf146c8722d64e9410b85eac6b5af67  pypy2-v6.0.0-linux64.tar.bz2' ]; \
+    tar xf pypy2-v6.0.0-linux64.tar.bz2; \
+    rm -rf pypy2-v6.0.0-linux64.tar.bz2; \
+    mv pypy2-v6.0.0-linux64 /pypy; \
+    wget http://security.debian.org/debian-security/pool/updates/main/o/openssl/libssl1.0.0_1.0.1t-1+deb7u4_amd64.deb; \
+    DEBIAN_FRONTEND=noninteractive dpkg -i libssl1.0.0_1.0.1t-1+deb7u4_amd64.deb; \
+    rm -rf libssl1.0.0_1.0.1t-1+deb7u4_amd64.deb; \
+    wget https://bootstrap.pypa.io/get-pip.py; \
+    /pypy/bin/pypy get-pip.py; \
+    rm -rf get-pip.py; \
+    \
+    /pypy/bin/pip install -r requirements-py2.txt; \
+    \
+    apt-get purge -y --auto-remove $buildDeps
+
+RUN set -ex; \
+    \
+    buildDeps=' \
+        gcc \
+        libc6-dev \
+        liblz4-dev \
+        libpcre3-dev \
+    '; \
+    apt-get update; \
+    apt-get install -y $buildDeps --no-install-recommends; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    pip install -r requirements-py2.txt; \
     \
     apt-get purge -y --auto-remove $buildDeps
 
@@ -85,12 +129,12 @@ COPY setup.py README.md ./
 
 RUN chown -R snuba:snuba /usr/src/snuba/
 
+RUN /pypy/bin/pip install -e . && /pypy/bin/snuba --help
 RUN pip install -e . && snuba --help
 
 ENV CLICKHOUSE_SERVER clickhouse-server:9000
 ENV CLICKHOUSE_TABLE sentry
 ENV FLASK_DEBUG 0
-
 
 EXPOSE 1218
 


### PR DESCRIPTION
Using the standard 2.7 container as the base, and dropping PyPy 2.7 into `/pypy` just for running the consumer.

I started with CPyhon 3.7, but the latest PyPy release is 3.5.0, which can't compile the kafka consumer apparently, and also it feels like giving people the idea they can use 3.7 features right now in a shared codebase is the wrong thing to do. I'm going to see about speeding up the client so we can just use CPython 3.7 across the board, but this fixes a number of API issues right now.