### PR TITLE
Only query ClickHouse in health check when doing a thorough check.

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -1,7 +1,7 @@
 deploy:
   services:
     - name: snuba-api
-      healthcheck: sleep 3 && curl -fsI 127.0.0.1:11218/health
+      healthcheck: sleep 3 && curl -fsI '127.0.0.1:11218/health?thorough=true'
       chef_roles:
         - snuba-api
     - name: snuba-consumer


### PR DESCRIPTION
Word on the streets (jtcunning) is we only care about whether the API is
responding to requests at all for load balancer health purposes.