### PR TITLE
Revert "Add temporary group_id hack to Sentry test inserts."

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -331,9 +331,6 @@ if application.debug or application.testing:
 
         rows = []
         for event in body:
-            # Temporary hack until we get `group_id` into all Sentry tests
-            event.setdefault('group_id', 0)
-
             _, processed = process_message(event)
             row = row_from_processed_event(processed)
             rows.append(row)


### PR DESCRIPTION
This reverts commit df09874de7fe9600665aab9a17c73a441f2643e2.

Blocked on https://github.com/getsentry/sentry/pull/9981