### PR TITLE
Remove snuba-consumer-monthly from freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -7,8 +7,4 @@ deploy:
     - name: snuba-consumer
       percent: 1.0
       chef_roles:
-       - snuba-consumer
-    - name: snuba-consumer-monthly
-      percent: 1.0
-      chef_roles:
-       - snuba-consumer
+        - snuba-consumer


### PR DESCRIPTION
I'm not 100% sure this is correct, but I noticed this in freight and I think this can be removed? Low priority though.

```
[snuba-consumer-63a9c5c7.i.getsentry.net] run: dockerctl stop snuba-consumer-monthly
[snuba-consumer-ac7ffdae.i.getsentry.net] out: warning: snuba-consumer-monthly not found.
```