### PR TITLE
Add metrics for number of inserts/alters.

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -55,7 +55,7 @@ def consumer(raw_events_topic, consumer_group, bootstrap_server, clickhouse_serv
 
     consumer = BatchingKafkaConsumer(
         raw_events_topic,
-        worker=ConsumerWorker(clickhouse, distributed_table_name, local_table_name),
+        worker=ConsumerWorker(clickhouse, distributed_table_name, local_table_name, metrics=metrics),
         max_batch_size=max_batch_size,
         max_batch_time=max_batch_time_ms,
         metrics=metrics,


### PR DESCRIPTION
@JTCunning realized we probably need visibility on the number of ALTER statements we run. Also note that `inserts` is the number of rows and not the number of `INSERT` statements (since we batch).

Can you think of any other metrics we need for this `group_id` stuff? :thinking: 