### PR TITLE
Use templated logging for query execution error logging

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -392,7 +392,7 @@ def raw_query(body, sql, client, timer, stats=None):
                         except BaseException as ex:
                             error = six.text_type(ex)
                             status = 500
-                            logger.error("Error running query: %s\n%s" % (sql, error))
+                            logger.error("Error running query: %s\n%s", sql, error)
                             result = {'error': error}
 
                     else:


### PR DESCRIPTION
Ideally we'd do something smarter with the stack trace or error message but I just want the emails to stop