### PR TITLE
Allow raw group_ids to be passed in for issues.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import six
 
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -193,14 +194,31 @@ def parse_and_run_query(validated_body, timer):
         from_clause = u'{} SAMPLE {}'.format(from_clause, sample)
 
     joins = []
-    issue_expr = util.issue_expr(body)
-    if issue_expr:
-        joins.append(issue_expr)
-        where_conditions.append(
-            ('timestamp', '>', util.Literal(
-                'ifNull(hash_timestamp, CAST(\'1970-01-01 00:00:00\', \'DateTime\'))')
+    prewhere_clause = ''
+    prewhere_conditions = []
+
+    issues = body.get('issues', [])
+    use_group_id_column = body.get('use_group_id_column')
+    if not use_group_id_column:
+        issue_expr = util.issue_expr(body)
+        if issue_expr:
+            joins.append(issue_expr)
+            where_conditions.append(
+                ('timestamp', '>', util.Literal(
+                    'ifNull(hash_timestamp, CAST(\'1970-01-01 00:00:00\', \'DateTime\'))')
+                )
             )
-        )
+
+        # Experiment, if only a single issue with a single hash, add that as a condition in PREWHERE
+        if issues \
+                and (len(issues) == 1) \
+                and (len(issues[0][2]) == 1) \
+                and (len(project_ids) == 1):
+
+            hash_ = issues[0][2][0]
+            hash_ = hash_[0] if isinstance(hash_, (list, tuple)) else hash_  # strip out tombstone
+            prewhere_conditions.append(['primary_hash', '=', hash_])
+
     if 'arrayjoin' in body:
         joins.append(u'ARRAY JOIN {}'.format(body['arrayjoin']))
     join_clause = ' '.join(joins)
@@ -209,18 +227,6 @@ def parse_and_run_query(validated_body, timer):
     if where_conditions:
         where_conditions = list(set(util.tuplify(where_conditions)))
         where_clause = u'WHERE {}'.format(util.condition_expr(where_conditions, body))
-
-    prewhere_clause = ''
-    prewhere_conditions = []
-    # Experiment, if only a single issue with a single hash, add that as a condition in PREWHERE
-    if 'issues' in body \
-            and (len(body['issues']) == 1) \
-            and (len(body['issues'][0][2]) == 1) \
-            and (len(project_ids) == 1):
-
-        hash_ = body['issues'][0][2][0]
-        hash_ = hash_[0] if isinstance(hash_, (list, tuple)) else hash_  # strip out tombstone
-        prewhere_conditions.append(['primary_hash', '=', hash_])
 
     if not prewhere_conditions and settings.PREWHERE_KEYS:
         prewhere_conditions.extend([c for c in where_conditions if c and c[0] in settings.PREWHERE_KEYS])
@@ -277,8 +283,8 @@ def parse_and_run_query(validated_body, timer):
         'referrer': request.referrer,
         'num_days': (to_date - from_date).days,
         'num_projects': len(project_ids),
-        'num_issues': len(body.get('issues', [])),
-        'num_hashes': sum(len(i[-1]) for i in body.get('issues', [])),
+        'num_issues': len(issues),
+        'num_hashes': sum(len(i[-1]) for i in issues) if not use_group_id_column else 0,
         'sample': sample,
     })
 

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -18,7 +18,7 @@ SDK_STATS_SCHEMA = {
         },
         'granularity': {
             'type': 'number',
-            'default': 86400, # SDK stats query defaults to 1-day bucketing
+            'default': 86400,  # SDK stats query defaults to 1-day bucketing
         },
         'groupby': {
             'type': 'array',
@@ -73,6 +73,10 @@ QUERY_SCHEMA = {
         'granularity': {
             'type': 'number',
             'default': 3600,
+        },
+        'use_group_id_column': {
+            'type': 'boolean',
+            'default': False
         },
         'issues': {
             'type': 'array',

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -13,7 +13,7 @@ import numbers
 import re
 import simplejson as json
 import six
-import _strptime # fixes _strptime deferred import issue
+import _strptime  # fixes _strptime deferred import issue
 import time
 
 from snuba import schemas, settings, state
@@ -88,6 +88,8 @@ def column_expr(column_name, body, alias=None, aggregate=None):
         expr = tag_expr(column_name)
     elif column_name in ['tags_key', 'tags_value']:
         expr = tags_expr(column_name, body)
+    elif body.get('use_group_id_column') and column_name == 'issue':
+        expr = 'group_id'
     else:
         expr = escape_col(column_name)
 
@@ -307,7 +309,7 @@ def raw_query(body, sql, client, timer, stats=None):
     fix some of the formatting issues in the result JSON
     """
     project_ids = to_list(body['project'])
-    project_id = project_ids[0] if project_ids else 0 # TODO rate limit on every project in the list?
+    project_id = project_ids[0] if project_ids else 0  # TODO rate limit on every project in the list?
     stats = stats or {}
     grl, gcl, prl, pcl, use_cache = state.get_configs([
         ('global_per_second_limit', 1000),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,11 +6,9 @@ from dateutil.tz import tz
 from functools import partial
 import pytest
 import pytz
-import sentry_sdk
 from sentry_sdk import Hub, Client
 import simplejson as json
 import six
-import sys
 import time
 import uuid
 
@@ -19,11 +17,15 @@ from snuba import processor, settings, state
 from base import BaseTest
 
 
+def hash_to_group_id(hash):
+    return int(hash[:16], 16)
+
+
 class TestApi(BaseTest):
     def setup_method(self, test_method):
         super(TestApi, self).setup_method(test_method)
         from snuba.api import application
-        assert application.testing == True
+        assert application.testing is True
         application.config['PROPAGATE_EXCEPTIONS'] = False
 
         self.app = application.test_client()
@@ -68,7 +70,7 @@ class TestApi(BaseTest):
                         'message': 'a message',
                         'platform': self.platforms[(tock * p) % len(self.platforms)],
                         'primary_hash': self.hashes[(tock * p) % len(self.hashes)],
-                        'group_id': int(self.hashes[(tock * p) % len(self.hashes)][:16], 16),
+                        'group_id': hash_to_group_id(self.hashes[(tock * p) % len(self.hashes)]),
                         'retention_days': settings.DEFAULT_RETENTION_DAYS,
                         'data': {
                             # Project N sends every Nth (mod len(hashes)) hash (and platform)
@@ -177,6 +179,21 @@ class TestApi(BaseTest):
             issues_expected = set(range(0, len(self.hashes), p))
             assert issues_found - issues_expected == set()
 
+        # test with use_group_id_column == True
+        for p in self.project_ids:
+            issues = [hash_to_group_id(h) for h in self.hashes]
+            result = json.loads(self.app.post('/query', data=json.dumps({
+                'project': p,
+                'granularity': 3600,
+                'issues': [],
+                'conditions': [['issue', 'IN', issues]],
+                'groupby': 'issue',
+                'use_group_id_column': True,
+            })).data)
+            issues_found = set([d['issue'] for d in result['data']])
+            issues_expected = set(issues)
+            assert issues_found - issues_expected == set()
+
     def test_no_issues(self):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': 1,
@@ -248,7 +265,6 @@ class TestApi(BaseTest):
         # LIMIT BY
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': self.project_ids,
-            'groupby': ['project_id'],
             'aggregations': [['count()', '', 'count']],
             'orderby': '-count',
             'groupby': 'environment',
@@ -647,14 +663,13 @@ class TestApi(BaseTest):
         test_timestamps = [d['time'] for d in result['data'][:90]]
         assert sorted(test_timestamps) == test_timestamps
 
-
     def test_nullable_datetime_columns(self):
         # Test that requesting a Nullable(DateTime) column does not throw
         query = {
             'project': 1,
             'selected_columns': ['received'],
         }
-        result = json.loads(self.app.post('/query', data=json.dumps(query)).data)
+        json.loads(self.app.post('/query', data=json.dumps(query)).data)
 
     def test_test_endpoints(self):
         project_id = 73
@@ -813,7 +828,7 @@ class TestApi(BaseTest):
                 'orderby': '-count',
             })).data)
             assert result['data'] == [{'count': 90}]
-            assert result['stats']['cache_hit'] == False
+            assert result['stats']['cache_hit'] is False
             query_1_id = result['stats']['query_id']
 
             # Then get the results for another tag, which we should be able
@@ -831,7 +846,7 @@ class TestApi(BaseTest):
                 'orderby': '-count',
             })).data)
             assert result['data'] == [{'count': 90}]
-            assert result['stats']['cache_hit'] == True
+            assert result['stats']['cache_hit'] is True
             result['stats']['query_id'] == query_1_id
 
             # Example 2: uniqes
@@ -850,7 +865,7 @@ class TestApi(BaseTest):
                 'limit': 200,
             })).data)
             assert result['data'] == [{'unique_values': 90}]
-            assert result['stats']['cache_hit'] == False
+            assert result['stats']['cache_hit'] is False
             query_1_id = result['stats']['query_id']
 
             # Then get the results for another tag, which we should be able
@@ -873,7 +888,7 @@ class TestApi(BaseTest):
                 'name': 'unique_values',
                 'type': 'UInt64'
             }]
-            assert result['stats']['cache_hit'] == True
+            assert result['stats']['cache_hit'] is True
             result['stats']['query_id'] == query_1_id
 
         finally:
@@ -893,7 +908,6 @@ class TestApi(BaseTest):
 
             result = json.loads(self.app.post('/query', data=json.dumps({
                 'project': 3,
-                'groupby': [],
                 'from_date': self.base_time.isoformat(),
                 'to_date': (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
                 'aggregations': [
@@ -911,12 +925,11 @@ class TestApi(BaseTest):
             assert len(result['data']) == 30
             assert sorted([int(d['tags[sentry:release]']) for d in result['data']]) == list(range(2, self.minutes, 6))
             assert set([c['name'] for c in result['meta']]) == set(['times_seen', 'first_seen', 'tags[sentry:release]'])
-            assert result['stats']['cache_hit'] == False
-            query_1_id = result['stats']['query_id']
+            assert result['stats']['cache_hit'] is False
+            result['stats']['query_id']
 
             result = json.loads(self.app.post('/query', data=json.dumps({
                 'project': 3,
-                'groupby': [],
                 'from_date': self.base_time.isoformat(),
                 'to_date': (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
                 'aggregations': [
@@ -937,7 +950,7 @@ class TestApi(BaseTest):
                 'first_seen': (self.base_time + timedelta(minutes=2)).replace(tzinfo=tz.tzutc()).isoformat(),
             }]
             assert set([c['name'] for c in result['meta']]) == set(['times_seen', 'first_seen', 'tags[os.name]'])
-            assert result['stats']['cache_hit'] == True
+            assert result['stats']['cache_hit'] is True
 
         finally:
             state.delete_config('use_query_id')


### PR DESCRIPTION
The decision on whether to use "old style" `GroupHash` for issues or raw `group_id` is left up to Sentry. Snuba detects which has been passed and does the right thing.

Frankly, I thought I'd have to do more, but I haven't found a query that failed me yet...

Related: https://github.com/getsentry/sentry/pull/10269