### PR TITLE
Fix KafkaError exception raise.

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -4,7 +4,7 @@ import simplejson as json
 import six
 import time
 
-from confluent_kafka import Consumer, KafkaError, KafkaException, Producer
+from confluent_kafka import Consumer, KafkaError, KafkaException
 
 from . import processor, settings
 from .writer import row_from_processed_event, write_rows
@@ -234,8 +234,7 @@ class BatchingKafkaConsumer(object):
 
     def _commit_message_delivery_callback(self, error, message):
         if error is not None:
-            # errors are KafkaError objects and inherit from BaseException
-            raise error
+            raise Exception(error.str())
 
     def _commit(self):
         retries = 3


### PR DESCRIPTION
It turns out that KafkaError doesn't subclass BaseException. Although
the code read that way to me: https://github.com/confluentinc/confluent-kafka-python/blob/79e4579d0b8e80dca0861257cbf61839c9e234f6/confluent_kafka/src/confluent_kafka.c#L40-L59

You can't instantiate the class as a user so it was annoying to verify,
but I managed to reproduce an error locally to try this out.

Fixes SNUBA-18K