### PR TITLE
feat: force_final flag

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -86,8 +86,9 @@ class TestState(BaseTest):
         assert state.get_configs([
             ('foo', 100),
             ('bar', 200),
-            ('noexist', 300)
-        ]) == [1, 2, 300]
+            ('noexist', 300),
+            ('noexist-2', None)
+        ]) == [1, 2, 300, None]
 
         state.set_configs({'bar': 'quux'})
         all_configs = state.get_all_configs()


### PR DESCRIPTION
If set to 1: All queries use FINAL
If set to 0: No queries use FINAL (even if they have recent replacements)
If unset: Queries use of FINAL depends on their projects' replacements.