### PR TITLE
Change `delete_groups` and `merge` to exclude `group_id`s from query

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -196,13 +196,13 @@ def parse_and_run_query(validated_body, timer):
 
     from_clause = u'FROM {}'.format(table)
 
-    enforce_final, exclude_group_ids = get_projects_query_flags(project_ids)
+    needs_final, exclude_group_ids = get_projects_query_flags(project_ids)
     if len(exclude_group_ids) > settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE:
         # Cap the number of groups to exclude by query and flip to using FINAL if necessary
-        enforce_final = True
+        needs_final = True
         exclude_group_ids = []
 
-    if force_final == 1 or (force_final is None and enforce_final):
+    if force_final == 1 or (force_final is None and needs_final):
         from_clause = u'{} FINAL'.format(from_clause)
     elif exclude_group_ids:
         where_conditions.append(('group_id', 'NOT IN', exclude_group_ids))

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -39,7 +39,7 @@ def set_project_exclude_groups(project_id, group_ids):
 
     p.zadd(key, **{str(group_id): now for group_id in group_ids})
     p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
-    p.expire(key, int(now + settings.REPLACER_KEY_TTL))
+    p.expire(key, int(settings.REPLACER_KEY_TTL))
 
     p.execute()
 

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -78,7 +78,7 @@ def get_projects_query_flags(project_ids):
     results = p.execute()
 
     enforce_final = any(results[0])
-    exclude_groups = {int(group_id) for group_id in sum(results[1:len(project_ids) + 1], [])}
+    exclude_groups = sorted({int(group_id) for group_id in sum(results[1:len(project_ids) + 1], [])})
 
     return (enforce_final, exclude_groups)
 

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -20,20 +20,67 @@ CLICKHOUSE_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 REQUIRED_COLUMNS = list(map(escape_col, settings.REQUIRED_COLUMNS))
 ALL_COLUMNS = list(map(escape_col, settings.WRITER_COLUMNS))
 
+EXCLUDE_GROUPS = object()
+ENFORCE_FINAL = object()
 
-def get_project_replacements_key(project_id):
-    return "project_replacements:%s" % project_id
+
+def get_project_exclude_groups_key(project_id):
+    return "project_exclude_groups:%s" % project_id
 
 
-def set_project_replacements_key(project_id):
+def set_project_exclude_groups(project_id, group_ids):
+    """Add {group_id: now, ...} to the ZSET for each `group_id` to exclude,
+    remove outdated entries based on `settings.REPLACER_KEY_TTL`, and expire
+    the entire ZSET incase it's rarely touched."""
+
+    now = time.time()
+    key = get_project_exclude_groups_key(project_id)
+    p = redis_client.pipeline()
+
+    p.zadd(key, **{str(group_id): now for group_id in group_ids})
+    p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
+    p.expire(key, int(now + settings.REPLACER_KEY_TTL))
+
+    p.execute()
+
+
+def get_project_enforce_final_key(project_id):
+    return "project_enforce_final:%s" % project_id
+
+
+def set_project_enforce_final(project_id):
     return redis_client.set(
-        get_project_replacements_key(project_id), True, ex=settings.REPLACER_KEY_TTL
+        get_project_enforce_final_key(project_id), True, ex=settings.REPLACER_KEY_TTL
     )
 
 
-def get_projects_with_replacements(project_ids):
-    keys = {get_project_replacements_key(project_id) for project_id in project_ids}
-    return any(redis_client.mget(keys))
+def get_projects_query_flags(project_ids):
+    """\
+    1. Fetch `enforce_final` for each Project
+    2. Fetch groups to exclude for each Project
+    3. Trim groups to exclude ZSET for each Project
+
+    Returns (enforce_final, group_ids_to_exclude)
+    """
+
+    now = time.time()
+    p = redis_client.pipeline()
+
+    p.mget({get_project_enforce_final_key(project_id) for project_id in project_ids})
+
+    exclude_groups_keys = {get_project_exclude_groups_key(project_id) for project_id in project_ids}
+    for exclude_groups_key in exclude_groups_keys:
+        p.zrevrangebyscore(exclude_groups_key, float('inf'), now - settings.REPLACER_KEY_TTL)
+
+    for exclude_groups_key in exclude_groups_keys:
+        p.zremrangebyscore(exclude_groups_key, float('-inf'), now - settings.REPLACER_KEY_TTL)
+
+    results = p.execute()
+
+    enforce_final = any(results[0])
+    exclude_groups = {int(group_id) for group_id in sum(results[1:len(project_ids) + 1], [])}
+
+    return (enforce_final, exclude_groups)
 
 
 class ReplacerWorker(AbstractBatchWorker):
@@ -65,18 +112,24 @@ class ReplacerWorker(AbstractBatchWorker):
         return processed
 
     def flush_batch(self, batch):
-        for count_query_template, insert_query_template, args in batch:
-            args.update({'dist_table_name': self.dist_table_name})
-            count = self.clickhouse.execute_robust(count_query_template % args)[0][0]
+        for count_query_template, insert_query_template, query_args, query_time_flags in batch:
+            query_args.update({'dist_table_name': self.dist_table_name})
+            count = self.clickhouse.execute_robust(count_query_template % query_args)[0][0]
 
             if count == 0:
                 continue
 
-            set_project_replacements_key(args['project_id'])
+            # query_time_flags == (type, project_id, [...data...])
+            flag_type, project_id = query_time_flags[:2]
+            if flag_type == ENFORCE_FINAL:
+                set_project_enforce_final(project_id)
+            elif flag_type == EXCLUDE_GROUPS:
+                group_ids = query_time_flags[2]
+                set_project_exclude_groups(project_id, group_ids)
 
             t = time.time()
-            logger.debug("Executing replace query: %s" % (insert_query_template % args))
-            self.clickhouse.execute_robust(insert_query_template % args)
+            logger.debug("Executing replace query: %s" % (insert_query_template % query_args))
+            self.clickhouse.execute_robust(insert_query_template % query_args)
             duration = int((time.time() - t) * 1000)
             logger.info("Replacing %s rows took %sms" % (count, duration))
             if self.metrics:
@@ -122,7 +175,9 @@ def process_delete_groups(message):
         'timestamp': timestamp.strftime(CLICKHOUSE_DATETIME_FORMAT),
     }
 
-    return (count_query_template, insert_query_template, query_args)
+    query_time_flags = (EXCLUDE_GROUPS, message['project_id'], group_ids)
+
+    return (count_query_template, insert_query_template, query_args, query_time_flags)
 
 
 SEEN_MERGE_TXN_CACHE = deque(maxlen=100)
@@ -172,7 +227,9 @@ def process_merge(message):
         'timestamp': timestamp.strftime(CLICKHOUSE_DATETIME_FORMAT),
     }
 
-    return (count_query_template, insert_query_template, query_args)
+    query_time_flags = (EXCLUDE_GROUPS, message['project_id'], previous_group_ids)
+
+    return (count_query_template, insert_query_template, query_args, query_time_flags)
 
 
 def process_unmerge(message):
@@ -212,4 +269,6 @@ def process_unmerge(message):
         'timestamp': timestamp.strftime(CLICKHOUSE_DATETIME_FORMAT),
     }
 
-    return (count_query_template, insert_query_template, query_args)
+    query_time_flags = (ENFORCE_FINAL, message['project_id'])
+
+    return (count_query_template, insert_query_template, query_args, query_time_flags)

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -327,6 +327,6 @@ REPLACER_MAX_MEMORY_USAGE = 10 * (1024**3)  # 10GB
 # run recently. Useful for decidig whether or not to add FINAL clause
 # to queries.
 REPLACER_KEY_TTL = 12 * 60 * 60
-REPLACER_MAX_GROUP_IDS_TO_EXCLUDE = 100
+REPLACER_MAX_GROUP_IDS_TO_EXCLUDE = 256
 
 TURBO_SAMPLE_RATE = 0.1

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -327,5 +327,6 @@ REPLACER_MAX_MEMORY_USAGE = 10 * (1024**3)  # 10GB
 # run recently. Useful for decidig whether or not to add FINAL clause
 # to queries.
 REPLACER_KEY_TTL = 12 * 60 * 60
+REPLACER_MAX_GROUP_IDS_TO_EXCLUDE = 100
 
 TURBO_SAMPLE_RATE = 0.1

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -1,6 +1,7 @@
 import pytz
 import re
 from datetime import datetime
+from functools import partial
 import simplejson as json
 
 from base import BaseTest, FakeKafkaMessage
@@ -13,15 +14,43 @@ from snuba.settings import PAYLOAD_DATETIME_FORMAT
 class TestReplacer(BaseTest):
     def setup_method(self, test_method):
         super(TestReplacer, self).setup_method(test_method)
+
+        from snuba.api import application
+        assert application.testing is True
+
+        self.app = application.test_client()
+        self.app.post = partial(self.app.post, headers={'referer': 'test'})
         self.replacer = replacer.ReplacerWorker(self.clickhouse, self.table)
+
+        self.project_id = 1
+        self._clear_replacer_keys([self.project_id])
 
     def _wrap(self, msg):
         return FakeKafkaMessage('topic', 0, 0, json.dumps(msg).encode('utf-8'))
 
+    def _clear_replacer_keys(self, project_ids):
+        redis_client.delete(
+            *([replacer.get_project_enforce_final_key(project_id) for project_id in project_ids]
+            + [replacer.get_project_exclude_groups_key(project_id) for project_id in project_ids])
+        )
+
+    def _issue_count(self, project_id, group_id=None):
+        args = {
+            'project': [project_id],
+            'aggregations': [['count()', '', 'count']],
+            'groupby': ['issue'],
+            'use_group_id_column': True,
+        }
+
+        if group_id:
+            args.setdefault('conditions', []).append(('group_id', '=', group_id))
+
+        return json.loads(self.app.post('/query', data=json.dumps(args)).data)['data']
+
     def test_delete_groups_process(self):
         timestamp = datetime.now(tz=pytz.utc)
         message = (2, 'end_delete_groups', {
-            'project_id': 1,
+            'project_id': self.project_id,
             'group_ids': [1, 2, 3],
             'datetime': timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
         })
@@ -34,17 +63,17 @@ class TestReplacer(BaseTest):
             "INSERT INTO %(dist_table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(dist_table_name)s FINAL WHERE project_id = %(project_id)s AND group_id IN (%(group_ids)s) AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
         assert query_args == {
             'group_ids': '1, 2, 3',
-            'project_id': 1,
+            'project_id': self.project_id,
             'required_columns': 'event_id, project_id, group_id, timestamp, deleted, retention_days',
             'select_columns': 'event_id, project_id, group_id, timestamp, 1, retention_days',
             'timestamp': timestamp.strftime(replacer.CLICKHOUSE_DATETIME_FORMAT),
         }
-        assert query_time_flags == (replacer.EXCLUDE_GROUPS, 1, [1, 2, 3])
+        assert query_time_flags == (replacer.EXCLUDE_GROUPS, self.project_id, [1, 2, 3])
 
     def test_merge_process(self):
         timestamp = datetime.now(tz=pytz.utc)
         message = (2, 'end_merge', {
-            'project_id': 1,
+            'project_id': self.project_id,
             'new_group_id': 2,
             'previous_group_ids': [1, 2],
             'datetime': timestamp.strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
@@ -60,15 +89,15 @@ class TestReplacer(BaseTest):
             'all_columns': 'event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level',
             'select_columns': 'event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, received, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level',
             'previous_group_ids': ", ".join(str(gid) for gid in [1, 2]),
-            'project_id': 1,
+            'project_id': self.project_id,
             'timestamp': timestamp.strftime(replacer.CLICKHOUSE_DATETIME_FORMAT),
         }
-        assert query_time_flags == (replacer.EXCLUDE_GROUPS, 1, [1, 2])
+        assert query_time_flags == (replacer.EXCLUDE_GROUPS, self.project_id, [1, 2])
 
     def test_unmerge_process(self):
         timestamp = datetime.now(tz=pytz.utc)
         message = (2, 'end_unmerge', {
-            'project_id': 1,
+            'project_id': self.project_id,
             'previous_group_id': 1,
             'new_group_id': 2,
             'hashes': ["a" * 32, "b" * 32],
@@ -86,33 +115,27 @@ class TestReplacer(BaseTest):
             'select_columns': 'event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, received, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level',
             'hashes': "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
             'previous_group_id': 1,
-            'project_id': 1,
+            'project_id': self.project_id,
             'timestamp': timestamp.strftime(replacer.CLICKHOUSE_DATETIME_FORMAT),
         }
-        assert query_time_flags == (replacer.ENFORCE_FINAL, 1)
+        assert query_time_flags == (replacer.ENFORCE_FINAL, self.project_id)
 
     def test_delete_groups_insert(self):
-        self.event['project_id'] = 1
+        self.event['project_id'] = self.project_id
         self.event['group_id'] = 1
         self.write_raw_events(self.event)
 
-        group_count_query = """
-            SELECT count()
-            FROM %s FINAL
-            WHERE project_id = 1
-            AND group_id = 1
-            AND deleted = 0
-        """ % self.table
-
-        assert self.clickhouse.execute(group_count_query)[0][0] == 1
+        assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
         test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
 
+        project_id = self.project_id
+
         class FakeMessage(object):
             def value(self):
                 return json.dumps((2, 'end_delete_groups', {
-                    'project_id': 1,
+                    'project_id': project_id,
                     'group_ids': [1],
                     'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
                 }))
@@ -120,34 +143,24 @@ class TestReplacer(BaseTest):
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])
 
-        assert self.clickhouse.execute(group_count_query)[0][0] == 0
+        assert self._issue_count(self.project_id) == []
 
     def test_merge_insert(self):
-        self.event['project_id'] = 1
+        self.event['project_id'] = self.project_id
         self.event['group_id'] = 1
         self.write_raw_events(self.event)
 
-        base_query = """
-            SELECT count()
-            FROM %s FINAL
-            WHERE project_id = 1
-            AND group_id = %s
-            AND deleted = 0
-        """
-
-        group1_count_query = base_query % (self.table, 1)
-        group2_count_query = base_query % (self.table, 2)
-
-        assert self.clickhouse.execute(group1_count_query)[0][0] == 1
-        assert self.clickhouse.execute(group2_count_query)[0][0] == 0
+        assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
         test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
 
+        project_id = self.project_id
+
         class FakeMessage(object):
             def value(self):
                 return json.dumps((2, 'end_merge', {
-                    'project_id': 1,
+                    'project_id': project_id,
                     'new_group_id': 2,
                     'previous_group_ids': [1],
                     'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
@@ -156,36 +169,25 @@ class TestReplacer(BaseTest):
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])
 
-        assert self.clickhouse.execute(group1_count_query)[0][0] == 0
-        assert self.clickhouse.execute(group2_count_query)[0][0] == 1
+        assert self._issue_count(1) == [{'count': 1, 'issue': 2}]
 
     def test_unmerge_insert(self):
-        self.event['project_id'] = 1
+        self.event['project_id'] = self.project_id
         self.event['group_id'] = 1
         self.event['primary_hash'] = 'a' * 32
         self.write_raw_events(self.event)
 
-        base_query = """
-            SELECT count()
-            FROM %s FINAL
-            WHERE project_id = 1
-            AND group_id = %s
-            AND deleted = 0
-        """
-
-        group1_count_query = base_query % (self.table, 1)
-        group2_count_query = base_query % (self.table, 2)
-
-        assert self.clickhouse.execute(group1_count_query)[0][0] == 1
-        assert self.clickhouse.execute(group2_count_query)[0][0] == 0
+        assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
         test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
 
+        project_id = self.project_id
+
         class FakeMessage(object):
             def value(self):
                 return json.dumps((2, 'end_unmerge', {
-                    'project_id': 1,
+                    'project_id': project_id,
                     'previous_group_id': 1,
                     'new_group_id': 2,
                     'hashes': ['a' * 32],
@@ -195,27 +197,23 @@ class TestReplacer(BaseTest):
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])
 
-        assert self.clickhouse.execute(group1_count_query)[0][0] == 0
-        assert self.clickhouse.execute(group2_count_query)[0][0] == 1
+        assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 2}]
 
     def test_query_time_flags(self):
         project_ids = [1, 2]
-        redis_client.delete(
-            *([replacer.get_project_enforce_final_key(project_id) for project_id in project_ids]
-            + [replacer.get_project_exclude_groups_key(project_id) for project_id in project_ids])
-        )
+        self._clear_replacer_keys(project_ids)
 
-        assert replacer.get_projects_query_flags(project_ids) == (False, set())
+        assert replacer.get_projects_query_flags(project_ids) == (False, [])
 
         replacer.set_project_enforce_final(100)
-        assert replacer.get_projects_query_flags(project_ids) == (False, set())
+        assert replacer.get_projects_query_flags(project_ids) == (False, [])
 
         replacer.set_project_enforce_final(1)
-        assert replacer.get_projects_query_flags(project_ids) == (True, set())
+        assert replacer.get_projects_query_flags(project_ids) == (True, [])
 
         replacer.set_project_enforce_final(2)
-        assert replacer.get_projects_query_flags(project_ids) == (True, set())
+        assert replacer.get_projects_query_flags(project_ids) == (True, [])
 
         replacer.set_project_exclude_groups(1, [1, 2])
         replacer.set_project_exclude_groups(2, [3, 4])
-        assert replacer.get_projects_query_flags(project_ids) == (True, set([1, 2, 3, 4]))
+        assert replacer.get_projects_query_flags(project_ids) == (True, [1, 2, 3, 4])


### PR DESCRIPTION
rather than using FINAL.

This is an optimization to reduce the number of cases where we need to
use FINAL.

If there are too many groups to exclude we flip back to using FINAL at
query time.

Unmerge is the one case where we can't easily "fix" queries simply by excluding
data.