### PR TITLE
Add simple local development schema migration tool.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -345,6 +345,10 @@ if application.debug or application.testing:
 
     ensure_table_exists()
 
+    if settings.CLICKHOUSE_TABLE == 'dev':
+        from snuba import migrate
+        migrate.run(clickhouse_rw, settings.CLICKHOUSE_TABLE)
+
     @application.route('/tests/insert', methods=['POST'])
     def write():
         from snuba.processor import process_message

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -1,0 +1,26 @@
+import logging
+import sys
+import click
+from clickhouse_driver import Client
+
+from snuba import settings
+
+
+@click.command()
+@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
+def migrate(log_level):
+    from snuba.migrate import logger, run
+
+    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
+
+    if settings.CLICKHOUSE_TABLE != 'dev':
+        logger.error("The migration tool is only intended for local development environment.")
+        sys.exit(1)
+
+    host, port = settings.CLICKHOUSE_SERVER.split(':')
+    clickhouse = Client(
+        host=host,
+        port=port,
+    )
+
+    run(clickhouse, settings.CLICKHOUSE_TABLE)

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -1,0 +1,19 @@
+"""\
+Simple schema migration tool. Only intended for local development environment.
+"""
+
+import logging
+
+logger = logging.getLogger('snuba.cleanup')
+
+
+def run(conn, clickhouse_table):
+    describe = conn.execute("DESCRIBE TABLE %s" % clickhouse_table)
+
+    schema = {}
+    for column, type_, default_type, default_expression in describe:
+        schema[column] = type_
+
+    if 'group_id' not in schema:
+        logger.info("Adding `group_id` column.")
+        conn.execute("ALTER TABLE %s ADD COLUMN group_id DEFAULT 0" % clickhouse_table)


### PR DESCRIPTION
This tool only runs on the `dev` table, and can either be run via the
CLI or it runs automatically on server start.

`group_id` is the first column we've added since people have started
doing local development against Snuba, it is intended as an
example/skeleton.

---

I wanted to get this in as we have a couple of new columns we'd like to add, and without an easy migration path missing new columns breaks local dev ingest.