### PR TITLE
feat: Assume conditions on array columns are any()

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -225,7 +225,7 @@ def parse_and_run_query(validated_body, timer):
     where_clause = ''
     if where_conditions:
         where_conditions = list(set(util.tuplify(where_conditions)))
-        where_clause = u'WHERE {}'.format(util.condition_expr(where_conditions, body))
+        where_clause = u'WHERE {}'.format(util.conditions_expr(where_conditions, body))
 
     prewhere_conditions = []
     if settings.PREWHERE_KEYS:
@@ -246,12 +246,12 @@ def parse_and_run_query(validated_body, timer):
 
     prewhere_clause = ''
     if prewhere_conditions:
-        prewhere_clause = u'PREWHERE {}'.format(util.condition_expr(prewhere_conditions, body))
+        prewhere_clause = u'PREWHERE {}'.format(util.conditions_expr(prewhere_conditions, body))
 
     having_clause = ''
     if having_conditions:
         assert groupby, 'found HAVING clause with no GROUP BY'
-        having_clause = u'HAVING {}'.format(util.condition_expr(having_conditions, body))
+        having_clause = u'HAVING {}'.format(util.conditions_expr(having_conditions, body))
 
     group_clause = ', '.join(util.column_expr(gb, body) for gb in groupby)
     if group_clause:

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -15,7 +15,7 @@ import six
 import _strptime  # fixes _strptime deferred import issue
 import time
 
-from snuba import schemas, settings, state
+from snuba import clickhouse, schemas, settings, state
 from snuba.clickhouse import escape_col, ALL_COLUMNS, PROMOTED_COLS, TAG_COLUMN_MAP, COLUMN_TAG_MAP
 
 
@@ -318,11 +318,29 @@ def conditions_expr(conditions, body, depth=0):
         ):
             lit = parse_datetime(lit)
 
-        lit = escape_literal(lit)
+        # If the LHS is a simple column name that refers to an array column
+        # and the RHS is a scalar value, we assume that the user actually means
+        # to check if any item in the array matches the predicate, so we return
+        # an `any(x == value for x in array_column)` type expression
+        # TODO if the condition is `!=` they probably actually mean `all(...)`
+        if (
+            isinstance(lhs, six.string_types) and
+            lhs in ALL_COLUMNS and
+            type(ALL_COLUMNS[lhs]) == clickhouse.Array and
+            not isinstance(lit, (list, tuple))
+            ):
+            return u'arrayExists(x -> assumeNotNull(x {} {}), {})'.format(
+                op,
+                escape_literal(lit),
+                column_expr(lhs, body)
+            )
+        else:
+            return u'{} {} {}'.format(
+                column_expr(lhs, body),
+                op,
+                escape_literal(lit)
+            )
 
-        lhs = column_expr(lhs, body)
-
-        return u'{} {} {}'.format(lhs, op, lit)
     elif depth == 1:
         sub = (conditions_expr(cond, body, depth + 1) for cond in conditions)
         sub = [s for s in sub if s]

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -295,7 +295,7 @@ def tuplify(nested):
     return nested
 
 
-def condition_expr(conditions, body, depth=0):
+def conditions_expr(conditions, body, depth=0):
     """
     Return a boolean expression suitable for putting in the WHERE clause of the
     query.  The expression is constructed by ANDing groups of OR expressions.
@@ -306,7 +306,7 @@ def condition_expr(conditions, body, depth=0):
         return ''
 
     if depth == 0:
-        sub = (condition_expr(cond, body, depth + 1) for cond in conditions)
+        sub = (conditions_expr(cond, body, depth + 1) for cond in conditions)
         return u' AND '.join(s for s in sub if s)
     elif is_condition(conditions):
         lhs, op, lit = conditions
@@ -324,7 +324,7 @@ def condition_expr(conditions, body, depth=0):
 
         return u'{} {} {}'.format(lhs, op, lit)
     elif depth == 1:
-        sub = (condition_expr(cond, body, depth + 1) for cond in conditions)
+        sub = (conditions_expr(cond, body, depth + 1) for cond in conditions)
         sub = [s for s in sub if s]
         res = u' OR '.join(sub)
         return u'({})'.format(res) if len(sub) > 1 else res

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -164,6 +164,10 @@ class TestUtil(BaseTest):
         assert conditions_expr(conditions, {}) == \
                 """(notEmpty((tags.value[indexOf(tags.key, 'sentry:environment')] AS `tags[sentry:environment]`)) = 'dev' OR notEmpty(`tags[sentry:environment]`) = 'prod') AND (notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 'joe' OR notEmpty(`tags[sentry:user]`) = 'bob')"""
 
+        # Test scalar condition on array column is expanded as an iterator.
+        conditions = [['exception_frames.filename', 'LIKE', '%foo%']]
+        assert conditions_expr(conditions, {}) == 'arrayExists(x -> assumeNotNull(x LIKE \'%foo%\'), exception_frames.filename)'
+
     def test_duplicate_expression_alias(self):
         body = {
             'aggregations': [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,7 +8,7 @@ from snuba.util import (
     all_referenced_columns,
     column_expr,
     complex_column_expr,
-    condition_expr,
+    conditions_expr,
     escape_literal,
     tuplify,
     Timer,
@@ -106,52 +106,52 @@ class TestUtil(BaseTest):
         assert escape_literal([1, 'a', date(2001, 1, 1)]) ==\
             "(1, 'a', toDate('2001-01-01'))"
 
-    def test_condition_expr(self):
+    def test_conditions_expr(self):
         conditions = [['a', '=', 1]]
-        assert condition_expr(conditions, {}) == 'a = 1'
+        assert conditions_expr(conditions, {}) == 'a = 1'
 
         conditions = [[['a', '=', 1]]]
-        assert condition_expr(conditions, {}) == 'a = 1'
+        assert conditions_expr(conditions, {}) == 'a = 1'
 
         conditions = [['a', '=', 1], ['b', '=', 2]]
-        assert condition_expr(conditions, {}) == 'a = 1 AND b = 2'
+        assert conditions_expr(conditions, {}) == 'a = 1 AND b = 2'
 
         conditions = [[['a', '=', 1], ['b', '=', 2]]]
-        assert condition_expr(conditions, {}) == '(a = 1 OR b = 2)'
+        assert conditions_expr(conditions, {}) == '(a = 1 OR b = 2)'
 
         conditions = [[['a', '=', 1], ['b', '=', 2]], ['c', '=', 3]]
-        assert condition_expr(conditions, {}) == '(a = 1 OR b = 2) AND c = 3'
+        assert conditions_expr(conditions, {}) == '(a = 1 OR b = 2) AND c = 3'
 
         conditions = [[['a', '=', 1], ['b', '=', 2]], [['c', '=', 3], ['d', '=', 4]]]
-        assert condition_expr(conditions, {}) == '(a = 1 OR b = 2) AND (c = 3 OR d = 4)'
+        assert conditions_expr(conditions, {}) == '(a = 1 OR b = 2) AND (c = 3 OR d = 4)'
 
         # Malformed condition input
         conditions = [[['a', '=', 1], []]]
-        assert condition_expr(conditions, {}) == 'a = 1'
+        assert conditions_expr(conditions, {}) == 'a = 1'
 
         # Test column expansion
         conditions = [[['tags[foo]', '=', 1], ['b', '=', 2]]]
         expanded = column_expr('tags[foo]', {})
-        assert condition_expr(conditions, {}) == '({} = 1 OR b = 2)'.format(expanded)
+        assert conditions_expr(conditions, {}) == '({} = 1 OR b = 2)'.format(expanded)
 
         # Test using alias if column has already been expanded in SELECT clause
         reuse_body = {}
         conditions = [[['tags[foo]', '=', 1], ['b', '=', 2]]]
         column_expr('tags[foo]', reuse_body)  # Expand it once so the next time is aliased
-        assert condition_expr(conditions, reuse_body) == '(`tags[foo]` = 1 OR b = 2)'
+        assert conditions_expr(conditions, reuse_body) == '(`tags[foo]` = 1 OR b = 2)'
 
         # Test special output format of LIKE
         conditions = [['primary_hash', 'LIKE', '%foo%']]
-        assert condition_expr(conditions, {}) == 'primary_hash LIKE \'%foo%\''
+        assert conditions_expr(conditions, {}) == 'primary_hash LIKE \'%foo%\''
 
         conditions = tuplify([[['notEmpty', ['arrayElement', ['exception_stacks.type', 1]]], '=', 1]])
-        assert condition_expr(conditions, {}) == 'notEmpty(arrayElement(exception_stacks.type, 1)) = 1'
+        assert conditions_expr(conditions, {}) == 'notEmpty(arrayElement(exception_stacks.type, 1)) = 1'
 
         conditions = tuplify([[['notEmpty', ['tags[sentry:user]']], '=', 1]])
-        assert condition_expr(conditions, {}) == 'notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 1'
+        assert conditions_expr(conditions, {}) == 'notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 1'
 
         conditions = tuplify([[['notEmpty', ['tags_key']], '=', 1]])
-        assert condition_expr(conditions, {}) == 'notEmpty((arrayJoin(tags.key) AS tags_key)) = 1'
+        assert conditions_expr(conditions, {}) == 'notEmpty((arrayJoin(tags.key) AS tags_key)) = 1'
 
         conditions = tuplify([
             [
@@ -161,7 +161,7 @@ class TestUtil(BaseTest):
                 [['notEmpty', ['tags[sentry:user]']], '=', 'joe'], [['notEmpty', ['tags[sentry:user]']], '=', 'bob']
             ],
         ])
-        assert condition_expr(conditions, {}) == \
+        assert conditions_expr(conditions, {}) == \
                 """(notEmpty((tags.value[indexOf(tags.key, 'sentry:environment')] AS `tags[sentry:environment]`)) = 'dev' OR notEmpty(`tags[sentry:environment]`) = 'prod') AND (notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 'joe' OR notEmpty(`tags[sentry:user]`) = 'bob')"""
 
     def test_duplicate_expression_alias(self):
@@ -180,7 +180,7 @@ class TestUtil(BaseTest):
         ]
         assert exprs == ['(topK(3)(logger) AS dupe_alias)', 'dupe_alias']
 
-    def test_complex_condition_expr(self):
+    def test_complex_conditions_expr(self):
         body = {}
 
         assert complex_column_expr(tuplify(['count', []]), body.copy()) == 'count()'


### PR DESCRIPTION
When you ask for `array = value`, convert this into an expression equivalent to `any(item = value for item in array)`

This still doesn't handle the case where multiple conditions on the same array column can individually be true, but are not both true for the same value. For this we would need to expand to:
```
any(item = x and item = y for item in array)
```
rather than what we currently do which is:
```
any(item = x for item in array) and any(item = y for item in array)
```
