### PR TITLE
Improve on ClickHouse schema modeling

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -366,7 +366,6 @@ if application.debug or application.testing:
         write_rows(
             clickhouse_rw,
             table=settings.CLICKHOUSE_TABLE,
-            columns=ALL_COLUMNS.escaped_column_names,
             rows=rows
         )
         return ('ok', 200, {'Content-Type': 'text/plain'})

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -321,7 +321,6 @@ class ConsumerWorker(AbstractBatchWorker):
             write_rows(
                 self.clickhouse,
                 self.dist_table_name,
-                ALL_COLUMNS.escaped_column_names,
                 inserts
             )
 

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -34,10 +34,13 @@ def run(conn, clickhouse_table):
     for column_name, column_type in local_schema.items():
         if column_name not in ALL_COLUMNS:
             logger.warn("Column '%s' exists in local ClickHouse but not in schema!", column_name)
-        elif column_type != str(ALL_COLUMNS[column_name]):
+            continue
+
+        expected_type = ALL_COLUMNS[column_name].type.for_schema()
+        if column_type != expected_type:
             logger.warn(
                 "Column '%s' type differs between local ClickHouse and schema! (expected: %s, is: %s)",
                 column_name,
-                str(ALL_COLUMNS[column_name]),
+                expected_type,
                 column_type
             )

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -328,8 +328,8 @@ def conditions_expr(conditions, body, depth=0):
         if (
             isinstance(lhs, six.string_types) and
             lhs in ALL_COLUMNS and
-            type(ALL_COLUMNS[lhs]) == clickhouse.Array and
-            lhs.split('.', 1)[0] != body.get('arrayjoin') and
+            type(ALL_COLUMNS[lhs].type) == clickhouse.Array and
+            ALL_COLUMNS[lhs].base_name != body.get('arrayjoin') and
             not isinstance(lit, (list, tuple))
             ):
             return u'arrayExists(x -> assumeNotNull(x {} {}), {})'.format(

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -47,7 +47,7 @@ def _create_missing_array(colname, event):
     return []
 
 
-def write_rows(connection, table, columns, rows, types_check=False):
+def write_rows(connection, table, rows, types_check=False, columns=ALL_COLUMNS.escaped_column_names):
     connection.execute_robust("""
         INSERT INTO %(table)s (%(colnames)s) VALUES""" % {
         'colnames': ", ".join(columns),

--- a/tests/base.py
+++ b/tests/base.py
@@ -210,7 +210,6 @@ class BaseTest(object):
         write_rows(
             self.clickhouse,
             table=self.table,
-            columns=ALL_COLUMNS.escaped_column_names,
             rows=rows,
             types_check=True
         )

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -1,0 +1,41 @@
+from base import BaseTest
+
+from snuba.clickhouse import (
+    ALL_COLUMNS,
+    Array, ColumnSet, Nested, Nullable, String, UInt,
+    escape_col
+)
+
+
+class TestClickhouse(BaseTest):
+    def test_escape_col(self):
+        assert escape_col(None) is None
+        assert escape_col('') == ''
+        assert escape_col('foo') == 'foo'
+        assert escape_col('foo.bar') == 'foo.bar'
+        assert escape_col('foo:bar') == '`foo:bar`'
+
+    def test_flattened(self):
+        assert ALL_COLUMNS['group_id'].type == UInt(64)
+        assert ALL_COLUMNS['group_id'].name == 'group_id'
+        assert ALL_COLUMNS['group_id'].base_name is None
+        assert ALL_COLUMNS['group_id'].flattened_name == 'group_id'
+
+        assert ALL_COLUMNS['exception_frames.in_app'].type == Array(Nullable(UInt(8)))
+        assert ALL_COLUMNS['exception_frames.in_app'].name == 'in_app'
+        assert ALL_COLUMNS['exception_frames.in_app'].base_name == 'exception_frames'
+        assert ALL_COLUMNS['exception_frames.in_app'].flattened_name == 'exception_frames.in_app'
+
+    def test_schema(self):
+        cols = ColumnSet([
+            ('foo', UInt(8)),
+            ('bar', Nested([
+                ('qux:mux', String())
+            ]))
+        ])
+
+        assert cols.column_names == ['foo', 'bar.qux:mux']
+        assert cols.escaped_column_names == ['foo', '`bar.qux:mux`']
+        assert cols.for_schema() == 'foo UInt8, bar Nested(`qux:mux` String)'
+        assert cols['foo'].type == UInt(8)
+        assert cols['bar.qux:mux'].type == Array(String())


### PR DESCRIPTION
Probably easiest to just look at tests and the API change to see what's actually going on here.

---

* Add `Column` and `FlattenedColumn` types so we can do things like:
  `ALL_COLUMNS['exception_frames.in_app'].base_name ==
  'exception_frames'`
* Stop using `str()` for schema printing as it was confusing, switch to
  `for_schema()` method.
* Use real `__repr__` and `__eq__` so messing around in REPL makes
  sense.