### PR TITLE
ops-188 Dockerfile changes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,23 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: [
+    '-c',
+    'docker pull us.gcr.io/$PROJECT_ID/$REPO_NAME:latest || true',
+  ]
+- name: 'gcr.io/cloud-builders/docker'
+  args: [
+            'build',
+            '-t', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+            '-t', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
+            '--build-arg', 'GETSENTRY_VERSION_SHA=$COMMIT_SHA',
+            '--cache-from', 'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+            '.'
+        ]
+images: [
+  'us.gcr.io/$PROJECT_ID/$REPO_NAME:latest',
+  'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
+  ]
+timeout: 60m
+logsBucket: 'gs://sentryio-cloudbuild-logs'
+


### PR DESCRIPTION
I reordered a bunch of the apt-get bits to happen in larger chunks, fewer times, as it speeds things up considerably. There's not much to be gained from multi-stage builds in this as we need to bring along most of the stuff we use, and we are already removing unnecessary packages as we go.  I also sorted all of the build_deps so that they are easier for humans to parse

gcloud build
new Dockerfile:
real    4m23.636s
user    0m2.920s
sys     0m0.311s

original Dockerfile:
real    7m37.166s
user    0m4.958s
sys     0m0.609s

Image sizes in gcloud registry are both 109MB