### PR TITLE
Remove _create_missing_array as it was only important when we had spl…

### DIFF
--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -11,44 +11,10 @@ def row_from_processed_event(event, columns=ALL_COLUMNS):
     for col in columns:
         value = event.get(col.flattened, None)
         if value is None and isinstance(col.type, Array):
-            value = _create_missing_array(col.flattened, event)
+            value = []
         values.append(value)
 
     return values
-
-
-def _create_missing_array(colname, event):
-    """
-    ClickHouse `Nested` columns are implemented as arrays and sibling columns
-    must have the same length as one another. The documentation states:
-    > During insertion, the system checks that they have the same length.
-    But as of this writing, this doesn't seem to be true:
-    https://github.com/yandex/ClickHouse/issues/2231
-
-    When a new `Nested` column is added to the schema, it may be missing
-    from pre-existing events in the processed data topic. We need
-    to write arrays of the same length as the sibling columns, so we
-    look at the event for the first sibling column and use its length
-    (since all siblings will have the same length).
-
-    It's important to note that this is (1) not fast and (2) only done
-    temporarily against processed events that are missing the new column.
-    Once the processor is updated and the writer moves on to those new
-    events, this method will not be called.
-    """
-    # This is plain array, not a nested column.
-    if '.' not in colname:
-        return []
-
-    prefix, _ = colname.split('.', 1)
-    prefix += '.'
-
-    for key in event.keys():
-        if key != colname and key.startswith(prefix):
-            return [None] * len(event[key])
-
-    # no siblings, empty array is safe!
-    return []
 
 
 def write_rows(connection, table, rows, types_check=False, columns=ALL_COLUMNS):

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,9 +1,8 @@
 from base import BaseTest
 
-from snuba import settings
 from snuba.clickhouse import ColumnSet, ALL_COLUMNS, METADATA_COLUMNS
 from snuba.processor import process_message
-from snuba.writer import row_from_processed_event, _create_missing_array
+from snuba.writer import row_from_processed_event
 
 
 class TestWriter(BaseTest):
@@ -39,13 +38,3 @@ class TestWriter(BaseTest):
 
         assert len(row) == len(columns_copy)
         assert sdk_name not in row
-
-    def test_fix_nested_array_size(self):
-        # no sibling columns == empty array
-        assert _create_missing_array('foo.bar', {'foo.bar': None}) == []
-
-        # empty sibling == empty array
-        assert _create_missing_array('foo.bar', {'foo.baz': []}) == []
-
-        # len 3 sibling == len 3 array
-        assert _create_missing_array('foo.bar', {'foo.baz': [1, 2, 3]}) == [None, None, None]


### PR DESCRIPTION
…it processing/writing topics

In addition, the scary ClickHouse bug (which we won't hit anyway now)
was fixed: https://github.com/yandex/ClickHouse/issues/2231