### PR TITLE
Add 'insert_distributed_sync=True' to Consumer (inserter) ClickHouse

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -57,6 +57,7 @@ def consumer(raw_events_topic, replacements_topic, consumer_group, bootstrap_ser
         port=int(clickhouse_server.split(':')[1]),
         client_settings={
             'load_balancing': 'in_order',
+            'insert_distributed_sync': True,
         },
         metrics=metrics
     )


### PR DESCRIPTION
settings.

This setting is required so that we assured the write will be available
on the first replica (via 'load_balancing': 'in_order') after the write
returns, so post-processing can query the written data.

It needs to be set here because we *don't* want to enforce this setting
on a global level until (at minimum) this bug is fixed: https://github.com/yandex/ClickHouse/issues/2640

If it were set at a global level the replacer would explode since it
writes the minimal number of columns to handle deletions.