### PR TITLE
Make running sentry tests against snuba easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ A service providing fast event searching, filtering and aggregation on arbitrary
 
 ## Requirements
 
-Snuba assumes a Clickhouse server endpoint at `CLICKHOUSE_SERVER` (default `localhost:9000`).
+Snuba assumes:
+
+1. A Clickhouse server endpoint at `CLICKHOUSE_SERVER` (default `localhost:9000`).
+2. A redis instance running at `REDIS_HOST` (default `localhost`). On port
+   `6379`
 
 ## Install / Run
 
@@ -13,7 +17,7 @@ Snuba assumes a Clickhouse server endpoint at `CLICKHOUSE_SERVER` (default `loca
 
     # Run API server
     snuba api
-    
+
 ## Sentry + Snuba
 
 Add the following line to `sentry.conf.py`:
@@ -23,9 +27,9 @@ Add the following line to `sentry.conf.py`:
 Create a docker volume for Clickhouse:
 
     `docker volume create clickhouse`
-    
+
 Run the clickhouse server:
-    
+
     docker run -d -p 9000:9000 -p 9009:9009 -p 8123:8123 --name=clickhouse -v clickhouse:/var/lib/clickhouse --ulimit nofile=262144:262144 yandex/clickhouse-server:18.14.9
 
 This can be managed with `docker stop clickhouse` and `docker start clickhouse` to stop/start the service.
@@ -35,17 +39,41 @@ Prepare Snuba environment
     git clone git@github.com:getsentry/snuba.git
     mkvirtualenv snuba
     pip install -e .
-  
+
 Run Snuba
 
     snuba api
-    
+
 Access raw clickhouse client (similar to psql):
-    
+
     docker run --rm --net=host -it yandex/clickhouse-client
-    
+
 Data is written into the table `dev`: `select count() from dev;`
 
+
+### Using docker-compose
+
+Snuba and its related services can be run via `docker-compose` which is a good
+option if you need a quick way to get snuba up and running to passively run it
+or to run sentry's test suites.
+
+To start the containers run
+
+    docker-compose up
+
+You can background the containers by adding the `-d` option to `up`. Your
+checkout will be mounted into the container allowing you to interactively work
+with any changes you make.
+
+You will need to rebuild the `web` image if you change any application
+dependencies.
+
+To run sentry's test suite against snuba, uncomment `SNUBA_SETTINGS: test` in
+the `docker-compose.yml` and restart your `web` container with:
+
+    docker-compose kill web
+    docker-compose rm web
+    docker-compose up web
 
 ## API
 
@@ -62,6 +90,7 @@ Settings are found in `settings.py`
 
 - `CLICKHOUSE_SERVER` : The endpoint for the clickhouse service.
 - `CLICKHOUSE_TABLE` : The clickhouse table name.
+- `REDIS_HOST` : The host redis is running on.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ You can background the containers by adding the `-d` option to `up`. Your
 checkout will be mounted into the container allowing you to interactively work
 with any changes you make.
 
-You will need to rebuild the `web` image if you change any application
+You will need to rebuild the `snuba-api` image if you change any application
 dependencies.
 
 To run sentry's test suite against snuba, uncomment `SNUBA_SETTINGS: test` in
-the `docker-compose.yml` and restart your `web` container with:
+the `docker-compose.yml` and restart your `snuba-api` container with:
 
-    docker-compose kill web
-    docker-compose rm web
-    docker-compose up web
+    docker-compose kill snuba-api
+    docker-compose rm snuba-api
+    docker-compose up snuba-api
 
 ## API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,23 @@
 version: '3'
 services:
   web:
+    build: ./
     ports:
       - "1218:1218"
+    volumes:
+      - ".:/usr/src/snuba/"
     command:
-      - snuba
-      - api
+      - "api"
+      - "--http"
+      - "0.0.0.0:1218"
+      - "--py-autoreload"
+      - "1"
+      - "--http-keepalive"
     environment: &snuba_env
       CLICKHOUSE_SERVER: 'clickhouse:9000'
       REDIS_HOST: 'redis'
+      # Uncomment this to run sentry's snuba testsuite
+      # SNUBA_SETTINGS: test
   clickhouse:
     image: yandex/clickhouse-server:18.14.9
     ports:
@@ -18,7 +27,10 @@ services:
       - "8123:8123"
     volumes:
       - "clickhouse:/var/lib/clickhouse"
-    ulimit:
-      - "nofile=262144:262144"
+    ulimits:
+      nofile: 262144
   redis:
     image: redis:3.2-alpine
+
+volumes:
+  clickhouse:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 version: '3'
 services:
-  web:
+  snuba-api:
     build: ./
     ports:
       - "1218:1218"
@@ -18,7 +18,7 @@ services:
       CLICKHOUSE_SERVER: 'clickhouse:9000'
       REDIS_HOST: 'redis'
       # Uncomment this to run sentry's snuba testsuite
-      # SNUBA_SETTINGS: test
+      #SNUBA_SETTINGS: test
   clickhouse:
     image: yandex/clickhouse-server:18.14.9
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+---
+version: '3'
+services:
+  web:
+    ports:
+      - "1218:1218"
+    command:
+      - snuba
+      - api
+    environment: &snuba_env
+      CLICKHOUSE_SERVER: 'clickhouse:9000'
+      REDIS_HOST: 'redis'
+  clickhouse:
+    image: yandex/clickhouse-server:18.14.9
+    ports:
+      - "9000:9000"
+      - "9009:9009"
+      - "8123:8123"
+    volumes:
+      - "clickhouse:/var/lib/clickhouse"
+    ulimit:
+      - "nofile=262144:262144"
+  redis:
+    image: redis:3.2-alpine

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -30,7 +30,7 @@ DOGSTATSD_PORT = 8125
 
 # Redis Options
 USE_REDIS_CLUSTER = False
-REDIS_HOST = 'localhost'
+REDIS_HOST = os.environ.get('REDIS_HOST', 'localhost')
 REDIS_PORT = 6379
 REDIS_DB = 1
 


### PR DESCRIPTION
I was trying to run the `snuba` suite for sentry and found it less than simple. I've updated the README with the missing steps (needed redis) and added a docker-compose file. Using `docker-compose` allows the end user to know less about how snuba and clickhouse work and get up and running more easily.