### PR TITLE
feat: Validate that timestamps fit into the clickhouse column

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -90,7 +90,7 @@ def _unicodify(s):
 
 def _hashify(h):
     if HASH_RE.match(h):
-        return None
+        return h
     return md5(force_bytes(h)).hexdigest()
 
 


### PR DESCRIPTION
A timestamp too far in the future can cause ingestion errors. This ensures it fits into the column.