### PR TITLE
feat: Query-side of search_message rename.

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -159,11 +159,6 @@ def extract_common(output, message, data):
     #        - "search_message" value stored in `search_message` column
     #        - "message" value stored in `message` column
     #
-    # When querying the data / searching:
-    #   If search_message is Null, the event is from pre-rename so the search message
-    #   is stored in the `message` column.
-    #   Otherwise search in the `search_message` column.
-    #   Practically we can achieve this by searching `coalesce(search_message, message)`
     output['search_message'] = _unicodify(message.get('search_message', None))
     if output['search_message'] is None:
         # Pre-rename scenario, we expect to find "message" at the top level

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -83,6 +83,11 @@ def column_expr(column_name, body, alias=None, aggregate=None):
         expr = tags_expr(column_name, body)
     elif column_name == 'issue':
         expr = 'group_id'
+    elif column_name == 'message':
+        # Because of the rename from message->search_message without backfill,
+        # records will have one or the other of these fields.
+        # TODO this can be removed once all data has search_message filled in.
+        expr = 'coalesce(search_message, message)'
     else:
         expr = escape_col(column_name)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -208,7 +208,10 @@ class TestUtil(BaseTest):
         assert complex_column_expr(tuplify(['emptyIfNull', ['project_id']]), body.copy()) == 'ifNull(project_id, \'\')'
         assert complex_column_expr(tuplify(['emptyIfNull', ['project_id'], 'foo']), body.copy()) == '(ifNull(project_id, \'\') AS foo)'
 
-        assert complex_column_expr(tuplify(['positionCaseInsensitive', ['message', "'lol 'single' quotes'"]]), body.copy()) == "positionCaseInsensitive(message, 'lol \\'single\\' quotes')"
+        # TODO once search_message is filled in everywhere, this can be just 'message' again.
+        message_expr = '(coalesce(search_message, message) AS message)'
+        assert complex_column_expr(tuplify(['positionCaseInsensitive', ['message', "'lol 'single' quotes'"]]), body.copy())\
+                == "positionCaseInsensitive({message_expr}, 'lol \\'single\\' quotes')".format(**locals())
 
 
         # dangerous characters are allowed but escaped in literals and column names


### PR DESCRIPTION
We still allow clients to refer to this as `message` so no client code
has to change for now, but we will transparently use search_message
instead if it is filled in.