### PR TITLE
bootstrap: Lower socket timeout

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -17,7 +17,8 @@ def bootstrap(bootstrap_server, force):
     from confluent_kafka.admin import AdminClient, NewTopic
 
     client = AdminClient({
-        'bootstrap.servers': ','.join(bootstrap_server)
+        'bootstrap.servers': ','.join(bootstrap_server),
+        'socket.timeout.ms': 1000,
     })
 
     topics = [NewTopic(o.pop('topic'), **o) for o in settings.KAFKA_TOPICS.values()]


### PR DESCRIPTION
Default is 60s, and this is pretty bad when you're trying to quickly
bootstrap, and in no legit scenario should you need a timeout that long.