### PR TITLE
conf: Correctly pull CLICKHOUSE_TABLE environment variable

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -21,7 +21,7 @@ PORT = 1218
 # Clickhouse Options
 CLICKHOUSE_SERVER = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000')
 CLICKHOUSE_CLUSTER = None
-CLICKHOUSE_TABLE = 'dev'
+CLICKHOUSE_TABLE = os.environ.get('CLICKHOUSE_TABLE', 'dev')
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # Dogstatsd Options


### PR DESCRIPTION
This is documented as such to work, and is even in the Dockerfile as a
default.