### PR TITLE
feat: Allow (almost) any column in PREWHERE

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -93,8 +93,13 @@ DEFAULT_RETENTION_DAYS = 90
 
 RETENTION_OVERRIDES = {}
 
-# the list of keys that will upgrade from a WHERE condition to a PREWHERE
-PREWHERE_KEYS = ['project_id']
+# Any condition has the potential to be made into a PREWHERE clause
+# but if you add the column name to PREWHERE_KEYS it will be preferred.
+PREWHERE_KEYS = []
+# These are columns that we do not want to turn into PREWHERE clauses
+# because they are too high-cardinality, not selective enough, or they
+# have already been used by indexes to hone in on a range of blocks.
+NOT_PREWHERE_KEYS = ['project_id', 'timestamp', 'deleted', 'tags_key', 'tags_value']
 MAX_PREWHERE_CONDITIONS = 1
 
 STATS_IN_RESPONSE = False


### PR DESCRIPTION
PREWHERE_KEYS is still a list of the highest priority columns to put in PREWHERE

NOT_PREWHERE_KEYS is a list of columns that should never go in PREWHERE

All other columns can potentially be made into a PREWHERE as long as
there is no arrayJoin on them and there are no other higher-priority
columns.