### PR TITLE
fix: dedupe IN conditions

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -232,7 +232,7 @@ def parse_and_run_query(validated_body, timer):
 
     where_clause = ''
     if where_conditions:
-        where_conditions = list(set(util.tuplify(where_conditions)))
+        where_conditions = util.tuplify(where_conditions)
         where_clause = u'WHERE {}'.format(util.conditions_expr(where_conditions, body))
 
     prewhere_conditions = []

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -174,6 +174,14 @@ class TestUtil(BaseTest):
         conditions = [['exception_frames.filename', 'NOT LIKE', '%foo%']]
         assert conditions_expr(conditions, {}) == 'arrayAll(x -> assumeNotNull(x NOT LIKE \'%foo%\'), exception_frames.filename)'
 
+        # Test that a duplicate IN condition is deduplicated even if
+        # the lists are in different orders.[
+        conditions = tuplify([
+            ['platform', 'IN', ['a', 'b', 'c']],
+            ['platform', 'IN', ['c', 'b', 'a']]
+        ])
+        assert conditions_expr(conditions, {}) == "platform IN ('a', 'b', 'c')"
+
     def test_duplicate_expression_alias(self):
         body = {
             'aggregations': [


### PR DESCRIPTION
Previously we would not catch the case where there were duplicate
project_id IN (...) clauses where the project_id lists were in different
order.