### PR TITLE
feat: Use query splitting for latest-event queries

### DIFF
--- a/snuba/split.py
+++ b/snuba/split.py
@@ -27,10 +27,11 @@ def split_query(query_func):
         from_date = util.parse_datetime(body['from_date'], date_align)
         limit = body.get('limit', 0)
         remaining_offset = body.get('offset', 0)
+        orderby = util.to_list(body.get('orderby'))
 
         if (
             use_split and limit and not body.get('groupby')
-            and body.get('orderby') == '-timestamp'
+            and orderby[:1] == ['-timestamp']
         ):
             overall_result = None
             split_end = to_date


### PR DESCRIPTION
The query to get the latest event for a group uses a complex
ordering key of [-timestamp, -event_id] but as long as -timestamp
is the first sort key, we should still be able to use this
walk-backwards query splitting technique.