### PR TITLE
feat: Group by received time.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -329,7 +329,7 @@ def sdk_distribution(validated_body, timer):
         ['uniq', 'project_id', 'projects'],
         ['count()', None, 'count'],
     ]
-    validated_body['groupby'].extend(['sdk_name', 'time'])
+    validated_body['groupby'].extend(['sdk_name', 'rtime'])
     result, status = parse_and_run_query(validated_body, timer)
     return (
         json.dumps(

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -1,15 +1,4 @@
 import os
-from collections import defaultdict
-
-
-class dynamicdict(defaultdict):
-    def __missing__(self, key):
-        if self.default_factory:
-            self.__setitem__(key, self.default_factory(key))
-            return self[key]
-        else:
-            return super(dynamicdict, self).__missing__(key)
-
 
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
 
@@ -45,16 +34,13 @@ CONFIG_MEMOIZE_TIMEOUT = 10
 SENTRY_DSN = None
 
 # Snuba Options
-TIME_GROUPS = dynamicdict(
-    lambda sec: 'toDateTime(intDiv(toUInt32(timestamp), {0}) * {0})'.format(sec),
-    {
-        3600: 'toStartOfHour(timestamp)',
-        60: 'toStartOfMinute(timestamp)',
-        86400: 'toDate(timestamp)',
-    }
-)
 
-TIME_GROUP_COLUMN = 'time'
+# Convenience columns that evaluate to a bucketed time, the
+# bucketing depends on the granularity parameter.
+TIME_GROUP_COLUMNS = {
+    'time': 'timestamp',
+    'rtime': 'received'
+}
 
 # Processor/Writer Options
 DEFAULT_BROKERS = ['localhost:9093']

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -58,6 +58,15 @@ def parse_datetime(value, alignment=1):
     dt = dateutil_parse(value, ignoretz=True).replace(microsecond=0)
     return dt - timedelta(seconds=(dt - dt.min).seconds % alignment)
 
+def time_expr(alias, granularity):
+    column = settings.TIME_GROUP_COLUMNS[alias]
+    template = {
+        3600: 'toStartOfHour({column})',
+        60: 'toStartOfMinute({column})',
+        86400: 'toDate({column})',
+    }.get(granularity, 'toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity})')
+
+    return template.format(column=column, granularity=granularity)
 
 def column_expr(column_name, body, alias=None, aggregate=None):
     """
@@ -75,8 +84,8 @@ def column_expr(column_name, body, alias=None, aggregate=None):
         return complex_column_expr(column_name, body)
     elif isinstance(column_name, six.string_types) and QUOTED_LITERAL_RE.match(column_name):
         return escape_literal(column_name[1:-1])
-    elif column_name == settings.TIME_GROUP_COLUMN:
-        expr = settings.TIME_GROUPS[body['granularity']]
+    elif column_name in settings.TIME_GROUP_COLUMNS:
+        expr = time_expr(column_name, body['granularity'])
     elif NESTED_COL_EXPR_RE.match(column_name):
         expr = tag_expr(column_name)
     elif column_name in ['tags_key', 'tags_value']:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -51,6 +51,9 @@ class TestUtil(BaseTest):
         assert column_expr('time', body.copy()) ==\
             "(toDate(timestamp) AS time)"
 
+        assert column_expr('rtime', body.copy()) ==\
+            "(toDate(received) AS rtime)"
+
         assert column_expr('col', body.copy(), aggregate='sum') ==\
             "(sum(col) AS col)"
 


### PR DESCRIPTION
Add `rtime` as a convenience column that can be grouped in the same
way as `time`, but uses the received time of the event rather than the
timestamp time. The `granularity` value applies to rtime in the same way
as time.