### PR TITLE
fix: Don't use snuba cache for wide queries

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -436,9 +436,10 @@ def raw_query(body, sql, client, timer, stats=None):
     }
 
     # Experiment, if we are going to grab more than X columns worth of data,
-    # don't use uncompressed_cache.
+    # don't use uncompressed_cache in clickhouse, or result cache in snuba.
     if len(all_referenced_columns(body)) > uc_max:
         query_settings['use_uncompressed_cache'] = 0
+        use_cache = 0
 
     timer.mark('get_configs')
 


### PR DESCRIPTION
To avoid slamming 100 row * 15 column results into redis cache.