### PR TITLE
perf: Don't count rates we don't need

### DIFF
--- a/snuba/state.py
+++ b/snuba/state.py
@@ -71,11 +71,11 @@ def rate_limit(bucket, per_second_limit=None, concurrent_limit=None):
     pipe.zremrangebyscore(bucket, '-inf', '({:f}'.format(now - rate_history_s))  # cleanup
     pipe.zadd(bucket, now + max_query_duration_s, query_id)  # add query
     if per_second_limit is None:
-        pipe.ping() # no-op if we don't need per-second
+        pipe.echo(0) # no-op if we don't need per-second
     else:
         pipe.zcount(bucket, now - rate_lookback_s, now)  # get historical
     if concurrent_limit is None:
-        pipe.ping()  # no-op if we don't need concurrent
+        pipe.echo(0)  # no-op if we don't need concurrent
     else:
         pipe.zcount(bucket, '({:f}'.format(now), '+inf')  # get concurrent
 

--- a/snuba/state.py
+++ b/snuba/state.py
@@ -71,11 +71,11 @@ def rate_limit(bucket, per_second_limit=None, concurrent_limit=None):
     pipe.zremrangebyscore(bucket, '-inf', '({:f}'.format(now - rate_history_s))  # cleanup
     pipe.zadd(bucket, now + max_query_duration_s, query_id)  # add query
     if per_second_limit is None:
-        pipe.echo(0) # no-op if we don't need per-second
+        pipe.exists("nosuchkey") # no-op if we don't need per-second
     else:
         pipe.zcount(bucket, now - rate_lookback_s, now)  # get historical
     if concurrent_limit is None:
-        pipe.echo(0)  # no-op if we don't need concurrent
+        pipe.exists("nosuchkey")  # no-op if we don't need concurrent
     else:
         pipe.zcount(bucket, '({:f}'.format(now), '+inf')  # get concurrent
 

--- a/snuba/static/dashboard.html
+++ b/snuba/static/dashboard.html
@@ -41,7 +41,7 @@
             let path = values.map(function (v, i) { return "L" + x(i) + "," + y(v); }).join()
             let strokepath = "M" + path.substring(1);
             let fillpath = "M0," + range[0] + path + "L" + this.state.width + "," + range[0] + "L0," + range[0]
-            let lastval = values.slice(-1)[0];
+            let lastval = values.slice(-1)[0] || 0;
             return (
               <svg className="sparkline" width={this.state.width} height={this.state.height} overflow="visible">
                 <rect width={this.state.width} height={this.state.height} fill={'#EEE'}/>

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -29,7 +29,7 @@ logger = logging.getLogger('snuba.util')
 NESTED_COL_EXPR_RE = re.compile('^(tags|contexts)\[([a-zA-Z0-9_\.:-]+)\]$')
 
 # example partition name: "('2018-03-13 00:00:00', 90)"
-PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2})', (\d+)\)")
+PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2})',\s*(\d+)\)")
 DATE_TYPE_RE = re.compile(r'(Nullable\()?Date\b')
 DATETIME_TYPE_RE = re.compile(r'(Nullable\()?DateTime\b')
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -1,7 +1,7 @@
 from flask import request
 
 from clickhouse_driver.errors import Error as ClickHouseError
-from collections import OrderedDict
+from collections import namedtuple, OrderedDict
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
 from dateutil.parser import parse as dateutil_parse
@@ -414,7 +414,7 @@ def raw_query(body, sql, client, timer, stats=None):
     project_id = project_ids[0] if project_ids else 0  # TODO rate limit on every project in the list?
     stats = stats or {}
     grl, gcl, prl, pcl, use_cache, uc_max = state.get_configs([
-        ('global_per_second_limit', 1000),
+        ('global_per_second_limit', None),
         ('global_concurrent_limit', 1000),
         ('project_per_second_limit', 1000),
         ('project_concurrent_limit', 1000),
@@ -531,17 +531,18 @@ def raw_query(body, sql, client, timer, stats=None):
 
                     else:
                         status = 429
+                        Reason = namedtuple('reason', 'scope name val limit')
                         reasons = [
-                            ('global', 'concurrent', g_concurr, gcl),
-                            ('global', 'per-second', g_rate, grl),
-                            ('project', 'concurrent', p_concurr, pcl),
-                            ('project', 'per-second', p_rate, prl)
+                            Reason('global', 'concurrent', g_concurr, gcl),
+                            Reason('global', 'per-second', g_rate, grl),
+                            Reason('project', 'concurrent', p_concurr, pcl),
+                            Reason('project', 'per-second', p_rate, prl)
                         ]
-                        reason = next((r for r in reasons if r[2] > r[3]), None)
+                        reason = next((r for r in reasons if r.limit is not None and r.val > r.limit), None)
                         result = {'error': {
                             'type': 'ratelimit',
                             'message': 'rate limit exceeded',
-                            'detail': reason and '{} {} of {:.0f} exceeds limit of {:.0f}'.format(*reason)
+                            'detail': reason and '{r.scope} {r.name} of {r.val:.0f} exceeds limit of {r.limit:.0f}'.format(r=reason)
                         }}
 
     stats.update(query_settings)


### PR DESCRIPTION
Also default the global rate limit to None so that we don't count it.
Global concurrent limit remains in effect.