### PR TITLE
fix: Don't use splitter for high offsets.

### DIFF
--- a/snuba/split.py
+++ b/snuba/split.py
@@ -37,6 +37,7 @@ def split_query(query_func):
         if (
             use_split and limit and not body.get('groupby')
             and orderby[:1] == ['-timestamp']
+            and remaining_offset < 1000
         ):
             overall_result = None
             split_end = to_date


### PR DESCRIPTION
With the current implementation of the splitter, we have to query
for limit+offset results and do the offset trimming ourselves in
memory. When people request high page numbers, we end up with some
very large datasets in memory, so this caps the offset at which we
will use the splitter.