### PR TITLE
feat: Add datasets class boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Snuba exposes an HTTP API (default port: `1218`) with the following endpoints.
 Settings are found in `settings.py`
 
 - `CLICKHOUSE_SERVER` : The endpoint for the clickhouse service.
-- `CLICKHOUSE_TABLE` : The clickhouse table name.
 - `REDIS_HOST` : The host redis is running on.
+- `DATASET_MODE` : If "local" runs Clickhouse local tables instead of distributed ones.
 
 ## Tests
 
@@ -61,7 +61,7 @@ Settings are found in `settings.py`
     export CLICKHOUSE_SERVER=127.0.0.1:9000
 
     make test
-    
+
 ## Testing Against Sentry
 
 ```
@@ -69,14 +69,14 @@ workon snuba
 git checkout your-snuba-branch
 snuba api
 ```
-And then in another terminal 
+And then in another terminal
 ```
 workon sentry
 git checkout master
 git pull
 sentry devservices up --exclude=snuba
 ```
-This will get the most recent version of Sentry on master, and bring up all snuba's dependencies. 
+This will get the most recent version of Sentry on master, and bring up all snuba's dependencies.
 
 You will want to run the following Sentry tests:
 ```

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -14,7 +14,8 @@ from snuba import schemas, settings, state, util
 from snuba.clickhouse import ClickhousePool
 from snuba.replacer import get_projects_query_flags
 from snuba.split import split_query
-
+from snuba.datasets.factory import get_dataset, get_enabled_dataset_names
+from snuba.datasets.schema import local_dataset_mode
 
 logger = logging.getLogger('snuba.api')
 logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL.upper()), format='%(asctime)s %(message)s')
@@ -40,7 +41,14 @@ else:
 
 def check_clickhouse():
     try:
-        return any(settings.CLICKHOUSE_TABLE == r[0] for r in clickhouse_ro.execute('show tables'))
+        clickhouse_tables = clickhouse_ro.execute('show tables')
+        for name in get_enabled_dataset_names():
+            dataset = get_dataset(name)
+            table_name = dataset.SCHEMA.get_table_name()
+            if (table_name,) not in clickhouse_tables:
+                return False
+        return True
+
     except Exception:
         return False
 
@@ -133,8 +141,6 @@ def health():
 @util.time_request('query')
 @util.validate_request(schemas.QUERY_SCHEMA)
 def query(validated_body=None, timer=None):
-    ensure_table_exists()
-
     if request.method == 'GET':
         query_template = schemas.generate(schemas.QUERY_SCHEMA)
         template_str = json.dumps(query_template, sort_keys=True, indent=4)
@@ -154,10 +160,15 @@ def query(validated_body=None, timer=None):
 @split_query
 def parse_and_run_query(validated_body, timer):
     body = deepcopy(validated_body)
+
+    name = body.get('dataset', settings.DEFAULT_DATASET_NAME)
+    dataset = get_dataset(name)
+    ensure_table_exists(dataset)
+    table = dataset.SCHEMA.get_table_name()
+
     turbo = body.get('turbo', False)
-    max_days, table, date_align, config_sample, force_final, max_group_ids_exclude = state.get_configs([
+    max_days, date_align, config_sample, force_final, max_group_ids_exclude = state.get_configs([
         ('max_days', None),
-        ('clickhouse_table', settings.CLICKHOUSE_TABLE),
         ('date_align_seconds', 1),
         ('sample', 1),
         # 1: always use FINAL, 0: never use final, undefined/None: use project setting.
@@ -176,8 +187,9 @@ def parse_and_run_query(validated_body, timer):
     where_conditions.extend([
         ('timestamp', '>=', from_date),
         ('timestamp', '<', to_date),
-        ('deleted', '=', 0),
     ])
+    where_conditions.extend(dataset.default_conditions(body))
+
     # NOTE: we rely entirely on the schema to make sure that regular snuba
     # queries are required to send a project_id filter. Some other special
     # internal query types do not require a project_id filter.
@@ -344,37 +356,40 @@ def sdk_distribution(validated_body, timer):
 if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
-    assert settings.CLICKHOUSE_TABLE in ('dev', 'test')
 
-    _ensured = False
+    _ensured = {}
 
-    def ensure_table_exists(force=False):
-        global _ensured
-
-        if not force and _ensured:
+    def ensure_table_exists(dataset, force=False):
+        if not force and _ensured.get(dataset, False):
             return
 
-        from snuba.clickhouse import get_table_definition, get_test_engine
+        assert local_dataset_mode(), "Cannot create table in distributed mode"
 
+        from snuba import migrate
+        migrate.rename_dev_table(clickhouse_rw)
+
+        from snuba.clickhouse import get_table_definition, get_test_engine
+        # We cannot build distributed tables this way. So this only works in local
+        # mode.
         clickhouse_rw.execute(
             get_table_definition(
-                name=settings.CLICKHOUSE_TABLE,
+                name=dataset.SCHEMA.get_local_table_name(),
                 engine=get_test_engine(),
             )
         )
 
-        if settings.CLICKHOUSE_TABLE == 'dev':
-            from snuba import migrate
-            migrate.run(clickhouse_rw, settings.CLICKHOUSE_TABLE)
+        migrate.run(clickhouse_rw, dataset.SCHEMA.get_table_name())
 
-        _ensured = True
+        _ensured[dataset] = True
 
     @application.route('/tests/insert', methods=['POST'])
     def write():
         from snuba.processor import process_message
         from snuba.writer import row_from_processed_event, write_rows
 
-        ensure_table_exists()
+        # TODO we need to make this work for multiple datasets
+        dataset = get_dataset('events')
+        ensure_table_exists(dataset)
         body = json.loads(request.data)
 
         rows = []
@@ -385,14 +400,18 @@ if application.debug or application.testing:
 
         write_rows(
             clickhouse_rw,
-            table=settings.CLICKHOUSE_TABLE,
+            table=dataset.SCHEMA.get_local_table_name(),
             rows=rows
         )
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
     @application.route('/tests/eventstream', methods=['POST'])
     def eventstream():
-        ensure_table_exists()
+        # TODO we need to make this work for multiple datasets
+        dataset = get_dataset('events')
+        ensure_table_exists(dataset)
+        table = dataset.SCHEMA.get_local_table_name()
+
         record = json.loads(request.data)
 
         version = record[0]
@@ -417,10 +436,10 @@ if application.debug or application.testing:
         type_ = record[1]
         if type_ == 'insert':
             from snuba.consumer import ConsumerWorker
-            worker = ConsumerWorker(clickhouse_rw, settings.CLICKHOUSE_TABLE, producer=None, replacements_topic=None)
+            worker = ConsumerWorker(clickhouse_rw, table, producer=None, replacements_topic=None)
         else:
             from snuba.replacer import ReplacerWorker
-            worker = ReplacerWorker(clickhouse_rw, settings.CLICKHOUSE_TABLE)
+            worker = ReplacerWorker(clickhouse_rw, table)
 
         processed = worker.process_message(message)
         if processed is not None:
@@ -431,13 +450,16 @@ if application.debug or application.testing:
 
     @application.route('/tests/drop', methods=['POST'])
     def drop():
-        clickhouse_rw.execute("DROP TABLE IF EXISTS %s" % settings.CLICKHOUSE_TABLE)
-        ensure_table_exists(force=True)
+        dataset = get_dataset('events')
+        table = dataset.SCHEMA.get_local_table_name()
+
+        clickhouse_rw.execute("DROP TABLE IF EXISTS %s" % table)
+        ensure_table_exists(dataset, force=True)
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
     @application.route('/tests/error')
     def error():
         1 / 0
 else:
-    def ensure_table_exists():
+    def ensure_table_exists(dataset, force=False):
         pass

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -4,6 +4,7 @@ import sys
 import click
 
 from snuba import settings
+from snuba.datasets.factory import get_dataset
 
 
 @click.command()
@@ -13,12 +14,15 @@ from snuba import settings
               help="If true, only print which partitions would be dropped.")
 @click.option('--database', default='default',
               help='Name of the database to target.')
-@click.option('--table', default=settings.DEFAULT_LOCAL_TABLE,
-              help='Name of the table to target.')
+@click.option('--dataset', default='events', type=click.Choice(['events']),
+              help='The dataset to target')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def cleanup(clickhouse_server, dry_run, database, table, log_level):
+def cleanup(clickhouse_server, dry_run, database, dataset, log_level):
     from snuba.cleanup import run_cleanup, logger
     from snuba.clickhouse import ClickhousePool
+
+    dataset = get_dataset(dataset)
+    table = dataset.SCHEMA.get_local_table_name()
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -4,17 +4,20 @@ import click
 from clickhouse_driver import Client
 
 from snuba import settings
+from snuba.datasets.factory import get_dataset
+from snuba.datasets.schema import local_dataset_mode
 
 
 @click.command()
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
 def migrate(log_level):
     from snuba.migrate import logger, run
-
+    # TODO: this only supports one dataset so far. More work is needed for the others.
+    dataset = get_dataset('events')
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
-    if settings.CLICKHOUSE_TABLE != 'dev':
-        logger.error("The migration tool is only intended for local development environment.")
+    if not local_dataset_mode():
+        logger.error("The migration tool can only work on local dataset mode.")
         sys.exit(1)
 
     host, port = settings.CLICKHOUSE_SERVER.split(':')
@@ -23,4 +26,5 @@ def migrate(log_level):
         port=port,
     )
 
-    run(clickhouse, settings.CLICKHOUSE_TABLE)
+    table = dataset.SCHEMA.get_local_table_name()
+    run(clickhouse, table)

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -3,7 +3,8 @@ import sys
 
 import click
 
-from snuba import settings
+from snuba import settings, datasets
+from snuba.datasets.factory import get_dataset
 
 
 @click.command()
@@ -11,17 +12,20 @@ from snuba import settings
               help='Clickhouse server to optimize.')
 @click.option('--database', default='default',
               help='Name of the database to target.')
-@click.option('--table', default=settings.DEFAULT_LOCAL_TABLE,
-              help='Name of the table to target.')
+@click.option('--dataset', default='events', type=click.Choice(['events']),
+              help='The dataset to target')
 @click.option('--timeout', default=10000, type=int,
               help='Clickhouse connection send/receive timeout, must be long enough for OPTIMIZE to complete.')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def optimize(clickhouse_server, database, table, timeout, log_level):
+def optimize(clickhouse_server, database, dataset, timeout, log_level):
     from datetime import datetime
     from snuba.clickhouse import ClickhousePool
     from snuba.optimize import run_optimize, logger
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
+
+    dataset = get_dataset(dataset)
+    table = dataset.SCHEMA.get_local_table_name()
 
     if not clickhouse_server:
         logger.error("Must provide at least one Clickhouse server.")

--- a/snuba/cli/perf.py
+++ b/snuba/cli/perf.py
@@ -19,6 +19,8 @@ import click
 import sys
 
 from snuba import settings
+from snuba.datasets.factory import get_dataset
+from snuba.datasets.schema import local_dataset_mode
 
 
 @click.command()
@@ -30,18 +32,21 @@ from snuba import settings
               default=False, help='Whether or not to profile writing.')
 @click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
               help='Clickhouse server to run perf against.')
-@click.option('--table-name', default='perf', help='Table name to use for inserts.')
+@click.option('--dataset', default='events', type=click.Choice(['events']),
+              help='The dataset to consume/run replacements for (currently only events supported)')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def perf(events_file, repeat, profile_process, profile_write, clickhouse_server, table_name, log_level):
+def perf(events_file, repeat, profile_process, profile_write, clickhouse_server, dataset, log_level):
     from snuba.clickhouse import ClickhousePool
     from snuba.perf import run, logger
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
-    if settings.CLICKHOUSE_TABLE != 'dev':
-        logger.error("The migration tool is only intended for local development environment.")
+    dataset = get_dataset(dataset)
+    if not local_dataset_mode():
+        logger.error("The perf tool is only intended for local dataset environment.")
         sys.exit(1)
 
+    table_name = dataset.SCHEMA.get_table_name()
     clickhouse = ClickhousePool(clickhouse_server.split(':')[0], port=int(clickhouse_server.split(':')[1]))
     run(
         events_file, clickhouse, table_name,

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -5,9 +5,7 @@ import time
 from six.moves import queue, range
 
 from clickhouse_driver import Client, errors
-
 from snuba import settings
-
 
 logger = logging.getLogger('snuba.clickhouse')
 
@@ -325,6 +323,7 @@ class ColumnSet(object):
     * `for_schema()` can be used to generate valid ClickHouse column names
       and types for a table schema.
     """
+
     def __init__(self, columns):
         self.columns = Column.to_columns(columns)
 
@@ -600,20 +599,21 @@ def get_distributed_engine(cluster, database, local_table,
     }
 
 
-def get_local_table_definition():
+def get_local_table_definition(dataset):
+    table = dataset.SCHEMA.get_local_table_name()
     return get_table_definition(
-        settings.DEFAULT_LOCAL_TABLE, get_replicated_engine(name=settings.DEFAULT_LOCAL_TABLE)
+        table, get_replicated_engine(name=table)
     )
 
 
-def get_dist_table_definition():
+def get_dist_table_definition(dataset):
     assert settings.CLICKHOUSE_CLUSTER, "CLICKHOUSE_CLUSTER is not set."
 
     return get_table_definition(
-        settings.DEFAULT_DIST_TABLE,
+        dataset.SCHEMA.get_table_name(),
         get_distributed_engine(
             cluster=settings.CLICKHOUSE_CLUSTER,
             database='default',
-            local_table=settings.DEFAULT_LOCAL_TABLE,
+            local_table=dataset.SCHEMA.get_local_table_name(),
         )
     )

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -1,0 +1,18 @@
+class DataSet(object):
+    """
+    A DataSet defines the complete set of data sources, schemas, and
+    transformations that are required to:
+        - Consume, transform, and insert data payloads from Kafka into Clickhouse.
+        - Define how Snuba API queries are transformed into SQL.
+
+    This is the the initial boilerplate. schema and processor will come.
+    """
+
+    SCHEMA = None
+
+    def default_conditions(self, body):
+        """
+        Return a list of the default conditions that should be applied to all
+        queries on this dataset.
+        """
+        return []

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,0 +1,18 @@
+from snuba.datasets import DataSet
+from snuba.datasets.schema import TableSchema
+
+
+class EventsDataSet(DataSet):
+    """
+    Represents the collection of classic sentry "error" type events
+    and the particular quirks of storing and querying them.
+    """
+
+    SCHEMA = TableSchema(
+        local_table_name='sentry_local',
+        dist_table_name='sentry_dist')
+
+    def default_conditions(self, body):
+        return [
+            ('deleted', '=', 0),
+        ]

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -1,0 +1,22 @@
+from snuba import settings
+from snuba.datasets.events import EventsDataSet
+
+DATASETS_IMPL = {}
+
+DATASETS_MAPPING = {
+    'events': EventsDataSet,
+}
+
+
+def get_dataset(name):
+    if name in DATASETS_IMPL:
+        return DATASETS_IMPL[name]
+
+    assert name not in settings.DISABLED_DATASETS, "Dataset %s not available in this environment" % name
+
+    dataset = DATASETS_IMPL[name] = DATASETS_MAPPING[name]()
+    return dataset
+
+
+def get_enabled_dataset_names():
+    return [name for name in DATASETS_MAPPING.keys() if name not in settings.DISABLED_DATASETS]

--- a/snuba/datasets/schema.py
+++ b/snuba/datasets/schema.py
@@ -1,0 +1,36 @@
+from snuba import settings
+
+
+def local_dataset_mode():
+    return settings.DATASET_MODE == "local"
+
+
+class TableSchema(object):
+    """
+    Represents the full set of columns in a clickhouse table, this only contains
+    basic metadata for now. The code to generate the schema comes in a followup PR.
+    """
+
+    TEST_TABLE_PREFIX = "test_"
+
+    def __init__(self, local_table_name, dist_table_name):
+        self.__local_table_name = local_table_name
+        self.__dist_table_name = dist_table_name
+
+    def __make_test_table(self, table_name):
+        return table_name if not settings.TESTING else "%s%s" % (self.TEST_TABLE_PREFIX, table_name)
+
+    def get_local_table_name(self):
+        """
+        This returns the local table name for a distributed environment.
+        It is supposed to be used in DDL commands and for maintenance.
+        """
+        return self.__make_test_table(self.__local_table_name)
+
+    def get_table_name(self):
+        """
+        This represents the table we interact with to send queries to Clickhouse.
+        In distributed mode this will be a distributed table. In local mode it is a local table.
+        """
+        table_name = self.__local_table_name if local_dataset_mode() else self.__dist_table_name
+        return self.__make_test_table(table_name)

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -68,3 +68,12 @@ def run(conn, clickhouse_table):
                 expected_type,
                 column_type
             )
+
+
+def rename_dev_table(conn):
+    # Migrate from the old events table to the new one if needed
+    from snuba.datasets.factory import get_dataset
+    local_table = get_dataset('events').SCHEMA.get_local_table_name()
+    clickhouse_tables = conn.execute('show tables')
+    if not (local_table,) in clickhouse_tables and ("dev",) in clickhouse_tables:
+        conn.execute("RENAME TABLE dev TO %s" % local_table)

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+from snuba import settings
+from snuba.datasets import factory
 import jsonschema
 import copy
 import six
@@ -37,6 +39,9 @@ SDK_STATS_SCHEMA = {
 QUERY_SCHEMA = {
     'type': 'object',
     'properties': {
+        'dataset': {
+            'enum': list(factory.DATASETS_MAPPING.keys()),
+        },
         # A condition is a 3-tuple of (column, operator, literal)
         # `conditions` is an array of conditions, or an array of arrays of conditions.
         # Conditions at the the top level are ANDed together.

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -1,4 +1,5 @@
 import os
+import six
 
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
 
@@ -7,10 +8,13 @@ DEBUG = True
 
 PORT = 1218
 
+DEFAULT_DATASET_NAME = 'events'
+DISABLED_DATASETS = {}
+DATASET_MODE = 'local'
+
 # Clickhouse Options
 CLICKHOUSE_SERVER = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000')
 CLICKHOUSE_CLUSTER = None
-CLICKHOUSE_TABLE = 'dev'
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # Dogstatsd Options
@@ -73,10 +77,7 @@ DEFAULT_ORDER_BY = '(project_id, toStartOfDay(timestamp), %s)' % DEFAULT_SAMPLE_
 DEFAULT_PARTITION_BY = '(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))'
 DEFAULT_VERSION_COLUMN = 'deleted'
 DEFAULT_SHARDING_KEY = 'cityHash64(toString(event_id))'
-DEFAULT_LOCAL_TABLE = 'sentry_local'
-DEFAULT_DIST_TABLE = 'sentry_dist'
 DEFAULT_RETENTION_DAYS = 90
-
 RETENTION_OVERRIDES = {}
 
 # the list of keys that will upgrade from a WHERE condition to a PREWHERE

--- a/snuba/settings_docker.py
+++ b/snuba/settings_docker.py
@@ -6,10 +6,6 @@ env = os.environ.get
 DEBUG = env('DEBUG', '0').lower() in ('1', 'true')
 
 CLICKHOUSE_SERVER = env('CLICKHOUSE_SERVER', 'localhost:9000')
-CLICKHOUSE_TABLE = env('CLICKHOUSE_TABLE', 'sentry')
-DEFAULT_DIST_TABLE = CLICKHOUSE_TABLE
-DEFAULT_LOCAL_TABLE = CLICKHOUSE_TABLE
-
 
 DEFAULT_BROKERS = env('DEFAULT_BROKERS', 'localhost:9092').split(',')
 

--- a/snuba/settings_test.py
+++ b/snuba/settings_test.py
@@ -1,7 +1,7 @@
 from snuba.settings_base import *  # NOQA
 
 TESTING = True
-CLICKHOUSE_TABLE = 'test'
+
 REDIS_DB = 2
 STATS_IN_RESPONSE = True
 CONFIG_MEMOIZE_TIMEOUT = 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,8 @@ import six
 import time
 import uuid
 
-from snuba import processor, settings, state
+from snuba import processor, settings, state, datasets
+from snuba.datasets.factory import get_dataset
 
 from base import BaseTest
 
@@ -802,8 +803,9 @@ class TestApi(BaseTest):
         assert result['data'] == []
 
         assert self.app.post('/tests/drop').status_code == 200
-
-        assert settings.CLICKHOUSE_TABLE not in self.clickhouse.execute("SHOW TABLES")
+        dataset = get_dataset('events')
+        table = dataset.SCHEMA.get_table_name()
+        assert table not in self.clickhouse.execute("SHOW TABLES")
 
     @pytest.mark.xfail
     def test_row_stats(self):


### PR DESCRIPTION
This is the second step to merge https://github.com/getsentry/snuba/pull/294

It introduce the dataset class. The only responsibility of this class in this pull request is to carry the table names for each dataset. Which means that table names are not resolved from settings anymore but from the dataset classes. The dataset class itself is defined in settings.

**Proposed rollout plan**
- update the production settings file by adding the new DATASETS field (without removing anything for backward compatibility.
- we do not pass the table name to scripts in production thus no need to change anything there.
- Rollout only a consumer or a replacer first. It would be backward compatible with api and will use the new code so we can see how it works in prod.
- When we are happy rollout the api
- remove the old fields from production settings.

** Test plan **
- all unit tests in the snuba codebase pass
- all snuba unit tests in sentry pass (these include dropping and rebuilding the table)
- bootstrapped snuba dev environment from scratch. Bot hthe database and the new dev table were built successfully both when calling the bootstrap script manually and with docker.
- test every script locally: consumer, replacer, migrate, bootstrap, perf, cleanup