### PR TITLE
feat: Move dataset ddl to the Dataset abstraction

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -368,14 +368,13 @@ if application.debug or application.testing:
         from snuba import migrate
         migrate.rename_dev_table(clickhouse_rw)
 
-        from snuba.clickhouse import get_table_definition, get_test_engine
         # We cannot build distributed tables this way. So this only works in local
         # mode.
         clickhouse_rw.execute(
             dataset.get_schema().get_local_table_definition()
         )
 
-        migrate.run(clickhouse_rw, dataset.get_schema().get_table_name())
+        migrate.run(clickhouse_rw, dataset.get_schema().get_local_table_name())
 
         _ensured[dataset] = True
 

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -356,38 +356,25 @@ def sdk_distribution(validated_body, timer):
 if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
-<<<<<<< HEAD
 
     _ensured = {}
 
-=======
-
-    _ensured = {}
-
->>>>>>> 91b46a123287dfbae35276d5f80f6a939205fd27
     def ensure_table_exists(dataset, force=False):
         if not force and _ensured.get(dataset, False):
             return
 
         assert local_dataset_mode(), "Cannot create table in distributed mode"
-<<<<<<< HEAD
 
         from snuba import migrate
         migrate.rename_dev_table(clickhouse_rw)
 
         from snuba.clickhouse import get_table_definition, get_test_engine
-=======
->>>>>>> 91b46a123287dfbae35276d5f80f6a939205fd27
         # We cannot build distributed tables this way. So this only works in local
         # mode.
         clickhouse_rw.execute(
             dataset.get_schema().get_local_table_definition()
         )
 
-<<<<<<< HEAD
-=======
-        from snuba import migrate
->>>>>>> 91b46a123287dfbae35276d5f80f6a939205fd27
         migrate.run(clickhouse_rw, dataset.get_schema().get_table_name())
 
         _ensured[dataset] = True

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -44,7 +44,7 @@ def check_clickhouse():
         clickhouse_tables = clickhouse_ro.execute('show tables')
         for name in get_enabled_dataset_names():
             dataset = get_dataset(name)
-            table_name = dataset.SCHEMA.get_table_name()
+            table_name = dataset.get_schema().get_table_name()
             if (table_name,) not in clickhouse_tables:
                 return False
         return True
@@ -164,7 +164,7 @@ def parse_and_run_query(validated_body, timer):
     name = body.get('dataset', settings.DEFAULT_DATASET_NAME)
     dataset = get_dataset(name)
     ensure_table_exists(dataset)
-    table = dataset.SCHEMA.get_table_name()
+    table = dataset.get_schema().get_table_name()
 
     turbo = body.get('turbo', False)
     max_days, date_align, config_sample, force_final, max_group_ids_exclude = state.get_configs([
@@ -372,13 +372,10 @@ if application.debug or application.testing:
         # We cannot build distributed tables this way. So this only works in local
         # mode.
         clickhouse_rw.execute(
-            get_table_definition(
-                name=dataset.SCHEMA.get_local_table_name(),
-                engine=get_test_engine(),
-            )
+            dataset.get_schema().get_local_table_definition()
         )
 
-        migrate.run(clickhouse_rw, dataset.SCHEMA.get_table_name())
+        migrate.run(clickhouse_rw, dataset.get_schema().get_table_name())
 
         _ensured[dataset] = True
 
@@ -400,7 +397,7 @@ if application.debug or application.testing:
 
         write_rows(
             clickhouse_rw,
-            table=dataset.SCHEMA.get_local_table_name(),
+            table=dataset.get_schema().get_table_name(),
             rows=rows
         )
         return ('ok', 200, {'Content-Type': 'text/plain'})
@@ -410,7 +407,7 @@ if application.debug or application.testing:
         # TODO we need to make this work for multiple datasets
         dataset = get_dataset('events')
         ensure_table_exists(dataset)
-        table = dataset.SCHEMA.get_local_table_name()
+        table = dataset.get_schema().get_table_name()
 
         record = json.loads(request.data)
 
@@ -451,7 +448,7 @@ if application.debug or application.testing:
     @application.route('/tests/drop', methods=['POST'])
     def drop():
         dataset = get_dataset('events')
-        table = dataset.SCHEMA.get_local_table_name()
+        table = dataset.get_schema().get_table_name()
 
         clickhouse_rw.execute("DROP TABLE IF EXISTS %s" % table)
         ensure_table_exists(dataset, force=True)

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -396,7 +396,7 @@ if application.debug or application.testing:
 
         write_rows(
             clickhouse_rw,
-            table=dataset.get_schema().get_table_name(),
+            table=dataset.get_schema().get_local_table_name(),
             rows=rows
         )
         return ('ok', 200, {'Content-Type': 'text/plain'})
@@ -406,7 +406,7 @@ if application.debug or application.testing:
         # TODO we need to make this work for multiple datasets
         dataset = get_dataset('events')
         ensure_table_exists(dataset)
-        table = dataset.get_schema().get_table_name()
+        table = dataset.get_schema().get_local_table_name()
 
         record = json.loads(request.data)
 
@@ -447,7 +447,7 @@ if application.debug or application.testing:
     @application.route('/tests/drop', methods=['POST'])
     def drop():
         dataset = get_dataset('events')
-        table = dataset.get_schema().get_table_name()
+        table = dataset.get_schema().get_local_table_name()
 
         clickhouse_rw.execute("DROP TABLE IF EXISTS %s" % table)
         ensure_table_exists(dataset, force=True)

--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -63,13 +63,10 @@ def bootstrap(bootstrap_server, kafka, force):
     # Need to better figure out if we are configured to use replicated
     # tables or distributed tables, etc.
 
-<<<<<<< HEAD
     # Migrate from the old table to the new one if needed
     from snuba import migrate
     migrate.rename_dev_table(ClickhousePool())
 
-=======
->>>>>>> 91b46a123287dfbae35276d5f80f6a939205fd27
     # For now just create the table for every dataset.
     for name in DATASETS_MAPPING.keys():
         dataset = get_dataset(name)

--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -46,7 +46,7 @@ def bootstrap(bootstrap_server, kafka, force):
             except Exception as e:
                 print("Failed to create topic %s: %s" % (topic, e))
 
-    from snuba.clickhouse import ClickhousePool, get_table_definition, get_test_engine
+    from snuba.clickhouse import ClickhousePool
 
     attempts = 0
     while True:
@@ -70,9 +70,4 @@ def bootstrap(bootstrap_server, kafka, force):
     # For now just create the table for every dataset.
     for name in DATASETS_MAPPING.keys():
         dataset = get_dataset(name)
-        ClickhousePool().execute(
-            get_table_definition(
-                dataset.SCHEMA.get_table_name(),
-                get_test_engine(),
-            )
-        )
+        ClickhousePool().execute(dataset.get_schema().get_local_table_definition())

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -22,7 +22,7 @@ def cleanup(clickhouse_server, dry_run, database, dataset, log_level):
     from snuba.clickhouse import ClickhousePool
 
     dataset = get_dataset(dataset)
-    table = dataset.SCHEMA.get_local_table_name()
+    table = dataset.get_schema().get_table_name()
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -22,7 +22,7 @@ def cleanup(clickhouse_server, dry_run, database, dataset, log_level):
     from snuba.clickhouse import ClickhousePool
 
     dataset = get_dataset(dataset)
-    table = dataset.get_schema().get_table_name()
+    table = dataset.get_schema().get_local_table_name()
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -65,7 +65,7 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     )
 
     dataset = get_dataset(dataset)
-    table = dataset.SCHEMA.get_table_name()
+    table = dataset.get_schema().get_table_name()
 
     producer = Producer({
         'bootstrap.servers': ','.join(bootstrap_server),

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -26,5 +26,5 @@ def migrate(log_level):
         port=port,
     )
 
-    table = dataset.SCHEMA.get_local_table_name()
+    table = dataset.get_schema().get_local_table_name()
     run(clickhouse, table)

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -25,7 +25,7 @@ def optimize(clickhouse_server, database, dataset, timeout, log_level):
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     dataset = get_dataset(dataset)
-    table = dataset.SCHEMA.get_local_table_name()
+    table = dataset.get_schema().get_table_name()
 
     if not clickhouse_server:
         logger.error("Must provide at least one Clickhouse server.")

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -25,7 +25,7 @@ def optimize(clickhouse_server, database, dataset, timeout, log_level):
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     dataset = get_dataset(dataset)
-    table = dataset.get_schema().get_table_name()
+    table = dataset.get_schema().get_local_table_name()
 
     if not clickhouse_server:
         logger.error("Must provide at least one Clickhouse server.")

--- a/snuba/cli/perf.py
+++ b/snuba/cli/perf.py
@@ -46,9 +46,8 @@ def perf(events_file, repeat, profile_process, profile_write, clickhouse_server,
         logger.error("The perf tool is only intended for local dataset environment.")
         sys.exit(1)
 
-    table_name = dataset.SCHEMA.get_table_name()
     clickhouse = ClickhousePool(clickhouse_server.split(':')[0], port=int(clickhouse_server.split(':')[1]))
     run(
-        events_file, clickhouse, table_name,
+        events_file, clickhouse, dataset,
         repeat=repeat, profile_process=profile_process, profile_write=profile_write
     )

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -69,7 +69,7 @@ def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_se
 
     replacer = BatchingKafkaConsumer(
         replacements_topic,
-        worker=ReplacerWorker(clickhouse, dataset.SCHEMA.get_table_name(), metrics=metrics),
+        worker=ReplacerWorker(clickhouse, dataset.get_schema().get_table_name(), metrics=metrics),
         max_batch_size=max_batch_size,
         max_batch_time=max_batch_time_ms,
         metrics=metrics,

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -374,246 +374,77 @@ class ColumnSet(object):
         return ', '.join(column.for_schema() for column in self.columns)
 
 
-METADATA_COLUMNS = ColumnSet([
-    # optional stream related data
-    ('offset', Nullable(UInt(64))),
-    ('partition', Nullable(UInt(16))),
-])
+# These functions are temporary and are used to help the migraiton of the DDL to
+# the dataset abstractions. Please do not introduce dependencies on them.
+# We need them right now because there is plenty of code that depends on the DDL of the
+# default dataset but that does not have access to the dataset object.
 
-PROMOTED_TAG_COLUMNS = ColumnSet([
-    # These are the classic tags, they are saved in Snuba exactly as they
-    # appear in the event body.
-    ('level', Nullable(String())),
-    ('logger', Nullable(String())),
-    ('server_name', Nullable(String())),  # future name: device_id?
-    ('transaction', Nullable(String())),
-    ('environment', Nullable(String())),
-    ('sentry:release', Nullable(String())),
-    ('sentry:dist', Nullable(String())),
-    ('sentry:user', Nullable(String())),
-    ('site', Nullable(String())),
-    ('url', Nullable(String())),
-])
-
-PROMOTED_CONTEXT_TAG_COLUMNS = ColumnSet([
-    # These are promoted tags that come in in `tags`, but are more closely
-    # related to contexts.  To avoid naming confusion with Clickhouse nested
-    # columns, they are stored in the database with s/./_/
-    # promoted tags
-    ('app_device', Nullable(String())),
-    ('device', Nullable(String())),
-    ('device_family', Nullable(String())),
-    ('runtime', Nullable(String())),
-    ('runtime_name', Nullable(String())),
-    ('browser', Nullable(String())),
-    ('browser_name', Nullable(String())),
-    ('os', Nullable(String())),
-    ('os_name', Nullable(String())),
-    ('os_rooted', Nullable(UInt(8))),
-])
-
-PROMOTED_CONTEXT_COLUMNS = ColumnSet([
-    ('os_build', Nullable(String())),
-    ('os_kernel_version', Nullable(String())),
-    ('device_name', Nullable(String())),
-    ('device_brand', Nullable(String())),
-    ('device_locale', Nullable(String())),
-    ('device_uuid', Nullable(String())),
-    ('device_model_id', Nullable(String())),
-    ('device_arch', Nullable(String())),
-    ('device_battery_level', Nullable(Float(32))),
-    ('device_orientation', Nullable(String())),
-    ('device_simulator', Nullable(UInt(8))),
-    ('device_online', Nullable(UInt(8))),
-    ('device_charging', Nullable(UInt(8))),
-])
-
-REQUIRED_COLUMNS = ColumnSet([
-    ('event_id', FixedString(32)),
-    ('project_id', UInt(64)),
-    ('group_id', UInt(64)),
-    ('timestamp', DateTime()),
-    ('deleted', UInt(8)),
-    ('retention_days', UInt(16)),
-])
-
-ALL_COLUMNS = REQUIRED_COLUMNS + [
-    # required for non-deleted
-    ('platform', Nullable(String())),
-    ('message', Nullable(String())),
-    ('primary_hash', Nullable(FixedString(32))),
-    ('received', Nullable(DateTime())),
-
-    ('search_message', Nullable(String())),
-    ('title', Nullable(String())),
-    ('location', Nullable(String())),
-
-    # optional user
-    ('user_id', Nullable(String())),
-    ('username', Nullable(String())),
-    ('email', Nullable(String())),
-    ('ip_address', Nullable(String())),
-
-    # optional geo
-    ('geo_country_code', Nullable(String())),
-    ('geo_region', Nullable(String())),
-    ('geo_city', Nullable(String())),
-
-    ('sdk_name', Nullable(String())),
-    ('sdk_version', Nullable(String())),
-    ('type', Nullable(String())),
-    ('version', Nullable(String())),
-] + METADATA_COLUMNS \
-  + PROMOTED_CONTEXT_COLUMNS \
-  + PROMOTED_TAG_COLUMNS \
-  + PROMOTED_CONTEXT_TAG_COLUMNS \
-  + [
-    # other tags
-    ('tags', Nested([
-        ('key', String()),
-        ('value', String()),
-    ])),
-
-    # other context
-    ('contexts', Nested([
-        ('key', String()),
-        ('value', String()),
-    ])),
-
-    # interfaces
-
-    # http interface
-    ('http_method', Nullable(String())),
-    ('http_referer', Nullable(String())),
-
-    # exception interface
-    ('exception_stacks', Nested([
-        ('type', Nullable(String())),
-        ('value', Nullable(String())),
-        ('mechanism_type', Nullable(String())),
-        ('mechanism_handled', Nullable(UInt(8))),
-    ])),
-    ('exception_frames', Nested([
-        ('abs_path', Nullable(String())),
-        ('filename', Nullable(String())),
-        ('package', Nullable(String())),
-        ('module', Nullable(String())),
-        ('function', Nullable(String())),
-        ('in_app', Nullable(UInt(8))),
-        ('colno', Nullable(UInt(32))),
-        ('lineno', Nullable(UInt(32))),
-        ('stack_level', UInt(16)),
-    ])),
-
-    # These are columns we added later in the life of the (current) production
-    # database. They don't necessarily belong here in a logical/readability sense
-    # but they are here to match the order of columns in production becase
-    # `insert_distributed_sync` is very sensitive to column existence and ordering.
-    ('culprit', Nullable(String())),
-    ('sdk_integrations', Array(String())),
-    ('modules', Nested([
-        ('name', String()),
-        ('version', String()),
-    ])),
-]
-
-# The set of columns, and associated keys that have been promoted
-# to the top level table namespace.
-PROMOTED_COLS = {
-    'tags': frozenset(col.flattened for col in (PROMOTED_TAG_COLUMNS + PROMOTED_CONTEXT_TAG_COLUMNS)),
-    'contexts': frozenset(col.flattened for col in PROMOTED_CONTEXT_COLUMNS),
-}
-
-# For every applicable promoted column,  a map of translations from the column
-# name  we save in the database to the tag we receive in the query.
-COLUMN_TAG_MAP = {
-    'tags': {col.flattened: col.flattened.replace('_', '.') for col in PROMOTED_CONTEXT_TAG_COLUMNS},
-    'contexts': {},
-}
-
-# And a reverse map from the tags the client expects to the database columns
-TAG_COLUMN_MAP = {
-    col: dict(map(reversed, trans.items())) for col, trans in COLUMN_TAG_MAP.items()
-}
-
-# The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
-# and they can/will use a promoted column.
-PROMOTED_TAGS = {
-    col: [COLUMN_TAG_MAP[col].get(x, x) for x in PROMOTED_COLS[col]]
-    for col in PROMOTED_COLS
-}
+def get_metadata_columns():
+    from snuba.datasets.factory import get_dataset
+    dataset = get_dataset("events")
+    return dataset.get_metadata_columns()
 
 
-def get_table_definition(name, engine, columns=ALL_COLUMNS):
-    return """
-    CREATE TABLE IF NOT EXISTS %(name)s (%(columns)s) ENGINE = %(engine)s""" % {
-        'columns': columns.for_schema(),
-        'engine': engine,
-        'name': name,
+def get_promoted_tag_columns():
+    from snuba.datasets.factory import get_dataset
+    dataset = get_dataset("events")
+    return dataset.get_promoted_tag_columns()
+
+
+def get_promoted_context_tag_columns():
+    from snuba.datasets.factory import get_dataset
+    dataset = get_dataset("events")
+    return dataset.get_promoted_context_tag_columns()
+
+
+def get_promoted_context_columns():
+    from snuba.datasets.factory import get_dataset
+    dataset = get_dataset("events")
+    return dataset.get_promoted_context_columns()
+
+
+def get_all_columns():
+    from snuba.datasets.factory import get_dataset
+    dataset = get_dataset("events")
+    return dataset.get_schema().get_all_columns()
+
+
+def get_required_columns():
+    from snuba.datasets.factory import get_dataset
+    dataset = get_dataset("events")
+    return dataset.get_required_columns()
+
+
+def get_promoted_cols():
+    # The set of columns, and associated keys that have been promoted
+    # to the top level table namespace.
+
+    return {
+        'tags': frozenset(col.flattened for col in (get_promoted_tag_columns() + get_promoted_context_tag_columns())),
+        'contexts': frozenset(col.flattened for col in get_promoted_context_columns()),
     }
 
 
-def get_test_engine(
-        order_by=settings.DEFAULT_ORDER_BY,
-        partition_by=settings.DEFAULT_PARTITION_BY,
-        version_column=settings.DEFAULT_VERSION_COLUMN,
-        sample_expr=settings.DEFAULT_SAMPLE_EXPR):
-    return """
-        ReplacingMergeTree(%(version_column)s)
-        PARTITION BY %(partition_by)s
-        ORDER BY %(order_by)s
-        SAMPLE BY %(sample_expr)s ;""" % {
-        'order_by': settings.DEFAULT_ORDER_BY,
-        'partition_by': settings.DEFAULT_PARTITION_BY,
-        'version_column': settings.DEFAULT_VERSION_COLUMN,
-        'sample_expr': settings.DEFAULT_SAMPLE_EXPR,
+def get_column_tag_map():
+    # For every applicable promoted column,  a map of translations from the column
+    # name  we save in the database to the tag we receive in the query.
+    return {
+        'tags': {col.flattened: col.flattened.replace('_', '.') for col in get_promoted_context_tag_columns()},
+        'contexts': {},
     }
 
 
-def get_replicated_engine(
-        name,
-        order_by=settings.DEFAULT_ORDER_BY,
-        partition_by=settings.DEFAULT_PARTITION_BY,
-        version_column=settings.DEFAULT_VERSION_COLUMN,
-        sample_expr=settings.DEFAULT_SAMPLE_EXPR):
-    return """
-        ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/%(name)s', '{replica}', %(version_column)s)
-        PARTITION BY %(partition_by)s
-        ORDER BY %(order_by)s
-        SAMPLE BY %(sample_expr)s;""" % {
-        'name': name,
-        'order_by': order_by,
-        'partition_by': partition_by,
-        'version_column': version_column,
-        'sample_expr': sample_expr,
+def get_tag_column_map():
+    # And a reverse map from the tags the client expects to the database columns
+    return {
+        col: dict(map(reversed, trans.items())) for col, trans in get_column_tag_map().items()
     }
 
 
-def get_distributed_engine(cluster, database, local_table,
-                           sharding_key=settings.DEFAULT_SHARDING_KEY):
-    return """Distributed(%(cluster)s, %(database)s, %(local_table)s, %(sharding_key)s);""" % {
-        'cluster': cluster,
-        'database': database,
-        'local_table': local_table,
-        'sharding_key': sharding_key,
+def get_promoted_tags():
+    # The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
+    # and they can/will use a promoted column.
+    return {
+        col: [get_column_tag_map()[col].get(x, x) for x in get_promoted_cols()[col]]
+        for col in get_promoted_cols()
     }
-
-
-def get_local_table_definition(dataset):
-    table = dataset.SCHEMA.get_local_table_name()
-    return get_table_definition(
-        table, get_replicated_engine(name=table)
-    )
-
-
-def get_dist_table_definition(dataset):
-    assert settings.CLICKHOUSE_CLUSTER, "CLICKHOUSE_CLUSTER is not set."
-
-    return get_table_definition(
-        dataset.SCHEMA.get_table_name(),
-        get_distributed_engine(
-            cluster=settings.CLICKHOUSE_CLUSTER,
-            database='default',
-            local_table=dataset.SCHEMA.get_local_table_name(),
-        )
-    )

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -374,7 +374,7 @@ class ColumnSet(object):
         return ', '.join(column.for_schema() for column in self.columns)
 
 
-# These functions are temporary and are used to help the migraiton of the DDL to
+# These functions are temporary and are used to help the migration of the DDL to
 # the dataset abstractions. Please do not introduce dependencies on them.
 # We need them right now because there is plenty of code that depends on the DDL of the
 # default dataset but that does not have access to the dataset object.
@@ -406,7 +406,7 @@ def get_promoted_context_columns():
 def get_all_columns():
     from snuba.datasets.factory import get_dataset
     dataset = get_dataset("events")
-    return dataset.get_schema().get_all_columns()
+    return dataset.get_schema().get_columns()
 
 
 def get_required_columns():

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -8,7 +8,11 @@ class DataSet(object):
     This is the the initial boilerplate. schema and processor will come.
     """
 
-    SCHEMA = None
+    def __init__(self):
+        self._schema = None
+
+    def get_schema(self):
+        return self._schema
 
     def default_conditions(self, body):
         """

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -8,8 +8,8 @@ class DataSet(object):
     This is the the initial boilerplate. schema and processor will come.
     """
 
-    def __init__(self):
-        self._schema = None
+    def __init__(self, schema):
+        self._schema = schema
 
     def get_schema(self):
         return self._schema

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -10,13 +10,15 @@ class EventsDataSet(DataSet):
     """
 
     def __init__(self):
-        self.__metadata_columns = ColumnSet([
+        super
+
+        metadata_columns = ColumnSet([
             # optional stream related data
             ('offset', Nullable(UInt(64))),
             ('partition', Nullable(UInt(16))),
         ])
 
-        self.__promoted_tag_columns = ColumnSet([
+        promoted_tag_columns = ColumnSet([
             # These are the classic tags, they are saved in Snuba exactly as they
             # appear in the event body.
             ('level', Nullable(String())),
@@ -31,7 +33,7 @@ class EventsDataSet(DataSet):
             ('url', Nullable(String())),
         ])
 
-        self.__promoted_context_tag_columns = ColumnSet([
+        promoted_context_tag_columns = ColumnSet([
             # These are promoted tags that come in in `tags`, but are more closely
             # related to contexts.  To avoid naming confusion with Clickhouse nested
             # columns, they are stored in the database with s/./_/
@@ -48,7 +50,7 @@ class EventsDataSet(DataSet):
             ('os_rooted', Nullable(UInt(8))),
         ])
 
-        self.__promoted_context_columns = ColumnSet([
+        promoted_context_columns = ColumnSet([
             ('os_build', Nullable(String())),
             ('os_kernel_version', Nullable(String())),
             ('device_name', Nullable(String())),
@@ -64,7 +66,7 @@ class EventsDataSet(DataSet):
             ('device_charging', Nullable(UInt(8))),
         ])
 
-        self.__required_columns = ColumnSet([
+        required_columns = ColumnSet([
             ('event_id', FixedString(32)),
             ('project_id', UInt(64)),
             ('group_id', UInt(64)),
@@ -73,7 +75,7 @@ class EventsDataSet(DataSet):
             ('retention_days', UInt(16)),
         ])
 
-        all_columns = self.__required_columns + [
+        all_columns = required_columns + [
             # required for non-deleted
             ('platform', Nullable(String())),
             ('message', Nullable(String())),
@@ -99,10 +101,10 @@ class EventsDataSet(DataSet):
             ('sdk_version', Nullable(String())),
             ('type', Nullable(String())),
             ('version', Nullable(String())),
-        ] + self.__metadata_columns \
-            + self.__promoted_context_columns \
-            + self.__promoted_tag_columns \
-            + self.__promoted_context_tag_columns \
+        ] + metadata_columns \
+            + promoted_context_columns \
+            + promoted_tag_columns \
+            + promoted_context_tag_columns \
             + [
                 # other tags
                 ('tags', Nested([
@@ -116,7 +118,6 @@ class EventsDataSet(DataSet):
                     ('value', String()),
                 ])),
 
-                # self.__promoted_context_tag_columns
                 # http interface
                 ('http_method', Nullable(String())),
                 ('http_referer', Nullable(String())),
@@ -153,14 +154,24 @@ class EventsDataSet(DataSet):
         ]
 
         sample_expr = 'cityHash64(toString(event_id))'
-        self._schema = ReplacingMergeTreeSchema(
-            all_columns=all_columns,
+        schema = ReplacingMergeTreeSchema(
+            columns=all_columns,
             local_table_name='sentry_local',
             dist_table_name='sentry_dist',
             order_by='(project_id, toStartOfDay(timestamp), %s)' % sample_expr,
             partition_by='(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))',
             version_column='deleted',
             sample_expr=sample_expr)
+
+        super(EventsDataSet, self).__init__(
+            schema
+        )
+
+        self.__metadata_columns = metadata_columns
+        self.__promoted_tag_columns = promoted_tag_columns
+        self.__promoted_context_tag_columns = promoted_context_tag_columns
+        self.__promoted_context_columns = promoted_context_columns
+        self.__required_columns = required_columns
 
     def default_conditions(self, body):
         return [
@@ -169,7 +180,7 @@ class EventsDataSet(DataSet):
 
     # These method should be removed once we will have dataset specific query processing in
     # the dataset class instead of util.py and when the dataset specific logic for processing
-    # Kafka messages will be in the daatset as well.
+    # Kafka messages will be in the dataset as well.
     def get_metadata_columns(self):
         return self.__metadata_columns
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -10,8 +10,6 @@ class EventsDataSet(DataSet):
     """
 
     def __init__(self):
-        super
-
         metadata_columns = ColumnSet([
             # optional stream related data
             ('offset', Nullable(UInt(64))),

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,5 +1,6 @@
+from snuba.clickhouse import Array, ColumnSet, DateTime, FixedString, Float, Nested, Nullable, UInt, String
 from snuba.datasets import DataSet
-from snuba.datasets.schema import TableSchema
+from snuba.datasets.schema import ReplacingMergeTreeSchema
 
 
 class EventsDataSet(DataSet):
@@ -8,11 +9,178 @@ class EventsDataSet(DataSet):
     and the particular quirks of storing and querying them.
     """
 
-    SCHEMA = TableSchema(
-        local_table_name='sentry_local',
-        dist_table_name='sentry_dist')
+    def __init__(self):
+        self.__metadata_columns = ColumnSet([
+            # optional stream related data
+            ('offset', Nullable(UInt(64))),
+            ('partition', Nullable(UInt(16))),
+        ])
+
+        self.__promoted_tag_columns = ColumnSet([
+            # These are the classic tags, they are saved in Snuba exactly as they
+            # appear in the event body.
+            ('level', Nullable(String())),
+            ('logger', Nullable(String())),
+            ('server_name', Nullable(String())),  # future name: device_id?
+            ('transaction', Nullable(String())),
+            ('environment', Nullable(String())),
+            ('sentry:release', Nullable(String())),
+            ('sentry:dist', Nullable(String())),
+            ('sentry:user', Nullable(String())),
+            ('site', Nullable(String())),
+            ('url', Nullable(String())),
+        ])
+
+        self.__promoted_context_tag_columns = ColumnSet([
+            # These are promoted tags that come in in `tags`, but are more closely
+            # related to contexts.  To avoid naming confusion with Clickhouse nested
+            # columns, they are stored in the database with s/./_/
+            # promoted tags
+            ('app_device', Nullable(String())),
+            ('device', Nullable(String())),
+            ('device_family', Nullable(String())),
+            ('runtime', Nullable(String())),
+            ('runtime_name', Nullable(String())),
+            ('browser', Nullable(String())),
+            ('browser_name', Nullable(String())),
+            ('os', Nullable(String())),
+            ('os_name', Nullable(String())),
+            ('os_rooted', Nullable(UInt(8))),
+        ])
+
+        self.__promoted_context_columns = ColumnSet([
+            ('os_build', Nullable(String())),
+            ('os_kernel_version', Nullable(String())),
+            ('device_name', Nullable(String())),
+            ('device_brand', Nullable(String())),
+            ('device_locale', Nullable(String())),
+            ('device_uuid', Nullable(String())),
+            ('device_model_id', Nullable(String())),
+            ('device_arch', Nullable(String())),
+            ('device_battery_level', Nullable(Float(32))),
+            ('device_orientation', Nullable(String())),
+            ('device_simulator', Nullable(UInt(8))),
+            ('device_online', Nullable(UInt(8))),
+            ('device_charging', Nullable(UInt(8))),
+        ])
+
+        self.__required_columns = ColumnSet([
+            ('event_id', FixedString(32)),
+            ('project_id', UInt(64)),
+            ('group_id', UInt(64)),
+            ('timestamp', DateTime()),
+            ('deleted', UInt(8)),
+            ('retention_days', UInt(16)),
+        ])
+
+        all_columns = self.__required_columns + [
+            # required for non-deleted
+            ('platform', Nullable(String())),
+            ('message', Nullable(String())),
+            ('primary_hash', Nullable(FixedString(32))),
+            ('received', Nullable(DateTime())),
+
+            ('search_message', Nullable(String())),
+            ('title', Nullable(String())),
+            ('location', Nullable(String())),
+
+            # optional user
+            ('user_id', Nullable(String())),
+            ('username', Nullable(String())),
+            ('email', Nullable(String())),
+            ('ip_address', Nullable(String())),
+
+            # optional geo
+            ('geo_country_code', Nullable(String())),
+            ('geo_region', Nullable(String())),
+            ('geo_city', Nullable(String())),
+
+            ('sdk_name', Nullable(String())),
+            ('sdk_version', Nullable(String())),
+            ('type', Nullable(String())),
+            ('version', Nullable(String())),
+        ] + self.__metadata_columns \
+            + self.__promoted_context_columns \
+            + self.__promoted_tag_columns \
+            + self.__promoted_context_tag_columns \
+            + [
+                # other tags
+                ('tags', Nested([
+                    ('key', String()),
+                    ('value', String()),
+                ])),
+
+                # other context
+                ('contexts', Nested([
+                    ('key', String()),
+                    ('value', String()),
+                ])),
+
+                # self.__promoted_context_tag_columns
+                # http interface
+                ('http_method', Nullable(String())),
+                ('http_referer', Nullable(String())),
+
+                # exception interface
+                ('exception_stacks', Nested([
+                    ('type', Nullable(String())),
+                    ('value', Nullable(String())),
+                    ('mechanism_type', Nullable(String())),
+                    ('mechanism_handled', Nullable(UInt(8))),
+                ])),
+                ('exception_frames', Nested([
+                    ('abs_path', Nullable(String())),
+                    ('filename', Nullable(String())),
+                    ('package', Nullable(String())),
+                    ('module', Nullable(String())),
+                    ('function', Nullable(String())),
+                    ('in_app', Nullable(UInt(8))),
+                    ('colno', Nullable(UInt(32))),
+                    ('lineno', Nullable(UInt(32))),
+                    ('stack_level', UInt(16)),
+                ])),
+
+                # These are columns we added later in the life of the (current) production
+                # database. They don't necessarily belong here in a logical/readability sense
+                # but they are here to match the order of columns in production becase
+                # `insert_distributed_sync` is very sensitive to column existence and ordering.
+                ('culprit', Nullable(String())),
+                ('sdk_integrations', Array(String())),
+                ('modules', Nested([
+                    ('name', String()),
+                    ('version', String()),
+                ])),
+        ]
+
+        sample_expr = 'cityHash64(toString(event_id))'
+        self._schema = ReplacingMergeTreeSchema(
+            all_columns=all_columns,
+            local_table_name='sentry_local',
+            dist_table_name='sentry_dist',
+            order_by='(project_id, toStartOfDay(timestamp), %s)' % sample_expr,
+            partition_by='(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))',
+            version_column='deleted',
+            sample_expr=sample_expr)
 
     def default_conditions(self, body):
         return [
             ('deleted', '=', 0),
         ]
+
+    # These method should be removed once we will have dataset specific query processing in
+    # the dataset class instead of util.py and when the dataset specific logic for processing
+    # Kafka messages will be in the daatset as well.
+    def get_metadata_columns(self):
+        return self.__metadata_columns
+
+    def get_promoted_tag_columns(self):
+        return self.__promoted_tag_columns
+
+    def get_promoted_context_tag_columns(self):
+        return self.__promoted_context_tag_columns
+
+    def get_promoted_context_columns(self):
+        return self.__promoted_context_columns
+
+    def get_required_columns(self):
+        return self.__required_columns

--- a/snuba/datasets/schema.py
+++ b/snuba/datasets/schema.py
@@ -13,8 +13,8 @@ class TableSchema(object):
 
     TEST_TABLE_PREFIX = "test_"
 
-    def __init__(self, all_columns, local_table_name, dist_table_name):
-        self.__all_columns = all_columns
+    def __init__(self, local_table_name, dist_table_name, columns):
+        self.__columns = columns
 
         self.__local_table_name = local_table_name
         self.__dist_table_name = dist_table_name
@@ -40,7 +40,7 @@ class TableSchema(object):
     def _get_table_definition(self, name, engine):
         return """
         CREATE TABLE IF NOT EXISTS %(name)s (%(columns)s) ENGINE = %(engine)s""" % {
-            'columns': self.__all_columns.for_schema(),
+            'columns': self.__columns.for_schema(),
             'engine': engine,
             'name': name,
         }
@@ -52,18 +52,18 @@ class TableSchema(object):
         )
 
     def _get_local_engine(self):
-        pass
+        raise NotImplementedError
 
-    def get_all_columns(self):
-        return self.__all_columns
+    def get_columns(self):
+        return self.__columns
 
 
 class ReplacingMergeTreeSchema(TableSchema):
 
-    def __init__(self, all_columns, local_table_name, dist_table_name,
+    def __init__(self, local_table_name, dist_table_name, columns,
             order_by, partition_by, version_column, sample_expr):
         super(ReplacingMergeTreeSchema, self).__init__(
-            all_columns=all_columns,
+            columns=columns,
             local_table_name=local_table_name,
             dist_table_name=dist_table_name)
         self.__order_by = order_by

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('snuba.migrate')
 
 
 def run(conn, clickhouse_table):
-    from snuba.clickhouse import ALL_COLUMNS
+    from snuba.clickhouse import get_all_columns
 
     get_schema = lambda: {
         column_name: column_type
@@ -56,11 +56,11 @@ def run(conn, clickhouse_table):
 
     # Warn user about any *other* schema diffs
     for column_name, column_type in local_schema.items():
-        if column_name not in ALL_COLUMNS:
+        if column_name not in get_all_columns():
             logger.warn("Column '%s' exists in local ClickHouse but not in schema!", column_name)
             continue
 
-        expected_type = ALL_COLUMNS[column_name].type.for_schema()
+        expected_type = get_all_columns()[column_name].type.for_schema()
         if column_type != expected_type:
             logger.warn(
                 "Column '%s' type differs between local ClickHouse and schema! (expected: %s, is: %s)",

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -73,7 +73,7 @@ def run(conn, clickhouse_table):
 def rename_dev_table(conn):
     # Migrate from the old events table to the new one if needed
     from snuba.datasets.factory import get_dataset
-    local_table = get_dataset('events').SCHEMA.get_local_table_name()
+    local_table = get_dataset('events').get_schema().get_local_table_name()
     clickhouse_tables = conn.execute('show tables')
     if not (local_table,) in clickhouse_tables and ("dev",) in clickhouse_tables:
         conn.execute("RENAME TABLE dev TO %s" % local_table)

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -57,18 +57,12 @@ def get_messages(events_file):
     return messages
 
 
-def run(events_file, clickhouse, table_name, repeat=1,
+def run(events_file, clickhouse, dataset, repeat=1,
         profile_process=False, profile_write=False):
-    from snuba.clickhouse import get_table_definition, get_test_engine
     from snuba.consumer import ConsumerWorker
 
-    clickhouse.execute(
-        get_table_definition(
-            name=table_name,
-            engine=get_test_engine(),
-        )
-    )
-
+    clickhouse.execute(dataset.get_schema().get_local_table_definition())
+    table_name = dataset.get_schema().get_table_name()
     consumer = ConsumerWorker(
         clickhouse=clickhouse,
         dist_table_name=table_name,

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -62,7 +62,7 @@ def run(events_file, clickhouse, dataset, repeat=1,
     from snuba.consumer import ConsumerWorker
 
     clickhouse.execute(dataset.get_schema().get_local_table_definition())
-    table_name = dataset.get_schema().get_local_table_definition()
+    table_name = dataset.get_schema().get_local_table_name()
     consumer = ConsumerWorker(
         clickhouse=clickhouse,
         dist_table_name=table_name,

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -62,7 +62,7 @@ def run(events_file, clickhouse, dataset, repeat=1,
     from snuba.consumer import ConsumerWorker
 
     clickhouse.execute(dataset.get_schema().get_local_table_definition())
-    table_name = dataset.get_schema().get_table_name()
+    table_name = dataset.get_schema().get_local_table_definition()
     consumer = ConsumerWorker(
         clickhouse=clickhouse,
         dist_table_name=table_name,

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -7,7 +7,7 @@ import six
 import _strptime  # fixes _strptime deferred import issue
 
 from snuba import settings
-from snuba.clickhouse import PROMOTED_TAG_COLUMNS
+from snuba.clickhouse import get_promoted_tag_columns
 from snuba.util import force_bytes
 
 
@@ -196,7 +196,7 @@ def extract_sdk(output, sdk):
 
 def extract_promoted_tags(output, tags):
     output.update({col.name: _unicodify(tags.get(col.name, None))
-        for col in PROMOTED_TAG_COLUMNS
+        for col in get_promoted_tag_columns()
     })
 
 

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -14,7 +14,6 @@ DATASET_MODE = 'local'
 
 # Clickhouse Options
 CLICKHOUSE_SERVER = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000')
-CLICKHOUSE_CLUSTER = None
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # Dogstatsd Options
@@ -71,12 +70,6 @@ KAFKA_TOPICS = {
     },
 }
 
-# project_id and timestamp are included for queries, event_id is included for ReplacingMergeTree
-DEFAULT_SAMPLE_EXPR = 'cityHash64(toString(event_id))'
-DEFAULT_ORDER_BY = '(project_id, toStartOfDay(timestamp), %s)' % DEFAULT_SAMPLE_EXPR
-DEFAULT_PARTITION_BY = '(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))'
-DEFAULT_VERSION_COLUMN = 'deleted'
-DEFAULT_SHARDING_KEY = 'cityHash64(toString(event_id))'
 DEFAULT_RETENTION_DAYS = 90
 RETENTION_OVERRIDES = {}
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -389,11 +389,12 @@ def conditions_expr(conditions, body, depth=0):
         # (IN, =, LIKE) are looking for rows where any array value matches, and
         # exclusionary operators (NOT IN, NOT LIKE, !=) are looking for rows
         # where all elements match (eg. all NOT LIKE 'foo').
+        all_columns = get_all_columns()
         if (
             isinstance(lhs, six.string_types) and
-            lhs in get_all_columns() and
-            type(get_all_columns()[lhs].type) == clickhouse.Array and
-            get_all_columns()[lhs].base_name != body.get('arrayjoin') and
+            lhs in all_columns and
+            type(all_columns[lhs].type) == clickhouse.Array and
+            all_columns[lhs].base_name != body.get('arrayjoin') and
             not isinstance(lit, (list, tuple))
             ):
             any_or_all = 'arrayExists' if op in schemas.POSITIVE_OPERATORS else 'arrayAll'

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -1,12 +1,12 @@
 import logging
 
-from snuba.clickhouse import ALL_COLUMNS, Array
+from snuba.clickhouse import get_all_columns, Array
 
 
 logger = logging.getLogger('snuba.writer')
 
 
-def row_from_processed_event(event, columns=ALL_COLUMNS):
+def row_from_processed_event(event, columns=get_all_columns()):
     values = []
     for col in columns:
         value = event.get(col.flattened, None)
@@ -17,7 +17,7 @@ def row_from_processed_event(event, columns=ALL_COLUMNS):
     return values
 
 
-def write_rows(connection, table, rows, types_check=False, columns=ALL_COLUMNS):
+def write_rows(connection, table, rows, types_check=False, columns=get_all_columns()):
     connection.execute_robust("""
         INSERT INTO %(table)s (%(colnames)s) VALUES""" % {
         'colnames': ", ".join(col.escaped for col in columns),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -804,7 +804,7 @@ class TestApi(BaseTest):
 
         assert self.app.post('/tests/drop').status_code == 200
         dataset = get_dataset('events')
-        table = dataset.SCHEMA.get_table_name()
+        table = dataset.get_schema().get_table_name()
         assert table not in self.clickhouse.execute("SHOW TABLES")
 
     @pytest.mark.xfail

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -4,7 +4,7 @@ from clickhouse_driver import Client, errors
 from mock import patch, call, Mock
 
 from snuba.clickhouse import (
-    ALL_COLUMNS,
+    get_all_columns,
     Array, ColumnSet, Nested, Nullable, String, UInt,
     escape_col,
     ClickhousePool
@@ -23,18 +23,18 @@ class TestClickhouse(BaseTest):
         # disallowed by the query schema, make sure we dont allow
         # injection anyway.
         assert escape_col("`") == r"`\``"
-        assert escape_col("production`; --") == "`production\`; --`"
+        assert escape_col("production`; --") == r"`production\`; --`"
 
     def test_flattened(self):
-        assert ALL_COLUMNS['group_id'].type == UInt(64)
-        assert ALL_COLUMNS['group_id'].name == 'group_id'
-        assert ALL_COLUMNS['group_id'].base_name is None
-        assert ALL_COLUMNS['group_id'].flattened == 'group_id'
+        assert get_all_columns()['group_id'].type == UInt(64)
+        assert get_all_columns()['group_id'].name == 'group_id'
+        assert get_all_columns()['group_id'].base_name is None
+        assert get_all_columns()['group_id'].flattened == 'group_id'
 
-        assert ALL_COLUMNS['exception_frames.in_app'].type == Array(Nullable(UInt(8)))
-        assert ALL_COLUMNS['exception_frames.in_app'].name == 'in_app'
-        assert ALL_COLUMNS['exception_frames.in_app'].base_name == 'exception_frames'
-        assert ALL_COLUMNS['exception_frames.in_app'].flattened == 'exception_frames.in_app'
+        assert get_all_columns()['exception_frames.in_app'].type == Array(Nullable(UInt(8)))
+        assert get_all_columns()['exception_frames.in_app'].name == 'in_app'
+        assert get_all_columns()['exception_frames.in_app'].base_name == 'exception_frames'
+        assert get_all_columns()['exception_frames.in_app'].flattened == 'exception_frames.in_app'
 
     def test_schema(self):
         cols = ColumnSet([
@@ -47,7 +47,6 @@ class TestClickhouse(BaseTest):
         assert cols.for_schema() == 'foo UInt8, bar Nested(`qux:mux` String)'
         assert cols['foo'].type == UInt(8)
         assert cols['bar.qux:mux'].type == Array(String())
-
 
     @patch('snuba.clickhouse.Client')
     def test_reconnect(self, FakeClient):

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,5 +1,6 @@
 from base import BaseTest
 
+from snuba.datasets.factory import get_dataset
 from snuba import perf
 
 
@@ -7,6 +8,7 @@ class TestPerf(BaseTest):
     def test(self):
         assert self.clickhouse.execute("SELECT COUNT() FROM %s" % self.table)[0][0] == 0
 
-        perf.run('tests/perf-event.json', self.clickhouse, self.table)
+        dataset = get_dataset('events')
+        perf.run('tests/perf-event.json', self.clickhouse, dataset)
 
         assert self.clickhouse.execute("SELECT COUNT() FROM %s" % self.table)[0][0] == 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,6 +1,6 @@
 from base import BaseTest
 
-from snuba.clickhouse import ColumnSet, ALL_COLUMNS, METADATA_COLUMNS
+from snuba.clickhouse import ColumnSet, get_all_columns, get_metadata_columns
 from snuba.processor import process_message
 from snuba.writer import row_from_processed_event
 
@@ -20,7 +20,7 @@ class TestWriter(BaseTest):
         # verify that the 'count of columns from event' + 'count of columns from metadata'
         # equals the 'count of columns' in the processed row tuple
         # note that the content is verified in processor tests
-        assert (len(processed) + len(METADATA_COLUMNS)) == len(row)
+        assert (len(processed) + len(get_metadata_columns())) == len(row)
 
     def test_unknown_columns(self):
         """Fields in a processed events are ignored if they don't have
@@ -31,8 +31,8 @@ class TestWriter(BaseTest):
         assert 'sdk_name' in processed
         sdk_name = processed['sdk_name']
 
-        columns_copy = ColumnSet([col for col in ALL_COLUMNS.columns if not col.name == 'sdk_name'])
-        assert len(columns_copy) == (len(ALL_COLUMNS) - 1)
+        columns_copy = ColumnSet([col for col in get_all_columns().columns if not col.name == 'sdk_name'])
+        assert len(columns_copy) == (len(get_all_columns()) - 1)
 
         row = row_from_processed_event(processed, columns_copy)
 


### PR DESCRIPTION
This is the third step of the original dataset PR: (https://github.com/getsentry/snuba/pull/294)

This one moves the DDL code into the dataset abstraction introduced in datasets/boilerplate.
Specifically:
- it moves all the functions used to generate the table structure into TableSchema
- it introduces a subclass of TableSchema for the specific table engine we use.
- It moves the columns definition for the datasets table into Events dataset
It still need a follow up to remvoe the direct dependencies on the default DDL that are scattered around the code base. See the dependencies on ALL_COLUMNS constant.