### PR TITLE
feat: Datasets. Start passing dataset around instead of table name

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -374,14 +374,14 @@ if application.debug or application.testing:
             dataset.get_schema().get_local_table_definition()
         )
 
-        migrate.run(clickhouse_rw, dataset.get_schema().get_local_table_name())
+        migrate.run(clickhouse_rw, dataset)
 
         _ensured[dataset] = True
 
     @application.route('/tests/insert', methods=['POST'])
     def write():
         from snuba.processor import process_message
-        from snuba.writer import row_from_processed_event, write_rows
+        from snuba.writer import write_rows
 
         # TODO we need to make this work for multiple datasets
         dataset = get_dataset('events')
@@ -391,14 +391,18 @@ if application.debug or application.testing:
         rows = []
         for event in body:
             _, processed = process_message(event)
-            row = row_from_processed_event(processed)
+            row = dataset.row_from_processed_message(processed)
             rows.append(row)
 
+<<<<<<< HEAD
         write_rows(
             clickhouse_rw,
             table=dataset.get_schema().get_local_table_name(),
             rows=rows
         )
+=======
+        write_rows(clickhouse_rw, dataset=dataset, rows=rows)
+>>>>>>> pass dataset to writer
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
     @application.route('/tests/eventstream', methods=['POST'])
@@ -406,7 +410,10 @@ if application.debug or application.testing:
         # TODO we need to make this work for multiple datasets
         dataset = get_dataset('events')
         ensure_table_exists(dataset)
+<<<<<<< HEAD
         table = dataset.get_schema().get_local_table_name()
+=======
+>>>>>>> pass dataset to writer
 
         record = json.loads(request.data)
 
@@ -432,10 +439,10 @@ if application.debug or application.testing:
         type_ = record[1]
         if type_ == 'insert':
             from snuba.consumer import ConsumerWorker
-            worker = ConsumerWorker(clickhouse_rw, table, producer=None, replacements_topic=None)
+            worker = ConsumerWorker(clickhouse_rw, dataset, producer=None, replacements_topic=None)
         else:
             from snuba.replacer import ReplacerWorker
-            worker = ReplacerWorker(clickhouse_rw, table)
+            worker = ReplacerWorker(clickhouse_rw, dataset)
 
         processed = worker.process_message(message)
         if processed is not None:

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -411,9 +411,13 @@ if application.debug or application.testing:
         dataset = get_dataset('events')
         ensure_table_exists(dataset)
 <<<<<<< HEAD
+<<<<<<< HEAD
         table = dataset.get_schema().get_local_table_name()
 =======
 >>>>>>> pass dataset to writer
+=======
+        table = dataset.get_schema().get_local_table_name()
+>>>>>>> Fix some table names
 
         record = json.loads(request.data)
 

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -394,15 +394,7 @@ if application.debug or application.testing:
             row = dataset.row_from_processed_message(processed)
             rows.append(row)
 
-<<<<<<< HEAD
-        write_rows(
-            clickhouse_rw,
-            table=dataset.get_schema().get_local_table_name(),
-            rows=rows
-        )
-=======
         write_rows(clickhouse_rw, dataset=dataset, rows=rows)
->>>>>>> pass dataset to writer
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
     @application.route('/tests/eventstream', methods=['POST'])
@@ -410,15 +402,6 @@ if application.debug or application.testing:
         # TODO we need to make this work for multiple datasets
         dataset = get_dataset('events')
         ensure_table_exists(dataset)
-<<<<<<< HEAD
-<<<<<<< HEAD
-        table = dataset.get_schema().get_local_table_name()
-=======
->>>>>>> pass dataset to writer
-=======
-        table = dataset.get_schema().get_local_table_name()
->>>>>>> Fix some table names
-
         record = json.loads(request.data)
 
         version = record[0]

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -65,7 +65,6 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     )
 
     dataset = get_dataset(dataset)
-    table = dataset.get_schema().get_table_name()
 
     producer = Producer({
         'bootstrap.servers': ','.join(bootstrap_server),
@@ -76,7 +75,7 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     consumer = BatchingKafkaConsumer(
         raw_events_topic,
         worker=ConsumerWorker(
-            clickhouse, table,
+            clickhouse, dataset,
             producer=producer, replacements_topic=replacements_topic, metrics=metrics
         ),
         max_batch_size=max_batch_size,

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -26,5 +26,4 @@ def migrate(log_level):
         port=port,
     )
 
-    table = dataset.get_schema().get_local_table_name()
-    run(clickhouse, table)
+    run(clickhouse, dataset)

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -69,7 +69,7 @@ def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_se
 
     replacer = BatchingKafkaConsumer(
         replacements_topic,
-        worker=ReplacerWorker(clickhouse, dataset.get_schema().get_table_name(), metrics=metrics),
+        worker=ReplacerWorker(clickhouse, dataset, metrics=metrics),
         max_batch_size=max_batch_size,
         max_batch_time=max_batch_time_ms,
         metrics=metrics,

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -427,11 +427,6 @@ def get_column_tag_map():
         'contexts': {},
     }
 
-def get_tag_column_map():
-    # And a reverse map from the tags the client expects to the database columns
-    return {
-        col: dict(map(reversed, trans.items())) for col, trans in get_column_tag_map().items()
-    }
 
 def get_tag_column_map():
     # And a reverse map from the tags the client expects to the database columns

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -403,12 +403,6 @@ def get_promoted_context_columns():
     return dataset.get_promoted_context_columns()
 
 
-def get_all_columns():
-    from snuba.datasets.factory import get_dataset
-    dataset = get_dataset("events")
-    return dataset.get_schema().get_columns()
-
-
 def get_required_columns():
     from snuba.datasets.factory import get_dataset
     dataset = get_dataset("events")
@@ -433,6 +427,11 @@ def get_column_tag_map():
         'contexts': {},
     }
 
+def get_tag_column_map():
+    # And a reverse map from the tags the client expects to the database columns
+    return {
+        col: dict(map(reversed, trans.items())) for col, trans in get_column_tag_map().items()
+    }
 
 def get_tag_column_map():
     # And a reverse map from the tags the client expects to the database columns

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -20,3 +20,15 @@ class DataSet(object):
         queries on this dataset.
         """
         return []
+
+    def row_from_processed_message(self, message):
+        from snuba.clickhouse import Array
+        values = []
+        columns = self.get_schema().get_all_columns()
+        for col in columns:
+            value = message.get(col.flattened, None)
+            if value is None and isinstance(col.type, Array):
+                value = []
+            values.append(value)
+
+        return values

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -1,3 +1,5 @@
+from snuba.clickhouse import Array
+
 class DataSet(object):
     """
     A DataSet defines the complete set of data sources, schemas, and
@@ -22,7 +24,6 @@ class DataSet(object):
         return []
 
     def row_from_processed_message(self, message):
-        from snuba.clickhouse import Array
         values = []
         columns = self.get_schema().get_columns()
         for col in columns:

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -24,7 +24,7 @@ class DataSet(object):
     def row_from_processed_message(self, message):
         from snuba.clickhouse import Array
         values = []
-        columns = self.get_schema().get_all_columns()
+        columns = self.get_schema().get_columns()
         for col in columns:
             value = message.get(col.flattened, None)
             if value is None and isinstance(col.type, Array):

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -54,7 +54,7 @@ def run(conn, dataset):
     local_schema = get_schema()
 
     # Warn user about any *other* schema diffs
-    columns = dataset.get_schema().get_all_columns()
+    columns = dataset.get_schema().get_columns()
     for column_name, column_type in local_schema.items():
         if column_name not in columns:
             logger.warn("Column '%s' exists in local ClickHouse but not in schema!", column_name)

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('snuba.migrate')
 
 
 def run(conn, dataset):
-    clickhouse_table = dataset.get_schema().get_table_name()
+    clickhouse_table = dataset.get_schema().get_local_table_name()
     get_schema = lambda: {
         column_name: column_type
         for column_name, column_type, default_type, default_expr

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -62,10 +62,9 @@ def run(events_file, clickhouse, dataset, repeat=1,
     from snuba.consumer import ConsumerWorker
 
     clickhouse.execute(dataset.get_schema().get_local_table_definition())
-    table_name = dataset.get_schema().get_local_table_name()
     consumer = ConsumerWorker(
         clickhouse=clickhouse,
-        dist_table_name=table_name,
+        dataset=dataset,
         producer=None,
         replacements_topic=None,
     )

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -94,7 +94,7 @@ class ReplacerWorker(AbstractBatchWorker):
         self.dataset = dataset
         self.dist_table_name = dataset.get_schema().get_table_name()
         self.metrics = metrics
-        self.__all_column_names = [col.escaped for col in dataset.get_schema().get_all_columns()]
+        self.__all_column_names = [col.escaped for col in dataset.get_schema().get_columns()]
 
     def process_message(self, message):
         message = json.loads(message.value())
@@ -113,7 +113,7 @@ class ReplacerWorker(AbstractBatchWorker):
                 processed = process_unmerge(event, self.__all_column_names)
             elif type_ == 'end_delete_tag':
                 processed = process_delete_tag(event,
-                    self.dataset.get_schema().get_all_columns(), self.__all_column_names)
+                    self.dataset.get_schema().get_columns(), self.__all_column_names)
             else:
                 raise InvalidMessageType("Invalid message type: {}".format(type_))
         else:

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -112,8 +112,7 @@ class ReplacerWorker(AbstractBatchWorker):
             elif type_ == 'end_unmerge':
                 processed = process_unmerge(event, self.__all_column_names)
             elif type_ == 'end_delete_tag':
-                processed = process_delete_tag(event,
-                    self.dataset.get_schema().get_columns(), self.__all_column_names)
+                processed = process_delete_tag(event, self.dataset.get_schema().get_columns())
             else:
                 raise InvalidMessageType("Invalid message type: {}".format(type_))
         else:
@@ -283,7 +282,7 @@ def process_unmerge(message, all_column_names):
     return (count_query_template, insert_query_template, query_args, query_time_flags)
 
 
-def process_delete_tag(message, all_columns, all_column_names):
+def process_delete_tag(message, all_columns):
     tag = message['tag']
     if not tag:
         return None
@@ -325,6 +324,7 @@ def process_delete_tag(message, all_columns, all_column_names):
         else:
             select_columns.append(col.escaped)
 
+    all_column_names = [col.escaped for col in all_columns]
     query_args = {
         'all_columns': ', '.join(all_column_names),
         'select_columns': ', '.join(select_columns),

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -8,7 +8,7 @@ import simplejson as json
 from batching_kafka_consumer import AbstractBatchWorker
 
 from . import settings
-from snuba.clickhouse import get_all_columns, get_required_columns, get_promoted_tags, get_tag_column_map, escape_col
+from snuba.clickhouse import get_required_columns, get_promoted_tags, get_tag_column_map, escape_col
 from snuba.processor import _hashify, InvalidMessageType, InvalidMessageVersion
 from snuba.redis import redis_client
 from snuba.util import escape_string
@@ -20,7 +20,6 @@ logger = logging.getLogger('snuba.replacer')
 CLICKHOUSE_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 
 REQUIRED_COLUMN_NAMES = [col.escaped for col in get_required_columns()]
-ALL_COLUMN_NAMES = [col.escaped for col in get_all_columns()]
 
 EXCLUDE_GROUPS = object()
 NEEDS_FINAL = object()
@@ -90,10 +89,12 @@ def get_projects_query_flags(project_ids):
 
 
 class ReplacerWorker(AbstractBatchWorker):
-    def __init__(self, clickhouse, dist_table_name, metrics=None):
+    def __init__(self, clickhouse, dataset, metrics=None):
         self.clickhouse = clickhouse
-        self.dist_table_name = dist_table_name
+        self.dataset = dataset
+        self.dist_table_name = dataset.get_schema().get_table_name()
         self.metrics = metrics
+        self.__all_column_names = [col.escaped for col in dataset.get_schema().get_all_columns()]
 
     def process_message(self, message):
         message = json.loads(message.value())
@@ -107,11 +108,12 @@ class ReplacerWorker(AbstractBatchWorker):
             elif type_ == 'end_delete_groups':
                 processed = process_delete_groups(event)
             elif type_ == 'end_merge':
-                processed = process_merge(event)
+                processed = process_merge(event, self.__all_column_names)
             elif type_ == 'end_unmerge':
-                processed = process_unmerge(event)
+                processed = process_unmerge(event, self.__all_column_names)
             elif type_ == 'end_delete_tag':
-                processed = process_delete_tag(event)
+                processed = process_delete_tag(event,
+                    self.dataset.get_schema().get_all_columns(), self.__all_column_names)
             else:
                 raise InvalidMessageType("Invalid message type: {}".format(type_))
         else:
@@ -190,7 +192,7 @@ def process_delete_groups(message):
 SEEN_MERGE_TXN_CACHE = deque(maxlen=100)
 
 
-def process_merge(message):
+def process_merge(message, all_column_names):
     # HACK: We were sending duplicates of the `end_merge` message from Sentry,
     # this is only for performance of the backlog.
     txn = message.get('transaction_id')
@@ -206,7 +208,7 @@ def process_merge(message):
 
     assert all(isinstance(gid, six.integer_types) for gid in previous_group_ids)
     timestamp = datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT)
-    select_columns = map(lambda i: i if i != 'group_id' else str(message['new_group_id']), ALL_COLUMN_NAMES)
+    select_columns = map(lambda i: i if i != 'group_id' else str(message['new_group_id']), all_column_names)
 
     where = """\
         WHERE project_id = %(project_id)s
@@ -227,7 +229,7 @@ def process_merge(message):
     """ + where
 
     query_args = {
-        'all_columns': ', '.join(ALL_COLUMN_NAMES),
+        'all_columns': ', '.join(all_column_names),
         'select_columns': ', '.join(select_columns),
         'project_id': message['project_id'],
         'previous_group_ids': ", ".join(str(gid) for gid in previous_group_ids),
@@ -239,14 +241,14 @@ def process_merge(message):
     return (count_query_template, insert_query_template, query_args, query_time_flags)
 
 
-def process_unmerge(message):
+def process_unmerge(message, all_column_names):
     hashes = message['hashes']
     if not hashes:
         return None
 
     assert all(isinstance(h, six.string_types) for h in hashes)
     timestamp = datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT)
-    select_columns = map(lambda i: i if i != 'group_id' else str(message['new_group_id']), ALL_COLUMN_NAMES)
+    select_columns = map(lambda i: i if i != 'group_id' else str(message['new_group_id']), all_column_names)
 
     where = """\
         WHERE project_id = %(project_id)s
@@ -268,7 +270,7 @@ def process_unmerge(message):
     """ + where
 
     query_args = {
-        'all_columns': ', '.join(ALL_COLUMN_NAMES),
+        'all_columns': ', '.join(all_column_names),
         'select_columns': ', '.join(select_columns),
         'previous_group_id': message['previous_group_id'],
         'project_id': message['project_id'],
@@ -281,7 +283,7 @@ def process_unmerge(message):
     return (count_query_template, insert_query_template, query_args, query_time_flags)
 
 
-def process_delete_tag(message):
+def process_delete_tag(message, all_columns, all_column_names):
     tag = message['tag']
     if not tag:
         return None
@@ -309,7 +311,7 @@ def process_delete_tag(message):
     """ + where
 
     select_columns = []
-    for col in get_all_columns():
+    for col in all_columns:
         if is_promoted and col.flattened == tag_column_name:
             select_columns.append('NULL')
         elif col.flattened == 'tags.key':
@@ -324,7 +326,7 @@ def process_delete_tag(message):
             select_columns.append(col.escaped)
 
     query_args = {
-        'all_columns': ', '.join(ALL_COLUMN_NAMES),
+        'all_columns': ', '.join(all_column_names),
         'select_columns': ', '.join(select_columns),
         'project_id': message['project_id'],
         'tag_str': escape_string(tag),

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -92,7 +92,6 @@ class ReplacerWorker(AbstractBatchWorker):
     def __init__(self, clickhouse, dataset, metrics=None):
         self.clickhouse = clickhouse
         self.dataset = dataset
-        self.dist_table_name = dataset.get_schema().get_table_name()
         self.metrics = metrics
         self.__all_column_names = [col.escaped for col in dataset.get_schema().get_columns()]
 
@@ -122,7 +121,7 @@ class ReplacerWorker(AbstractBatchWorker):
 
     def flush_batch(self, batch):
         for count_query_template, insert_query_template, query_args, query_time_flags in batch:
-            query_args.update({'dist_table_name': self.dist_table_name})
+            query_args.update({'dist_table_name': self.dataset.get_schema().get_table_name()})
             count = self.clickhouse.execute_robust(count_query_template % query_args)[0][0]
             if count == 0:
                 continue

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -19,7 +19,7 @@ import _strptime  # NOQA fixes _strptime deferred import issue
 import time
 
 from snuba import clickhouse, schemas, settings, state
-from snuba.clickhouse import escape_col, get_all_columns, get_promoted_cols, get_tag_column_map, get_column_tag_map
+from snuba.clickhouse import escape_col, get_promoted_cols, get_tag_column_map, get_column_tag_map
 
 
 logger = logging.getLogger('snuba.util')
@@ -46,8 +46,8 @@ def to_list(value):
     return value if isinstance(value, list) else [value]
 
 
-def string_col(col):
-    col_type = get_all_columns().get(col, None)
+def string_col(dataset, col):
+    col_type = dataset.get_schema().get_columns().get(col, None)
     col_type = str(col_type) if col_type else None
 
     if col_type and 'String' in col_type and 'FixedString' not in col_type:
@@ -134,7 +134,7 @@ def is_function(column_expr, depth=0):
     else:
         return None
 
-def column_expr(column_name, body, alias=None, aggregate=None):
+def column_expr(dataset, column_name, body, alias=None, aggregate=None):
     """
     Certain special column names expand into more complex expressions. Return
     a 2-tuple of:
@@ -147,15 +147,15 @@ def column_expr(column_name, body, alias=None, aggregate=None):
     column_name = column_name or ''
 
     if is_function(column_name, 0):
-        return complex_column_expr(column_name, body)
+        return complex_column_expr(dataset, column_name, body)
     elif isinstance(column_name, six.string_types) and QUOTED_LITERAL_RE.match(column_name):
         return escape_literal(column_name[1:-1])
     elif column_name in settings.TIME_GROUP_COLUMNS:
         expr = time_expr(column_name, body['granularity'])
     elif NESTED_COL_EXPR_RE.match(column_name):
-        expr = tag_expr(column_name)
+        expr = tag_expr(dataset, column_name)
     elif column_name in ['tags_key', 'tags_value']:
-        expr = tags_expr(column_name, body)
+        expr = tags_expr(dataset, column_name, body)
     elif column_name == 'issue':
         expr = 'group_id'
     elif column_name == 'message':
@@ -174,7 +174,7 @@ def column_expr(column_name, body, alias=None, aggregate=None):
     return alias_expr(expr, alias, body)
 
 
-def complex_column_expr(expr, body, depth=0):
+def complex_column_expr(dataset, expr, body, depth=0):
     function_tuple = is_function(expr, depth)
     if function_tuple is None:
         raise ValueError('complex_column_expr was given an expr %s that is not a function at depth %d.' % (expr, depth))
@@ -185,14 +185,14 @@ def complex_column_expr(expr, body, depth=0):
     while i < len(args):
         next_2 = args[i:i+2]
         if is_function(next_2, depth+1):
-            out.append(complex_column_expr(next_2, body, depth+1))
+            out.append(complex_column_expr(dataset, next_2, body, depth+1))
             i += 2
         else:
             nxt = args[i]
             if is_function(nxt, depth + 1):  # Embedded function
-                out.append(complex_column_expr(nxt, body, depth + 1))
+                out.append(complex_column_expr(dataset, nxt, body, depth + 1))
             elif isinstance(nxt, six.string_types):
-                out.append(column_expr(nxt, body))
+                out.append(column_expr(dataset, nxt, body))
             else:
                 out.append(escape_literal(nxt))
             i += 1
@@ -225,7 +225,7 @@ def alias_expr(expr, alias, body):
         return u'({} AS {})'.format(expr, alias)
 
 
-def tag_expr(column_name):
+def tag_expr(dataset, column_name):
     """
     Return an expression for the value of a single named tag.
 
@@ -238,7 +238,7 @@ def tag_expr(column_name):
     if col in get_promoted_cols():
         actual_tag = get_tag_column_map()[col].get(tag, tag)
         if actual_tag in get_promoted_cols()[col]:
-            return string_col(actual_tag)
+            return string_col(dataset, actual_tag)
 
     # For the rest, return an expression that looks it up in the nested tags.
     return u'{col}.value[indexOf({col}.key, {tag})]'.format(**{
@@ -247,7 +247,7 @@ def tag_expr(column_name):
     })
 
 
-def tags_expr(column_name, body):
+def tags_expr(dataset, column_name, body):
     """
     Return an expression that array-joins on tags to produce an output with one
     row per tag.
@@ -268,7 +268,7 @@ def tags_expr(column_name, body):
             col
         )
         val_list = u'arrayConcat([{}], {}.value)'.format(
-            ', '.join(string_col(p) for p in promoted),
+            ', '.join(string_col(dataset, p) for p in promoted),
             col
         )
 
@@ -352,7 +352,7 @@ def tuplify(nested):
     return nested
 
 
-def conditions_expr(conditions, body, depth=0):
+def conditions_expr(dataset, conditions, body, depth=0):
     """
     Return a boolean expression suitable for putting in the WHERE clause of the
     query.  The expression is constructed by ANDing groups of OR expressions.
@@ -364,7 +364,7 @@ def conditions_expr(conditions, body, depth=0):
 
     if depth == 0:
         # dedupe conditions at top level, but keep them in order
-        sub = OrderedDict((conditions_expr(cond, body, depth + 1), None) for cond in conditions)
+        sub = OrderedDict((conditions_expr(dataset, cond, body, depth + 1), None) for cond in conditions)
         return u' AND '.join(s for s in sub.keys() if s)
     elif is_condition(conditions):
         lhs, op, lit = conditions
@@ -389,12 +389,12 @@ def conditions_expr(conditions, body, depth=0):
         # (IN, =, LIKE) are looking for rows where any array value matches, and
         # exclusionary operators (NOT IN, NOT LIKE, !=) are looking for rows
         # where all elements match (eg. all NOT LIKE 'foo').
-        all_columns = get_all_columns()
+        columns = dataset.get_schema().get_columns()
         if (
             isinstance(lhs, six.string_types) and
-            lhs in all_columns and
-            type(all_columns[lhs].type) == clickhouse.Array and
-            all_columns[lhs].base_name != body.get('arrayjoin') and
+            lhs in columns and
+            type(columns[lhs].type) == clickhouse.Array and
+            columns[lhs].base_name != body.get('arrayjoin') and
             not isinstance(lit, (list, tuple))
             ):
             any_or_all = 'arrayExists' if op in schemas.POSITIVE_OPERATORS else 'arrayAll'
@@ -402,17 +402,17 @@ def conditions_expr(conditions, body, depth=0):
                 any_or_all,
                 op,
                 escape_literal(lit),
-                column_expr(lhs, body)
+                column_expr(dataset, lhs, body)
             )
         else:
             return u'{} {} {}'.format(
-                column_expr(lhs, body),
+                column_expr(dataset, lhs, body),
                 op,
                 escape_literal(lit)
             )
 
     elif depth == 1:
-        sub = (conditions_expr(cond, body, depth + 1) for cond in conditions)
+        sub = (conditions_expr(dataset, cond, body, depth + 1) for cond in conditions)
         sub = [s for s in sub if s]
         res = u' OR '.join(sub)
         return u'({})'.format(res) if len(sub) > 1 else res

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -1,23 +1,12 @@
 import logging
 
-from snuba.clickhouse import get_all_columns, Array
-
-
 logger = logging.getLogger('snuba.writer')
 
 
-def row_from_processed_event(event, columns=get_all_columns()):
-    values = []
-    for col in columns:
-        value = event.get(col.flattened, None)
-        if value is None and isinstance(col.type, Array):
-            value = []
-        values.append(value)
-
-    return values
-
-
-def write_rows(connection, table, rows, types_check=False, columns=get_all_columns()):
+def write_rows(connection, dataset, rows, types_check=False, columns=None):
+    if columns is None:
+        columns = dataset.get_schema().get_all_columns()
+    table = dataset.get_schema().get_table_name()
     connection.execute_robust("""
         INSERT INTO %(table)s (%(colnames)s) VALUES""" % {
         'colnames': ", ".join(col.escaped for col in columns),

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -5,7 +5,7 @@ logger = logging.getLogger('snuba.writer')
 
 def write_rows(connection, dataset, rows, types_check=False, columns=None):
     if columns is None:
-        columns = dataset.get_schema().get_all_columns()
+        columns = dataset.get_schema().get_columns()
     table = dataset.get_schema().get_table_name()
     connection.execute_robust("""
         INSERT INTO %(table)s (%(colnames)s) VALUES""" % {

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -26,15 +26,16 @@ class TestClickhouse(BaseTest):
         assert escape_col("production`; --") == r"`production\`; --`"
 
     def test_flattened(self):
-        assert get_all_columns()['group_id'].type == UInt(64)
-        assert get_all_columns()['group_id'].name == 'group_id'
-        assert get_all_columns()['group_id'].base_name is None
-        assert get_all_columns()['group_id'].flattened == 'group_id'
+        columns = self.dataset.get_schema().get_all_columns()
+        assert columns['group_id'].type == UInt(64)
+        assert columns['group_id'].name == 'group_id'
+        assert columns['group_id'].base_name is None
+        assert columns['group_id'].flattened == 'group_id'
 
-        assert get_all_columns()['exception_frames.in_app'].type == Array(Nullable(UInt(8)))
-        assert get_all_columns()['exception_frames.in_app'].name == 'in_app'
-        assert get_all_columns()['exception_frames.in_app'].base_name == 'exception_frames'
-        assert get_all_columns()['exception_frames.in_app'].flattened == 'exception_frames.in_app'
+        assert columns['exception_frames.in_app'].type == Array(Nullable(UInt(8)))
+        assert columns['exception_frames.in_app'].name == 'in_app'
+        assert columns['exception_frames.in_app'].base_name == 'exception_frames'
+        assert columns['exception_frames.in_app'].flattened == 'exception_frames.in_app'
 
     def test_schema(self):
         cols = ColumnSet([

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -26,7 +26,7 @@ class TestClickhouse(BaseTest):
         assert escape_col("production`; --") == r"`production\`; --`"
 
     def test_flattened(self):
-        columns = self.dataset.get_schema().get_all_columns()
+        columns = self.dataset.get_schema().get_columns()
         assert columns['group_id'].type == UInt(64)
         assert columns['group_id'].name == 'group_id'
         assert columns['group_id'].base_name is None

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -4,7 +4,6 @@ from clickhouse_driver import Client, errors
 from mock import patch, call, Mock
 
 from snuba.clickhouse import (
-    get_all_columns,
     Array, ColumnSet, Nested, Nullable, String, UInt,
     escape_col,
     ClickhousePool

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -100,7 +100,7 @@ class TestConsumer(BaseTest):
             def partition(self):
                 return 456
 
-        test_worker = ConsumerWorker(self.clickhouse, self.table, FakeKafkaProducer(), 'topic')
+        test_worker = ConsumerWorker(self.clickhouse, self.dataset, FakeKafkaProducer(), 'topic')
         batch = [test_worker.process_message(FakeMessage())]
         test_worker.flush_batch(batch)
 
@@ -109,7 +109,7 @@ class TestConsumer(BaseTest):
         ) == [(self.event['project_id'], self.event['event_id'], 123, 456)]
 
     def test_skip_too_old(self):
-        test_worker = ConsumerWorker(self.clickhouse, self.table, FakeKafkaProducer(), 'topic')
+        test_worker = ConsumerWorker(self.clickhouse, self.dataset, FakeKafkaProducer(), 'topic')
 
         event = self.event
         old_timestamp = datetime.utcnow() - timedelta(days=300)
@@ -127,7 +127,7 @@ class TestConsumer(BaseTest):
     def test_produce_replacement_messages(self):
         topic = 'topic'
         producer = FakeKafkaProducer()
-        test_worker = ConsumerWorker(self.clickhouse, self.table, producer, topic)
+        test_worker = ConsumerWorker(self.clickhouse, self.dataset, producer, topic)
 
         test_worker.flush_batch([
             (processor.REPLACE, ('1', {'project_id': 1})),

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -19,7 +19,7 @@ class TestReplacer(BaseTest):
 
         self.app = application.test_client()
         self.app.post = partial(self.app.post, headers={'referer': 'test'})
-        self.replacer = replacer.ReplacerWorker(self.clickhouse, self.table)
+        self.replacer = replacer.ReplacerWorker(self.clickhouse, self.dataset)
 
         self.project_id = 1
 
@@ -167,7 +167,7 @@ class TestReplacer(BaseTest):
         assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
-        test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
+        test_worker = replacer.ReplacerWorker(self.clickhouse, self.dataset)
 
         project_id = self.project_id
 
@@ -192,7 +192,7 @@ class TestReplacer(BaseTest):
         assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
-        test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
+        test_worker = replacer.ReplacerWorker(self.clickhouse, self.dataset)
 
         project_id = self.project_id
 
@@ -219,7 +219,7 @@ class TestReplacer(BaseTest):
         assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
-        test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
+        test_worker = replacer.ReplacerWorker(self.clickhouse, self.dataset)
 
         project_id = self.project_id
 
@@ -259,7 +259,7 @@ class TestReplacer(BaseTest):
         assert _issue_count(total=True) == [{'count': 1, 'issue': 1}]
 
         timestamp = datetime.now(tz=pytz.utc)
-        test_worker = replacer.ReplacerWorker(self.clickhouse, self.table)
+        test_worker = replacer.ReplacerWorker(self.clickhouse, self.dataset)
 
         class FakeMessage(object):
             def value(self):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -23,19 +23,19 @@ class TestUtil(BaseTest):
             'granularity': 86400
         }
         # Single tag expression
-        assert column_expr('tags[foo]', body.copy()) ==\
+        assert column_expr(self.dataset, 'tags[foo]', body.copy()) ==\
             "(tags.value[indexOf(tags.key, \'foo\')] AS `tags[foo]`)"
 
         # Promoted tag expression / no translation
-        assert column_expr('tags[server_name]', body.copy()) ==\
+        assert column_expr(self.dataset, 'tags[server_name]', body.copy()) ==\
             "(server_name AS `tags[server_name]`)"
 
         # Promoted tag expression / with translation
-        assert column_expr('tags[app.device]', body.copy()) ==\
+        assert column_expr(self.dataset, 'tags[app.device]', body.copy()) ==\
             "(app_device AS `tags[app.device]`)"
 
         # All tag keys expression
-        assert column_expr('tags_key', body.copy()) == (
+        assert column_expr(self.dataset, 'tags_key', body.copy()) == (
             '(arrayJoin(tags.key) AS tags_key)'
         )
 
@@ -43,65 +43,65 @@ class TestUtil(BaseTest):
         tag_group_body = {
             'groupby': ['tags_key', 'tags_value']
         }
-        assert column_expr('tags_key', tag_group_body) == (
+        assert column_expr(self.dataset, 'tags_key', tag_group_body) == (
             '(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) '
             'AS all_tags))[1] AS tags_key)'
         )
 
-        assert column_expr('time', body.copy()) ==\
+        assert column_expr(self.dataset, 'time', body.copy()) ==\
             "(toDate(timestamp) AS time)"
 
-        assert column_expr('rtime', body.copy()) ==\
+        assert column_expr(self.dataset, 'rtime', body.copy()) ==\
             "(toDate(received) AS rtime)"
 
-        assert column_expr('col', body.copy(), aggregate='sum') ==\
+        assert column_expr(self.dataset, 'col', body.copy(), aggregate='sum') ==\
             "(sum(col) AS col)"
 
-        assert column_expr('col', body.copy(), alias='summation', aggregate='sum') ==\
+        assert column_expr(self.dataset, 'col', body.copy(), alias='summation', aggregate='sum') ==\
             "(sum(col) AS summation)"
 
         # Special cases where count() doesn't need a column
-        assert column_expr('', body.copy(), alias='count', aggregate='count()') ==\
+        assert column_expr(self.dataset, '', body.copy(), alias='count', aggregate='count()') ==\
             "(count() AS count)"
 
-        assert column_expr('', body.copy(), alias='aggregate', aggregate='count()') ==\
+        assert column_expr(self.dataset, '', body.copy(), alias='aggregate', aggregate='count()') ==\
             "(count() AS aggregate)"
 
         # Columns that need escaping
-        assert column_expr('sentry:release', body.copy()) == '`sentry:release`'
+        assert column_expr(self.dataset, 'sentry:release', body.copy()) == '`sentry:release`'
 
         # Columns that start with a negative sign (used in orderby to signify
         # sort order) retain the '-' sign outside the escaping backticks (if any)
-        assert column_expr('-timestamp', body.copy()) == '-timestamp'
-        assert column_expr('-sentry:release', body.copy()) == '-`sentry:release`'
+        assert column_expr(self.dataset, '-timestamp', body.copy()) == '-timestamp'
+        assert column_expr(self.dataset, '-sentry:release', body.copy()) == '-`sentry:release`'
 
         # A 'column' that is actually a string literal
-        assert column_expr('\'hello world\'', body.copy()) == '\'hello world\''
+        assert column_expr(self.dataset, '\'hello world\'', body.copy()) == '\'hello world\''
 
         # Complex expressions (function calls) involving both string and column arguments
-        assert column_expr(tuplify(['concat', ['a', '\':\'', 'b']]), body.copy()) == 'concat(a, \':\', b)'
+        assert column_expr(self.dataset, tuplify(['concat', ['a', '\':\'', 'b']]), body.copy()) == 'concat(a, \':\', b)'
 
         group_id_body = body.copy()
-        assert column_expr('issue', group_id_body) == '(group_id AS issue)'
+        assert column_expr(self.dataset, 'issue', group_id_body) == '(group_id AS issue)'
 
         # turn uniq() into ifNull(uniq(), 0) so it doesn't return null where a number was expected.
-        assert column_expr('tags[environment]', body.copy(), alias='unique_envs', aggregate='uniq') == "(ifNull(uniq(environment), 0) AS unique_envs)"
+        assert column_expr(self.dataset, 'tags[environment]', body.copy(), alias='unique_envs', aggregate='uniq') == "(ifNull(uniq(environment), 0) AS unique_envs)"
 
     def test_alias_in_alias(self):
         body = {
             'groupby': ['tags_key', 'tags_value']
         }
-        assert column_expr('tags_key', body) == (
+        assert column_expr(self.dataset, 'tags_key', body) == (
             '(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) '
             'AS all_tags))[1] AS tags_key)'
         )
 
         # If we want to use `tags_key` again, make sure we use the
         # already-created alias verbatim
-        assert column_expr('tags_key', body) == 'tags_key'
+        assert column_expr(self.dataset, 'tags_key', body) == 'tags_key'
         # If we also want to use `tags_value`, make sure that we use
         # the `all_tags` alias instead of re-expanding the tags arrayJoin
-        assert column_expr('tags_value', body) == '((all_tags)[2] AS tags_value)'
+        assert column_expr(self.dataset, 'tags_value', body) == '((all_tags)[2] AS tags_value)'
 
     def test_escape(self):
         assert escape_literal(r"'") == r"'\''"
@@ -113,50 +113,50 @@ class TestUtil(BaseTest):
 
     def test_conditions_expr(self):
         conditions = [['a', '=', 1]]
-        assert conditions_expr(conditions, {}) == 'a = 1'
+        assert conditions_expr(self.dataset, conditions, {}) == 'a = 1'
 
         conditions = [[['a', '=', 1]]]
-        assert conditions_expr(conditions, {}) == 'a = 1'
+        assert conditions_expr(self.dataset, conditions, {}) == 'a = 1'
 
         conditions = [['a', '=', 1], ['b', '=', 2]]
-        assert conditions_expr(conditions, {}) == 'a = 1 AND b = 2'
+        assert conditions_expr(self.dataset, conditions, {}) == 'a = 1 AND b = 2'
 
         conditions = [[['a', '=', 1], ['b', '=', 2]]]
-        assert conditions_expr(conditions, {}) == '(a = 1 OR b = 2)'
+        assert conditions_expr(self.dataset, conditions, {}) == '(a = 1 OR b = 2)'
 
         conditions = [[['a', '=', 1], ['b', '=', 2]], ['c', '=', 3]]
-        assert conditions_expr(conditions, {}) == '(a = 1 OR b = 2) AND c = 3'
+        assert conditions_expr(self.dataset, conditions, {}) == '(a = 1 OR b = 2) AND c = 3'
 
         conditions = [[['a', '=', 1], ['b', '=', 2]], [['c', '=', 3], ['d', '=', 4]]]
-        assert conditions_expr(conditions, {}) == '(a = 1 OR b = 2) AND (c = 3 OR d = 4)'
+        assert conditions_expr(self.dataset, conditions, {}) == '(a = 1 OR b = 2) AND (c = 3 OR d = 4)'
 
         # Malformed condition input
         conditions = [[['a', '=', 1], []]]
-        assert conditions_expr(conditions, {}) == 'a = 1'
+        assert conditions_expr(self.dataset, conditions, {}) == 'a = 1'
 
         # Test column expansion
         conditions = [[['tags[foo]', '=', 1], ['b', '=', 2]]]
-        expanded = column_expr('tags[foo]', {})
-        assert conditions_expr(conditions, {}) == '({} = 1 OR b = 2)'.format(expanded)
+        expanded = column_expr(self.dataset, 'tags[foo]', {})
+        assert conditions_expr(self.dataset, conditions, {}) == '({} = 1 OR b = 2)'.format(expanded)
 
         # Test using alias if column has already been expanded in SELECT clause
         reuse_body = {}
         conditions = [[['tags[foo]', '=', 1], ['b', '=', 2]]]
-        column_expr('tags[foo]', reuse_body)  # Expand it once so the next time is aliased
-        assert conditions_expr(conditions, reuse_body) == '(`tags[foo]` = 1 OR b = 2)'
+        column_expr(self.dataset, 'tags[foo]', reuse_body)  # Expand it once so the next time is aliased
+        assert conditions_expr(self.dataset, conditions, reuse_body) == '(`tags[foo]` = 1 OR b = 2)'
 
         # Test special output format of LIKE
         conditions = [['primary_hash', 'LIKE', '%foo%']]
-        assert conditions_expr(conditions, {}) == 'primary_hash LIKE \'%foo%\''
+        assert conditions_expr(self.dataset, conditions, {}) == 'primary_hash LIKE \'%foo%\''
 
         conditions = tuplify([[['notEmpty', ['arrayElement', ['exception_stacks.type', 1]]], '=', 1]])
-        assert conditions_expr(conditions, {}) == 'notEmpty(arrayElement(exception_stacks.type, 1)) = 1'
+        assert conditions_expr(self.dataset, conditions, {}) == 'notEmpty(arrayElement(exception_stacks.type, 1)) = 1'
 
         conditions = tuplify([[['notEmpty', ['tags[sentry:user]']], '=', 1]])
-        assert conditions_expr(conditions, {}) == 'notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 1'
+        assert conditions_expr(self.dataset, conditions, {}) == 'notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 1'
 
         conditions = tuplify([[['notEmpty', ['tags_key']], '=', 1]])
-        assert conditions_expr(conditions, {}) == 'notEmpty((arrayJoin(tags.key) AS tags_key)) = 1'
+        assert conditions_expr(self.dataset, conditions, {}) == 'notEmpty((arrayJoin(tags.key) AS tags_key)) = 1'
 
         conditions = tuplify([
             [
@@ -166,16 +166,16 @@ class TestUtil(BaseTest):
                 [['notEmpty', ['tags[sentry:user]']], '=', 'joe'], [['notEmpty', ['tags[sentry:user]']], '=', 'bob']
             ],
         ])
-        assert conditions_expr(conditions, {}) == \
+        assert conditions_expr(self.dataset, conditions, {}) == \
             """(notEmpty((tags.value[indexOf(tags.key, 'sentry:environment')] AS `tags[sentry:environment]`)) = 'dev' OR notEmpty(`tags[sentry:environment]`) = 'prod') AND (notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 'joe' OR notEmpty(`tags[sentry:user]`) = 'bob')"""
 
         # Test scalar condition on array column is expanded as an iterator.
         conditions = [['exception_frames.filename', 'LIKE', '%foo%']]
-        assert conditions_expr(conditions, {}) == 'arrayExists(x -> assumeNotNull(x LIKE \'%foo%\'), exception_frames.filename)'
+        assert conditions_expr(self.dataset, conditions, {}) == 'arrayExists(x -> assumeNotNull(x LIKE \'%foo%\'), exception_frames.filename)'
 
         # Test negative scalar condition on array column is expanded as an all() type iterator.
         conditions = [['exception_frames.filename', 'NOT LIKE', '%foo%']]
-        assert conditions_expr(conditions, {}) == 'arrayAll(x -> assumeNotNull(x NOT LIKE \'%foo%\'), exception_frames.filename)'
+        assert conditions_expr(self.dataset, conditions, {}) == 'arrayAll(x -> assumeNotNull(x NOT LIKE \'%foo%\'), exception_frames.filename)'
 
         # Test that a duplicate IN condition is deduplicated even if
         # the lists are in different orders.[
@@ -183,7 +183,7 @@ class TestUtil(BaseTest):
             ['platform', 'IN', ['a', 'b', 'c']],
             ['platform', 'IN', ['c', 'b', 'a']]
         ])
-        assert conditions_expr(conditions, {}) == "platform IN ('a', 'b', 'c')"
+        assert conditions_expr(self.dataset, conditions, {}) == "platform IN ('a', 'b', 'c')"
 
     def test_duplicate_expression_alias(self):
         body = {
@@ -196,64 +196,64 @@ class TestUtil(BaseTest):
         # to the same thing, one ends up overwriting the other.
         # This may not be ideal as it may mask bugs in query conditions
         exprs = [
-            column_expr(col, body, alias, agg)
+            column_expr(self.dataset, col, body, alias, agg)
             for (agg, col, alias) in body['aggregations']
         ]
         assert exprs == ['(topK(3)(logger) AS dupe_alias)', 'dupe_alias']
 
     def test_nested_aggregate_legacy_format(self):
         priority = ['toUInt64(plus(multiply(log(times_seen), 600), last_seen))', '', 'priority']
-        assert column_expr('', {'aggregations': [priority]}, priority[2], priority[0]) == '(toUInt64(plus(multiply(log(times_seen), 600), last_seen)) AS priority)'
+        assert column_expr(self.dataset, '', {'aggregations': [priority]}, priority[2], priority[0]) == '(toUInt64(plus(multiply(log(times_seen), 600), last_seen)) AS priority)'
 
         top_k = ['topK(3)', 'logger', 'top_3']
-        assert column_expr(top_k[1], {'aggregations': [top_k]}, top_k[2], top_k[0]) == '(topK(3)(logger) AS top_3)'
+        assert column_expr(self.dataset, top_k[1], {'aggregations': [top_k]}, top_k[2], top_k[0]) == '(topK(3)(logger) AS top_3)'
 
     def test_complex_conditions_expr(self):
         body = {}
 
-        assert complex_column_expr(tuplify(['count', []]), body.copy()) == 'count()'
-        assert complex_column_expr(tuplify(['notEmpty', ['foo']]), body.copy()) == 'notEmpty(foo)'
-        assert complex_column_expr(tuplify(['notEmpty', ['arrayElement', ['foo', 1]]]), body.copy()) == 'notEmpty(arrayElement(foo, 1))'
-        assert complex_column_expr(tuplify(['foo', ['bar', ['qux'], 'baz']]), body.copy()) == 'foo(bar(qux), baz)'
-        assert complex_column_expr(tuplify(['foo', [], 'a']), body.copy()) == '(foo() AS a)'
-        assert complex_column_expr(tuplify(['foo', ['b', 'c'], 'd']), body.copy()) == '(foo(b, c) AS d)'
-        assert complex_column_expr(tuplify(['foo', ['b', 'c', ['d']]]), body.copy()) == 'foo(b, c(d))'
+        assert complex_column_expr(self.dataset, tuplify(['count', []]), body.copy()) == 'count()'
+        assert complex_column_expr(self.dataset, tuplify(['notEmpty', ['foo']]), body.copy()) == 'notEmpty(foo)'
+        assert complex_column_expr(self.dataset, tuplify(['notEmpty', ['arrayElement', ['foo', 1]]]), body.copy()) == 'notEmpty(arrayElement(foo, 1))'
+        assert complex_column_expr(self.dataset, tuplify(['foo', ['bar', ['qux'], 'baz']]), body.copy()) == 'foo(bar(qux), baz)'
+        assert complex_column_expr(self.dataset, tuplify(['foo', [], 'a']), body.copy()) == '(foo() AS a)'
+        assert complex_column_expr(self.dataset, tuplify(['foo', ['b', 'c'], 'd']), body.copy()) == '(foo(b, c) AS d)'
+        assert complex_column_expr(self.dataset, tuplify(['foo', ['b', 'c', ['d']]]), body.copy()) == 'foo(b, c(d))'
 
-        assert complex_column_expr(tuplify(['top3', ['project_id']]), body.copy()) == 'topK(3)(project_id)'
-        assert complex_column_expr(tuplify(['top10', ['project_id'], 'baz']), body.copy()) == '(topK(10)(project_id) AS baz)'
+        assert complex_column_expr(self.dataset, tuplify(['top3', ['project_id']]), body.copy()) == 'topK(3)(project_id)'
+        assert complex_column_expr(self.dataset, tuplify(['top10', ['project_id'], 'baz']), body.copy()) == '(topK(10)(project_id) AS baz)'
 
-        assert complex_column_expr(tuplify(['emptyIfNull', ['project_id']]), body.copy()) == 'ifNull(project_id, \'\')'
-        assert complex_column_expr(tuplify(['emptyIfNull', ['project_id'], 'foo']), body.copy()) == '(ifNull(project_id, \'\') AS foo)'
+        assert complex_column_expr(self.dataset, tuplify(['emptyIfNull', ['project_id']]), body.copy()) == 'ifNull(project_id, \'\')'
+        assert complex_column_expr(self.dataset, tuplify(['emptyIfNull', ['project_id'], 'foo']), body.copy()) == '(ifNull(project_id, \'\') AS foo)'
 
-        assert complex_column_expr(tuplify(['or', ['a', 'b']]), body.copy()) == 'or(a, b)'
-        assert complex_column_expr(tuplify(['and', ['a', 'b']]), body.copy()) == 'and(a, b)'
-        assert complex_column_expr(tuplify(['or', [['or', ['a', 'b']], 'c']]), body.copy()) == 'or(or(a, b), c)'
-        assert complex_column_expr(tuplify(['and', [['and', ['a', 'b']], 'c']]), body.copy()) == 'and(and(a, b), c)'
+        assert complex_column_expr(self.dataset, tuplify(['or', ['a', 'b']]), body.copy()) == 'or(a, b)'
+        assert complex_column_expr(self.dataset, tuplify(['and', ['a', 'b']]), body.copy()) == 'and(a, b)'
+        assert complex_column_expr(self.dataset, tuplify(['or', [['or', ['a', 'b']], 'c']]), body.copy()) == 'or(or(a, b), c)'
+        assert complex_column_expr(self.dataset, tuplify(['and', [['and', ['a', 'b']], 'c']]), body.copy()) == 'and(and(a, b), c)'
         # (A OR B) AND C
-        assert complex_column_expr(tuplify(['and', [['or', ['a', 'b']], 'c']]), body.copy()) == 'and(or(a, b), c)'
+        assert complex_column_expr(self.dataset, tuplify(['and', [['or', ['a', 'b']], 'c']]), body.copy()) == 'and(or(a, b), c)'
         # (A AND B) OR C
-        assert complex_column_expr(tuplify(['or', [['and', ['a', 'b']], 'c']]), body.copy()) == 'or(and(a, b), c)'
+        assert complex_column_expr(self.dataset, tuplify(['or', [['and', ['a', 'b']], 'c']]), body.copy()) == 'or(and(a, b), c)'
         # A OR B OR C OR D
-        assert complex_column_expr(tuplify(['or', [['or', [['or', ['c', 'd']], 'b']], 'a']]), body.copy()) == 'or(or(or(c, d), b), a)'
+        assert complex_column_expr(self.dataset, tuplify(['or', [['or', [['or', ['c', 'd']], 'b']], 'a']]), body.copy()) == 'or(or(or(c, d), b), a)'
 
-        assert complex_column_expr(tuplify(['if', [['in', ['release', 'tuple', ["'foo'"], ], ], 'release', "'other'"], 'release', ]), body.copy()) == "(if(in(release, tuple('foo')), release, 'other') AS release)"
-        assert complex_column_expr(tuplify(['if', ['in', ['release', 'tuple', ["'foo'"]], 'release', "'other'", ], 'release']), body.copy()) == "(if(in(release, tuple('foo')), release, 'other') AS release)"
+        assert complex_column_expr(self.dataset, tuplify(['if', [['in', ['release', 'tuple', ["'foo'"], ], ], 'release', "'other'"], 'release', ]), body.copy()) == "(if(in(release, tuple('foo')), release, 'other') AS release)"
+        assert complex_column_expr(self.dataset, tuplify(['if', ['in', ['release', 'tuple', ["'foo'"]], 'release', "'other'", ], 'release']), body.copy()) == "(if(in(release, tuple('foo')), release, 'other') AS release)"
 
         # TODO once search_message is filled in everywhere, this can be just 'message' again.
         message_expr = '(coalesce(search_message, message) AS message)'
-        assert complex_column_expr(tuplify(['positionCaseInsensitive', ['message', "'lol 'single' quotes'"]]), body.copy())\
+        assert complex_column_expr(self.dataset, tuplify(['positionCaseInsensitive', ['message', "'lol 'single' quotes'"]]), body.copy())\
             == "positionCaseInsensitive({message_expr}, 'lol \\'single\\' quotes')".format(**locals())
 
         # dangerous characters are allowed but escaped in literals and column names
-        assert complex_column_expr(tuplify(['safe', ['fo`o', "'ba'r'"]]), body.copy()) == r"safe(`fo\`o`, 'ba\'r')"
+        assert complex_column_expr(self.dataset, tuplify(['safe', ['fo`o', "'ba'r'"]]), body.copy()) == r"safe(`fo\`o`, 'ba\'r')"
 
         # Dangerous characters not allowed in functions
         with pytest.raises(AssertionError):
-            assert complex_column_expr(tuplify([r"dang'erous", ['message', '`']]), body.copy())
+            assert complex_column_expr(self.dataset, tuplify([r"dang'erous", ['message', '`']]), body.copy())
 
         # Or nested functions
         with pytest.raises(AssertionError):
-            assert complex_column_expr(tuplify([r"safe", ['dang`erous', ['message']]]), body.copy())
+            assert complex_column_expr(self.dataset, tuplify([r"safe", ['dang`erous', ['message']]]), body.copy())
 
     def test_referenced_columns(self):
         # a = 1 AND b = 1

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -30,5 +30,5 @@ class TestWriter(BaseTest):
         processed['unknown_field'] = "unknown_value"
         row = self.dataset.row_from_processed_message(processed)
 
-        assert len(row) == len(self.dataset.get_schema().get_all_columns())
+        assert len(row) == len(self.dataset.get_schema().get_columns())
         assert "sdk_name" not in row


### PR DESCRIPTION
We need to remove the get_all_columns() function from clickhouse.py Because that is dataset aware and makes sense in a world with one single dataset.

In order to achieve this we need to make a lot of classes dataset aware and drop the assumption that there is one dataset only.