### PR TITLE
feat(CDC): Add GroupedMessage dataset

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -386,10 +386,7 @@ if application.debug or application.testing:
 
         rows = []
         for event in body:
-            _, processed = dataset.get_processor().process_message(
-                event,
-                KafkaMessageMetadata(message_offset=None, partition=None),
-            )
+            _, processed = dataset.get_processor().process_message(event)
             row = dataset.row_from_processed_message(processed)
             rows.append(row)
 

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -12,6 +12,7 @@ import simplejson as json
 
 from snuba import schemas, settings, state, util
 from snuba.clickhouse import ClickhousePool
+from snuba.consumer import KafkaMessageMetadata
 from snuba.replacer import get_projects_query_flags
 from snuba.split import split_query
 from snuba.datasets.factory import get_dataset, get_enabled_dataset_names
@@ -386,7 +387,9 @@ if application.debug or application.testing:
         rows = []
         for event in body:
             _, processed = dataset.get_processor().process_message(
-                event, {})
+                event,
+                KafkaMessageMetadata(message_offset=None, partition=None),
+            )
             row = dataset.row_from_processed_message(processed)
             rows.append(row)
 

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -12,7 +12,6 @@ import simplejson as json
 
 from snuba import schemas, settings, state, util
 from snuba.clickhouse import ClickhousePool
-from snuba.consumer import KafkaMessageMetadata
 from snuba.replacer import get_projects_query_flags
 from snuba.split import split_query
 from snuba.datasets.factory import get_dataset, get_enabled_dataset_names
@@ -185,6 +184,10 @@ def parse_and_run_query(validated_body, timer):
         from_date = to_date - timedelta(days=max_days)
 
     where_conditions = body.get('conditions', [])
+    where_conditions.extend([
+        ('timestamp', '>=', from_date),
+        ('timestamp', '<', to_date),
+    ])
     where_conditions.extend(dataset.default_conditions(body))
 
     # NOTE: we rely entirely on the schema to make sure that regular snuba

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -184,10 +184,6 @@ def parse_and_run_query(validated_body, timer):
         from_date = to_date - timedelta(days=max_days)
 
     where_conditions = body.get('conditions', [])
-    where_conditions.extend([
-        ('timestamp', '>=', from_date),
-        ('timestamp', '<', to_date),
-    ])
     where_conditions.extend(dataset.default_conditions(body))
 
     # NOTE: we rely entirely on the schema to make sure that regular snuba
@@ -380,7 +376,6 @@ if application.debug or application.testing:
 
     @application.route('/tests/insert', methods=['POST'])
     def write():
-        from snuba.processor import process_message
         from snuba.writer import write_rows
 
         # TODO we need to make this work for multiple datasets
@@ -390,7 +385,8 @@ if application.debug or application.testing:
 
         rows = []
         for event in body:
-            _, processed = dataset.get_processor().process_message(event)
+            _, processed = dataset.get_processor().process_message(
+                event, {})
             row = dataset.row_from_processed_message(processed)
             rows.append(row)
 

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -21,7 +21,7 @@ from snuba.datasets.factory import get_dataset
               help='Kafka bootstrap server to use.')
 @click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
               help='Clickhouse server to write to.')
-@click.option('--dataset', default='events', type=click.Choice(['events']),
+@click.option('--dataset', default='events', type=click.Choice(['events', 'groupedmessage']),
               help='The dataset to target')
 @click.option('--max-batch-size', default=settings.DEFAULT_MAX_BATCH_SIZE,
               help='Max number of messages to batch in memory before writing to Kafka.')

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -24,6 +24,9 @@ class ConsumerWorker(AbstractBatchWorker):
         self.metrics = metrics
 
     def process_message(self, message):
+        # TODO: consider moving this inside the processor so we can do a quick
+        # processing of messages we want to filter out without fully parsing the
+        # json.
         value = json.loads(message.value())
 
         processed = self.__dataset.get_processor().process_message(value)

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -10,6 +10,9 @@ from .writer import write_rows
 
 logger = logging.getLogger('snuba.consumer')
 
+KAFKA_MESSAGE_OFFSET_KEY = 'kafka_message_offset'
+KAFKA_PARTITION_KEY = 'kafka_partition'
+
 
 class InvalidActionType(Exception):
     pass
@@ -28,8 +31,11 @@ class ConsumerWorker(AbstractBatchWorker):
         # processing of messages we want to filter out without fully parsing the
         # json.
         value = json.loads(message.value())
-
-        processed = self.__dataset.get_processor().process_message(value)
+        metadata = {
+            KAFKA_MESSAGE_OFFSET_KEY: message.offset(),
+            KAFKA_PARTITION_KEY: message.partition(),
+        }
+        processed = self.__dataset.get_processor().process_message(value, metadata)
         if processed is None:
             return None
 

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -13,7 +13,7 @@ logger = logging.getLogger('snuba.consumer')
 
 KafkaMessageMetadata = collections.namedtuple(
     'KafkaMessageMetadata',
-    'message_offset partition'
+    'offset partition'
 )
 
 
@@ -34,7 +34,7 @@ class ConsumerWorker(AbstractBatchWorker):
         # processing of messages we want to filter out without fully parsing the
         # json.
         value = json.loads(message.value())
-        metadata = KafkaMessageMetadata(message_offset=message.offset(), partition=message.partition())
+        metadata = KafkaMessageMetadata(offset=message.offset(), partition=message.partition())
         processed = self.__dataset.get_processor().process_message(value, metadata)
         if processed is None:
             return None

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -1,0 +1,56 @@
+from snuba import processor
+from snuba.processor import MessageProcessor
+
+
+class CdcProcessor(MessageProcessor):
+
+    def __init__(self, pg_table):
+        self.pg_table = pg_table
+
+    def _process_begin(self, xid):
+        pass
+
+    def _process_commit(self):
+        pass
+
+    def _process_insert(self, xid, columnnames, columnvalues):
+        pass
+
+    def _process_update(self, xid, key, columnnames, columnvalues):
+        pass
+
+    def _process_delete(self, xid, key):
+        pass
+
+    def process_message(self, value):
+        assert isinstance(value, dict)
+        event = value['event']
+        if event == 'begin':
+            xid = value['xid']
+            message = self._process_begin(xid)
+        elif event == 'commit':
+            message = self._process_commit()
+        elif event == 'change':
+            table_name = value['table']
+            if table_name != self.pg_table:
+                return None
+
+            operation = value['kind']
+            xid = value['xid']
+            if operation == 'insert':
+                message = self._process_insert(
+                    xid, value['columnnames'], value['columnvalues'])
+            elif operation == 'update':
+                message = self._process_update(
+                    xid, value['oldkeys'], value['columnnames'], value['columnvalues'])
+            elif operation == 'delete':
+                message = self._process_delete(xid)
+            else:
+                raise
+        else:
+            raise
+
+        if message is None:
+            return None
+
+        return (processor.INSERT, message)

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -30,7 +30,7 @@ class CdcProcessor(MessageProcessor):
         partition = metadata.partition
         assert partition == KAFKA_ONLY_PARTITION, 'CDC can only work with single partition topics for consistency'
 
-        offset = metadata.message_offset
+        offset = metadata.offset
         event = value['event']
         if event == 'begin':
             message = self._process_begin(offset)

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -44,7 +44,7 @@ class CdcProcessor(MessageProcessor):
                 message = self._process_update(
                     xid, value['oldkeys'], value['columnnames'], value['columnvalues'])
             elif operation == 'delete':
-                message = self._process_delete(xid)
+                message = self._process_delete(xid, value['oldkeys'])
             else:
                 raise ValueError("Invalid value for operation in replication log: %s" % value['kind'])
         else:

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -1,4 +1,5 @@
 from snuba import processor
+from snuba.consumer import KAFKA_MESSAGE_OFFSET_KEY
 from snuba.processor import MessageProcessor
 
 
@@ -7,44 +8,46 @@ class CdcProcessor(MessageProcessor):
     def __init__(self, pg_table):
         self.pg_table = pg_table
 
-    def _process_begin(self, xid):
+    def _process_begin(self, offset):
         pass
 
-    def _process_commit(self):
+    def _process_commit(self, offset):
         pass
 
-    def _process_insert(self, xid, columnnames, columnvalues):
+    def _process_insert(self, offset, columnnames, columnvalues):
         pass
 
-    def _process_update(self, xid, key, columnnames, columnvalues):
+    def _process_update(self, offset, key, columnnames, columnvalues):
         pass
 
-    def _process_delete(self, xid, key):
+    def _process_delete(self, offset, key):
         pass
 
-    def process_message(self, value):
+    def process_message(self, value, metadata):
         assert isinstance(value, dict)
+        assert isinstance(metadata, dict)
+
+        offset = metadata[KAFKA_MESSAGE_OFFSET_KEY]
+
         event = value['event']
         if event == 'begin':
-            xid = value['xid']
-            message = self._process_begin(xid)
+            message = self._process_begin(offset)
         elif event == 'commit':
-            message = self._process_commit()
+            message = self._process_commit(offset)
         elif event == 'change':
             table_name = value['table']
             if table_name != self.pg_table:
                 return None
 
             operation = value['kind']
-            xid = value['xid']
             if operation == 'insert':
                 message = self._process_insert(
-                    xid, value['columnnames'], value['columnvalues'])
+                    offset, value['columnnames'], value['columnvalues'])
             elif operation == 'update':
                 message = self._process_update(
-                    xid, value['oldkeys'], value['columnnames'], value['columnvalues'])
+                    offset, value['oldkeys'], value['columnnames'], value['columnvalues'])
             elif operation == 'delete':
-                message = self._process_delete(xid, value['oldkeys'])
+                message = self._process_delete(offset, value['oldkeys'])
             else:
                 raise ValueError("Invalid value for operation in replication log: %s" % value['kind'])
         else:

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -46,9 +46,9 @@ class CdcProcessor(MessageProcessor):
             elif operation == 'delete':
                 message = self._process_delete(xid)
             else:
-                raise
+                raise ValueError("Invalid value for operation in replication log: %s" % value['kind'])
         else:
-            raise
+            raise ValueError("Invalid value for event in replication log: %s" % value['event'])
 
         if message is None:
             return None

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -1,6 +1,7 @@
 from snuba import processor
-from snuba.consumer import KAFKA_MESSAGE_OFFSET_KEY
 from snuba.processor import MessageProcessor
+
+KAFKA_ONLY_PARTITION = 0  # CDC only works with single partition topics. So partition must be 0
 
 
 class CdcProcessor(MessageProcessor):
@@ -25,10 +26,11 @@ class CdcProcessor(MessageProcessor):
 
     def process_message(self, value, metadata):
         assert isinstance(value, dict)
-        assert isinstance(metadata, dict)
 
-        offset = metadata[KAFKA_MESSAGE_OFFSET_KEY]
+        partition = metadata.partition
+        assert partition == KAFKA_ONLY_PARTITION, 'CDC can only work with single partition topics for consistency'
 
+        offset = metadata.message_offset
         event = value['event']
         if event == 'begin':
             message = self._process_begin(offset)

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -13,10 +13,8 @@ class GroupedMessageDataSet(DataSet):
     def __init__(self):
         columns = ColumnSet([
             # columns to maintain the dataset
-            # for now this is actually the 32 bit commit_id, but we are trying to
-            # get the 64 bit one from postgres, thus we will create the column as
-            # 64 bit.
-            ('commit_id', UInt(64)),
+            # Kafka topic offset
+            ('offset', UInt(64)),
             # PG columns
             ('id', UInt(64)),
             ('logger', String()),
@@ -47,7 +45,7 @@ class GroupedMessageDataSet(DataSet):
             dist_table_name='groupedmessage_dist',
             order_by='(project_id, id)',
             partition_by=None,
-            version_column='commit_id',
+            version_column='offset',
             sample_expr='id',
         )
 

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,0 +1,58 @@
+from snuba.clickhouse import ColumnSet, DateTime, Nullable, String, UInt
+from snuba.datasets import DataSet
+from snuba.datasets.cdc.groupedmessage_processor import GroupedMessageProcessor
+from snuba.datasets.schema import ReplacingMergeTreeSchema
+
+
+class GroupedMessageDataSet(DataSet):
+    """
+    This is a full clone of postgres groupedmessage
+    generated through change capture.
+    """
+
+    def __init__(self):
+        columns = ColumnSet([
+            # columns to maintain the dataset
+            ('commit_id', UInt(64)),
+            ('deleted', UInt(8)),
+            # PG columns
+            ('id', UInt(64)),
+            ('logger', String()),
+            ('level', UInt(32)),
+            ('message', String()),
+            ('view', Nullable(String())),
+            ('status', UInt(32)),
+            ('times_seen', UInt(64)),
+            ('last_seen', DateTime()),
+            ('first_seen', DateTime()),
+            ('data', Nullable(String())),
+            ('score', UInt(32)),
+            ('project_id', UInt(64)),
+            ('time_spent_total', UInt(32)),
+            ('time_spent_count', UInt(32)),
+            ('resolved_at', Nullable(DateTime())),
+            ('active_at', Nullable(DateTime())),
+            ('is_public', Nullable(UInt(8))),
+            ('platform', Nullable(String())),
+            ('num_comments', Nullable(UInt(32))),
+            ('first_release_id', Nullable(UInt(64))),
+            ('short_id', Nullable(UInt(64))),
+        ])
+
+        schema = ReplacingMergeTreeSchema(
+            columns=columns,
+            local_table_name='groupedmessage_local',
+            dist_table_name='groupedmessage_dist',
+            order_by='(project_id, toStartOfDay(first_seen), id)',
+            partition_by='toMonday(last_seen)',
+            version_column='commit_id',
+            sample_expr='id',
+        )
+
+        super(GroupedMessageDataSet, self).__init__(
+            schema=schema,
+            processor=GroupedMessageProcessor(),
+            default_topic="cdc",
+            default_replacement_topic=None,
+            default_commit_log_topic=None,
+        )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -13,8 +13,10 @@ class GroupedMessageDataSet(DataSet):
     def __init__(self):
         columns = ColumnSet([
             # columns to maintain the dataset
+            # for now this is actually the 32 bit commit_id, but we are trying to
+            # get the 64 bit one from postgres, thus we will create the column as
+            # 64 bit.
             ('commit_id', UInt(64)),
-            ('deleted', UInt(8)),
             # PG columns
             ('id', UInt(64)),
             ('logger', String()),
@@ -22,29 +24,29 @@ class GroupedMessageDataSet(DataSet):
             ('message', String()),
             ('view', Nullable(String())),
             ('status', UInt(32)),
-            ('times_seen', UInt(64)),
+            #('times_seen', UInt(64)),
             ('last_seen', DateTime()),
             ('first_seen', DateTime()),
-            ('data', Nullable(String())),
-            ('score', UInt(32)),
+            #('data', Nullable(String())),
+            #('score', UInt(32)),
             ('project_id', UInt(64)),
-            ('time_spent_total', UInt(32)),
-            ('time_spent_count', UInt(32)),
-            ('resolved_at', Nullable(DateTime())),
+            #('time_spent_total', UInt(32)),
+            #('time_spent_count', UInt(32)),
+            #('resolved_at', Nullable(DateTime())),
             ('active_at', Nullable(DateTime())),
-            ('is_public', Nullable(UInt(8))),
+            #('is_public', Nullable(UInt(8))),
             ('platform', Nullable(String())),
-            ('num_comments', Nullable(UInt(32))),
+            #('num_comments', Nullable(UInt(32))),
             ('first_release_id', Nullable(UInt(64))),
-            ('short_id', Nullable(UInt(64))),
+            #('short_id', Nullable(UInt(64))),
         ])
 
         schema = ReplacingMergeTreeSchema(
             columns=columns,
             local_table_name='groupedmessage_local',
             dist_table_name='groupedmessage_dist',
-            order_by='(project_id, toStartOfDay(first_seen), id)',
-            partition_by='toMonday(last_seen)',
+            order_by='(project_id, id)',
+            partition_by=None,
             version_column='commit_id',
             sample_expr='id',
         )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -17,26 +17,11 @@ class GroupedMessageDataSet(DataSet):
             ('offset', UInt(64)),
             # PG columns
             ('id', UInt(64)),
-            ('logger', String()),
-            ('level', UInt(32)),
-            ('message', String()),
-            ('view', Nullable(String())),
-            ('status', UInt(32)),
-            #('times_seen', UInt(64)),
+            ('status', UInt(8)),
             ('last_seen', DateTime()),
             ('first_seen', DateTime()),
-            #('data', Nullable(String())),
-            #('score', UInt(32)),
-            ('project_id', UInt(64)),
-            #('time_spent_total', UInt(32)),
-            #('time_spent_count', UInt(32)),
-            #('resolved_at', Nullable(DateTime())),
             ('active_at', Nullable(DateTime())),
-            #('is_public', Nullable(UInt(8))),
-            ('platform', Nullable(String())),
-            #('num_comments', Nullable(UInt(32))),
             ('first_release_id', Nullable(UInt(64))),
-            #('short_id', Nullable(UInt(64))),
         ])
 
         schema = ReplacingMergeTreeSchema(

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,4 +1,4 @@
-from snuba.clickhouse import ColumnSet, DateTime, Nullable, String, UInt
+from snuba.clickhouse import ColumnSet, DateTime, Nullable, UInt
 from snuba.datasets import DataSet
 from snuba.datasets.cdc.groupedmessage_processor import GroupedMessageProcessor
 from snuba.datasets.schema import ReplacingMergeTreeSchema
@@ -6,8 +6,8 @@ from snuba.datasets.schema import ReplacingMergeTreeSchema
 
 class GroupedMessageDataSet(DataSet):
     """
-    This is a full clone of postgres groupedmessage
-    generated through change capture.
+    This is a clone of the bare minimum fields we need from postgres groupedmessage table
+    to replace such a table in event search.
     """
 
     def __init__(self):
@@ -15,11 +15,16 @@ class GroupedMessageDataSet(DataSet):
             # columns to maintain the dataset
             # Kafka topic offset
             ('offset', UInt(64)),
+            # GroupStatus in Sentry does not have a 'DELETED' state that reflects the deletion
+            # of the record. Having a dedicated clickhouse-only flag to identify this case seems
+            # more consistent than add an additional value into the status field below that does not
+            # exists on the Sentry side.
+            ('record_deleted', UInt(8)),
             # PG columns
             ('id', UInt(64)),
-            ('status', UInt(8)),
-            ('last_seen', DateTime()),
-            ('first_seen', DateTime()),
+            ('status', Nullable(UInt(8))),
+            ('last_seen', Nullable(DateTime())),
+            ('first_seen', Nullable(DateTime())),
             ('active_at', Nullable(DateTime())),
             ('first_release_id', Nullable(UInt(64))),
         ])
@@ -28,7 +33,7 @@ class GroupedMessageDataSet(DataSet):
             columns=columns,
             local_table_name='groupedmessage_local',
             dist_table_name='groupedmessage_dist',
-            order_by='(project_id, id)',
+            order_by='id',
             partition_by=None,
             version_column='offset',
             sample_expr='id',

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -19,22 +19,23 @@ class GroupedMessageProcessor(CdcProcessor):
 
     def __build_record(self, xid, columnnames, columnvalues):
         raw_data = dict(zip(columnnames, columnvalues))
-        string_cols = [
-            'logger', 'message', 'view', 'data', 'platform'
-        ]
-        for c in string_cols:
-            raw_data[c] = _unicodify(raw_data[c])
+        output = {
+            'commit_id': xid,
+            'id': raw_data['id'],
+            'logger': _unicodify(raw_data['logger']),
+            'level': raw_data['level'],
+            'message': _unicodify(raw_data['message']),
+            'view': _unicodify(raw_data['view']),
+            'status': raw_data['status'],
+            'last_seen': self.__prepare_date(raw_data['last_seen']),
+            'first_seen': self.__prepare_date(raw_data['first_seen']),
+            'project_id': raw_data['project_id'] or 0,
+            'active_at': self.__prepare_date(raw_data['active_at']),
+            'platform': _unicodify(raw_data['platform']),
+            'first_release_id': raw_data['first_release_id'],
+        }
 
-        raw_data['last_seen'] = self.__prepare_date(raw_data['last_seen'])
-        raw_data['first_seen'] = self.__prepare_date(raw_data['first_seen'])
-        raw_data['resolved_at'] = self.__prepare_date(raw_data['resolved_at']) if raw_data['resolved_at'] else None
-        raw_data['active_at'] = self.__prepare_date(raw_data['active_at'])
-        raw_data['is_public'] = 1 if raw_data['is_public'] else 0
-        raw_data['project_id'] = raw_data['project_id'] or 0
-
-        raw_data['commit_id'] = xid
-        raw_data['deleted'] = 1 if raw_data['status'] == self.DELETED_STATUS else 0
-        return raw_data
+        return output
 
     def _process_insert(self, xid, columnnames, columnvalues):
         return self.__build_record(xid, columnnames, columnvalues)

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-from snuba.processor import _unicodify
 from snuba.datasets.cdc.cdcprocessors import CdcProcessor
 
 
@@ -20,16 +19,10 @@ class GroupedMessageProcessor(CdcProcessor):
         output = {
             'offset': offset,
             'id': raw_data['id'],
-            'logger': _unicodify(raw_data['logger']),
-            'level': raw_data['level'],
-            'message': _unicodify(raw_data['message']),
-            'view': _unicodify(raw_data['view']),
             'status': raw_data['status'],
             'last_seen': self.__prepare_date(raw_data['last_seen']),
             'first_seen': self.__prepare_date(raw_data['first_seen']),
-            'project_id': raw_data['project_id'] or 0,
             'active_at': self.__prepare_date(raw_data['active_at']),
-            'platform': _unicodify(raw_data['platform']),
             'first_release_id': raw_data['first_release_id'],
         }
 

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -41,4 +41,12 @@ class GroupedMessageProcessor(CdcProcessor):
         return self.__build_record(xid, columnnames, columnvalues)
 
     def _process_update(self, xid, key, columnnames, columnvalues):
+        new_id = columnvalues[columnnames.index('id')]
+        key_names = key['keynames']
+        key_values = key['keyvalues']
+        old_id = key_values[key_names.index('id')]
+        # We cannot support a change in the identity of the record
+        # clickhouse will use the identity column to find rows to merge.
+        # if we change it, merging won't work.
+        assert old_id == new_id, 'Changing Primary Key is not supported.'
         return self.__build_record(xid, columnnames, columnvalues)

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+
+from snuba.processor import _unicodify
+from snuba.datasets.cdc.cdcprocessors import CdcProcessor
+
+
+class GroupedMessageProcessor(CdcProcessor):
+
+    def __init__(self):
+        super(GroupedMessageProcessor, self).__init__(
+            pg_table='sentry_groupedmessage',
+        )
+
+    DELETED_STATUS = 3
+
+    def __prepare_date(self, dt):
+        return datetime.strptime(
+            "%s00" % dt, '%Y-%m-%d %H:%M:%S%z')
+
+    def __build_record(self, xid, columnnames, columnvalues):
+        raw_data = dict(zip(columnnames, columnvalues))
+        string_cols = [
+            'logger', 'message', 'view', 'data', 'platform'
+        ]
+        for c in string_cols:
+            raw_data[c] = _unicodify(raw_data[c])
+
+        raw_data['last_seen'] = self.__prepare_date(raw_data['last_seen'])
+        raw_data['first_seen'] = self.__prepare_date(raw_data['first_seen'])
+        raw_data['resolved_at'] = self.__prepare_date(raw_data['resolved_at']) if raw_data['resolved_at'] else None
+        raw_data['active_at'] = self.__prepare_date(raw_data['active_at'])
+        raw_data['is_public'] = 1 if raw_data['is_public'] else 0
+        raw_data['project_id'] = raw_data['project_id'] or 0
+
+        raw_data['commit_id'] = xid
+        raw_data['deleted'] = 1 if raw_data['status'] == self.DELETED_STATUS else 0
+        return raw_data
+
+    def _process_insert(self, xid, columnnames, columnvalues):
+        return self.__build_record(xid, columnnames, columnvalues)
+
+    def _process_update(self, xid, key, columnnames, columnvalues):
+        return self.__build_record(xid, columnnames, columnvalues)

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -1,5 +1,5 @@
-from datetime import datetime
 
+from dateutil.parser import parse as dateutil_parse
 from snuba.datasets.cdc.cdcprocessors import CdcProcessor
 
 
@@ -10,19 +10,15 @@ class GroupedMessageProcessor(CdcProcessor):
             pg_table='sentry_groupedmessage',
         )
 
-    def __prepare_date(self, dt):
-        return datetime.strptime(
-            "%s00" % dt, '%Y-%m-%d %H:%M:%S%z')
-
     def __build_record(self, offset, columnnames, columnvalues):
         raw_data = dict(zip(columnnames, columnvalues))
         output = {
             'offset': offset,
             'id': raw_data['id'],
             'status': raw_data['status'],
-            'last_seen': self.__prepare_date(raw_data['last_seen']),
-            'first_seen': self.__prepare_date(raw_data['first_seen']),
-            'active_at': self.__prepare_date(raw_data['active_at']),
+            'last_seen': dateutil_parse(raw_data['last_seen']),
+            'first_seen': dateutil_parse(raw_data['first_seen']),
+            'active_at': dateutil_parse(raw_data['active_at']),
             'first_release_id': raw_data['first_release_id'],
         }
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -314,6 +314,6 @@ class EventsProcessor(MessageProcessor):
     def __init__(self, promoted_tag_columns):
         self.__promoted_tag_columns = promoted_tag_columns
 
-    def process_message(self, value):
+    def process_message(self, value, mtadata):
         return process_message(self.__promoted_tag_columns,
             value)

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -202,7 +202,17 @@ class EventsDataSet(DataSet):
         self.__required_columns = required_columns
 
     def default_conditions(self, body):
+        date_align = state.get_configs([
+            ('date_align_seconds', 1),
+        ])[0]
+
+        to_date = util.parse_datetime(body['to_date'], date_align)
+        from_date = util.parse_datetime(body['from_date'], date_align)
+        assert from_date <= to_date
+
         return [
+            ('timestamp', '>=', from_date),
+            ('timestamp', '<', to_date),
             ('deleted', '=', 0),
         ]
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -324,5 +324,5 @@ class EventsProcessor(MessageProcessor):
     def __init__(self, promoted_tag_columns):
         self.__promoted_tag_columns = promoted_tag_columns
 
-    def process_message(self, value, metadata):
+    def process_message(self, value, metadata=None):
         return process_message(self.__promoted_tag_columns, value)

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -202,17 +202,7 @@ class EventsDataSet(DataSet):
         self.__required_columns = required_columns
 
     def default_conditions(self, body):
-        date_align = state.get_configs([
-            ('date_align_seconds', 1),
-        ])[0]
-
-        to_date = util.parse_datetime(body['to_date'], date_align)
-        from_date = util.parse_datetime(body['from_date'], date_align)
-        assert from_date <= to_date
-
         return [
-            ('timestamp', '>=', from_date),
-            ('timestamp', '<', to_date),
             ('deleted', '=', 0),
         ]
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,5 +1,5 @@
 import re
-from snuba import state, util
+from snuba import state
 from snuba.clickhouse import (
     Array,
     ColumnSet,
@@ -15,13 +15,11 @@ from snuba.clickhouse import (
 from snuba.datasets import DataSet
 from snuba.datasets.schema import ReplacingMergeTreeSchema
 from snuba.processor import MessageProcessor, process_message
-from snuba.settings import TIME_GROUP_COLUMNS
 from snuba.util import (
     alias_expr,
     all_referenced_columns,
     escape_literal,
     string_col,
-    time_expr,
 )
 
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -324,6 +324,5 @@ class EventsProcessor(MessageProcessor):
     def __init__(self, promoted_tag_columns):
         self.__promoted_tag_columns = promoted_tag_columns
 
-    def process_message(self, value, mtadata):
-        return process_message(self.__promoted_tag_columns,
-            value)
+    def process_message(self, value, metadata):
+        return process_message(self.__promoted_tag_columns, value)

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -4,6 +4,7 @@ DATASETS_IMPL = {}
 
 DATASET_NAMES = {
     'events',
+    'groupedmessage',
 }
 
 
@@ -14,8 +15,10 @@ def get_dataset(name):
     assert name not in settings.DISABLED_DATASETS, "Dataset %s not available in this environment" % name
 
     from snuba.datasets.events import EventsDataSet
+    from snuba.datasets.cdc.groupedmessage import GroupedMessageDataSet
     dataset_mappings = {
         'events': EventsDataSet,
+        'groupedmessage': GroupedMessageDataSet
     }
 
     dataset = DATASETS_IMPL[name] = dataset_mappings[name]()

--- a/snuba/datasets/schema.py
+++ b/snuba/datasets/schema.py
@@ -72,13 +72,15 @@ class ReplacingMergeTreeSchema(TableSchema):
         self.__sample_expr = sample_expr
 
     def _get_local_engine(self):
+        partition_by_clause = "PARTITION BY %s" % \
+            self.__partition_by if self.__partition_by else ''
         return """
             ReplacingMergeTree(%(version_column)s)
-            PARTITION BY %(partition_by)s
+             %(partition_by_clause)s
             ORDER BY %(order_by)s
             SAMPLE BY %(sample_expr)s ;""" % {
             'order_by': self.__order_by,
-            'partition_by': self.__partition_by,
+            'partition_by_clause': partition_by_clause,
             'version_column': self.__version_column,
             'sample_expr': self.__sample_expr,
         }

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -27,7 +27,7 @@ class MessageProcessor(object):
     event stream into a row or statement to be inserted or executed against clickhouse.
     """
 
-    def process_message(self, value, metadata):
+    def process_message(self, value, metadata=None):
         raise NotImplementedError
 
 

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -27,7 +27,7 @@ class MessageProcessor(object):
     event stream into a row or statement to be inserted or executed against clickhouse.
     """
 
-    def process_message(self, value):
+    def process_message(self, value, metadata):
         raise NotImplementedError
 
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -122,6 +122,12 @@ class TestConsumer(BaseTest):
             def value(self):
                 return json.dumps((0, 'insert', event))
 
+            def partition(self):
+                return 1
+
+            def offset(self):
+                return 42
+
         assert test_worker.process_message(FakeMessage()) is None
 
     def test_produce_replacement_messages(self):

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -79,7 +79,7 @@ class TestGroupedMessageProcessor(BaseTest):
         processor = GroupedMessageProcessor()
 
         metadata = KafkaMessageMetadata(
-            message_offset=42,
+            offset=42,
             partition=0,
         )
 

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -1,0 +1,92 @@
+import pytz
+import simplejson as json
+from datetime import datetime
+
+from base import BaseTest
+from snuba.datasets.cdc.groupedmessage_processor import GroupedMessageProcessor
+
+
+class TestGroupedMessageProcessor(BaseTest):
+
+    BEGIN_MSG = '{"event":"begin","xid":2380836}'
+    COMMIT_MSG = '{"event":"commit"}'
+    UPDATE_MSG = (
+        '{"event":"change","xid":2380866,"kind":"update","schema":"public",'
+        '"table":"sentry_groupedmessage","columnnames":["id","logger","level","message",'
+        '"view","status","times_seen","last_seen","first_seen","data","score","project_id",'
+        '"time_spent_total","time_spent_count","resolved_at","active_at","is_public","platform",'
+        '"num_comments","first_release_id","short_id"],"columntypes":["bigint","character varying(64)",'
+        '"integer","text","character varying(200)","integer","integer","timestamp with time zone",'
+        '"timestamp with time zone","text","integer","bigint","integer","integer",'
+        '"timestamp with time zone","timestamp with time zone","boolean","character varying(64)","integer",'
+        '"bigint","bigint"],"columnvalues":[74,"",40,'
+        '"<module> ZeroDivisionError integer division or modulo by zero client3.py __main__ in <module>",'
+        '"__main__ in <module>",0,2,"2019-06-19 06:46:28+00","2019-06-19 06:45:32+00",'
+        '"eJyT7tuwzAM3PkV2pzJiO34VRSdmvxAgA5dCtViDAGyJEi0AffrSxrZOlSTjrzj3Z1MrOBekCWHBcQaPj4xhXe72WyDv6YU0ouynnDGpMxzrEJSSzCrC+p7Vz8sgNhAvhdOZ/pKOKHd0PC5C9yqtjuPddcPQ9n0w8hPiLRHsWvZGsWD/91xI'
+        'ya2IFxz7vJWfTUlHHnwSCEBUkbTZrxCCcOf2baY/XTU1VJm9cjHL4JriHPYvOnliyP0Jt2q4SpLkz7v6owW9E9rEOvl0PawczxcvkLIWppxg==",'
+        '1560926969,2,0,0,null,"2019-06-19 06:45:32+00",false,"python",0,null,20],'
+        '"oldkeys":{"keynames":["id"],"keytypes":["bigint"],"keyvalues":[74]}}'
+    )
+
+    INSERT_MSG = (
+        '{"event":"change","xid":2380866,"kind":"insert","schema":"public",'
+        '"table":"sentry_groupedmessage","columnnames":["id","logger","level","message",'
+        '"view","status","times_seen","last_seen","first_seen","data","score","project_id",'
+        '"time_spent_total","time_spent_count","resolved_at","active_at","is_public","platform",'
+        '"num_comments","first_release_id","short_id"],"columntypes":["bigint","character varying(64)",'
+        '"integer","text","character varying(200)","integer","integer","timestamp with time zone",'
+        '"timestamp with time zone","text","integer","bigint","integer","integer",'
+        '"timestamp with time zone","timestamp with time zone","boolean","character varying(64)","integer",'
+        '"bigint","bigint"],"columnvalues":[74,"",40,'
+        '"<module> ZeroDivisionError integer division or modulo by zero client3.py __main__ in <module>",'
+        '"__main__ in <module>",0,2,"2019-06-19 06:46:28+00","2019-06-19 06:45:32+00",'
+        '"eJyT7tuwzAM3PkV2pzJiO34VRSdmvxAgA5dCtViDAGyJEi0AffrSxrZOlSTjrzj3Z1MrOBekCWHBcQaPj4xhXe72WyDv6YU0ouynnDGpMxzrEJSSzCrC+p7Vz8sgNhAvhdOZ/pKOKHd0PC5C9yqtjuPddcPQ9n0w8hPiLRHsWvZGsWD/91xI'
+        'ya2IFxz7vJWfTUlHHnwSCEBUkbTZrxCCcOf2baY/XTU1VJm9cjHL4JriHPYvOnliyP0Jt2q4SpLkz7v6owW9E9rEOvl0PawczxcvkLIWppxg==",'
+        '1560926969,2,0,0,null,"2019-06-19 06:45:32+00",false,"python",0,null,20]'
+        '}'
+    )
+
+    PROCESSED = {
+        'commit_id': 2380866,
+        'deleted': 0,
+        'id': 74,
+        'logger': '',
+        'level': 40,
+        'message': '<module> ZeroDivisionError integer division or modulo by zero client3.py __main__ in <module>',
+        'view': '__main__ in <module>',
+        'status': 0,
+        'times_seen': 2,
+        'last_seen': datetime(2019, 6, 19, 6, 46, 28, tzinfo=pytz.UTC),
+        'first_seen': datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
+        'data': 'eJyT7tuwzAM3PkV2pzJiO34VRSdmvxAgA5dCtViDAGyJEi0AffrSxrZOlSTjrzj3Z1MrOBekCWHBcQaPj4xhXe72WyDv6YU0ouynnDGpMxzrEJSSzCrC+p7Vz8sgNhAvhdOZ/pKOKHd0PC5C9yqtjuPddcPQ9n0w8hPiLRHsWvZGsWD/91xIya2IFxz7vJWfTUlHHnwSCEBUkbTZrxCCcOf2baY/XTU1VJm9cjHL4JriHPYvOnliyP0Jt2q4SpLkz7v6owW9E9rEOvl0PawczxcvkLIWppxg==',
+        'score': 1560926969,
+        'project_id': 2,
+        'time_spent_total': 0,
+        'time_spent_count': 0,
+        'resolved_at': None,
+        'active_at': datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
+        'is_public': 0,
+        'platform': 'python',
+        'num_comments': 0,
+        'first_release_id': None,
+        'short_id': 20,
+    }
+
+    def test_messages(self):
+        processor = GroupedMessageProcessor()
+
+        begin_msg = json.loads(self.BEGIN_MSG)
+        ret = processor.process_message(begin_msg)
+        assert ret is None
+
+        commit_msg = json.loads(self.COMMIT_MSG)
+        ret = processor.process_message(commit_msg)
+        assert ret is None
+
+        insert_msg = json.loads(self.INSERT_MSG)
+        ret = processor.process_message(insert_msg)
+        assert ret[1] == self.PROCESSED
+
+        update_msg = json.loads(self.UPDATE_MSG)
+        ret = processor.process_message(update_msg)
+        assert ret[1] == self.PROCESSED

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -48,28 +48,18 @@ class TestGroupedMessageProcessor(BaseTest):
 
     PROCESSED = {
         'commit_id': 2380866,
-        'deleted': 0,
         'id': 74,
         'logger': '',
         'level': 40,
         'message': '<module> ZeroDivisionError integer division or modulo by zero client3.py __main__ in <module>',
         'view': '__main__ in <module>',
         'status': 0,
-        'times_seen': 2,
         'last_seen': datetime(2019, 6, 19, 6, 46, 28, tzinfo=pytz.UTC),
         'first_seen': datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
-        'data': 'eJyT7tuwzAM3PkV2pzJiO34VRSdmvxAgA5dCtViDAGyJEi0AffrSxrZOlSTjrzj3Z1MrOBekCWHBcQaPj4xhXe72WyDv6YU0ouynnDGpMxzrEJSSzCrC+p7Vz8sgNhAvhdOZ/pKOKHd0PC5C9yqtjuPddcPQ9n0w8hPiLRHsWvZGsWD/91xIya2IFxz7vJWfTUlHHnwSCEBUkbTZrxCCcOf2baY/XTU1VJm9cjHL4JriHPYvOnliyP0Jt2q4SpLkz7v6owW9E9rEOvl0PawczxcvkLIWppxg==',
-        'score': 1560926969,
         'project_id': 2,
-        'time_spent_total': 0,
-        'time_spent_count': 0,
-        'resolved_at': None,
         'active_at': datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
-        'is_public': 0,
         'platform': 'python',
-        'num_comments': 0,
         'first_release_id': None,
-        'short_id': 20,
     }
 
     def test_messages(self):

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -3,6 +3,7 @@ import simplejson as json
 from datetime import datetime
 
 from base import BaseTest
+from snuba.consumer import KAFKA_MESSAGE_OFFSET_KEY, KAFKA_PARTITION_KEY
 from snuba.datasets.cdc.groupedmessage_processor import GroupedMessageProcessor
 
 
@@ -47,7 +48,7 @@ class TestGroupedMessageProcessor(BaseTest):
     )
 
     PROCESSED = {
-        'commit_id': 2380866,
+        'offset': 42,
         'id': 74,
         'logger': '',
         'level': 40,
@@ -65,18 +66,23 @@ class TestGroupedMessageProcessor(BaseTest):
     def test_messages(self):
         processor = GroupedMessageProcessor()
 
+        metadata = {
+            KAFKA_MESSAGE_OFFSET_KEY: 42,
+            KAFKA_PARTITION_KEY: 1,
+        }
+
         begin_msg = json.loads(self.BEGIN_MSG)
-        ret = processor.process_message(begin_msg)
+        ret = processor.process_message(begin_msg, metadata)
         assert ret is None
 
         commit_msg = json.loads(self.COMMIT_MSG)
-        ret = processor.process_message(commit_msg)
+        ret = processor.process_message(commit_msg, metadata)
         assert ret is None
 
         insert_msg = json.loads(self.INSERT_MSG)
-        ret = processor.process_message(insert_msg)
+        ret = processor.process_message(insert_msg, metadata)
         assert ret[1] == self.PROCESSED
 
         update_msg = json.loads(self.UPDATE_MSG)
-        ret = processor.process_message(update_msg)
+        ret = processor.process_message(update_msg, metadata)
         assert ret[1] == self.PROCESSED

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -50,16 +50,10 @@ class TestGroupedMessageProcessor(BaseTest):
     PROCESSED = {
         'offset': 42,
         'id': 74,
-        'logger': '',
-        'level': 40,
-        'message': '<module> ZeroDivisionError integer division or modulo by zero client3.py __main__ in <module>',
-        'view': '__main__ in <module>',
         'status': 0,
         'last_seen': datetime(2019, 6, 19, 6, 46, 28, tzinfo=pytz.UTC),
         'first_seen': datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
-        'project_id': 2,
         'active_at': datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
-        'platform': 'python',
         'first_release_id': None,
     }
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -179,6 +179,12 @@ class TestReplacer(BaseTest):
                     'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
                 }))
 
+            def partition(self):
+                return 1
+
+            def offset(self):
+                return 42
+
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])
 
@@ -204,6 +210,12 @@ class TestReplacer(BaseTest):
                     'previous_group_ids': [1],
                     'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
                 }))
+
+            def partition(self):
+                return 1
+
+            def offset(self):
+                return 42
 
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])
@@ -232,6 +244,12 @@ class TestReplacer(BaseTest):
                     'hashes': ['a' * 32],
                     'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
                 }))
+
+            def partition(self):
+                return 1
+
+            def offset(self):
+                return 42
 
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])
@@ -268,6 +286,12 @@ class TestReplacer(BaseTest):
                     'tag': 'browser.name',
                     'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
                 }))
+
+            def partition(self):
+                return 1
+
+            def offset(self):
+                return 42
 
         processed = test_worker.process_message(FakeMessage())
         test_worker.flush_batch([processed])


### PR DESCRIPTION
This is the first CDC dataset.

This is supposed to replicate groupedmessage table from postgres sentry DB.
It uses a ReplacingMergeTree table partitioned on the first seen event (so that we can drop old groups). 