### PR TITLE
fix: Disable groupedmessage

### DIFF
--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -4,7 +4,6 @@ DATASETS_IMPL = {}
 
 DATASET_NAMES = {
     'events',
-    'groupedmessage',
 }
 
 
@@ -18,7 +17,6 @@ def get_dataset(name):
     from snuba.datasets.cdc.groupedmessage import GroupedMessageDataSet
     dataset_mappings = {
         'events': EventsDataSet,
-        'groupedmessage': GroupedMessageDataSet
     }
 
     dataset = DATASETS_IMPL[name] = dataset_mappings[name]()


### PR DESCRIPTION
Prevent the healthcheck endpoint from failing since the table is not there in prod.