### PR TITLE
fix: reenable Groupedmessage dataset

### DIFF
--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -4,6 +4,7 @@ DATASETS_IMPL = {}
 
 DATASET_NAMES = {
     'events',
+    'groupedmessage',
 }
 
 
@@ -17,6 +18,7 @@ def get_dataset(name):
     from snuba.datasets.cdc.groupedmessage import GroupedMessageDataSet
     dataset_mappings = {
         'events': EventsDataSet,
+        'groupedmessage': GroupedMessageDataSet,
     }
 
     dataset = DATASETS_IMPL[name] = dataset_mappings[name]()


### PR DESCRIPTION
Do not merge unless:
1) the groupedmessage remote table is created in prod
or
2) the groupedmessage is added to the DISABLED_DATASET setting
Otherwise healthcheck fails