### PR TITLE
ref(settings): Split host and port in ClickHouse settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,8 @@ RUN set -ex; \
     rm -rf ~/.cache/pip; \
     apt-get purge -y --auto-remove $buildDeps
 
-ENV CLICKHOUSE_SERVER clickhouse-server:9000
+# XXX: Why is this defined here?
+ENV CLICKHOUSE_HOST clickhouse-server
 ENV FLASK_DEBUG 0
 ARG SNUBA_VERSION_SHA
 ENV SNUBA_RELEASE=$SNUBA_VERSION_SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,8 +111,6 @@ RUN set -ex; \
     rm -rf ~/.cache/pip; \
     apt-get purge -y --auto-remove $buildDeps
 
-# XXX: Why is this defined here?
-ENV CLICKHOUSE_HOST clickhouse-server
 ENV FLASK_DEBUG 0
 ARG SNUBA_VERSION_SHA
 ENV SNUBA_RELEASE=$SNUBA_VERSION_SHA

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Data is written into the table `dev`: `select count() from dev;`
 
 Snuba assumes:
 
-1. A Clickhouse server endpoint at `CLICKHOUSE_SERVER` (default `localhost:9000`).
+1. A Clickhouse server endpoint at `CLICKHOUSE_HOST` (default `localhost`).
 2. A redis instance running at `REDIS_HOST` (default `localhost`). On port
    `6379`
 
@@ -50,7 +50,7 @@ Snuba exposes an HTTP API (default port: `1218`) with the following endpoints.
 
 Settings are found in `settings.py`
 
-- `CLICKHOUSE_SERVER` : The endpoint for the clickhouse service.
+- `CLICKHOUSE_HOST` : The hostname for the clickhouse service.
 - `REDIS_HOST` : The host redis is running on.
 - `DATASET_MODE` : If "local" runs Clickhouse local tables instead of distributed ones.
 
@@ -58,7 +58,7 @@ Settings are found in `settings.py`
 
     pip install -e .
 
-    export CLICKHOUSE_SERVER=127.0.0.1:9000
+    export CLICKHOUSE_HOST=127.0.0.1:9000
 
     make test
 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@ Settings are found in `settings.py`
 ## Tests
 
     pip install -e .
-
-    export CLICKHOUSE_HOST=127.0.0.1:9000
-
     make test
 
 ## Testing Against Sentry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "1"
       - "--http-keepalive"
     environment: &snuba_env
-      CLICKHOUSE_SERVER: 'clickhouse:9000'
+      CLICKHOUSE_HOST: 'clickhouse'
       REDIS_HOST: 'redis'
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -8,8 +8,10 @@ from snuba.datasets.factory import get_dataset
 
 
 @click.command()
-@click.option('--clickhouse-server', multiple=True,
-              help='Clickhouse server to cleanup.')
+@click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
+              help='Clickhouse server to write to.')
+@click.option('--clickhouse-port', default=settings.CLICKHOUSE_PORT, type=int,
+              help='Clickhouse native port to write to.')
 @click.option('--dry-run', type=bool, default=True,
               help="If true, only print which partitions would be dropped.")
 @click.option('--database', default='default',
@@ -17,7 +19,7 @@ from snuba.datasets.factory import get_dataset
 @click.option('--dataset', default='events', type=click.Choice(['events']),
               help='The dataset to target')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def cleanup(clickhouse_server, dry_run, database, dataset, log_level):
+def cleanup(clickhouse_host, clickhouse_port, dry_run, database, dataset, log_level):
     from snuba.cleanup import run_cleanup, logger
     from snuba.clickhouse import ClickhousePool
 
@@ -31,6 +33,6 @@ def cleanup(clickhouse_server, dry_run, database, dataset, log_level):
         sys.exit(1)
 
     for server in clickhouse_server:
-        clickhouse = ClickhousePool(server.split(':')[0], port=int(server.split(':')[1]))
+        clickhouse = ClickhousePool(clickhouse_host, clickhouse_port)
         num_dropped = run_cleanup(clickhouse, database, table, dry_run=dry_run)
         logger.info("Dropped %s partitions on %s" % (num_dropped, server))

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import click
 
@@ -28,11 +27,6 @@ def cleanup(clickhouse_host, clickhouse_port, dry_run, database, dataset, log_le
 
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
-    if not clickhouse_server:
-        logger.error("Must provide at least one Clickhouse server.")
-        sys.exit(1)
-
-    for server in clickhouse_server:
-        clickhouse = ClickhousePool(clickhouse_host, clickhouse_port)
-        num_dropped = run_cleanup(clickhouse, database, table, dry_run=dry_run)
-        logger.info("Dropped %s partitions on %s" % (num_dropped, server))
+    clickhouse = ClickhousePool(clickhouse_host, clickhouse_port)
+    num_dropped = run_cleanup(clickhouse, database, table, dry_run=dry_run)
+    logger.info("Dropped %s partitions on %s" % (num_dropped, clickhouse_host))

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -19,8 +19,10 @@ from snuba.datasets.factory import get_dataset
               help='Consumer group use for consuming the raw events topic.')
 @click.option('--bootstrap-server', default=settings.DEFAULT_BROKERS, multiple=True,
               help='Kafka bootstrap server to use.')
-@click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
+@click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
               help='Clickhouse server to write to.')
+@click.option('--clickhouse-native-port', default=settings.CLICKHOUSE_NATIVE_PORT, type=int,
+              help='Clickhouse native port to write to.')
 @click.option('--dataset', default='events', type=click.Choice(['events', 'groupedmessage']),
               help='The dataset to target')
 @click.option('--max-batch-size', default=settings.DEFAULT_MAX_BATCH_SIZE,
@@ -37,7 +39,7 @@ from snuba.datasets.factory import get_dataset
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
 def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_group,
-             bootstrap_server, clickhouse_server, dataset, max_batch_size, max_batch_time_ms,
+             bootstrap_server, clickhouse_host, clickhouse_native_port, dataset, max_batch_size, max_batch_time_ms,
              auto_offset_reset, queued_max_messages_kbytes, queued_min_messages, log_level,
              dogstatsd_host, dogstatsd_port):
 
@@ -62,8 +64,8 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     )
 
     clickhouse = ClickhousePool(
-        host=clickhouse_server.split(':')[0],
-        port=int(clickhouse_server.split(':')[1]),
+        host=clickhouse_host,
+        port=clickhouse_native_port,
         client_settings={
             'load_balancing': 'in_order',
             'insert_distributed_sync': True,

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -21,7 +21,7 @@ from snuba.datasets.factory import get_dataset
               help='Kafka bootstrap server to use.')
 @click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
               help='Clickhouse server to write to.')
-@click.option('--clickhouse-native-port', default=settings.CLICKHOUSE_NATIVE_PORT, type=int,
+@click.option('--clickhouse-port', default=settings.CLICKHOUSE_PORT, type=int,
               help='Clickhouse native port to write to.')
 @click.option('--dataset', default='events', type=click.Choice(['events', 'groupedmessage']),
               help='The dataset to target')
@@ -39,7 +39,7 @@ from snuba.datasets.factory import get_dataset
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
 def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_group,
-             bootstrap_server, clickhouse_host, clickhouse_native_port, dataset, max_batch_size, max_batch_time_ms,
+             bootstrap_server, clickhouse_host, clickhouse_port, dataset, max_batch_size, max_batch_time_ms,
              auto_offset_reset, queued_max_messages_kbytes, queued_min_messages, log_level,
              dogstatsd_host, dogstatsd_port):
 
@@ -65,7 +65,7 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
 
     clickhouse = ClickhousePool(
         host=clickhouse_host,
-        port=clickhouse_native_port,
+        port=clickhouse_port,
         client_settings={
             'load_balancing': 'in_order',
             'insert_distributed_sync': True,

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -20,10 +20,9 @@ def migrate(log_level):
         logger.error("The migration tool can only work on local dataset mode.")
         sys.exit(1)
 
-    host, port = settings.CLICKHOUSE_SERVER.split(':')
     clickhouse = Client(
-        host=host,
-        port=port,
+        host=settings.CLICKHOUSE_HOST,
+        port=settings.CLICKHOUSE_NATIVE_PORT,
     )
 
     run(clickhouse, dataset)

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -22,7 +22,7 @@ def migrate(log_level):
 
     clickhouse = Client(
         host=settings.CLICKHOUSE_HOST,
-        port=settings.CLICKHOUSE_NATIVE_PORT,
+        port=settings.CLICKHOUSE_PORT,
     )
 
     run(clickhouse, dataset)

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 import click
 
@@ -29,12 +28,7 @@ def optimize(clickhouse_host, clickhouse_port, database, dataset, timeout, log_l
     dataset = get_dataset(dataset)
     table = dataset.get_schema().get_local_table_name()
 
-    if not clickhouse_server:
-        logger.error("Must provide at least one Clickhouse server.")
-        sys.exit(1)
-
     today = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-    for server in clickhouse_server:
-        clickhouse = ClickhousePool(clickhouse_host, clickhouse_port, send_receive_timeout=timeout)
-        num_dropped = run_optimize(clickhouse, database, table, before=today)
-        logger.info("Optimized %s partitions on %s" % (num_dropped, server))
+    clickhouse = ClickhousePool(clickhouse_host, clickhouse_port, send_receive_timeout=timeout)
+    num_dropped = run_optimize(clickhouse, database, table, before=today)
+    logger.info("Optimized %s partitions on %s" % (num_dropped, clickhouse_host))

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -8,8 +8,10 @@ from snuba.datasets.factory import get_dataset
 
 
 @click.command()
-@click.option('--clickhouse-server', multiple=True,
-              help='Clickhouse server to optimize.')
+@click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
+              help='Clickhouse server to write to.')
+@click.option('--clickhouse-port', default=settings.CLICKHOUSE_PORT, type=int,
+              help='Clickhouse native port to write to.')
 @click.option('--database', default='default',
               help='Name of the database to target.')
 @click.option('--dataset', default='events', type=click.Choice(['events']),
@@ -17,7 +19,7 @@ from snuba.datasets.factory import get_dataset
 @click.option('--timeout', default=10000, type=int,
               help='Clickhouse connection send/receive timeout, must be long enough for OPTIMIZE to complete.')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def optimize(clickhouse_server, database, dataset, timeout, log_level):
+def optimize(clickhouse_host, clickhouse_port, database, dataset, timeout, log_level):
     from datetime import datetime
     from snuba.clickhouse import ClickhousePool
     from snuba.optimize import run_optimize, logger
@@ -33,8 +35,6 @@ def optimize(clickhouse_server, database, dataset, timeout, log_level):
 
     today = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
     for server in clickhouse_server:
-        clickhouse = ClickhousePool(
-            server.split(':')[0], port=int(server.split(':')[1]), send_receive_timeout=timeout
-        )
+        clickhouse = ClickhousePool(clickhouse_host, clickhouse_port, send_receive_timeout=timeout)
         num_dropped = run_optimize(clickhouse, database, table, before=today)
         logger.info("Optimized %s partitions on %s" % (num_dropped, server))

--- a/snuba/cli/perf.py
+++ b/snuba/cli/perf.py
@@ -30,12 +30,14 @@ from snuba.datasets.schema import local_dataset_mode
               default=False, help='Whether or not to profile processing.')
 @click.option('--profile-write/--no-profile-write',
               default=False, help='Whether or not to profile writing.')
-@click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
-              help='Clickhouse server to run perf against.')
+@click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
+              help='Clickhouse server to write to.')
+@click.option('--clickhouse-native-port', default=settings.CLICKHOUSE_NATIVE_PORT, type=int,
+              help='Clickhouse native port to write to.')
 @click.option('--dataset', default='events', type=click.Choice(['events']),
               help='The dataset to consume/run replacements for (currently only events supported)')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def perf(events_file, repeat, profile_process, profile_write, clickhouse_server, dataset, log_level):
+def perf(events_file, repeat, profile_process, profile_write, clickhouse_host, clickhouse_native_port, dataset, log_level):
     from snuba.clickhouse import ClickhousePool
     from snuba.perf import run, logger
 
@@ -46,7 +48,11 @@ def perf(events_file, repeat, profile_process, profile_write, clickhouse_server,
         logger.error("The perf tool is only intended for local dataset environment.")
         sys.exit(1)
 
-    clickhouse = ClickhousePool(clickhouse_server.split(':')[0], port=int(clickhouse_server.split(':')[1]))
+    clickhouse = ClickhousePool(
+        host=clickhouse_host,
+        port=clickhouse_native_port,
+    )
+
     run(
         events_file, clickhouse, dataset,
         repeat=repeat, profile_process=profile_process, profile_write=profile_write

--- a/snuba/cli/perf.py
+++ b/snuba/cli/perf.py
@@ -32,12 +32,12 @@ from snuba.datasets.schema import local_dataset_mode
               default=False, help='Whether or not to profile writing.')
 @click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
               help='Clickhouse server to write to.')
-@click.option('--clickhouse-native-port', default=settings.CLICKHOUSE_NATIVE_PORT, type=int,
+@click.option('--clickhouse-port', default=settings.CLICKHOUSE_PORT, type=int,
               help='Clickhouse native port to write to.')
 @click.option('--dataset', default='events', type=click.Choice(['events']),
               help='The dataset to consume/run replacements for (currently only events supported)')
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def perf(events_file, repeat, profile_process, profile_write, clickhouse_host, clickhouse_native_port, dataset, log_level):
+def perf(events_file, repeat, profile_process, profile_write, clickhouse_host, clickhouse_port, dataset, log_level):
     from snuba.clickhouse import ClickhousePool
     from snuba.perf import run, logger
 
@@ -50,7 +50,7 @@ def perf(events_file, repeat, profile_process, profile_write, clickhouse_host, c
 
     clickhouse = ClickhousePool(
         host=clickhouse_host,
-        port=clickhouse_native_port,
+        port=clickhouse_port,
     )
 
     run(

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -14,8 +14,10 @@ from snuba.datasets.factory import get_dataset
               help='Consumer group use for consuming the replacements topic.')
 @click.option('--bootstrap-server', default=settings.DEFAULT_BROKERS, multiple=True,
               help='Kafka bootstrap server to use.')
-@click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
+@click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
               help='Clickhouse server to write to.')
+@click.option('--clickhouse-native-port', default=settings.CLICKHOUSE_NATIVE_PORT, type=int,
+              help='Clickhouse native port to write to.')
 @click.option('--dataset', default='events', type=click.Choice(['events']),
               help='The dataset to consume/run replacements for (currently only events supported)')
 @click.option('--max-batch-size', default=settings.DEFAULT_MAX_BATCH_SIZE,
@@ -31,7 +33,7 @@ from snuba.datasets.factory import get_dataset
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
-def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_server, dataset,
+def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_host, clickhouse_native_port, dataset,
              max_batch_size, max_batch_time_ms, auto_offset_reset, queued_max_messages_kbytes,
              queued_min_messages, log_level, dogstatsd_host, dogstatsd_port):
 
@@ -66,8 +68,8 @@ def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_se
     }
 
     clickhouse = ClickhousePool(
-        host=clickhouse_server.split(':')[0],
-        port=int(clickhouse_server.split(':')[1]),
+        host=clickhouse_host,
+        port=clickhouse_native_port,
         client_settings=client_settings,
     )
 

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -16,7 +16,7 @@ from snuba.datasets.factory import get_dataset
               help='Kafka bootstrap server to use.')
 @click.option('--clickhouse-host', default=settings.CLICKHOUSE_HOST,
               help='Clickhouse server to write to.')
-@click.option('--clickhouse-native-port', default=settings.CLICKHOUSE_NATIVE_PORT, type=int,
+@click.option('--clickhouse-port', default=settings.CLICKHOUSE_PORT, type=int,
               help='Clickhouse native port to write to.')
 @click.option('--dataset', default='events', type=click.Choice(['events']),
               help='The dataset to consume/run replacements for (currently only events supported)')
@@ -33,7 +33,7 @@ from snuba.datasets.factory import get_dataset
 @click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
-def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_host, clickhouse_native_port, dataset,
+def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_host, clickhouse_port, dataset,
              max_batch_size, max_batch_time_ms, auto_offset_reset, queued_max_messages_kbytes,
              queued_min_messages, log_level, dogstatsd_host, dogstatsd_port):
 
@@ -69,7 +69,7 @@ def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_ho
 
     clickhouse = ClickhousePool(
         host=clickhouse_host,
-        port=clickhouse_native_port,
+        port=clickhouse_port,
         client_settings=client_settings,
     )
 

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -32,8 +32,8 @@ def escape_col(col):
 
 class ClickhousePool(object):
     def __init__(self,
-                 host=settings.CLICKHOUSE_SERVER.split(':')[0],
-                 port=int(settings.CLICKHOUSE_SERVER.split(':')[1]),
+                 host=settings.CLICKHOUSE_HOST,
+                 port=settings.CLICKHOUSE_NATIVE_PORT,
                  connect_timeout=1,
                  send_receive_timeout=300,
                  max_pool_size=settings.CLICKHOUSE_MAX_POOL_SIZE,

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -33,7 +33,7 @@ def escape_col(col):
 class ClickhousePool(object):
     def __init__(self,
                  host=settings.CLICKHOUSE_HOST,
-                 port=settings.CLICKHOUSE_NATIVE_PORT,
+                 port=settings.CLICKHOUSE_PORT,
                  connect_timeout=1,
                  send_receive_timeout=300,
                  max_pool_size=settings.CLICKHOUSE_MAX_POOL_SIZE,

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -16,7 +16,7 @@ DATASET_MODE = 'local'
 # TODO: Warn about using `CLICKHOUSE_SERVER`, users should use the new settings instead.
 [default_clickhouse_host, default_clickhouse_port] = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000').split(':', 1)
 CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', default_clickhouse_host)
-CLICKHOUSE_NATIVE_PORT = int(os.environ.get('CLICKHOUSE_NATIVE_PORT', default_clickhouse_port))
+CLICKHOUSE_PORT = int(os.environ.get('CLICKHOUSE_PORT', default_clickhouse_port))
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # Dogstatsd Options

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -13,7 +13,10 @@ DISABLED_DATASETS = {}
 DATASET_MODE = 'local'
 
 # Clickhouse Options
-CLICKHOUSE_SERVER = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000')
+# TODO: Warn about using `CLICKHOUSE_SERVER`, users should use the new settings instead.
+[default_clickhouse_host, default_clickhouse_port] = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000').split(':', 1)
+CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', default_clickhouse_host)
+CLICKHOUSE_NATIVE_PORT = int(os.environ.get('CLICKHOUSE_NATIVE_PORT', default_clickhouse_port))
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # Dogstatsd Options

--- a/snuba/settings_docker.py
+++ b/snuba/settings_docker.py
@@ -5,8 +5,6 @@ env = os.environ.get
 
 DEBUG = env('DEBUG', '0').lower() in ('1', 'true')
 
-CLICKHOUSE_SERVER = env('CLICKHOUSE_SERVER', 'localhost:9000')
-
 DEFAULT_BROKERS = env('DEFAULT_BROKERS', 'localhost:9092').split(',')
 
 REDIS_HOST = env('REDIS_HOST', 'localhost')


### PR DESCRIPTION
Splits the `CLICKHOUSE_SERVER` setting into `CLICKHOUSE_HOST` and `CLICKHOUSE_PORT` settings. This allows for configuring additional ports later, such as the ClickHouse HTTP interface port.

This maintains the existing `CLICKHOUSE_SERVER` setting (mostly to avoid thrashing on Sentry devservices), but the command line interfaces that previously accepted `--clickhouse-server` now accept `--clickhouse-host` and `--clickhouse-port` instead.