### PR TITLE
feat(issueless events): Hide group_id = 0 on events dataset

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -328,9 +328,9 @@ def parse_and_run_query(validated_body, timer):
         validated_body, sql, clickhouse_ro, timer, stats
     )
 
+
 # Special internal endpoints that compute global aggregate data that we want to
 # use internally.
-
 
 @application.route('/internal/sdk-stats', methods=['POST'])
 @util.time_request('sdk-stats')

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -328,9 +328,9 @@ def parse_and_run_query(validated_body, timer):
         validated_body, sql, clickhouse_ro, timer, stats
     )
 
-
 # Special internal endpoints that compute global aggregate data that we want to
 # use internally.
+
 
 @application.route('/internal/sdk-stats', methods=['POST'])
 @util.time_request('sdk-stats')

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -228,8 +228,8 @@ class EventsDataSet(DataSet):
             return self._tag_expr(column_name)
         elif column_name in ['tags_key', 'tags_value']:
             return self._tags_expr(column_name, body)
-        elif column_name == 'issue':
-            return 'group_id'
+        elif column_name == 'issue' or column_name == 'group_id':
+            return 'nullIf(group_id, 0)'
         elif column_name == 'message':
             # Because of the rename from message->search_message without backfill,
             # records will have one or the other of these fields.

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -133,7 +133,7 @@ class EventsProcessor(MessageProcessor):
         output['event_id'] = message['event_id']
         project_id = message['project_id']
         output['project_id'] = project_id
-        output['group_id'] = message['group_id']
+        output['group_id'] = message['group_id'] or 0
 
         # This is not ideal but it should never happen anyways
         timestamp = _ensure_valid_date(datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT))

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -72,7 +72,8 @@ class TestEventsDataSet(BaseEventsTest):
         assert column_expr(self.dataset, tuplify(['concat', ['a', '\':\'', 'b']]), body.copy()) == 'concat(a, \':\', b)'
 
         group_id_body = body.copy()
-        assert column_expr(self.dataset, 'issue', group_id_body) == '(group_id AS issue)'
+        assert column_expr(self.dataset, 'issue', group_id_body) == '(nullIf(group_id, 0) AS issue)'
+        assert column_expr(self.dataset, 'group_id', group_id_body) == '(nullIf(group_id, 0) AS group_id)'
 
         # turn uniq() into ifNull(uniq(), 0) so it doesn't return null where a number was expected.
         assert column_expr(self.dataset, 'tags[environment]', body.copy(), alias='unique_envs', aggregate='uniq') == "(ifNull(uniq(environment), 0) AS unique_envs)"


### PR DESCRIPTION
The current implementation of issueless events requires the group_id in clickhouse to be 0 (the column is not nullable and making it nullable has a high cost).
On the Sentry side issueless events have group == None. The fact the group_id is 0 is an implementation detail that should not be visible to Sentry, thus we can map this value to NULL on the Snuba interface. This happens both during ingestion and when querying.