### PR TITLE
feat(structured dataset config): Structured settings. Distilled version

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -57,10 +57,10 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     dataset = get_dataset(dataset_name)
 
     if not bootstrap_server:
-        if dataset_name in settings.DEFAULT_DATASET_BROKERS:
-            bootstrap_server = settings.DEFAULT_DATASET_BROKERS[dataset_name]
-        else:
-            bootstrap_server = settings.DEFAULT_BROKERS
+        bootstrap_server = settings.DEFAULT_DATASET_BROKERS.get(
+            dataset_name,
+            settings.DEFAULT_BROKERS,
+        )
 
     raw_events_topic = raw_events_topic or dataset.get_default_topic()
     replacements_topic = replacements_topic or dataset.get_default_replacement_topic()

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -54,10 +54,11 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     dataset_name = dataset
     dataset = get_dataset(dataset_name)
 
-    dataset_brokers = settings.DEFAULT_DATASET_BROKERS
-    bootstrap_server = bootstrap_server or dataset_brokers.get(dataset_name)
     if not bootstrap_server:
-        bootstrap_server = settings.DEFAULT_BROKERS
+        if dataset_name in settings.DEFAULT_DATASET_BROKERS:
+            bootstrap_server = settings.DEFAULT_DATASET_BROKERS[dataset_name]
+        else:
+            bootstrap_server = settings.DEFAULT_BROKERS
 
     raw_events_topic = raw_events_topic or dataset.get_default_topic()
     replacements_topic = replacements_topic or dataset.get_default_replacement_topic()

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -17,7 +17,7 @@ from snuba.datasets.factory import get_dataset
               help='Topic for committed offsets to be written to, triggering post-processing task(s)')
 @click.option('--consumer-group', default='snuba-consumers',
               help='Consumer group use for consuming the raw events topic.')
-@click.option('--bootstrap-server', default=settings.DEFAULT_BROKERS, multiple=True,
+@click.option('--bootstrap-server', default=None, multiple=True,
               help='Kafka bootstrap server to use.')
 @click.option('--clickhouse-server', default=settings.CLICKHOUSE_SERVER,
               help='Clickhouse server to write to.')
@@ -53,6 +53,11 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
     logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
     dataset_name = dataset
     dataset = get_dataset(dataset_name)
+
+    dataset_brokers = settings.DEFAULT_DATASET_BROKERS
+    bootstrap_server = bootstrap_server or dataset_brokers.get(dataset_name)
+    if not bootstrap_server:
+        bootstrap_server = settings.DEFAULT_BROKERS
 
     raw_events_topic = raw_events_topic or dataset.get_default_topic()
     replacements_topic = replacements_topic or dataset.get_default_replacement_topic()

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -48,10 +48,7 @@ TIME_GROUP_COLUMNS = {
 
 # Processor/Writer Options
 DEFAULT_BROKERS = ['localhost:9093']
-DEFAULT_DATASET_BROKERS = {
-    'events': ['localhost:9093'],
-    'groupedmessage': ['localhost:9093'],
-}
+DEFAULT_DATASET_BROKERS = {}
 
 DEFAULT_MAX_BATCH_SIZE = 50000
 DEFAULT_MAX_BATCH_TIME_MS = 2 * 1000

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -48,6 +48,11 @@ TIME_GROUP_COLUMNS = {
 
 # Processor/Writer Options
 DEFAULT_BROKERS = ['localhost:9093']
+DEFAULT_DATASET_BROKERS = {
+    'events': ['localhost:9093'],
+    'groupedmessage': ['localhost:9093'],
+}
+
 DEFAULT_MAX_BATCH_SIZE = 50000
 DEFAULT_MAX_BATCH_TIME_MS = 2 * 1000
 DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/358 introduces a way to have structured config in Snuba. That will take time to review and agree upon. 
Unfortunately we need to be able to define brokers config per dataset in order to test Change Capture, thus that PR would block the CDC test.
This is the bare minimum we need to unblock that test, while #358 is the "professional edition" with a full schema, a proper override mechanism and consistent support across snuba.