### PR TITLE
feat(writer): Add HTTPBatchWriter

### DIFF
--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -23,16 +23,14 @@ class DataSet(object):
         return self.__processor
 
     def get_writer(self, options=None):
-        from snuba.clickhouse import ClickhousePool
-        from snuba.writer import NativeDriverBatchWriter
+        from snuba import settings
+        from snuba.writer import HTTPBatchWriter
 
-        pool_opts = {}
-        if options is not None:
-            pool_opts['client_settings'] = options
-
-        return NativeDriverBatchWriter(
+        return HTTPBatchWriter(
             self._schema,
-            ClickhousePool(**pool_opts),
+            settings.CLICKHOUSE_HOST,
+            settings.CLICKHOUSE_HTTP_PORT,
+            options,
         )
 
     def default_conditions(self, body):

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -17,6 +17,7 @@ DATASET_MODE = 'local'
 [default_clickhouse_host, default_clickhouse_port] = os.environ.get('CLICKHOUSE_SERVER', 'localhost:9000').split(':', 1)
 CLICKHOUSE_HOST = os.environ.get('CLICKHOUSE_HOST', default_clickhouse_host)
 CLICKHOUSE_PORT = int(os.environ.get('CLICKHOUSE_PORT', default_clickhouse_port))
+CLICKHOUSE_HTTP_PORT = int(os.environ.get('CLICKHOUSE_HTTP_PORT', 8123))
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # Dogstatsd Options

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -43,7 +43,8 @@ class NativeDriverBatchWriter(BatchWriter):
 
 
 class HTTPBatchWriter(BatchWriter):
-    def __init__(self, host, port, options=None):
+    def __init__(self, schema, host, port, options=None):
+        self.__schema = schema
         self.__base_url = 'http://{host}:{port}/'.format(host=host, port=port)
         self.__options = options if options is not None else {}
 
@@ -56,9 +57,9 @@ class HTTPBatchWriter(BatchWriter):
     def __encode(self, row):
         return json.dumps(row, default=self.__default).encode('utf-8')
 
-    def write(self, schema, rows):
+    def write(self, rows):
         parameters = self.__options.copy()
-        parameters['query'] = "INSERT INTO {table} FORMAT JSONEachRow".format(table=schema.get_table_name())
+        parameters['query'] = "INSERT INTO {table} FORMAT JSONEachRow".format(table=self.__schema.get_table_name())
         requests.post(
             urljoin(self.__base_url, '?' + urlencode(parameters)),
             data=imap(self.__encode, rows),

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -1,6 +1,12 @@
+import json
 import logging
+from datetime import datetime
 
-from snuba.clickhouse import Array
+import requests
+from six.moves import map as imap
+from six.moves.urllib.parse import urlencode, urljoin
+
+from snuba.clickhouse import DATETIME_FORMAT, Array
 
 
 logger = logging.getLogger('snuba.writer')
@@ -34,3 +40,26 @@ class NativeDriverBatchWriter(BatchWriter):
             'colnames': ", ".join(col.escaped for col in columns),
             'table': self.__schema.get_table_name(),
         }, [self.__row_to_column_list(columns, row) for row in rows], types_check=False)
+
+
+class HTTPBatchWriter(BatchWriter):
+    def __init__(self, host, port, options=None):
+        self.__base_url = 'http://{host}:{port}/'.format(host=host, port=port)
+        self.__options = options if options is not None else {}
+
+    def __default(self, value):
+        if isinstance(value, datetime):
+            return value.strftime(DATETIME_FORMAT)
+        else:
+            raise TypeError
+
+    def __encode(self, row):
+        return json.dumps(row, default=self.__default).encode('utf-8')
+
+    def write(self, schema, rows):
+        parameters = self.__options.copy()
+        parameters['query'] = "INSERT INTO {table} FORMAT JSONEachRow".format(table=schema.get_table_name())
+        requests.post(
+            urljoin(self.__base_url, '?' + urlencode(parameters)),
+            data=imap(self.__encode, rows),
+        ).raise_for_status()


### PR DESCRIPTION
Adds a `BatchWriter` implementation that writes via HTTP rather than via the native driver, using [Chunked transfer encoding](https://en.wikipedia.org/wiki/Chunked_transfer_encoding) for efficient memory utilization during serialization.

This also:

- switches the default `DataSet.get_writer` implementation to return the `HTTPBatchWriter` rather than the `NativeDriverBatchWriter`
- adds the `CLICKHOUSE_HTTP_PORT` option (defaulting to 8123)