### PR TITLE
fix(writer): Use correct type for insert_distributed_sync setting

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -26,7 +26,7 @@ class ConsumerWorker(AbstractBatchWorker):
         self.metrics = metrics
         self.__writer = dataset.get_writer({
             'load_balancing': 'in_order',
-            'insert_distributed_sync': True,
+            'insert_distributed_sync': 1,
         })
 
     def process_message(self, message):


### PR DESCRIPTION
[ClickHouse doesn't have booleans](https://clickhouse.yandex/docs/en/data_types/boolean/), so use `1` to represent that a setting is enabled, rather than `True`.