### PR TITLE
test(datasets): Remove old test functions

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -378,6 +378,7 @@ if application.debug or application.testing:
 
         _ensured[dataset] = True
 
+    @application.route('/tests/<dataset_name>/insert', methods=['POST'])
     def write(dataset_name):
         from snuba.processor import MessageProcessor
 
@@ -394,14 +395,7 @@ if application.debug or application.testing:
 
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
-    @application.route('/tests/insert', methods=['POST'])
-    def write_events():
-        return write('events')
-
-    @application.route('/tests/<dataset_name>/insert', methods=['POST'])
-    def write_generic(dataset_name):
-        return write(dataset_name)
-
+    @application.route('/tests/<dataset_name>/eventstream', methods=['POST'])
     def eventstream(dataset_name):
         dataset = get_dataset(dataset_name)
         ensure_table_exists(dataset)
@@ -441,14 +435,7 @@ if application.debug or application.testing:
 
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
-    @application.route('/tests/eventstream', methods=['POST'])
-    def eventstream_events():
-        return eventstream('events')
-
-    @application.route('/tests/<dataset_name>/eventstream', methods=['POST'])
-    def eventstream_generic(dataset_name):
-        return eventstream(dataset_name)
-
+    @application.route('/tests/<dataset_name>/drop', methods=['POST'])
     def drop(dataset_name):
         dataset = get_dataset(dataset_name)
         table = dataset.get_schema().get_local_table_name()
@@ -456,15 +443,6 @@ if application.debug or application.testing:
         clickhouse_rw.execute("DROP TABLE IF EXISTS %s" % table)
         ensure_table_exists(dataset, force=True)
         return ('ok', 200, {'Content-Type': 'text/plain'})
-
-    @application.route('/tests/drop', methods=['POST'])
-    def drop_events():
-        return drop('events')
-
-    @application.route('/tests/<dataset_name>/drop', methods=['POST'])
-    def drop_generic(dataset_name):
-        return drop(dataset_name)
-
 
     @application.route('/tests/error')
     def error():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -800,7 +800,7 @@ class TestApi(BaseEventsTest):
                 'received': time.mktime(self.base_time.timetuple()),
             }
         })
-        response = self.app.post('/tests/eventstream', data=json.dumps(event))
+        response = self.app.post('/tests/events/eventstream', data=json.dumps(event))
         assert response.status_code == 200
 
         query = {
@@ -822,13 +822,13 @@ class TestApi(BaseEventsTest):
             'group_ids': [group_id],
             'datetime': (self.base_time + timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
         })
-        response = self.app.post('/tests/eventstream', data=json.dumps(event))
+        response = self.app.post('/tests/events/eventstream', data=json.dumps(event))
         assert response.status_code == 200
 
         result = json.loads(self.app.post('/query', data=json.dumps(query)).data)
         assert result['data'] == []
 
-        assert self.app.post('/tests/drop').status_code == 200
+        assert self.app.post('/tests/events/drop').status_code == 200
         dataset = get_dataset('events')
         table = dataset.get_schema().get_table_name()
         assert table not in self.clickhouse.execute("SHOW TABLES")


### PR DESCRIPTION
* https://github.com/getsentry/snuba/pull/366 introduced more generic test endpoints
* https://github.com/getsentry/sentry/pull/14111 made Sentry use those generic test endpoints

This PR removes the old non-generic test endpoints.