### PR TITLE
fix(writer): Temporarily switch back to native driver batch writer

### DIFF
--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -23,14 +23,16 @@ class DataSet(object):
         return self.__processor
 
     def get_writer(self, options=None):
-        from snuba import settings
-        from snuba.writer import HTTPBatchWriter
+        from snuba.clickhouse import ClickhousePool
+        from snuba.writer import NativeDriverBatchWriter
 
-        return HTTPBatchWriter(
+        pool_opts = {}
+        if options is not None:
+            pool_opts['client_settings'] = options
+
+        return NativeDriverBatchWriter(
             self._schema,
-            settings.CLICKHOUSE_HOST,
-            settings.CLICKHOUSE_HTTP_PORT,
-            options,
+            ClickhousePool(**pool_opts),
         )
 
     def default_conditions(self, body):


### PR DESCRIPTION
Just making sure we don't accidentally deploy the HTTP writer again until we are able to identify and fix the encoding issue.

This is a partial revert of 378636c294b7046df7ab0dc98a37b1c5c3241437.