### PR TITLE
fix(writer): Temporarily switch back to native driver batch writer, again

### DIFF
--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -23,14 +23,16 @@ class DataSet(object):
         return self.__processor
 
     def get_writer(self, options=None):
-        from snuba import settings
-        from snuba.writer import HTTPBatchWriter
+        from snuba.clickhouse import ClickhousePool
+        from snuba.writer import NativeDriverBatchWriter
 
-        return HTTPBatchWriter(
+        pool_opts = {}
+        if options is not None:
+            pool_opts['client_settings'] = options
+
+        return NativeDriverBatchWriter(
             self._schema,
-            settings.CLICKHOUSE_HOST,
-            settings.CLICKHOUSE_HTTP_PORT,
-            options,
+            ClickhousePool(**pool_opts),
         )
 
     def default_conditions(self, body):


### PR DESCRIPTION
Like 07ac892, just making sure we don't accidentally deploy the HTTP
writer again until we are able to fix the encoding issue.

This reverts commit 869b7c011fc81010a66cc215cf0802dd1a8980b6.