### PR TITLE
ref: Upgrade to Python 3.7, run consumer in CPython, switch to HTTP writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
 dist: trusty
 language: python
 python:
-  - "2.7"
   - "3.6"
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
 services:
   - docker
-dist: trusty
+dist: xenial
 language: python
 python:
-  - "3.6"
+  - "3.7"
 cache:
   pip: true
 before_install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2-slim
+FROM python:3.6-slim
 
 RUN groupadd -r snuba && useradd -r -g snuba snuba
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.7-slim
 
 RUN groupadd -r snuba && useradd -r -g snuba snuba
 

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -25,11 +25,7 @@ if [ "$1" = 'api' ]; then
 fi
 
 if snuba "$1" --help > /dev/null 2>&1; then
-  if [ "$1" = 'consumer' ] || [ "$1" = 'replacer' ]; then
-    set -- /pypy/bin/snuba "$@"
-  else
-    set -- snuba "$@"
-  fi
+  set -- snuba "$@"
 fi
 
 exec gosu snuba "$@"

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -23,16 +23,14 @@ class DataSet(object):
         return self.__processor
 
     def get_writer(self, options=None):
-        from snuba.clickhouse import ClickhousePool
-        from snuba.writer import NativeDriverBatchWriter
+        from snuba import settings
+        from snuba.writer import HTTPBatchWriter
 
-        pool_opts = {}
-        if options is not None:
-            pool_opts['client_settings'] = options
-
-        return NativeDriverBatchWriter(
+        return HTTPBatchWriter(
             self._schema,
-            ClickhousePool(**pool_opts),
+            settings.CLICKHOUSE_HOST,
+            settings.CLICKHOUSE_HTTP_PORT,
+            options,
         )
 
     def default_conditions(self, body):

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -90,7 +90,7 @@ def _unicodify(s):
     if isinstance(s, dict) or isinstance(s, list):
         return json.dumps(s)
 
-    return six.text_type(s)
+    return six.text_type(s).encode('utf8', errors='backslashreplace').decode('utf8')
 
 
 def _hashify(h):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,8 @@
+import pytest
+
+from snuba.processor import _unicodify
+
+
+def test_unicodify():
+    # invalid utf-8 surrogate should be replaced with escape sequence
+    assert _unicodify('\ud83c').encode('utf8') == b'\\ud83c'


### PR DESCRIPTION
This consolidates all of the runnable parts of Snuba on CPython 3.7 (api, consumer, and replacer), removing the PyPy runtime. This also removes Python 2 support so that we don't have to worry about cross-compatibility, test matrixes, or anything else like that. This also switches the default `DataSet` writer to the `HTTPBatchWriter`, hopefully for the last time.

The rationale for bundling all of these changes together is because of Unicode, as mentioned in [this ticket for Python](https://bugs.python.org/issue26260):

> Well, Python 2 decoder didn't respect the Unicode standard.

ClickHouse is stricter, and [will error when sent only the initial half of a surrogate pair](https://github.com/yandex/ClickHouse/blob/6cc3027a84def9499edd2c0f03d10b0858f836ea/dbms/src/IO/ReadHelpers.cpp#L356-L357), which is what we were seeing from the consumer.

The actual behavior is pretty straightforward to demonstrate. This is the bad behavior demonstrated in Python 2, using [the U+D83C high surrogate](https://www.fileformat.info/info/unicode/char/d83c/index.htm):

```
ted@veneno % python
Python 2.7.15 (default, Feb 12 2019, 11:44:53) 
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
>>> u"\ud83c".encode('utf8')
'\xed\xa0\xbc'  # not valid Unicode
>>> u"\ud83c".encode('utf8', errors='backslashreplace') 
'\xed\xa0\xbc'  # still not valid Unicode
>>> json.dumps({"text": u"\ud83c".encode('utf8')})
'{"text": "\\ud83c"}'  # valid JSON structure containing invalid Unicode value
```

This is the correct behavior demonstrated in Python 3:

```
ted@veneno % python3
Python 3.7.2 (default, Feb 12 2019, 08:16:11) 
[Clang 9.0.0 (clang-900.0.39.2)] on darwin
>>> "\ud83c".encode('utf8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud83c' in position 0: surrogates not allowed
>>> "\ud83c".encode('utf8', errors='backslashreplace') 
b'\\ud83c'  # is valid unicode
>>> json.loads('{"text": "\\ud83c"}')
{'text': '\ud83c'}  # we will still be able to consume JSON containing the invalid Unicode
```

There's no Python 2 fix for this, beyond writing a function to do an `O(n)` scan of the string and replace the invalid characters ourselves (more or less mirroring the ClickHouse implementation linked above.)

I replayed the offending events through the pipeline before (on Python 2) and after (on Python 3) this change, and was able to replicate the failures on Python 2 and successfully write the events on Python 3.