### PR TITLE
ref: Remove `six`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         'simplegeneric==0.8.1',
         'simplejson==3.15.0',
         'singledispatch==3.4.0.3',
-        'six==1.11.0',
         'traceback2==1.4.0',
         'traitlets==4.3.2',
         'unittest2==1.1.0',

--- a/snuba/clickhouse.py
+++ b/snuba/clickhouse.py
@@ -1,8 +1,7 @@
 import logging
+import queue
 import re
 import time
-
-from six.moves import queue, range
 
 from clickhouse_driver import Client, errors
 from snuba import settings

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -1,7 +1,6 @@
 import collections
 import logging
 import simplejson as json
-import six
 
 from batching_kafka_consumer import AbstractBatchWorker
 
@@ -74,7 +73,7 @@ class ConsumerWorker(AbstractBatchWorker):
             for key, replacement in replacements:
                 self.producer.produce(
                     self.replacements_topic,
-                    key=six.text_type(key).encode('utf-8'),
+                    key=str(key).encode('utf-8'),
                     value=json.dumps(replacement).encode('utf-8'),
                     on_delivery=self.delivery_callback,
                 )

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import logging
-import six
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba import settings
@@ -75,7 +74,7 @@ class EventsProcessor(MessageProcessor):
                                     'end_unmerge', 'end_delete_tag'):
                             # pass raw events along to republish
                             action_type = self.REPLACE
-                            processed = (six.text_type(event['project_id']), message)
+                            processed = (str(event['project_id']), message)
                         else:
                             raise InvalidMessageType("Invalid message type: {}".format(type_))
 
@@ -269,7 +268,7 @@ class EventsProcessor(MessageProcessor):
     def extract_extra_contexts(self, output, contexts):
         context_keys = []
         context_values = []
-        valid_types = (int, float) + six.string_types
+        valid_types = (int, float, str)
         for ctx_name, ctx_obj in contexts.items():
             if isinstance(ctx_obj, dict):
                 ctx_obj.pop('type', None)  # ignore type alias

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -1,7 +1,6 @@
 import cProfile
 import logging
 import os
-import six
 import tempfile
 import time
 from itertools import chain
@@ -20,8 +19,8 @@ class FakeKafkaMessage(object):
         self._value = value
         self._key = key
         self._headers = {
-            six.text_type(k): six.text_type(v) if v else None
-            for k, v in six.iteritems(headers)
+            str(k): str(v) if v else None
+            for k, v in headers.items()
         } if headers else None
         self._headers = headers
         self._error = error
@@ -115,7 +114,7 @@ def run(events_file, dataset, repeat=1,
     time_total = (time_finish - time_start) * 1000
     num_events = len(processed)
 
-    logger.info("Number of events: %s" % six.text_type(num_events).rjust(10, ' '))
+    logger.info("Number of events: %s" % str(num_events).rjust(10, ' '))
     logger.info("Total:            %sms" % format_time(time_total))
     logger.info("Total process:    %sms" % format_time(time_to_process))
     logger.info("Total write:      %sms" % format_time(time_to_write))

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -2,7 +2,6 @@ from datetime import datetime
 import re
 from hashlib import md5
 import simplejson as json
-import six
 
 from snuba.util import force_bytes
 
@@ -90,7 +89,7 @@ def _unicodify(s):
     if isinstance(s, dict) or isinstance(s, list):
         return json.dumps(s)
 
-    return six.text_type(s).encode('utf8', errors='backslashreplace').decode('utf8')
+    return str(s).encode('utf8', errors='backslashreplace').decode('utf8')
 
 
 def _hashify(h):

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -1,5 +1,4 @@
 import logging
-import six
 import time
 from collections import deque
 from datetime import datetime
@@ -150,7 +149,7 @@ def process_delete_groups(message, required_columns):
     if not group_ids:
         return None
 
-    assert all(isinstance(gid, six.integer_types) for gid in group_ids)
+    assert all(isinstance(gid, int) for gid in group_ids)
     timestamp = datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT)
     select_columns = map(lambda i: i if i != 'deleted' else '1', required_columns)
 
@@ -202,7 +201,7 @@ def process_merge(message, all_column_names):
     if not previous_group_ids:
         return None
 
-    assert all(isinstance(gid, six.integer_types) for gid in previous_group_ids)
+    assert all(isinstance(gid, int) for gid in previous_group_ids)
     timestamp = datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT)
     select_columns = map(lambda i: i if i != 'group_id' else str(message['new_group_id']), all_column_names)
 
@@ -242,7 +241,7 @@ def process_unmerge(message, all_column_names):
     if not hashes:
         return None
 
-    assert all(isinstance(h, six.string_types) for h in hashes)
+    assert all(isinstance(h, str) for h in hashes)
     timestamp = datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT)
     select_columns = map(lambda i: i if i != 'group_id' else str(message['new_group_id']), all_column_names)
 
@@ -284,7 +283,7 @@ def process_delete_tag(message, dataset):
     if not tag:
         return None
 
-    assert isinstance(tag, six.string_types)
+    assert isinstance(tag, str)
     timestamp = datetime.strptime(message['datetime'], settings.PAYLOAD_DATETIME_FORMAT)
     tag_column_name = dataset.get_tag_column_map()['tags'].get(tag, tag)
     is_promoted = tag in dataset.get_promoted_tags()['tags']

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -3,7 +3,6 @@ from snuba import settings
 from snuba.datasets import factory
 import jsonschema
 import copy
-import six
 
 CONDITION_OPERATORS = ['>', '<', '>=', '<=', '=', '!=', 'IN', 'NOT IN', 'IS NULL', 'IS NOT NULL', 'LIKE', 'NOT LIKE']
 POSITIVE_OPERATORS = ['>', '<', '>=', '<=', '=', 'IN', 'IS NULL', 'LIKE']
@@ -302,7 +301,7 @@ def validate(value, schema, set_defaults=True):
     orig = jsonschema.Draft6Validator.VALIDATORS['properties']
 
     def validate_and_default(validator, properties, instance, schema):
-        for property, subschema in six.iteritems(properties):
+        for property, subschema in properties.items():
             if 'default' in subschema:
                 if callable(subschema['default']):
                     instance.setdefault(property, subschema['default']())
@@ -334,7 +333,7 @@ def generate(schema):
         default = schema['default']
         return default() if callable(default) else default
     elif typ == 'object':
-        return {prop: generate(subschema) for prop, subschema in six.iteritems(schema.get('properties', {}))}
+        return {prop: generate(subschema) for prop, subschema in schema.get('properties', {}).items()}
     elif typ == 'array':
         return []
     elif typ == 'string':

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -1,5 +1,4 @@
 import os
-import six
 
 LOG_LEVEL = os.environ.get('LOG_LEVEL', 'INFO')
 

--- a/snuba/state.py
+++ b/snuba/state.py
@@ -6,7 +6,6 @@ import logging
 import random
 import re
 import simplejson as json
-import six
 import time
 import uuid
 
@@ -200,7 +199,7 @@ def abtest(value):
     1000:1/2000:1 => returns 1000 or 2000 with equal weight
     1000:2/2000:1 => returns 1000 twice as often as 2000
     """
-    if isinstance(value, six.string_types) and ABTEST_RE.match(value):
+    if isinstance(value, str) and ABTEST_RE.match(value):
         values = ABTEST_RE.findall(value)
         total_weight = sum(int(weight or 1) for (_, weight) in values)
         r = random.randint(1, total_weight)
@@ -236,7 +235,7 @@ def set_config(key, value, user=None):
 
 
 def set_configs(values, user=None):
-    for k, v in six.iteritems(values):
+    for k, v in values.items():
         set_config(k, v, user=user)
 
 
@@ -250,14 +249,14 @@ def get_configs(key_defaults):
 
 
 def get_all_configs():
-    return {k: abtest(v) for k, v in six.iteritems(get_raw_configs())}
+    return {k: abtest(v) for k, v in get_raw_configs().items()}
 
 
 @memoize(settings.CONFIG_MEMOIZE_TIMEOUT)
 def get_raw_configs():
     try:
         all_configs = rds.hgetall(config_hash)
-        return {k.decode('utf-8'): numeric(v.decode('utf-8')) for k, v in six.iteritems(all_configs) if v is not None}
+        return {k.decode('utf-8'): numeric(v.decode('utf-8')) for k, v in all_configs.items() if v is not None}
     except Exception as ex:
         logger.exception(ex)
         return {}

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -3,8 +3,7 @@ import logging
 from datetime import datetime
 
 import requests
-from six.moves import map as imap
-from six.moves.urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin
 
 from snuba.clickhouse import DATETIME_FORMAT, Array
 
@@ -62,5 +61,5 @@ class HTTPBatchWriter(BatchWriter):
         parameters['query'] = "INSERT INTO {table} FORMAT JSONEachRow".format(table=self.__schema.get_table_name())
         requests.post(
             urljoin(self.__base_url, '?' + urlencode(parameters)),
-            data=imap(self.__encode, rows),
+            data=map(self.__encode, rows),
         ).raise_for_status()

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,7 +2,6 @@ import calendar
 from hashlib import md5
 from datetime import datetime, timedelta
 import uuid
-import six
 
 from batching_kafka_consumer import AbstractBatchWorker, BatchingKafkaConsumer
 from confluent_kafka import TopicPartition
@@ -89,7 +88,7 @@ class FakeKafkaConsumer(object):
         return [
             TopicPartition(topic, partition, offset)
             for (topic, partition), offset in
-            six.iteritems(self.positions)
+            self.positions.items()
         ]
 
     def close(self, *args, **kwargs):

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -1,6 +1,5 @@
 import calendar
 import pytest
-import six
 from collections import OrderedDict
 from datetime import datetime, timedelta
 
@@ -160,56 +159,56 @@ class TestEventsProcessor(BaseEventsTest):
         message = (2, 'start_delete_groups', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_end_delete_groups(self):
         project_id = 1
         message = (2, 'end_delete_groups', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message( message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_start_merge(self):
         project_id = 1
         message = (2, 'start_merge', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_end_merge(self):
         project_id = 1
         message = (2, 'end_merge', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_start_unmerge(self):
         project_id = 1
         message = (2, 'start_unmerge', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_end_unmerge(self):
         project_id = 1
         message = (2, 'end_unmerge', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_start_delete_tag(self):
         project_id = 1
         message = (2, 'start_delete_tag', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_v2_end_delete_tag(self):
         project_id = 1
         message = (2, 'end_delete_tag', {'project_id': project_id})
         processor = self.dataset.get_processor()
         assert processor.process_message(message) == \
-            (processor.REPLACE, (six.text_type(project_id), message))
+            (processor.REPLACE, (str(project_id), message))
 
     def test_extract_sdk(self):
         sdk = {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,7 +7,6 @@ import pytest
 import pytz
 from sentry_sdk import Hub, Client
 import simplejson as json
-import six
 import time
 import uuid
 
@@ -76,7 +75,7 @@ class TestApi(BaseEventsTest):
                             'tags': {
                                 # Sentry
                                 'environment': self.environments[(tock * p) % len(self.environments)],
-                                'sentry:release': six.text_type(tick),
+                                'sentry:release': str(tick),
                                 'sentry:dist': 'dist1',
                                 'os.name': 'windows',
                                 'os.rooted': 1,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -4,7 +4,6 @@ from mock import patch
 import simplejson as json
 import time
 from datadog import statsd
-from six.moves import range
 
 from base import (
     BaseTest,


### PR DESCRIPTION
We don't need to have cross-compatibility between 2 and 3 any longer.

Follow up to #376. See SNS-167.