### PR TITLE
ref: Remove unused definitions from schema

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -79,35 +79,6 @@ QUERY_SCHEMA = {
             'type': 'number',
             'default': 3600,
         },
-        'use_group_id_column': {
-            # TODO this flag is deprecated and is ignored by the code.
-            # Remove it when clients are no longer sending it.
-            'type': ['boolean', 'number'],
-            'default': True
-        },
-        'issues': {
-            'type': 'array',
-            'items': {
-                'type': 'array',
-                'minItems': 3,
-                'maxItems': 3,
-                'items': [
-                    {'type': 'number'},
-                    {'type': 'number'},
-                    {
-                        'type': 'array',
-                        'items': {
-                            'anyOf': [
-                                {'$ref': '#/definitions/fingerprint_hash'},
-                                {'$ref': '#/definitions/fingerprint_hash_with_tombstone'},
-                            ],
-                        },
-                        'minItems': 1,
-                    },
-                ],
-            },
-            'default': [],
-        },
         'project': {
             'anyOf': [
                 {'type': 'number'},
@@ -247,8 +218,6 @@ QUERY_SCHEMA = {
         'column_name': {
             'type': 'string',
             'anyOf': [
-                # Special computed column created from `issues` definition
-                {'enum': ['issue', '-issue']},
                 {'pattern': '^-?[a-zA-Z0-9_.]+$', },
                 {'pattern': r'^-?tags\[[a-zA-Z0-9_.:-]+\]$', },
             ],

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -197,24 +197,6 @@ QUERY_SCHEMA = {
     'additionalProperties': False,
 
     'definitions': {
-        'fingerprint_hash': {
-            'type': 'string',
-            'minLength': 32,
-            'maxLength': 32,
-            'pattern': '^[0-9a-f]{32}$',
-        },
-        'fingerprint_hash_with_tombstone': {
-            'type': 'array',
-            'items': [
-                {'$ref': '#/definitions/fingerprint_hash'},
-                {
-                    'anyOf': [
-                        {'type': 'null'},
-                        {'pattern': r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'},
-                    ]
-                },
-            ],
-        },
         'column_name': {
             'type': 'string',
             'anyOf': [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,7 +174,6 @@ class TestApi(BaseEventsTest):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': 1,
             'granularity': 3600,
-            'issues': [],
             'groupby': 'issue',
         })).data)
         assert 'error' not in result
@@ -442,7 +441,6 @@ class TestApi(BaseEventsTest):
 
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': 3,
-            'issues': [(i, 3, [j]) for i, j in enumerate(self.hashes)],
             'groupby': 'project_id',
             'aggregations': [['uniq', 'issue', 'aggregate']],
         })).data)
@@ -450,7 +448,6 @@ class TestApi(BaseEventsTest):
 
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': 3,
-            'issues': [(i, 3, [j]) for i, j in enumerate(self.hashes)],
             'groupby': ['project_id', 'time'],
             'aggregations': [['uniq', 'issue', 'aggregate']],
         })).data)
@@ -564,12 +561,10 @@ class TestApi(BaseEventsTest):
     def test_column_expansion(self):
         # If there is a condition on an already SELECTed column, then use the
         # column alias instead of the full column expression again.
-        issues = [(i, 2, [j]) for i, j in enumerate(self.hashes)]
         response = json.loads(self.app.post('/query', data=json.dumps({
             'project': 2,
             'granularity': 3600,
             'groupby': 'issue',
-            'issues': issues,
             'conditions': [
                 ['issue', '=', 0],
                 ['issue', '=', 1],
@@ -669,7 +664,6 @@ class TestApi(BaseEventsTest):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': 1,
             'granularity': 3600,
-            'issues': [(i, 1, [j]) for i, j in enumerate(self.hashes)],
             'groupby': 'issue',
         })).data)
 


### PR DESCRIPTION
[Old style](https://www.beeradvocate.com/beer/profile/447/1727/) group expansion is not supported any longer in Snuba, as of getsentry/snuba#203.

A cursory skim of [getsentry/sentry](https://github.com/getsentry/sentry) didn't return any results for these schema attributes. (See also getsentry/sentry#14243.)