### PR TITLE
feat: Implement stub subcription endpoints

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from flask import Flask, render_template, request
 from markdown import markdown
+from uuid import uuid1
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
@@ -447,6 +448,20 @@ if application.debug or application.testing:
     @application.route('/tests/error')
     def error():
         1 / 0
+
+    @application.route('/subscriptions', methods=['POST'])
+    def create_subscription():
+        return json.dumps({'subscription_id': uuid1().hex}), 202, {'Content-Type': 'application/json'}
+
+
+    @application.route('/subscriptions/<uuid>/renew', methods=['POST'])
+    def renew_subscription(uuid):
+        return 'ok', 202, {'Content-Type': 'text/plain'}
+
+
+    @application.route('/subscriptions/<uuid>', methods=['DELETE'])
+    def delete_subscription(uuid):
+        return 'ok', 202, {'Content-Type': 'text/plain'}
 else:
     def ensure_table_exists(dataset, force=False):
         pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import calendar
 from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_datetime
 from functools import partial
+from mock import patch
 import pytest
 import pytz
 from sentry_sdk import Hub, Client
@@ -13,17 +14,21 @@ import uuid
 from snuba import settings, state
 from snuba.datasets.factory import get_dataset
 
-from base import BaseEventsTest
+from base import BaseEventsTest, BaseTest
 
 
-class TestApi(BaseEventsTest):
+class BaseApiTest(BaseEventsTest):
     def setup_method(self, test_method):
-        super(TestApi, self).setup_method(test_method)
+        super(BaseApiTest, self).setup_method(test_method)
         from snuba.api import application
         assert application.testing is True
         application.config['PROPAGATE_EXCEPTIONS'] = False
-
         self.app = application.test_client()
+
+
+class TestApi(BaseApiTest):
+    def setup_method(self, test_method):
+        super(TestApi, self).setup_method(test_method)
         self.app.post = partial(self.app.post, headers={'referer': 'test'})
 
         # values for test data
@@ -971,3 +976,28 @@ class TestApi(BaseEventsTest):
             'debug': True,
         })).data)
         assert sorted(r['project_id'] for r in response['data']) == [3]
+
+
+class TestCreateSubscriptionApi(BaseApiTest):
+    def test(self):
+        expected_uuid = uuid.uuid1()
+
+        with patch('snuba.api.uuid1') as uuid4:
+            uuid4.return_value = expected_uuid
+            resp = self.app.post('/subscriptions')
+
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        assert data == {'subscription_id': expected_uuid.hex}
+
+
+class TestRenewSubscriptionApi(BaseApiTest):
+    def test(self):
+        resp = self.app.post('/subscriptions/{}/renew'.format(uuid.uuid4().hex))
+        assert resp.status_code == 202
+
+
+class TestDeleteSubscriptionApi(BaseApiTest):
+    def test(self):
+        resp = self.app.delete('/subscriptions/{}'.format(uuid.uuid4().hex))
+        assert resp.status_code == 202


### PR DESCRIPTION
This introduces stubbed subscription endpoints, based on the spec we've discussed previously. Mostly for testing the integration from sentry.