### PR TITLE
Revert "build(prewhere): Change default prewhere settings"

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -63,7 +63,7 @@ DEFAULT_RETENTION_DAYS = 90
 RETENTION_OVERRIDES = {}
 
 # the list of keys that will upgrade from a WHERE condition to a PREWHERE
-PREWHERE_KEYS = ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
+PREWHERE_KEYS = ['project_id']
 MAX_PREWHERE_CONDITIONS = 1
 
 STATS_IN_RESPONSE = False


### PR DESCRIPTION
Reverts getsentry/snuba#384

This seems to be causing test failures on the Sentry test suite:
```_________________ SnubaSearchTest.test_all_fields_do_not_error _________________
1192Traceback (most recent call last):
1193  File "/home/travis/build/getsentry/sentry/tests/snuba/search/test_backend.py", line 1574, in test_all_fields_do_not_error
1194    test_query('has:%s' % key)
1195  File "/home/travis/build/getsentry/sentry/tests/snuba/search/test_backend.py", line 1569, in test_query
1196    self.fail('Query %s errored. Error info: %s' % (query, e))
1197  File "/opt/python/2.7.13/lib/python2.7/unittest/case.py", line 410, in fail
1198    raise self.failureException(msg)
1199AssertionError: Query has:issue.id errored. Error info: HTTPConnectionPool(host='localhost', port=1218): Max retries exceeded with url: /query (Caused by ReadTimeoutError("HTTPConnectionPool(host='localhost', port=1218): Read timed out. (read timeout=30)",))
1200- generated xml file: /home/travis/build/getsentry/sentry/.artifacts/snuba.junit.xml -
```

When the test is running, snuba logs show:
```
2019-08-02 10:15:06,110 Exception on /query [POST]
Traceback (most recent call last):
  File "/Users/manu/.virtualenvs/snuba/lib/python3.7/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/manu/.virtualenvs/snuba/lib/python3.7/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/manu/.virtualenvs/snuba/lib/python3.7/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/manu/.virtualenvs/snuba/lib/python3.7/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/Users/manu/.virtualenvs/snuba/lib/python3.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/manu/.virtualenvs/snuba/lib/python3.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/manu/workspace/snuba/snuba/util.py", line 634, in wrapper
    return func(*args, **kwargs)
  File "/Users/manu/workspace/snuba/snuba/util.py", line 589, in wrapper
    return func(*args, **kwargs)
  File "/Users/manu/workspace/snuba/snuba/api.py", line 149, in query
    result, status = parse_and_run_query(validated_body, timer)
  File "/Users/manu/workspace/snuba/snuba/split.py", line 93, in wrapper
    return query_func(*args, **kwargs)
  File "/Users/manu/workspace/snuba/snuba/api.py", line 269, in parse_and_run_query
    for cols, cond in prewhere_candidates
TypeError: '<' not supported between instances of 'str' and 'tuple'
```

Will figure out the root cause after this PR.