### PR TITLE
ref(settings): Use proper and modern py3 importlib

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -11,7 +11,7 @@ def _load_settings(obj=locals()):
 
     settings = os.environ.get('SNUBA_SETTINGS', 'base')
 
-    if settings.starstwith('/'):
+    if settings.startswith('/'):
         if not settings.endswith('.py'):
             settings += '.py'
 

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -10,18 +10,18 @@ def _load_settings(obj=locals()):
     import os
 
     settings = os.environ.get('SNUBA_SETTINGS', 'base')
-    if not settings.startswith('/') and not settings.startswith('settings_'):
-        settings = '.settings_%s' % settings
-    elif not settings.endswith('.py'):
-        settings += '.py'
 
-    if settings.startswith('/'):
+    if settings.starstwith('/'):
+        if not settings.endswith('.py'):
+            settings += '.py'
+
         # Code below is adapted from https://stackoverflow.com/a/41595552/90297S
         settings_spec = importlib.util.spec_from_file_location('snuba.settings.custom', settings)
         settings_module = importlib.util.module_from_spec(settings_spec)
         settings_spec.loader.exec_module(settings_module)
     else:
-        settings_module = importlib.import_module(settings, 'snuba')
+        module_format = '.%s' if settings.startswith('settings_') else '.settings_'
+        settings_module = importlib.import_module(module_format % settings, 'snuba')
 
     for attr in dir(settings_module):
         if attr.isupper():

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -20,7 +20,7 @@ def _load_settings(obj=locals()):
         settings_module = importlib.util.module_from_spec(settings_spec)
         settings_spec.loader.exec_module(settings_module)
     else:
-        module_format = '.%s' if settings.startswith('settings_') else '.settings_'
+        module_format = '.%s' if settings.startswith('settings_') else '.settings_%s'
         settings_module = importlib.import_module(module_format % settings, 'snuba')
 
     for attr in dir(settings_module):


### PR DESCRIPTION
Using `__file__` and manual path logic is deprecated as of Python 3 and this patch updates our settings implementation to follow the new best practices.