### PR TITLE
Revert "Revert "build(prewhere): Change default prewhere settings""

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -63,7 +63,7 @@ DEFAULT_RETENTION_DAYS = 90
 RETENTION_OVERRIDES = {}
 
 # the list of keys that will upgrade from a WHERE condition to a PREWHERE
-PREWHERE_KEYS = ['project_id']
+PREWHERE_KEYS = ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
 MAX_PREWHERE_CONDITIONS = 1
 
 STATS_IN_RESPONSE = False


### PR DESCRIPTION
Reverts getsentry/snuba#389

The issue was fixed in Sentry: https://github.com/getsentry/sentry/pull/14282