### PR TITLE
fix: SIGTERM to kill consumer and replacer

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -98,5 +98,6 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, consumer_gr
         consumer.signal_shutdown()
 
     signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
 
     consumer.run()

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -92,5 +92,6 @@ def replacer(replacements_topic, consumer_group, bootstrap_server, clickhouse_ho
         replacer.signal_shutdown()
 
     signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
 
     replacer.run()


### PR DESCRIPTION
Kubernetes sends a `SIGTERM` when shutting down the consumer and replacer. Today, when we get a `SIGTERM`, the consumer and replacer are killed, but not gracefully. This PR makes them die gracefully by trapping the `SIGTERM`.

## Testing
Before this PR, when the consumer or replacer got a `SIGTERM`, it died violently:
```
$ snuba consumer --log-level=debug
2019-08-06 15:24:26,129 Starting
...
[1]    95627 terminated  snuba replacer --log-level=debug
```

After this PR, when the consumer or replacer gets a `SIGTERM`, it dies gracefully:
```
$ snuba consumer --log-level=debug
2019-08-06 15:24:26,129 Starting
...
2019-08-06 15:24:37,162 Shutdown signalled
2019-08-06 15:24:37,162 Stopping
2019-08-06 15:24:37,162 Resetting in-memory batch
2019-08-06 15:24:37,162 Stopping worker
2019-08-06 15:24:37,162 Stopping consumer
2019-08-06 15:24:37,184 Stopped
```