### PR TITLE
fix(settings): Use a reasonable default port for `KAFKA_BROKERS`

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -50,7 +50,7 @@ TIME_GROUP_COLUMNS = {
 }
 
 # Processor/Writer Options
-DEFAULT_BROKERS = ['localhost:9093']
+DEFAULT_BROKERS = ['localhost:9092']
 DEFAULT_DATASET_BROKERS = {}
 
 DEFAULT_MAX_BATCH_SIZE = 50000


### PR DESCRIPTION
The reasonable default port to use for sending data Kafka is the default port Kafka is listening at.