### PR TITLE
ref: Remove redundant conditional from RECORD_QUERIES

### DIFF
--- a/snuba/state.py
+++ b/snuba/state.py
@@ -285,16 +285,15 @@ def record_query(data):
             .ltrim(queries_list, 0, max_redis_queries - 1)\
             .execute()
 
-        if settings.RECORD_QUERIES:
-            if kfk is None:
-                kfk = Producer({
-                    'bootstrap.servers': ','.join(settings.DEFAULT_BROKERS)
-                })
+        if kfk is None:
+            kfk = Producer({
+                'bootstrap.servers': ','.join(settings.DEFAULT_BROKERS)
+            })
 
-            kfk.produce(
-                settings.QUERIES_TOPIC,
-                data.encode('utf-8'),
-            )
+        kfk.produce(
+            settings.QUERIES_TOPIC,
+            data.encode('utf-8'),
+        )
     except Exception as ex:
         logger.exception(ex)
         pass


### PR DESCRIPTION
The only caller of `record_query` is `raw_query`, which already wraps the invocation of this function with this conditional: https://github.com/getsentry/snuba/blob/cf3e0ff076fa22bf03c223e648336a32f488f3f0/snuba/util.py#L509-L528