### PR TITLE
fix: Return a Sequence of config changes instead of Iterable

### DIFF
--- a/snuba/state.py
+++ b/snuba/state.py
@@ -267,10 +267,7 @@ def delete_config(key, user=None):
 
 
 def get_config_changes():
-    return map(
-        json.loads,
-        rds.lrange(config_changes_list, 0, -1),
-    )
+    return [json.loads(change) for change in rds.lrange(config_changes_list, 0, -1)]
 
 
 # Query Recording


### PR DESCRIPTION
This is necessary for JSON serialization to work correctly without any special-casing, and preserves the Python 2 behavior. Fixes SNUBA-1GX.