### PR TITLE
feat(api) Add support for column list in aggregate functions

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -243,7 +243,10 @@ def dataset_query(dataset, body, timer):
 
 def format_query(dataset, body, table, prewhere_conditions, final) -> str:
     """Generate a SQL string from the parameters."""
-    aggregate_exprs = [util.column_expr(dataset, col, body, alias, agg) for (agg, col, alias) in body['aggregations']]
+    aggregate_exprs = [
+        util.column_expr(dataset, col, body, alias, agg)
+        for (agg, col, alias) in body['aggregations']
+    ]
     groupby = util.to_list(body['groupby'])
     group_exprs = [util.column_expr(dataset, gb, body) for gb in groupby]
     selected_cols = [util.column_expr(dataset, util.tuplify(colname), body) for colname in body.get('selected_columns', [])]

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -34,6 +34,7 @@ GENERIC_QUERY_SCHEMA = {
                     }, {
                         # Aggregate column
                         'anyOf': [
+                            {'$ref': '#/definitions/column_list'},
                             {'$ref': '#/definitions/column_name'},
                             {'enum': ['']},
                             {'type': 'null'},

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -505,6 +505,16 @@ class TestApi(BaseApiTest):
             assert len(data[idx]['top_platforms']) == 1
             assert data[idx]['top_platforms'][0] in self.platforms
 
+    def test_aggregate_with_multiple_arguments(self):
+        result = json.loads(self.app.post('/query', data=json.dumps({
+            'project': 3,
+            'groupby': 'project_id',
+            'aggregations': [['argMax', ['event_id', 'timestamp'], 'latest_event']],
+        })).data)
+        assert len(result['data']) == 1
+        assert 'latest_event' in result['data'][0]
+        assert 'project_id' in result['data'][0]
+
     def test_having_conditions(self):
         result = json.loads(self.app.post('/query', data=json.dumps({
             'project': 2,
@@ -1081,7 +1091,7 @@ class TestApi(BaseApiTest):
             'groupby': 'project_id',
             'debug': True,
         })).data)
-        assert sorted(r['project_id'] for r in response['data']) == [1,2,3]
+        assert sorted(r['project_id'] for r in response['data']) == [1, 2, 3]
 
         # only project 3 has a search_message with 'long search' in it
         response = json.loads(self.app.post('/query', data=json.dumps({


### PR DESCRIPTION
We have a use-case in sentry where we want to use `argMax()` which requires multiple columns to work. While this function is allowed in `selected_columns` it is actually an aggregate value and should probably be in `aggregations`. This expands the schema and query builder to allow lists of columns in aggregations functions.

This may all be a bad idea as I'm a snuba noob.

Refs getsentry/sentry#14321