### PR TITLE
ref: Remove `force_final` configuration and simplify `FINAL` handling

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -449,9 +449,11 @@ if application.debug or application.testing:
     def create_subscription():
         return json.dumps({'subscription_id': uuid1().hex}), 202, {'Content-Type': 'application/json'}
 
+
     @application.route('/subscriptions/<uuid>/renew', methods=['POST'])
     def renew_subscription(uuid):
         return 'ok', 202, {'Content-Type': 'text/plain'}
+
 
     @application.route('/subscriptions/<uuid>', methods=['DELETE'])
     def delete_subscription(uuid):

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -177,7 +177,7 @@ def parse_and_run_query(validated_body, timer):
         ('force_final', 0 if turbo else None),
         ('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE),
     ])
-    stats = {}
+
     to_date = util.parse_datetime(body['to_date'], date_align)
     from_date = util.parse_datetime(body['from_date'], date_align)
     assert from_date <= to_date
@@ -317,14 +317,14 @@ def parse_and_run_query(validated_body, timer):
 
     timer.mark('prepare_query')
 
-    stats.update({
+    stats = {
         'clickhouse_table': table,
         'final': used_final,
         'referrer': request.referrer,
         'num_days': (to_date - from_date).days,
         'num_projects': len(project_ids),
         'sample': sample,
-    })
+    }
 
     return util.raw_query(
         validated_body, sql, clickhouse_ro, timer, stats


### PR DESCRIPTION
This now has the following behavior, in English:

- If a query has `turbo`, it will never use `FINAL`. These `turbo` queries also do not special case excluded groups to avoid strange phenomena when groups could appear to be "resurrected" if the exclusion set grows larger than the maximum allowable size.
- Queries that are not marked with `turbo` and require final will use `FINAL`.
- Queries that are not marked with `turbo` and do not require final will use the group exclusion set, *unless* the size of the exclusion set exceeds the configured limit, in which case the query will run with `FINAL` instead. (Any queries that use `FINAL` will *not* use the group exclusion set, since the utility of the exclusion set is redundant with the behavior of `FINAL`.)