### PR TITLE
ref(reader): Return date and datetimes instead of strings

### DIFF
--- a/snuba/split.py
+++ b/snuba/split.py
@@ -138,12 +138,10 @@ def split_query(query_func):
             conditions.append(('event_id', 'IN', event_ids))
 
             timestamps = [event['timestamp'] for event in result['data']]
-            from_date = util.parse_datetime(min(timestamps))
+            body['from_date'] = min(timestamps).isoformat()
             # We add 1 second since this gets translated to ('timestamp', '<', to_date)
             # and events are stored with a granularity of 1 second.
-            to_date = util.parse_datetime(max(timestamps)) + timedelta(seconds=1)
-            body['from_date'] = from_date.isoformat()
-            body['to_date'] = to_date.isoformat()
+            body['to_date'] = (max(timestamps) + timedelta(seconds=1)).isoformat()
             body['offset'] = 0
             body['limit'] = len(event_ids)
 


### PR DESCRIPTION
This code will need to be shared between the HTTP (JSON) reader (getsentry/snuba#406) and the native reader, so this extracts it from the `NativeDriverReader`.

Formatting the datetime is object is already handled as part of the JSON serializer in the API: https://github.com/getsentry/snuba/blob/4b36a882c3ed167dbe84dba9e17eb4b2ec9e5352/snuba/api.py#L156

It makes more sense to pass around a datetime object than a string, since this avoids unnecessary type conversions in components such as the splitter.