### PR TITLE
fix(reader): Correctly handle totals row

### DIFF
--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -47,15 +47,23 @@ def transform_date_columns(result: Result) -> Result:
     Convert timezone-naive date and datetime values into timezone aware
     datetimes.
     """
+
+    def iterate_rows():
+        if 'totals' in result:
+            return itertools.chain(result['data'], [result['totals']])
+        else:
+            return iter(result["data"])
+
     for col in result["meta"]:
         if DATETIME_TYPE_RE.match(col["type"]):
-            for row in itertools.chain(result["data"], [result.get("totals", {})]):
+            for row in iterate_rows():
                 row[col["name"]] = row[col["name"]].replace(tzinfo=tz.tzutc())
         elif DATE_TYPE_RE.match(col["type"]):
-            for row in itertools.chain(result["data"], [result.get("totals", {})]):
+            for row in iterate_rows():
                 row[col["name"]] = datetime(
                     *(row[col["name"]].timetuple()[:6])
                 ).replace(tzinfo=tz.tzutc())
+
     return result
 
 

--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -16,11 +16,7 @@ if TYPE_CHECKING:
     Row = MutableMapping[str, Any]
     Result = TypedDict(
         "Result",
-        {
-            "meta": Sequence[Column],
-            "data": Sequence[Row],
-            "totals": Row,
-        },
+        {"meta": Sequence[Column], "data": Sequence[Row], "totals": Row},
         total=False,
     )
 
@@ -49,8 +45,8 @@ def transform_date_columns(result: Result) -> Result:
     """
 
     def iterate_rows():
-        if 'totals' in result:
-            return itertools.chain(result['data'], [result['totals']])
+        if "totals" in result:
+            return itertools.chain(result["data"], [result["totals"]])
         else:
             return iter(result["data"])
 


### PR DESCRIPTION
Fixes a regression introduced with getsentry/snuba#414 when rewriting date types in the `totals` row.

Before:
```
(snuba) ted@veneno % git co master
Switched to branch 'master'
(snuba) ted@veneno % python -m mypy --follow-imports skip snuba/reader.py
snuba/reader.py:52: error: Unsupported target for indexed assignment
snuba/reader.py:52: error: Value of type "Collection[str]" is not indexable
snuba/reader.py:55: error: Unsupported target for indexed assignment
snuba/reader.py:56: error: Value of type "Collection[str]" is not indexable
```

After:
```
(snuba) ted@veneno % git co reader-date-formatting-fix
Switched to branch 'reader-date-formatting-fix'
(snuba) ted@veneno % python -m mypy --follow-imports skip snuba/reader.py
```  