### PR TITLE
ref(api): Enable dataset-specific query schemas

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -3,7 +3,7 @@ import os
 
 from copy import deepcopy
 from datetime import datetime, timedelta
-from flask import Flask, render_template, request
+from flask import Flask, redirect, render_template, request
 from markdown import markdown
 from uuid import uuid1
 import sentry_sdk
@@ -173,7 +173,7 @@ def health():
 @util.time_request('query')
 def unqualified_query_view(*, timer: Timer):
     if request.method == 'GET':
-        raise NotImplementedError  # redirect to the default dataset URL
+        return redirect(f"/{settings.DEFAULT_DATASET_NAME}/query", code=302)
     elif request.method == 'POST':
         body = json.loads(request.data)  # TODO: error handling
         dataset = get_dataset(body.pop('dataset', settings.DEFAULT_DATASET_NAME))  # TODO: error handling

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -20,6 +20,8 @@ from snuba.split import split_query
 from snuba.datasets.factory import get_dataset, get_enabled_dataset_names
 from snuba.datasets.schema import local_dataset_mode
 from snuba.redis import redis_client
+from snuba.util import Timer
+
 
 logger = logging.getLogger('snuba.api')
 logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL.upper()), format='%(asctime)s %(message)s')
@@ -169,7 +171,7 @@ def health():
 
 @application.route('/query', methods=['GET', 'POST'])
 @util.time_request('query')
-def unqualified_query_view(*, timer):
+def unqualified_query_view(*, timer: Timer):
     if request.method == 'GET':
         raise NotImplementedError  # redirect to the default dataset URL
     elif request.method == 'POST':
@@ -182,7 +184,7 @@ def unqualified_query_view(*, timer):
 
 @application.route('/<dataset_name>/query', methods=['GET', 'POST'])
 @util.time_request('query')
-def dataset_query_view(*, dataset_name, timer):
+def dataset_query_view(*, dataset_name: str, timer: Timer):
     dataset = get_dataset(dataset_name)  # TODO: error handling
     if request.method == 'GET':
         return render_template(

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -98,7 +98,8 @@ def handle_bad_request(exception: BadRequest):
 
 @application.errorhandler(InvalidDatasetError)
 def handle_invalid_dataset(exception: InvalidDatasetError):
-    return str(exception), 404, {'Content-Type': 'text/plain'}
+    data = {'error': {'type': 'dataset', 'message': str(exception)}}
+    return json.dumps(data, sort_keys=True, indent=4), 404, {'Content-Type': 'application/json'}
 
 
 @application.route('/')

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -1,6 +1,7 @@
 from typing import Mapping
 
 from snuba.clickhouse import escape_col
+from snuba.schemas import QUERY_SCHEMA
 
 
 class Dataset(object):
@@ -73,6 +74,9 @@ class Dataset(object):
         external source when present.
         """
         raise NotImplementedError
+
+    def get_query_schema(self):
+        return QUERY_SCHEMA
 
 
 class TimeSeriesDataset(Dataset):

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -1,7 +1,6 @@
 from typing import Mapping
 
 from snuba.clickhouse import escape_col
-from snuba.schemas import QUERY_SCHEMA
 
 
 class Dataset(object):
@@ -76,7 +75,7 @@ class Dataset(object):
         raise NotImplementedError
 
     def get_query_schema(self):
-        return QUERY_SCHEMA
+        raise NotImplementedError('dataset does not support queries')
 
 
 class TimeSeriesDataset(Dataset):

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -14,6 +14,7 @@ from snuba.clickhouse import (
 from snuba.datasets import TimeSeriesDataset
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schema import ReplacingMergeTreeSchema
+from snuba.schemas import QUERY_SCHEMA
 from snuba.util import (
     alias_expr,
     all_referenced_columns,
@@ -334,3 +335,6 @@ class EventsDataset(TimeSeriesDataset):
             # bother creating the k/v tuples to arrayJoin on, or the all_tags alias
             # to re-use as we won't need it.
             return 'arrayJoin({})'.format(key_list if k_or_v == 'key' else val_list)
+
+    def get_query_schema(self):
+        return QUERY_SCHEMA

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -31,8 +31,8 @@ def get_dataset(name):
 
     try:
         dataset = DATASETS_IMPL[name] = dataset_mappings[name]()
-    except KeyError:
-        raise InvalidDatasetError(f"dataset {name!r} does not exist")
+    except KeyError as error:
+        raise InvalidDatasetError(f"dataset {name!r} does not exist") from error
 
     return dataset
 

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -9,11 +9,16 @@ DATASET_NAMES = {
 }
 
 
+class InvalidDatasetError(Exception):
+    """Exception raised on invalid dataset access."""
+
+
 def get_dataset(name):
     if name in DATASETS_IMPL:
         return DATASETS_IMPL[name]
 
-    assert name not in settings.DISABLED_DATASETS, "Dataset %s not available in this environment" % name
+    if name in settings.DISABLED_DATASETS:
+        raise InvalidDatasetError(f"dataset {name!r} is not available in this environment")
 
     from snuba.datasets.events import EventsDataset
     from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
@@ -24,7 +29,11 @@ def get_dataset(name):
         'outcomes': OutcomesDataset,
     }
 
-    dataset = DATASETS_IMPL[name] = dataset_mappings[name]()
+    try:
+        dataset = DATASETS_IMPL[name] = dataset_mappings[name]()
+    except KeyError:
+        raise InvalidDatasetError(f"dataset {name!r} does not exist")
+
     return dataset
 
 

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from snuba.datasets import factory
 import jsonschema
 import copy
 
@@ -37,9 +36,6 @@ SDK_STATS_SCHEMA = {
 QUERY_SCHEMA = {
     'type': 'object',
     'properties': {
-        'dataset': {
-            'enum': list(factory.DATASET_NAMES),
-        },
         # A condition is a 3-tuple of (column, operator, literal)
         # `conditions` is an array of conditions, or an array of arrays of conditions.
         # Conditions at the the top level are ANDed together.


### PR DESCRIPTION
This contains several interrelated changes:

1. The query schema for processing a dataset is now exposed as `Dataset.get_query_schema`.
2. `get_dataset` now raises an `InvalidDatasetError` when attempting to reference a nonexistent or disabled dataset (these would raise an unhandled `KeyError` or `AssertionError`, respectively.) This exception is automatically translated to a 404 response.
3. This adds the `/<dataset_name>/query` route that should be used for all new requests. The existing unqualified `/query` endpoint will redirect to the default dataset query page on `GET` requests, or use the `dataset` key in the request body to determine which dataset should handle the request. This endpoint should be put on a deprecation plan.
4. `dataset` was removed from the query schema, since it is redundant with the URL path parameter. It's current behavior is maintained for legacy purposes in the unqualified query view, described above.
5. This removes the `validate_request` decorator, since one schema is no longer applicable to queries for all datasets.
6. Various type annotations or refinements to function signatures (e.g. using `*` where appropriate to denote functions that only take keyword arguments.)

Query processing is still coupled to the generic query schema for all datasets — meaning that `events` is likely the only dataset that will function properly. This will be improved in a later change.