### PR TITLE
Move stub subscription endpoints out of dev

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -434,6 +434,21 @@ def sdk_distribution(*, timer: Timer):
     )
 
 
+@application.route('/subscriptions', methods=['POST'])
+def create_subscription():
+    return json.dumps({'subscription_id': uuid1().hex}), 202, {'Content-Type': 'application/json'}
+
+
+@application.route('/subscriptions/<uuid>/renew', methods=['POST'])
+def renew_subscription(uuid):
+    return 'ok', 202, {'Content-Type': 'text/plain'}
+
+
+@application.route('/subscriptions/<uuid>', methods=['DELETE'])
+def delete_subscription(uuid):
+    return 'ok', 202, {'Content-Type': 'text/plain'}
+
+
 if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
@@ -530,19 +545,6 @@ if application.debug or application.testing:
     def error():
         1 / 0
 
-    @application.route('/subscriptions', methods=['POST'])
-    def create_subscription():
-        return json.dumps({'subscription_id': uuid1().hex}), 202, {'Content-Type': 'application/json'}
-
-
-    @application.route('/subscriptions/<uuid>/renew', methods=['POST'])
-    def renew_subscription(uuid):
-        return 'ok', 202, {'Content-Type': 'text/plain'}
-
-
-    @application.route('/subscriptions/<uuid>', methods=['DELETE'])
-    def delete_subscription(uuid):
-        return 'ok', 202, {'Content-Type': 'text/plain'}
 else:
     def ensure_table_exists(dataset, force=False):
         pass


### PR DESCRIPTION
Would be handy to have these endpoints available in prod so that my code that calls them doesn't fail.