### PR TITLE
ref(api): Stop sorting keys when JSON encoding

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -93,7 +93,7 @@ def handle_bad_request(exception: BadRequest):
         else:
             raise TypeError()
 
-    return json.dumps(data, sort_keys=True, indent=4, default=default_encode), 400, {'Content-Type': 'application/json'}
+    return json.dumps(data, indent=4, default=default_encode), 400, {'Content-Type': 'application/json'}
 
 
 @application.errorhandler(InvalidDatasetError)
@@ -213,7 +213,6 @@ def dataset_query_view(*, dataset_name: str, timer: Timer):
             'query.html',
             query_template=json.dumps(
                 schemas.generate(dataset.get_query_schema()),
-                sort_keys=True,
                 indent=4,
             ),
         )
@@ -234,7 +233,6 @@ def dataset_query(dataset, body, timer):
     return (
         json.dumps(
             result,
-            for_json=True,
             default=lambda obj: obj.isoformat() if isinstance(obj, datetime) else obj),
         status,
         {'Content-Type': 'application/json'}

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -233,6 +233,7 @@ def dataset_query(dataset, body, timer):
     return (
         json.dumps(
             result,
+            for_json=True,
             default=lambda obj: obj.isoformat() if isinstance(obj, datetime) else obj),
         status,
         {'Content-Type': 'application/json'}


### PR DESCRIPTION
As of Python 3.7, dictionaries are iterated in insertion order.

There are several places that insertion order, rather than lexicographical order, would be a useful property when a human is reading the output of the JSON — for instance, [HTTP 400 responses will include the `type` and `message` before other contextual information](https://github.com/getsentry/snuba/blob/718d4c4c9121874c885767e6791a167e7ca1c2bc/snuba/api.py#L76-L86), and the `/<dataset>/query` endpoint now will generate the query structure in the same order as a SQL statement, followed by the options, which will be rendered near other associated options. For example:

```json
{
    "selected_columns": [],
    "aggregations": [],
    "arrayjoin": null,
    "sample": null,
    "conditions": [],
    "groupby": [],
    "totals": false,
    "having": [],
    "orderby": null,
    "limit": 1000,
    "offset": null,
    "limitby": [],
    "from_date": "2019-08-12T00:07:47",
    "to_date": "2019-08-17T00:07:47",
    "granularity": 3600,
    "project": null,
    "turbo": false,
    "consistent": false,
    "debug": null
}
```