### PR TITLE
ref(api): Split out "query" and "extensions" into separate data structures

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -322,8 +322,6 @@ def format_query(dataset, body, table, prewhere_conditions, final) -> str:
 def parse_and_run_query(dataset, query, extensions, timer):
     body = {**query, **extensions}
 
-    table = dataset.get_schema().get_table_name()
-
     max_days, date_align, config_sample = state.get_configs([
         ('max_days', None),
         ('date_align_seconds', 1),
@@ -554,6 +552,7 @@ if application.debug or application.testing:
     @application.route('/tests/error')
     def error():
         1 / 0
+
 else:
     def ensure_table_exists(dataset, force=False):
         pass

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -74,7 +74,7 @@ class Dataset(object):
         """
         raise NotImplementedError
 
-    def get_query_options_schema(self):
+    def get_query_extensions_schema(self):
         raise NotImplementedError('dataset does not support queries')
 
 

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -74,7 +74,7 @@ class Dataset(object):
         """
         raise NotImplementedError
 
-    def get_query_schema(self):
+    def get_query_options_schema(self):
         raise NotImplementedError('dataset does not support queries')
 
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -14,7 +14,7 @@ from snuba.clickhouse import (
 from snuba.datasets import TimeSeriesDataset
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schema import ReplacingMergeTreeSchema
-from snuba.schemas import EVENTS_QUERY_SCHEMA
+from snuba.schemas import EVENTS_QUERY_OPTIONS_SCHEMA
 from snuba.util import (
     alias_expr,
     all_referenced_columns,
@@ -336,5 +336,5 @@ class EventsDataset(TimeSeriesDataset):
             # to re-use as we won't need it.
             return 'arrayJoin({})'.format(key_list if k_or_v == 'key' else val_list)
 
-    def get_query_schema(self):
-        return EVENTS_QUERY_SCHEMA
+    def get_query_options_schema(self):
+        return EVENTS_QUERY_OPTIONS_SCHEMA

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -14,7 +14,7 @@ from snuba.clickhouse import (
 from snuba.datasets import TimeSeriesDataset
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schema import ReplacingMergeTreeSchema
-from snuba.schemas import EVENTS_QUERY_OPTIONS_SCHEMA
+from snuba.schemas import EVENTS_QUERY_EXTENSIONS_SCHEMA
 from snuba.util import (
     alias_expr,
     all_referenced_columns,
@@ -336,5 +336,5 @@ class EventsDataset(TimeSeriesDataset):
             # to re-use as we won't need it.
             return 'arrayJoin({})'.format(key_list if k_or_v == 'key' else val_list)
 
-    def get_query_options_schema(self):
-        return EVENTS_QUERY_OPTIONS_SCHEMA
+    def get_query_extensions_schema(self):
+        return EVENTS_QUERY_EXTENSIONS_SCHEMA

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -7,7 +7,7 @@ CONDITION_OPERATORS = ['>', '<', '>=', '<=', '=', '!=', 'IN', 'NOT IN', 'IS NULL
 POSITIVE_OPERATORS = ['>', '<', '>=', '<=', '=', 'IN', 'IS NULL', 'LIKE']
 
 
-def get_time_series_query_schema_properties(default_granularity: int, default_window: timedelta):
+def get_time_series_query_extension_schema_properties(default_granularity: int, default_window: timedelta):
     return {
         'from_date': {
             'type': 'string',
@@ -198,19 +198,19 @@ GENERIC_QUERY_SCHEMA = {
     }
 }
 
-SDK_STATS_QUERY_OPTIONS_SCHEMA = {
+SDK_STATS_QUERY_EXTENSIONS_SCHEMA = {
     'type': 'object',
-    'properties': get_time_series_query_schema_properties(
+    'properties': get_time_series_query_extension_schema_properties(
             default_granularity=86400,  # SDK stats query defaults to 1-day bucketing
             default_window=timedelta(days=1),
     ),
     'additionalProperties': False,
 }
 
-EVENTS_QUERY_OPTIONS_SCHEMA = {
+EVENTS_QUERY_EXTENSIONS_SCHEMA = {
     'type': 'object',
     'properties': {
-        **get_time_series_query_schema_properties(
+        **get_time_series_query_extension_schema_properties(
             default_granularity=3600,
             default_window=timedelta(days=5),
         ),

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -208,6 +208,7 @@ SDK_STATS_QUERY_OPTIONS_SCHEMA = {
 }
 
 EVENTS_QUERY_OPTIONS_SCHEMA = {
+    'type': 'object',
     'properties': {
         **get_time_series_query_schema_properties(
             default_granularity=3600,
@@ -243,6 +244,37 @@ EVENTS_QUERY_OPTIONS_SCHEMA = {
     'required': ['project'],
     'additionalProperties': False,
 }
+
+
+def get_composite_schema(schemas):
+    """
+    Merge two object schemas together, returning a new schema that contains
+    properties, definitions, and required fields from both.
+    """
+    result = {
+        'type': 'object',
+        'properties': {},
+        'definitions': {},
+        'required': set(),
+        'additionalProperties': False,
+    }
+
+    for schema in schemas:
+        assert schema['type'] == 'object'
+
+        assert not set(result['properties'].keys()) & set(schema['properties'].keys()), 'property name conflict'
+        result['properties'].update(schema['properties'])
+
+        assert not set(result['definitions'].keys()) & set(schema.get('definitions', {}).keys()), 'definition name conflict'
+        result['definitions'].update(schema.get('definitions', {}))
+
+        result['required'].update(schema.get('required', []))
+
+        assert schema['additionalProperties'] is False, 'schema must not allow additional properties'
+
+    result['required'] = list(result['required'])
+
+    return result
 
 
 def validate(value, schema, set_defaults=True):

--- a/snuba/split.py
+++ b/snuba/split.py
@@ -14,32 +14,32 @@ MIN_COLS = ['project_id', 'event_id', 'timestamp']
 
 def split_query(query_func):
 
-    def wrapper(dataset, body, *args, **kwargs):
+    def wrapper(dataset, query, options, *args, **kwargs):
         use_split = state.get_configs([
             ('use_split', 0),
         ])
-        limit = body.get('limit', 0)
-        remaining_offset = body.get('offset', 0)
-        orderby = util.to_list(body.get('orderby'))
+        limit = query.get('limit', 0)
+        remaining_offset = query.get('offset', 0)
+        orderby = util.to_list(query.get('orderby'))
 
-        common_conditions = use_split and limit and not body.get('groupby')
+        common_conditions = use_split and limit and not query.get('groupby')
 
         if common_conditions:
-            total_col_count = len(util.all_referenced_columns(body))
-            min_col_count = len(util.all_referenced_columns({**body, 'selected_columns': MIN_COLS}))
+            total_col_count = len(util.all_referenced_columns(query))
+            min_col_count = len(util.all_referenced_columns({**query, 'selected_columns': MIN_COLS}))
 
             if (
-                body.get('selected_columns')
-                and not body.get('aggregations')
+                query.get('selected_columns')
+                and not query.get('aggregations')
                 and total_col_count > min_col_count
             ):
-                return col_split(dataset, body, *args, **kwargs)
+                return col_split(dataset, query, options, *args, **kwargs)
             elif orderby[:1] == ['-timestamp'] and remaining_offset < 1000:
-                return time_split(dataset, body, *args, **kwargs)
+                return time_split(dataset, query, options, *args, **kwargs)
 
-        return query_func(dataset, body, *args, **kwargs)
+        return query_func(dataset, query, options, *args, **kwargs)
 
-    def time_split(dataset, body, *args, **kwargs):
+    def time_split(dataset, query, options, *args, **kwargs):
         """
         If a query is:
             - ORDER BY timestamp DESC
@@ -56,11 +56,11 @@ def split_query(query_func):
             ('split_step', 3600),  # default 1 hour
         ])
 
-        limit = body.get('limit', 0)
-        remaining_offset = body.get('offset', 0)
+        limit = query.get('limit', 0)
+        remaining_offset = query.get('offset', 0)
 
-        to_date = util.parse_datetime(body['to_date'], date_align)
-        from_date = util.parse_datetime(body['from_date'], date_align)
+        to_date = util.parse_datetime(options['to_date'], date_align)
+        from_date = util.parse_datetime(options['from_date'], date_align)
 
         overall_result = None
         split_end = to_date
@@ -68,18 +68,18 @@ def split_query(query_func):
         total_results = 0
         status = 0
         while split_start < split_end and total_results < limit:
-            body['from_date'] = split_start.isoformat()
-            body['to_date'] = split_end.isoformat()
+            options['from_date'] = split_start.isoformat()
+            options['to_date'] = split_end.isoformat()
             # Because its paged, we have to ask for (limit+offset) results
             # and set offset=0 so we can then trim them ourselves.
-            body['offset'] = 0
-            body['limit'] = limit - total_results + remaining_offset
+            query['offset'] = 0
+            query['limit'] = limit - total_results + remaining_offset
 
-            # The query function may mutate the request body during query
-            # evaluation, so we need to copy the body to ensure that the query
-            # has not been modified in between this call and the next loop
+            # The query function may mutate the request body and options during
+            # query evaluation, so we need to copy the body to ensure that they
+            # have not been modified in between this call and the next loop
             # iteration, if needed.
-            result, status = query_func(dataset, copy.deepcopy(body), *args, **kwargs)
+            result, status = query_func(dataset, copy.deepcopy(query), copy.deepcopy(options), *args, **kwargs)
 
             # If something failed, discard all progress and just return that
             if status != 200:
@@ -118,19 +118,19 @@ def split_query(query_func):
 
         return overall_result, status
 
-    def col_split(dataset, body, *args, **kwargs):
+    def col_split(dataset, query, options, *args, **kwargs):
         """
         Split query in 2 steps if a large number of columns is being selected.
             - First query only selects event_id and project_id.
             - Second query selects all fields for only those events.
             - Shrink the date range.
         """
-        # The query function may mutate the request body during query
-        # evaluation, so we need to copy the body to ensure that the query has
-        # not been modified by the time we're ready to run the full query.
-        minimal_query = copy.deepcopy(body)
+        # The query function may mutate the request query or options during
+        # query evaluation, so we need to copy them to ensure that the query
+        # has not been modified by the time we're ready to run the full query.
+        minimal_query = copy.deepcopy(query)
         minimal_query.update({'selected_columns': MIN_COLS})
-        result, status = query_func(dataset, minimal_query, *args, **kwargs)
+        result, status = query_func(dataset, minimal_query, copy.deepcopy(options), *args, **kwargs)
         del minimal_query
 
         # If something failed, just return
@@ -138,22 +138,18 @@ def split_query(query_func):
             return result, status
 
         if result['data']:
-            project_ids = list(set([event['project_id'] for event in result['data']]))
-            body['project_id'] = project_ids
-
             event_ids = list(set([event['event_id'] for event in result['data']]))
-            body['conditions'].append(('event_id', 'IN', event_ids))
+            query['conditions'].append(('event_id', 'IN', event_ids))
+            query['offset'] = 0
+            query['limit'] = len(event_ids)
 
             timestamps = [event['timestamp'] for event in result['data']]
-            from_date = util.parse_datetime(min(timestamps))
+            options['from_date'] = util.parse_datetime(min(timestamps)).isoformat()
             # We add 1 second since this gets translated to ('timestamp', '<', to_date)
             # and events are stored with a granularity of 1 second.
-            to_date = util.parse_datetime(max(timestamps)) + timedelta(seconds=1)
-            body['from_date'] = from_date.isoformat()
-            body['to_date'] = to_date.isoformat()
-            body['offset'] = 0
-            body['limit'] = len(event_ids)
+            options['to_date'] = (util.parse_datetime(max(timestamps)) + timedelta(seconds=1)).isoformat()
+            options['project'] = list(set([event['project_id'] for event in result['data']]))
 
-        return query_func(dataset, body, *args, **kwargs)
+        return query_func(dataset, query, options, *args, **kwargs)
 
     return wrapper

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -207,7 +207,7 @@ def is_condition(cond_or_list):
     )
 
 
-def all_referenced_columns(body):
+def all_referenced_columns(query):
     """
     Return the set of all columns that are used by a query.
     """
@@ -215,16 +215,16 @@ def all_referenced_columns(body):
 
     # These fields can reference column names
     for field in ['arrayjoin', 'groupby', 'orderby', 'selected_columns']:
-        if field in body:
-            col_exprs.extend(to_list(body[field]))
+        if field in query:
+            col_exprs.extend(to_list(query[field]))
 
     # Conditions need flattening as they can be nested as AND/OR
-    if 'conditions' in body:
-        flat_conditions = list(chain(*[[c] if is_condition(c) else c for c in body['conditions']]))
+    if 'conditions' in query:
+        flat_conditions = list(chain(*[[c] if is_condition(c) else c for c in query['conditions']]))
         col_exprs.extend([c[0] for c in flat_conditions])
 
-    if 'aggregations' in body:
-        col_exprs.extend([a[1] for a in body['aggregations']])
+    if 'aggregations' in query:
+        col_exprs.extend([a[1] for a in query['aggregations']])
 
     # Return the set of all columns referenced in any expression
     return set(chain(*[columns_in_expr(ex) for ex in col_exprs]))


### PR DESCRIPTION
This is another step towards splitting out the generic query functionality and dataset-specific extensions.

This introduces the idea of a "composite schema" that merges N different schemata together — in our specific usage, this is the generic query schema, and any "extensions" that a dataset may use, such time series options. (I haven't split up the extensions into the `Dataset` class hierarchy yet, that is likely one of the next steps.) I see this as a short-term compatibility shim, so haven't invested too much into making it too user-friendly. Eventually I'd like to introduce a version 2 protocol that splits the schema into:

```python
{
  "query": …,
  "extensions": …,  # may contain another level for each "extension", e.g. {"timeseries": …, }
}
```

To limit the scope of this change, this is folded back into a `body` variable in `parse_and_run_query` so that this change only really applies to the API endpoint and the query splitter. Later changes will address more of the tricky bits such as `column_expr`, `condition_expr`, and `raw_query`.