### PR TITLE
fix(query): Conditions cannot include datetime objects

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -324,8 +324,8 @@ def parse_and_run_query(dataset, body, timer):
     body.setdefault('conditions', [])
 
     body['conditions'].extend([
-        ('timestamp', '>=', from_date),
-        ('timestamp', '<', to_date),
+        ('timestamp', '>=', from_date.isoformat()),
+        ('timestamp', '<', to_date.isoformat()),
     ])
 
     body['conditions'].extend(dataset.default_conditions())


### PR DESCRIPTION
The query will run, but will fail to record stats because these cannot be JSON serialized as part of query recording or cache writeback. This passes tests because while `record_query` is on the critical path, it is not run as part of the test suite. This is another reason for removing it from the critical path of query execution. That wouldn't necessary handle the cache case — we'll need to figure out how to address that as well.

Fixes SNUBA-1J1, SNUBA-1J0, SNUBA-1HZ.