### PR TITLE
ref(reader): Generalize date/datetime handling

### DIFF
--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import itertools
 import re
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence
 
 from dateutil.tz import tz
 
@@ -12,13 +13,10 @@ if TYPE_CHECKING:
     from mypy_extensions import TypedDict
 
     Column = TypedDict("Column", {"name": str, "type": str})
+    Row = MutableMapping[str, Any]
     Result = TypedDict(
         "Result",
-        {
-            "meta": Sequence[Column],
-            "data": Sequence[Mapping[str, Any]],
-            "totals": Mapping[str, Any],
-        },
+        {"meta": Sequence[Column], "data": Sequence[Row], "totals": Row},
         total=False,
     )
 
@@ -36,11 +34,40 @@ class Reader(ABC):
         raise NotImplementedError
 
 
+DATE_TYPE_RE = re.compile(r"(Nullable\()?Date\b")
+DATETIME_TYPE_RE = re.compile(r"(Nullable\()?DateTime\b")
+
+
+def transform_date_columns(result: Result) -> Result:
+    """
+    Converts timezone-naive date and datetime values returned by ClickHouse
+    into ISO 8601 formatted strings (including the UTC offset.)
+    """
+
+    def iterate_rows():
+        if "totals" in result:
+            return itertools.chain(result["data"], [result["totals"]])
+        else:
+            return iter(result["data"])
+
+    for col in result["meta"]:
+        if DATETIME_TYPE_RE.match(col["type"]):
+            for row in iterate_rows():
+                row[col["name"]] = (
+                    row[col["name"]].replace(tzinfo=tz.tzutc()).isoformat()
+                )
+        elif DATE_TYPE_RE.match(col["type"]):
+            for row in iterate_rows():
+                row[col["name"]] = (
+                    datetime(*(row[col["name"]].timetuple()[:6]))
+                    .replace(tzinfo=tz.tzutc())
+                    .isoformat()
+                )
+
+    return result
+
+
 class NativeDriverReader(Reader):
-
-    DATE_TYPE_RE = re.compile(r"(Nullable\()?Date\b")
-    DATETIME_TYPE_RE = re.compile(r"(Nullable\()?DateTime\b")
-
     def __init__(self, client):
         self.__client = client
 
@@ -54,27 +81,14 @@ class NativeDriverReader(Reader):
         data = [{c[0]: d[i] for i, c in enumerate(meta)} for d in data]
         meta = [{"name": m[0], "type": m[1]} for m in meta]
 
-        for col in meta:
-            # Convert naive datetime strings back to TZ aware ones, and stringify
-            # TODO maybe this should be in the json serializer
-            if self.DATETIME_TYPE_RE.match(col["type"]):
-                for d in data:
-                    d[col["name"]] = (
-                        d[col["name"]].replace(tzinfo=tz.tzutc()).isoformat()
-                    )
-            elif self.DATE_TYPE_RE.match(col["type"]):
-                for d in data:
-                    dt = datetime(*(d[col["name"]].timetuple()[:6])).replace(
-                        tzinfo=tz.tzutc()
-                    )
-                    d[col["name"]] = dt.isoformat()
-
         if with_totals:
             assert len(data) > 0
             totals = data.pop(-1)
-            return {"data": data, "meta": meta, "totals": totals}
+            result = {"data": data, "meta": meta, "totals": totals}
         else:
-            return {"data": data, "meta": meta}
+            result = {"data": data, "meta": meta}
+
+        return transform_date_columns(result)
 
     def execute(
         self,


### PR DESCRIPTION
This is essentially a partial revert of getsentry/snuba#417 that
maintains the existing behavior (date/datetimes are reformatted as ISO
8601 strings in the response body) instead of returning them as
timezone-aware datetime objects which broke the cache writeback.

This is more prep work for getsentry/snuba#406 (specifically addressing [this comment](https://github.com/getsentry/snuba/pull/406#discussion_r313950249).)