### PR TITLE
ref: Create DDLs

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -525,9 +525,9 @@ if application.debug or application.testing:
     @application.route('/tests/<dataset_name>/drop', methods=['POST'])
     def drop(dataset_name):
         dataset = get_dataset(dataset_name)
-        table = dataset.get_schema().get_local_table_name()
 
-        clickhouse_rw.execute("DROP TABLE IF EXISTS %s" % table)
+        for statement in dataset.get_ddl().drop_statements():
+            clickhouse_rw.execute(statement)
         ensure_table_exists(dataset, force=True)
         redis_client.flushdb()
         return ('ok', 200, {'Content-Type': 'text/plain'})

--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -83,4 +83,6 @@ def bootstrap(bootstrap_server, kafka, force):
     # For now just create the table for every dataset.
     for name in DATASET_NAMES:
         dataset = get_dataset(name)
-        ClickhousePool().execute(dataset.get_schema().get_local_table_definition())
+
+        for statement in dataset.get_ddl().create_statements():
+            ClickhousePool().execute(statement)

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -13,9 +13,10 @@ class Dataset(object):
     This is the the initial boilerplate. schema and processor will come.
     """
 
-    def __init__(self, schema, *, processor, default_topic,
+    def __init__(self, schema, *, ddl, processor, default_topic,
             default_replacement_topic, default_commit_log_topic):
         self._schema = schema
+        self.__ddl = ddl
         self.__processor = processor
         self.__default_topic = default_topic
         self.__default_replacement_topic = default_replacement_topic
@@ -23,6 +24,9 @@ class Dataset(object):
 
     def get_schema(self):
         return self._schema
+
+    def get_ddl(self):
+        return self.__ddl
 
     def get_processor(self):
         return self.__processor

--- a/snuba/datasets/ddl.py
+++ b/snuba/datasets/ddl.py
@@ -1,0 +1,9 @@
+class DDL(object):
+    def __init__(self, schemas=[]):
+        self.__schemas = schemas
+
+    def create_statements(self):
+        return map(lambda schema: schema.get_local_table_definition(), self.__schemas)
+
+    def drop_statements(self):
+        return map(lambda schema: schema.get_local_drop_table_statement(), self.__schemas)

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -14,6 +14,7 @@ from snuba.clickhouse import (
 from snuba.datasets import TimeSeriesDataset
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schema import ReplacingMergeTreeSchema
+from snuba.datasets.ddl import DDL
 from snuba.schemas import EVENTS_QUERY_SCHEMA
 from snuba.util import (
     alias_expr,
@@ -187,6 +188,7 @@ class EventsDataset(TimeSeriesDataset):
 
         super(EventsDataset, self).__init__(
             schema=schema,
+            ddl=DDL([schema]),
             processor=EventsProcessor(promoted_tag_columns),
             default_topic="events",
             default_replacement_topic="event-replacements",

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -13,6 +13,7 @@ from snuba.clickhouse import (
 from snuba.datasets import Dataset
 from snuba.processor import _ensure_valid_date, MessageProcessor, _unicodify
 from snuba.datasets.schema import MergeTreeSchema
+from snuba.datasets.ddl import DDL
 from snuba import settings
 
 
@@ -64,6 +65,7 @@ class OutcomesDataset(Dataset):
 
         super(OutcomesDataset, self).__init__(
             schema=schema,
+            ddl=DDL([schema]),
             processor=OutcomesProcessor(),
             default_topic="outcomes",
             default_replacement_topic=None,

--- a/snuba/datasets/schema.py
+++ b/snuba/datasets/schema.py
@@ -51,6 +51,9 @@ class TableSchema(object):
             self._get_local_engine()
         )
 
+    def get_local_drop_table_statement(self):
+        return "DROP TABLE IF EXISTS %s" % self.get_local_table_name()
+
     def _get_local_engine(self):
         raise NotImplementedError
 

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -14,6 +14,7 @@ from snuba.clickhouse import (
 )
 from snuba.datasets import Dataset
 from snuba.datasets.schema import ReplacingMergeTreeSchema
+from snuba.datasets.ddl import DDL
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 
 
@@ -77,6 +78,7 @@ class TransactionsDataset(Dataset):
 
         super(TransactionsDataset, self).__init__(
             schema=schema,
+            ddl=DDL([schema]),
             processor=TransactionsMessageProcessor(),
             default_topic="events",
             default_replacement_topic=None,

--- a/tests/base.py
+++ b/tests/base.py
@@ -130,14 +130,19 @@ class BaseTest(object):
             self.table = self.dataset.get_schema().get_table_name()
             self.clickhouse = ClickhousePool()
 
-            self.clickhouse.execute("DROP TABLE IF EXISTS %s" % self.table)
-            self.clickhouse.execute(self.dataset.get_schema().get_local_table_definition())
+            for statement in self.dataset.get_ddl().drop_statements():
+                self.clickhouse.execute(statement)
+
+            for statement in self.dataset.get_ddl().create_statements():
+                self.clickhouse.execute(statement)
 
             redis_client.flushdb()
 
     def teardown_method(self, test_method):
         if self.dataset_name:
-            self.clickhouse.execute("DROP TABLE IF EXISTS %s" % self.table)
+            for statement in self.dataset.get_ddl().drop_statements():
+                self.clickhouse.execute(statement)
+
             redis_client.flushdb()
 
 


### PR DESCRIPTION
Allows you to have create statements and drop statements for a dataset.

This becomes particularly useful when we have multiple schemas for a dataset,
like in outcomes. With outcomes, we will have three schemas: the read schema,
write schema and the materialized view, which pipes content from the write
table to the read table.

So, instead of exposing all the schemas to the call site while bootstrapping,
we will only expose a DDL instance, which contains the `CREATE TABLE` and `DROP
TABLE` commands.

## Next steps:
Once this PR is in master, rebase https://github.com/getsentry/snuba/pull/428/files to use `get_ddls` instead of `get_schemas`.

The places where we use `get_schemas` in that PR that have not been replaced by `get_ddls` will be replaced with `[dataset.get_write_schema(), dataset.get_read_schema()]`