### PR TITLE
ref(schemas): Tighten up more restrictions around numeric types 

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -52,8 +52,10 @@ GENERIC_QUERY_SCHEMA = {
             '$ref': '#/definitions/column_name',
         },
         'sample': {
-            'type': 'number',
-            'min': 0,
+            'anyOf': [
+                {'type': 'integer', 'minimum': 0},
+                {'type': 'number', 'minimum': 0.0, 'maximum': 1.0},
+            ],
         },
         'conditions': {
             'type': 'array',
@@ -104,15 +106,17 @@ GENERIC_QUERY_SCHEMA = {
         'limit': {
             'type': 'integer',
             'default': 1000,
+            'minimum': 0,
             'maximum': 10000,
         },
         'offset': {
             'type': 'integer',
+            'minimum': 0,
         },
         'limitby': {
             'type': 'array',
             'items': [
-                {'type': 'integer'},
+                {'type': 'integer', 'minimum': 0},
                 {'$ref': '#/definitions/column_name'},
             ]
         },
@@ -211,10 +215,10 @@ PROJECT_EXTENSION_SCHEMA = {
     'properties': {
         'project': {
             'anyOf': [
-                {'type': 'integer'},
+                {'type': 'integer', 'minimum': 0},
                 {
                     'type': 'array',
-                    'items': {'type': 'integer'},
+                    'items': {'type': 'integer', 'minimum': 0},
                     'minItems': 1,
                 },
             ]
@@ -243,6 +247,7 @@ def get_time_series_extension_properties(default_granularity: int, default_windo
             'granularity': {
                 'type': 'number',
                 'default': default_granularity,
+                'minimum': 0,
             },
         },
         'additionalProperties': False,

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -215,10 +215,10 @@ PROJECT_EXTENSION_SCHEMA = {
     'properties': {
         'project': {
             'anyOf': [
-                {'type': 'integer', 'minimum': 0},
+                {'type': 'integer', 'minimum': 1},
                 {
                     'type': 'array',
-                    'items': {'type': 'integer', 'minimum': 0},
+                    'items': {'type': 'integer', 'minimum': 1},
                     'minItems': 1,
                 },
             ]
@@ -247,7 +247,7 @@ def get_time_series_extension_properties(default_granularity: int, default_windo
             'granularity': {
                 'type': 'number',
                 'default': default_granularity,
-                'minimum': 0,
+                'minimum': 1,
             },
         },
         'additionalProperties': False,


### PR DESCRIPTION
Similar to getsentry/snuba#436.

- Makes the sample query validated the same as the ClickHouse `SAMPLE` clause.
- Sets lower bounds of 0 on unsigned integers (limit, offset, limitby, project, granularity.)