### PR TITLE
(fix) Fix schema loading in query endpoint

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -213,7 +213,7 @@ def dataset_query_view(*, dataset_name: str, timer: Timer):
         return render_template(
             'query.html',
             query_template=json.dumps(
-                schemas.generate(dataset.get_query_schema()),
+                dataset.get_query_schema().generate_template(),
                 indent=4,
             ),
         )
@@ -380,7 +380,6 @@ def parse_and_run_query(dataset, body, timer):
     table = dataset.get_schema().get_table_name()
 
     sql = format_query(dataset, body, table, prewhere_conditions, final)
-
     timer.mark('prepare_query')
 
     stats = {

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -3,7 +3,7 @@ import itertools
 from collections import ChainMap
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Mapping
+from typing import Any, Mapping, Union
 
 import jsonschema
 
@@ -307,6 +307,26 @@ class RequestSchema:
 
         return Request(query, extensions)
 
+    def __generate_template_impl(self, schema) -> Union[Schema, str, None]:
+        """
+        Generate a (not necessarily valid) object that can be used as a template
+        from the provided schema
+        """
+        typ = schema.get('type')
+        if 'default' in schema:
+            default = schema['default']
+            return default() if callable(default) else default
+        elif typ == 'object':
+            return {prop: self.__generate_template_impl(subschema) for prop, subschema in schema.get('properties', {}).items()}
+        elif typ == 'array':
+            return []
+        elif typ == 'string':
+            return ""
+        return None
+
+    def generate_template(self) -> Schema:
+        return self.__generate_template_impl(self.__composite_schema)
+
 
 EVENTS_QUERY_SCHEMA = RequestSchema(GENERIC_QUERY_SCHEMA, {
     'performance': PERFORMANCE_EXTENSION_SCHEMA,
@@ -375,21 +395,3 @@ def validate_jsonschema(value, schema, set_defaults=True):
     ).validate(value, schema)
 
     return value
-
-
-def generate(schema):
-    """
-    Generate a (not necessarily valid) object that can be used as a template
-    from the provided schema
-    """
-    typ = schema.get('type')
-    if 'default' in schema:
-        default = schema['default']
-        return default() if callable(default) else default
-    elif typ == 'object':
-        return {prop: generate(subschema) for prop, subschema in schema.get('properties', {}).items()}
-    elif typ == 'array':
-        return []
-    elif typ == 'string':
-        return ""
-    return None

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -307,7 +307,7 @@ class RequestSchema:
 
         return Request(query, extensions)
 
-    def __generate_template_impl(self, schema) -> Union[Schema, str, None]:
+    def __generate_template_impl(self, schema) -> Any:
         """
         Generate a (not necessarily valid) object that can be used as a template
         from the provided schema
@@ -324,7 +324,7 @@ class RequestSchema:
             return ""
         return None
 
-    def generate_template(self) -> Schema:
+    def generate_template(self) -> Any:
         return self.__generate_template_impl(self.__composite_schema)
 
 


### PR DESCRIPTION
/query endpoint is broken because the schemas.generate function (that builds the template) expects a dictionary. Now we are passing a RequestSchema object.
Moving the template generation into the RequestSchema so that we do not have to expose the schema internals 