### PR TITLE
perf: Improve cdc consumer perf step 1

### DIFF
--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -38,5 +38,5 @@ def bulk_load(dataset, dest_table, source, log_level):
         dataset.get_writer({}, dest_table),
         settings.BULK_CLICKHOUSE_BUFFER,
     )
-    import cProfile
-    cProfile.runctx("loader.load(writer)", None, locals(), filename="prof_fast3.txt")
+
+    loader.load(writer)

--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -38,4 +38,5 @@ def bulk_load(dataset, dest_table, source, log_level):
         dataset.get_writer({}, dest_table),
         settings.BULK_CLICKHOUSE_BUFFER,
     )
-    loader.load(writer)
+    import cProfile
+    cProfile.runctx("loader.load(writer)", None, locals(), filename="prof_fast3.txt")

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -1,12 +1,27 @@
 from __future__ import annotations
+import re
 
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence, Type
 
 from snuba.processor import MessageProcessor
 from snuba.writer import WriterTableRow
 
 KAFKA_ONLY_PARTITION = 0  # CDC only works with single partition topics. So partition must be 0
+
+POSTGRES_DATE_FORMAT_WITH_NS = "%Y-%m-%d %H:%M:%S.%f%z"
+POSTGRES_DATE_FORMAT_WITHOUT_NS = "%Y-%m-%d %H:%M:%S%z"
+
+date_with_nanosec = re.compile("^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.")
+
+
+def parse_poostgres_datetime(date: str) -> datetime:
+    date = f"{date}00"
+    if (date_with_nanosec.match(date)):
+        return datetime.strptime(date, POSTGRES_DATE_FORMAT_WITH_NS)
+    else:
+        return datetime.strptime(date, POSTGRES_DATE_FORMAT_WITHOUT_NS)
 
 
 class CdcMessageRow(ABC):

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -16,7 +16,9 @@ POSTGRES_DATE_FORMAT_WITHOUT_NS = "%Y-%m-%d %H:%M:%S%z"
 date_with_nanosec = re.compile("^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.")
 
 
-def parse_poostgres_datetime(date: str) -> datetime:
+def parse_postgres_datetime(date: str) -> datetime:
+    # Postgres dates express the timezone in hours while strptime expects
+    # the timezone to be expressed in HHmm, thus we need to add 00 as minutes.
     date = f"{date}00"
     if (date_with_nanosec.match(date)):
         return datetime.strptime(date, POSTGRES_DATE_FORMAT_WITH_NS)

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
 
 from dataclasses import dataclass
-from snuba.datasets.cdc.cdcprocessors import CdcProcessor, CdcMessageRow, parse_poostgres_datetime
+from snuba.datasets.cdc.cdcprocessors import CdcProcessor, CdcMessageRow, parse_postgres_datetime
 from snuba.writer import WriterTableRow
 
 
@@ -37,9 +37,9 @@ class GroupedMessageRow(CdcMessageRow):
             record_deleted=False,
             record_content=GroupMessageRecord(
                 status=raw_data['status'],
-                last_seen=parse_poostgres_datetime(raw_data['last_seen']),
-                first_seen=parse_poostgres_datetime(raw_data['first_seen']),
-                active_at=parse_poostgres_datetime(raw_data['active_at']),
+                last_seen=parse_postgres_datetime(raw_data['last_seen']),
+                first_seen=parse_postgres_datetime(raw_data['first_seen']),
+                active_at=parse_postgres_datetime(raw_data['active_at']),
                 first_release_id=raw_data['first_release_id'],
             )
         )
@@ -54,9 +54,9 @@ class GroupedMessageRow(CdcMessageRow):
             record_deleted=False,
             record_content=GroupMessageRecord(
                 status=int(row['status']),
-                last_seen=parse_poostgres_datetime(row['last_seen']),
-                first_seen=parse_poostgres_datetime(row['first_seen']),
-                active_at=parse_poostgres_datetime(row['active_at']),
+                last_seen=parse_postgres_datetime(row['last_seen']),
+                first_seen=parse_postgres_datetime(row['first_seen']),
+                active_at=parse_postgres_datetime(row['active_at']),
                 first_release_id=int(row['first_release_id']) if row['first_release_id'] else None,
             )
         )

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -4,8 +4,7 @@ from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
 
 from dataclasses import dataclass
-from dateutil.parser import parse as dateutil_parse
-from snuba.datasets.cdc.cdcprocessors import CdcProcessor, CdcMessageRow
+from snuba.datasets.cdc.cdcprocessors import CdcProcessor, CdcMessageRow, parse_poostgres_datetime
 from snuba.writer import WriterTableRow
 
 
@@ -38,9 +37,9 @@ class GroupedMessageRow(CdcMessageRow):
             record_deleted=False,
             record_content=GroupMessageRecord(
                 status=raw_data['status'],
-                last_seen=dateutil_parse(raw_data['last_seen']),
-                first_seen=dateutil_parse(raw_data['first_seen']),
-                active_at=dateutil_parse(raw_data['active_at']),
+                last_seen=parse_poostgres_datetime(raw_data['last_seen']),
+                first_seen=parse_poostgres_datetime(raw_data['first_seen']),
+                active_at=parse_poostgres_datetime(raw_data['active_at']),
                 first_release_id=raw_data['first_release_id'],
             )
         )
@@ -55,9 +54,9 @@ class GroupedMessageRow(CdcMessageRow):
             record_deleted=False,
             record_content=GroupMessageRecord(
                 status=int(row['status']),
-                last_seen=dateutil_parse(row['last_seen']),
-                first_seen=dateutil_parse(row['first_seen']),
-                active_at=dateutil_parse(row['active_at']),
+                last_seen=parse_poostgres_datetime(row['last_seen']),
+                first_seen=parse_poostgres_datetime(row['first_seen']),
+                active_at=parse_poostgres_datetime(row['active_at']),
                 first_release_id=int(row['first_release_id']) if row['first_release_id'] else None,
             )
         )

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -43,7 +43,7 @@ SENTRY_DSN = None
 # Snuba Options
 
 SNAPSHOT_LOAD_PRODUCT = 'snuba'
-BULK_CLICKHOUSE_BUFFER = 1000
+BULK_CLICKHOUSE_BUFFER = 10000
 
 # Processor/Writer Options
 DEFAULT_BROKERS = ['localhost:9092']


### PR DESCRIPTION
This removes the dependency on dateutils that was taking 80% of the cumulative time when bulk loading a dump from postgres.

with cProfile
before:
> 201201    0.215    0.000   80.551    0.000 /Users/filippopacifici/snuba/snuba/datasets/cdc/groupedmessage.py:58(<lambda>)
after:
>   201201    0.203    0.000   14.231    0.000 /Users/filippopacifici/snuba/snuba/datasets/cdc/groupedmessage.py:58(<lambda>
