### PR TITLE
fix: Add `safe_dumps` function that converts non-dict `Mapping` types to dict before serialization

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,3 +1,4 @@
+from collections import ChainMap
 from base import BaseEventsTest
 from functools import partial
 from mock import patch
@@ -8,6 +9,7 @@ import time
 import uuid
 
 from snuba import state
+from snuba.state import safe_dumps
 
 
 class TestState(BaseEventsTest):
@@ -167,3 +169,13 @@ class TestState(BaseEventsTest):
         assert state.abtest('1000/2000:5') in (1000, 2000)
         assert state.abtest('1000/2000:0') == 1000
         assert state.abtest('1.5:1/-1.5:1') in (1.5, -1.5)
+
+
+def test_safe_dumps():
+    assert safe_dumps(
+        ChainMap({'a': 1}, {'b': 2}),
+        sort_keys=True,
+    ) == safe_dumps(
+        {'a': 1, 'b': 2},
+        sort_keys=True,
+    )


### PR DESCRIPTION
This is kind of an annoying hack for a few reasons:

- This doesn't prevent this issue from happening in other parts of the codebase, this only works for query recording, and will likely happen again elsewhere later.
- This requires materializing the contents of the `ChainMap` into a dictionary, which kind of defeats the purpose of using the `ChainMap` in the first place.

Fixes SNUBA-1J9, SNUBA-1JA.