### PR TITLE
feat(datasets) Split query format logic from api.py and add ClickhouseQuery

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -14,6 +14,7 @@ import jsonschema
 
 from snuba import schemas, settings, state, util
 from snuba.clickhouse.native import ClickhousePool
+from snuba.clickhouse.query import ClickhouseQuery
 from snuba.replacer import get_projects_query_flags
 from snuba.split import split_query
 from snuba.datasets.factory import InvalidDatasetError, get_dataset, get_enabled_dataset_names
@@ -237,7 +238,7 @@ def dataset_query(dataset, body, timer):
         dataset,
         validate_request_content(body, dataset.get_query_schema(), timer),
         timer,
-     )
+    )
 
     return (
         json.dumps(
@@ -247,74 +248,6 @@ def dataset_query(dataset, body, timer):
         status,
         {'Content-Type': 'application/json'}
     )
-
-
-def format_query(dataset, request: Request, table, prewhere_conditions, final) -> str:
-    """Generate a SQL string from the parameters."""
-    body = request.body
-
-    aggregate_exprs = [util.column_expr(dataset, col, body, alias, agg) for (agg, col, alias) in body['aggregations']]
-    groupby = util.to_list(body['groupby'])
-    group_exprs = [util.column_expr(dataset, gb, body) for gb in groupby]
-    selected_cols = [util.column_expr(dataset, util.tuplify(colname), body) for colname in body.get('selected_columns', [])]
-    select_clause = u'SELECT {}'.format(', '.join(group_exprs + aggregate_exprs + selected_cols))
-
-    from_clause = u'FROM {}'.format(table)
-    if final:
-        from_clause = u'{} FINAL'.format(from_clause)
-    if 'sample' in body:
-        from_clause = u'{} SAMPLE {}'.format(from_clause, body['sample'])
-
-    join_clause = ''
-    if 'arrayjoin' in body:
-        join_clause = u'ARRAY JOIN {}'.format(body['arrayjoin'])
-
-    where_clause = ''
-    if body['conditions']:
-        where_clause = u'WHERE {}'.format(util.conditions_expr(dataset, body['conditions'], body))
-
-    prewhere_clause = ''
-    if prewhere_conditions:
-        prewhere_clause = u'PREWHERE {}'.format(util.conditions_expr(dataset, prewhere_conditions, body))
-
-    group_clause = ''
-    if groupby:
-        group_clause = 'GROUP BY ({})'.format(', '.join(util.column_expr(dataset, gb, body) for gb in groupby))
-        if body.get('totals', False):
-            group_clause = '{} WITH TOTALS'.format(group_clause)
-
-    having_clause = ''
-    having_conditions = body.get('having', [])
-    if having_conditions:
-        assert groupby, 'found HAVING clause with no GROUP BY'
-        having_clause = u'HAVING {}'.format(util.conditions_expr(dataset, having_conditions, body))
-
-    order_clause = ''
-    if body.get('orderby'):
-        orderby = [util.column_expr(dataset, util.tuplify(ob), body) for ob in util.to_list(body['orderby'])]
-        orderby = [u'{} {}'.format(ob.lstrip('-'), 'DESC' if ob.startswith('-') else 'ASC') for ob in orderby]
-        order_clause = u'ORDER BY {}'.format(', '.join(orderby))
-
-    limitby_clause = ''
-    if 'limitby' in body:
-        limitby_clause = 'LIMIT {} BY {}'.format(*body['limitby'])
-
-    limit_clause = ''
-    if 'limit' in body:
-        limit_clause = 'LIMIT {}, {}'.format(body.get('offset', 0), body['limit'])
-
-    return ' '.join([c for c in [
-        select_clause,
-        from_clause,
-        join_clause,
-        prewhere_clause,
-        where_clause,
-        group_clause,
-        having_clause,
-        order_clause,
-        limitby_clause,
-        limit_clause
-    ] if c])
 
 
 @split_query
@@ -382,8 +315,9 @@ def parse_and_run_query(dataset, request: Request, timer):
             request.query['conditions'] = list(filter(lambda cond: cond not in prewhere_conditions, request.query['conditions']))
 
     table = dataset.get_dataset_schemas().get_read_schema().get_table_name()
-
-    sql = format_query(dataset, request, table, prewhere_conditions, final)
+    # TODO: consider moving the performance logic and the pre_where generation into
+    # ClickhouseQuery since they are Clickhouse specific
+    sql = ClickhouseQuery(dataset, request, prewhere_conditions, final).format()
 
     timer.mark('prepare_query')
 

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,0 +1,90 @@
+from typing import Sequence
+
+from snuba import util
+from snuba.datasets import Dataset
+from snuba.schemas import Request
+
+
+class ClickhouseQuery:
+    def __init__(self,
+        dataset: Dataset,
+        # TODO: replace this with snuba.query. Query as soon as the PR is committed
+        request: Request,
+        prewhere_conditions: Sequence[str],
+        final: bool,
+    ) -> None:
+        self.__dataset = dataset
+        self.__request = request
+        self.__prewhere_conditions = prewhere_conditions
+        self.__final = final
+
+    def format(self) -> str:
+        """Generate a SQL string from the parameters."""
+        body = self.__request.body
+        table = self.__dataset \
+            .get_dataset_schemas() \
+            .get_read_schema() \
+            .get_table_name()
+
+        aggregate_exprs = [util.column_expr(self.__dataset, col, body, alias, agg) for (agg, col, alias) in body['aggregations']]
+        groupby = util.to_list(body['groupby'])
+        group_exprs = [util.column_expr(self.__dataset, gb, body) for gb in groupby]
+        selected_cols = [util.column_expr(self.__dataset, util.tuplify(colname), body) for colname in body.get('selected_columns', [])]
+        select_clause = u'SELECT {}'.format(', '.join(group_exprs + aggregate_exprs + selected_cols))
+
+        from_clause = u'FROM {}'.format(table)
+        if self.__final:
+            from_clause = u'{} FINAL'.format(from_clause)
+        if 'sample' in body:
+            from_clause = u'{} SAMPLE {}'.format(from_clause, body['sample'])
+
+        join_clause = ''
+        if 'arrayjoin' in body:
+            join_clause = u'ARRAY JOIN {}'.format(body['arrayjoin'])
+
+        where_clause = ''
+        if body['conditions']:
+            where_clause = u'WHERE {}'.format(util.conditions_expr(self.__dataset, body['conditions'], body))
+
+        prewhere_clause = ''
+        if self.__prewhere_conditions:
+            prewhere_clause = u'PREWHERE {}'.format(util.conditions_expr(self.__dataset, self.__prewhere_conditions, body))
+
+        group_clause = ''
+        if groupby:
+            group_clause = 'GROUP BY ({})'.format(', '.join(util.column_expr(self.__dataset, gb, body) for gb in groupby))
+            if body.get('totals', False):
+                group_clause = '{} WITH TOTALS'.format(group_clause)
+
+        having_clause = ''
+        having_conditions = body.get('having', [])
+        if having_conditions:
+            assert groupby, 'found HAVING clause with no GROUP BY'
+            having_clause = u'HAVING {}'.format(util.conditions_expr(self.__dataset, having_conditions, body))
+
+        order_clause = ''
+        if body.get('orderby'):
+            orderby = [util.column_expr(self.__dataset, util.tuplify(ob), body) for ob in util.to_list(body['orderby'])]
+            orderby = [u'{} {}'.format(ob.lstrip('-'), 'DESC' if ob.startswith('-') else 'ASC') for ob in orderby]
+            order_clause = u'ORDER BY {}'.format(', '.join(orderby))
+
+        limitby_clause = ''
+        if 'limitby' in body:
+            limitby_clause = 'LIMIT {} BY {}'.format(*body['limitby'])
+
+        limit_clause = ''
+        if 'limit' in body:
+            limit_clause = 'LIMIT {}, {}'.format(body.get('offset', 0), body['limit'])
+
+        return ' '.join([c for c in [
+            select_clause,
+            from_clause,
+            join_clause,
+            prewhere_clause,
+            where_clause,
+            group_clause,
+            having_clause,
+            order_clause,
+            limitby_clause,
+            limit_clause
+        ] if c])


### PR DESCRIPTION
This helps us reason in terms of Snuba query processing vs Clickhouse query when we do processing without having to do some deep refactoring of query generation (which will come later).
I think this is useful at this point because we are introducing query processors (which should process the snuba query and not the clickhouse one), joins (which should impact clickhouse query generation).