### PR TITLE
ref: Make prewhere candidates dataset specific

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -362,24 +362,23 @@ def parse_and_run_query(dataset, request: Request, timer):
             request.query['sample'] = settings.TURBO_SAMPLE_RATE
 
     prewhere_conditions = []
-    if settings.PREWHERE_KEYS:
-        # Add any condition to PREWHERE if:
-        # - It is a single top-level condition (not OR-nested), and
-        # - Any of its referenced columns are in PREWHERE_KEYS
-        prewhere_candidates = [
-            (util.columns_in_expr(cond[0]), cond)
-            for cond in request.query['conditions'] if util.is_condition(cond) and
-            any(col in settings.PREWHERE_KEYS for col in util.columns_in_expr(cond[0]))
-        ]
-        # Use the condition that has the highest priority (based on the
-        # position of its columns in the PREWHERE_KEYS list)
-        prewhere_candidates = sorted([
-            (min(settings.PREWHERE_KEYS.index(col) for col in cols if col in settings.PREWHERE_KEYS), cond)
-            for cols, cond in prewhere_candidates
-        ], key=lambda priority_and_col: priority_and_col[0])
-        if prewhere_candidates:
-            prewhere_conditions = [cond for _, cond in prewhere_candidates][:settings.MAX_PREWHERE_CONDITIONS]
-            request.query['conditions'] = list(filter(lambda cond: cond not in prewhere_conditions, request.query['conditions']))
+    # Add any condition to PREWHERE if:
+    # - It is a single top-level condition (not OR-nested), and
+    # - Any of its referenced columns are in dataset.get_prewhere_keys()
+    prewhere_candidates = [
+        (util.columns_in_expr(cond[0]), cond)
+        for cond in request.query['conditions'] if util.is_condition(cond) and
+        any(col in dataset.get_prewhere_keys() for col in util.columns_in_expr(cond[0]))
+    ]
+    # Use the condition that has the highest priority (based on the
+    # position of its columns in the prewhere keys list)
+    prewhere_candidates = sorted([
+        (min(dataset.get_prewhere_keys().index(col) for col in cols if col in dataset.get_prewhere_keys()), cond)
+        for cols, cond in prewhere_candidates
+    ], key=lambda priority_and_col: priority_and_col[0])
+    if prewhere_candidates:
+        prewhere_conditions = [cond for _, cond in prewhere_candidates][:settings.MAX_PREWHERE_CONDITIONS]
+        request.query['conditions'] = list(filter(lambda cond: cond not in prewhere_conditions, request.query['conditions']))
 
     table = dataset.get_dataset_schemas().get_read_schema().get_table_name()
 

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -2,7 +2,7 @@ import json
 import rapidjson
 
 from datetime import datetime
-from typing import Optional, Mapping, List
+from typing import Optional, Mapping, Sequence
 
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.util import escape_col
@@ -114,7 +114,7 @@ class Dataset(object):
     def get_query_schema(self):
         raise NotImplementedError('dataset does not support queries')
 
-    def get_prewhere_keys(self) -> List[str]:
+    def get_prewhere_keys(self) -> Sequence[str]:
         """
         Returns the keys that will be upgraded from a WHERE condition to a PREWHERE.
 

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -2,7 +2,7 @@ import json
 import rapidjson
 
 from datetime import datetime
-from typing import Optional, Mapping
+from typing import Optional, Mapping, List
 
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.util import escape_col
@@ -113,6 +113,15 @@ class Dataset(object):
 
     def get_query_schema(self):
         raise NotImplementedError('dataset does not support queries')
+
+    def get_prewhere_keys(self) -> List[str]:
+        """
+        Returns the keys that will be upgraded from a WHERE condition to a PREWHERE.
+
+        This is an ordered list, from highest priority to lowest priority. So, a column at index 1 will be upgraded
+        before a column at index 2. This is relevant when we have a maximum number of prewhere keys.
+        """
+        return []
 
 
 class TimeSeriesDataset(Dataset):

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
 
 from snuba.datasets.cdc import CdcDataset
@@ -65,3 +67,6 @@ class GroupedMessageDataset(CdcDataset):
             dest_table=dest_table,
             row_processor=lambda row: GroupedMessageRow.from_bulk(row).to_clickhouse(),
         )
+
+    def get_prewhere_keys(self) -> Sequence[str]:
+        return ['project_id']

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,5 +1,5 @@
 import re
-from typing import List
+from typing import Sequence
 
 from snuba import state
 from snuba.clickhouse.columns import (
@@ -347,5 +347,5 @@ class EventsDataset(TimeSeriesDataset):
     def get_query_schema(self):
         return EVENTS_QUERY_SCHEMA
 
-    def get_prewhere_keys(self) -> List[str]:
+    def get_prewhere_keys(self) -> Sequence[str]:
         return ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,4 +1,6 @@
 import re
+from typing import List
+
 from snuba import state
 from snuba.clickhouse.columns import (
     Array,
@@ -344,3 +346,6 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_query_schema(self):
         return EVENTS_QUERY_SCHEMA
+
+    def get_prewhere_keys(self) -> List[str]:
+        return ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from snuba.clickhouse.columns import (
     ColumnSet,
     DateTime,
@@ -86,3 +88,6 @@ class TransactionsDataset(Dataset):
             processor=TransactionsMessageProcessor(),
             default_topic="events",
         )
+
+    def get_prewhere_keys(self) -> Sequence[str]:
+        return ['event_id', 'project_id']

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -60,8 +60,6 @@ DISCARD_OLD_EVENTS = True
 DEFAULT_RETENTION_DAYS = 90
 RETENTION_OVERRIDES = {}
 
-# the list of keys that will upgrade from a WHERE condition to a PREWHERE
-PREWHERE_KEYS = ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
 MAX_PREWHERE_CONDITIONS = 1
 
 STATS_IN_RESPONSE = False


### PR DESCRIPTION
Each dataset will need its own prewhere keys. So, let's make it so.

To the reviewer: I'd suggest putting a [`?w=1`](https://github.com/getsentry/snuba/pull/460/files?w=1) in the url to remove all the whitespace changes.

I'll create a PR to remove it from the [ops repo](https://github.com/getsentry/ops/blob/master/k8s/services/snuba/configmap.yaml#L52) once this change is approved.