### PR TITLE
ref: Remove performance extensions and make them query settings

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -14,6 +14,7 @@ import jsonschema
 from uuid import UUID
 
 from snuba import schemas, settings, state, util
+from snuba.query.schema import QUERY_SETTINGS_SCHEMA
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clickhouse.query import ClickhouseQuery
 from snuba.query.timeseries import TimeSeriesExtensionProcessor
@@ -282,7 +283,7 @@ def parse_and_run_query(dataset, request: Request, timer):
     if project_ids:
         request.query.add_conditions([('project_id', 'IN', project_ids)])
 
-    turbo = request.extensions['performance'].get('turbo', False)
+    turbo = request.query_settings.get('turbo', False)
     if not turbo:
         final, exclude_group_ids = get_projects_query_flags(project_ids)
         if not final and exclude_group_ids:
@@ -347,6 +348,7 @@ def sdk_distribution(*, timer: Timer):
         parse_request_body(http_request),
         RequestSchema(
             schemas.SDK_STATS_BASE_SCHEMA,
+            QUERY_SETTINGS_SCHEMA,
             schemas.SDK_STATS_EXTENSIONS_SCHEMA,
         ),
         timer,

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -14,7 +14,7 @@ import jsonschema
 from uuid import UUID
 
 from snuba import schemas, settings, state, util
-from snuba.query.schema import QUERY_SETTINGS_SCHEMA
+from snuba.query.schema import SETTINGS_SCHEMA
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clickhouse.query import ClickhouseQuery
 from snuba.query.timeseries import TimeSeriesExtensionProcessor
@@ -348,7 +348,7 @@ def sdk_distribution(*, timer: Timer):
         parse_request_body(http_request),
         RequestSchema(
             schemas.SDK_STATS_BASE_SCHEMA,
-            QUERY_SETTINGS_SCHEMA,
+            SETTINGS_SCHEMA,
             schemas.SDK_STATS_EXTENSIONS_SCHEMA,
         ),
         timer,

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -268,15 +268,13 @@ def parse_and_run_query(dataset, request: Request, timer):
     from_date, to_date = TimeSeriesExtensionProcessor.get_time_limit(request.extensions['timeseries'])
 
     extensions = dataset.get_extensions()
-
-    query_hints = {}
+    query_hints = request.settings.get_query_hints()
 
     for name, extension in extensions.items():
         extension.get_processor().process_query(
             request.query,
             request.extensions[name],
-            request.settings,
-            query_hints
+            query_hints,
         )
     request.query.add_conditions(dataset.default_conditions())
 
@@ -304,14 +302,12 @@ def parse_and_run_query(dataset, request: Request, timer):
     source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
     # TODO: consider moving the performance logic and the pre_where generation into
     # ClickhouseQuery since they are Clickhouse specific
-    clickhouse_query = ClickhouseQuery(dataset, request, prewhere_conditions, query_hints)
-
-    sql = clickhouse_query.format()
+    sql = ClickhouseQuery(dataset, request, prewhere_conditions, query_hints).format()
     timer.mark('prepare_query')
 
     stats = {
         'clickhouse_table': source,
-        'final': clickhouse_query.get_final(),
+        'final': query_hints.final,
         'referrer': http_request.referrer,
         'num_days': (to_date - from_date).days,
         'sample': request.query.get_sample(),

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -283,7 +283,7 @@ def parse_and_run_query(dataset, request: Request, timer):
     if project_ids:
         request.query.add_conditions([('project_id', 'IN', project_ids)])
 
-    turbo = request.query_settings.get('turbo', False)
+    turbo = request.settings.get('turbo', False)
     if not turbo:
         final, exclude_group_ids = get_projects_query_flags(project_ids)
         if not final and exclude_group_ids:

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -277,6 +277,9 @@ def parse_and_run_query(dataset, request: Request, timer):
         )
     request.query.add_conditions(dataset.default_conditions())
 
+    if request.settings.turbo:
+        request.query.set_final(False)
+
     prewhere_conditions = []
     # Add any condition to PREWHERE if:
     # - It is a single top-level condition (not OR-nested), and

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -311,7 +311,7 @@ def parse_and_run_query(dataset, request: Request, timer):
 
     stats = {
         'clickhouse_table': source,
-        'final': clickhouse_query.final,
+        'final': clickhouse_query.get_final(),
         'referrer': http_request.referrer,
         'num_days': (to_date - from_date).days,
         'sample': request.query.get_sample(),

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Sequence, Any, Mapping
 
 from snuba import util, settings
 from snuba.datasets import Dataset
@@ -12,10 +12,12 @@ class ClickhouseQuery:
         # body anymore.
         request: Request,
         prewhere_conditions: Sequence[str],
+        query_state: Mapping[str, Any],
     ) -> None:
         self.__dataset = dataset
         self.__request = request
         self.__prewhere_conditions = prewhere_conditions
+        self.__query_state = query_state
 
         turbo = self.__request.settings.get('turbo', False)
         self.final = False  # this is a public variable so that api can read it for stats
@@ -24,8 +26,8 @@ class ClickhouseQuery:
             self.final = False
             if self.__request.query.get_sample() is None:
                 request.query.set_sample(settings.TURBO_SAMPLE_RATE)
-        elif 'final' in self.__request.state:
-            self.final = self.__request.state['final']
+        elif 'final' in self.__query_state:
+            self.final = self.__query_state['final']
 
     def format(self) -> str:
         """Generate a SQL string from the parameters."""

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -12,12 +12,12 @@ class ClickhouseQuery:
         # body anymore.
         request: Request,
         prewhere_conditions: Sequence[str],
-        query_state: Mapping[str, Any],
+        query_hints: Mapping[str, Any],
     ) -> None:
         self.__dataset = dataset
         self.__request = request
         self.__prewhere_conditions = prewhere_conditions
-        self.__query_state = query_state
+        self.__query_hints = query_hints
 
         turbo = self.__request.settings.get('turbo', False)
         self.final = False  # this is a public variable so that api can read it for stats
@@ -26,8 +26,8 @@ class ClickhouseQuery:
             self.final = False
             if self.__request.query.get_sample() is None:
                 request.query.set_sample(settings.TURBO_SAMPLE_RATE)
-        elif 'final' in self.__query_state:
-            self.final = self.__query_state['final']
+        elif 'final' in self.__query_hints:
+            self.final = self.__query_hints['final']
 
     def format(self) -> str:
         """Generate a SQL string from the parameters."""

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -49,7 +49,7 @@ class ClickhouseQuery:
             from_clause = u'{} FINAL'.format(from_clause)
 
         if query.get_sample():
-            from_clause = u'{} SAMPLE {}'.format(from_clause, self.__request.query.get_sample())
+            from_clause = u'{} SAMPLE {}'.format(from_clause, query.get_sample())
 
         join_clause = ''
         if 'arrayjoin' in body:

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba import util
+from snuba import util, settings
 from snuba.datasets import Dataset
 from snuba.request import Request
 
@@ -38,8 +38,13 @@ class ClickhouseQuery:
         if self.__request.query.get_final():
             from_clause = u'{} FINAL'.format(from_clause)
 
-        if query.get_sample():
-            from_clause = u'{} SAMPLE {}'.format(from_clause, query.get_sample())
+        if self.__request.settings.turbo:
+            sample_rate = settings.TURBO_SAMPLE_RATE
+        else:
+            sample_rate = query.get_sample()
+
+        if sample_rate:
+            from_clause = u'{} SAMPLE {}'.format(from_clause, sample_rate)
 
         join_clause = ''
         if 'arrayjoin' in body:

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,9 +1,8 @@
 from typing import Sequence
 
-from snuba import util, settings
+from snuba import util
 from snuba.datasets import Dataset
 from snuba.request import Request
-from snuba.query.query import QueryHints
 
 
 class ClickhouseQuery:
@@ -13,12 +12,10 @@ class ClickhouseQuery:
         # body anymore.
         request: Request,
         prewhere_conditions: Sequence[str],
-        query_hints: QueryHints,
     ) -> None:
         self.__dataset = dataset
         self.__request = request
         self.__prewhere_conditions = prewhere_conditions
-        self.__query_hints = query_hints
 
     def format(self) -> str:
         """Generate a SQL string from the parameters."""
@@ -38,7 +35,7 @@ class ClickhouseQuery:
 
         from_clause = u'FROM {}'.format(source)
 
-        if self.__query_hints.final:
+        if self.__request.query.get_final():
             from_clause = u'{} FINAL'.format(from_clause)
 
         if query.get_sample():

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -20,10 +20,6 @@ class ClickhouseQuery:
         self.__prewhere_conditions = prewhere_conditions
         self.__query_hints = query_hints
 
-        if self.__query_hints.turbo:
-            if self.__request.query.get_sample() is None:
-                request.query.set_sample(settings.TURBO_SAMPLE_RATE)
-
     def format(self) -> str:
         """Generate a SQL string from the parameters."""
         body = self.__request.body

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Any, Mapping
+from typing import Sequence
 
 from snuba import util, settings
 from snuba.datasets import Dataset

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -48,7 +48,7 @@ class ClickhouseQuery:
         if self.final:
             from_clause = u'{} FINAL'.format(from_clause)
 
-        if self.__request.query.get_sample():
+        if query.get_sample():
             from_clause = u'{} SAMPLE {}'.format(from_clause, self.__request.query.get_sample())
 
         join_clause = ''

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -38,10 +38,12 @@ class ClickhouseQuery:
         if self.__request.query.get_final():
             from_clause = u'{} FINAL'.format(from_clause)
 
-        if self.__request.settings.turbo:
+        if query.get_sample():
+            sample_rate = query.get_sample()
+        elif self.__request.settings.turbo:
             sample_rate = settings.TURBO_SAMPLE_RATE
         else:
-            sample_rate = query.get_sample()
+            sample_rate = None
 
         if sample_rate:
             from_clause = u'{} SAMPLE {}'.format(from_clause, sample_rate)

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -20,14 +20,17 @@ class ClickhouseQuery:
         self.__query_hints = query_hints
 
         turbo = self.__request.settings.get('turbo', False)
-        self.final = False  # this is a public variable so that api can read it for stats
+        self.__final = False
 
         if turbo:
-            self.final = False
+            self.__final = False
             if self.__request.query.get_sample() is None:
                 request.query.set_sample(settings.TURBO_SAMPLE_RATE)
         elif 'final' in self.__query_hints:
-            self.final = self.__query_hints['final']
+            self.__final = self.__query_hints['final']
+
+    def get_final(self):
+        return self.__final
 
     def format(self) -> str:
         """Generate a SQL string from the parameters."""
@@ -47,7 +50,7 @@ class ClickhouseQuery:
 
         from_clause = u'FROM {}'.format(source)
 
-        if self.final:
+        if self.__final:
             from_clause = u'{} FINAL'.format(from_clause)
 
         if query.get_sample():

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -18,11 +18,7 @@ from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.query.extensions import (
-    PerformanceExtension,
-    ProjectExtension,
-    QueryExtension,
-)
+from snuba.query.extensions import QueryExtension
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -22,7 +22,7 @@ from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.query.extensions import QueryExtension
 from snuba.query.timeseries import TimeSeriesExtension
-from snuba.query.project_extension import ProjectWithGroupsExtension
+from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 
 from snuba.util import (
     alias_expr,
@@ -390,7 +390,9 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {
-            'project': ProjectWithGroupsExtension(),
+            'project': ProjectExtension(
+                processor=ProjectWithGroupsProcessor()
+            ),
             'timeseries': TimeSeriesExtension(
                 default_granularity=3600,
                 default_window=timedelta(days=5),

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -20,7 +20,6 @@ from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.query.extensions import (
-    PerformanceExtension,
     ProjectExtension,
     QueryExtension,
 )
@@ -385,7 +384,6 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {
-            'performance': PerformanceExtension(),
             'project': ProjectExtension(),
             'timeseries': TimeSeriesExtension(
                 default_granularity=3600,

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -22,7 +22,7 @@ from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.query.extensions import QueryExtension
 from snuba.query.timeseries import TimeSeriesExtension
-from snuba.query.project_extension import ProjectExtension
+from snuba.query.project_extension import ProjectWithGroupsExtension
 
 from snuba.util import (
     alias_expr,
@@ -390,7 +390,7 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {
-            'project': ProjectExtension(),
+            'project': ProjectWithGroupsExtension(),
             'timeseries': TimeSeriesExtension(
                 default_granularity=3600,
                 default_window=timedelta(days=5),

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -20,11 +20,9 @@ from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
-from snuba.query.extensions import (
-    ProjectExtension,
-    QueryExtension,
-)
+from snuba.query.extensions import QueryExtension
 from snuba.query.timeseries import TimeSeriesExtension
+from snuba.query.project_extension import ProjectExtension
 
 from snuba.util import (
     alias_expr,

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -21,7 +21,6 @@ from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import (
-    PerformanceExtension,
     ProjectExtension,
     QueryExtension,
 )
@@ -130,7 +129,6 @@ class TransactionsDataset(TimeSeriesDataset):
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {
-            'performance': PerformanceExtension(),
             'project': ProjectExtension(),
             'timeseries': TimeSeriesExtension(
                 default_granularity=3600,

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -23,7 +23,7 @@ from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import QueryExtension
 from snuba.query.timeseries import TimeSeriesExtension
-from snuba.query.project_extension import ProjectExtension
+from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
 
 
 class TransactionsTableWriter(TableWriter):
@@ -135,7 +135,9 @@ class TransactionsDataset(TimeSeriesDataset):
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {
-            'project': ProjectExtension(),
+            'project': ProjectExtension(
+                processor=ProjectExtensionProcessor()
+            ),
             'timeseries': TimeSeriesExtension(
                 default_granularity=3600,
                 default_window=timedelta(days=5),

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -21,11 +21,9 @@ from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
-from snuba.query.extensions import (
-    ProjectExtension,
-    QueryExtension,
-)
+from snuba.query.extensions import QueryExtension
 from snuba.query.timeseries import TimeSeriesExtension
+from snuba.query.project_extension import ProjectExtension
 
 
 class TransactionsTableWriter(TableWriter):

--- a/snuba/query/extensions.py
+++ b/snuba/query/extensions.py
@@ -1,13 +1,7 @@
 from abc import ABC
 
-from snuba.query.query_processor import (
-    DummyExtensionProcessor,
-    ExtensionQueryProcessor,
-    ProjectExtensionProcessor
-)
-from snuba.schemas import (
-    Schema
-)
+from snuba.query.query_processor import ExtensionQueryProcessor
+from snuba.schemas import Schema
 
 
 class QueryExtension(ABC):
@@ -29,31 +23,3 @@ class QueryExtension(ABC):
 
     def get_processor(self) -> ExtensionQueryProcessor:
         return self.__processor
-
-
-PROJECT_EXTENSION_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        'project': {
-            'anyOf': [
-                {'type': 'integer', 'minimum': 1},
-                {
-                    'type': 'array',
-                    'items': {'type': 'integer', 'minimum': 1},
-                    'minItems': 1,
-                },
-            ]
-        },
-    },
-    # Need to select down to the project level for customer isolation and performance
-    'required': ['project'],
-    'additionalProperties': False,
-}
-
-
-class ProjectExtension(QueryExtension):
-    def __init__(self) -> None:
-        super().__init__(
-            schema=PROJECT_EXTENSION_SCHEMA,
-            processor=ProjectExtensionProcessor(),
-        )

--- a/snuba/query/extensions.py
+++ b/snuba/query/extensions.py
@@ -2,7 +2,8 @@ from abc import ABC
 
 from snuba.query.query_processor import (
     DummyExtensionProcessor,
-    ExtensionQueryProcessor
+    ExtensionQueryProcessor,
+    ProjectExtensionProcessor
 )
 from snuba.schemas import (
     Schema
@@ -54,5 +55,5 @@ class ProjectExtension(QueryExtension):
     def __init__(self) -> None:
         super().__init__(
             schema=PROJECT_EXTENSION_SCHEMA,
-            processor=DummyExtensionProcessor(),
+            processor=ProjectExtensionProcessor(),
         )

--- a/snuba/query/extensions.py
+++ b/snuba/query/extensions.py
@@ -49,37 +49,6 @@ PROJECT_EXTENSION_SCHEMA = {
     'additionalProperties': False,
 }
 
-PERFORMANCE_EXTENSION_SCHEMA = {
-    'type': 'object',
-    'properties': {
-        # Never add FINAL to queries, enable sampling
-        'turbo': {
-            'type': 'boolean',
-            'default': False,
-        },
-        # Force queries to hit the first shard replica, ensuring the query
-        # sees data that was written before the query. This burdens the
-        # first replica, so should only be used when absolutely necessary.
-        'consistent': {
-            'type': 'boolean',
-            'default': False,
-        },
-        'debug': {
-            'type': 'boolean',
-            'default': False,
-        },
-    },
-    'additionalProperties': False,
-}
-
-
-class PerformanceExtension(QueryExtension):
-    def __init__(self) -> None:
-        super().__init__(
-            schema=PERFORMANCE_EXTENSION_SCHEMA,
-            processor=DummyExtensionProcessor(),
-        )
-
 
 class ProjectExtension(QueryExtension):
     def __init__(self) -> None:

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -37,13 +37,11 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
             extension_data: ExtensionData,
             request_settings: Mapping[str, bool],
             query_hints: Mapping[str, Any],
-            stats: Mapping[str, Any],
     ) -> None:
         # NOTE: we rely entirely on the schema to make sure that regular snuba
         # queries are required to send a project_id filter. Some other special
         # internal query types do not require a project_id filter.
         project_ids = util.to_list(extension_data['project'])
-        stats.update({'num_projects': len(project_ids)})
 
         if project_ids:
             query.add_conditions([('project_id', 'IN', project_ids)])

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -42,6 +42,11 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
 
 
 class ProjectWithGroupsProcessor(ProjectExtensionProcessor):
+    """
+    Extension processor that makes changes to the query by
+    1. Adding the project
+    2. Taking into consideration groups that should be excluded (groups are excluded because of replacement).
+    """
 
     def process_query(
             self,

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -33,9 +33,6 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
             extension_data: ExtensionData,
             query_hints: QueryHints,
     ) -> None:
-        # NOTE: we rely entirely on the schema to make sure that regular snuba
-        # queries are required to send a project_id filter. Some other special
-        # internal query types do not require a project_id filter.
         project_ids = util.to_list(extension_data['project'])
 
         if project_ids:
@@ -50,9 +47,6 @@ class ProjectWithGroupsProcessor(ProjectExtensionProcessor):
             extension_data: ExtensionData,
             query_hints: QueryHints,
     ) -> None:
-        # NOTE: we rely entirely on the schema to make sure that regular snuba
-        # queries are required to send a project_id filter. Some other special
-        # internal query types do not require a project_id filter.
         project_ids = util.to_list(extension_data['project'])
 
         if project_ids:

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -3,10 +3,9 @@ from typing import Mapping, Any
 from snuba import settings, util
 from snuba.state import get_config
 from snuba.replacer import get_projects_query_flags
-from snuba.query.extensions import ExtensionQueryProcessor
-from snuba.query.extensions import QueryExtension
+from snuba.query.extensions import ExtensionQueryProcessor, QueryExtension
 from snuba.query.query_processor import ExtensionData
-from snuba.query.query import Query
+from snuba.query.query import Query, QueryHints
 
 
 PROJECT_EXTENSION_SCHEMA = {
@@ -35,8 +34,7 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
             self,
             query: Query,
             extension_data: ExtensionData,
-            request_settings: Mapping[str, bool],
-            query_hints: Mapping[str, Any],
+            query_hints: QueryHints,
     ) -> None:
         # NOTE: we rely entirely on the schema to make sure that regular snuba
         # queries are required to send a project_id filter. Some other special
@@ -46,20 +44,18 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
         if project_ids:
             query.add_conditions([('project_id', 'IN', project_ids)])
 
-        turbo = request_settings.get('turbo', False)
-        if not turbo:
+        if not query_hints.turbo:
             final, exclude_group_ids = get_projects_query_flags(project_ids)
             if not final and exclude_group_ids:
                 # If the number of groups to exclude exceeds our limit, the query
                 # should just use final instead of the exclusion set.
                 max_group_ids_exclude = get_config('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE)
                 if len(exclude_group_ids) > max_group_ids_exclude:
-                    query_hints.update({'final': True})
+                    query_hints.final = True
                 else:
-                    query_hints.update({'final': False})
                     query.add_conditions([(['assumeNotNull', ['group_id']], 'NOT IN', exclude_group_ids)])
             else:
-                query_hints.update({'final': final})
+                query_hints.final = final
 
 
 class ProjectExtension(QueryExtension):

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -1,10 +1,9 @@
 from snuba import settings, util
-from snuba.state import get_config
-from snuba.replacer import get_projects_query_flags
 from snuba.query.extensions import ExtensionQueryProcessor, QueryExtension
-from snuba.query.query_processor import ExtensionData
 from snuba.query.query import Query, QueryHints
-
+from snuba.query.query_processor import ExtensionData
+from snuba.replacer import get_projects_query_flags
+from snuba.state import get_config
 
 PROJECT_EXTENSION_SCHEMA = {
     'type': 'object',

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -1,0 +1,72 @@
+from typing import Mapping, Any
+
+from snuba import settings, util
+from snuba.state import get_config
+from snuba.replacer import get_projects_query_flags
+from snuba.query.extensions import ExtensionQueryProcessor
+from snuba.query.extensions import QueryExtension
+from snuba.query.query_processor import ExtensionData
+from snuba.query.query import Query
+
+
+PROJECT_EXTENSION_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'project': {
+            'anyOf': [
+                {'type': 'integer', 'minimum': 1},
+                {
+                    'type': 'array',
+                    'items': {'type': 'integer', 'minimum': 1},
+                    'minItems': 1,
+                },
+            ]
+        },
+    },
+    # Need to select down to the project level for customer isolation and performance
+    'required': ['project'],
+    'additionalProperties': False,
+}
+
+
+class ProjectExtensionProcessor(ExtensionQueryProcessor):
+
+    def process_query(
+            self,
+            query: Query,
+            extension_data: ExtensionData,
+            request_settings: Mapping[str, bool],
+            query_hints: Mapping[str, Any],
+            stats: Mapping[str, Any],
+    ) -> None:
+        # NOTE: we rely entirely on the schema to make sure that regular snuba
+        # queries are required to send a project_id filter. Some other special
+        # internal query types do not require a project_id filter.
+        project_ids = util.to_list(extension_data['project'])
+        stats.update({'num_projects': len(project_ids)})
+
+        if project_ids:
+            query.add_conditions([('project_id', 'IN', project_ids)])
+
+        turbo = request_settings.get('turbo', False)
+        if not turbo:
+            final, exclude_group_ids = get_projects_query_flags(project_ids)
+            if not final and exclude_group_ids:
+                # If the number of groups to exclude exceeds our limit, the query
+                # should just use final instead of the exclusion set.
+                max_group_ids_exclude = get_config('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE)
+                if len(exclude_group_ids) > max_group_ids_exclude:
+                    query_hints.update({'final': True})
+                else:
+                    query_hints.update({'final': False})
+                    query.add_conditions([(['assumeNotNull', ['group_id']], 'NOT IN', exclude_group_ids)])
+            else:
+                query_hints.update({'final': final})
+
+
+class ProjectExtension(QueryExtension):
+    def __init__(self) -> None:
+        super().__init__(
+            schema=PROJECT_EXTENSION_SCHEMA,
+            processor=ProjectExtensionProcessor(),
+        )

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -73,16 +73,8 @@ class ProjectWithGroupsProcessor(ProjectExtensionProcessor):
 
 
 class ProjectExtension(QueryExtension):
-    def __init__(self) -> None:
+    def __init__(self, processor: ProjectExtensionProcessor) -> None:
         super().__init__(
             schema=PROJECT_EXTENSION_SCHEMA,
-            processor=ProjectExtensionProcessor(),
-        )
-
-
-class ProjectWithGroupsExtension(QueryExtension):
-    def __init__(self) -> None:
-        super().__init__(
-            schema=PROJECT_EXTENSION_SCHEMA,
-            processor=ProjectWithGroupsProcessor()
+            processor=processor,
         )

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -123,13 +123,6 @@ class Query:
     def set_offset(self, offset: int) -> None:
         self.__body["offset"] = offset
 
-    # TODO(manu): get this out of query
-    def set_final(self, final: bool) -> None:
-        self.__body["final"] = final
-
-    def get_final(self) -> bool:
-        return self.__body.get('final', False)
-
     @deprecated(
         details="Do not access the internal query representation "
         "use the specific accessor methods instead.")

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -123,6 +123,13 @@ class Query:
     def set_offset(self, offset: int) -> None:
         self.__body["offset"] = offset
 
+    # TODO(manu): get this out of query
+    def set_final(self, final: bool) -> None:
+        self.__body["final"] = final
+
+    def get_final(self) -> bool:
+        return self.__body.get('final', False)
+
     @deprecated(
         details="Do not access the internal query representation "
         "use the specific accessor methods instead.")

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -11,6 +11,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from dataclasses import dataclass
 
 
 Condition = Union[
@@ -128,3 +129,9 @@ class Query:
         "use the specific accessor methods instead.")
     def get_body(self) -> Mapping[str, Any]:
         return self.__body
+
+
+@dataclass
+class QueryHints:
+    turbo: bool
+    final: bool

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from deprecation import deprecated
 from typing import (
     Any,
@@ -11,7 +12,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from dataclasses import dataclass
 
 
 Condition = Union[

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from deprecation import deprecated
 from typing import (
     Any,
@@ -52,6 +51,7 @@ class Query:
         # TODO: make the parser produce this data structure directly
         # in order not to expose the internal representation.
         self.__body = body
+        self.__final = False
 
     def __extend_sequence(self,
         field: str,
@@ -124,18 +124,14 @@ class Query:
     def set_offset(self, offset: int) -> None:
         self.__body["offset"] = offset
 
+    def get_final(self) -> bool:
+        return self.__final
+
+    def set_final(self, final) -> None:
+        self.__final = final
+
     @deprecated(
         details="Do not access the internal query representation "
         "use the specific accessor methods instead.")
     def get_body(self) -> Mapping[str, Any]:
         return self.__body
-
-
-@dataclass
-class QueryHints:
-    """
-    A mutable structure that is meant to be modified by the extension processors so that it can pass hints
-    for the construction of the clickhouse query
-    """
-    turbo: bool
-    final: bool

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -133,5 +133,9 @@ class Query:
 
 @dataclass
 class QueryHints:
+    """
+    A mutable structure that is meant to be modified by the extension processors so that it can pass hints
+    for the construction of the clickhouse query
+    """
     turbo: bool
     final: bool

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -34,8 +34,8 @@ class Query:
     Represents a parsed query we can edit during query processing.
 
     This is the bare minimum abstraction to avoid depending on a mutable
-    Mapping around the code base. Fully untagling the query representation
-    from the code depnding on it wil ltake a lot of PRs, but at least we
+    Mapping around the code base. Fully untangling the query representation
+    from the code depending on it wil take a lot of PRs, but at least we
     have a basic abstraction to move functionalities to.
     It is also the base to split the Clickhouse specific query into
     an abstract Snuba query and a concrete Clickhouse query, but

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -109,9 +109,6 @@ class Query:
     def get_sample(self) -> Optional[float]:
         return self.__body.get("sample")
 
-    def set_sample(self, sample: float) -> None:
-        self.__body["sample"] = sample
-
     def get_limit(self) -> int:
         return self.__body.get('limit', 0)
 

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -60,4 +60,4 @@ class DummyExtensionProcessor(ExtensionQueryProcessor):
             request_settings: Mapping[str, bool],
             query_hints: Mapping[str, Any],
     ) -> None:
-        return query
+        pass

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Mapping, TypeVar
 
-from snuba.query.query import Query, QueryHints
+from snuba.query.query import Query
+from snuba.request.request_settings import RequestSettings
 
 ExtensionData = Mapping[str, Any]
 
@@ -21,7 +22,7 @@ class QueryProcessor(ABC, Generic[TQueryProcessContext]):
     def process_query(self,
         query: Query,
         context_data: TQueryProcessContext,
-        query_hints: QueryHints,
+        request_settings: RequestSettings,
     ) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since
@@ -44,7 +45,7 @@ class ExtensionQueryProcessor(QueryProcessor[ExtensionData]):
     def process_query(
             self, query: Query,
             extension_data: ExtensionData,
-            query_hints: QueryHints,
+            request_settings: RequestSettings,
     ) -> None:
         raise NotImplementedError
 
@@ -55,6 +56,6 @@ class DummyExtensionProcessor(ExtensionQueryProcessor):
             self,
             query: Query,
             extension_data: ExtensionData,
-            query_hints: QueryHints,
+            request_settings: RequestSettings,
     ) -> None:
         pass

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Mapping, TypeVar
 
-from snuba.query.query import Query
+from snuba.query.query import Query, QueryHints
 
 ExtensionData = Mapping[str, Any]
 
@@ -21,8 +21,7 @@ class QueryProcessor(ABC, Generic[TQueryProcessContext]):
     def process_query(self,
         query: Query,
         context_data: TQueryProcessContext,
-        request_settings: Mapping[str, bool],
-        query_hints: Mapping[str, Any],  # used to pass hints from the extension processors to the clickhouse query
+        query_hints: QueryHints,  # used to pass hints from the extension processors to the clickhouse query
     ) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since
@@ -45,8 +44,7 @@ class ExtensionQueryProcessor(QueryProcessor[ExtensionData]):
     def process_query(
             self, query: Query,
             extension_data: ExtensionData,
-            request_settings: Mapping[str, bool],
-            query_hints: Mapping[str, Any],
+            query_hints: QueryHints,
     ) -> None:
         raise NotImplementedError
 
@@ -57,7 +55,6 @@ class DummyExtensionProcessor(ExtensionQueryProcessor):
             self,
             query: Query,
             extension_data: ExtensionData,
-            request_settings: Mapping[str, bool],
-            query_hints: Mapping[str, Any],
+            query_hints: QueryHints,
     ) -> None:
         pass

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -21,7 +21,7 @@ class QueryProcessor(ABC, Generic[TQueryProcessContext]):
     def process_query(self,
         query: Query,
         context_data: TQueryProcessContext,
-        query_hints: QueryHints,  # used to pass hints from the extension processors to the clickhouse query
+        query_hints: QueryHints,
     ) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -25,7 +25,7 @@ class QueryProcessor(ABC, Generic[TQueryProcessContext]):
         query: Query,
         context_data: TQueryProcessContext,
         request_settings: Mapping[str, bool],
-        request_state: Mapping[str, Any]
+        query_state: Mapping[str, Any]
     ) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since
@@ -49,7 +49,7 @@ class ExtensionQueryProcessor(QueryProcessor[ExtensionData]):
             self, query: Query,
             extension_data: ExtensionData,
             request_settings: Mapping[str, bool],
-            request_state: Mapping[str, Any]
+            query_state: Mapping[str, Any]
     ) -> None:
         raise NotImplementedError
 
@@ -61,7 +61,7 @@ class DummyExtensionProcessor(ExtensionQueryProcessor):
             query: Query,
             extension_data: ExtensionData,
             request_settings: Mapping[str, bool],
-            request_state: Mapping[str, Any]
+            query_state: Mapping[str, Any]
     ) -> None:
         return query
 
@@ -73,13 +73,13 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
             query: Query,
             extension_data: ExtensionData,
             request_settings: Mapping[str, bool],
-            request_state: Mapping[str, Any]
+            query_state: Mapping[str, Any]
     ) -> None:
         # NOTE: we rely entirely on the schema to make sure that regular snuba
         # queries are required to send a project_id filter. Some other special
         # internal query types do not require a project_id filter.
         project_ids = util.to_list(extension_data['project'])
-        request_state.update({'num_projects': len(project_ids)})
+        query_state.update({'num_projects': len(project_ids)})
 
         if project_ids:
             query.add_conditions([('project_id', 'IN', project_ids)])
@@ -92,9 +92,9 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
                 # should just use final instead of the exclusion set.
                 max_group_ids_exclude = get_config('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE)
                 if len(exclude_group_ids) > max_group_ids_exclude:
-                    request_state.update({'final': True})
+                    query_state.update({'final': True})
                 else:
-                    request_state.update({'final': False})
+                    query_state.update({'final': False})
                     query.add_conditions([(['assumeNotNull', ['group_id']], 'NOT IN', exclude_group_ids)])
             else:
-                request_state.update({'final': final})
+                query_state.update({'final': final})

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -23,7 +23,6 @@ class QueryProcessor(ABC, Generic[TQueryProcessContext]):
         context_data: TQueryProcessContext,
         request_settings: Mapping[str, bool],
         query_hints: Mapping[str, Any],  # used to pass hints from the extension processors to the clickhouse query
-        stats: Mapping[str, Any],
     ) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since
@@ -48,7 +47,6 @@ class ExtensionQueryProcessor(QueryProcessor[ExtensionData]):
             extension_data: ExtensionData,
             request_settings: Mapping[str, bool],
             query_hints: Mapping[str, Any],
-            stats: Mapping[str, Any],
     ) -> None:
         raise NotImplementedError
 
@@ -61,6 +59,5 @@ class DummyExtensionProcessor(ExtensionQueryProcessor):
             extension_data: ExtensionData,
             request_settings: Mapping[str, bool],
             query_hints: Mapping[str, Any],
-            stats: Mapping[str, Any],
     ) -> None:
         return query

--- a/snuba/query/query_processor.py
+++ b/snuba/query/query_processor.py
@@ -25,7 +25,7 @@ class QueryProcessor(ABC, Generic[TQueryProcessContext]):
         query: Query,
         context_data: TQueryProcessContext,
         request_settings: Mapping[str, bool],
-        state: Mapping[str, Any]
+        request_state: Mapping[str, Any]
     ) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since
@@ -45,25 +45,41 @@ class ExtensionQueryProcessor(QueryProcessor[ExtensionData]):
     """
 
     @abstractmethod
-    def process_query(self, query: Query, extension_data: ExtensionData, request_settings: Mapping[str, bool], state: Mapping[str, Any]) -> None:
+    def process_query(
+            self, query: Query,
+            extension_data: ExtensionData,
+            request_settings: Mapping[str, bool],
+            request_state: Mapping[str, Any]
+    ) -> None:
         raise NotImplementedError
 
 
 class DummyExtensionProcessor(ExtensionQueryProcessor):
 
-    def process_query(self, query: Query, extension_data: ExtensionData, request_settings: Mapping[str, bool], state: Mapping[str, Any]) -> None:
+    def process_query(
+            self,
+            query: Query,
+            extension_data: ExtensionData,
+            request_settings: Mapping[str, bool],
+            request_state: Mapping[str, Any]
+    ) -> None:
         return query
 
 
 class ProjectExtensionProcessor(ExtensionQueryProcessor):
 
-    # TODO(manu): make sure this is fine by https://github.com/getsentry/snuba/pull/473
-    def process_query(self, query: Query, extension_data: ExtensionData, request_settings: Mapping[str, bool], state: Mapping[str, Any]) -> None:
+    def process_query(
+            self,
+            query: Query,
+            extension_data: ExtensionData,
+            request_settings: Mapping[str, bool],
+            request_state: Mapping[str, Any]
+    ) -> None:
         # NOTE: we rely entirely on the schema to make sure that regular snuba
         # queries are required to send a project_id filter. Some other special
         # internal query types do not require a project_id filter.
         project_ids = util.to_list(extension_data['project'])
-        state.update({'num_projects': len(project_ids)})
+        request_state.update({'num_projects': len(project_ids)})
 
         if project_ids:
             query.add_conditions([('project_id', 'IN', project_ids)])
@@ -76,9 +92,9 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
                 # should just use final instead of the exclusion set.
                 max_group_ids_exclude = get_config('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE)
                 if len(exclude_group_ids) > max_group_ids_exclude:
-                    state.update({'final': True})
+                    request_state.update({'final': True})
                 else:
-                    state.update({'final': False})
+                    request_state.update({'final': False})
                     query.add_conditions([(['assumeNotNull', ['group_id']], 'NOT IN', exclude_group_ids)])
             else:
-                state.update({'final': final})
+                request_state.update({'final': final})

--- a/snuba/query/schema.py
+++ b/snuba/query/schema.py
@@ -177,3 +177,26 @@ GENERIC_QUERY_SCHEMA = {
         },
     }
 }
+
+QUERY_SETTINGS_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        # Never add FINAL to queries, enable sampling
+        'turbo': {
+            'type': 'boolean',
+            'default': False,
+        },
+        # Force queries to hit the first shard replica, ensuring the query
+        # sees data that was written before the query. This burdens the
+        # first replica, so should only be used when absolutely necessary.
+        'consistent': {
+            'type': 'boolean',
+            'default': False,
+        },
+        'debug': {
+            'type': 'boolean',
+            'default': False,
+        },
+    },
+    'additionalProperties': False,
+}

--- a/snuba/query/schema.py
+++ b/snuba/query/schema.py
@@ -178,7 +178,7 @@ GENERIC_QUERY_SCHEMA = {
     }
 }
 
-QUERY_SETTINGS_SCHEMA = {
+SETTINGS_SCHEMA = {
     'type': 'object',
     'properties': {
         # Never add FINAL to queries, enable sampling

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -36,7 +36,6 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
             extension_data: ExtensionData,
             settings: Mapping[str, bool],
             query_hints: Mapping[str, Any],
-            stats: Mapping[str, Any]
     ) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -30,7 +30,13 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
 
         return (from_date, to_date)
 
-    def process_query(self, query: Query, extension_data: ExtensionData, settings: Mapping[str, bool], state: Mapping[str, Any]) -> None:
+    def process_query(
+            self,
+            query: Query,
+            extension_data: ExtensionData,
+            settings: Mapping[str, bool],
+            request_state: Mapping[str, Any]
+    ) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([
             (self.__timestamp_column, '>=', from_date.isoformat()),

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -30,7 +30,7 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
 
         return (from_date, to_date)
 
-    def process_query(self, query: Query, extension_data: ExtensionData, settings: Mapping[str, bool]) -> None:
+    def process_query(self, query: Query, extension_data: ExtensionData, settings: Mapping[str, bool], state: Mapping[str, Any]) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([
             (self.__timestamp_column, '>=', from_date.isoformat()),

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -30,7 +30,7 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
 
         return (from_date, to_date)
 
-    def process_query(self, query: Query, extension_data: ExtensionData) -> None:
+    def process_query(self, query: Query, extension_data: ExtensionData, settings: Mapping[str, bool]) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([
             (self.__timestamp_column, '>=', from_date.isoformat()),

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -5,8 +5,9 @@ from snuba import state
 from snuba.util import parse_datetime
 from snuba.query.extensions import QueryExtension
 from snuba.query.query_processor import ExtensionQueryProcessor
-from snuba.query.query import Query, QueryHints
+from snuba.query.query import Query
 from snuba.query.query_processor import ExtensionData
+from snuba.request.request_settings import RequestSettings
 from snuba.schemas import get_time_series_extension_properties
 
 
@@ -34,7 +35,7 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
             self,
             query: Query,
             extension_data: ExtensionData,
-            query_hints: QueryHints,
+            request_settings: RequestSettings,
     ) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -5,7 +5,7 @@ from snuba import state
 from snuba.util import parse_datetime
 from snuba.query.extensions import QueryExtension
 from snuba.query.query_processor import ExtensionQueryProcessor
-from snuba.query.query import Query
+from snuba.query.query import Query, QueryHints
 from snuba.query.query_processor import ExtensionData
 from snuba.schemas import get_time_series_extension_properties
 
@@ -34,8 +34,7 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
             self,
             query: Query,
             extension_data: ExtensionData,
-            settings: Mapping[str, bool],
-            query_hints: Mapping[str, Any],
+            query_hints: QueryHints,
     ) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -35,7 +35,8 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
             query: Query,
             extension_data: ExtensionData,
             settings: Mapping[str, bool],
-            request_state: Mapping[str, Any]
+            query_hints: Mapping[str, Any],
+            stats: Mapping[str, Any]
     ) -> None:
         from_date, to_date = self.get_time_limit(extension_data)
         query.add_conditions([

--- a/snuba/request.py
+++ b/snuba/request.py
@@ -17,7 +17,7 @@ from snuba.schemas import Schema, validate_jsonschema
 class Request:
     query: Query
     settings: Mapping[str, bool]  # settings provided by the request
-    state: Mapping[str, Any]  # intermediate state
+    state: Mapping[str, Any]  # intermediate state; used to pass state from query processors to clickhouse query
     extensions: Mapping[str, Mapping[str, Any]]
 
     @property

--- a/snuba/request.py
+++ b/snuba/request.py
@@ -90,9 +90,15 @@ class RequestSchema:
         for extension_name, extension_schema in self.__extension_schemas.items():
             extensions[extension_name] = {key: value.pop(key) for key in extension_schema['properties'].keys() if key in value}
 
+        query = Query(query_body)
+        request_settings = RequestSettings(settings['turbo'], settings['consistent'], settings['debug'])
+
+        if request_settings.turbo and query.get_sample() is None:
+            query.set_sample(settings.TURBO_SAMPLE_RATE)
+
         return Request(
-            Query(query_body),
-            RequestSettings(settings['turbo'], settings['consistent'], settings['debug']),
+            query,
+            request_settings,
             extensions
         )
 

--- a/snuba/request.py
+++ b/snuba/request.py
@@ -16,7 +16,7 @@ from snuba.schemas import Schema, validate_jsonschema
 @dataclass(frozen=True)
 class Request:
     query: Query
-    settings: Mapping[str, str]
+    settings: Mapping[str, bool]
     extensions: Mapping[str, Mapping[str, Any]]
 
     @property

--- a/snuba/request.py
+++ b/snuba/request.py
@@ -16,7 +16,8 @@ from snuba.schemas import Schema, validate_jsonschema
 @dataclass(frozen=True)
 class Request:
     query: Query
-    settings: Mapping[str, bool]
+    settings: Mapping[str, bool]  # settings provided by the request
+    state: Mapping[str, Any]  # intermediate state
     extensions: Mapping[str, Mapping[str, Any]]
 
     @property
@@ -77,7 +78,7 @@ class RequestSchema:
         for extension_name, extension_schema in self.__extension_schemas.items():
             extensions[extension_name] = {key: value.pop(key) for key in extension_schema['properties'].keys() if key in value}
 
-        return Request(Query(query_body), settings, extensions)
+        return Request(Query(query_body), settings, {}, extensions)
 
     def __generate_template_impl(self, schema) -> Any:
         """

--- a/snuba/request.py
+++ b/snuba/request.py
@@ -17,7 +17,6 @@ from snuba.schemas import Schema, validate_jsonschema
 class Request:
     query: Query
     settings: Mapping[str, bool]  # settings provided by the request
-    state: Mapping[str, Any]  # intermediate state; used to pass state from query processors to clickhouse query
     extensions: Mapping[str, Mapping[str, Any]]
 
     @property
@@ -78,7 +77,7 @@ class RequestSchema:
         for extension_name, extension_schema in self.__extension_schemas.items():
             extensions[extension_name] = {key: value.pop(key) for key in extension_schema['properties'].keys() if key in value}
 
-        return Request(Query(query_body), settings, {}, extensions)
+        return Request(Query(query_body), settings, extensions)
 
     def __generate_template_impl(self, schema) -> Any:
         """

--- a/snuba/request.py
+++ b/snuba/request.py
@@ -9,13 +9,14 @@ from typing import Any, Mapping
 
 from snuba.query.extensions import QueryExtension
 from snuba.query.query import Query
-from snuba.query.schema import GENERIC_QUERY_SCHEMA
+from snuba.query.schema import GENERIC_QUERY_SCHEMA, QUERY_SETTINGS_SCHEMA
 from snuba.schemas import Schema, validate_jsonschema
 
 
 @dataclass(frozen=True)
 class Request:
     query: Query
+    query_settings: Mapping[str, str]
     extensions: Mapping[str, Mapping[str, Any]]
 
     @property
@@ -27,8 +28,9 @@ class Request:
 
 
 class RequestSchema:
-    def __init__(self, query_schema: Schema, extensions_schemas: Mapping[str, Schema]):
+    def __init__(self, query_schema: Schema, query_settings_schema: Schema, extensions_schemas: Mapping[str, Schema]):
         self.__query_schema = query_schema
+        self.__query_settings_schema = query_settings_schema
         self.__extension_schemas = extensions_schemas
 
         self.__composite_schema = {
@@ -39,7 +41,7 @@ class RequestSchema:
             'additionalProperties': False,
         }
 
-        for schema in itertools.chain([self.__query_schema], self.__extension_schemas.values()):
+        for schema in itertools.chain([self.__query_schema, self.__query_settings_schema], self.__extension_schemas.values()):
             assert schema['type'] == 'object', 'subschema must be object'
             assert schema['additionalProperties'] is False, 'subschema must not allow additional properties'
             self.__composite_schema['required'].extend(schema.get('required', []))
@@ -57,23 +59,25 @@ class RequestSchema:
     @classmethod
     def build_with_extensions(cls, extensions: Mapping[str, QueryExtension]) -> RequestSchema:
         generic_schema = GENERIC_QUERY_SCHEMA
+        query_settings_schema = QUERY_SETTINGS_SCHEMA
         extensions_schemas = {
             extension_key: extension.get_schema()
             for extension_key, extension
             in extensions.items()
         }
-        return cls(generic_schema, extensions_schemas)
+        return cls(generic_schema, query_settings_schema, extensions_schemas)
 
     def validate(self, value) -> Request:
         value = validate_jsonschema(value, self.__composite_schema)
 
         query_body = {key: value.pop(key) for key in self.__query_schema['properties'].keys() if key in value}
+        query_settings = {key: value.pop(key) for key in self.__query_settings_schema['properties'].keys() if key in value}
 
         extensions = {}
         for extension_name, extension_schema in self.__extension_schemas.items():
             extensions[extension_name] = {key: value.pop(key) for key in extension_schema['properties'].keys() if key in value}
 
-        return Request(Query(query_body), extensions)
+        return Request(Query(query_body), query_settings, extensions)
 
     def __generate_template_impl(self, schema) -> Any:
         """

--- a/snuba/request/__init__.py
+++ b/snuba/request/__init__.py
@@ -8,8 +8,9 @@ from deprecation import deprecated
 from typing import Any, Mapping
 
 from snuba.query.extensions import QueryExtension
-from snuba.query.query import Query, QueryHints
+from snuba.query.query import Query
 from snuba.query.schema import GENERIC_QUERY_SCHEMA, SETTINGS_SCHEMA
+from snuba.request.request_settings import RequestSettings
 from snuba.schemas import Schema, validate_jsonschema
 
 
@@ -25,19 +26,6 @@ class Request:
         "use the specific accessor methods on the query object instead.")
     def body(self):
         return ChainMap(self.query.get_body(), *self.extensions.values())
-
-
-@dataclass(frozen=True)
-class RequestSettings:
-    turbo: bool
-    consistent: bool
-    debug: bool
-
-    def get_query_hints(self) -> QueryHints:
-        return QueryHints(
-            turbo=self.turbo,
-            final=False
-        )
 
 
 class RequestSchema:

--- a/snuba/request/__init__.py
+++ b/snuba/request/__init__.py
@@ -78,15 +78,9 @@ class RequestSchema:
         for extension_name, extension_schema in self.__extension_schemas.items():
             extensions[extension_name] = {key: value.pop(key) for key in extension_schema['properties'].keys() if key in value}
 
-        query = Query(query_body)
-        request_settings = RequestSettings(settings['turbo'], settings['consistent'], settings['debug'])
-
-        if request_settings.turbo and query.get_sample() is None:
-            query.set_sample(settings.TURBO_SAMPLE_RATE)
-
         return Request(
-            query,
-            request_settings,
+            Query(query_body),
+            RequestSettings(settings['turbo'], settings['consistent'], settings['debug']),
             extensions
         )
 

--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class RequestSettings:
+    turbo: bool
+    consistent: bool
+    debug: bool

--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass(frozen=True)
 class RequestSettings:
     turbo: bool

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -16,7 +16,6 @@ import time
 
 from snuba import settings, state
 from snuba.query.schema import CONDITION_OPERATORS, POSITIVE_OPERATORS
-from snuba.request import Request
 
 
 logger = logging.getLogger('snuba.util')
@@ -376,7 +375,7 @@ def escape_literal(value):
         raise ValueError(u'Do not know how to escape {} for SQL'.format(type(value)))
 
 
-def raw_query(request: Request, sql, client, timer, stats=None):
+def raw_query(request, sql, client, timer, stats=None):
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -453,7 +453,7 @@ def raw_query(request: Request, sql, client, timer, stats=None):
                         # Force query to use the first shard replica, which
                         # should have synchronously received any cluster writes
                         # before this query is run.
-                        consistent = request.extensions['performance'].get('consistent', False)
+                        consistent = request.query_settings.get('consistent', False)
                         stats['consistent'] = consistent
                         if consistent:
                             query_settings['load_balancing'] = 'in_order'
@@ -538,7 +538,7 @@ def raw_query(request: Request, sql, client, timer, stats=None):
 
     result['timing'] = timer
 
-    if settings.STATS_IN_RESPONSE or request.extensions['performance'].get('debug', False):
+    if settings.STATS_IN_RESPONSE or request.query_settings.get('debug', False):
         result['stats'] = stats
         result['sql'] = sql
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -17,7 +17,6 @@ import time
 from snuba import settings, state
 from snuba.query.schema import CONDITION_OPERATORS, POSITIVE_OPERATORS
 
-
 logger = logging.getLogger('snuba.util')
 
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -16,6 +16,7 @@ import time
 
 from snuba import settings, state
 from snuba.query.schema import CONDITION_OPERATORS, POSITIVE_OPERATORS
+from snuba.request import Request
 
 logger = logging.getLogger('snuba.util')
 
@@ -374,7 +375,7 @@ def escape_literal(value):
         raise ValueError(u'Do not know how to escape {} for SQL'.format(type(value)))
 
 
-def raw_query(request, sql, client, timer, stats=None):
+def raw_query(request: Request, sql, client, timer, stats=None):
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -453,7 +453,7 @@ def raw_query(request: Request, sql, client, timer, stats=None):
                         # Force query to use the first shard replica, which
                         # should have synchronously received any cluster writes
                         # before this query is run.
-                        consistent = request.query_settings.get('consistent', False)
+                        consistent = request.settings.get('consistent', False)
                         stats['consistent'] = consistent
                         if consistent:
                             query_settings['load_balancing'] = 'in_order'
@@ -538,7 +538,7 @@ def raw_query(request: Request, sql, client, timer, stats=None):
 
     result['timing'] = timer
 
-    if settings.STATS_IN_RESPONSE or request.query_settings.get('debug', False):
+    if settings.STATS_IN_RESPONSE or request.settings.get('debug', False):
         result['stats'] = stats
         result['sql'] = sql
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -452,7 +452,7 @@ def raw_query(request: Request, sql, client, timer, stats=None):
                         # Force query to use the first shard replica, which
                         # should have synchronously received any cluster writes
                         # before this query is run.
-                        consistent = request.settings.get('consistent', False)
+                        consistent = request.settings.consistent
                         stats['consistent'] = consistent
                         if consistent:
                             query_settings['load_balancing'] = 'in_order'
@@ -537,7 +537,7 @@ def raw_query(request: Request, sql, client, timer, stats=None):
 
     result['timing'] = timer
 
-    if settings.STATS_IN_RESPONSE or request.settings.get('debug', False):
+    if settings.STATS_IN_RESPONSE or request.settings.debug:
         result['stats'] = stats
         result['sql'] = sql
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -157,14 +157,14 @@ class BaseTest(object):
             for statement in self.dataset.get_dataset_schemas().get_create_statements():
                 self.clickhouse.execute(statement)
 
-            redis_client.flushdb()
+        redis_client.flushdb()
 
     def teardown_method(self, test_method):
         if self.dataset_name:
             for statement in self.dataset.get_dataset_schemas().get_drop_statements():
                 self.clickhouse.execute(statement)
 
-            redis_client.flushdb()
+        redis_client.flushdb()
 
 
 class BaseDatasetTest(BaseTest):

--- a/tests/clickhouse/test_query.py
+++ b/tests/clickhouse/test_query.py
@@ -1,0 +1,62 @@
+from base import BaseEventsTest
+from mock import patch
+
+from snuba.clickhouse.query import ClickhouseQuery
+from snuba.query.query import Query
+from snuba.request import Request, RequestSettings
+
+
+class TestClickhouseQuery(BaseEventsTest):
+    def test_provided_sample_should_be_used(self):
+        query = Query({
+            "conditions": [],
+            "aggregations": [],
+            "groupby": [],
+            "sample": 0.1
+        })
+        request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
+        request = Request(query=query, settings=request_settings, extensions={})
+
+        clickhouse_query = ClickhouseQuery(dataset=self.dataset, request=request, prewhere_conditions=[])
+
+        assert 'SAMPLE 0.1' in clickhouse_query.format()
+
+    def test_provided_sample_should_be_used_with_turbo(self):
+        query = Query({
+            "conditions": [],
+            "aggregations": [],
+            "groupby": [],
+            "sample": 0.1
+        })
+        request_settings = RequestSettings(turbo=True, consistent=False, debug=False)
+        request = Request(query=query, settings=request_settings, extensions={})
+        clickhouse_query = ClickhouseQuery(dataset=self.dataset, request=request, prewhere_conditions=[])
+
+        assert 'SAMPLE 0.1' in clickhouse_query.format()
+
+    @patch("snuba.settings.TURBO_SAMPLE_RATE", 0.2)
+    def test_when_sample_is_not_provided_with_turbo(self):
+        query = Query({
+            "conditions": [],
+            "aggregations": [],
+            "groupby": [],
+        })
+        request_settings = RequestSettings(turbo=True, consistent=False, debug=False)
+
+        request = Request(query=query, settings=request_settings, extensions={})
+        clickhouse_query = ClickhouseQuery(dataset=self.dataset, request=request, prewhere_conditions=[])
+
+        assert "SAMPLE 0.2" in clickhouse_query.format()
+
+    def test_when_sample_is_not_provided_without_turbo(self):
+        query = Query({
+            "conditions": [],
+            "aggregations": [],
+            "groupby": [],
+        })
+        request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
+
+        request = Request(query=query, settings=request_settings, extensions={})
+        clickhouse_query = ClickhouseQuery(dataset=self.dataset, request=request, prewhere_conditions=[])
+
+        assert 'SAMPLE' not in clickhouse_query.format()

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -1,14 +1,11 @@
-from base import BaseTest
-
 import pytest
 from typing import Sequence
 
-from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsExtension
+from base import BaseTest
+from snuba import replacer, state
+from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor, ProjectWithGroupsProcessor
 from snuba.query.query import Query, Condition, QueryHints
 from snuba.schemas import validate_jsonschema
-from snuba import replacer, state
-from snuba.redis import redis_client
-
 
 project_extension_test_data = [
     (
@@ -32,7 +29,9 @@ project_extension_test_data = [
 
 @pytest.mark.parametrize("raw_data, expected_conditions", project_extension_test_data)
 def test_project_extension_query_processing(raw_data: dict, expected_conditions: Sequence[Condition]):
-    extension = ProjectExtension()
+    extension = ProjectExtension(
+        processor=ProjectExtensionProcessor()
+    )
     valid_data = validate_jsonschema(raw_data, extension.get_schema())
     query = Query({
         "conditions": []
@@ -48,7 +47,9 @@ class TestProjectExtensionWithGroups(BaseTest):
         super().setup_method(test_method)
         raw_data = {'project': 2}
         
-        self.extension = ProjectWithGroupsExtension()
+        self.extension = ProjectExtension(
+            processor=ProjectWithGroupsProcessor()
+        )
         self.valid_data = validate_jsonschema(raw_data, self.extension.get_schema())
         self.query = Query({
             "conditions": []

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -1,0 +1,101 @@
+from base import BaseTest
+
+import pytest
+from typing import Sequence
+
+from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsExtension
+from snuba.query.query import Query, Condition, QueryHints
+from snuba.schemas import validate_jsonschema
+from snuba import replacer, state
+from snuba.redis import redis_client
+
+
+project_extension_test_data = [
+    (
+        {
+            'project': 2
+        },
+        [
+            ('project_id', 'IN', [2])
+        ]
+    ),
+    (
+        {
+            'project': [2, 3]
+        },
+        [
+            ('project_id', 'IN', [2, 3])
+        ]
+    )
+]
+
+
+@pytest.mark.parametrize("raw_data, expected_conditions", project_extension_test_data)
+def test_project_extension_query_processing(raw_data: dict, expected_conditions: Sequence[Condition]):
+    extension = ProjectExtension()
+    valid_data = validate_jsonschema(raw_data, extension.get_schema())
+    query = Query({
+        "conditions": []
+    })
+    query_hints = QueryHints(turbo=False, final=False)
+
+    extension.get_processor().process_query(query, valid_data, query_hints)
+    assert query.get_conditions() == expected_conditions
+
+
+class TestProjectExtensionWithGroups(BaseTest):
+    def setup_method(self, test_method):
+        super().setup_method(test_method)
+        raw_data = {'project': 2}
+        
+        self.extension = ProjectWithGroupsExtension()
+        self.valid_data = validate_jsonschema(raw_data, self.extension.get_schema())
+        self.query = Query({
+            "conditions": []
+        })
+
+    def test_with_turbo(self):
+        query_hints = QueryHints(turbo=True, final=False)
+
+        self.extension.get_processor().process_query(self.query, self.valid_data, query_hints)
+        assert self.query.get_conditions() == [('project_id', 'IN', [2])]
+
+    def test_without_turbo_with_projects_needing_final(self):
+        query_hints = QueryHints(turbo=False, final=False)
+        replacer.set_project_needs_final(2)
+
+        self.extension.get_processor().process_query(self.query, self.valid_data, query_hints)
+        assert self.query.get_conditions() == [('project_id', 'IN', [2])]
+        assert query_hints.final
+
+    def test_without_turbo_without_projects_needing_final(self):
+        query_hints = QueryHints(turbo=False, final=False)
+
+        self.extension.get_processor().process_query(self.query, self.valid_data, query_hints)
+        assert self.query.get_conditions() == [('project_id', 'IN', [2])]
+        assert not query_hints.final
+
+    def test_when_there_are_not_many_groups_to_exclude(self):
+        query_hints = QueryHints(turbo=False, final=False)
+        state.set_config('max_group_ids_exclude', 5)
+        replacer.set_project_exclude_groups(2, [100, 101, 102])
+
+        self.extension.get_processor().process_query(self.query, self.valid_data, query_hints)
+
+        expected = [
+            ('project_id', 'IN', [2]),
+            (['assumeNotNull', ['group_id']], 'NOT IN', [100, 101, 102])
+        ]
+
+        assert self.query.get_conditions() == expected
+        assert not query_hints.final
+
+    def test_when_there_are_too_many_groups_to_exclude(self):
+        query_hints = QueryHints(turbo=False, final=False)
+        state.set_config('max_group_ids_exclude', 2)
+        replacer.set_project_exclude_groups(2, [100, 101, 102])
+
+        self.extension.get_processor().process_query(self.query, self.valid_data, query_hints)
+
+        assert self.query.get_conditions() == [('project_id', 'IN', [2])]
+        assert query_hints.final

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from snuba import state
 from snuba.query.timeseries import TimeSeriesExtension
-from snuba.query.query import Query, Condition
+from snuba.query.query import Query, Condition, QueryHints
 from snuba.schemas import validate_jsonschema
 
 
@@ -57,6 +57,7 @@ def test_query_extension_processing(raw_data: dict, expected_conditions: Sequenc
     query = Query({
         "conditions": []
     })
+    query_hints = QueryHints(turbo=False, final=False)
 
-    extension.get_processor().process_query(query, valid_data, {}, {})
+    extension.get_processor().process_query(query, valid_data, query_hints)
     assert query.get_conditions() == expected_conditions

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -58,5 +58,5 @@ def test_query_extension_processing(raw_data: dict, expected_conditions: Sequenc
         "conditions": []
     })
 
-    extension.get_processor().process_query(query, valid_data, {}, {}, {})
+    extension.get_processor().process_query(query, valid_data, {}, {})
     assert query.get_conditions() == expected_conditions

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -58,5 +58,5 @@ def test_query_extension_processing(raw_data: dict, expected_conditions: Sequenc
         "conditions": []
     })
 
-    extension.get_processor().process_query(query, valid_data, {})
+    extension.get_processor().process_query(query, valid_data, {}, {})
     assert query.get_conditions() == expected_conditions

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -4,7 +4,8 @@ from typing import Sequence
 
 from snuba import state
 from snuba.query.timeseries import TimeSeriesExtension
-from snuba.query.query import Query, Condition, QueryHints
+from snuba.query.query import Query, Condition
+from snuba.request.request_settings import RequestSettings
 from snuba.schemas import validate_jsonschema
 
 
@@ -57,7 +58,8 @@ def test_query_extension_processing(raw_data: dict, expected_conditions: Sequenc
     query = Query({
         "conditions": []
     })
-    query_hints = QueryHints(turbo=False, final=False)
 
-    extension.get_processor().process_query(query, valid_data, query_hints)
+    request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
+
+    extension.get_processor().process_query(query, valid_data, request_settings)
     assert query.get_conditions() == expected_conditions

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -58,5 +58,5 @@ def test_query_extension_processing(raw_data: dict, expected_conditions: Sequenc
         "conditions": []
     })
 
-    extension.get_processor().process_query(query, valid_data, {}, {})
+    extension.get_processor().process_query(query, valid_data, {}, {}, {})
     assert query.get_conditions() == expected_conditions

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -58,5 +58,5 @@ def test_query_extension_processing(raw_data: dict, expected_conditions: Sequenc
         "conditions": []
     })
 
-    extension.get_processor().process_query(query, valid_data)
+    extension.get_processor().process_query(query, valid_data, {})
     assert query.get_conditions() == expected_conditions


### PR DESCRIPTION
The performance processor would have to depend on the project processor (see number 2 [here](https://github.com/getsentry/snuba/pull/456#discussion_r323309038)).

So, instead, move the performance logic into query settings.