### PR TITLE
feat(datasets) Support timeseries extension. Lite Edition.

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -270,52 +270,52 @@ def parse_and_run_query(dataset, request: Request, timer):
     # NOTE: we rely entirely on the schema to make sure that regular snuba
     # queries are required to send a project_id filter. Some other special
     # internal query types do not require a project_id filter.
-    project_ids=util.to_list(request.extensions['project']['project'])
+    project_ids = util.to_list(request.extensions['project']['project'])
     if project_ids:
         request.query['conditions'].append(('project_id', 'IN', project_ids))
 
-    turbo=request.extensions['performance'].get('turbo', False)
+    turbo = request.extensions['performance'].get('turbo', False)
     if not turbo:
-        final, exclude_group_ids=get_projects_query_flags(project_ids)
+        final, exclude_group_ids = get_projects_query_flags(project_ids)
         if not final and exclude_group_ids:
             # If the number of groups to exclude exceeds our limit, the query
             # should just use final instead of the exclusion set.
-            max_group_ids_exclude=state.get_config('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE)
+            max_group_ids_exclude = state.get_config('max_group_ids_exclude', settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE)
             if len(exclude_group_ids) > max_group_ids_exclude:
-                final=True
+                final = True
             else:
                 request.query['conditions'].append((['assumeNotNull', ['group_id']], 'NOT IN', exclude_group_ids))
     else:
-        final=False
+        final = False
         if 'sample' not in request.query:
-            request.query['sample']=settings.TURBO_SAMPLE_RATE
+            request.query['sample'] = settings.TURBO_SAMPLE_RATE
 
-    prewhere_conditions=[]
+    prewhere_conditions = []
     # Add any condition to PREWHERE if:
     # - It is a single top-level condition (not OR-nested), and
     # - Any of its referenced columns are in dataset.get_prewhere_keys()
-    prewhere_candidates=[
+    prewhere_candidates = [
         (util.columns_in_expr(cond[0]), cond)
         for cond in request.query['conditions'] if util.is_condition(cond) and
         any(col in dataset.get_prewhere_keys() for col in util.columns_in_expr(cond[0]))
     ]
     # Use the condition that has the highest priority (based on the
     # position of its columns in the prewhere keys list)
-    prewhere_candidates=sorted([
+    prewhere_candidates = sorted([
         (min(dataset.get_prewhere_keys().index(col) for col in cols if col in dataset.get_prewhere_keys()), cond)
         for cols, cond in prewhere_candidates
     ], key=lambda priority_and_col: priority_and_col[0])
     if prewhere_candidates:
-        prewhere_conditions=[cond for _, cond in prewhere_candidates][:settings.MAX_PREWHERE_CONDITIONS]
-        request.query['conditions']=list(filter(lambda cond: cond not in prewhere_conditions, request.query['conditions']))
+        prewhere_conditions = [cond for _, cond in prewhere_candidates][:settings.MAX_PREWHERE_CONDITIONS]
+        request.query['conditions'] = list(filter(lambda cond: cond not in prewhere_conditions, request.query['conditions']))
 
-    table=dataset.get_dataset_schemas().get_read_schema().get_table_name()
+    table = dataset.get_dataset_schemas().get_read_schema().get_table_name()
     # TODO: consider moving the performance logic and the pre_where generation into
     # ClickhouseQuery since they are Clickhouse specific
-    sql=ClickhouseQuery(dataset, request, prewhere_conditions, final).format()
+    sql = ClickhouseQuery(dataset, request, prewhere_conditions, final).format()
     timer.mark('prepare_query')
 
-    stats={
+    stats = {
         'clickhouse_table': table,
         'final': final,
         'referrer': http_request.referrer,
@@ -333,7 +333,7 @@ def parse_and_run_query(dataset, request: Request, timer):
 @application.route('/internal/sdk-stats', methods=['POST'])
 @util.time_request('sdk-stats')
 def sdk_distribution(*, timer: Timer):
-    request=validate_request_content(
+    request = validate_request_content(
         parse_request_body(http_request),
         RequestSchema(
             SDK_STATS_BASE_SCHEMA,
@@ -342,19 +342,19 @@ def sdk_distribution(*, timer: Timer):
         timer,
     )
 
-    request.query['aggregations']=[
+    request.query['aggregations'] = [
         ['uniq', 'project_id', 'projects'],
         ['count()', None, 'count'],
     ]
     request.query['groupby'].extend(['sdk_name', 'rtime'])
-    request.extensions['project']={
+    request.extensions['project'] = {
         'project': [],
     }
 
-    dataset=get_dataset('events')
+    dataset = get_dataset('events')
     ensure_table_exists(dataset)
 
-    result, status=parse_and_run_query(dataset, request, timer)
+    result, status = parse_and_run_query(dataset, request, timer)
     return (
         json.dumps(
             result,
@@ -384,7 +384,7 @@ if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
 
-    _ensured={}
+    _ensured = {}
 
     def ensure_table_exists(dataset, force=False):
         if not force and _ensured.get(dataset, False):
@@ -402,18 +402,18 @@ if application.debug or application.testing:
 
         migrate.run(clickhouse_rw, dataset)
 
-        _ensured[dataset]=True
+        _ensured[dataset] = True
 
     @application.route('/tests/<dataset_name>/insert', methods=['POST'])
     def write(dataset_name):
         from snuba.processor import MessageProcessor
 
-        dataset=get_dataset(dataset_name)
+        dataset = get_dataset(dataset_name)
         ensure_table_exists(dataset)
 
-        rows=[]
+        rows = []
         for message in json.loads(http_request.data):
-            action, row=dataset.get_processor().process_message(message)
+            action, row = dataset.get_processor().process_message(message)
             assert action is MessageProcessor.INSERT
             rows.append(row)
 
@@ -423,17 +423,17 @@ if application.debug or application.testing:
 
     @application.route('/tests/<dataset_name>/eventstream', methods=['POST'])
     def eventstream(dataset_name):
-        dataset=get_dataset(dataset_name)
+        dataset = get_dataset(dataset_name)
         ensure_table_exists(dataset)
-        record=json.loads(http_request.data)
+        record = json.loads(http_request.data)
 
-        version=record[0]
+        version = record[0]
         if version != 2:
             raise RuntimeError("Unsupported protocol version: %s" % record)
 
         class Message(object):
             def __init__(self, value):
-                self._value=value
+                self._value = value
 
             def value(self):
                 return self._value
@@ -444,26 +444,26 @@ if application.debug or application.testing:
             def offset(self):
                 return None
 
-        message=Message(http_request.data)
+        message = Message(http_request.data)
 
-        type_=record[1]
+        type_ = record[1]
         if type_ == 'insert':
             from snuba.consumer import ConsumerWorker
-            worker=ConsumerWorker(dataset, producer=None, replacements_topic=None)
+            worker = ConsumerWorker(dataset, producer=None, replacements_topic=None)
         else:
             from snuba.replacer import ReplacerWorker
-            worker=ReplacerWorker(clickhouse_rw, dataset)
+            worker = ReplacerWorker(clickhouse_rw, dataset)
 
-        processed=worker.process_message(message)
+        processed = worker.process_message(message)
         if processed is not None:
-            batch=[processed]
+            batch = [processed]
             worker.flush_batch(batch)
 
         return ('ok', 200, {'Content-Type': 'text/plain'})
 
     @application.route('/tests/<dataset_name>/drop', methods=['POST'])
     def drop(dataset_name):
-        dataset=get_dataset(dataset_name)
+        dataset = get_dataset(dataset_name)
         for statement in dataset.get_dataset_schemas().get_drop_statements():
             clickhouse_rw.execute(statement)
 

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -7,7 +7,7 @@ from clickhouse_driver import Client, errors
 
 from snuba import settings
 from snuba.clickhouse.columns import Array
-from snuba.reader import Reader, Result, transform_date_columns
+from snuba.reader import Reader, Result, transform_columns
 from snuba.writer import BatchWriter, WriterTableRow
 
 
@@ -149,7 +149,7 @@ class NativeDriverReader(Reader):
         else:
             result = {"data": data, "meta": meta}
 
-        return transform_date_columns(result)
+        return transform_columns(result)
 
     def execute(
         self,

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -207,6 +207,7 @@ class EventsDataset(TimeSeriesDataset):
                 'time': 'timestamp',
                 'rtime': 'received'
             },
+            timestamp_column='timestamp',
         )
 
         self.__metadata_columns = metadata_columns

--- a/snuba/datasets/schema.py
+++ b/snuba/datasets/schema.py
@@ -21,7 +21,7 @@ class Schema(object):
 
         self.__local_table_name = local_table_name
         self.__dist_table_name = dist_table_name
-        self.__migration_function = migration_function if migration_function else lambda schema: []
+        self.__migration_function = migration_function if migration_function else lambda table, schema: []
 
     def _make_test_table(self, table_name):
         return table_name if not settings.TESTING else "%s%s" % (self.TEST_TABLE_PREFIX, table_name)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -93,8 +93,8 @@ class TransactionsDataset(TimeSeriesDataset):
             processor=TransactionsMessageProcessor(),
             default_topic="events",
             time_group_columns={
-                'start_ts': 'start_ts',
-                'end_ts': 'end_ts',
+                'bucketed_start': 'start_ts',
+                'bucketed_end': 'end_ts',
             },
             timestamp_column='start_ts',
         )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -93,6 +93,8 @@ class TransactionsDataset(TimeSeriesDataset):
             processor=TransactionsMessageProcessor(),
             default_topic="events",
             time_group_columns={
+                'start_ts': 'start_ts',
+                'end_ts': 'end_ts',
             },
             timestamp_column='start_ts',
         )

--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -39,11 +39,15 @@ class Reader(ABC):
 DATE_TYPE_RE = re.compile(r"(Nullable\()?Date\b")
 DATETIME_TYPE_RE = re.compile(r"(Nullable\()?DateTime\b")
 
+UUID_TYPE_RE = re.compile(r"(Nullable\()?UUID\b")
 
-def transform_date_columns(result: Result) -> Result:
+
+def transform_columns(result: Result) -> Result:
     """
-    Converts timezone-naive date and datetime values returned by ClickHouse
-    into ISO 8601 formatted strings (including the UTC offset.)
+    Converts Clickhouse results into formatted strings. Specifically:
+    - timezone-naive date and datetime values returned by ClickHouse
+       into ISO 8601 formatted strings (including the UTC offset.)
+    - UUID objects into strings
     """
 
     def iterate_rows():
@@ -65,5 +69,8 @@ def transform_date_columns(result: Result) -> Result:
                     .replace(tzinfo=tz.tzutc())
                     .isoformat()
                 )
+        elif UUID_TYPE_RE.match(col["type"]):
+            for row in iterate_rows():
+                row[col["name"]] = str(row[col["name"]])
 
     return result

--- a/snuba/state.py
+++ b/snuba/state.py
@@ -279,8 +279,6 @@ def get_config_changes():
 def safe_dumps_default(value: Any) -> Any:
     if isinstance(value, Mapping):
         return {**value}
-    elif isinstance(value, uuid.UUID):
-        return str(value)
     raise TypeError(f'Cannot convert object of type {type(value).__name__} to JSON-safe type')
 
 
@@ -333,4 +331,4 @@ def get_result(query_id):
 def set_result(query_id, result):
     timeout = get_config('cache_expiry_sec', 1)
     key = '{}{}'.format(query_cache_prefix, query_id)
-    return rds.set(key, safe_dumps(result), ex=timeout)
+    return rds.set(key, json.dumps(result), ex=timeout)


### PR DESCRIPTION
The professional edition is in #456 .

This is the shortest possible path to support the Transaciotns dataset. 
1) turn the transactions dataset into a TimeseriesDataset (which should be)
2) support the proper deserialization of UUID
3) move the timeseries extension related logic outside of api.py
4) add a temporary method to the dataset to process extensions.