### PR TITLE
fix(datasets): Do not run by mistake events migrations on the other datasets

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -399,7 +399,6 @@ if application.debug or application.testing:
         assert local_dataset_mode(), "Cannot create table in distributed mode"
 
         from snuba import migrate
-        migrate.rename_dev_table(clickhouse_rw)
 
         # We cannot build distributed tables this way. So this only works in local
         # mode.

--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -76,10 +76,6 @@ def bootstrap(bootstrap_server, kafka, force):
     # Need to better figure out if we are configured to use replicated
     # tables or distributed tables, etc.
 
-    # Migrate from the old table to the new one if needed
-    from snuba import migrate
-    migrate.rename_dev_table(ClickhousePool())
-
     # Create the tables for every dataset.
     for name in DATASET_NAMES:
         dataset = get_dataset(name)

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -34,7 +34,7 @@ from snuba.util import (
 NESTED_COL_EXPR_RE = re.compile(r'^(tags|contexts)\[([a-zA-Z0-9_\.:-]+)\]$')
 
 
-def events_migraitons(clickhouse_table: str, current_schema: Mapping[str, str]) -> Sequence[str]:
+def events_migrations(clickhouse_table: str, current_schema: Mapping[str, str]) -> Sequence[str]:
     # Add/remove known migrations
     ret = []
     if 'group_id' not in current_schema:
@@ -221,7 +221,7 @@ class EventsDataset(TimeSeriesDataset):
             partition_by='(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))',
             version_column='deleted',
             sample_expr=sample_expr,
-            migration_function=events_migraitons)
+            migration_function=events_migrations)
 
         dataset_schemas = DatasetSchemas(
             read_schema=schema,

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -19,7 +19,7 @@ def _run_schema(conn, schema):
 
     migrations = schema.get_migration_statements()(clickhouse_table, local_schema)
     for statement in migrations:
-        logger.info(f"Executing migraiton: {statement}")
+        logger.info(f"Executing migration: {statement}")
         conn.execute(statement)
 
     # Refresh after alters


### PR DESCRIPTION
Running a query (in a development environment) on a dataset other than events still runs the migraitons hardcoded for events. This breaks the table definition for anything other than events.
This moves the migration statement generation into the schema, so that they will be executed only for the dataset that defines them.
I think we should get rid of this concept of migration entirely.