### PR TITLE
fix(transactions) Fix incorrect column reference

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -94,7 +94,7 @@ class TransactionsDataset(TimeSeriesDataset):
             default_topic="events",
             time_group_columns={
                 'bucketed_start': 'start_ts',
-                'bucketed_end': 'end_ts',
+                'bucketed_end': 'finish_ts',
             },
             timestamp_column='start_ts',
         )


### PR DESCRIPTION
There is no `end_ts` column. There is a `finish_ts` column though.