### PR TITLE
feat(apm): insert_allow_materialized_columns to query options for transaction INSERT

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, MutableMapping, Optional, Sequence
 
 from snuba.clickhouse.columns import (
     ColumnSet,
@@ -101,8 +101,8 @@ class TransactionsDataset(TimeSeriesDataset):
         )
 
     def __update_options(self,
-        options: Optional[Mapping[str, Any]]=None,
-    ) -> Mapping[str, Any]:
+        options: Optional[MutableMapping[str, Any]]=None,
+    ) -> MutableMapping[str, Any]:
         if options is None:
             options = {}
         if "insert_allow_materialized_columns" not in options:
@@ -110,7 +110,7 @@ class TransactionsDataset(TimeSeriesDataset):
         return options
 
     def get_writer(self,
-        options: Optional[Mapping[str, Any]]=None,
+        options: Optional[MutableMapping[str, Any]]=None,
         table_name: Optional[str]=None,
     ) -> BatchWriter:
         return super().get_writer(
@@ -119,7 +119,7 @@ class TransactionsDataset(TimeSeriesDataset):
         )
 
     def get_bulk_writer(self,
-        options: Optional[Mapping[str, Any]]=None,
+        options: Optional[MutableMapping[str, Any]]=None,
         table_name: Optional[str]=None,
     ) -> BatchWriter:
         return super().get_bulk_writer(

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from snuba.clickhouse.columns import (
     ColumnSet,
@@ -15,6 +15,7 @@ from snuba.clickhouse.columns import (
     UUID,
     WithDefault,
 )
+from snuba.clickhouse.http import BatchWriter
 from snuba.datasets import TimeSeriesDataset
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.schema import ReplacingMergeTreeSchema
@@ -97,6 +98,33 @@ class TransactionsDataset(TimeSeriesDataset):
                 'bucketed_end': 'finish_ts',
             },
             timestamp_column='start_ts',
+        )
+
+    def __update_options(self,
+        options: Optional[Mapping[str, Any]]=None,
+    ) -> Mapping[str, Any]:
+        if options is None:
+            options = {}
+        if "insert_allow_materialized_columns" not in options:
+            options["insert_allow_materialized_columns"] = 1
+        return options
+
+    def get_writer(self,
+        options: Optional[Mapping[str, Any]]=None,
+        table_name: Optional[str]=None,
+    ) -> BatchWriter:
+        return super().get_writer(
+            self.__update_options(options),
+            table_name,
+        )
+
+    def get_bulk_writer(self,
+        options: Optional[Mapping[str, Any]]=None,
+        table_name: Optional[str]=None,
+    ) -> BatchWriter:
+        return super().get_bulk_writer(
+            self.__update_options(options),
+            table_name,
         )
 
     def get_query_schema(self):


### PR DESCRIPTION
The insert_allow_materialized_columns option is needed to write materialized columns on distributed tables. Transactions is a distributed table with materialized columns.

> 2019-09-17 11:44:19,988 http://localhost:8123 "POST /?load_balancing=in_order&insert_distributed_sync=1&insert_allow_materialized_columns=1&query=INSERT+INTO+transactions_local+FORMAT+JSONEachRow HTTP/1.1" 200 None

In order to reduce the impact this now applies only to the transactions dataset. IF it turns out to work fine we can remove the special case.
