### PR TITLE
feat(cdc) Change MessageProcessor return type to support cdc updates to identity key

### DIFF
--- a/snuba/api.py
+++ b/snuba/api.py
@@ -415,7 +415,7 @@ if application.debug or application.testing:
 
     @application.route('/tests/<dataset_name>/insert', methods=['POST'])
     def write(dataset_name):
-        from snuba.processor import MessageProcessor
+        from snuba.processor import ProcessorAction
 
         dataset = get_dataset(dataset_name)
         ensure_table_exists(dataset)
@@ -426,7 +426,7 @@ if application.debug or application.testing:
                 .get_stream_loader() \
                 .get_processor() \
                 .process_message(message)
-            assert action is MessageProcessor.INSERT
+            assert action is ProcessorAction.INSERT
             rows.append(row)
 
         enforce_table_writer(dataset).get_writer().write(rows)

--- a/snuba/api.py
+++ b/snuba/api.py
@@ -422,12 +422,13 @@ if application.debug or application.testing:
 
         rows = []
         for message in json.loads(http_request.data):
-            action, row = enforce_table_writer(dataset) \
+            processed_message = enforce_table_writer(dataset) \
                 .get_stream_loader() \
                 .get_processor() \
                 .process_message(message)
-            assert action is ProcessorAction.INSERT
-            rows.append(row)
+            if processed_message:
+                assert processed_message.action is ProcessorAction.INSERT
+                rows.extend(processed_message.data)
 
         enforce_table_writer(dataset).get_writer().write(rows)
 

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -109,7 +109,7 @@ class CdcProcessor(MessageProcessor):
         if old_key != new_key:
             ret.extend(self._process_delete(offset, key))
 
-        ret.extend(self._message_row_class.from_wal(
+        ret.append(self._message_row_class.from_wal(
             offset,
             columnnames,
             columnvalues

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -114,15 +114,15 @@ class GroupedMessageProcessor(CdcProcessor):
     def _process_delete(self,
         offset: int,
         key: Mapping[str, Any],
-    ) -> Optional[WriterTableRow]:
+    ) -> Sequence[WriterTableRow]:
         key_names = key['keynames']
         key_values = key['keyvalues']
         project_id = key_values[key_names.index('project_id')]
         id = key_values[key_names.index('id')]
-        return GroupedMessageRow(
+        return [GroupedMessageRow(
             offset=offset,
             project_id=project_id,
             id=id,
             record_deleted=True,
             record_content=None
-        ).to_clickhouse()
+        ).to_clickhouse()]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 import uuid
 
 from snuba.clickhouse.columns import (
@@ -12,7 +13,7 @@ from snuba.clickhouse.columns import (
 )
 from snuba.datasets import Dataset
 from snuba.datasets.dataset_schemas import DatasetSchemas
-from snuba.processor import _ensure_valid_date, MessageProcessor, _unicodify
+from snuba.processor import _ensure_valid_date, MessageProcessor, ProcessorAction, ProcessedMessage, _unicodify
 from snuba.datasets.schemas.tables import MergeTreeSchema, SummingMergeTreeSchema, MaterializedViewSchema
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba import settings
@@ -25,7 +26,7 @@ READ_DIST_TABLE_NAME = 'outcomes_hourly_dist'
 
 
 class OutcomesProcessor(MessageProcessor):
-    def process_message(self, value, metadata):
+    def process_message(self, value, metadata) -> Optional[ProcessedMessage]:
         assert isinstance(value, dict)
         v_uuid = value.get('event_id')
         message = {
@@ -40,7 +41,10 @@ class OutcomesProcessor(MessageProcessor):
             'event_id': str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
         }
 
-        return (self.INSERT, message)
+        return ProcessedMessage(
+            action=ProcessorAction.INSERT,
+            data=[message],
+        )
 
 
 class OutcomesDataset(Dataset):

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 import ipaddress
 import uuid
@@ -6,6 +7,8 @@ import uuid
 from snuba.processor import (
     _as_dict_safe,
     MessageProcessor,
+    ProcessorAction,
+    ProcessedMessage,
     _ensure_valid_date,
     _ensure_valid_ip,
     _unicodify
@@ -34,8 +37,8 @@ class TransactionsMessageProcessor(MessageProcessor):
         milliseconds = int(timestamp.microsecond / 1000)
         return (timestamp, milliseconds)
 
-    def process_message(self, message, metadata=None):
-        action_type = self.INSERT
+    def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
+        action_type = ProcessorAction.INSERT
         processed = {'deleted': 0}
         if not (isinstance(message, (list, tuple)) and len(message) >= 2):
             return None
@@ -112,4 +115,7 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed['partition'] = metadata.partition
             processed['offset'] = metadata.offset
 
-        return (action_type, processed)
+        return ProcessedMessage(
+            action=action_type,
+            data=[processed],
+        )

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -1,9 +1,11 @@
 import ipaddress
-from datetime import datetime
 import re
+
+from datetime import datetime
+from enum import Enum
 from hashlib import md5
 import simplejson as json
-from typing import Any, Optional, Union
+from typing import Any, NamedTuple, Optional, Sequence, Union
 
 from snuba.util import force_bytes
 
@@ -11,16 +13,27 @@ HASH_RE = re.compile(r'^[0-9a-f]{32}$', re.IGNORECASE)
 MAX_UINT32 = 2 ** 32 - 1
 
 
+class ProcessorAction(Enum):
+    INSERT = 0
+    REPLACE = 1
+
+
+class ProcessedMessage(NamedTuple):
+    action: ProcessorAction
+    data: Sequence[Any]
+
+
 class MessageProcessor(object):
     """
     The Processor is responsible for converting an incoming message body from the
     event stream into a row or statement to be inserted or executed against clickhouse.
     """
-    # action types
-    INSERT = 0
-    REPLACE = 1
 
-    def process_message(self, message, metadata=None):
+    def process_message(
+        self,
+        message,
+        metadata=None,
+    ) -> Optional[ProcessedMessage]:
         raise NotImplementedError
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -210,7 +210,7 @@ class BaseEventsTest(BaseDatasetTest):
             if 'primary_hash' not in event:
                 event = wrap_raw_event(event)
             _, processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(event)
-            out.append(processed)
+            out.extend(processed)
 
         return self.write_processed_records(out)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -209,8 +209,11 @@ class BaseEventsTest(BaseDatasetTest):
         for event in events:
             if 'primary_hash' not in event:
                 event = wrap_raw_event(event)
-            _, processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(event)
-            out.extend(processed)
+            processed = enforce_table_writer(self.dataset) \
+                .get_stream_loader() \
+                .get_processor() \
+                .process_message(event)
+            out.extend(processed.data)
 
         return self.write_processed_records(out)
 

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -10,6 +10,7 @@ from snuba.datasets.factory import enforce_table_writer
 from snuba.processor import (
     InvalidMessageType,
     InvalidMessageVersion,
+    ProcessedMessage,
     ProcessorAction,
 )
 from snuba.datasets.events_processor import (
@@ -23,16 +24,16 @@ from snuba.datasets.events_processor import (
 
 class TestEventsProcessor(BaseEventsTest):
     def test_simple(self):
-        _, processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(self.event)
+        processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(self.event)
 
         for field in ('event_id', 'project_id', 'message', 'platform'):
-            assert processed[0][field] == self.event[field]
+            assert processed.data[0][field] == self.event[field]
 
     def test_simple_version_0(self):
-        _, processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message((0, 'insert', self.event))
+        processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message((0, 'insert', self.event))
 
         for field in ('event_id', 'project_id', 'message', 'platform'):
-            assert processed[0][field] == self.event[field]
+            assert processed.data[0][field] == self.event[field]
 
     def test_simple_version_1(self):
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
@@ -53,16 +54,16 @@ class TestEventsProcessor(BaseEventsTest):
     def test_unexpected_obj(self):
         self.event['message'] = {'what': 'why is this in the message'}
 
-        _, processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(self.event)
+        processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(self.event)
 
-        assert processed[0]['message'] == '{"what": "why is this in the message"}'
+        assert processed.data[0]['message'] == '{"what": "why is this in the message"}'
 
     def test_hash_invalid_primary_hash(self):
         self.event['primary_hash'] = b"'tinymce' \u063a\u064a\u0631 \u0645\u062d".decode('unicode-escape')
 
-        _, processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(self.event)
+        processed = enforce_table_writer(self.dataset).get_stream_loader().get_processor().process_message(self.event)
 
-        assert processed[0]['primary_hash'] == 'a52ccc1a61c2258e918b43b5aff50db1'
+        assert processed.data[0]['primary_hash'] == 'a52ccc1a61c2258e918b43b5aff50db1'
 
     def test_extract_required(self):
         now = datetime.utcnow()
@@ -175,56 +176,79 @@ class TestEventsProcessor(BaseEventsTest):
         message = (2, 'start_delete_groups', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_v2_end_delete_groups(self):
         project_id = 1
         message = (2, 'end_delete_groups', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_v2_start_merge(self):
         project_id = 1
         message = (2, 'start_merge', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)])
 
     def test_v2_end_merge(self):
         project_id = 1
         message = (2, 'end_merge', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_v2_start_unmerge(self):
         project_id = 1
         message = (2, 'start_unmerge', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_v2_end_unmerge(self):
         project_id = 1
         message = (2, 'end_unmerge', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_v2_start_delete_tag(self):
         project_id = 1
         message = (2, 'start_delete_tag', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_v2_end_delete_tag(self):
         project_id = 1
         message = (2, 'end_delete_tag', {'project_id': project_id})
         processor = enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         assert processor.process_message(message) == \
-            (ProcessorAction.REPLACE, [(str(project_id), message)])
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[(str(project_id), message)],
+        )
 
     def test_extract_sdk(self):
         sdk = {

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -9,6 +9,7 @@ import uuid
 
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.consumer import KafkaMessageMetadata
+from snuba.processor import ProcessorAction
 
 
 @dataclass
@@ -191,5 +192,5 @@ class TestTransactionsProcessor(BaseTest):
         processor = TransactionsMessageProcessor()
         ret = processor.process_message(message.serialize(), meta)
 
-        assert ret[0] == TransactionsMessageProcessor.INSERT
-        assert ret[1] == message.build_result(meta)
+        assert ret[0] == ProcessorAction.INSERT
+        assert ret[1] == [message.build_result(meta)]

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -192,5 +192,5 @@ class TestTransactionsProcessor(BaseTest):
         processor = TransactionsMessageProcessor()
         ret = processor.process_message(message.serialize(), meta)
 
-        assert ret[0] == ProcessorAction.INSERT
-        assert ret[1] == [message.build_result(meta)]
+        assert ret.action == ProcessorAction.INSERT
+        assert ret.data == [message.build_result(meta)]

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -8,7 +8,7 @@ from uuid import uuid1
 from base import FakeKafkaProducer, message as build_msg
 from snuba.consumers.snapshot_worker import SnapshotAwareWorker
 from snuba.datasets.factory import enforce_table_writer, get_dataset
-from snuba.processor import MessageProcessor
+from snuba.processor import ProcessorAction
 from snuba.stateful_consumer.control_protocol import TransactionData
 
 
@@ -61,15 +61,15 @@ class TestSnapshotWorker:
         (
             INSERT_MSG % {"xid": 120},
             (
-                MessageProcessor.INSERT,
-                PROCESSED,
+                ProcessorAction.INSERT,
+                [PROCESSED],
             )
         ),
         (
             INSERT_MSG % {"xid": 210},
             (
-                MessageProcessor.INSERT,
-                PROCESSED,
+                ProcessorAction.INSERT,
+                [PROCESSED],
             )
         )
     ]

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -2,13 +2,13 @@ import pytest
 import pytz
 
 from datetime import datetime
-from typing import Any, Mapping, Optional, Tuple
+from typing import Optional
 from uuid import uuid1
 
 from base import FakeKafkaProducer, message as build_msg
 from snuba.consumers.snapshot_worker import SnapshotAwareWorker
-from snuba.datasets.factory import enforce_table_writer, get_dataset
-from snuba.processor import ProcessorAction
+from snuba.datasets.factory import get_dataset
+from snuba.processor import ProcessorAction, ProcessedMessage
 from snuba.stateful_consumer.control_protocol import TransactionData
 
 
@@ -60,16 +60,16 @@ class TestSnapshotWorker:
         ),
         (
             INSERT_MSG % {"xid": 120},
-            (
-                ProcessorAction.INSERT,
-                [PROCESSED],
+            ProcessedMessage(
+                action=ProcessorAction.INSERT,
+                data=[PROCESSED],
             )
         ),
         (
             INSERT_MSG % {"xid": 210},
-            (
-                ProcessorAction.INSERT,
-                [PROCESSED],
+            ProcessedMessage(
+                action=ProcessorAction.INSERT,
+                data=[PROCESSED],
             )
         )
     ]
@@ -78,7 +78,7 @@ class TestSnapshotWorker:
     def test_send_message(
         self,
         message: bytes,
-        expected: Optional[Tuple[int, Mapping[str, Any]]],
+        expected: Optional[ProcessedMessage],
     ) -> None:
         dataset = get_dataset("groupedmessage")
         snapshot_id = uuid1()

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -16,6 +16,7 @@ from base import (
 
 from snuba.consumer import ConsumerWorker
 from snuba.datasets.factory import enforce_table_writer
+from snuba.processor import ProcessedMessage, ProcessorAction
 
 
 class TestConsumer(BaseEventsTest):
@@ -144,8 +145,14 @@ class TestConsumer(BaseEventsTest):
         test_worker = ConsumerWorker(self.dataset, producer, replacement_topic.topic_name)
 
         test_worker.flush_batch([
-            (enforce_table_writer(self.dataset).get_stream_loader().get_processor().REPLACE, ('1', {'project_id': 1})),
-            (enforce_table_writer(self.dataset).get_stream_loader().get_processor().REPLACE, ('2', {'project_id': 2})),
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[('1', {'project_id': 1})],
+            ),
+            ProcessedMessage(
+                action=ProcessorAction.REPLACE,
+                data=[('2', {'project_id': 2})],
+            ),
         ])
 
         assert [(m._topic, m._key, m._value) for m in producer.messages] == \

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -102,8 +102,8 @@ class TestGroupedMessage(BaseDatasetTest):
 
         insert_msg = json.loads(self.INSERT_MSG)
         ret = processor.process_message(insert_msg, metadata)
-        assert ret[1] == self.PROCESSED
-        self.write_processed_records(ret[1])
+        assert ret.data == [self.PROCESSED]
+        self.write_processed_records(ret.data)
         cp = ClickhousePool()
         ret = cp.execute("SELECT * FROM test_groupedmessage_local;")
         assert ret[0] == (
@@ -120,11 +120,11 @@ class TestGroupedMessage(BaseDatasetTest):
 
         update_msg = json.loads(self.UPDATE_MSG)
         ret = processor.process_message(update_msg, metadata)
-        assert ret[1] == self.PROCESSED
+        assert ret.data == [self.PROCESSED]
 
         delete_msg = json.loads(self.DELETE_MSG)
         ret = processor.process_message(delete_msg, metadata)
-        assert ret[1] == self.DELETED
+        assert ret.data == [self.DELETED]
 
     def test_bulk_load(self):
         row = GroupedMessageRow.from_bulk({


### PR DESCRIPTION
Turns out we have messages like this on the WAL from postgres:

```
{‘event’: ‘change’, ‘xid’: 3868207, ‘timestamp’: ‘2019-09-23 21:36:11.100383+00’, ‘kind’: ‘update’, ‘schema’: ‘public’, ‘table’: ‘sentry_groupasignee’, ‘columnnames’: [‘id’, ‘project_id’, ‘group_id’, ‘user_id’, ‘date_added’, ‘team_id’], ‘columntypes’: [‘bigint’, ‘bigint’, ‘bigint’, ‘integer’, ‘timestamp with time zone’, ‘bigint’], ‘columnvalues’: [34, 2, 1361, 3, ‘2019-09-19 00:02:01.442973+00’, None], ‘oldkeys’: {‘keynames’: [‘project_id’, ‘group_id’], ‘keytypes’: [‘bigint’, ‘bigint’], ‘keyvalues’: [2, 1384]}}
```

This is an update that changes value of the replica identity of a row. This is not supported by cdc in the way it works today. Though there is a way to make it work by turning the update into a DELETE  + INSERT, which is almost as consistent as the standard clickhouse update done through merge.

In order to make this work we need some refactoring allowing MessageProcessor to return a list of rows and not forcing a 1:1 relationship between Kafka messages and clickhouse rows.