### PR TITLE
feat(devserver) Run the transaction consumer in devserver mode

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -34,7 +34,7 @@ def devserver(bootstrap, workers):
         os.execvp(daemons[0][1][0], daemons[0][1])
 
     daemons += [
-        ('transaction-consumer', ['snuba', 'consumer', '--auto-offset-reset=latest', '--log-level=debug', '--dataset=transactions', '--consumer-group=g2']),
+        ('transaction-consumer', ['snuba', 'consumer', '--auto-offset-reset=latest', '--log-level=debug', '--dataset=transactions', '--consumer-group=transactions_group']),
         ('consumer', ['snuba', 'consumer', '--auto-offset-reset=latest', '--log-level=debug']),
         ('replacer', ['snuba', 'replacer', '--auto-offset-reset=latest', '--log-level=debug']),
     ]

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -34,6 +34,7 @@ def devserver(bootstrap, workers):
         os.execvp(daemons[0][1][0], daemons[0][1])
 
     daemons += [
+        ('transaction-consumer', ['snuba', 'consumer', '--auto-offset-reset=latest', '--log-level=debug', '--dataset=transactions', '--consumer-group=g2']),
         ('consumer', ['snuba', 'consumer', '--auto-offset-reset=latest', '--log-level=debug']),
         ('replacer', ['snuba', 'replacer', '--auto-offset-reset=latest', '--log-level=debug']),
     ]


### PR DESCRIPTION
Sentry will soon start querying the transactions dataset. Local developement will require the transactions consumer to be running for sentry to be useful.

Refs SEN-1037