### PR TITLE
feat(apm): Support tags in transactions dataset

### DIFF
--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -258,7 +258,7 @@ class EventsDataset(TimeSeriesDataset):
         ]
 
     def column_expr(self, column_name, body):
-        ret = self.__tags_processor._process_tags_expression(column_name, body)
+        ret = self.__tags_processor.process_tags_expression(column_name, body)
         if ret:
             return ret
         elif column_name == 'issue' or column_name == 'group_id':

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,9 +1,6 @@
-import re
-
 from datetime import timedelta
 from typing import Mapping, Sequence
 
-from snuba import state
 from snuba.clickhouse.columns import (
     Array,
     ColumnSet,
@@ -20,23 +17,13 @@ from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
+from snuba.datasets.tags_dataset import TagColumnProcessor
 from snuba.query.extensions import (
     PerformanceExtension,
     ProjectExtension,
     QueryExtension,
 )
 from snuba.query.timeseries import TimeSeriesExtension
-
-from snuba.util import (
-    alias_expr,
-    all_referenced_columns,
-    escape_literal,
-    string_col,
-)
-
-
-# A column name like "tags[url]"
-NESTED_COL_EXPR_RE = re.compile(r'^(tags|contexts)\[([a-zA-Z0-9_\.:-]+)\]$')
 
 
 def events_migrations(clickhouse_table: str, current_schema: Mapping[str, str]) -> Sequence[str]:
@@ -259,16 +246,21 @@ class EventsDataset(TimeSeriesDataset):
         self.__promoted_context_columns = promoted_context_columns
         self.__required_columns = required_columns
 
+        self.__tags_processor = TagColumnProcessor(
+            columns=all_columns,
+            promoted_columns=self._get_promoted_columns(),
+            column_tag_map=self._get_column_tag_map(),
+        )
+
     def default_conditions(self):
         return [
             ('deleted', '=', 0),
         ]
 
     def column_expr(self, column_name, body):
-        if NESTED_COL_EXPR_RE.match(column_name):
-            return self._tag_expr(column_name)
-        elif column_name in ['tags_key', 'tags_value']:
-            return self._tags_expr(column_name, body)
+        ret = self.__tags_processor._process_tags_expression(column_name, body)
+        if ret:
+            return ret
         elif column_name == 'issue' or column_name == 'group_id':
             return 'nullIf(group_id, 0)'
         elif column_name == 'message':
@@ -278,9 +270,6 @@ class EventsDataset(TimeSeriesDataset):
             return 'coalesce(search_message, message)'
         else:
             return super().column_expr(column_name, body)
-
-    def get_metadata_columns(self):
-        return self.__metadata_columns
 
     def get_promoted_tag_columns(self):
         return self.__promoted_tag_columns
@@ -325,72 +314,6 @@ class EventsDataset(TimeSeriesDataset):
             col: [self._get_column_tag_map()[col].get(x, x) for x in self._get_promoted_columns()[col]]
             for col in self._get_promoted_columns()
         }
-
-    def _tag_expr(self, column_name):
-        """
-        Return an expression for the value of a single named tag.
-
-        For tags/contexts, we expand the expression depending on whether the tag is
-        "promoted" to a top level column, or whether we have to look in the tags map.
-        """
-        col, tag = NESTED_COL_EXPR_RE.match(column_name).group(1, 2)
-
-        # For promoted tags, return the column name.
-        if col in self._get_promoted_columns():
-            actual_tag = self.get_tag_column_map()[col].get(tag, tag)
-            if actual_tag in self._get_promoted_columns()[col]:
-                return string_col(self, actual_tag)
-
-        # For the rest, return an expression that looks it up in the nested tags.
-        return u'{col}.value[indexOf({col}.key, {tag})]'.format(**{
-            'col': col,
-            'tag': escape_literal(tag)
-        })
-
-    def _tags_expr(self, column_name, body):
-        """
-        Return an expression that array-joins on tags to produce an output with one
-        row per tag.
-        """
-        assert column_name in ['tags_key', 'tags_value']
-        col, k_or_v = column_name.split('_', 1)
-        nested_tags_only = state.get_config('nested_tags_only', 1)
-
-        # Generate parallel lists of keys and values to arrayJoin on
-        if nested_tags_only:
-            key_list = '{}.key'.format(col)
-            val_list = '{}.value'.format(col)
-        else:
-            promoted = self._get_promoted_columns()[col]
-            col_map = self._get_column_tag_map()[col]
-            key_list = u'arrayConcat([{}], {}.key)'.format(
-                u', '.join(u'\'{}\''.format(col_map.get(p, p)) for p in promoted),
-                col
-            )
-            val_list = u'arrayConcat([{}], {}.value)'.format(
-                ', '.join(string_col(self, p) for p in promoted),
-                col
-            )
-
-        cols_used = all_referenced_columns(body) & set(['tags_key', 'tags_value'])
-        if len(cols_used) == 2:
-            # If we use both tags_key and tags_value in this query, arrayjoin
-            # on (key, value) tag tuples.
-            expr = (u'arrayJoin(arrayMap((x,y) -> [x,y], {}, {}))').format(
-                key_list,
-                val_list
-            )
-
-            # put the all_tags expression in the alias cache so we can use the alias
-            # to refer to it next time (eg. 'all_tags[1] AS tags_key'). instead of
-            # expanding the whole tags expression again.
-            expr = alias_expr(expr, 'all_tags', body)
-            return u'({})[{}]'.format(expr, 1 if k_or_v == 'key' else 2)
-        else:
-            # If we are only ever going to use one of tags_key or tags_value, don't
-            # bother creating the k/v tuples to arrayJoin on, or the all_tags alias
-            # to re-use as we won't need it.
-            return 'arrayJoin({})'.format(key_list if k_or_v == 'key' else val_list)
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -29,20 +29,20 @@ class TagColumnProcessor:
         # The ColumnSet of the dataset. Used to format promoted
         # columns with the right type.
         self.__columns = columns
-        # Keeps a dictionary of promoted columns. the key of the mapping
+        # Keeps a dictionary of promoted columns. The key of the mapping
         # can be 'tags' or 'contexts'. The values is a set of flattened
         # columns.
         self.__promoted_columns = promoted_columns
         # A mapping between column representing promoted tags and the
-        # correspinding tag.
+        # corresponding tag.
         self.__column_tag_map = column_tag_map
 
-    def process_tags_expression(self,
+    def process_column_expression(self,
         column_name: str,
         body: MutableMapping[str, Any],
     ) -> Union[None, Any]:
         """
-        This method resolves the tag or context processes it and formats
+        This method resolves the tag or context, processes it and formats
         the column expression for the query. It is supposed to be called
         by column_expr methods in the datasets.
 
@@ -52,8 +52,7 @@ class TagColumnProcessor:
             return self.__tag_expr(column_name)
         elif column_name in ['tags_key', 'tags_value']:
             return self.__tags_expr(column_name, body)
-        else:
-            return None
+        return None
 
     def __get_tag_column_map(self) -> Mapping[str, Mapping[str, str]]:
         # And a reverse map from the tags the client expects to the database columns

--- a/snuba/datasets/tags_dataset.py
+++ b/snuba/datasets/tags_dataset.py
@@ -1,0 +1,115 @@
+import re
+from typing import Any, Mapping, Set, Union
+
+from snuba import state
+from snuba.clickhouse.columns import ColumnSet
+from snuba.util import (
+    alias_expr,
+    all_referenced_columns,
+    escape_literal,
+    escape_col,
+)
+
+# A column name like "tags[url]"
+NESTED_COL_EXPR_RE = re.compile(r'^(tags|contexts)\[([a-zA-Z0-9_\.:-]+)\]$')
+
+
+class TagColumnProcessor:
+
+    def __init__(self,
+        columns: ColumnSet,
+        promoted_columns: Mapping[str, Set[str]],
+        column_tag_map: Mapping[str, Mapping[str, str]]
+    ) -> None:
+        self.__columns = columns
+        self.__promoted_columns = promoted_columns
+        self.__column_tag_map = column_tag_map
+
+    def _process_tags_expression(self, column_name, body) -> Union[None, Any]:
+        if NESTED_COL_EXPR_RE.match(column_name):
+            return self.__tag_expr(column_name)
+        elif column_name in ['tags_key', 'tags_value']:
+            return self.__tags_expr(column_name, body)
+        else:
+            return None
+
+    def get_tag_column_map(self):
+        # And a reverse map from the tags the client expects to the database columns
+        return {
+            col: dict(map(reversed, trans.items())) for col, trans in self.__column_tag_map.items()
+        }
+
+    def __string_col(self, col):
+        col_type = self.__columns.get(col, None)
+        col_type = str(col_type) if col_type else None
+
+        if col_type and 'String' in col_type and 'FixedString' not in col_type:
+            return escape_col(col)
+        else:
+            return 'toString({})'.format(escape_col(col))
+
+    def __tag_expr(self, column_name):
+        """
+        Return an expression for the value of a single named tag.
+
+        For tags/contexts, we expand the expression depending on whether the tag is
+        "promoted" to a top level column, or whether we have to look in the tags map.
+        """
+        col, tag = NESTED_COL_EXPR_RE.match(column_name).group(1, 2)
+
+        # For promoted tags, return the column name.
+        if col in self.__promoted_columns:
+            actual_tag = self.get_tag_column_map()[col].get(tag, tag)
+            if actual_tag in self.__promoted_columns[col]:
+                return self.__string_col(actual_tag)
+
+        # For the rest, return an expression that looks it up in the nested tags.
+        return u'{col}.value[indexOf({col}.key, {tag})]'.format(**{
+            'col': col,
+            'tag': escape_literal(tag)
+        })
+
+    def __tags_expr(self, column_name, body):
+        """
+        Return an expression that array-joins on tags to produce an output with one
+        row per tag.
+        """
+        assert column_name in ['tags_key', 'tags_value']
+        col, k_or_v = column_name.split('_', 1)
+        nested_tags_only = state.get_config('nested_tags_only', 1)
+
+        # Generate parallel lists of keys and values to arrayJoin on
+        if nested_tags_only:
+            key_list = '{}.key'.format(col)
+            val_list = '{}.value'.format(col)
+        else:
+            promoted = self.__promoted_columns[col]
+            col_map = self.__column_tag_map[col]
+            key_list = u'arrayConcat([{}], {}.key)'.format(
+                u', '.join(u'\'{}\''.format(col_map.get(p, p)) for p in promoted),
+                col
+            )
+            val_list = u'arrayConcat([{}], {}.value)'.format(
+                ', '.join(self.__string_col(p) for p in promoted),
+                col
+            )
+
+        cols_used = all_referenced_columns(body) & set(['tags_key', 'tags_value'])
+        if len(cols_used) == 2:
+            # If we use both tags_key and tags_value in this query, arrayjoin
+            # on (key, value) tag tuples.
+            expr = (u'arrayJoin(arrayMap((x,y) -> [x,y], {}, {}))').format(
+                key_list,
+                val_list
+            )
+
+            # put the all_tags expression in the alias cache so we can use the alias
+            # to refer to it next time (eg. 'all_tags[1] AS tags_key'). instead of
+            # expanding the whole tags expression again.
+            expr = alias_expr(expr, 'all_tags', body)
+            return u'({})[{}]'.format(expr, 1 if k_or_v == 'key' else 2)
+        else:
+            # If we are only ever going to use one of tags_key or tags_value, don't
+            # bother creating the k/v tuples to arrayJoin on, or the all_tags alias
+            # to re-use as we won't need it.
+            return 'arrayJoin({})'.format(key_list if k_or_v == 'key' else val_list)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -175,7 +175,7 @@ class TransactionsDataset(TimeSeriesDataset):
             return 'IPv4NumToString(ip_address_v4)'
         if column_name == 'ip_address_v6':
             return 'IPv6NumToString(ip_address_v6)'
-        ret = self.__tags_processor._process_tags_expression(column_name, body)
+        ret = self.__tags_processor.process_tags_expression(column_name, body)
         if ret:
             return ret
         return super().column_expr(column_name, body)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -20,7 +20,7 @@ from snuba.datasets import TimeSeriesDataset
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
-from snuba.datasets.tags_dataset import TagColumnProcessor
+from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import (
     PerformanceExtension,
@@ -175,9 +175,10 @@ class TransactionsDataset(TimeSeriesDataset):
             return 'IPv4NumToString(ip_address_v4)'
         if column_name == 'ip_address_v6':
             return 'IPv6NumToString(ip_address_v6)'
-        ret = self.__tags_processor.process_tags_expression(column_name, body)
-        if ret:
-            return ret
+        processed_column = self.__tags_processor.process_column_expression(column_name, body)
+        if processed_column:
+            # If processed_column is None, this was not a tag/context expression
+            return processed_column
         return super().column_expr(column_name, body)
 
     def get_prewhere_keys(self) -> Sequence[str]:

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -44,16 +44,6 @@ def to_list(value):
     return value if isinstance(value, list) else [value]
 
 
-def string_col(dataset, col):
-    col_type = dataset.get_dataset_schemas().get_read_schema().get_columns().get(col, None)
-    col_type = str(col_type) if col_type else None
-
-    if col_type and 'String' in col_type and 'FixedString' not in col_type:
-        return escape_col(col)
-    else:
-        return 'toString({})'.format(escape_col(col))
-
-
 def escape_col(col):
     if not col:
         return col

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,7 +94,6 @@ class TestApi(BaseApiTest):
                             }
                         }
                     }))
-        print(events[0])
         self.write_processed_records(events)
 
     def redis_db_size(self):

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -65,8 +65,9 @@ class TestTransactionsApi(BaseApiTest):
                                 'received': calendar.timegm((self.base_time + timedelta(minutes=tick)).timetuple()),
                                 'type': 'transaction',
                                 'transaction': '/api/do_things',
-                                'start_timestamp': calendar.timegm((self.base_time + timedelta(minutes=tick)).timetuple()),
-                                'timestamp': calendar.timegm((self.base_time + timedelta(minutes=tick)).timetuple()),
+
+                                'start_timestamp': datetime.timestamp(self.base_time + timedelta(minutes=tick)),
+                                'timestamp': datetime.timestamp(self.base_time + timedelta(minutes=tick)),
                                 'tags': {
                                     # Sentry
                                     'environment': self.environments[(tock * p) % len(self.environments)],


### PR DESCRIPTION
The transactions table has nested columns for tags and contexts that work exactly like for events.
This means we can apply the same column logic to resolve expressions like 'tags[level]' or 'tags_key'.
The logic is in the events dataset class, so this PR extracts this logic and moves it in a dedicated class TagColumnProcessor.
I decided to move it in a separate class instead of introducing a new parent class so that we can remove some of the tags-column mapping methods that seem generally confusing.

test plan:
- unit tests
- queries like 

```
{
    "selected_columns": ["event_id", "tags[level]", "tags[trace.span]"],
    "project": [1],
    "from_date": "2019-09-22T06:39:21",
    "to_date": "2019-09-27T06:39:21",
    "granularity": 3600
}
...
{
    "data": [
        {
            "event_id": "66ae5c87-bcf7-467f-883b-00593273c7be",
            "tags[level]": "error",
            "tags[trace.span]": "bffb3c6e79877176"
        },
        {
            "event_id": "5797241f-bb30-4c09-a117-ada4b485ed92",
            "tags[level]": "error",
            "tags[trace.span]": "aab6490aabb7136b"
        },
....
```