### PR TITLE
fix(transactions) Fix query splitting for transaction dataset

### DIFF
--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -94,9 +94,18 @@ class Dataset(object):
         return []
 
     def get_min_columns(self) -> Sequence[str]:
+        """
+        Return a list of the smallest subset of columns for a dataset.
+
+        This subset must include an event_id and timestamp type column, and
+        is used by the query splitter to help optimize loading wide results.
+        """
         return NotImplementedError('dataset does not support get_min_columns')
 
     def get_timestamp_column(self) -> str:
+        """
+        Return the name of the datetime column from get_min_columns.
+        """
         return NotImplementedError('dataset does not support get_timestamp_column')
 
 

--- a/snuba/datasets/__init__.py
+++ b/snuba/datasets/__init__.py
@@ -93,6 +93,12 @@ class Dataset(object):
         """
         return []
 
+    def get_min_columns(self) -> Sequence[str]:
+        return NotImplementedError('dataset does not support get_min_columns')
+
+    def get_timestamp_column(self) -> str:
+        return NotImplementedError('dataset does not support get_timestamp_column')
+
 
 class TimeSeriesDataset(Dataset):
     def __init__(self, *args,
@@ -133,9 +139,9 @@ class TimeSeriesDataset(Dataset):
     def process_condition(self, condition) -> Tuple[str, str, any]:
         lhs, op, lit = condition
         if (
-            lhs in self.__time_parse_columns and
-            op in ('>', '<', '>=', '<=', '=', '!=') and
-            isinstance(lit, str)
+            lhs in self.__time_parse_columns
+            and op in ('>', '<', '>=', '<=', '=', '!=')
+            and isinstance(lit, str)
         ):
             lit = parse_datetime(lit)
         return lhs, op, lit

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -256,6 +256,12 @@ class EventsDataset(TimeSeriesDataset):
             (qualified_column('deleted', table_alias), '=', 0),
         ]
 
+    def get_min_columns(self) -> Sequence[str]:
+        return ('event_id', 'project_id', 'timestamp')
+
+    def get_timestamp_column(self) -> str:
+        return 'timestamp'
+
     def column_expr(self, column_name, body, table_alias: str=""):
         processed_column = self.__tags_processor.process_column_expression(column_name, body, table_alias)
         if processed_column:

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -179,5 +179,11 @@ class TransactionsDataset(TimeSeriesDataset):
             return processed_column
         return super().column_expr(column_name, body)
 
+    def get_min_columns(self) -> Sequence[str]:
+        return ('event_id', 'project_id', 'start_ts')
+
+    def get_timestamp_column(self) -> str:
+        return 'start_ts'
+
     def get_prewhere_keys(self) -> Sequence[str]:
         return ['event_id', 'project_id']

--- a/snuba/split.py
+++ b/snuba/split.py
@@ -10,7 +10,6 @@ from snuba.request import Request
 # worst case (there are 0 results in the database) would have us making 4
 # queries before hitting the 90d limit (2+20+200+2000 hours == 92 days).
 STEP_GROWTH = 10
-MIN_COLS = ['project_id', 'event_id', 'timestamp']
 
 
 def split_query(query_func):

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -141,3 +141,22 @@ class TestTransactionsApi(BaseApiTest):
         assert response.status_code == 200
         assert len(data['data']) > 1, data
         assert 'transaction_name' in data['data'][0]
+
+    def test_split_query(self):
+        skew = timedelta(minutes=180)
+        response = self.app.post('/query', data=json.dumps({
+            'dataset': 'transactions',
+            'project': 1,
+            'selected_columns': [
+                'event_id',
+                'project_id',
+                'transaction_name',
+                'transaction_hash',
+                'tags_key'
+            ],
+            'from_date': (self.base_time - skew).replace(tzinfo=pytz.utc).isoformat(),
+            'to_date': (self.base_time + timedelta(minutes=self.minutes)).replace(tzinfo=pytz.utc).isoformat(),
+        }))
+        data = json.loads(response.data)
+        assert response.status_code == 200
+        assert len(data['data']) > 1, data


### PR DESCRIPTION
The transaction dataset does not have a timestamp column. I've added dataset methods to get the minimum column set and timestamp attribute key.

Refs SEN-1037