### PR TITLE
feat(datasets) Upgrade clickhouse driver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'certifi==2018.4.16',
         'chardet==3.0.4',
         'click==6.7',
-        'clickhouse-driver==0.0.18',
+        'clickhouse-driver==0.1.1',
         'colorama==0.3.9',
         'configparser==3.5.0',
         'confluent-kafka==0.11.5',

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -123,6 +123,22 @@ class TestTransactionsApi(BaseApiTest):
         assert 'ip_address_v4' in data['data'][0]
         assert 'ip_address_v6' in data['data'][0]
 
+    def test_read_lowcard(self):
+        skew = timedelta(minutes=180)
+        response = self.app.post('/query', data=json.dumps({
+            'dataset': 'transactions',
+            'project': 1,
+            'selected_columns': ['transaction_op', 'platform'],
+            'from_date': (self.base_time - skew).replace(tzinfo=pytz.utc).isoformat(),
+            'to_date': (self.base_time + timedelta(minutes=self.minutes)).replace(tzinfo=pytz.utc).isoformat(),
+            'orderby': 'start_ts'
+        }))
+        data = json.loads(response.data)
+        assert response.status_code == 200
+        assert len(data['data']) > 1, data
+        assert 'platform' in data['data'][0]
+        assert data['data'][0]['transaction_op'] == "http"
+
     def test_start_ts_microsecond_truncation(self):
         skew = timedelta(minutes=180)
         response = self.app.post('/query', data=json.dumps({


### PR DESCRIPTION
Clickhosue driver version 0.0.18 does not know about ipv4 and ipv6 types (probably it was built in the 1960s before TCP/IP was a thing - or maybe (less likely) it was built before Clickhosue had those column types).
Upgrading it since the new version supports a few nice column types we are now using in the transactions dataset:
- lowcardinality
- ip addresses

test plan:
- snuba unit tests pass
- sentry tests against snuba pass