### PR TITLE
ref(kafka): Remove tests that duplicate batching consumer tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 import uuid
 
-from batching_kafka_consumer import AbstractBatchWorker, BatchingKafkaConsumer
 from confluent_kafka import TopicPartition, KafkaError
 from confluent_kafka.admin import (
     ClusterMetadata,
@@ -115,29 +114,6 @@ class FakeKafkaConsumer(object):
             topic: topic_meta
         }
         return meta
-
-
-class FakeBatchingKafkaConsumer(BatchingKafkaConsumer):
-    def create_consumer(self, *args, **kwargs):
-        return FakeKafkaConsumer()
-
-
-class FakeWorker(AbstractBatchWorker):
-    def __init__(self, *args, **kwargs):
-        super(FakeWorker, self).__init__(*args, **kwargs)
-        self.processed = []
-        self.flushed = []
-        self.shutdown_calls = 0
-
-    def process_message(self, message):
-        self.processed.append(message.value())
-        return message.value()
-
-    def flush_batch(self, batch):
-        self.flushed.append(batch)
-
-    def shutdown(self):
-        self.shutdown_calls += 1
 
 
 class BaseTest(object):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,17 +1,10 @@
 import calendar
 from datetime import datetime, timedelta
-from mock import patch
 import simplejson as json
-import time
-from datadog import statsd
 
 from base import (
     BaseEventsTest,
-    FakeBatchingKafkaConsumer,
-    FakeKafkaMessage,
     FakeKafkaProducer,
-    FakeWorker,
-    get_event
 )
 
 from snuba.consumer import ConsumerWorker
@@ -20,79 +13,6 @@ from snuba.processor import ProcessedMessage, ProcessorAction
 
 
 class TestConsumer(BaseEventsTest):
-    def test_batch_size(self):
-        consumer = FakeBatchingKafkaConsumer(
-            'topic',
-            worker=FakeWorker(),
-            max_batch_size=2,
-            max_batch_time=100,
-            metrics=statsd,
-            bootstrap_servers=None,
-            group_id='group',
-            commit_log_topic='commits',
-            producer=FakeKafkaProducer(),
-        )
-
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
-        for x in range(len(consumer.consumer.items)):
-            consumer._run_once()
-        consumer._shutdown()
-
-        assert consumer.worker.processed == [1, 2, 3]
-        assert consumer.worker.flushed == [[1, 2]]
-        assert consumer.worker.shutdown_calls == 1
-        assert consumer.consumer.commit_calls == 1
-        assert consumer.consumer.close_calls == 1
-
-        assert len(consumer.producer.messages) == 1
-        commit_message = consumer.producer.messages[0]
-        assert commit_message.topic() == 'commits'
-        assert commit_message.key() == '{}:{}:{}'.format('topic', 0, 'group').encode('utf-8')
-        assert commit_message.value() == '{}'.format(2 + 1).encode('utf-8')  # offsets are last processed message offset + 1
-
-    @patch('time.time')
-    def test_batch_time(self, mock_time):
-        consumer = FakeBatchingKafkaConsumer(
-            'topic',
-            worker=FakeWorker(),
-            max_batch_size=100,
-            max_batch_time=2000,
-            metrics=statsd,
-            bootstrap_servers=None,
-            group_id='group',
-            commit_log_topic='commits',
-            producer=FakeKafkaProducer(),
-        )
-
-        mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 0).timetuple())
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
-        for x in range(len(consumer.consumer.items)):
-            consumer._run_once()
-
-        mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 1).timetuple())
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [4, 5, 6]]
-        for x in range(len(consumer.consumer.items)):
-            consumer._run_once()
-
-        mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 5).timetuple())
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [7, 8, 9]]
-        for x in range(len(consumer.consumer.items)):
-            consumer._run_once()
-
-        consumer._shutdown()
-
-        assert consumer.worker.processed == [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        assert consumer.worker.flushed == [[1, 2, 3, 4, 5, 6]]
-        assert consumer.worker.shutdown_calls == 1
-        assert consumer.consumer.commit_calls == 1
-        assert consumer.consumer.close_calls == 1
-
-        assert len(consumer.producer.messages) == 1
-        commit_message = consumer.producer.messages[0]
-        assert commit_message.topic() == 'commits'
-        assert commit_message.key() == '{}:{}:{}'.format('topic', 0, 'group').encode('utf-8')
-        assert commit_message.value() == '{}'.format(6 + 1).encode('utf-8')  # offsets are last processed message offset + 1
-
     def test_offsets(self):
         event = self.event
 
@@ -157,33 +77,3 @@ class TestConsumer(BaseEventsTest):
 
         assert [(m._topic, m._key, m._value) for m in producer.messages] == \
             [('event-replacements', b'1', b'{"project_id": 1}'), ('event-replacements', b'2', b'{"project_id": 2}')]
-
-    def test_dead_letter_topic(self):
-        class FailingFakeWorker(FakeWorker):
-            def process_message(*args, **kwargs):
-                1 / 0
-
-        producer = FakeKafkaProducer()
-        consumer = FakeBatchingKafkaConsumer(
-            'topic',
-            worker=FailingFakeWorker(),
-            max_batch_size=100,
-            max_batch_time=2000,
-            metrics=statsd,
-            bootstrap_servers=None,
-            group_id='group',
-            producer=producer,
-            dead_letter_topic='dlt'
-        )
-
-        message = FakeKafkaMessage('topic', partition=1, offset=2, key='key', value='value')
-        consumer.consumer.items = [message]
-        consumer._run_once()
-
-        assert len(producer.messages) == 1
-        produced_message = producer.messages[0]
-
-        assert ('dlt', message.key(), message.value()) \
-            == (produced_message.topic(), produced_message.key(), produced_message.value())
-
-        assert produced_message.headers() == {'partition': '1', 'offset': '2', 'topic': 'topic'}


### PR DESCRIPTION
This removes several tests that are already run as part of the batching-kafka-consumer library test suite: https://github.com/getsentry/batching-kafka-consumer/blob/master/tests/test_consumer.py

These would/will also be duplicated as of #485 (albeit not line-for-line.)

This also removes several classes that are/were solely used for supporting these tests.