### PR TITLE
ref(tests): Remove `mock` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'Markdown==2.6.11',
         'MarkupSafe==1.0',
         'mccabe==0.6.1',
-        'mock==2.0.0',
         'more-itertools==4.2.0',
         'packaging==17.1',
         'parso==0.2.1',

--- a/tests/clickhouse/test_query.py
+++ b/tests/clickhouse/test_query.py
@@ -1,5 +1,5 @@
 from base import BaseEventsTest
-from mock import patch
+from unittest.mock import patch
 
 from snuba.clickhouse.query import ClickhouseQuery
 from snuba.query.query import Query

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ import calendar
 from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_datetime
 from functools import partial
-from mock import patch
+from unittest.mock import patch
 import pytest
 import pytz
 from sentry_sdk import Hub, Client

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -1,7 +1,7 @@
 from base import BaseEventsTest
 
 from clickhouse_driver import errors
-from mock import patch, call
+from unittest.mock import patch, call
 
 from snuba.clickhouse.columns import Array, ColumnSet, Nested, Nullable, String, UInt
 from snuba.datasets.factory import enforce_table_writer

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,7 +1,7 @@
 from collections import ChainMap
 from base import BaseEventsTest
 from functools import partial
-from mock import patch
+from unittest.mock import patch
 import random
 import simplejson as json
 from threading import Thread


### PR DESCRIPTION
This was moved into the standard library as `mock.unittest` as of Python 3.3.