### PR TITLE
ref(kafka): Improvements to vendorized batching consumer

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -92,6 +92,3 @@ class ConsumerWorker(AbstractBatchWorker):
                 )
 
             self.producer.flush()
-
-    def shutdown(self):
-        pass

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -159,9 +159,6 @@ class ReplacerWorker(AbstractBatchWorker):
             self.metrics.timing('replacements.count', count)
             self.metrics.timing('replacements.duration', duration)
 
-    def shutdown(self) -> None:
-        pass
-
 
 def process_delete_groups(message, required_columns) -> Optional[Replacement]:
     group_ids = message['group_ids']

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -71,7 +71,7 @@ class Offsets:
     hi: int
 
 
-class BatchingKafkaConsumer(object):
+class BatchingKafkaConsumer:
     """The `BatchingKafkaConsumer` is an abstraction over most Kafka consumer's main event
     loops. For this reason it uses inversion of control: the user provides an implementation
     for the `AbstractBatchWorker` and then the `BatchingKafkaConsumer` handles the rest.

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -13,14 +13,14 @@ from typing import (
 )
 
 from confluent_kafka import (
+    OFFSET_BEGINNING,
+    OFFSET_END,
+    OFFSET_INVALID,
+    OFFSET_STORED,
     Consumer,
     KafkaError,
     KafkaException,
     Message,
-    OFFSET_BEGINNING,
-    OFFSET_END,
-    OFFSET_STORED,
-    OFFSET_INVALID,
     Producer,
     TopicPartition,
 )

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -45,15 +45,6 @@ class AbstractBatchWorker(ABC):
         """
         pass
 
-    @abstractmethod
-    def shutdown(self):
-        """Called when the `BatchingKafkaConsumer` is shutting down (because it
-        was signalled to do so). Provides the worker a chance to do any final
-        cleanup.
-
-        A simple example would be closing any remaining backend connections."""
-        pass
-
 
 class BatchingKafkaConsumer(object):
     """The `BatchingKafkaConsumer` is an abstraction over most Kafka consumer's main event
@@ -243,9 +234,7 @@ class BatchingKafkaConsumer(object):
         # drop in-memory events, letting the next consumer take over where we left off
         self._reset_batch()
 
-        # tell the consumer to shutdown, and close the consumer
-        logger.debug("Stopping worker")
-        self.worker.shutdown()
+        # close the consumer
         logger.debug("Stopping consumer")
         self.consumer.close()
         logger.debug("Stopped")

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -111,7 +111,6 @@ class FakeWorker(AbstractBatchWorker):
         super(FakeWorker, self).__init__(*args, **kwargs)
         self.processed = []
         self.flushed = []
-        self.shutdown_calls = 0
 
     def process_message(self, message):
         self.processed.append(message.value())
@@ -119,9 +118,6 @@ class FakeWorker(AbstractBatchWorker):
 
     def flush_batch(self, batch):
         self.flushed.append(batch)
-
-    def shutdown(self):
-        self.shutdown_calls += 1
 
 
 class TestConsumer(object):
@@ -145,7 +141,6 @@ class TestConsumer(object):
 
         assert consumer.worker.processed == [1, 2, 3]
         assert consumer.worker.flushed == [[1, 2]]
-        assert consumer.worker.shutdown_calls == 1
         assert consumer.consumer.commit_calls == 1
         assert consumer.consumer.close_calls == 1
 
@@ -188,7 +183,6 @@ class TestConsumer(object):
 
         assert consumer.worker.processed == [1, 2, 3, 4, 5, 6, 7, 8, 9]
         assert consumer.worker.flushed == [[1, 2, 3, 4, 5, 6]]
-        assert consumer.worker.shutdown_calls == 1
         assert consumer.consumer.commit_calls == 1
         assert consumer.consumer.close_calls == 1
 


### PR DESCRIPTION
- Remove unused `shutdown` method.
- Remove unused dead letter queue functionality.
- `black` format Python code.
- Add type hints for all methods and (minor data structure changes to support this.)

## Test Plan

All of these things should presumably already be covered. 🤞 