### PR TITLE
ref(tests): Improvements to Kafka and consumer tests

### DIFF
--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -12,7 +12,7 @@ from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 logger = logging.getLogger('snuba.perf')
 
 
-class FakeKafkaMessage(object):
+class FakeConfluentKafkaMessage(object):
     def __init__(self, topic, partition, offset, value, key=None, headers=None, error=None):
         self._topic = topic
         self._partition = partition
@@ -49,11 +49,11 @@ class FakeKafkaMessage(object):
 
 
 def get_messages(events_file):
-    "Create a FakeKafkaMessage for each JSON event in the file."
+    "Create a fake Kafka message for each JSON event in the file."
     messages = []
     raw_events = open(events_file).readlines()
     for raw_event in raw_events:
-        messages.append(FakeKafkaMessage('events', 1, 0, raw_event))
+        messages.append(FakeConfluentKafkaMessage('events', 1, 0, raw_event))
     return messages
 
 

--- a/tests/backends/confluent_kafka.py
+++ b/tests/backends/confluent_kafka.py
@@ -1,0 +1,100 @@
+from unittest.mock import MagicMock
+
+from confluent_kafka import TopicPartition, KafkaError
+from confluent_kafka.admin import (
+    ClusterMetadata,
+    PartitionMetadata,
+    TopicMetadata,
+)
+
+from snuba.perf import FakeConfluentKafkaMessage
+
+
+class FakeConfluentKafkaProducer(object):
+    def __init__(self):
+        self.messages = []
+        self._callbacks = []
+
+    def poll(self, *args, **kwargs):
+        while self._callbacks:
+            callback, message = self._callbacks.pop()
+            callback(None, message)
+        return 0
+
+    def flush(self):
+        return self.poll()
+
+    def produce(self, topic, value, key=None, headers=None, on_delivery=None):
+        message = FakeConfluentKafkaMessage(
+            topic=topic,
+            partition=None,  # XXX: the partition is unknown (depends on librdkafka)
+            offset=None,  # XXX: the offset is unknown (depends on state)
+            key=key,
+            value=value,
+            headers=headers,
+        )
+        self.messages.append(message)
+        if on_delivery is not None:
+            self._callbacks.append((on_delivery, message))
+
+
+class FakeConfluentKafkaConsumer(object):
+    def __init__(self):
+        self.items = []
+        self.commit_calls = 0
+        self.close_calls = 0
+        self.positions = {}
+
+    def poll(self, *args, **kwargs):
+        try:
+            message = self.items.pop(0)
+        except IndexError:
+            return None
+
+        self.positions[(message.topic(), message.partition())] = message.offset() + 1
+
+        return message
+
+    def commit(self, *args, **kwargs):
+        self.commit_calls += 1
+        return [
+            TopicPartition(topic, partition, offset)
+            for (topic, partition), offset in
+            self.positions.items()
+        ]
+
+    def close(self, *args, **kwargs):
+        self.close_calls += 1
+
+    def subscribe(self, *args, **kwargs):
+        pass
+
+    def list_topics(self, topic):
+        meta = ClusterMetadata()
+        topic_meta = TopicMetadata()
+        topic_meta.topic = topic
+        topic_meta.partitions = {
+            0: PartitionMetadata()
+        }
+        meta.topics = {
+            topic: topic_meta
+        }
+        return meta
+
+
+def build_confluent_kafka_message(offset, partition, value, eof=False) -> FakeConfluentKafkaMessage:
+    if eof:
+        error = MagicMock()
+        error.code.return_value = KafkaError._PARTITION_EOF
+    else:
+        error = None
+
+    return FakeConfluentKafkaMessage(
+        topic="topic",
+        partition=partition,
+        offset=offset,
+        value=value,
+        key=None,
+        headers=None,
+        error=error,
+    )

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,7 +15,7 @@ from snuba import settings
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.clickhouse.native import ClickhousePool
 from snuba.redis import redis_client
-from snuba.perf import FakeKafkaMessage
+from snuba.perf import FakeConfluentKafkaMessage
 
 
 def wrap_raw_event(event):
@@ -59,7 +59,7 @@ class FakeKafkaProducer(object):
         return self.poll()
 
     def produce(self, topic, value, key=None, headers=None, on_delivery=None):
-        message = FakeKafkaMessage(
+        message = FakeConfluentKafkaMessage(
             topic=topic,
             partition=None,  # XXX: the partition is unknown (depends on librdkafka)
             offset=None,  # XXX: the offset is unknown (depends on state)
@@ -219,14 +219,14 @@ class BaseApiTest(BaseEventsTest):
         self.app = application.test_client()
 
 
-def message(offset, partition, value, eof=False) -> FakeKafkaMessage:
+def message(offset, partition, value, eof=False) -> FakeConfluentKafkaMessage:
     if eof:
         error = MagicMock()
         error.code.return_value = KafkaError._PARTITION_EOF
     else:
         error = None
 
-    return FakeKafkaMessage(
+    return FakeConfluentKafkaMessage(
         topic="topic",
         partition=partition,
         offset=offset,

--- a/tests/base.py
+++ b/tests/base.py
@@ -44,7 +44,7 @@ def get_event():
     return wrap_raw_event(raw_event)
 
 
-class FakeKafkaProducer(object):
+class FakeConfluentKafkaProducer(object):
     def __init__(self):
         self.messages = []
         self._callbacks = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,21 +1,12 @@
 import calendar
 from hashlib import md5
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock
 import uuid
-
-from confluent_kafka import TopicPartition, KafkaError
-from confluent_kafka.admin import (
-    ClusterMetadata,
-    PartitionMetadata,
-    TopicMetadata,
-)
 
 from snuba import settings
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.clickhouse.native import ClickhousePool
 from snuba.redis import redis_client
-from snuba.perf import FakeConfluentKafkaMessage
 
 
 def wrap_raw_event(event):
@@ -42,78 +33,6 @@ def get_event():
     raw_event['datetime'] = (timestamp - timedelta(seconds=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     raw_event['received'] = int(calendar.timegm((timestamp - timedelta(seconds=1)).timetuple()))
     return wrap_raw_event(raw_event)
-
-
-class FakeConfluentKafkaProducer(object):
-    def __init__(self):
-        self.messages = []
-        self._callbacks = []
-
-    def poll(self, *args, **kwargs):
-        while self._callbacks:
-            callback, message = self._callbacks.pop()
-            callback(None, message)
-        return 0
-
-    def flush(self):
-        return self.poll()
-
-    def produce(self, topic, value, key=None, headers=None, on_delivery=None):
-        message = FakeConfluentKafkaMessage(
-            topic=topic,
-            partition=None,  # XXX: the partition is unknown (depends on librdkafka)
-            offset=None,  # XXX: the offset is unknown (depends on state)
-            key=key,
-            value=value,
-            headers=headers,
-        )
-        self.messages.append(message)
-        if on_delivery is not None:
-            self._callbacks.append((on_delivery, message))
-
-
-class FakeConfluentKafkaConsumer(object):
-    def __init__(self):
-        self.items = []
-        self.commit_calls = 0
-        self.close_calls = 0
-        self.positions = {}
-
-    def poll(self, *args, **kwargs):
-        try:
-            message = self.items.pop(0)
-        except IndexError:
-            return None
-
-        self.positions[(message.topic(), message.partition())] = message.offset() + 1
-
-        return message
-
-    def commit(self, *args, **kwargs):
-        self.commit_calls += 1
-        return [
-            TopicPartition(topic, partition, offset)
-            for (topic, partition), offset in
-            self.positions.items()
-        ]
-
-    def close(self, *args, **kwargs):
-        self.close_calls += 1
-
-    def subscribe(self, *args, **kwargs):
-        pass
-
-    def list_topics(self, topic):
-        meta = ClusterMetadata()
-        topic_meta = TopicMetadata()
-        topic_meta.topic = topic
-        topic_meta.partitions = {
-            0: PartitionMetadata()
-        }
-        meta.topics = {
-            topic: topic_meta
-        }
-        return meta
 
 
 class BaseTest(object):
@@ -217,21 +136,3 @@ class BaseApiTest(BaseEventsTest):
         assert application.testing is True
         application.config['PROPAGATE_EXCEPTIONS'] = False
         self.app = application.test_client()
-
-
-def message(offset, partition, value, eof=False) -> FakeConfluentKafkaMessage:
-    if eof:
-        error = MagicMock()
-        error.code.return_value = KafkaError._PARTITION_EOF
-    else:
-        error = None
-
-    return FakeConfluentKafkaMessage(
-        topic="topic",
-        partition=partition,
-        offset=offset,
-        value=value,
-        key=None,
-        headers=None,
-        error=error,
-    )

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,7 +72,7 @@ class FakeConfluentKafkaProducer(object):
             self._callbacks.append((on_delivery, message))
 
 
-class FakeKafkaConsumer(object):
+class FakeConfluentKafkaConsumer(object):
     def __init__(self):
         self.items = []
         self.commit_calls = 0

--- a/tests/consumers/test_strict_consumer.py
+++ b/tests/consumers/test_strict_consumer.py
@@ -5,22 +5,21 @@ from unittest.mock import patch
 from unittest.mock import MagicMock
 
 
-from base import FakeKafkaConsumer, message
+from base import FakeConfluentKafkaMessage, FakeKafkaConsumer, message
 
 from snuba.consumers.strict_consumer import CommitDecision, NoPartitionAssigned, StrictConsumer
-from snuba.perf import FakeKafkaMessage
 
 
 class TestStrictConsumer:
 
-    def __message(self, offset, partition, value, eof=False) -> FakeKafkaMessage:
+    def __message(self, offset, partition, value, eof=False) -> FakeConfluentKafkaMessage:
         if eof:
             error = MagicMock()
             error.code.return_value = KafkaError._PARTITION_EOF
         else:
             error = None
 
-        return FakeKafkaMessage(
+        return FakeConfluentKafkaMessage(
             topic="my_topic",
             partition=partition,
             offset=offset,

--- a/tests/consumers/test_strict_consumer.py
+++ b/tests/consumers/test_strict_consumer.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from unittest.mock import MagicMock
 
 
-from base import FakeConfluentKafkaMessage, FakeKafkaConsumer, message
+from base import FakeConfluentKafkaMessage, FakeConfluentKafkaConsumer, message
 
 from snuba.consumers.strict_consumer import CommitDecision, NoPartitionAssigned, StrictConsumer
 
@@ -43,7 +43,7 @@ class TestStrictConsumer:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_empty_topic(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
             message(0, 0, None, True),
         ]
@@ -57,7 +57,7 @@ class TestStrictConsumer:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_failure(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         create_consumer.return_value = kafka_consumer
 
         on_message = MagicMock()
@@ -70,7 +70,7 @@ class TestStrictConsumer:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_one_message(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         create_consumer.return_value = kafka_consumer
 
         msg = message(0, 0, "ABCABC", False)
@@ -89,7 +89,7 @@ class TestStrictConsumer:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_commits(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         create_consumer.return_value = kafka_consumer
         error = MagicMock()
         error.code.return_value = KafkaError._PARTITION_EOF

--- a/tests/consumers/test_strict_consumer.py
+++ b/tests/consumers/test_strict_consumer.py
@@ -5,29 +5,12 @@ from unittest.mock import patch
 from unittest.mock import MagicMock
 
 
-from base import FakeConfluentKafkaMessage, FakeConfluentKafkaConsumer, message
+from base import FakeConfluentKafkaConsumer, message
 
 from snuba.consumers.strict_consumer import CommitDecision, NoPartitionAssigned, StrictConsumer
 
 
 class TestStrictConsumer:
-
-    def __message(self, offset, partition, value, eof=False) -> FakeConfluentKafkaMessage:
-        if eof:
-            error = MagicMock()
-            error.code.return_value = KafkaError._PARTITION_EOF
-        else:
-            error = None
-
-        return FakeConfluentKafkaMessage(
-            topic="my_topic",
-            partition=partition,
-            offset=offset,
-            value=value,
-            key=None,
-            headers=None,
-            error=error,
-        )
 
     def __consumer(self, on_message) -> StrictConsumer:
         return StrictConsumer(

--- a/tests/consumers/test_strict_consumer.py
+++ b/tests/consumers/test_strict_consumer.py
@@ -4,10 +4,8 @@ from confluent_kafka import KafkaError
 from unittest.mock import patch
 from unittest.mock import MagicMock
 
-
-from base import FakeConfluentKafkaConsumer, message
-
 from snuba.consumers.strict_consumer import CommitDecision, NoPartitionAssigned, StrictConsumer
+from tests.backends.confluent_kafka import FakeConfluentKafkaConsumer, build_confluent_kafka_message
 
 
 class TestStrictConsumer:
@@ -28,7 +26,7 @@ class TestStrictConsumer:
     def test_empty_topic(self, create_consumer) -> None:
         kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
         create_consumer.return_value = kafka_consumer
 
@@ -56,10 +54,10 @@ class TestStrictConsumer:
         kafka_consumer = FakeConfluentKafkaConsumer()
         create_consumer.return_value = kafka_consumer
 
-        msg = message(0, 0, "ABCABC", False)
+        msg = build_confluent_kafka_message(0, 0, "ABCABC", False)
         kafka_consumer.items = [
             msg,
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
 
         on_message = MagicMock()
@@ -77,10 +75,10 @@ class TestStrictConsumer:
         error = MagicMock()
         error.code.return_value = KafkaError._PARTITION_EOF
         kafka_consumer.items = [
-            message(0, 0, "ABCABC", False),
-            message(1, 0, "ABCABC", False),
-            message(2, 0, "ABCABC", False),
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, "ABCABC", False),
+            build_confluent_kafka_message(1, 0, "ABCABC", False),
+            build_confluent_kafka_message(2, 0, "ABCABC", False),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
 
         on_message = MagicMock()

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import uuid1
 
-from base import FakeKafkaProducer, message as build_msg
+from base import FakeConfluentKafkaProducer, message as build_msg
 from snuba.consumers.snapshot_worker import SnapshotAwareWorker
 from snuba.datasets.factory import get_dataset
 from snuba.processor import ProcessorAction, ProcessedMessage
@@ -91,7 +91,7 @@ class TestSnapshotWorker:
 
         worker = SnapshotAwareWorker(
             dataset=dataset,
-            producer=FakeKafkaProducer(),
+            producer=FakeConfluentKafkaProducer(),
             snapshot_id=str(snapshot_id),
             transaction_data=transact_data,
             replacements_topic=None,

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -5,12 +5,12 @@ from datetime import datetime
 from typing import Optional
 from uuid import uuid1
 
-from base import FakeConfluentKafkaProducer, message as build_msg
 from snuba.consumers.snapshot_worker import SnapshotAwareWorker
 from snuba.datasets.factory import get_dataset
 from snuba.processor import ProcessorAction, ProcessedMessage
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
+from tests.backends.confluent_kafka import FakeConfluentKafkaProducer, build_confluent_kafka_message
 
 
 INSERT_MSG = (
@@ -99,6 +99,6 @@ class TestSnapshotWorker:
         )
 
         ret = worker.process_message(
-            build_msg(1, 0, message)
+            build_confluent_kafka_message(1, 0, message)
         )
         assert ret == expected

--- a/tests/stateful_consumer/test_bootstrap_state.py
+++ b/tests/stateful_consumer/test_bootstrap_state.py
@@ -1,11 +1,10 @@
 from unittest.mock import patch
 
-from base import FakeConfluentKafkaConsumer, message
-
 from snuba.datasets.factory import get_dataset
 from snuba.stateful_consumer import ConsumerStateCompletionEvent
 from snuba.consumers.strict_consumer import StrictConsumer
 from snuba.stateful_consumer.states.bootstrap import BootstrapState
+from tests.backends.confluent_kafka import FakeConfluentKafkaConsumer, build_confluent_kafka_message
 
 
 class TestBootstrapState:
@@ -26,7 +25,7 @@ class TestBootstrapState:
     def test_empty_topic(self, create_consumer) -> None:
         kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
         create_consumer.return_value = kafka_consumer
 
@@ -45,13 +44,13 @@ class TestBootstrapState:
     def test_snapshot_for_other_table(self, create_consumer) -> None:
         kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
-            message(
+            build_confluent_kafka_message(
                 0,
                 0,
                 '{"snapshot-id":"abc123", "tables": ["someone_else"], "product":"snuba", "event":"snapshot-init"}',
                 False,
             ),
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
         create_consumer.return_value = kafka_consumer
 
@@ -70,13 +69,13 @@ class TestBootstrapState:
     def test_init_snapshot(self, create_consumer) -> None:
         kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
-            message(
+            build_confluent_kafka_message(
                 0,
                 0,
                 '{"snapshot-id":"abc123", "tables": ["sentry_groupedmessage"], "product":"snuba", "event":"snapshot-init"}',
                 False,
             ),
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
         create_consumer.return_value = kafka_consumer
 
@@ -95,19 +94,19 @@ class TestBootstrapState:
     def test_snapshot_loaded(self, create_consumer) -> None:
         kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
-            message(
+            build_confluent_kafka_message(
                 0,
                 0,
                 '{"snapshot-id":"abc123", "product":"somewhere-else", "tables": [], "event":"snapshot-init"}',
                 False,
             ),
-            message(
+            build_confluent_kafka_message(
                 1,
                 0,
                 '{"snapshot-id":"abc123", "product":"snuba", "tables": ["sentry_groupedmessage"], "event":"snapshot-init"}',
                 False,
             ),
-            message(
+            build_confluent_kafka_message(
                 2,
                 0,
                 (
@@ -117,7 +116,7 @@ class TestBootstrapState:
                 ),
                 False,
             ),
-            message(0, 0, None, True),
+            build_confluent_kafka_message(0, 0, None, True),
         ]
         create_consumer.return_value = kafka_consumer
 

--- a/tests/stateful_consumer/test_bootstrap_state.py
+++ b/tests/stateful_consumer/test_bootstrap_state.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from base import FakeKafkaConsumer, message
+from base import FakeConfluentKafkaConsumer, message
 
 from snuba.datasets.factory import get_dataset
 from snuba.stateful_consumer import ConsumerStateCompletionEvent
@@ -24,7 +24,7 @@ class TestBootstrapState:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_empty_topic(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
             message(0, 0, None, True),
         ]
@@ -43,7 +43,7 @@ class TestBootstrapState:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_snapshot_for_other_table(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
             message(
                 0,
@@ -68,7 +68,7 @@ class TestBootstrapState:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_init_snapshot(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
             message(
                 0,
@@ -93,7 +93,7 @@ class TestBootstrapState:
 
     @patch('snuba.consumers.strict_consumer.StrictConsumer._create_consumer')
     def test_snapshot_loaded(self, create_consumer) -> None:
-        kafka_consumer = FakeKafkaConsumer()
+        kafka_consumer = FakeConfluentKafkaConsumer()
         kafka_consumer.items = [
             message(
                 0,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -4,7 +4,7 @@ import simplejson as json
 
 from base import (
     BaseEventsTest,
-    FakeKafkaProducer,
+    FakeConfluentKafkaProducer,
 )
 
 from snuba.consumer import ConsumerWorker
@@ -32,7 +32,7 @@ class TestConsumer(BaseEventsTest):
                 return 456
 
         replacement_topic = enforce_table_writer(self.dataset).get_stream_loader().get_replacement_topic_spec()
-        test_worker = ConsumerWorker(self.dataset, FakeKafkaProducer(), replacement_topic.topic_name, self.metrics)
+        test_worker = ConsumerWorker(self.dataset, FakeConfluentKafkaProducer(), replacement_topic.topic_name, self.metrics)
         batch = [test_worker.process_message(FakeMessage())]
         test_worker.flush_batch(batch)
 
@@ -42,7 +42,7 @@ class TestConsumer(BaseEventsTest):
 
     def test_skip_too_old(self):
         replacement_topic = enforce_table_writer(self.dataset).get_stream_loader().get_replacement_topic_spec()
-        test_worker = ConsumerWorker(self.dataset, FakeKafkaProducer(), replacement_topic.topic_name, self.metrics)
+        test_worker = ConsumerWorker(self.dataset, FakeConfluentKafkaProducer(), replacement_topic.topic_name, self.metrics)
 
         event = self.event
         old_timestamp = datetime.utcnow() - timedelta(days=300)
@@ -64,7 +64,7 @@ class TestConsumer(BaseEventsTest):
         assert test_worker.process_message(FakeMessage()) is None
 
     def test_produce_replacement_messages(self):
-        producer = FakeKafkaProducer()
+        producer = FakeConfluentKafkaProducer()
         replacement_topic = enforce_table_writer(self.dataset).get_stream_loader().get_replacement_topic_spec()
         test_worker = ConsumerWorker(self.dataset, producer, replacement_topic.topic_name, self.metrics)
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -2,15 +2,12 @@ import calendar
 from datetime import datetime, timedelta
 import simplejson as json
 
-from base import (
-    BaseEventsTest,
-    FakeConfluentKafkaProducer,
-)
-
 from snuba.consumer import ConsumerWorker
 from snuba.datasets.factory import enforce_table_writer
 from snuba.processor import ProcessedMessage, ProcessorAction
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
+from tests.base import BaseEventsTest
+from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 
 
 class TestConsumer(BaseEventsTest):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -7,7 +7,7 @@ from snuba.datasets.factory import enforce_table_writer
 from snuba.processor import ProcessedMessage, ProcessorAction
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from tests.base import BaseEventsTest
-from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
+from tests.backends.confluent_kafka import FakeConfluentKafkaProducer, build_confluent_kafka_message
 
 
 class TestConsumer(BaseEventsTest):
@@ -17,20 +17,15 @@ class TestConsumer(BaseEventsTest):
     def test_offsets(self):
         event = self.event
 
-        class FakeMessage(object):
-            def value(self):
-                # event doesn't really matter
-                return json.dumps((0, 'insert', event))
-
-            def offset(self):
-                return 123
-
-            def partition(self):
-                return 456
+        message = build_confluent_kafka_message(
+            123,
+            456,
+            json.dumps((0, 'insert', event))  # event doesn't really matter
+        )
 
         replacement_topic = enforce_table_writer(self.dataset).get_stream_loader().get_replacement_topic_spec()
         test_worker = ConsumerWorker(self.dataset, FakeConfluentKafkaProducer(), replacement_topic.topic_name, self.metrics)
-        batch = [test_worker.process_message(FakeMessage())]
+        batch = [test_worker.process_message(message)]
         test_worker.flush_batch(batch)
 
         assert self.clickhouse.execute(
@@ -48,17 +43,9 @@ class TestConsumer(BaseEventsTest):
         event['data']['datetime'] = old_timestamp_str
         event['data']['received'] = int(calendar.timegm(old_timestamp.timetuple()))
 
-        class FakeMessage(object):
-            def value(self):
-                return json.dumps((0, 'insert', event))
+        message = build_confluent_kafka_message(42, 1, json.dumps((0, 'insert', event)))
 
-            def partition(self):
-                return 1
-
-            def offset(self):
-                return 42
-
-        assert test_worker.process_message(FakeMessage()) is None
+        assert test_worker.process_message(message) is None
 
     def test_produce_replacement_messages(self):
         producer = FakeConfluentKafkaProducer()

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from functools import partial
 import simplejson as json
 
-from base import BaseEventsTest, FakeKafkaMessage
+from base import BaseEventsTest, FakeConfluentKafkaMessage
 
 from snuba import replacer
 from snuba.clickhouse import DATETIME_FORMAT
@@ -26,7 +26,7 @@ class TestReplacer(BaseEventsTest):
         self.project_id = 1
 
     def _wrap(self, msg):
-        return FakeKafkaMessage('topic', 0, 0, json.dumps(msg).encode('utf-8'))
+        return FakeConfluentKafkaMessage('topic', 0, 0, json.dumps(msg).encode('utf-8'))
 
     def _issue_count(self, project_id, group_id=None):
         args = {

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from functools import partial
 import simplejson as json
 
-from base import BaseEventsTest, FakeConfluentKafkaMessage
-
 from snuba import replacer
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
+from tests.base import BaseEventsTest
+from tests.backends.confluent_kafka import FakeConfluentKafkaMessage
 
 
 class TestReplacer(BaseEventsTest):

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -9,7 +9,7 @@ from snuba.clickhouse import DATETIME_FORMAT
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from tests.base import BaseEventsTest
-from tests.backends.confluent_kafka import FakeConfluentKafkaMessage
+from tests.backends.confluent_kafka import build_confluent_kafka_message
 
 
 class TestReplacer(BaseEventsTest):
@@ -26,7 +26,7 @@ class TestReplacer(BaseEventsTest):
         self.project_id = 1
 
     def _wrap(self, msg):
-        return FakeConfluentKafkaMessage('topic', 0, 0, json.dumps(msg).encode('utf-8'))
+        return build_confluent_kafka_message(0, 0, json.dumps(msg).encode('utf-8'))
 
     def _issue_count(self, project_id, group_id=None):
         args = {
@@ -172,21 +172,17 @@ class TestReplacer(BaseEventsTest):
 
         project_id = self.project_id
 
-        class FakeMessage(object):
-            def value(self):
-                return json.dumps((2, 'end_delete_groups', {
-                    'project_id': project_id,
-                    'group_ids': [1],
-                    'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                }))
+        message = build_confluent_kafka_message(
+            42,
+            1,
+            json.dumps((2, 'end_delete_groups', {
+                'project_id': project_id,
+                'group_ids': [1],
+                'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
+            }))
+        )
 
-            def partition(self):
-                return 1
-
-            def offset(self):
-                return 42
-
-        processed = self.replacer.process_message(FakeMessage())
+        processed = self.replacer.process_message(message)
         self.replacer.flush_batch([processed])
 
         assert self._issue_count(self.project_id) == []
@@ -202,22 +198,18 @@ class TestReplacer(BaseEventsTest):
 
         project_id = self.project_id
 
-        class FakeMessage(object):
-            def value(self):
-                return json.dumps((2, 'end_merge', {
-                    'project_id': project_id,
-                    'new_group_id': 2,
-                    'previous_group_ids': [1],
-                    'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                }))
+        message = build_confluent_kafka_message(
+            42,
+            1,
+            json.dumps((2, 'end_merge', {
+                'project_id': project_id,
+                'new_group_id': 2,
+                'previous_group_ids': [1],
+                'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
+            })),
+        )
 
-            def partition(self):
-                return 1
-
-            def offset(self):
-                return 42
-
-        processed = self.replacer.process_message(FakeMessage())
+        processed = self.replacer.process_message(message)
         self.replacer.flush_batch([processed])
 
         assert self._issue_count(1) == [{'count': 1, 'issue': 2}]
@@ -234,23 +226,19 @@ class TestReplacer(BaseEventsTest):
 
         project_id = self.project_id
 
-        class FakeMessage(object):
-            def value(self):
-                return json.dumps((2, 'end_unmerge', {
-                    'project_id': project_id,
-                    'previous_group_id': 1,
-                    'new_group_id': 2,
-                    'hashes': ['a' * 32],
-                    'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                }))
+        message = build_confluent_kafka_message(
+            42,
+            1,
+            json.dumps((2, 'end_unmerge', {
+                'project_id': project_id,
+                'previous_group_id': 1,
+                'new_group_id': 2,
+                'hashes': ['a' * 32],
+                'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
+            })),
+        )
 
-            def partition(self):
-                return 1
-
-            def offset(self):
-                return 42
-
-        processed = self.replacer.process_message(FakeMessage())
+        processed = self.replacer.process_message(message)
         self.replacer.flush_batch([processed])
 
         assert self._issue_count(self.project_id) == [{'count': 1, 'issue': 2}]
@@ -277,21 +265,17 @@ class TestReplacer(BaseEventsTest):
 
         timestamp = datetime.now(tz=pytz.utc)
 
-        class FakeMessage(object):
-            def value(self):
-                return json.dumps((2, 'end_delete_tag', {
-                    'project_id': project_id,
-                    'tag': 'browser.name',
-                    'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                }))
+        message = build_confluent_kafka_message(
+            42,
+            1,
+            json.dumps((2, 'end_delete_tag', {
+                'project_id': project_id,
+                'tag': 'browser.name',
+                'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
+            })),
+        )
 
-            def partition(self):
-                return 1
-
-            def offset(self):
-                return 42
-
-        processed = self.replacer.process_message(FakeMessage())
+        processed = self.replacer.process_message(message)
         self.replacer.flush_batch([processed])
 
         assert _issue_count() == []

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -6,35 +6,7 @@ from confluent_kafka import TopicPartition
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
-from base import FakeConfluentKafkaMessage
-
-
-class FakeKafkaProducer(object):
-    def __init__(self):
-        self.messages = []
-        self._callbacks = []
-
-    def poll(self, *args, **kwargs):
-        while self._callbacks:
-            callback, message = self._callbacks.pop()
-            callback(None, message)
-        return 0
-
-    def flush(self):
-        return self.poll()
-
-    def produce(self, topic, value, key=None, headers=None, on_delivery=None):
-        message = FakeConfluentKafkaMessage(
-            topic=topic,
-            partition=None,  # XXX: the partition is unknown (depends on librdkafka)
-            offset=None,  # XXX: the offset is unknown (depends on state)
-            key=key,
-            value=value,
-            headers=headers,
-        )
-        self.messages.append(message)
-        if on_delivery is not None:
-            self._callbacks.append((on_delivery, message))
+from base import FakeConfluentKafkaMessage, FakeConfluentKafkaProducer
 
 
 class FakeKafkaConsumer(object):
@@ -95,7 +67,7 @@ class TestConsumer(object):
             bootstrap_servers=None,
             group_id='group',
             commit_log_topic='commits',
-            producer=FakeKafkaProducer(),
+            producer=FakeConfluentKafkaProducer(),
             metrics=DummyMetricsBackend(strict=True),
         )
 
@@ -125,7 +97,7 @@ class TestConsumer(object):
             bootstrap_servers=None,
             group_id='group',
             commit_log_topic='commits',
-            producer=FakeKafkaProducer(),
+            producer=FakeConfluentKafkaProducer(),
             metrics=DummyMetricsBackend(strict=True),
         )
 

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -6,42 +6,7 @@ from confluent_kafka import TopicPartition
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
-
-
-class FakeKafkaMessage(object):
-    def __init__(self, topic, partition, offset, value, key=None, headers=None, error=None):
-        self._topic = topic
-        self._partition = partition
-        self._offset = offset
-        self._value = value
-        self._key = key
-        self._headers = {
-            str(k): str(v) if v else None
-            for k, v in headers.items()
-        } if headers else None
-        self._headers = headers
-        self._error = error
-
-    def topic(self):
-        return self._topic
-
-    def partition(self):
-        return self._partition
-
-    def offset(self):
-        return self._offset
-
-    def value(self):
-        return self._value
-
-    def key(self):
-        return self._key
-
-    def headers(self):
-        return self._headers
-
-    def error(self):
-        return self._error
+from base import FakeConfluentKafkaMessage
 
 
 class FakeKafkaProducer(object):
@@ -59,7 +24,7 @@ class FakeKafkaProducer(object):
         return self.poll()
 
     def produce(self, topic, value, key=None, headers=None, on_delivery=None):
-        message = FakeKafkaMessage(
+        message = FakeConfluentKafkaMessage(
             topic=topic,
             partition=None,  # XXX: the partition is unknown (depends on librdkafka)
             offset=None,  # XXX: the offset is unknown (depends on state)
@@ -134,7 +99,7 @@ class TestConsumer(object):
             metrics=DummyMetricsBackend(strict=True),
         )
 
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
+        consumer.consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
         for x in range(len(consumer.consumer.items)):
             consumer._run_once()
         consumer._shutdown()
@@ -165,17 +130,17 @@ class TestConsumer(object):
         )
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 0).timetuple())
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
+        consumer.consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
         for x in range(len(consumer.consumer.items)):
             consumer._run_once()
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 1).timetuple())
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [4, 5, 6]]
+        consumer.consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [4, 5, 6]]
         for x in range(len(consumer.consumer.items)):
             consumer._run_once()
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 5).timetuple())
-        consumer.consumer.items = [FakeKafkaMessage('topic', 0, i, i) for i in [7, 8, 9]]
+        consumer.consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [7, 8, 9]]
         for x in range(len(consumer.consumer.items)):
             consumer._run_once()
 

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -6,7 +6,7 @@ from confluent_kafka import TopicPartition
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
-from base import FakeConfluentKafkaMessage, FakeConfluentKafkaProducer
+from tests.backends.confluent_kafka import FakeConfluentKafkaMessage, FakeConfluentKafkaProducer
 
 
 class FakeKafkaConsumer(object):


### PR DESCRIPTION
- Includes `Confluent` in the name of all classes that purposefully act as objects that would be returned by the `confluent_kafka` library, and move those objects to `backends.confluent_kafka` (with the exception of `FakeConfluentKafkaMessage` which is still used in the main codebase, for the time being.)As part of the batching consumer refactoring, many stream-based components (such as implementations of `AbstractBatchWorker`) will no longer interact with the Confluent classes, but implementations of abstract classes that are similar enough to the Confluent ones to be easily confused unless we're careful. Other components (e.g. `StrictConsumer`) will still require the Confluent consumer, so the distinction is even more important.
- Consolidates the fake classes used by the batching consumer tests suite and all other Kafka-based tests.
- Consolidates many duplicate `FakeMessage` implementations to use the `FakeConfluentKafkaMessage`.
- Removes some dead code.

## Test Plan

These are tests, and they still run.