### PR TITLE
ref(tests): Make `tests` a package

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -28,7 +28,7 @@ def wrap_raw_event(event):
 
 
 def get_event():
-    from fixtures import raw_event
+    from tests.fixtures import raw_event
     timestamp = datetime.utcnow()
     raw_event['datetime'] = (timestamp - timedelta(seconds=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     raw_event['received'] = int(calendar.timegm((timestamp - timedelta(seconds=1)).timetuple()))

--- a/tests/clickhouse/test_query.py
+++ b/tests/clickhouse/test_query.py
@@ -1,4 +1,4 @@
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 from unittest.mock import patch
 
 from snuba.clickhouse.query import ClickhouseQuery

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -1,4 +1,4 @@
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 
 from snuba.query.parsing import ParsingContext
 from snuba.util import (

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -3,7 +3,7 @@ import pytest
 from collections import OrderedDict
 from datetime import datetime, timedelta
 
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 
 from snuba import settings
 from snuba.datasets.factory import enforce_table_writer

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -2,7 +2,7 @@ import pytz
 import simplejson as json
 from datetime import datetime
 
-from base import BaseDatasetTest
+from tests.base import BaseDatasetTest
 from snuba.clickhouse.native import ClickhousePool
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.cdc.groupassignee_processor import GroupAssigneeProcessor, GroupAssigneeRow

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -1,4 +1,4 @@
-from base import BaseTest
+from tests.base import BaseTest
 
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -1,7 +1,7 @@
 import pytest
 from typing import Sequence
 
-from base import BaseTest
+from tests.base import BaseTest
 from snuba import replacer, state
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor, ProjectWithGroupsProcessor
 from snuba.query.query import Query, Condition
@@ -99,7 +99,7 @@ class TestProjectExtensionWithGroups(BaseTest):
     def setup_method(self, test_method):
         super().setup_method(test_method)
         raw_data = {'project': 2}
-        
+
         self.extension = ProjectExtension(
             processor=ProjectWithGroupsProcessor()
         )

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 import uuid
 
-from base import BaseTest
+from tests.base import BaseTest
 from snuba import state
 from snuba.state.rate_limit import (
     rate_limit,

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -1,5 +1,5 @@
 from collections import ChainMap
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 from functools import partial
 import random
 import simplejson as json

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ from snuba import settings, state
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.redis import redis_client
 
-from base import BaseApiTest
+from tests.base import BaseApiTest
 
 
 class TestApi(BaseApiTest):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,4 +1,4 @@
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 
 from datetime import datetime, timedelta
 

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -1,4 +1,4 @@
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 
 from clickhouse_driver import errors
 from unittest.mock import patch, call

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -2,7 +2,7 @@ import pytz
 import simplejson as json
 from datetime import datetime
 
-from base import BaseDatasetTest
+from tests.base import BaseDatasetTest
 from snuba.clickhouse.native import ClickhousePool
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.cdc.groupedmessage_processor import GroupedMessageProcessor, GroupedMessageRow

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,4 +1,4 @@
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 
 from datetime import datetime, timedelta
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,4 +1,4 @@
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba import perf

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -9,7 +9,7 @@ import uuid
 from snuba import settings, state
 from snuba.datasets.factory import enforce_table_writer
 
-from base import BaseApiTest
+from tests.base import BaseApiTest
 
 
 class TestTransactionsApi(BaseApiTest):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 import pytest
 
-from base import BaseTest
+from tests.base import BaseTest
 
 from snuba.datasets.factory import get_dataset
 from snuba import state

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2,7 +2,7 @@ import pytest
 
 from typing import Iterable
 
-from base import BaseEventsTest
+from tests.base import BaseEventsTest
 from snuba.clickhouse.http import ClickHouseError, HTTPBatchWriter
 from snuba.datasets.factory import enforce_table_writer
 from snuba import settings


### PR DESCRIPTION
This allows it to be importable by mypy.

This also makes all `test.*` imports absolute because otherwise tests won't run for some reason I don't care to figure out.

## Test Plan

They still run, imports into `tests.fixtures` no longer report as `Any` with `reveal_type` when type checking.