### PR TITLE
ref(tests): Improve validity of Kafka message values in tests 

### DIFF
--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import time
 from itertools import chain
+from typing import Optional
 
 from snuba.util import settings_override
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
@@ -13,7 +14,10 @@ logger = logging.getLogger('snuba.perf')
 
 
 class FakeConfluentKafkaMessage(object):
-    def __init__(self, topic, partition, offset, value, key=None, headers=None, error=None):
+    def __init__(self, topic: str, partition: int, offset, value: Optional[bytes], key=None, headers=None, error=None) -> None:
+        if value is not None:
+            assert isinstance(value, bytes)
+
         self._topic = topic
         self._partition = partition
         self._offset = offset
@@ -35,7 +39,7 @@ class FakeConfluentKafkaMessage(object):
     def offset(self):
         return self._offset
 
-    def value(self):
+    def value(self) -> Optional[bytes]:
         return self._value
 
     def key(self):
@@ -53,7 +57,7 @@ def get_messages(events_file):
     messages = []
     raw_events = open(events_file).readlines()
     for raw_event in raw_events:
-        messages.append(FakeConfluentKafkaMessage('events', 1, 0, raw_event))
+        messages.append(FakeConfluentKafkaMessage('events', 1, 0, raw_event.encode('utf-8')))
     return messages
 
 

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -22,6 +22,7 @@ from snuba.clickhouse.query import ClickhouseQuery
 from snuba.query.timeseries import TimeSeriesExtensionProcessor
 from snuba.datasets.factory import InvalidDatasetError, enforce_table_writer, get_dataset, get_enabled_dataset_names
 from snuba.datasets.schemas.tables import TableSchema
+from snuba.perf import FakeConfluentKafkaMessage
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
 from snuba.redis import redis_client
@@ -430,20 +431,7 @@ if application.debug or application.testing:
         if version != 2:
             raise RuntimeError("Unsupported protocol version: %s" % record)
 
-        class Message(object):
-            def __init__(self, value):
-                self._value = value
-
-            def value(self):
-                return self._value
-
-            def partition(self):
-                return None
-
-            def offset(self):
-                return None
-
-        message = Message(http_request.data)
+        message = FakeConfluentKafkaMessage('topic', 0, 0, http_request.data)
 
         type_ = record[1]
         metrics = DummyMetricsBackend()

--- a/tests/backends/confluent_kafka.py
+++ b/tests/backends/confluent_kafka.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest.mock import MagicMock
 
 from confluent_kafka import TopicPartition, KafkaError
@@ -82,10 +83,11 @@ class FakeConfluentKafkaConsumer(object):
         return meta
 
 
-def build_confluent_kafka_message(offset, partition, value, eof=False) -> FakeConfluentKafkaMessage:
+def build_confluent_kafka_message(offset: int, partition: int, value: Optional[bytes], eof: bool = False) -> FakeConfluentKafkaMessage:
     if eof:
         error = MagicMock()
         error.code.return_value = KafkaError._PARTITION_EOF
+        assert value is None
     else:
         error = None
 

--- a/tests/consumers/test_strict_consumer.py
+++ b/tests/consumers/test_strict_consumer.py
@@ -54,7 +54,7 @@ class TestStrictConsumer:
         kafka_consumer = FakeConfluentKafkaConsumer()
         create_consumer.return_value = kafka_consumer
 
-        msg = build_confluent_kafka_message(0, 0, "ABCABC", False)
+        msg = build_confluent_kafka_message(0, 0, b"ABCABC", False)
         kafka_consumer.items = [
             msg,
             build_confluent_kafka_message(0, 0, None, True),
@@ -75,9 +75,9 @@ class TestStrictConsumer:
         error = MagicMock()
         error.code.return_value = KafkaError._PARTITION_EOF
         kafka_consumer.items = [
-            build_confluent_kafka_message(0, 0, "ABCABC", False),
-            build_confluent_kafka_message(1, 0, "ABCABC", False),
-            build_confluent_kafka_message(2, 0, "ABCABC", False),
+            build_confluent_kafka_message(0, 0, b"ABCABC", False),
+            build_confluent_kafka_message(1, 0, b"ABCABC", False),
+            build_confluent_kafka_message(2, 0, b"ABCABC", False),
             build_confluent_kafka_message(0, 0, None, True),
         ]
 

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -78,7 +78,7 @@ class TestSnapshotWorker:
     @pytest.mark.parametrize("message, expected", test_data)
     def test_send_message(
         self,
-        message: bytes,
+        message: str,
         expected: Optional[ProcessedMessage],
     ) -> None:
         dataset = get_dataset("groupedmessage")
@@ -99,6 +99,6 @@ class TestSnapshotWorker:
         )
 
         ret = worker.process_message(
-            build_confluent_kafka_message(1, 0, message)
+            build_confluent_kafka_message(1, 0, message.encode('utf-8'))
         )
         assert ret == expected

--- a/tests/stateful_consumer/test_bootstrap_state.py
+++ b/tests/stateful_consumer/test_bootstrap_state.py
@@ -47,7 +47,7 @@ class TestBootstrapState:
             build_confluent_kafka_message(
                 0,
                 0,
-                '{"snapshot-id":"abc123", "tables": ["someone_else"], "product":"snuba", "event":"snapshot-init"}',
+                b'{"snapshot-id":"abc123", "tables": ["someone_else"], "product":"snuba", "event":"snapshot-init"}',
                 False,
             ),
             build_confluent_kafka_message(0, 0, None, True),
@@ -72,7 +72,7 @@ class TestBootstrapState:
             build_confluent_kafka_message(
                 0,
                 0,
-                '{"snapshot-id":"abc123", "tables": ["sentry_groupedmessage"], "product":"snuba", "event":"snapshot-init"}',
+                b'{"snapshot-id":"abc123", "tables": ["sentry_groupedmessage"], "product":"snuba", "event":"snapshot-init"}',
                 False,
             ),
             build_confluent_kafka_message(0, 0, None, True),
@@ -97,22 +97,22 @@ class TestBootstrapState:
             build_confluent_kafka_message(
                 0,
                 0,
-                '{"snapshot-id":"abc123", "product":"somewhere-else", "tables": [], "event":"snapshot-init"}',
+                b'{"snapshot-id":"abc123", "product":"somewhere-else", "tables": [], "event":"snapshot-init"}',
                 False,
             ),
             build_confluent_kafka_message(
                 1,
                 0,
-                '{"snapshot-id":"abc123", "product":"snuba", "tables": ["sentry_groupedmessage"], "event":"snapshot-init"}',
+                b'{"snapshot-id":"abc123", "product":"snuba", "tables": ["sentry_groupedmessage"], "event":"snapshot-init"}',
                 False,
             ),
             build_confluent_kafka_message(
                 2,
                 0,
                 (
-                    '{"snapshot-id":"abc123", "event":"snapshot-loaded",'
-                    '"transaction-info": {"xmin":123, "xmax":124, "xip-list": []}'
-                    '}'
+                    b'{"snapshot-id":"abc123", "event":"snapshot-loaded",'
+                    b'"transaction-info": {"xmin":123, "xmax":124, "xip-list": []}'
+                    b'}'
                 ),
                 False,
             ),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -20,7 +20,7 @@ class TestConsumer(BaseEventsTest):
         message = build_confluent_kafka_message(
             123,
             456,
-            json.dumps((0, 'insert', event))  # event doesn't really matter
+            json.dumps((0, 'insert', event)).encode('utf-8')  # event doesn't really matter
         )
 
         replacement_topic = enforce_table_writer(self.dataset).get_stream_loader().get_replacement_topic_spec()
@@ -43,7 +43,11 @@ class TestConsumer(BaseEventsTest):
         event['data']['datetime'] = old_timestamp_str
         event['data']['received'] = int(calendar.timegm(old_timestamp.timetuple()))
 
-        message = build_confluent_kafka_message(42, 1, json.dumps((0, 'insert', event)))
+        message = build_confluent_kafka_message(
+            42,
+            1,
+            json.dumps((0, 'insert', event)).encode('utf-8'),
+        )
 
         assert test_worker.process_message(message) is None
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -179,7 +179,7 @@ class TestReplacer(BaseEventsTest):
                 'project_id': project_id,
                 'group_ids': [1],
                 'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-            }))
+            })).encode('utf-8'),
         )
 
         processed = self.replacer.process_message(message)
@@ -206,7 +206,7 @@ class TestReplacer(BaseEventsTest):
                 'new_group_id': 2,
                 'previous_group_ids': [1],
                 'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-            })),
+            })).encode('utf-8'),
         )
 
         processed = self.replacer.process_message(message)
@@ -235,7 +235,7 @@ class TestReplacer(BaseEventsTest):
                 'new_group_id': 2,
                 'hashes': ['a' * 32],
                 'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-            })),
+            })).encode('utf-8'),
         )
 
         processed = self.replacer.process_message(message)
@@ -272,7 +272,7 @@ class TestReplacer(BaseEventsTest):
                 'project_id': project_id,
                 'tag': 'browser.name',
                 'datetime': timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-            })),
+            })).encode('utf-8'),
         )
 
         processed = self.replacer.process_message(message)

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -40,13 +40,13 @@ class TestConsumer(object):
             metrics=DummyMetricsBackend(strict=True),
         )
 
-        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
+        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, f'{i}'.encode('utf-8')) for i in [1, 2, 3]]
         for x in range(len(consumer.items)):
             batching_consumer._run_once()
         batching_consumer._shutdown()
 
-        assert worker.processed == [1, 2, 3]
-        assert worker.flushed == [[1, 2]]
+        assert worker.processed == [b'1', b'2', b'3']
+        assert worker.flushed == [[b'1', b'2']]
         assert consumer.commit_calls == 1
         assert consumer.close_calls == 1
 
@@ -74,24 +74,24 @@ class TestConsumer(object):
         )
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 0).timetuple())
-        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [1, 2, 3]]
+        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, f'{i}'.encode('utf-8')) for i in [1, 2, 3]]
         for x in range(len(consumer.items)):
             batching_consumer._run_once()
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 1).timetuple())
-        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [4, 5, 6]]
+        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, f'{i}'.encode('utf-8')) for i in [4, 5, 6]]
         for x in range(len(consumer.items)):
             batching_consumer._run_once()
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 5).timetuple())
-        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, i) for i in [7, 8, 9]]
+        consumer.items = [FakeConfluentKafkaMessage('topic', 0, i, f'{i}'.encode('utf-8')) for i in [7, 8, 9]]
         for x in range(len(consumer.items)):
             batching_consumer._run_once()
 
         batching_consumer._shutdown()
 
-        assert worker.processed == [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        assert worker.flushed == [[1, 2, 3, 4, 5, 6]]
+        assert worker.processed == [b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9']
+        assert worker.flushed == [[b'1', b'2', b'3', b'4', b'5', b'6']]
         assert consumer.commit_calls == 1
         assert consumer.close_calls == 1
 


### PR DESCRIPTION
- Ensure that all `FakeConfluentKafkaMessage` `value` attributes are either `bytes` or `None`, not `str`. This ensures the return type is the same return types as would be provided by the Confluent Kafka consumer.
- Use `FakeConfluentKafkaMessage` in the testing API views for consistency with other parts of the codebase.