### PR TITLE
ref(streams): Extract commit log functionality from batching consumer

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -42,7 +42,7 @@ def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse
     from snuba.clickhouse.native import ClickhousePool
     from snuba.replacer import ReplacerWorker
     from snuba.utils.streams.batching import BatchingKafkaConsumer
-    from snuba.utils.streams.kafka import TransportError, build_kafka_consumer
+    from snuba.utils.streams.kafka import KafkaConsumer, TransportError, build_kafka_consumer_configuration
 
     sentry_sdk.init(dsn=settings.SENTRY_DSN)
     dataset = get_dataset(dataset)
@@ -78,12 +78,14 @@ def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse
     )
 
     replacer = BatchingKafkaConsumer(
-        build_kafka_consumer(
-            bootstrap_servers=bootstrap_server,
-            group_id=consumer_group,
-            auto_offset_reset=auto_offset_reset,
-            queued_max_messages_kbytes=queued_max_messages_kbytes,
-            queued_min_messages=queued_min_messages,
+        KafkaConsumer(
+            build_kafka_consumer_configuration(
+                bootstrap_servers=bootstrap_server,
+                group_id=consumer_group,
+                auto_offset_reset=auto_offset_reset,
+                queued_max_messages_kbytes=queued_max_messages_kbytes,
+                queued_min_messages=queued_min_messages,
+            ),
         ),
         replacements_topic,
         worker=ReplacerWorker(clickhouse, dataset, metrics=metrics),

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -90,9 +90,6 @@ def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse
         max_batch_size=max_batch_size,
         max_batch_time=max_batch_time_ms,
         metrics=metrics,
-        group_id=consumer_group,
-        producer=None,
-        commit_log_topic=None,
         recoverable_errors=[TransportError],
     )
 

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -8,7 +8,7 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
-from snuba.utils.streams.kafka import KafkaMessage, TransportError, build_kafka_consumer
+from snuba.utils.streams.kafka import KafkaConsumerWithCommitLog, KafkaMessage, TransportError, build_kafka_consumer
 
 
 class ConsumerBuilder:
@@ -56,6 +56,8 @@ class ConsumerBuilder:
             else None
         self.commit_log_topic = commit_log_topic or default_commit_log_topic_name
 
+        # XXX: This can result in a producer being built in cases where it's
+        # not actually required.
         self.producer = Producer({
             'bootstrap.servers': ','.join(self.bootstrap_servers),
             'partitioner': 'consistent',
@@ -78,22 +80,33 @@ class ConsumerBuilder:
         self.queued_min_messages = queued_min_messages
 
     def __build_consumer(self, worker: AbstractBatchWorker[KafkaMessage]) -> BatchingKafkaConsumer:
+        consumer = build_kafka_consumer(
+            bootstrap_servers=self.bootstrap_servers,
+            group_id=self.group_id,
+            auto_offset_reset=self.auto_offset_reset,
+            queued_max_messages_kbytes=self.queued_max_messages_kbytes,
+            queued_min_messages=self.queued_min_messages,
+        )
+
+        if self.commit_log_topic is not None:
+            # XXX: This does not type check correctly, since
+            # ``KafkaConsumerWithCommitLog`` isn't a subtype of
+            # ``KafkaConsumer``. This would be relatively easy to fix, but the
+            # implementation of ``KafkaConsumerWithCommitLog`` is likely to
+            # change anyway.
+            consumer = KafkaConsumerWithCommitLog(
+                consumer,
+                self.producer,
+                self.commit_log_topic,
+            )
+
         return BatchingKafkaConsumer(
-            build_kafka_consumer(
-                bootstrap_servers=self.bootstrap_servers,
-                group_id=self.group_id,
-                auto_offset_reset=self.auto_offset_reset,
-                queued_max_messages_kbytes=self.queued_max_messages_kbytes,
-                queued_min_messages=self.queued_min_messages,
-            ),
+            consumer,
             self.raw_topic,
             worker=worker,
             max_batch_size=self.max_batch_size,
             max_batch_time=self.max_batch_time_ms,
             metrics=self.metrics,
-            group_id=self.group_id,
-            producer=self.producer,
-            commit_log_topic=self.commit_log_topic,
             recoverable_errors=[TransportError],
         )
 

--- a/snuba/utils/streams/abstract.py
+++ b/snuba/utils/streams/abstract.py
@@ -30,7 +30,8 @@ class Message(Generic[TStream, TOffset, TValue]):
     """
     Represents a single message within a stream.
     """
-    __slots__ = ['stream', 'offset', 'value']
+
+    __slots__ = ["stream", "offset", "value"]
 
     stream: TStream
     offset: TOffset

--- a/snuba/utils/streams/abstract.py
+++ b/snuba/utils/streams/abstract.py
@@ -138,12 +138,13 @@ class Consumer(ABC, Generic[TStream, TOffset, TValue]):
         raise NotImplementedError
 
     @abstractmethod
-    def close(self) -> None:
+    def close(self, timeout: Optional[float] = None) -> None:
         """
         Close the consumer. This stops consuming messages, *may* commit
         staged offsets (depending on the implementation), and ends its
         subscription.
 
-        Raises a ``RuntimeError`` if called on a closed consumer.
+        Raises a ``TimeoutError`` if the consumer is unable to be closed
+        before the timeout is reached.
         """
         raise NotImplementedError

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -24,8 +24,8 @@ from confluent_kafka import (
 from confluent_kafka import Message as ConfluentMessage
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
-from snuba.utils.streams.abstract import ConsumerError
-from snuba.utils.streams.kafka import KafkaConsumer, KafkaMessage, TopicPartition
+from snuba.utils.streams.abstract import Consumer, ConsumerError, Message
+from snuba.utils.streams.kafka import TopicPartition
 
 
 logger = logging.getLogger("batching-kafka-consumer")
@@ -103,9 +103,9 @@ class BatchingKafkaConsumer:
 
     def __init__(
         self,
-        consumer: KafkaConsumer,
+        consumer: Consumer[TopicPartition, int, bytes],
         topic: str,
-        worker: AbstractBatchWorker[KafkaMessage],
+        worker: AbstractBatchWorker[Message[TopicPartition, int, bytes]],
         max_batch_size: int,
         max_batch_time: int,
         group_id: str,
@@ -185,7 +185,7 @@ class BatchingKafkaConsumer:
 
         self.shutdown = True
 
-    def _handle_message(self, msg: KafkaMessage) -> None:
+    def _handle_message(self, msg: Message[TopicPartition, int, bytes]) -> None:
         start = time.time()
 
         # set the deadline only after the first message for this batch is seen

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -2,13 +2,14 @@ import logging
 import time
 from typing import Any, Callable, Mapping, NamedTuple, Optional, Sequence
 
+from confluent_kafka import OFFSET_BEGINNING, OFFSET_END, OFFSET_INVALID, OFFSET_STORED
 from confluent_kafka import Consumer as ConfluentConsumer
 from confluent_kafka import KafkaError, KafkaException
 from confluent_kafka import Message as ConfluentMessage
+from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka import TopicPartition as ConfluentTopicPartition
 
 from snuba.utils.streams.abstract import Consumer, ConsumerError, EndOfStream, Message
-
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,7 @@ class TransportError(ConsumerError):
 
 class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
     def __init__(self, configuration: Mapping[str, Any]) -> None:
+        self.configuration = configuration  # XXX: Reconsider this?
         self.__consumer = ConfluentConsumer(configuration)
 
     def __wrap_assignment_callback(
@@ -139,3 +141,77 @@ def build_kafka_consumer(
             "enable.partition.eof": False,
         }
     )
+
+
+class KafkaConsumerWithCommitLog(Consumer[TopicPartition, int, bytes]):
+
+    # Set of logical (not literal) offsets to not publish to the commit log.
+    # https://github.com/confluentinc/confluent-kafka-python/blob/443177e1c83d9b66ce30f5eb8775e062453a738b/tests/test_enums.py#L22-L25
+    LOGICAL_OFFSETS = frozenset(
+        [OFFSET_BEGINNING, OFFSET_END, OFFSET_STORED, OFFSET_INVALID]
+    )
+
+    def __init__(
+        self,
+        consumer: KafkaConsumer,
+        producer: ConfluentProducer,
+        commit_log_topic: str,
+    ) -> None:
+        self.__consumer = consumer
+        self.__producer = producer
+        self.__commit_log_topic = commit_log_topic
+
+    def subscribe(
+        self,
+        topics: Sequence[str],
+        on_assign: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
+        on_revoke: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
+    ) -> None:
+        self.__consumer.subscribe(topics, on_assign, on_revoke)
+
+    def poll(self, timeout: Optional[float] = None) -> Optional[KafkaMessage]:
+        self.__producer.poll(0.0)
+        return self.__consumer.poll(timeout)
+
+    def __commit_message_delivery_callback(
+        self, error: Optional[KafkaError], message: ConfluentMessage
+    ) -> None:
+        if error is not None:
+            raise Exception(error.str())
+
+    def commit(self) -> Mapping[TopicPartition, int]:
+        offsets = self.__consumer.commit()
+
+        if self.__commit_log_topic:
+            for stream, offset in offsets.items():
+                # XXX: This is an abstraction leak from the Kafka consumer.
+                if offset in self.LOGICAL_OFFSETS:
+                    logger.debug(
+                        "Skipped publishing logical offset (%r) to commit log for %s",
+                        offset,
+                        stream,
+                    )
+                    continue
+                elif offset < 0:
+                    logger.warning(
+                        "Found unexpected negative offset (%r) after commit for %s",
+                        offset,
+                        stream,
+                    )
+
+                self.__producer.produce(
+                    self.__commit_log_topic,
+                    key="{}:{}:{}".format(
+                        stream.topic,
+                        stream.partition,
+                        self.__consumer.configuration["group_id"],
+                    ).encode("utf-8"),
+                    value="{}".format(offset).encode("utf-8"),
+                    on_delivery=self.__commit_message_delivery_callback,
+                )
+
+        return offsets
+
+    def close(self) -> None:
+        self.__producer.flush()
+        self.__consumer.close()

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -28,7 +28,6 @@ class TransportError(ConsumerError):
 
 class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
     def __init__(self, configuration: Mapping[str, Any]) -> None:
-        self.configuration = configuration  # XXX: Reconsider this?
         self.__consumer = ConfluentConsumer(configuration)
 
     def __wrap_assignment_callback(
@@ -122,28 +121,26 @@ DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 10000
 
 
-def build_kafka_consumer(
+def build_kafka_consumer_configuration(
     bootstrap_servers: Sequence[str],
     group_id: str,
     auto_offset_reset: str = "error",
     queued_max_messages_kbytes: int = DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
     queued_min_messages: int = DEFAULT_QUEUED_MIN_MESSAGES,
-) -> KafkaConsumer:
-    return KafkaConsumer(
-        {
-            "enable.auto.commit": False,
-            "bootstrap.servers": ",".join(bootstrap_servers),
-            "group.id": group_id,
-            "default.topic.config": {"auto.offset.reset": auto_offset_reset},
-            # overridden to reduce memory usage when there's a large backlog
-            "queued.max.messages.kbytes": queued_max_messages_kbytes,
-            "queued.min.messages": queued_min_messages,
-            "enable.partition.eof": False,
-        }
-    )
+) -> Mapping[str, Any]:
+    return {
+        "enable.auto.commit": False,
+        "bootstrap.servers": ",".join(bootstrap_servers),
+        "group.id": group_id,
+        "default.topic.config": {"auto.offset.reset": auto_offset_reset},
+        # overridden to reduce memory usage when there's a large backlog
+        "queued.max.messages.kbytes": queued_max_messages_kbytes,
+        "queued.min.messages": queued_min_messages,
+        "enable.partition.eof": False,
+    }
 
 
-class KafkaConsumerWithCommitLog(Consumer[TopicPartition, int, bytes]):
+class KafkaConsumerWithCommitLog(KafkaConsumer):
 
     # Set of logical (not literal) offsets to not publish to the commit log.
     # https://github.com/confluentinc/confluent-kafka-python/blob/443177e1c83d9b66ce30f5eb8775e062453a738b/tests/test_enums.py#L22-L25
@@ -153,25 +150,18 @@ class KafkaConsumerWithCommitLog(Consumer[TopicPartition, int, bytes]):
 
     def __init__(
         self,
-        consumer: KafkaConsumer,
+        configuration: Mapping[str, Any],
         producer: ConfluentProducer,
         commit_log_topic: str,
     ) -> None:
-        self.__consumer = consumer
+        super().__init__(configuration)
         self.__producer = producer
         self.__commit_log_topic = commit_log_topic
-
-    def subscribe(
-        self,
-        topics: Sequence[str],
-        on_assign: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
-        on_revoke: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
-    ) -> None:
-        self.__consumer.subscribe(topics, on_assign, on_revoke)
+        self.__group_id = configuration["group.id"]
 
     def poll(self, timeout: Optional[float] = None) -> Optional[KafkaMessage]:
         self.__producer.poll(0.0)
-        return self.__consumer.poll(timeout)
+        return super().poll(timeout)
 
     def __commit_message_delivery_callback(
         self, error: Optional[KafkaError], message: ConfluentMessage
@@ -180,7 +170,7 @@ class KafkaConsumerWithCommitLog(Consumer[TopicPartition, int, bytes]):
             raise Exception(error.str())
 
     def commit(self) -> Mapping[TopicPartition, int]:
-        offsets = self.__consumer.commit()
+        offsets = super().commit()
 
         if self.__commit_log_topic:
             for stream, offset in offsets.items():
@@ -202,9 +192,7 @@ class KafkaConsumerWithCommitLog(Consumer[TopicPartition, int, bytes]):
                 self.__producer.produce(
                     self.__commit_log_topic,
                     key="{}:{}:{}".format(
-                        stream.topic,
-                        stream.partition,
-                        self.__consumer.configuration["group_id"],
+                        stream.topic, stream.partition, self.__group_id
                     ).encode("utf-8"),
                     value="{}".format(offset).encode("utf-8"),
                     on_delivery=self.__commit_message_delivery_callback,
@@ -214,4 +202,4 @@ class KafkaConsumerWithCommitLog(Consumer[TopicPartition, int, bytes]):
 
     def close(self) -> None:
         self.__producer.flush()
-        self.__consumer.close()
+        super().close()

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -7,7 +7,6 @@ from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.abstract import Consumer
 from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
 from snuba.utils.streams.kafka import KafkaMessage, TopicPartition
-from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 
 
 class FakeKafkaConsumer(Consumer[TopicPartition, int, bytes]):
@@ -62,16 +61,12 @@ class TestConsumer(object):
     def test_batch_size(self) -> None:
         consumer = FakeKafkaConsumer()
         worker = FakeWorker()
-        producer = FakeConfluentKafkaProducer()
         batching_consumer = BatchingKafkaConsumer(
             consumer,
             'topic',
             worker=worker,
             max_batch_size=2,
             max_batch_time=100,
-            group_id='group',
-            commit_log_topic='commits',
-            producer=producer,
             metrics=DummyMetricsBackend(strict=True),
         )
 
@@ -85,26 +80,16 @@ class TestConsumer(object):
         assert consumer.commit_calls == 1
         assert consumer.close_calls == 1
 
-        assert len(producer.messages) == 1
-        commit_message = producer.messages[0]
-        assert commit_message.topic() == 'commits'
-        assert commit_message.key() == '{}:{}:{}'.format('topic', 0, 'group').encode('utf-8')
-        assert commit_message.value() == '{}'.format(2 + 1).encode('utf-8')  # offsets are last processed message offset + 1
-
     @patch('time.time')
     def test_batch_time(self, mock_time: Any) -> None:
         consumer = FakeKafkaConsumer()
         worker = FakeWorker()
-        producer = FakeConfluentKafkaProducer()
         batching_consumer = BatchingKafkaConsumer(
             consumer,
             'topic',
             worker=worker,
             max_batch_size=100,
             max_batch_time=2000,
-            group_id='group',
-            commit_log_topic='commits',
-            producer=producer,
             metrics=DummyMetricsBackend(strict=True),
         )
 
@@ -129,9 +114,3 @@ class TestConsumer(object):
         assert worker.flushed == [[b'1', b'2', b'3', b'4', b'5', b'6']]
         assert consumer.commit_calls == 1
         assert consumer.close_calls == 1
-
-        assert len(producer.messages) == 1
-        commit_message = producer.messages[0]
-        assert commit_message.topic() == 'commits'
-        assert commit_message.key() == '{}:{}:{}'.format('topic', 0, 'group').encode('utf-8')
-        assert commit_message.value() == '{}'.format(6 + 1).encode('utf-8')  # offsets are last processed message offset + 1

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -7,7 +7,8 @@ from typing import Iterator
 from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka.admin import AdminClient, NewTopic
 from snuba.utils.streams.abstract import EndOfStream, Message
-from snuba.utils.streams.kafka import KafkaConsumer, TopicPartition
+from snuba.utils.streams.kafka import KafkaConsumer, KafkaConsumerWithCommitLog, TopicPartition
+from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 
 
 configuration = {"bootstrap.servers": "127.0.0.1"}
@@ -88,3 +89,44 @@ def test_consumer(topic: str) -> None:
 
     with pytest.raises(RuntimeError):
         consumer.close()
+
+
+def test_commit_log_consumer(topic: str) -> None:
+    # XXX: This would be better as an integration test (or at least a test
+    # against an abstract Producer interface) instead of against a test against
+    # a mock.
+    commit_log_producer = FakeConfluentKafkaProducer()
+
+    consumer = KafkaConsumerWithCommitLog(
+        {
+            **configuration,
+            "auto.offset.reset": "earliest",
+            "enable.auto.commit": "false",
+            "enable.auto.offset.store": "true",
+            "enable.partition.eof": "true",
+            "group.id": "test",
+            "session.timeout.ms": 10000,
+            "default.topic.config": {  # XXX: Need to upgrade confluent-kafka
+                "auto.offset.reset": "earliest",
+            }
+        },
+        commit_log_producer,
+        'commit-log',
+    )
+
+    consumer.subscribe([topic])
+
+    producer = ConfluentProducer(configuration)
+    producer.produce(topic)
+    assert producer.flush(5.0) is 0
+
+    message = consumer.poll(10.0)  # XXX: getting the subscription is slow
+    assert isinstance(message, Message)
+
+    assert consumer.commit() == {TopicPartition(topic, 0): message.offset + 1}
+
+    assert len(commit_log_producer.messages) == 1
+    commit_message = commit_log_producer.messages[0]
+    assert commit_message.topic() == 'commit-log'
+    assert commit_message.key() == '{}:{}:{}'.format(topic, 0, 'test').encode('utf-8')
+    assert commit_message.value() == '{}'.format(message.offset + 1).encode('utf-8')  # offsets are last processed message offset + 1

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -87,8 +87,7 @@ def test_consumer(topic: str) -> None:
     with pytest.raises(RuntimeError):
         consumer.commit()
 
-    with pytest.raises(RuntimeError):
-        consumer.close()
+    consumer.close()
 
 
 def test_commit_log_consumer(topic: str) -> None:


### PR DESCRIPTION
This removes the commit log functionality from the `BatchingKafkaConsumer`, moving it to the `Consumer` implementation.

This effectively decouples the `BatchingKafkaConsumer` from being dependent on the Confluent Kafka APIs or Kafka-specific types like `TopicPartition`, but I haven't gone as far as genericising the type bounds in `BatchingKafkaConsumer` or updating the naming and documentation yet solely to reduce the size of this change. That will be done in a follow up.

## Test Plan

I've adapted the existing test to work with the new class. It is more dependent on mocks than I'd like, but to improve that we'll need to implement a Producer interface which doesn't seem like it should be a priority at the moment.