### PR TITLE
feat(datasets) Simplify join structure

### DIFF
--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -10,9 +10,9 @@ from snuba.datasets.schemas.join import (
     JoinConditionExpression,
     JoinCondition,
     JoinedSchema,
-    JoinStructure,
+    JoinClause,
     JoinType,
-    SchemaJoinedSource,
+    TableJoinNode,
 )
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.extensions import QueryExtension
@@ -36,12 +36,12 @@ class Groups(TimeSeriesDataset):
         self.__grouped_message = get_dataset("groupedmessage")
         self.__events = get_dataset("events")
 
-        join_structure = JoinStructure(
-            left_source=SchemaJoinedSource(
+        join_structure = JoinClause(
+            left_node=TableJoinNode(
                 self.GROUPS_ALIAS,
                 self.__grouped_message.get_dataset_schemas().get_read_schema(),
             ),
-            right_source=SchemaJoinedSource(
+            right_node=TableJoinNode(
                 self.EVENTS_ALIAS,
                 self.__events.get_dataset_schemas().get_read_schema(),
             ),

--- a/snuba/datasets/schemas/join.py
+++ b/snuba/datasets/schemas/join.py
@@ -131,4 +131,4 @@ class JoinedSchema(Schema):
         return QualifiedColumnSet(column_sets)
 
     def get_data_source(self) -> str:
-        return self.__join_structure.get_data_source()
+        return str(self.__source)

--- a/snuba/datasets/schemas/join.py
+++ b/snuba/datasets/schemas/join.py
@@ -9,6 +9,7 @@ from typing import Mapping, NamedTuple, Sequence
 
 from snuba.clickhouse.columns import QualifiedColumnSet
 from snuba.datasets.schemas import Schema
+from snuba.datasets.schemas.tables import TableSchema
 
 
 class JoinType(Enum):
@@ -40,7 +41,7 @@ class JoinCondition:
             f"{self.right.table_alias}.{self.right.column}"
 
 
-class JoinedSource(ABC):
+class JoinNode(ABC):
     """
     Represent an abstract node in the Join Structure tree. It can be
     a schema that will have an alias or another join structure.
@@ -59,13 +60,13 @@ class JoinedSource(ABC):
 
 
 @dataclass(frozen=True)
-class SchemaJoinedSource(JoinedSource):
+class TableJoinNode(JoinNode):
     """
     Represent one qualified data source in the JOIN expression.
     It can be a table or a view.
     """
     alias: str
-    schema: Schema
+    schema: TableSchema
 
     def __str__(self) -> str:
         return f"{self.schema.get_data_source()} {self.alias}"
@@ -75,28 +76,7 @@ class SchemaJoinedSource(JoinedSource):
 
 
 @dataclass(frozen=True)
-class SubJoinSource(JoinedSource):
-    """
-    Represents a sub expression in the join clause, which is a join on its own.
-    """
-    structure: JoinStructure
-
-    def __str__(self) -> str:
-        return f"{self.structure.get_data_source()}"
-
-    def get_schemas(self) -> Mapping[str, Schema]:
-        left = self.structure.left_source.get_schemas()
-        right = self.structure.right_source.get_schemas()
-        overlapping_aliases = left.keys() & right.keys()
-        for alias in overlapping_aliases:
-            # Ensures none defines the same alias twice in the join referring
-            # to different tables.
-            assert left[alias] == right[alias]
-        return ChainMap(left, right)
-
-
-@dataclass(frozen=True)
-class JoinStructure:
+class JoinClause(JoinNode):
     """
     Abstracts the join clause as a tree.
     Every node in the tree is either a join itself or a
@@ -106,37 +86,47 @@ class JoinStructure:
     This does not validate the join makes sense nor it checks
     the aliases are valid.
     """
-    left_source: JoinedSource
-    right_source: JoinedSource
+    left_node: JoinNode
+    right_node: JoinNode
     mapping: Sequence[JoinCondition]
     join_type: JoinType
 
-    def get_data_source(self) -> str:
+    def __str__(self) -> str:
         on_clause = " AND ".join([str(m) for m in self.mapping])
-        return f"{self.left_source} {self.join_type.value} JOIN {self.right_source} ON {on_clause}"
+        return f"{self.left_node} {self.join_type.value} JOIN {self.right_node} ON {on_clause}"
+
+    def get_schemas(self) -> Mapping[str, Schema]:
+        left = self.left_node.get_schemas()
+        right = self.right_node.get_schemas()
+        overlapping_aliases = left.keys() & right.keys()
+        for alias in overlapping_aliases:
+            # Ensures none defines the same alias twice in the join referring
+            # to different tables.
+            assert left[alias] == right[alias]
+        return ChainMap(left, right)
 
 
 class JoinedSchema(Schema):
     """
     Read only schema that represent multiple joined schemas.
-    The join clause is defined by the JoinStructure object
+    The join clause is defined by the JoinClause object
     that keeps reference to the schemas we are joining.
     """
 
     def __init__(self,
-        join_root: JoinStructure,
+        join_root: JoinNode,
     ) -> None:
         super().__init__(
             columns=self.__get_columns(join_root),
         )
-        self.__join_structure = join_root
+        self.__source = join_root
 
-    def __get_columns(self, structure: JoinStructure) -> QualifiedColumnSet:
+    def __get_columns(self, structure: JoinNode) -> QualifiedColumnSet:
         """
         Extracts all the columns recursively from the joined schemas and
         builds a column set that preserves the structure.
         """
-        schemas = SubJoinSource(structure).get_schemas()
+        schemas = structure.get_schemas()
         column_sets = {alias: schema.get_columns() for alias, schema in schemas.items()}
         return QualifiedColumnSet(column_sets)
 

--- a/tests/datasets/schemas/join_examples.py
+++ b/tests/datasets/schemas/join_examples.py
@@ -8,10 +8,10 @@ from snuba.datasets.schemas.tables import MergeTreeSchema
 from snuba.datasets.schemas.join import (
     JoinConditionExpression,
     JoinCondition,
-    JoinStructure,
+    JoinClause,
     JoinType,
-    SchemaJoinedSource,
-    SubJoinSource,
+    TableJoinNode,
+    JoinClause,
 )
 
 
@@ -58,9 +58,9 @@ table3 = MergeTreeSchema(
 )
 
 
-simple_join_structure = JoinStructure(
-    SchemaJoinedSource("t1", table1),
-    SchemaJoinedSource("t2", table2),
+simple_join_structure = JoinClause(
+    TableJoinNode("t1", table1),
+    TableJoinNode("t2", table2),
     [
         JoinCondition(
             left=JoinConditionExpression(table_alias="t1", column="c1"),
@@ -74,21 +74,19 @@ simple_join_structure = JoinStructure(
     JoinType.INNER
 )
 
-complex_join_structure = JoinStructure(
-    SubJoinSource(
-        JoinStructure(
-            SchemaJoinedSource("t1", table1),
-            SchemaJoinedSource("t2", table2),
-            [
-                JoinCondition(
-                    left=JoinConditionExpression(table_alias="t1", column="c1"),
-                    right=JoinConditionExpression(table_alias="t2", column="c2"),
-                ),
-            ],
-            JoinType.FULL
-        ),
+complex_join_structure = JoinClause(
+    JoinClause(
+        TableJoinNode("t1", table1),
+        TableJoinNode("t2", table2),
+        [
+            JoinCondition(
+                left=JoinConditionExpression(table_alias="t1", column="c1"),
+                right=JoinConditionExpression(table_alias="t2", column="c2"),
+            ),
+        ],
+        JoinType.FULL
     ),
-    SchemaJoinedSource("t3", table3),
+    TableJoinNode("t3", table3),
     [
         JoinCondition(
             left=JoinConditionExpression(table_alias="t1", column="c1"),

--- a/tests/datasets/test_join_source.py
+++ b/tests/datasets/test_join_source.py
@@ -20,5 +20,4 @@ test_data = [
 
 @pytest.mark.parametrize("structure, expected", test_data)
 def test_join_source(structure, expected):
-    join_clause = structure.get_data_source()
-    assert join_clause == expected
+    assert str(structure) == expected


### PR DESCRIPTION
While I was adding the FROM clause abstraction to the Query class I realized that the join tree structure could be simplified and that I could improve the naming of the classes. This change was orthogonal with respect to the Query changes so I extracted it into its own PR

test plan:
- the groups dataset works
- all the tests pass