### PR TITLE
ref: Make POST /tests/outcomes/insert work

### DIFF
--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -29,7 +29,7 @@ READ_DIST_TABLE_NAME = 'outcomes_hourly_dist'
 
 
 class OutcomesProcessor(MessageProcessor):
-    def process_message(self, value, metadata) -> Optional[ProcessedMessage]:
+    def process_message(self, value, metadata=None) -> Optional[ProcessedMessage]:
         assert isinstance(value, dict)
         v_uuid = value.get('event_id')
         message = {


### PR DESCRIPTION
So that https://github.com/getsentry/snuba/blob/master/snuba/views.py#L415 works.

Events and transactions have the metadata as optional and outcomes is not using it. So, also set the default to `None`.