### PR TITLE
ref(streams): Add offset value to ``EndOfStream`` exception

### DIFF
--- a/snuba/utils/streams/abstract.py
+++ b/snuba/utils/streams/abstract.py
@@ -46,13 +46,16 @@ class ConsumerError(Exception):
     """
 
 
-class EndOfStream(ConsumerError, Generic[TStream]):
+class EndOfStream(ConsumerError, Generic[TStream, TOffset]):
     """
     Raised when there are no more messages to consume from the stream.
     """
 
-    def __init__(self, stream: TStream):
+    def __init__(self, stream: TStream, offset: TOffset):
+        # The stream that the consumer has reached the end of.
         self.stream = stream
+        # The next unconsumed offset (where there is currently no message.)
+        self.offset = offset
 
 
 class Consumer(ABC, Generic[TStream, TOffset, TValue]):

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -68,7 +68,10 @@ class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
         if error is not None:
             code = error.code()
             if code == KafkaError._PARTITION_EOF:
-                raise EndOfStream(TopicPartition(message.topic(), message.partition()))
+                raise EndOfStream(
+                    TopicPartition(message.topic(), message.partition()),
+                    message.offset(),
+                )
             elif code == KafkaError._TRANSPORT:
                 raise TransportError(str(error))
             else:

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -1,6 +1,5 @@
 import pytest
 import uuid
-import time
 from unittest import mock
 from typing import Iterator
 

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -54,6 +54,7 @@ def test_consumer(topic: str) -> None:
         consumer.poll(10.0)  # XXX: getting the subcription is slow
     except EndOfStream as error:
         assert error.stream == TopicPartition(topic, 0)
+        assert error.offset == 0
     else:
         raise AssertionError('expected EndOfStream error')
 
@@ -67,11 +68,16 @@ def test_consumer(topic: str) -> None:
     message = consumer.poll(1.0)
     assert isinstance(message, Message)
     assert message.stream == TopicPartition(topic, 0)
+    assert message.offset == 0
     assert message.value == value
 
-    start = time.time()
-    assert consumer.poll(0.0) is None
-    assert time.time() - start < 0.001  # consumer should not block
+    try:
+        assert consumer.poll(1.0) is None
+    except EndOfStream as error:
+        assert error.stream == TopicPartition(topic, 0)
+        assert error.offset == 1
+    else:
+        raise AssertionError('expected EndOfStream error')
 
     assert consumer.commit() == {TopicPartition(topic, 0): message.offset + 1}
 


### PR DESCRIPTION
Small change extracted from my branch that adds `seek`/`tell` to the `Consumer` API. This will be useful for testing those changes.

## Test Plan

Integration test included.