### PR TITLE
ref(streams): Add `unsubscribe` to Consumer API

### DIFF
--- a/snuba/utils/streams/abstract.py
+++ b/snuba/utils/streams/abstract.py
@@ -93,6 +93,15 @@ class Consumer(ABC, Generic[TStream, TOffset, TValue]):
         raise NotImplementedError
 
     @abstractmethod
+    def unsubscribe(self) -> None:
+        """
+        Unsubscribe from streams.
+
+        Raises a ``RuntimeError`` if called on a closed consumer.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def poll(
         self, timeout: Optional[float] = None
     ) -> Optional[Message[TStream, TOffset, TValue]]:

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -75,6 +75,9 @@ class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
 
         self.__consumer.subscribe(topics, **kwargs)
 
+    def unsubscribe(self) -> None:
+        self.__consumer.unsubscribe()
+
     def poll(self, timeout: Optional[float] = None) -> Optional[KafkaMessage]:
         message: Optional[ConfluentMessage] = self.__consumer.poll(
             *[timeout] if timeout is not None else []

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -24,6 +24,9 @@ class FakeKafkaConsumer(Consumer[TopicPartition, int, bytes]):
     ) -> None:
         pass  # XXX: This is a bit of a smell.
 
+    def unsubscribe(self) -> None:
+        pass  # XXX: This is a bit of a smell.
+
     def poll(
         self, timeout: Optional[float] = None
     ) -> Optional[KafkaMessage]:


### PR DESCRIPTION
This adds test coverage to the revocation callback, which will be affected by the `tell`/`seek` changes.

## Test Plan

Integration tests included.