### PR TITLE
ref(kafka): Remove deprecated `default.topic.config` consumer configuration

### DIFF
--- a/scripts/reset-kafka-offsets.py
+++ b/scripts/reset-kafka-offsets.py
@@ -21,9 +21,7 @@ consumer_config = {
     'enable.auto.commit': False,
     'bootstrap.servers': '127.0.0.1:9093',
     'group.id': group_id,
-    'default.topic.config': {
-        'auto.offset.reset': 'error',
-    },
+    'auto.offset.reset': 'error',
 }
 
 consumer = Consumer(consumer_config)

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -68,9 +68,6 @@ class StrictConsumer:
             'group.id': group_id,
             'enable.partition.eof': 'true',
             'auto.offset.reset': initial_auto_offset_reset,
-            'default.topic.config': {
-                'auto.offset.reset': initial_auto_offset_reset,
-            },
         }
 
         self.__consumer = self._create_consumer(consumer_config)

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -165,7 +165,7 @@ def build_kafka_consumer_configuration(
         "enable.auto.commit": False,
         "bootstrap.servers": ",".join(bootstrap_servers),
         "group.id": group_id,
-        "default.topic.config": {"auto.offset.reset": auto_offset_reset},
+        "auto.offset.reset": auto_offset_reset,
         # overridden to reduce memory usage when there's a large backlog
         "queued.max.messages.kbytes": queued_max_messages_kbytes,
         "queued.min.messages": queued_min_messages,

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -110,9 +110,6 @@ def test_commit_log_consumer(topic: str) -> None:
             "enable.partition.eof": "true",
             "group.id": "test",
             "session.timeout.ms": 10000,
-            "default.topic.config": {  # XXX: Need to upgrade confluent-kafka
-                "auto.offset.reset": "earliest",
-            }
         },
         commit_log_producer,
         'commit-log',


### PR DESCRIPTION
This was deprecated in [v1.0.0 of confluent-kafka](https://github.com/confluentinc/confluent-kafka-python/releases/tag/v1.0.0).