### PR TITLE
feat(transactions): Align event_id field to events dataset

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -175,6 +175,8 @@ class TransactionsDataset(TimeSeriesDataset):
             return 'IPv4NumToString(ip_address_v4)'
         if column_name == 'ip_address_v6':
             return 'IPv6NumToString(ip_address_v6)'
+        if column_name == 'event_id':
+            return 'replaceAll(toString(event_id), \'-\', \'\')'
         processed_column = self.__tags_processor.process_column_expression(column_name, query, parsing_context, table_alias)
         if processed_column:
             # If processed_column is None, this was not a tag/context expression


### PR DESCRIPTION
Always treat the event_id column as a hex string, like the events
dataset.

This ensures that we get correct results when a query contains a
condition on the event_id column, and we return properly formatted event
IDs to the end user.