### PR TITLE
feat(streams): Add `seek`/`tell` to Consumer API

### DIFF
--- a/snuba/utils/streams/abstract.py
+++ b/snuba/utils/streams/abstract.py
@@ -139,6 +139,24 @@ class Consumer(ABC, Generic[TStream, TOffset, TValue]):
         raise NotImplementedError
 
     @abstractmethod
+    def tell(self) -> Mapping[TStream, TOffset]:
+        """
+        Return the read offsets for all assigned streams.
+
+        Raises a ``RuntimeError`` if called on a closed consumer.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def seek(self, offsets: Mapping[TStream, TOffset]) -> None:
+        """
+        Change the read offsets for the provided streams.
+
+        Raises a ``RuntimeError`` if called on a closed consumer.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def commit(self) -> Mapping[TStream, TOffset]:
         """
         Commit staged offsets for all streams that this consumer is assigned

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -251,13 +251,13 @@ class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
                     for stream, offset in offsets.items()
                 ]
             )
-            self.__offsets.update(offsets)
         else:
             for stream, offset in offsets.items():
                 self.__consumer.seek(
                     ConfluentTopicPartition(stream.topic, stream.partition, offset)
                 )
-                self.__offsets[stream] = offset
+
+        self.__offsets.update(offsets)
 
     def seek(self, offsets: Mapping[TopicPartition, int]) -> None:
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -37,7 +37,7 @@ class TransportError(ConsumerError):
 
 class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
     """
-    The behavior of the of this consumer differs slightly from the Confluent
+    The behavior of this consumer differs slightly from the Confluent
     consumer during rebalancing operations. Whenever a partition is assigned
     to this consumer, offsets are *always* automatically reset to the
     committed offset for that partition (or if no offsets have been committed

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -179,6 +179,16 @@ class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
                 if on_revoke is not None:
                     on_revoke(streams)
             finally:
+                for stream in streams:
+                    try:
+                        self.__offsets.pop(stream)
+                    except KeyError:
+                        # If there was an error during assignment, this stream
+                        # may have never been added to the offsets mapping.
+                        logger.warning(
+                            "failed to delete offset for unknown stream: %r", stream
+                        )
+
                 self.__state = KafkaConsumerState.CONSUMING
 
         self.__consumer.subscribe(

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -242,9 +242,9 @@ class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
 
     def __seek(self, offsets: Mapping[TopicPartition, int]) -> None:
         if self.__state is KafkaConsumerState.ASSIGNING:
-            # Trying to use ``seek`` while in an assignment callback will yield
-            # throw an "Erroneous state" error, so seeking actually happens via
-            # assignment in the callback.
+            # Calling ``seek`` on the Confluent consumer from an assignment
+            # callback will throw an "Erroneous state" error. Instead,
+            # partition offsets have to be initialized by calling ``assign``.
             self.__consumer.assign(
                 [
                     ConfluentTopicPartition(stream.topic, stream.partition, offset)

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -39,6 +39,12 @@ class FakeKafkaConsumer(Consumer[TopicPartition, int, bytes]):
 
         return message
 
+    def tell(self) -> Mapping[TopicPartition, int]:
+        return self.__positions
+
+    def seek(self, offsets: Mapping[TopicPartition, int]) -> None:
+        raise NotImplementedError  # XXX: This is a bit more of a smell.
+
     def commit(self) -> Mapping[TopicPartition, int]:
         self.commit_calls += 1
         return self.positions

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -1,6 +1,5 @@
 import pytest
 import uuid
-from unittest import mock
 from typing import Iterator, Sequence
 
 from confluent_kafka import Producer as ConfluentProducer
@@ -102,6 +101,11 @@ def test_consumer(topic: str) -> None:
     consumer.unsubscribe()
 
     assert consumer.poll(1.0) is None
+
+    assert consumer.tell() == {}
+
+    with pytest.raises(ConsumerError):
+        consumer.seek({TopicPartition(topic, 0): 0})
 
     consumer.close()
 


### PR DESCRIPTION
This adds `seek` and `tell` methods for updating consumer read positions.

This differs from the Confluent API in a few ways:

- `tell` will always return an absolute and valid offset (including during subscription callbacks), unlike the `confluent_kafka.TopicPartition` instances provided to the native callbacks and the native `Consumer.positions()` API
- `seek` works consistently during the subscription callbacks (rebalancing states) as well as during normal consumption

## Test Plan

This includes some basic integration tests, but could really use some multi-consumer integration tests.