### PR TITLE
ref(streams): Consistent handling of stream start point on assignment

### DIFF
--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -37,7 +37,7 @@ class TransportError(ConsumerError):
 
 class KafkaConsumer(Consumer[TopicPartition, int, bytes]):
     """
-    The behavior of the of this consumer differs slightly from the Confluent
+    The behavior of this consumer differs slightly from the Confluent
     consumer during rebalancing operations. Whenever a partition is assigned
     to this consumer, offsets are *always* automatically reset to the
     committed offset for that partition (or if no offsets have been committed


### PR DESCRIPTION
This is extracted from #526 to make it a bit easier to review (which was in turn extracted from #478, which was extracted from the `SynchronizedConsumer`, which I don't think was extracted from anywhere in particular.)

## Test Plan

The all offset resolution paths and callback changes are tested by new or existing tests.