### PR TITLE
fix(processing) Skip invalid transaction events

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Optional
 
-import ipaddress
 import uuid
 
 from snuba.processor import (
@@ -58,6 +57,8 @@ class TransactionsMessageProcessor(MessageProcessor):
             event,
             datetime.fromtimestamp(data['timestamp']),
         )
+        if not data.get('contexts', {}).get('trace'):
+            return None
 
         transaction_ctx = data["contexts"]["trace"]
         trace_id = transaction_ctx["trace_id"]

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -165,6 +165,60 @@ class TransactionEvent:
 
 class TestTransactionsProcessor(BaseTest):
 
+    def test_skip_non_transactions(self):
+        message = TransactionEvent(
+            event_id='e5e062bf2e1d4afd96fd2f90b6770431',
+            trace_id='7400045b25c443b885914600aa83ad04',
+            span_id='8841662216cc598b',
+            transaction_name='/organizations/:orgId/issues/',
+            op='navigation',
+            start_timestamp=1565303393.917,
+            timestamp=1565303392.918,
+            platform='python',
+            dist='',
+            user_name='me',
+            user_id='myself',
+            user_email='me@myself.com',
+            ipv4='127.0.0.1',
+            ipv6=None,
+            environment='prod',
+            release='34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a',
+        )
+        payload = message.serialize()
+        # Force an invalid event
+        payload[2]['data']['type'] = 'error'
+
+        meta = KafkaMessageMetadata(offset=1, partition=2)
+        processor = TransactionsMessageProcessor()
+        assert processor.process_message(payload, meta) is None
+
+    def test_missing_trace_context(self):
+        message = TransactionEvent(
+            event_id='e5e062bf2e1d4afd96fd2f90b6770431',
+            trace_id='7400045b25c443b885914600aa83ad04',
+            span_id='8841662216cc598b',
+            transaction_name='/organizations/:orgId/issues/',
+            op='navigation',
+            start_timestamp=1565303393.917,
+            timestamp=1565303392.918,
+            platform='python',
+            dist='',
+            user_name='me',
+            user_id='myself',
+            user_email='me@myself.com',
+            ipv4='127.0.0.1',
+            ipv6=None,
+            environment='prod',
+            release='34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a',
+        )
+        payload = message.serialize()
+        # Force an invalid event
+        del payload[2]['data']['contexts']
+
+        meta = KafkaMessageMetadata(offset=1, partition=2)
+        processor = TransactionsMessageProcessor()
+        assert processor.process_message(payload, meta) is None
+
     def test_base_process(self):
         message = TransactionEvent(
             event_id='e5e062bf2e1d4afd96fd2f90b6770431',


### PR DESCRIPTION
If we receive events that lack `contexts.trace` we should skip those events as they are invalid. The current event validation does not catch transaction events that are lacking trace context so we do it here for now.

I've not handled the trace context being malformed as that hasn't happened _yet_ and the better solution is to fix event validation.