### PR TITLE
Add some type hints in state/__init__

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -8,7 +8,6 @@ import re
 import simplejson as json
 import time
 import uuid
-from collections.abc import Mapping as MappingCollection
 from functools import partial
 from typing import Any, Iterator, Mapping, Optional, Sequence
 
@@ -207,7 +206,7 @@ def get_config_changes() -> Sequence[Any]:
 
 
 def safe_dumps_default(value: Any) -> Any:
-    if isinstance(value, MappingCollection):
+    if isinstance(value, Mapping):
         return {**value}
     raise TypeError(f'Cannot convert object of type {type(value).__name__} to JSON-safe type')
 


### PR DESCRIPTION
Same as #530  but addresses state/__init__
This does not fix anything, it just declare the types according to what the functions do. The idea is that a lot of errors like:

- Function is missing a type annotation
- Call to untyped function "blabla" in typed context
will be replaced by meaningful errors highlighting what we are doing wrong.

```
(snuba) bash-3.2$ mypy --strict snuba | wc -l
     720
(snuba) bash-3.2$ git checkout master 
Your branch is up to date with 'origin/master'.
(snuba) bash-3.2$ mypy --strict snuba | wc -l
     732
```