### PR TITLE
fix(cdc) Fix bootstrap override for strict consumer

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -73,7 +73,6 @@ def consumer(raw_events_topic, replacements_topic, commit_log_topic, control_top
         context = ConsumerStateMachine(
             consumer_builder=consumer_builder,
             topic=control_topic or dataset.get_default_control_topic(),
-            bootstrap_servers=bootstrap_server,
             group_id=consumer_group,
             dataset=dataset,
         )

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -95,7 +95,7 @@ class StrictConsumer:
             if self.__on_partitions_revoked:
                 self.__on_partitions_revoked(consumer, partitions)
 
-        logger.debug("Subscribing strict consuemr to topic %s", topic)
+        logger.debug("Subscribing strict consuemr to topic %s on broker %r", topic, bootstrap_servers)
         self.__consumer.subscribe(
             [topic],
             on_assign=_on_partitions_assigned,

--- a/snuba/stateful_consumer/consumer_state_machine.py
+++ b/snuba/stateful_consumer/consumer_state_machine.py
@@ -21,13 +21,11 @@ class ConsumerStateMachine(StateMachine[ConsumerStateCompletionEvent, Optional[C
         self,
         consumer_builder: ConsumerBuilder,
         topic: str,
-        bootstrap_servers: Sequence[str],
         group_id: str,
         dataset: CdcDataset,
     ) -> None:
         self.__consumer_builder = consumer_builder
         self.__topic = topic
-        self.__bootstrap_servers = bootstrap_servers
         self.__group_id = group_id
         self.__dataset = dataset
 
@@ -63,7 +61,7 @@ class ConsumerStateMachine(StateMachine[ConsumerStateCompletionEvent, Optional[C
         elif state_class == BootstrapState:
             return BootstrapState(
                 topic=self.__topic,
-                bootstrap_servers=self.__bootstrap_servers,
+                bootstrap_servers=self.__consumer_builder.bootstrap_servers,
                 group_id=self.__group_id,
                 dataset=self.__dataset,
             )


### PR DESCRIPTION
The strict consumer during stateful consumer bootstrap was picking up the bootstrap server only from the command line and skipping the value in the configuration and the dataset override.

Now we pick it up from the consumer builder.