### PR TITLE
ref(streams): Remove remaining coupling between batching consumer and Kafka

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -41,7 +41,7 @@ def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse
     from snuba import util
     from snuba.clickhouse.native import ClickhousePool
     from snuba.replacer import ReplacerWorker
-    from snuba.utils.streams.batching import BatchingKafkaConsumer
+    from snuba.utils.streams.batching import BatchingConsumer
     from snuba.utils.streams.kafka import KafkaConsumer, TransportError, build_kafka_consumer_configuration
 
     sentry_sdk.init(dsn=settings.SENTRY_DSN)
@@ -77,7 +77,7 @@ def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse
         client_settings=client_settings,
     )
 
-    replacer = BatchingKafkaConsumer(
+    replacer = BatchingConsumer(
         KafkaConsumer(
             build_kafka_consumer_configuration(
                 bootstrap_servers=bootstrap_server,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -7,7 +7,7 @@ from snuba.consumers.snapshot_worker import SnapshotAwareWorker
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
-from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
+from snuba.utils.streams.batching import AbstractBatchWorker, BatchingConsumer
 from snuba.utils.streams.kafka import KafkaConsumer, KafkaConsumerWithCommitLog, KafkaMessage, TransportError, build_kafka_consumer_configuration
 
 
@@ -79,7 +79,7 @@ class ConsumerBuilder:
         self.queued_max_messages_kbytes = queued_max_messages_kbytes
         self.queued_min_messages = queued_min_messages
 
-    def __build_consumer(self, worker: AbstractBatchWorker[KafkaMessage]) -> BatchingKafkaConsumer:
+    def __build_consumer(self, worker: AbstractBatchWorker[KafkaMessage]) -> BatchingConsumer:
         configuration = build_kafka_consumer_configuration(
             bootstrap_servers=self.bootstrap_servers,
             group_id=self.group_id,
@@ -97,7 +97,7 @@ class ConsumerBuilder:
                 self.commit_log_topic,
             )
 
-        return BatchingKafkaConsumer(
+        return BatchingConsumer(
             consumer,
             self.raw_topic,
             worker=worker,
@@ -107,7 +107,7 @@ class ConsumerBuilder:
             recoverable_errors=[TransportError],
         )
 
-    def build_base_consumer(self) -> BatchingKafkaConsumer:
+    def build_base_consumer(self) -> BatchingConsumer:
         """
         Builds the consumer with a ConsumerWorker.
         """
@@ -124,7 +124,7 @@ class ConsumerBuilder:
         self,
         snapshot_id: SnapshotId,
         transaction_data: TransactionData,
-    ) -> BatchingKafkaConsumer:
+    ) -> BatchingConsumer:
         """
         Builds the consumer with a ConsumerWorker able to handle snapshots.
         """

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.abstract import Consumer
-from snuba.utils.streams.batching import AbstractBatchWorker, BatchingKafkaConsumer
+from snuba.utils.streams.batching import AbstractBatchWorker, BatchingConsumer
 from snuba.utils.streams.kafka import KafkaMessage, TopicPartition
 
 
@@ -64,7 +64,7 @@ class TestConsumer(object):
     def test_batch_size(self) -> None:
         consumer = FakeKafkaConsumer()
         worker = FakeWorker()
-        batching_consumer = BatchingKafkaConsumer(
+        batching_consumer = BatchingConsumer(
             consumer,
             'topic',
             worker=worker,
@@ -87,7 +87,7 @@ class TestConsumer(object):
     def test_batch_time(self, mock_time: Any) -> None:
         consumer = FakeKafkaConsumer()
         worker = FakeWorker()
-        batching_consumer = BatchingKafkaConsumer(
+        batching_consumer = BatchingConsumer(
             consumer,
             'topic',
             worker=worker,


### PR DESCRIPTION
The batching consumer now works with any abstract Consumer implementation, as long as the messages returned by that Consumer match the type expected by the batch worker. This updates type signatures and documentation to reflect that.