### PR TITLE
ref(streams): Add generic type variable to worker result

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -26,7 +26,7 @@ class InvalidActionType(Exception):
     pass
 
 
-class ConsumerWorker(AbstractBatchWorker[KafkaMessage]):
+class ConsumerWorker(AbstractBatchWorker[KafkaMessage, ProcessedMessage]):
     def __init__(self, dataset, producer, replacements_topic, metrics: MetricsBackend):
         self.__dataset = dataset
         self.producer = producer

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -7,7 +7,7 @@ from snuba.consumers.snapshot_worker import SnapshotAwareWorker
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
-from snuba.utils.streams.batching import AbstractBatchWorker, BatchingConsumer
+from snuba.utils.streams.batching import BatchingConsumer
 from snuba.utils.streams.kafka import KafkaConsumer, KafkaConsumerWithCommitLog, KafkaMessage, TransportError, build_kafka_consumer_configuration
 
 
@@ -79,7 +79,7 @@ class ConsumerBuilder:
         self.queued_max_messages_kbytes = queued_max_messages_kbytes
         self.queued_min_messages = queued_min_messages
 
-    def __build_consumer(self, worker: AbstractBatchWorker[KafkaMessage]) -> BatchingConsumer:
+    def __build_consumer(self, worker: ConsumerWorker) -> BatchingConsumer:
         configuration = build_kafka_consumer_configuration(
             bootstrap_servers=self.bootstrap_servers,
             group_id=self.group_id,

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -99,7 +99,7 @@ class Replacement:
     query_time_flags: Any
 
 
-class ReplacerWorker(AbstractBatchWorker[KafkaMessage]):
+class ReplacerWorker(AbstractBatchWorker[KafkaMessage, Replacement]):
     def __init__(self, clickhouse: ClickhousePool, dataset: Dataset, metrics: MetricsBackend) -> None:
         self.clickhouse = clickhouse
         self.dataset = dataset

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -47,7 +47,7 @@ class FakeKafkaConsumer(Consumer[TopicPartition, int, bytes]):
         self.close_calls += 1
 
 
-class FakeWorker(AbstractBatchWorker[KafkaMessage]):
+class FakeWorker(AbstractBatchWorker[KafkaMessage, Any]):
     def __init__(self) -> None:
         self.processed: MutableSequence[Optional[Any]] = []
         self.flushed: MutableSequence[Sequence[Any]] = []


### PR DESCRIPTION
Follow up to comment in #541 and also noted prior.

## Test Plan

md5 /tmp/report-*
MD5 (/tmp/report-branch.txt) = c25b579da83ef69106c0cb9ba8785eeb
MD5 (/tmp/report-master.txt) = c25b579da83ef69106c0cb9ba8785eeb