### PR TITLE
ref(streams): Use result type in batching consumer

### DIFF
--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -3,7 +3,6 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
-    Any,
     Generic,
     MutableMapping,
     MutableSequence,
@@ -112,7 +111,7 @@ class BatchingConsumer:
 
         self.shutdown = False
 
-        self.__batch_results: MutableSequence[Any] = []
+        self.__batch_results: MutableSequence[TResult] = []
         self.__batch_offsets: MutableMapping[TStream, Offsets[TOffset]] = {}
         self.__batch_deadline: Optional[float] = None
         self.__batch_messages_processed_count: int = 0


### PR DESCRIPTION
Missed a spot in 19777d8c9fa595360175c1229fa9d835b8640a1c