### PR TITLE
feat: Support column name aliases in selected columns

### DIFF
--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -11,6 +11,7 @@ from snuba.util import (
     escape_alias,
     escape_literal,
     function_expr,
+    is_alias_column_expr,
     is_condition,
     is_function,
     QUOTED_LITERAL_RE,
@@ -42,6 +43,9 @@ def column_expr(dataset, column_name, query: Query, parsing_context: ParsingCont
     elif isinstance(column_name, str) and QUOTED_LITERAL_RE.match(column_name):
         return escape_literal(column_name[1:-1])
     else:
+        # Handle column alias
+        if is_alias_column_expr(column_name):
+            (column_name, _, alias) = column_name
         expr = dataset.column_expr(column_name, query, parsing_context)
 
     if aggregate:

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -155,6 +155,23 @@ def is_function(column_expr: Any, depth: int=0) -> Optional[Tuple[Any, ...]]:
         return None
 
 
+def is_alias_column_expr(column_expr: Any) -> bool:
+    """
+    Returns True if column_expr is an alias column expression, otherwise False.
+
+    An alias column expression is a 3-tuple of (column_name, None, alias)
+    """
+    if (
+        isinstance(column_expr, (list, tuple))
+        and len(column_expr) == 3
+        and isinstance(column_expr[0], str)
+        and column_expr[1] is None
+        and isinstance(column_expr[2], str)
+    ):
+        return True
+    return False
+
+
 def alias_expr(expr: str, alias: str, parsing_context: ParsingContext) -> str:
     """
     Return the correct expression to use in the final SQL. Keeps a cache of
@@ -200,9 +217,11 @@ def columns_in_expr(expr: Any) -> Sequence[str]:
     if isinstance(expr, str):
         cols.append(expr.lstrip('-'))
     elif (isinstance(expr, (list, tuple)) and len(expr) >= 2
-          and isinstance(expr[1], (list, tuple))):
+            and isinstance(expr[1], (list, tuple))):
         for func_arg in expr[1]:
             cols.extend(columns_in_expr(func_arg))
+    elif is_alias_column_expr(expr):
+        cols.append(expr[0])
     return cols
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -159,6 +159,16 @@ class TestUtil(BaseTest):
         assert column_expr(dataset, top_k[1], Query({'aggregations': [top_k]}, source), ParsingContext(), top_k[2], top_k[0]) == '(topK(3)(logger) AS top_3)'
 
     @pytest.mark.parametrize('dataset', DATASETS)
+    def test_column_expr(self, dataset):
+        source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
+        col = ('event_id', None, 'event.id')
+        query = Query({"selected_columns": [
+            col,
+        ]}, source)
+        parsing_context = ParsingContext()
+        assert column_expr(dataset, col, query=query, parsing_context=parsing_context)
+
+    @pytest.mark.parametrize('dataset', DATASETS)
     def test_complex_conditions_expr(self, dataset):
         source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
         query = Query({}, source)


### PR DESCRIPTION
Selected columns of the form [col_name, None, alias] are interpreted
as "col_name AS alias".

This will help simplify mapping between internal names and
external aliases in Sentry.