### PR TITLE
ref(streams): Refine working, staged, and committed offsets API

### DIFF
--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -175,8 +175,7 @@ class BatchingConsumer:
         if result is not None:
             self.__batch_results.append(result)
 
-        # XXX: abstraction leak/invalid type
-        self.consumer.stage_offsets({msg.stream: msg.offset + 1})
+        self.consumer.stage_offsets({msg.stream: msg.next_offset})
 
         duration = (time.time() - start) * 1000
         self.__batch_messages_processed_count += 1

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -63,8 +63,8 @@ class AbstractBatchWorker(ABC, Generic[TMessage, TResult]):
 @dataclass
 class Offsets(Generic[TOffset]):
     __slots__ = ["lo", "hi"]
-    lo: TOffset
-    hi: TOffset
+    lo: TOffset  # inclusive
+    hi: TOffset  # exclusive
 
 
 class BatchingConsumer:
@@ -183,9 +183,9 @@ class BatchingConsumer:
         self.__metrics.timing("process_message", duration)
 
         if msg.stream in self.__batch_offsets:
-            self.__batch_offsets[msg.stream].hi = msg.offset
+            self.__batch_offsets[msg.stream].hi = msg.next_offset
         else:
-            self.__batch_offsets[msg.stream] = Offsets(msg.offset, msg.offset)
+            self.__batch_offsets[msg.stream] = Offsets(msg.offset, msg.next_offset)
 
     def _shutdown(self) -> None:
         logger.debug("Stopping")

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -175,6 +175,9 @@ class BatchingConsumer:
         if result is not None:
             self.__batch_results.append(result)
 
+        # XXX: abstraction leak/invalid type
+        self.consumer.stage_offsets({msg.stream: msg.offset + 1})
+
         duration = (time.time() - start) * 1000
         self.__batch_messages_processed_count += 1
         self.__batch_processing_time_ms += duration
@@ -251,5 +254,5 @@ class BatchingConsumer:
         self._reset_batch()
 
     def _commit(self) -> None:
-        offsets = self.consumer.commit()
+        offsets = self.consumer.commit_offsets()
         logger.debug("Committed offsets: %s", offsets)

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -175,7 +175,7 @@ class BatchingConsumer:
         if result is not None:
             self.__batch_results.append(result)
 
-        self.consumer.stage_offsets({msg.stream: msg.next_offset})
+        self.consumer.stage_offsets({msg.stream: msg.get_next_offset()})
 
         duration = (time.time() - start) * 1000
         self.__batch_messages_processed_count += 1
@@ -183,9 +183,9 @@ class BatchingConsumer:
         self.__metrics.timing("process_message", duration)
 
         if msg.stream in self.__batch_offsets:
-            self.__batch_offsets[msg.stream].hi = msg.next_offset
+            self.__batch_offsets[msg.stream].hi = msg.get_next_offset()
         else:
-            self.__batch_offsets[msg.stream] = Offsets(msg.offset, msg.next_offset)
+            self.__batch_offsets[msg.stream] = Offsets(msg.offset, msg.get_next_offset())
 
     def _shutdown(self) -> None:
         logger.debug("Stopping")

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -96,7 +96,9 @@ def test_consumer(topic: str) -> None:
     assert message.offset == 0
     assert message.value == value
 
-    assert consumer.commit() == {TopicPartition(topic, 0): message.get_next_offset()}
+    assert consumer.commit_offsets() == {TopicPartition(topic, 0): message.get_next_offset()}
+
+    assert consumer.commit_offsets() == {}
 
     consumer.unsubscribe()
 
@@ -125,7 +127,7 @@ def test_consumer(topic: str) -> None:
         consumer.seek({TopicPartition(topic, 0): 0})
 
     with pytest.raises(RuntimeError):
-        consumer.commit()
+        consumer.commit_offsets()
 
     consumer.close()
 
@@ -260,7 +262,7 @@ def test_commit_log_consumer(topic: str) -> None:
     message = consumer.poll(10.0)  # XXX: getting the subscription is slow
     assert isinstance(message, Message)
 
-    assert consumer.commit() == {TopicPartition(topic, 0): message.get_next_offset()}
+    assert consumer.commit_offsets() == {TopicPartition(topic, 0): message.get_next_offset()}
 
     assert len(commit_log_producer.messages) == 1
     commit_message = commit_log_producer.messages[0]


### PR DESCRIPTION
This moves all offset management into the abstract `Consumer` API.