### PR TITLE
Temporary dataset for raw outcomes

### DIFF
--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -13,6 +13,7 @@ DATASET_NAMES: Set[str] = {
     'groupedmessage',
     'transactions',
     'outcomes',
+    'outcomes_raw',
 }
 
 
@@ -32,6 +33,7 @@ def get_dataset(name: str) -> Dataset:
     from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
     from snuba.datasets.transactions import TransactionsDataset
     from snuba.datasets.outcomes import OutcomesDataset
+    from snuba.datasets.outcomes_raw import OutcomesRawDataset
     from snuba.datasets.groups import Groups
 
     dataset_factories: MutableMapping[str, Callable[[], Dataset]] = {
@@ -41,6 +43,7 @@ def get_dataset(name: str) -> Dataset:
         'groups': Groups,
         'transactions': TransactionsDataset,
         'outcomes': OutcomesDataset,
+        'outcomes_raw': OutcomesRawDataset,
     }
 
     try:

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,0 +1,72 @@
+from datetime import timedelta
+from typing import Mapping, Sequence
+
+from snuba.datasets.dataset import TimeSeriesDataset
+from snuba.clickhouse.columns import (
+    ColumnSet,
+    DateTime,
+    LowCardinality,
+    Nullable,
+    String,
+    UInt,
+    UUID,
+)
+from snuba.datasets.schemas.tables import MergeTreeSchema
+from snuba.datasets.dataset_schemas import DatasetSchemas
+from snuba.query.extensions import QueryExtension
+from snuba.query.organization_extension import OrganizationExtension
+from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
+from snuba.query.timeseries import TimeSeriesExtension
+
+
+class OutcomesRawDataset(TimeSeriesDataset):
+    def __init__(self):
+        read_columns = ColumnSet([
+            ('org_id', UInt(64)),
+            ('project_id', UInt(64)),
+            ('key_id', Nullable(UInt(64))),
+            ('timestamp', DateTime()),
+            ('outcome', UInt(8)),
+            ('reason', LowCardinality(Nullable(String()))),
+            ('event_id', Nullable(UUID())),
+        ])
+
+        read_schema = MergeTreeSchema(
+            columns=read_columns,
+            local_table_name='outcomes_raw_local',
+            dist_table_name='outcomes_raw_dist',
+            order_by='(org_id, project_id, timestamp)',
+            partition_by='(toMonday(timestamp))',
+            settings={
+                'index_granularity': 16384
+            })
+
+        dataset_schemas = DatasetSchemas(
+            read_schema=read_schema,
+            write_schema=None,
+            intermediary_schemas=[]
+        )
+
+        super().__init__(
+            dataset_schemas=dataset_schemas,
+            time_group_columns={
+                'time': 'timestamp',
+            },
+            time_parse_columns=('timestamp',)
+        )
+
+    def get_extensions(self) -> Mapping[str, QueryExtension]:
+        return {
+            'project': ProjectExtension(
+                processor=ProjectWithGroupsProcessor(project_column="project_id")
+            ),
+            'timeseries': TimeSeriesExtension(
+                default_granularity=3600,
+                default_window=timedelta(days=7),
+                timestamp_column='timestamp',
+            ),
+            'organization': OrganizationExtension(),
+        }
+
+    def get_prewhere_keys(self) -> Sequence[str]:
+        return ['project_id', 'org_id']


### PR DESCRIPTION
This is to test the accuracy of Snuba outcomes for stats queries that are too short to be served by the materialized view.

test:
```
{
    "selected_columns": ["key_id"],
    "project": [2],
    "from_date": "2019-10-18T16:48:16",
    "to_date": "2019-10-25T16:48:16",
    "granularity": 3600,
    "organization": 1
}
```

turns into 

```
SELECT key_id FROM outcomes_raw_local PREWHERE project_id IN (2) WHERE timestamp >= toDateTime('2019-10-18T16:48:16') AND timestamp < toDateTime('2019-10-25T16:48:16') AND org_id = 1 LIM
IT 0, 1000
```