### PR TITLE
Remove project extension from outcomes raw dataset

### DIFF
--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -57,9 +57,6 @@ class OutcomesRawDataset(TimeSeriesDataset):
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:
         return {
-            'project': ProjectExtension(
-                processor=ProjectWithGroupsProcessor(project_column="project_id")
-            ),
             'timeseries': TimeSeriesExtension(
                 default_granularity=3600,
                 default_window=timedelta(days=7),


### PR DESCRIPTION
Project_id may not always be there in outcomes, so we should not require it when querying the dataset. 
This removes the extension itself.

Test:
This query:
```
{
    "selected_columns": ["timestamp"],
    "from_date": "2019-10-18T18:33:25",
    "to_date": "2019-10-25T18:33:25",
    "granularity": 3600,
    "organization": 1
}
```
works.