### PR TITLE
ref(streams): Add commit retry policy to Consumer

### DIFF
--- a/snuba/utils/streams/consumers/backends/kafka.py
+++ b/snuba/utils/streams/consumers/backends/kafka.py
@@ -1,5 +1,4 @@
 import logging
-import time
 from enum import Enum
 from typing import (
     Any,
@@ -14,7 +13,7 @@ from typing import (
 
 from confluent_kafka import OFFSET_BEGINNING, OFFSET_END, OFFSET_INVALID, OFFSET_STORED
 from confluent_kafka import Consumer as ConfluentConsumer
-from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka import KafkaError
 from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka import TopicPartition as ConfluentTopicPartition
@@ -279,31 +278,10 @@ class KafkaConsumerBackend(ConsumerBackend[TopicPartition, int, bytes]):
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:
             raise InvalidState(self.__state)
 
-        result: Optional[Sequence[ConfluentTopicPartition]] = None
-
-        retries_remaining = 3
-        while result is None:
-            try:
-                result = self.__consumer.commit(asynchronous=False)
-                assert result is not None
-            except KafkaException as e:
-                if not e.args[0].code() in (
-                    KafkaError.REQUEST_TIMED_OUT,
-                    KafkaError.NOT_COORDINATOR_FOR_GROUP,
-                    KafkaError._WAIT_COORD,
-                ):
-                    raise
-
-                if not retries_remaining:
-                    raise
-
-                logger.warning(
-                    "Commit failed: %s (%d retries remaining)",
-                    str(e),
-                    retries_remaining,
-                )
-                retries_remaining -= 1
-                time.sleep(1)
+        result: Optional[Sequence[ConfluentTopicPartition]] = self.__consumer.commit(
+            asynchronous=False
+        )
+        assert result is not None  # synchronous commit should return result immediately
 
         offsets: MutableMapping[TopicPartition, int] = {}
 

--- a/tests/utils/streams/consumers/test_consumer.py
+++ b/tests/utils/streams/consumers/test_consumer.py
@@ -1,0 +1,33 @@
+from unittest.mock import Mock, sentinel
+
+from snuba.utils.retries import NoRetryPolicy, BasicRetryPolicy, constant_delay
+from snuba.utils.streams.consumers.backends.abstract import ConsumerBackend
+from snuba.utils.streams.consumers.consumer import Consumer
+
+
+def test_commit_retry_no_policy() -> None:
+    backend = Mock(spec=ConsumerBackend)
+    consumer = Consumer(backend, commit_retry_policy=NoRetryPolicy())
+
+    backend.commit.side_effect = Exception("error")
+
+    try:
+        consumer.commit()
+    except Exception as e:
+        assert e is backend.commit.side_effect
+    else:
+        assert False, "expected commit to raise"
+
+    assert backend.commit.call_count == 1
+
+
+def test_commit_retry_basic_policy() -> None:
+    backend = Mock(spec=ConsumerBackend)
+    consumer = Consumer(
+        backend, commit_retry_policy=BasicRetryPolicy(3, constant_delay(1.0))
+    )
+
+    backend.commit.side_effect = [Exception("error"), sentinel.COMMIT_RESULT]
+
+    assert consumer.commit() is sentinel.COMMIT_RESULT
+    assert backend.commit.call_count == 2


### PR DESCRIPTION
This moves the commit retry logic from the consumer backend to the consumer (so that it can be shared between all backends), and allows it to be configured via the consumer builder, maintaining the existing behavior.