### PR TITLE
fix(tests): Remove nondeterministic test assertion

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -267,9 +267,6 @@ class TestApi(BaseApiTest):
 
         assert len(result['data']) == 1
         assert result['totals']
-        # project row
-        assert result['data'][0]['project_id'] == 1
-        assert result['data'][0]['count'] == 1
 
         # totals row
         assert result['totals']['project_id'] == 0  # totals row is zero or empty for non-aggregate cols


### PR DESCRIPTION
All of the rows in the result set have the same `count` value under aggregation (`1`), so they all have equal chance of being returned as the first and only row due to the limit clause in the original query.

Removing the `ORDER BY` and `LIMIT` clauses from the underlying query show that the `project_id` column only has a ~55% chance of being the value being asserted:

```
SELECT 
    project_id, 
    count()
FROM 
(
    SELECT 
        project_id, 
        received, 
        count() AS count
    FROM test_sentry_local 
    PREWHERE project_id IN (1, 2, 3)
    WHERE (timestamp >= toDateTime('2019-10-31T01:22:29')) AND (timestamp < toDateTime('2019-11-05T01:22:29')) AND (deleted = 0)
    GROUP BY (project_id, received)
) 
GROUP BY project_id
┌─project_id─┬─count()─┐
│          3 │      60 │
│          2 │      90 │
│          1 │     180 │
└────────────┴─────────┘
3 rows in set. Elapsed: 0.007 sec. 
```

The non-totals row values aren't significant to this test, so this removes them.