### PR TITLE
ref(streams): Update assignment callback signature to include offsets

### DIFF
--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import (
     Generic,
+    Mapping,
     MutableMapping,
     MutableSequence,
     Optional,
@@ -123,7 +124,7 @@ class BatchingConsumer:
         # The types passed to the `except` clause must be a tuple, not a Sequence.
         self.__recoverable_errors = tuple(recoverable_errors or [])
 
-        def on_partitions_assigned(streams: Sequence[TStream]) -> None:
+        def on_partitions_assigned(streams: Mapping[TStream, TOffset]) -> None:
             logger.info("New streams assigned: %r", streams)
 
         def on_partitions_revoked(streams: Sequence[TStream]) -> None:

--- a/snuba/utils/streams/consumers/backends/abstract.py
+++ b/snuba/utils/streams/consumers/backends/abstract.py
@@ -19,7 +19,7 @@ class ConsumerBackend(ABC, Generic[TStream, TOffset, TValue]):
     def subscribe(
         self,
         topics: Sequence[str],
-        on_assign: Optional[Callable[[Sequence[TStream]], None]] = None,
+        on_assign: Optional[Callable[[Mapping[TStream, TOffset]], None]] = None,
         on_revoke: Optional[Callable[[Sequence[TStream]], None]] = None,
     ) -> None:
         """

--- a/snuba/utils/streams/consumers/backends/kafka.py
+++ b/snuba/utils/streams/consumers/backends/kafka.py
@@ -136,7 +136,7 @@ class KafkaConsumerBackend(ConsumerBackend[TopicPartition, int, bytes]):
     def subscribe(
         self,
         topics: Sequence[str],
-        on_assign: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
+        on_assign: Optional[Callable[[Mapping[TopicPartition, int]], None]] = None,
         on_revoke: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
     ) -> None:
         if self.__state is not KafkaConsumerState.CONSUMING:
@@ -170,7 +170,7 @@ class KafkaConsumerBackend(ConsumerBackend[TopicPartition, int, bytes]):
 
             try:
                 if on_assign is not None:
-                    on_assign(list(offsets.keys()))
+                    on_assign(offsets)
             finally:
                 self.__state = KafkaConsumerState.CONSUMING
 

--- a/snuba/utils/streams/consumers/consumer.py
+++ b/snuba/utils/streams/consumers/consumer.py
@@ -39,6 +39,15 @@ class Consumer(Generic[TStream, TOffset, TValue]):
         are called when the subscription state changes with the updated
         assignment for this consumer.
 
+        If provided, the ``on_assign`` callback is called with a mapping of
+        streams to their offsets (at this point, the working offset and the
+        committed offset are the same for each stream) on each subscription
+        change. Similarly, the ``on_revoke`` callback (if provided) is called
+        with a sequence of streams that are being removed from this
+        consumer's assignment. (This callback does not include the offsets,
+        as the working offset and committed offset may differ, in some cases
+        by substantial margin.)
+
         Raises a ``RuntimeError`` if called on a closed consumer.
         """
         return self.__backend.subscribe(topics, on_assign, on_revoke)

--- a/snuba/utils/streams/consumers/consumer.py
+++ b/snuba/utils/streams/consumers/consumer.py
@@ -29,7 +29,7 @@ class Consumer(Generic[TStream, TOffset, TValue]):
     def subscribe(
         self,
         topics: Sequence[str],
-        on_assign: Optional[Callable[[Sequence[TStream]], None]] = None,
+        on_assign: Optional[Callable[[Mapping[TStream, TOffset]], None]] = None,
         on_revoke: Optional[Callable[[Sequence[TStream]], None]] = None,
     ) -> None:
         """

--- a/tests/utils/streams/consumers/backends/test_kafka.py
+++ b/tests/utils/streams/consumers/backends/test_kafka.py
@@ -1,6 +1,6 @@
 import pytest
 import uuid
-from typing import Iterator, Sequence
+from typing import Iterator, Mapping, Sequence
 
 from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka.admin import AdminClient, NewTopic
@@ -52,10 +52,9 @@ def test_consumer_backend(topic: str) -> None:
 
     backend = build_backend()
 
-    def assignment_callback(streams: Sequence[TopicPartition]):
+    def assignment_callback(streams: Mapping[TopicPartition, int]):
         assignment_callback.called = True
-        assert streams == [TopicPartition(topic, 0)]
-        assert backend.tell() == {TopicPartition(topic, 0): 0}
+        assert streams == {TopicPartition(topic, 0): 0}
 
         backend.seek({TopicPartition(topic, 0): 1})
 

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -20,7 +20,7 @@ class FakeKafkaConsumerBackend(ConsumerBackend[TopicPartition, int, bytes]):
     def subscribe(
         self,
         topics: Sequence[str],
-        on_assign: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
+        on_assign: Optional[Callable[[Mapping[TopicPartition, int]], None]] = None,
         on_revoke: Optional[Callable[[Sequence[TopicPartition]], None]] = None,
     ) -> None:
         pass  # XXX: This is a bit of a smell.


### PR DESCRIPTION
The Kafka consumer backend was already operating under the constraint that offsets needed to be available at assignment time. This ensures the other backends also support this constraint, and also makes it more obvious as part of the API. From a practical standpoint, this should make some of the synchronized consumer pieces a bit more straightforward.