### PR TITLE
Fix column escaping with on ORDER BY

### DIFF
--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -3,6 +3,7 @@ import re
 from typing import OrderedDict
 import _strptime  # NOQA fixes _strptime deferred import issue
 
+from snuba import state
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.schema import POSITIVE_OPERATORS
@@ -13,6 +14,7 @@ from snuba.util import (
     function_expr,
     is_condition,
     is_function,
+    NEGATE_RE,
     QUOTED_LITERAL_RE,
 )
 
@@ -43,12 +45,40 @@ def column_expr(dataset, column_name, query: Query, parsing_context: ParsingCont
         return escape_literal(column_name[1:-1])
     else:
         expr = dataset.column_expr(column_name, query, parsing_context)
-
     if aggregate:
         expr = function_expr(aggregate, expr)
 
-    alias = escape_alias(alias or column_name)
-    return alias_expr(expr, alias, parsing_context)
+    strip_negation = state.get_config('process_alias_without_neg', 0)
+    if strip_negation:
+        # in the ORDER BY clause, column_expr may receive column names prefixed with
+        # `-`. This is meant to be used for ORDER BY ... DESC.
+        # This means we need to keep the `-` outside of the aliased expression when
+        # we produce something like (COL AS alias) otherwise we build an invalid
+        # syntax.
+        # Worse, since escape_alias already does half of this work and keeps `-`
+        # outside of the escaped expression we end up in this situation:
+        #
+        # -events.event_id becomes (-events.event_id AS -`events.event_id`)
+        #
+        # Thus here we strip the `-` before processing escaping and aliases and we
+        # attach it back to the expression right before returning so that
+        # -events.event_id becomes -(events.event_id AS `events.event_id`)
+        # or
+        # -`events.event_id`
+        # if the alias already existed.
+        #
+        # The proper solution would be to strip the `-` before getting to column
+        # processing, but this will be done with the new column abstraction.
+        negate, col = NEGATE_RE.match(column_name).groups()
+        alias = escape_alias(alias or col)
+        expr_negate, expr = NEGATE_RE.match(expr).groups()
+        # expr_negate and negate should never be inconsistent with each other. Though
+        # will ensure this works properly before moving the `-` stripping at the beginning
+        # of the method to cover tags as well.
+        return f"{negate or expr_negate}{alias_expr(expr, alias, parsing_context)}"
+    else:
+        alias = escape_alias(alias or column_name)
+        return alias_expr(expr, alias, parsing_context)
 
 
 def complex_column_expr(dataset, expr, query: Query, parsing_context: ParsingContext, depth=0):

--- a/tests/datasets/test_join_columns.py
+++ b/tests/datasets/test_join_columns.py
@@ -172,7 +172,7 @@ def test_duplicate_expression_alias():
     assert exprs == ['(topK(3)(events.logger) AS dupe_alias)', 'dupe_alias']
 
 
-def test_order_by(self):
+def test_order_by():
     state.set_config('process_alias_without_neg', 1)
     dataset = get_dataset("groups")
     source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
@@ -180,17 +180,17 @@ def test_order_by(self):
     query = Query(body, source)
 
     assert column_expr(
-        self.dataset,
+        dataset,
         '-events.event_id',
         deepcopy(query),
         ParsingContext()
-    ) == "-(exception_stacks.type AS `expcetion_stacks.type`)"
+    ) == "-(events.event_id AS `events.event_id`)"
 
     context = ParsingContext()
     context.add_alias("`events.event_id`")
     assert column_expr(
-        self.dataset,
+        dataset,
         '-events.event_id',
         deepcopy(query),
-        ParsingContext()
+        context,
     ) == "-`events.event_id`"

--- a/tests/datasets/test_join_columns.py
+++ b/tests/datasets/test_join_columns.py
@@ -11,7 +11,6 @@ from snuba.util import tuplify
 def test_simple_column_expr():
     dataset = get_dataset("groups")
     source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
-    state.set_config('use_escape_alias', 1)
 
     body = {
         'granularity': 86400
@@ -171,3 +170,27 @@ def test_duplicate_expression_alias():
         for (agg, col, alias) in body['aggregations']
     ]
     assert exprs == ['(topK(3)(events.logger) AS dupe_alias)', 'dupe_alias']
+
+
+def test_order_by(self):
+    state.set_config('process_alias_without_neg', 1)
+    dataset = get_dataset("groups")
+    source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
+    body = {}
+    query = Query(body, source)
+
+    assert column_expr(
+        self.dataset,
+        '-events.event_id',
+        deepcopy(query),
+        ParsingContext()
+    ) == "-(exception_stacks.type AS `expcetion_stacks.type`)"
+
+    context = ParsingContext()
+    context.add_alias("`events.event_id`")
+    assert column_expr(
+        self.dataset,
+        '-events.event_id',
+        deepcopy(query),
+        ParsingContext()
+    ) == "-`events.event_id`"


### PR DESCRIPTION
When trying to ORDER BY a query by a column that contains a `.` this is what happens if we ORDER BY DESC:

```
ORDER BY (-events.last_seen AS -`events.last_seen`) DESC
```

This syntax is wrong. 
This happens for an interaction in column_expr between the logic that assigns the an alias to the column and the logic that escapes the alias:

-events.last_seen is interpreted as:
A column name to escape when generating the alias -> `events.last_seen`
But the escaping logic already takes the `-` out (the reason is not clear, it seems that should not happen at that point) -> -`events.last_seen`
since -events.last_seen and the escaped alias -`events.last_seen` are not the same string column_expr decides to create an alias thus the broken string above.

This is the smallest fix for the common case: it strips the '-' from the column nam,e and from the alias before applying escaping and aliasing and add it back later.
A good fix would be a complete redesign of the approach that would not pass the '-' character to column_expr at all, but that will be achieved through the new columns data model.

Test plan:
- added two unit tests for the corner cases
- the api tests still pass (with the feature on) both from snuba and from sentry
- I can run this query properly:
```
{
    "selected_columns": ["events.timestamp"],
    "orderby": ["-events.event_id"],
    "project": [1],
    "from_date": "2019-11-03T06:14:46",
    "to_date": "2019-11-08T06:14:46",
    "granularity": 3600
}
```


SNS-290