### PR TITLE
feat(datasets) Pre Where Query Processor

### DIFF
--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,5 +1,3 @@
-from typing import Sequence
-
 from snuba import settings as snuba_settings
 from snuba import util
 from snuba.query.columns import (
@@ -22,7 +20,6 @@ class ClickhouseQuery:
         dataset: Dataset,
         query: Query,
         settings: RequestSettings,
-        prewhere_conditions: Sequence[str],
     ) -> None:
         parsing_context = ParsingContext()
 
@@ -57,8 +54,8 @@ class ClickhouseQuery:
             where_clause = u'WHERE {}'.format(conditions_expr(dataset, query.get_conditions(), query, parsing_context))
 
         prewhere_clause = ''
-        if prewhere_conditions:
-            prewhere_clause = u'PREWHERE {}'.format(conditions_expr(dataset, prewhere_conditions, query, parsing_context))
+        if query.get_prewhere():
+            prewhere_clause = u'PREWHERE {}'.format(conditions_expr(dataset, query.get_prewhere(), query, parsing_context))
 
         group_clause = ''
         if groupby:

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -64,6 +64,7 @@ class GroupedMessageDataset(CdcDataset):
             local_table_name='groupedmessage_local',
             dist_table_name='groupedmessage_dist',
             mandatory_conditions=[('record_deleted', '=', 0)],
+            prewhere_candidates=["project_id", "id"],
             order_by='(project_id, id)',
             partition_by=None,
             version_column='offset',

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -6,7 +6,6 @@ from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.types import Condition
 from snuba.util import escape_col, parse_datetime, qualified_column
 
@@ -114,15 +113,6 @@ class Dataset(object):
         that are applied to queries after parsing and before running them on Clickhouse.
         These are applied in sequence in the same order as they are defined and are supposed
         to be stateless.
-        """
-        return self._get_custom_query_processors() + [
-            PrewhereProcessor()
-        ]
-
-    def _get_custom_query_processors(self) -> Sequence[QueryProcessor]:
-        """
-        Returns the list of query processors that can be specified by the
-        dataset configuration
         """
         return []
 

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -101,15 +101,6 @@ class Dataset(object):
         """
         raise NotImplementedError('dataset does not support queries')
 
-    def get_prewhere_keys(self) -> Sequence[str]:
-        """
-        Returns the keys that will be upgraded from a WHERE condition to a PREWHERE.
-
-        This is an ordered list, from highest priority to lowest priority. So, a column at index 1 will be upgraded
-        before a column at index 2. This is relevant when we have a maximum number of prewhere keys.
-        """
-        return []
-
     def get_split_query_spec(self) -> Union[None, ColumnSplitSpec]:
         """
         Return the parameters to perform the column split of the query.

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -6,6 +6,7 @@ from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.types import Condition
 from snuba.util import escape_col, parse_datetime, qualified_column
 
@@ -113,6 +114,15 @@ class Dataset(object):
         that are applied to queries after parsing and before running them on Clickhouse.
         These are applied in sequence in the same order as they are defined and are supposed
         to be stateless.
+        """
+        return self._get_custom_query_processors() + [
+            PrewhereProcessor()
+        ]
+
+    def _get_custom_query_processors(self) -> Sequence[QueryProcessor]:
+        """
+        Returns the list of query processors that can be specified by the
+        dataset configuration
         """
         return []
 

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -21,7 +21,6 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
@@ -235,12 +234,11 @@ class DiscoverDataset(TimeSeriesDataset):
             time_parse_columns=["timestamp", "start_ts", "finish_ts"],
         )
 
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
+    def _get_custom_query_processors(self) -> Sequence[QueryProcessor]:
         discover_source = self.get_dataset_schemas().get_read_schema().get_data_source()
 
         return [
             DatasetSelector(discover_source, self.__transactions_columns),
-            PrewhereProcessor(),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -21,7 +21,7 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
-from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
@@ -88,9 +88,9 @@ class DiscoverSource(RelationalSource):
             .get_data_source()
         )
 
-    def get_prewhere_candiates(self) -> Sequence[str]:
+    def get_prewhere_candidates(self) -> Sequence[str]:
         if self.__table_source:
-            return self.__table_source.get_prewhere_candiates()
+            return self.__table_source.get_prewhere_candidates()
         return []
 
 
@@ -240,7 +240,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
         return [
             DatasetSelector(discover_source, self.__transactions_columns),
-            PreWhereProcessor(),
+            PrewhereProcessor(),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -21,6 +21,7 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
@@ -234,11 +235,12 @@ class DiscoverDataset(TimeSeriesDataset):
             time_parse_columns=["timestamp", "start_ts", "finish_ts"],
         )
 
-    def _get_custom_query_processors(self) -> Sequence[QueryProcessor]:
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
         discover_source = self.get_dataset_schemas().get_read_schema().get_data_source()
 
         return [
             DatasetSelector(discover_source, self.__transactions_columns),
+            PrewhereProcessor(),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -21,6 +21,7 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.prewhere import PreWhereProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
@@ -86,6 +87,11 @@ class DiscoverSource(RelationalSource):
             .get_read_schema()
             .get_data_source()
         )
+
+    def get_prewhere_candiates(self) -> Sequence[str]:
+        if self.__table_source:
+            return self.__table_source.get_prewhere_candiates()
+        return []
 
 
 class DatasetSelector(QueryProcessor):
@@ -234,6 +240,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
         return [
             DatasetSelector(discover_source, self.__transactions_columns),
+            PreWhereProcessor(),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -18,11 +18,9 @@ from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import MigrationSchemaColumn, ReplacingMergeTreeSchema
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
-from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.util import qualified_column
@@ -337,8 +335,3 @@ class EventsDataset(TimeSeriesDataset):
                 timestamp_column='timestamp',
             ),
         }
-
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [
-            PrewhereProcessor()
-        ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -18,7 +18,7 @@ from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import MigrationSchemaColumn, ReplacingMergeTreeSchema
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
@@ -340,5 +340,5 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
-            PreWhereProcessor()
+            PrewhereProcessor()
         ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -18,9 +18,11 @@ from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import MigrationSchemaColumn, ReplacingMergeTreeSchema
 from snuba.datasets.tags_column_processor import TagColumnProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
+from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.util import qualified_column
@@ -335,3 +337,8 @@ class EventsDataset(TimeSeriesDataset):
                 timestamp_column='timestamp',
             ),
         }
+
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            PrewhereProcessor()
+        ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Mapping, Sequence, Tuple, Union
+from typing import Mapping, Sequence, Union
 
 from snuba.clickhouse.columns import (
     Array,
@@ -18,10 +18,11 @@ from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import MigrationSchemaColumn, ReplacingMergeTreeSchema
 from snuba.datasets.tags_column_processor import TagColumnProcessor
+from snuba.query.processors.prewhere import PreWhereProcessor
 from snuba.query.query import Query
-from snuba.query.types import Condition
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
+from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.util import qualified_column
@@ -334,5 +335,9 @@ class EventsDataset(TimeSeriesDataset):
             ),
         }
 
-    def get_prewhere_keys(self) -> Sequence[str]:
-        return ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            PreWhereProcessor(
+                ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
+            )
+        ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -212,6 +212,9 @@ class EventsDataset(TimeSeriesDataset):
             local_table_name='sentry_local',
             dist_table_name='sentry_dist',
             mandatory_conditions=[('deleted', '=', 0)],
+            prewhere_candidates=[
+                'event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id',
+            ],
             order_by='(project_id, toStartOfDay(timestamp), %s)' % sample_expr,
             partition_by='(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))',
             version_column='deleted',
@@ -337,7 +340,5 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
-            PreWhereProcessor(
-                ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
-            )
+            PreWhereProcessor()
         ]

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -55,6 +55,10 @@ class Groups(TimeSeriesDataset):
                     # expression.
                     (qualified_column('record_deleted', self.GROUPS_ALIAS), '=', 0)
                 ],
+                prewhere_candidates=[
+                    qualified_column(col, self.GROUPS_ALIAS)
+                    for col in groupedmessage_source.get_prewhere_candiates()
+                ],
                 alias=self.GROUPS_ALIAS,
             ),
             right_node=TableJoinNode(
@@ -62,6 +66,10 @@ class Groups(TimeSeriesDataset):
                 columns=events_source.get_columns(),
                 mandatory_conditions=[
                     (qualified_column('deleted', self.EVENTS_ALIAS), '=', 0)
+                ],
+                prewhere_candidates=[
+                    qualified_column(col, self.EVENTS_ALIAS)
+                    for col in events_source.get_prewhere_candiates()
                 ],
                 alias=self.EVENTS_ALIAS,
             ),

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -17,6 +17,7 @@ from snuba.query.columns import QUALIFIED_COLUMN_REGEX
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.processors.join_optimizers import SimpleJoinOptimizer
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
@@ -156,7 +157,8 @@ class Groups(TimeSeriesDataset):
         # queries.
         return []
 
-    def _get_custom_query_processors(self) -> Sequence[QueryProcessor]:
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             SimpleJoinOptimizer(),
+            PrewhereProcessor(),
         ]

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -17,7 +17,6 @@ from snuba.query.columns import QUALIFIED_COLUMN_REGEX
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.processors.join_optimizers import SimpleJoinOptimizer
-from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
@@ -157,8 +156,7 @@ class Groups(TimeSeriesDataset):
         # queries.
         return []
 
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
+    def _get_custom_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             SimpleJoinOptimizer(),
-            PrewhereProcessor(),
         ]

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -17,7 +17,7 @@ from snuba.query.columns import QUALIFIED_COLUMN_REGEX
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.processors.join_optimizers import SimpleJoinOptimizer
-from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
@@ -58,7 +58,7 @@ class Groups(TimeSeriesDataset):
                 ],
                 prewhere_candidates=[
                     qualified_column(col, self.GROUPS_ALIAS)
-                    for col in groupedmessage_source.get_prewhere_candiates()
+                    for col in groupedmessage_source.get_prewhere_candidates()
                 ],
                 alias=self.GROUPS_ALIAS,
             ),
@@ -70,7 +70,7 @@ class Groups(TimeSeriesDataset):
                 ],
                 prewhere_candidates=[
                     qualified_column(col, self.EVENTS_ALIAS)
-                    for col in events_source.get_prewhere_candiates()
+                    for col in events_source.get_prewhere_candidates()
                 ],
                 alias=self.EVENTS_ALIAS,
             ),
@@ -160,5 +160,5 @@ class Groups(TimeSeriesDataset):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             SimpleJoinOptimizer(),
-            PreWhereProcessor(),
+            PrewhereProcessor(),
         ]

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -17,6 +17,7 @@ from snuba.query.columns import QUALIFIED_COLUMN_REGEX
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.processors.join_optimizers import SimpleJoinOptimizer
+from snuba.query.processors.prewhere import PreWhereProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
@@ -159,4 +160,5 @@ class Groups(TimeSeriesDataset):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             SimpleJoinOptimizer(),
+            PreWhereProcessor(),
         ]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -18,7 +18,7 @@ from snuba.datasets.schemas.tables import MergeTreeSchema, SummingMergeTreeSchem
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
-from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba import settings
@@ -173,5 +173,5 @@ class OutcomesDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
-            PreWhereProcessor(),
+            PrewhereProcessor(),
         ]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -129,6 +129,7 @@ class OutcomesDataset(TimeSeriesDataset):
         materialized_view = MaterializedViewSchema(
             local_materialized_view_name='outcomes_mv_hourly_local',
             dist_materialized_view_name='outcomes_mv_hourly_dist',
+            prewhere_candidates=['project_id', 'org_id'],
             columns=materialized_view_columns,
             query=query,
             local_source_table_name=WRITE_LOCAL_TABLE_NAME,
@@ -172,5 +173,5 @@ class OutcomesDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
-            PreWhereProcessor(['project_id', 'org_id'])
+            PreWhereProcessor(),
         ]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -18,6 +18,8 @@ from snuba.datasets.schemas.tables import MergeTreeSchema, SummingMergeTreeSchem
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
+from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba import settings
 
@@ -168,5 +170,7 @@ class OutcomesDataset(TimeSeriesDataset):
             'organization': OrganizationExtension(),
         }
 
-    def get_prewhere_keys(self) -> Sequence[str]:
-        return ['project_id', 'org_id']
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            PreWhereProcessor(['project_id', 'org_id'])
+        ]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -18,8 +18,6 @@ from snuba.datasets.schemas.tables import MergeTreeSchema, SummingMergeTreeSchem
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
-from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba import settings
 
@@ -170,8 +168,3 @@ class OutcomesDataset(TimeSeriesDataset):
             ),
             'organization': OrganizationExtension(),
         }
-
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [
-            PrewhereProcessor(),
-        ]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -18,6 +18,8 @@ from snuba.datasets.schemas.tables import MergeTreeSchema, SummingMergeTreeSchem
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
+from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba import settings
 
@@ -168,3 +170,8 @@ class OutcomesDataset(TimeSeriesDataset):
             ),
             'organization': OrganizationExtension(),
         }
+
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            PrewhereProcessor(),
+        ]

--- a/snuba/datasets/schemas/__init__.py
+++ b/snuba/datasets/schemas/__init__.py
@@ -46,7 +46,7 @@ class RelationalSource(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_prewhere_candiates(self) -> Sequence[str]:
+    def get_prewhere_candidates(self) -> Sequence[str]:
         """
         Returns the list of keys that can be promoted to PREWHERE conditions
         if found in the conditions field of the query.

--- a/snuba/datasets/schemas/__init__.py
+++ b/snuba/datasets/schemas/__init__.py
@@ -50,6 +50,10 @@ class RelationalSource(ABC):
         """
         Returns the list of keys that can be promoted to PREWHERE conditions
         if found in the conditions field of the query.
+        pre where keys depend on the actual table used to run the query, so,
+        since the query processors can change the datasource of the query, the
+        list of candidates must be associated to the data source itself and not
+        to the dataset.
         """
         raise NotImplementedError
 

--- a/snuba/datasets/schemas/__init__.py
+++ b/snuba/datasets/schemas/__init__.py
@@ -45,6 +45,14 @@ class RelationalSource(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def get_prewhere_candiates(self) -> Sequence[str]:
+        """
+        Returns the list of keys that can be promoted to PREWHERE conditions
+        if found in the conditions field of the query.
+        """
+        raise NotImplementedError
+
 
 class Schema(ABC):
     """

--- a/snuba/datasets/schemas/join.py
+++ b/snuba/datasets/schemas/join.py
@@ -70,9 +70,10 @@ class TableJoinNode(TableSource, JoinNode):
         table_name: str,
         columns: ColumnSet,
         mandatory_conditions: Optional[Sequence[Condition]],
+        prewhere_candidates: Optional[Sequence[str]],
         alias: str,
     ) -> None:
-        super().__init__(table_name, columns, mandatory_conditions)
+        super().__init__(table_name, columns, mandatory_conditions, prewhere_candidates)
         self.__alias = alias
 
     def format_from(self) -> str:
@@ -127,6 +128,13 @@ class JoinClause(JoinNode):
         for table in tables.values():
             all_conditions.extend(table.get_mandatory_conditions())
         return all_conditions
+
+    def get_prewhere_candiates(self) -> Sequence[str]:
+        """
+        The pre where condition can only come from the leftmost table in the
+        join.
+        """
+        return self.left_node.get_prewhere_candiates()
 
 
 class JoinedSchema(Schema):

--- a/snuba/datasets/schemas/join.py
+++ b/snuba/datasets/schemas/join.py
@@ -129,12 +129,12 @@ class JoinClause(JoinNode):
             all_conditions.extend(table.get_mandatory_conditions())
         return all_conditions
 
-    def get_prewhere_candiates(self) -> Sequence[str]:
+    def get_prewhere_candidates(self) -> Sequence[str]:
         """
         The pre where condition can only come from the leftmost table in the
         join.
         """
-        return self.left_node.get_prewhere_candiates()
+        return self.left_node.get_prewhere_candidates()
 
 
 class JoinedSchema(Schema):

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -36,7 +36,7 @@ class TableSource(RelationalSource):
     def get_mandatory_conditions(self) -> Sequence[Condition]:
         return self.__mandatory_conditions
 
-    def get_prewhere_candiates(self) -> Sequence[str]:
+    def get_prewhere_candidates(self) -> Sequence[str]:
         return self.__prewhere_candidates
 
 

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -20,10 +20,12 @@ class TableSource(RelationalSource):
         table_name: str,
         columns: ColumnSet,
         mandatory_conditions: Optional[Sequence[Condition]] = None,
+        prewhere_candidates: Optional[Sequence[str]] = None,
     ) -> None:
         self.__table_name = table_name
         self.__columns = columns
         self.__mandatory_conditions = mandatory_conditions or []
+        self.__prewhere_candidates = prewhere_candidates or []
 
     def format_from(self) -> str:
         return self.__table_name
@@ -33,6 +35,9 @@ class TableSource(RelationalSource):
 
     def get_mandatory_conditions(self) -> Sequence[Condition]:
         return self.__mandatory_conditions
+
+    def get_prewhere_candiates(self) -> Sequence[str]:
+        return self.__prewhere_candidates
 
 
 class MigrationSchemaColumn(NamedTuple):
@@ -58,6 +63,7 @@ class TableSchema(Schema, ABC):
         local_table_name: str,
         dist_table_name: str,
         mandatory_conditions: Optional[Sequence[Condition]]=None,
+        prewhere_candidates: Optional[Sequence[str]] = None,
         migration_function: Optional[Callable[[str, Mapping[str, MigrationSchemaColumn]], Sequence[str]]]=None,
     ):
         self.__migration_function = migration_function if migration_function else lambda table, schema: []
@@ -67,6 +73,7 @@ class TableSchema(Schema, ABC):
             self.get_table_name(),
             columns,
             mandatory_conditions,
+            prewhere_candidates,
         )
 
     def get_data_source(self) -> TableSource:
@@ -128,6 +135,7 @@ class MergeTreeSchema(WritableTableSchema):
         local_table_name: str,
         dist_table_name: str,
         mandatory_conditions: Optional[Sequence[Condition]]=None,
+        prewhere_candidates: Optional[Sequence[str]] = None,
         order_by: str,
         partition_by: Optional[str],
         sample_expr: Optional[str]=None,
@@ -139,6 +147,7 @@ class MergeTreeSchema(WritableTableSchema):
             local_table_name=local_table_name,
             dist_table_name=dist_table_name,
             mandatory_conditions=mandatory_conditions,
+            prewhere_candidates=prewhere_candidates,
             migration_function=migration_function)
         self.__order_by = order_by
         self.__partition_by = partition_by
@@ -197,6 +206,7 @@ class ReplacingMergeTreeSchema(MergeTreeSchema):
         local_table_name: str,
         dist_table_name: str,
         mandatory_conditions: Optional[Sequence[Condition]]=None,
+        prewhere_candidates: Optional[Sequence[str]] = None,
         order_by: str,
         partition_by: str,
         version_column: str,
@@ -209,6 +219,7 @@ class ReplacingMergeTreeSchema(MergeTreeSchema):
             local_table_name=local_table_name,
             dist_table_name=dist_table_name,
             mandatory_conditions=mandatory_conditions,
+            prewhere_candidates=prewhere_candidates,
             order_by=order_by,
             partition_by=partition_by,
             sample_expr=sample_expr,
@@ -235,6 +246,7 @@ class MaterializedViewSchema(TableSchema):
             local_materialized_view_name: str,
             dist_materialized_view_name: str,
             mandatory_conditions: Optional[Sequence[Condition]]=None,
+            prewhere_candidates: Optional[Sequence[str]] = None,
             query: str,
             local_source_table_name: str,
             local_destination_table_name: str,
@@ -246,6 +258,7 @@ class MaterializedViewSchema(TableSchema):
             local_table_name=local_materialized_view_name,
             dist_table_name=dist_materialized_view_name,
             mandatory_conditions=mandatory_conditions,
+            prewhere_candidates=prewhere_candidates,
             migration_function=migration_function,
         )
 

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -24,6 +24,8 @@ from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
+from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
@@ -199,3 +201,8 @@ class TransactionsDataset(TimeSeriesDataset):
             project_column="project_id",
             timestamp_column="start_ts",
         )
+
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            PrewhereProcessor(),
+        ]

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -24,6 +24,8 @@ from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
+from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.prewhere import PreWhereProcessor
 from snuba.query.query import Query
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
@@ -116,6 +118,7 @@ class TransactionsDataset(TimeSeriesDataset):
             local_table_name='transactions_local',
             dist_table_name='transactions_dist',
             mandatory_conditions=[],
+            prewhere_candidates=['event_id', 'project_id'],
             order_by='(project_id, toStartOfDay(start_ts), transaction_hash, start_ts, start_ms, trace_id, span_id)',
             partition_by='(retention_days, toMonday(start_ts))',
             version_column='deleted',
@@ -199,5 +202,7 @@ class TransactionsDataset(TimeSeriesDataset):
             timestamp_column="start_ts",
         )
 
-    def get_prewhere_keys(self) -> Sequence[str]:
-        return ['event_id', 'project_id']
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            PreWhereProcessor(),
+        ]

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -24,8 +24,6 @@ from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
-from snuba.query.query_processor import QueryProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
@@ -201,8 +199,3 @@ class TransactionsDataset(TimeSeriesDataset):
             project_column="project_id",
             timestamp_column="start_ts",
         )
-
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [
-            PrewhereProcessor(),
-        ]

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -25,7 +25,7 @@ from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query_processor import QueryProcessor
-from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
@@ -204,5 +204,5 @@ class TransactionsDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
-            PreWhereProcessor(),
+            PrewhereProcessor(),
         ]

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -10,8 +10,7 @@ from snuba.request.request_settings import RequestSettings
 class PreWhereProcessor(QueryProcessor):
     """
     Moves top level conditions into the pre-where clause
-    according to the list of candidates provided when initializing
-    this object.
+    according to the list of candidates provided by the query data source.
 
     In order for a condition to become a pre-where condition it has
     to be:
@@ -20,31 +19,29 @@ class PreWhereProcessor(QueryProcessor):
       constructor.
     """
 
-    def __init__(self, prewhere_keys: Sequence[str]) -> None:
-        # This is an ordered list, from highest priority to lowest priority. So, a column at index 1 will be upgraded
-        # before a column at index 2. This is relevant when we have a maximum number of prewhere keys.
-        self.__prewhere_keys = prewhere_keys
-
     def process_query(self,
         query: Query,
         request_settings: RequestSettings,
     ) -> None:
+        pre_where_keys = query.get_data_source().get_prewhere_candiates()
+        if not pre_where_keys:
+            return
         prewhere_conditions: Sequence[Condition] = []
         # Add any condition to PREWHERE if:
         # - It is a single top-level condition (not OR-nested), and
-        # - Any of its referenced columns are in self.__prewhere_keys
+        # - Any of its referenced columns are in pre_where_keys
         conditions = query.get_conditions()
         if not conditions:
             return
         prewhere_candidates = [
             (util.columns_in_expr(cond[0]), cond)
             for cond in conditions if util.is_condition(cond) and
-            any(col in self.__prewhere_keys for col in util.columns_in_expr(cond[0]))
+            any(col in pre_where_keys for col in util.columns_in_expr(cond[0]))
         ]
         # Use the condition that has the highest priority (based on the
         # position of its columns in the prewhere keys list)
         prewhere_candidates = sorted([
-            (min(self.__prewhere_keys.index(col) for col in cols if col in self.__prewhere_keys), cond)
+            (min(pre_where_keys.index(col) for col in cols if col in pre_where_keys), cond)
             for cols, cond in prewhere_candidates
         ], key=lambda priority_and_col: priority_and_col[0])
         if prewhere_candidates:

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from snuba import settings, util
 from snuba.query.query import Query
@@ -7,7 +7,7 @@ from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
 
 
-class PreWhereProcessor(QueryProcessor):
+class PrewhereProcessor(QueryProcessor):
     """
     Moves top level conditions into the pre-where clause
     according to the list of candidates provided by the query data source.
@@ -19,33 +19,38 @@ class PreWhereProcessor(QueryProcessor):
       constructor.
     """
 
+    def __init__(self, max_prewhere_conditions: Optional[int] = None) -> None:
+        self.__max_prewhere_conditions: int = max_prewhere_conditions \
+            if max_prewhere_conditions is not None \
+            else settings.MAX_PREWHERE_CONDITIONS
+
     def process_query(self,
         query: Query,
         request_settings: RequestSettings,
     ) -> None:
-        pre_where_keys = query.get_data_source().get_prewhere_candiates()
-        if not pre_where_keys:
+        prewhere_keys = query.get_data_source().get_prewhere_candidates()
+        if not prewhere_keys:
             return
         prewhere_conditions: Sequence[Condition] = []
         # Add any condition to PREWHERE if:
         # - It is a single top-level condition (not OR-nested), and
-        # - Any of its referenced columns are in pre_where_keys
+        # - Any of its referenced columns are in prewhere_keys
         conditions = query.get_conditions()
         if not conditions:
             return
         prewhere_candidates = [
             (util.columns_in_expr(cond[0]), cond)
             for cond in conditions if util.is_condition(cond) and
-            any(col in pre_where_keys for col in util.columns_in_expr(cond[0]))
+            any(col in prewhere_keys for col in util.columns_in_expr(cond[0]))
         ]
         # Use the condition that has the highest priority (based on the
         # position of its columns in the prewhere keys list)
         prewhere_candidates = sorted([
-            (min(pre_where_keys.index(col) for col in cols if col in pre_where_keys), cond)
+            (min(prewhere_keys.index(col) for col in cols if col in prewhere_keys), cond)
             for cols, cond in prewhere_candidates
         ], key=lambda priority_and_col: priority_and_col[0])
         if prewhere_candidates:
-            prewhere_conditions = [cond for _, cond in prewhere_candidates][:settings.MAX_PREWHERE_CONDITIONS]
+            prewhere_conditions = [cond for _, cond in prewhere_candidates][:self.__max_prewhere_conditions]
             query.set_conditions(
                 list(filter(lambda cond: cond not in prewhere_conditions, conditions))
             )

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from snuba import settings, util
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+class PreWhereProcessor(QueryProcessor):
+    """
+    Moves top level conditions into the pre-where clause
+    according to the list of candidates provided when initializing
+    this object.
+
+    In order for a condition to become a pre-where condition it has
+    to be:
+    - a single top-level condition (not in an OR statement)
+    - any of its referenced columns must be in the list provided to the
+      constructor.
+    """
+
+    def __init__(self, prewhere_keys: Sequence[str]) -> None:
+        # This is an ordered list, from highest priority to lowest priority. So, a column at index 1 will be upgraded
+        # before a column at index 2. This is relevant when we have a maximum number of prewhere keys.
+        self.__prewhere_keys = prewhere_keys
+
+    def process_query(self,
+        query: Query,
+        request_settings: RequestSettings,
+    ) -> None:
+        prewhere_conditions = []
+        # Add any condition to PREWHERE if:
+        # - It is a single top-level condition (not OR-nested), and
+        # - Any of its referenced columns are in self.__prewhere_keys
+        prewhere_candidates = [
+            (util.columns_in_expr(cond[0]), cond)
+            for cond in query.get_conditions() if util.is_condition(cond) and
+            any(col in self.__prewhere_keys for col in util.columns_in_expr(cond[0]))
+        ]
+        # Use the condition that has the highest priority (based on the
+        # position of its columns in the prewhere keys list)
+        prewhere_candidates = sorted([
+            (min(self.__prewhere_keys.index(col) for col in cols if col in self.__prewhere_keys), cond)
+            for cols, cond in prewhere_candidates
+        ], key=lambda priority_and_col: priority_and_col[0])
+        if prewhere_candidates:
+            prewhere_conditions = [cond for _, cond in prewhere_candidates][:settings.MAX_PREWHERE_CONDITIONS]
+            query.set_conditions(
+                list(filter(lambda cond: cond not in prewhere_conditions, query.get_conditions()))
+            )
+        query.set_prewhere(prewhere_conditions)

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -125,12 +125,18 @@ class Query:
         self.__extend_sequence("conditions", conditions)
 
     def get_prewhere(self) -> Sequence[Condition]:
+        """
+        Temporary method until pre where management is moved to Clickhouse query
+        """
         return self.__prewhere_conditions
 
     def set_prewhere(
         self,
         conditions: Sequence[Condition]
     ) -> None:
+        """
+        Temporary method until pre where management is moved to Clickhouse query
+        """
         self.__prewhere_conditions = conditions
 
     def set_arrayjoin(

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -60,6 +60,7 @@ class Query:
         self.__body = body
         self.__final = False
         self.__data_source = data_source
+        self.__prewhere_conditions: Sequence[Condition] = []
 
     def get_data_source(self) -> RelationalSource:
         return self.__data_source
@@ -122,6 +123,15 @@ class Query:
         conditions: Sequence[Condition],
     ) -> None:
         self.__extend_sequence("conditions", conditions)
+
+    def get_prewhere(self) -> Sequence[Condition]:
+        return self.__prewhere_conditions
+
+    def set_prewhere(
+        self,
+        conditions: Sequence[Condition]
+    ) -> None:
+        self.__prewhere_conditions = conditions
 
     def set_arrayjoin(
         self,
@@ -218,6 +228,7 @@ class Query:
         # Conditions need flattening as they can be nested as AND/OR
         self.__add_flat_conditions(col_exprs, self.get_conditions())
         self.__add_flat_conditions(col_exprs, self.get_having())
+        self.__add_flat_conditions(col_exprs, self.get_prewhere())
 
         if self.get_aggregations():
             col_exprs.extend([a[1] for a in self.get_aggregations()])

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -318,10 +318,11 @@ def parse_and_run_query(dataset, request: Request, timer) -> QueryResult:
     request.query.add_conditions(relational_source.get_mandatory_conditions())
 
     source = relational_source.format_from()
+    request.query.set_prewhere(prewhere_conditions)
     with sentry_sdk.start_span(description="create_query", op="db"):
         # TODO: consider moving the performance logic and the pre_where generation into
         # ClickhouseQuery since they are Clickhouse specific
-        query = ClickhouseQuery(dataset, request.query, request.settings, prewhere_conditions)
+        query = ClickhouseQuery(dataset, request.query, request.settings)
     timer.mark('prepare_query')
 
     stats = {

--- a/tests/clickhouse/test_query.py
+++ b/tests/clickhouse/test_query.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from snuba.clickhouse.query import ClickhouseQuery
 from snuba.query.query import Query
-from snuba.request import Request, RequestSettings
+from snuba.request import RequestSettings
 
 
 class TestClickhouseQuery(BaseEventsTest):
@@ -24,7 +24,6 @@ class TestClickhouseQuery(BaseEventsTest):
             dataset=self.dataset,
             query=query,
             settings=request_settings,
-            prewhere_conditions=[],
         )
 
         assert 'SAMPLE 0.1' in clickhouse_query.format_sql()
@@ -45,7 +44,6 @@ class TestClickhouseQuery(BaseEventsTest):
             dataset=self.dataset,
             query=query,
             settings=request_settings,
-            prewhere_conditions=[],
         )
 
         assert 'SAMPLE 0.1' in clickhouse_query.format_sql()
@@ -67,7 +65,6 @@ class TestClickhouseQuery(BaseEventsTest):
             dataset=self.dataset,
             query=query,
             settings=request_settings,
-            prewhere_conditions=[],
         )
 
         assert "SAMPLE 0.2" in clickhouse_query.format_sql()
@@ -88,7 +85,6 @@ class TestClickhouseQuery(BaseEventsTest):
             dataset=self.dataset,
             query=query,
             settings=request_settings,
-            prewhere_conditions=[],
         )
 
         assert 'SAMPLE' not in clickhouse_query.format_sql()

--- a/tests/datasets/schemas/join_examples.py
+++ b/tests/datasets/schemas/join_examples.py
@@ -58,8 +58,8 @@ table3 = MergeTreeSchema(
 
 
 simple_join_structure = JoinClause(
-    TableJoinNode(table1.format_from(), table1.get_columns(), [], "t1"),
-    TableJoinNode(table2.format_from(), table2.get_columns(), [], "t2"),
+    TableJoinNode(table1.format_from(), table1.get_columns(), [], [], "t1"),
+    TableJoinNode(table2.format_from(), table2.get_columns(), [], [], "t2"),
     [
         JoinCondition(
             left=JoinConditionExpression(table_alias="t1", column="t1c1"),
@@ -75,8 +75,8 @@ simple_join_structure = JoinClause(
 
 complex_join_structure = JoinClause(
     JoinClause(
-        TableJoinNode(table1.format_from(), table1.get_columns(), [], "t1"),
-        TableJoinNode(table2.format_from(), table2.get_columns(), [], "t2"),
+        TableJoinNode(table1.format_from(), table1.get_columns(), [], [], "t1"),
+        TableJoinNode(table2.format_from(), table2.get_columns(), [], [], "t2"),
         [
             JoinCondition(
                 left=JoinConditionExpression(table_alias="t1", column="t1c1"),
@@ -85,7 +85,7 @@ complex_join_structure = JoinClause(
         ],
         JoinType.FULL
     ),
-    TableJoinNode(table3.format_from(), table3.get_columns(), [], "t3"),
+    TableJoinNode(table3.format_from(), table3.get_columns(), [], [], "t3"),
     [
         JoinCondition(
             left=JoinConditionExpression(table_alias="t1", column="t1c1"),

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -3,7 +3,7 @@ import pytest
 from snuba import settings
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
-from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.request.request_settings import RequestSettings
 
@@ -75,7 +75,7 @@ def test_prewhere(query_body, keys, new_conditions, prewhere_conditions) -> None
     )
 
     request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
-    processor = PreWhereProcessor()
+    processor = PrewhereProcessor()
     processor.process_query(query, request_settings)
 
     assert query.get_conditions() == new_conditions

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -71,11 +71,11 @@ def test_prewhere(query_body, keys, new_conditions, prewhere_conditions) -> None
     settings.MAX_PREWHERE_CONDITIONS = 2
     query = Query(
         query_body,
-        TableSource("my_table", ColumnSet([])),
+        TableSource("my_table", ColumnSet([]), None, keys),
     )
 
     request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
-    processor = PreWhereProcessor(keys)
+    processor = PreWhereProcessor()
     processor.process_query(query, request_settings)
 
     assert query.get_conditions() == new_conditions

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -1,0 +1,82 @@
+import pytest
+
+from snuba import settings
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.schemas.tables import TableSource
+from snuba.query.processors.prewhere import PreWhereProcessor
+from snuba.query.query import Query
+from snuba.request.request_settings import RequestSettings
+
+
+test_data = [
+    (
+        {
+            "conditions": [
+                [["positionCaseInsensitive", ["message", "abc"]], "!=", 0]
+            ],
+        },
+        ["event_id", "issue", "tags[sentry:release]", "message", "environment", "project_id"],
+        [],
+        [
+            [["positionCaseInsensitive", ["message", "abc"]], "!=", 0]
+        ],
+    ),
+    (
+        # Add pre-where condition in the expected order
+        {
+            "conditions": [
+                ["d", "=", "1"],
+                ["c", "=", "3"],
+                ["a", "=", "1"],
+                ["b", "=", "2"],
+            ],
+        },
+        ["a", "b", "c"],
+        [
+            ["d", "=", "1"],
+            ["c", "=", "3"],
+        ],
+        [
+            ["a", "=", "1"],
+            ["b", "=", "2"],
+        ],
+    ),
+    (
+        # Do not add conditions that are parts of an OR
+        {
+            "conditions": [
+                [
+                    ["a", "=", "1"],
+                    ["b", "=", "2"],
+                ],
+                ["c", "=", "3"],
+            ],
+        },
+        ["a", "b", "c"],
+        [
+            [
+                ["a", "=", "1"],
+                ["b", "=", "2"],
+            ],
+        ],
+        [
+            ["c", "=", "3"],
+        ],
+    )
+]
+
+
+@pytest.mark.parametrize("query_body, keys, new_conditions, prewhere_conditions", test_data)
+def test_prewhere(query_body, keys, new_conditions, prewhere_conditions) -> None:
+    settings.MAX_PREWHERE_CONDITIONS = 2
+    query = Query(
+        query_body,
+        TableSource("my_table", ColumnSet([])),
+    )
+
+    request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
+    processor = PreWhereProcessor(keys)
+    processor.process_query(query, request_settings)
+
+    assert query.get_conditions() == new_conditions
+    assert query.get_prewhere() == prewhere_conditions

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -19,6 +19,7 @@ def test_empty_query():
     assert query.get_limit() is None
     assert query.get_offset() == 0
     assert query.has_totals() is False
+    assert query.get_prewhere() == []
 
     assert query.get_data_source().format_from() == "my_table"
 
@@ -104,6 +105,11 @@ def test_edit_query():
 
     query.set_granularity(7200)
     assert query.get_granularity() == 7200
+
+    query.set_prewhere([["pc6", "=", "10"]])
+    assert query.get_prewhere() == [
+        ["pc6", "=", "10"]
+    ]
 
 
 def test_referenced_columns():
@@ -196,5 +202,6 @@ def test_referenced_columns():
         ]
     }
     query = Query(body, source)
-    assert query.get_all_referenced_columns() == set(['a', 'b', 'c', 'd', 'e'])
+    query.set_prewhere([["pc6", "=", "10"]])
+    assert query.get_all_referenced_columns() == set(['a', 'b', 'c', 'd', 'e', 'pc6'])
     assert query.get_columns_referenced_in_having() == set(['b', 'c', 'd', 'e'])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -419,7 +419,7 @@ class TestApi(BaseApiTest):
 
     def test_prewhere_conditions(self):
         settings.MAX_PREWHERE_CONDITIONS = 1
-        prewhere_keys = get_dataset('events').get_prewhere_keys()
+        prewhere_keys = ['event_id', 'issue', 'tags[sentry:release]', 'message', 'environment', 'project_id']
 
         # Before we run our test, make sure the column exists in our prewhere keys
         assert 'message' in prewhere_keys


### PR DESCRIPTION
Move the pre-where logic from the view.py file into a Query Processor so that every dataset can provide its own way to provide pre-where conditions.

Besides moving some query processing dataset specific out of view.py, this makes it easy to introduce the new data model in that we would not have logic that specifically modifies the query condition outside of query processors.

test plan:
- added a unit test for this
- the existing pre where test in test_api still works