### PR TITLE
ref(cli): Move `--log-level` to root level `snuba` argument

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -1,10 +1,14 @@
 import click
+import logging
 from pkgutil import walk_packages
+
+from snuba import settings
 
 
 @click.group()
 @click.version_option()
-def main():
+@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
+def main(*, log_level: str):
     """\b
                      o
                     O
@@ -15,6 +19,7 @@ def main():
     O  O   o O   o  o   O o   O
 `OoO'  o   O `OoO'o `OoO' `OoO'o
 """
+    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(levelname)-8s %(message)s')
 
 
 for loader, module_name, is_pkg in walk_packages(__path__, __name__ + '.'):

--- a/snuba/cli/api.py
+++ b/snuba/cli/api.py
@@ -1,12 +1,14 @@
 import click
 
+from snuba import settings
+
 
 @click.command()
 @click.option('--debug', is_flag=True)
-def api(debug):
-    from snuba import settings
+@click.option('--port', type=int, default=settings.PORT)
+def api(*, debug: bool, port: int):
     from snuba.views import application
     from werkzeug.serving import WSGIRequestHandler
 
     WSGIRequestHandler.protocol_version = "HTTP/1.1"
-    application.run(port=settings.PORT, threaded=True, debug=debug)
+    application.run(port=port, threaded=True, debug=debug)

--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -15,12 +15,10 @@ from snuba.writer import BufferedWriterWrapper
               help='Source of the dump. Depending on the dataset it may have different meaning.')
 @click.option('--dest-table',
               help='Clickhouse destination table.')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def bulk_load(dataset, dest_table, source, log_level):
+def bulk_load(dataset, dest_table, source):
     import sentry_sdk
 
     sentry_sdk.init(dsn=settings.SENTRY_DSN)
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     logger = logging.getLogger('snuba.load-snapshot')
     logger.info("Start bulk load process for dataset %s, from source %s", dataset, source)

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -1,5 +1,3 @@
-import logging
-
 import click
 
 from snuba import settings
@@ -17,8 +15,7 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset, DATASET_NA
               help='Name of the database to target.')
 @click.option('--dataset', default='events', type=click.Choice(DATASET_NAMES),
               help='The dataset to target')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def cleanup(clickhouse_host, clickhouse_port, dry_run, database, dataset, log_level):
+def cleanup(clickhouse_host, clickhouse_port, dry_run, database, dataset):
     """
     Deletes stale partitions for ClickHouse tables
     """
@@ -28,8 +25,6 @@ def cleanup(clickhouse_host, clickhouse_port, dry_run, database, dataset, log_le
 
     dataset = get_dataset(dataset)
     table = enforce_table_writer(dataset).get_schema().get_local_table_name()
-
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     clickhouse = ClickhousePool(clickhouse_host, clickhouse_port)
     num_dropped = run_cleanup(clickhouse, database, table, dry_run=dry_run)

--- a/snuba/cli/confirm_load.py
+++ b/snuba/cli/confirm_load.py
@@ -20,8 +20,7 @@ from snuba.stateful_consumer.control_protocol import TransactionData, SnapshotLo
               help='The dataset to bulk load')
 @click.option('--source',
               help='Source of the dump. Depending on the dataset it may have different meaning.')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def confirm_load(control_topic, bootstrap_server, dataset, source, log_level):
+def confirm_load(control_topic, bootstrap_server, dataset, source):
     """
     Confirms the snapshot has been loaded by sending the
     snapshot-loaded message on the control topic.
@@ -29,7 +28,6 @@ def confirm_load(control_topic, bootstrap_server, dataset, source, log_level):
     import sentry_sdk
 
     sentry_sdk.init(dsn=settings.SENTRY_DSN)
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     logger = logging.getLogger('snuba.loaded-snapshot')
     logger.info("Sending load completion message for dataset %s, from source %s", dataset, source)

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -1,4 +1,3 @@
-import logging
 import signal
 
 import click
@@ -35,19 +34,17 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
               help='Maximum number of kilobytes per topic+partition in the local consumer queue.')
 @click.option('--queued-min-messages', default=settings.DEFAULT_QUEUED_MIN_MESSAGES, type=int,
               help='Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
 @click.option('--stateful-consumer', default=False, type=bool, help='Runs a stateful consumer (that manages snapshots) instead of a basic one.')
 def consumer(raw_events_topic, replacements_topic, commit_log_topic, control_topic, consumer_group,
              bootstrap_server, dataset, max_batch_size, max_batch_time_ms,
-             auto_offset_reset, queued_max_messages_kbytes, queued_min_messages, log_level,
+             auto_offset_reset, queued_max_messages_kbytes, queued_min_messages,
              dogstatsd_host, dogstatsd_port, stateful_consumer):
 
     import sentry_sdk
     sentry_sdk.init(dsn=settings.SENTRY_DSN)
 
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
     dataset_name = dataset
     dataset = get_dataset(dataset_name)
 

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 import click
 from clickhouse_driver import Client
@@ -9,12 +8,10 @@ from snuba.util import local_dataset_mode
 
 
 @click.command()
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def migrate(log_level):
+def migrate():
     from snuba.migrate import logger, run
     # TODO: this only supports one dataset so far. More work is needed for the others.
     dataset = get_dataset('events')
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     if not local_dataset_mode():
         logger.error("The migration tool can only work on local dataset mode.")

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -1,5 +1,3 @@
-import logging
-
 import click
 
 from snuba import settings
@@ -17,13 +15,10 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset, DATASET_NA
               help='The dataset to target')
 @click.option('--timeout', default=10000, type=int,
               help='Clickhouse connection send/receive timeout, must be long enough for OPTIMIZE to complete.')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def optimize(clickhouse_host, clickhouse_port, database, dataset, timeout, log_level):
+def optimize(clickhouse_host, clickhouse_port, database, dataset, timeout):
     from datetime import datetime
     from snuba.clickhouse.native import ClickhousePool
     from snuba.optimize import run_optimize, logger
-
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     dataset = get_dataset(dataset)
     table = enforce_table_writer(dataset).get_schema().get_local_table_name()

--- a/snuba/cli/perf.py
+++ b/snuba/cli/perf.py
@@ -14,11 +14,9 @@ main `events` topic. Retrieving a sample file is left as an excercise for the
 reader, or you can use the `tests/perf-event.json` file with a high repeat count.
 """
 
-import logging
 import click
 import sys
 
-from snuba import settings
 from snuba.datasets.factory import get_dataset, DATASET_NAMES
 from snuba.util import local_dataset_mode
 
@@ -32,11 +30,8 @@ from snuba.util import local_dataset_mode
               default=False, help='Whether or not to profile writing.')
 @click.option('--dataset', default='events', type=click.Choice(DATASET_NAMES),
               help='The dataset to consume/run replacements for (currently only events supported)')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
-def perf(events_file, repeat, profile_process, profile_write, dataset, log_level):
+def perf(events_file, repeat, profile_process, profile_write, dataset):
     from snuba.perf import run, logger
-
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     dataset = get_dataset(dataset)
     if not local_dataset_mode():

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -1,4 +1,3 @@
-import logging
 import signal
 
 import click
@@ -30,12 +29,11 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset
               help='Maximum number of kilobytes per topic+partition in the local consumer queue.')
 @click.option('--queued-min-messages', default=settings.DEFAULT_QUEUED_MIN_MESSAGES, type=int,
               help='Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.')
-@click.option('--log-level', default=settings.LOG_LEVEL, help='Logging level to use.')
 @click.option('--dogstatsd-host', default=settings.DOGSTATSD_HOST, help='Host to send DogStatsD metrics to.')
 @click.option('--dogstatsd-port', default=settings.DOGSTATSD_PORT, type=int, help='Port to send DogStatsD metrics to.')
 def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse_host, clickhouse_port, dataset,
              max_batch_size, max_batch_time_ms, auto_offset_reset, queued_max_messages_kbytes,
-             queued_min_messages, log_level, dogstatsd_host, dogstatsd_port):
+             queued_min_messages, dogstatsd_host, dogstatsd_port):
 
     import sentry_sdk
     from snuba import util
@@ -47,8 +45,6 @@ def replacer(*, replacements_topic, consumer_group, bootstrap_server, clickhouse
 
     sentry_sdk.init(dsn=settings.SENTRY_DSN)
     dataset = get_dataset(dataset)
-
-    logging.basicConfig(level=getattr(logging, log_level.upper()), format='%(asctime)s %(message)s')
 
     stream_loader = enforce_table_writer(dataset).get_stream_loader()
     default_replacement_topic_spec = stream_loader.get_replacement_topic_spec()


### PR DESCRIPTION
This was duplicated on most commands, and wasn't an option at all on a few others. This moves it to the root level. This also adds the log level in the log line.

This is technically a breaking change, since [Click distinguishes between command arguments and their subcommand arguments](https://click.palletsprojects.com/en/7.x/commands/#passing-parameters). This isn't used by [`devservices`](https://github.com/getsentry/sentry/blob/939fe55994c6483be6d1137a9501949d7ef92192/src/sentry/runner/commands/devservices.py#L123-L125) but we should probably double check to make sure it's not passed explicitly by any operations scripts.

This also adds `--port` to `snuba api` since it wasn't already there. (I needed to spin up an api server in development to test this, and already had one running and was surprised this didn't already exist.)