### PR TITLE
ci: Upgrade clickhouse in CI and docker compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: xenial
 before_install:
   - docker run -d --network host --name zookeeper -e ZOOKEEPER_CLIENT_PORT=2181 confluentinc/cp-zookeeper:4.1.0
   - docker run -d --network host --name kafka -e KAFKA_ZOOKEEPER_CONNECT=localhost:2181 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 confluentinc/cp-kafka:4.1.0
-  - docker run -d --net host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:19.4
+  - docker run -d --net host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:19.11
   - make travis-start-redis-cluster
   - docker build -t getsentry/snuba .
   - docker ps -a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test
   clickhouse:
-    image: yandex/clickhouse-server:19.4
+    image: yandex/clickhouse-server:19.11
     ports:
       - "9000:9000"
       - "9009:9009"


### PR DESCRIPTION
We are still referencing an old version of Clickhouse. Upgrading to 19.11