### PR TITLE
fix(discover): Fix promoted tag columns

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -146,9 +146,9 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("timestamp", DateTime()),
                 ("platform", Nullable(String())),
                 ("environment", Nullable(String())),
-                ("sentry:release", Nullable(String())),
-                ("sentry:dist", Nullable(String())),
-                ("sentry:user", Nullable(String())),
+                ("release", Nullable(String())),
+                ("dist", Nullable(String())),
+                ("user", Nullable(String())),
                 ("transaction", Nullable(String())),
                 ("message", Nullable(String())),
                 # User
@@ -269,12 +269,6 @@ class DiscoverDataset(TimeSeriesDataset):
                 return "'transaction'"
             if column_name == "timestamp":
                 return "finish_ts"
-            if column_name == "sentry:release":
-                return "release"
-            if column_name == "sentry:dist":
-                return "dist"
-            if column_name == "sentry:user":
-                return "user"
             if column_name == "username":
                 return "user_name"
             if column_name == "email":
@@ -286,6 +280,12 @@ class DiscoverDataset(TimeSeriesDataset):
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:
+            if column_name == "release":
+                column_name = "tags[sentry:release]"
+            if column_name == "dist":
+                column_name = "tags[sentry:dist]"
+            if column_name == "user":
+                column_name = "tags[sentry:user]"
             if self.__transactions_columns.get(column_name):
                 return "NULL"
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -111,7 +111,7 @@ class TestDiscoverApi(BaseApiTest):
                 {
                     "dataset": "discover",
                     "project": self.project_id,
-                    "selected_columns": ["type", "tags[custom_tag]"],
+                    "selected_columns": ["type", "tags[custom_tag]", "release"],
                     "conditions": [["type", "!=", "transaction"]],
                     "orderby": "timestamp",
                     "limit": 1000,
@@ -122,7 +122,7 @@ class TestDiscoverApi(BaseApiTest):
 
         assert response.status_code == 200
         assert len(data["data"]) == 1, data
-        assert data["data"][0] == {"type": "error", "tags[custom_tag]": "custom_value"}
+        assert data["data"][0] == {"type": "error", "tags[custom_tag]": "custom_value", "release": None}
 
         response = self.app.post(
             "/query",
@@ -130,7 +130,7 @@ class TestDiscoverApi(BaseApiTest):
                 {
                     "dataset": "discover",
                     "project": 1,
-                    "selected_columns": ["type", "tags[foo]", "group_id"],
+                    "selected_columns": ["type", "tags[foo]", "group_id", "release"],
                     "conditions": [["type", "=", "transaction"]],
                     "orderby": "timestamp",
                     "limit": 1,
@@ -144,6 +144,7 @@ class TestDiscoverApi(BaseApiTest):
             "type": "transaction",
             "tags[foo]": "baz",
             "group_id": None,
+            "release": "1",
         }
 
     def test_aggregations(self):


### PR DESCRIPTION
Fixes the release, dist and user columns. These were not previously
working correctly in the events dataset since they are tags.

Renamed from "sentry:release", "sentry:user" and "sentry:dist" to
"release", "user" and "dist", since this seems more straightforward.