### PR TITLE
fix(joins) Disable SAMPLE clause for joins

### DIFF
--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -35,12 +35,15 @@ class ClickhouseQuery:
         if query.get_final():
             from_clause = u'{} FINAL'.format(from_clause)
 
-        if query.get_sample():
-            sample_rate = query.get_sample()
-        elif settings.get_turbo():
-            sample_rate = snuba_settings.TURBO_SAMPLE_RATE
-        else:
+        if not query.get_data_source().supports_sample():
             sample_rate = None
+        else:
+            if query.get_sample():
+                sample_rate = query.get_sample()
+            elif settings.get_turbo():
+                sample_rate = snuba_settings.TURBO_SAMPLE_RATE
+            else:
+                sample_rate = None
 
         if sample_rate:
             from_clause = u'{} SAMPLE {}'.format(from_clause, sample_rate)

--- a/snuba/datasets/schemas/__init__.py
+++ b/snuba/datasets/schemas/__init__.py
@@ -57,6 +57,15 @@ class RelationalSource(ABC):
         """
         raise NotImplementedError
 
+    def supports_sample(self) -> bool:
+        """
+        TODO: This is a temporary method to prevent Clickhouse query to try to
+        add the SAMPLE clause to a JOIN expression, where SAMPLE not only is formatted
+        differently, but would have to be rethought since, in a join SAMPLE would
+        have to be applied table by table.
+        """
+        return True
+
 
 class Schema(ABC):
     """

--- a/snuba/datasets/schemas/join.py
+++ b/snuba/datasets/schemas/join.py
@@ -59,6 +59,12 @@ class JoinNode(RelationalSource, ABC):
         """
         raise NotImplementedError
 
+    def supports_sample(self) -> bool:
+        """
+        Disable the sample clause in joins
+        """
+        return False
+
 
 class TableJoinNode(TableSource, JoinNode):
     """
@@ -81,6 +87,12 @@ class TableJoinNode(TableSource, JoinNode):
 
     def get_tables(self) -> Mapping[str, TableSource]:
         return {self.__alias: self}
+
+    def supports_sample(self) -> bool:
+        """
+        Individual tables support SAMPLE
+        """
+        return True
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This is a hack to prevent JOINS from failing when the SAMPLE condition is passed.
Clickhouse SAMPLE clause applies to tables, not to the FROM clause as a whole, thus it would be:

> FROM table A SAMPLE 0.1 LEFT JOIN table B SAMPLE 0.2 ON .....

The sampling coefficient passed to the Snuba query is only one, so we need to revisit what it means for JOINS (I suspect we would just apply that to the external table), and we need to make the format logic aware of the SAMPLE parameter (which is already in plan, but requires the new query structure). 
In the meantime, the only case SAMPLE is being passed to a JOIN query has value 1, and it is done as a hack to prevent TURBO mode to add its own SAMPLE clause
https://github.com/getsentry/sentry/blob/master/src/sentry/search/snuba/backend.py#L689-L690

So this change does not have any impact on the query itself.