### PR TITLE
fix: Provide time parse columns for Groups dataset

### DIFF
--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -100,7 +100,13 @@ class Groups(TimeSeriesDataset):
         super().__init__(
             dataset_schemas=dataset_schemas,
             time_group_columns={"events.time": "events.timestamp"},
-            time_parse_columns=["events.timestamp"],
+            time_parse_columns=[
+                "events.timestamp",
+                "events.received",
+                "groups.last_seen",
+                "groups.first_seen",
+                "groups.active_at",
+            ],
         )
 
     def column_expr(


### PR DESCRIPTION
The Groups dataset missed the list of columns to parse as DateTime, thus it was trying to complare DateTime Clickhouse columns with strings on queries.

test:
```
{
    "selected_columns": ["events.event_id"],
    "conditions": [["groups.first_seen", ">=", "2019-10-17T00:41:26"]],
    "project": [1],
    "from_date": "2019-11-16T01:02:32",
    "to_date": "2019-11-21T01:02:32",
    "granularity": 3600
}
```

This query works now.