### PR TITLE
feat(query formatter) Add a Visitor to do Clickhouse specific formatting of Expressions

### DIFF
--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -1,6 +1,6 @@
 from typing import Mapping
 
-from snuba.util import escape_col
+from snuba.clickhouse.escaping import escape_col
 
 
 class Column(object):

--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -1,6 +1,6 @@
 from typing import Mapping
 
-from snuba.clickhouse.escaping import escape_col
+from snuba.clickhouse.escaping import escape_identifier
 
 
 class Column(object):
@@ -19,7 +19,7 @@ class Column(object):
         )
 
     def for_schema(self):
-        return "{} {}".format(escape_col(self.name), self.type.for_schema())
+        return "{} {}".format(escape_identifier(self.name), self.type.for_schema())
 
     @staticmethod
     def to_columns(columns):
@@ -35,7 +35,7 @@ class FlattenedColumn(object):
         self.flattened = (
             "{}.{}".format(self.base_name, self.name) if self.base_name else self.name
         )
-        self.escaped = escape_col(self.flattened)
+        self.escaped = escape_identifier(self.flattened)
 
     def __repr__(self):
         return "FlattenedColumn({}, {}, {})".format(

--- a/snuba/clickhouse/escaping.py
+++ b/snuba/clickhouse/escaping.py
@@ -36,5 +36,5 @@ def escape_alias(alias: Optional[str]) -> Optional[str]:
     return escape_expression(alias, SAFE_ALIAS_RE)
 
 
-def escape_col(col: Optional[str]) -> Optional[str]:
+def escape_identifier(col: Optional[str]) -> Optional[str]:
     return escape_expression(col, SAFE_COL_RE)

--- a/snuba/clickhouse/escaping.py
+++ b/snuba/clickhouse/escaping.py
@@ -1,0 +1,40 @@
+import re
+
+from typing import Optional, Pattern
+
+ESCAPE_STRING_RE = re.compile(r"(['\\])")
+ESCAPE_COL_RE = re.compile(r"([`\\])")
+NEGATE_RE = re.compile(r"^(-?)(.*)$")
+SAFE_COL_RE = re.compile(r"^-?([a-zA-Z_][a-zA-Z0-9_\.]*)$")
+# Alias escaping is different than column names when we introduce table aliases.
+# Using the column escaping function would consider "." safe, which is not for
+# an alias.
+SAFE_ALIAS_RE = re.compile(r"^-?[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def escape_string(str: str) -> str:
+    str = ESCAPE_STRING_RE.sub(r"\\\1", str)
+    return "'{}'".format(str)
+
+
+def escape_expression(expr: Optional[str], regex: Pattern[str]) -> Optional[str]:
+    if not expr:
+        return expr
+    elif regex.match(expr):
+        # Column/Alias is safe to use without wrapping.
+        return expr
+    else:
+        # Column/Alias needs special characters escaped, and to be wrapped with
+        # backticks. If the column starts with a '-', keep that outside the
+        # backticks as it is not part of the column name, but used by the query
+        # generator to signify the sort order if we are sorting by this column.
+        col = ESCAPE_COL_RE.sub(r"\\\1", expr)
+        return "{}`{}`".format(*NEGATE_RE.match(col).groups())
+
+
+def escape_alias(alias: Optional[str]) -> Optional[str]:
+    return escape_expression(alias, SAFE_ALIAS_RE)
+
+
+def escape_col(col: Optional[str]) -> Optional[str]:
+    return escape_expression(col, SAFE_COL_RE)

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -1,0 +1,90 @@
+from typing import Optional, Sequence
+from snuba.query.expressions import (
+    Column,
+    CurriedFunctionCall,
+    Expression,
+    ExpressionVisitor,
+    FunctionCall,
+    Literal,
+)
+from snuba.query.parsing import ParsingContext
+from snuba.util import escape_col
+
+# Tokens used when formatting. Defining them as costant
+# will make it easy (if/when needed) to make some changes
+# to the layout of the output.
+NULL = "NULL"
+COMMA = ","
+SPACE = " "
+TRUE = "true"
+FALSE = "false"
+QUOTE = "'"
+OPEN_BRACKET = "("
+CLOSED_BRACKET = ")"
+DOT = "."
+
+
+class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
+    """
+    This Visitor implementation is able to format one expression in the Snuba
+    Query for Clickhouse.
+
+    The only state mainained is the PrasingContext, which allows us to resolve
+    aliases and can be reused when formatting multiple expressions.
+
+    When passing an instance of this class to the accept method of
+    the visited expression, the return value is the formatted string.
+    """
+
+    def __init__(self, parsing_context: Optional[ParsingContext] = None) -> None:
+        self.__parsing_context = parsing_context or ParsingContext()
+
+    def __escape(self, column: str) -> str:
+        return escape_col(column)
+
+    def __alias(self, formatted_exp: str, alias: Optional[str]) -> str:
+        if not alias:
+            return formatted_exp
+        elif self.__parsing_context.is_alias_present(alias):
+            return alias
+        else:
+            self.__parsing_context.add_alias(alias)
+            return (
+                f"{OPEN_BRACKET}{formatted_exp}{SPACE}AS{SPACE}{alias}{CLOSED_BRACKET}"
+            )
+
+    def visitLiteral(self, exp: Literal) -> str:
+        if exp.value is None:
+            return NULL
+        elif exp.value is True:
+            return TRUE
+        elif exp.value is False:
+            return FALSE
+        elif isinstance(exp.value, str):
+            return f"{QUOTE}{exp.value}{QUOTE}"
+        elif isinstance(exp.value, (int, float)):
+            return str(exp.value)
+        else:
+            raise ValueError(f"Invalid literal type {type(exp.value)}")
+
+    def visitColumn(self, exp: Column) -> str:
+        ret = []
+        if exp.table_name:
+            ret.append(self.__escape(exp.table_name))
+            ret.append(DOT)
+        ret.append(self.__escape(exp.column_name))
+        return self.__alias("".join(ret), exp.alias)
+
+    def __visit_params(self, parameters: Sequence[Expression]) -> str:
+        ret = [p.accept(self) for p in parameters]
+        param_list = ", ".join(ret)
+        return f"{OPEN_BRACKET}{param_list}{CLOSED_BRACKET}"
+
+    def visitFunctionCall(self, exp: FunctionCall) -> str:
+        ret = f"{exp.function_name}{self.__visit_params(exp.parameters)}"
+        return self.__alias(ret, exp.alias)
+
+    def visitCurriedFunctionCall(self, exp: CurriedFunctionCall) -> str:
+        int_func = exp.internal_function.accept(self)
+        ret = f"{int_func}{self.__visit_params(exp.parameters)}"
+        return self.__alias(ret, exp.alias)

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
     Literal,
 )
 from snuba.query.parsing import ParsingContext
-from snuba.util import escape_col
+from snuba.util import escape_alias, escape_col, escape_literal
 
 # Tokens used when formatting. Defining them as costant
 # will make it easy (if/when needed) to make some changes
@@ -34,24 +34,24 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
 
     When passing an instance of this class to the accept method of
     the visited expression, the return value is the formatted string.
+
+    This Formatter produces a properly escaped string. The result should never
+    be further escaped. This should be the only place where expression
+    escaping happens as it is done by each method that formats a specific
+    type of expression.
     """
 
     def __init__(self, parsing_context: Optional[ParsingContext] = None) -> None:
         self.__parsing_context = parsing_context or ParsingContext()
 
-    def __escape(self, column: str) -> str:
-        return escape_col(column)
-
     def __alias(self, formatted_exp: str, alias: Optional[str]) -> str:
         if not alias:
             return formatted_exp
         elif self.__parsing_context.is_alias_present(alias):
-            return alias
+            return escape_alias(alias)
         else:
             self.__parsing_context.add_alias(alias)
-            return (
-                f"{OPEN_BRACKET}{formatted_exp}{SPACE}AS{SPACE}{alias}{CLOSED_BRACKET}"
-            )
+            return f"{OPEN_BRACKET}{formatted_exp}{SPACE}AS{SPACE}{escape_alias(alias)}{CLOSED_BRACKET}"
 
     def visitLiteral(self, exp: Literal) -> str:
         if exp.value is None:
@@ -60,19 +60,17 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             return TRUE
         elif exp.value is False:
             return FALSE
-        elif isinstance(exp.value, str):
-            return f"{QUOTE}{exp.value}{QUOTE}"
-        elif isinstance(exp.value, (int, float)):
-            return str(exp.value)
+        elif isinstance(exp.value, (str, int, float)):
+            return escape_literal(exp.value)
         else:
             raise ValueError(f"Invalid literal type {type(exp.value)}")
 
     def visitColumn(self, exp: Column) -> str:
         ret = []
         if exp.table_name:
-            ret.append(self.__escape(exp.table_name))
+            ret.append(escape_col(exp.table_name))
             ret.append(DOT)
-        ret.append(self.__escape(exp.column_name))
+        ret.append(escape_col(exp.column_name))
         return self.__alias("".join(ret), exp.alias)
 
     def __visit_params(self, parameters: Sequence[Expression]) -> str:
@@ -81,7 +79,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         return f"{OPEN_BRACKET}{param_list}{CLOSED_BRACKET}"
 
     def visitFunctionCall(self, exp: FunctionCall) -> str:
-        ret = f"{exp.function_name}{self.__visit_params(exp.parameters)}"
+        ret = f"{escape_col(exp.function_name)}{self.__visit_params(exp.parameters)}"
         return self.__alias(ret, exp.alias)
 
     def visitCurriedFunctionCall(self, exp: CurriedFunctionCall) -> str:

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
     Literal,
 )
 from snuba.query.parsing import ParsingContext
-from snuba.clickhouse.escaping import escape_alias, escape_col, escape_string
+from snuba.clickhouse.escaping import escape_alias, escape_identifier, escape_string
 
 # Tokens used when formatting. Defining them as constant
 # will make it easy (if/when needed) to make some changes
@@ -77,9 +77,9 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
     def visitColumn(self, exp: Column) -> str:
         ret = []
         if exp.table_name:
-            ret.append(escape_col(exp.table_name) or "")
+            ret.append(escape_identifier(exp.table_name) or "")
             ret.append(DOT)
-        ret.append(escape_col(exp.column_name) or "")
+        ret.append(escape_identifier(exp.column_name) or "")
         return self.__alias("".join(ret), exp.alias)
 
     def __visit_params(self, parameters: Sequence[Expression]) -> str:
@@ -88,7 +88,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         return f"{OPEN_PAREN}{param_list}{CLOSED_PAREN}"
 
     def visitFunctionCall(self, exp: FunctionCall) -> str:
-        ret = f"{escape_col(exp.function_name)}{self.__visit_params(exp.parameters)}"
+        ret = f"{escape_identifier(exp.function_name)}{self.__visit_params(exp.parameters)}"
         return self.__alias(ret, exp.alias)
 
     def visitCurriedFunctionCall(self, exp: CurriedFunctionCall) -> str:

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
     Literal,
 )
 from snuba.query.parsing import ParsingContext
-from snuba.util import escape_alias, escape_col, escape_string
+from snuba.clickhouse.escaping import escape_alias, escape_col, escape_string
 
 # Tokens used when formatting. Defining them as constant
 # will make it easy (if/when needed) to make some changes

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -1,6 +1,6 @@
 from typing import Optional, Mapping, NamedTuple, Sequence, Tuple, Union
 
-from snuba.clickhouse.escaping import escape_col
+from snuba.clickhouse.escaping import escape_identifier
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.table_storage import TableWriter
 from snuba.query.extensions import QueryExtension
@@ -91,7 +91,7 @@ class Dataset(object):
         Return an expression for the column name. Handle special column aliases
         that evaluate to something else.
         """
-        return escape_col(qualified_column(column_name, table_alias))
+        return escape_identifier(qualified_column(column_name, table_alias))
 
     def process_condition(self, condition) -> Tuple[str, str, any]:
         """

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -1,5 +1,6 @@
 from typing import Optional, Mapping, NamedTuple, Sequence, Tuple, Union
 
+from snuba.clickhouse.escaping import escape_col
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.table_storage import TableWriter
 from snuba.query.extensions import QueryExtension
@@ -7,7 +8,7 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.types import Condition
-from snuba.util import escape_col, parse_datetime, qualified_column
+from snuba.util import parse_datetime, qualified_column
 
 
 class ColumnSplitSpec(NamedTuple):

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -3,12 +3,12 @@ from typing import Any, Mapping, Set, Union
 
 from snuba import state
 from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.escaping import escape_col
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.util import (
     alias_expr,
     escape_literal,
-    escape_col,
     qualified_column,
 )
 

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping, Set, Union
 
 from snuba import state
 from snuba.clickhouse.columns import ColumnSet
-from snuba.clickhouse.escaping import escape_col
+from snuba.clickhouse.escaping import escape_identifier
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.util import (
@@ -72,9 +72,9 @@ class TagColumnProcessor:
         col_type = str(col_type) if col_type else None
 
         if col_type and "String" in col_type and "FixedString" not in col_type:
-            return escape_col(col)
+            return escape_identifier(col)
         else:
-            return "toString({})".format(escape_col(col))
+            return "toString({})".format(escape_identifier(col))
 
     def __tag_expr(self, column_name: str, table_alias: str = "",) -> str:
         """

--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -3,17 +3,16 @@ import re
 from typing import OrderedDict
 import _strptime  # NOQA fixes _strptime deferred import issue
 
+from snuba.clickhouse.escaping import escape_alias, NEGATE_RE
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.schema import POSITIVE_OPERATORS
 from snuba.util import (
     alias_expr,
-    escape_alias,
     escape_literal,
     function_expr,
     is_condition,
     is_function,
-    NEGATE_RE,
     QUOTED_LITERAL_RE,
 )
 

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -64,9 +64,8 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
 
     The original Visitor pattern does not foresee a return type for visit and accept
     methods, instead it relies on having the Visitor class stateful (any side effect a visit method
-    could produce has to make changes to the state of the class). This implementation
-    allows the Visitor to define a return type which is generic. This makes it possible
-    to traverse the Expression in a stateless way.
+    could produce has to make changes to the state of the visitor object). This implementation
+    allows the Visitor to define a return type which is generic.
     """
 
     @abstractmethod

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -42,6 +42,41 @@ class Expression(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def accept(self, visitor: ExpressionVisitor) -> None:
+        """
+        Accepts a visitor class to traverse the tree. The only role of this method is to
+        call the right visit method on the visitor object. Requiring the implementation
+        to call the method with the right type forces us to keep the visitor interface
+        up to date every time we create a new subclass of Expression.
+        """
+        raise NotImplementedError
+
+
+class ExpressionVisitor(ABC):
+    """
+    Implementation of a Visitor pattern to simplify traversal of the AST while preserving
+    the structure and delegating the control of the traversal algorithm to the client.
+    This pattern is generally used for evaluation or formatting. While the iteration
+    defined above is for stateless use cases where the order of the nodes is not important.
+    """
+
+    @abstractmethod
+    def visitLiteral(self, exp: Literal) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visitColumn(self, exp: Column) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visitFunctionCall(self, exp: FunctionCall) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visitCurriedFunctionCall(self, exp: CurriedFunctionCall) -> None:
+        raise NotImplementedError
+
 
 @dataclass(frozen=True)
 class Literal(Expression):
@@ -56,6 +91,9 @@ class Literal(Expression):
 
     def __iter__(self) -> Iterator[Expression]:
         yield self
+
+    def accept(self, visitor: ExpressionVisitor) -> None:
+        visitor.visitLiteral(self)
 
 
 @dataclass(frozen=True)
@@ -72,6 +110,9 @@ class Column(Expression):
 
     def __iter__(self) -> Iterator[Expression]:
         yield self
+
+    def accept(self, visitor: ExpressionVisitor) -> None:
+        visitor.visitColumn(self)
 
 
 @dataclass(frozen=True)
@@ -118,6 +159,9 @@ class FunctionCall(Expression):
                 yield sub
         yield self
 
+    def accept(self, visitor: ExpressionVisitor) -> None:
+        visitor.visitFunctionCall(self)
+
 
 @dataclass(frozen=True)
 class CurriedFunctionCall(Expression):
@@ -160,3 +204,6 @@ class CurriedFunctionCall(Expression):
             for sub in child:
                 yield sub
         yield self
+
+    def accept(self, visitor: ExpressionVisitor) -> None:
+        visitor.visitCurriedFunctionCall(self)

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -18,10 +18,11 @@ from typing import (
     Union,
 )
 
+from snuba.clickhouse.escaping import SAFE_COL_RE
 from snuba.datasets.schemas import RelationalSource
 from snuba.query.expressions import Expression
 from snuba.query.types import Condition
-from snuba.util import SAFE_COL_RE, columns_in_expr, is_condition, to_list
+from snuba.util import columns_in_expr, is_condition, to_list
 
 Aggregation = Union[
     Tuple[Any, Any, Any], Sequence[Any],

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -8,12 +8,12 @@ from typing import Any, Mapping, Optional, Sequence
 import simplejson as json
 
 from snuba.clickhouse import DATETIME_FORMAT
+from snuba.clickhouse.escaping import escape_col, escape_string
 from snuba.clickhouse.native import ClickhousePool
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import enforce_table_writer
 from snuba.processor import InvalidMessageType, InvalidMessageVersion, _hashify
 from snuba.redis import redis_client
-from snuba.util import escape_col, escape_string
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker
 from snuba.utils.streams.consumers.backends.kafka import KafkaMessage

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Optional, Sequence
 import simplejson as json
 
 from snuba.clickhouse import DATETIME_FORMAT
-from snuba.clickhouse.escaping import escape_col, escape_string
+from snuba.clickhouse.escaping import escape_identifier, escape_string
 from snuba.clickhouse.native import ClickhousePool
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import enforce_table_writer
@@ -404,7 +404,7 @@ def process_delete_tag(message, dataset) -> Optional[Replacement]:
         "select_columns": ", ".join(select_columns),
         "project_id": message["project_id"],
         "tag_str": escape_string(tag),
-        "tag_column": escape_col(tag_column_name),
+        "tag_column": escape_identifier(tag_column_name),
         "timestamp": timestamp.strftime(DATETIME_FORMAT),
     }
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -19,7 +19,7 @@ import re
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba import settings
-from snuba.clickhouse.escaping import escape_col, escape_string
+from snuba.clickhouse.escaping import escape_identifier, escape_string
 from snuba.query.parsing import ParsingContext
 from snuba.query.schema import CONDITION_OPERATORS
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -69,7 +69,7 @@ def function_expr(fn: str, args_expr: str = "") -> str:
         match = APDEX_FUNCTION_RE.match(fn)
         if match:
             return "(countIf({col} <= {satisfied}) + (countIf(({col} > {satisfied}) AND ({col} <= {tolerated})) / 2)) / count()".format(
-                col=escape_col(match.group(1)),
+                col=escape_identifier(match.group(1)),
                 satisfied=match.group(2),
                 tolerated=int(match.group(2)) * 4,
             )

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -9,7 +9,6 @@ from typing import (
     Mapping,
     NamedTuple,
     Optional,
-    Pattern,
     Sequence,
     Tuple,
     Union,
@@ -20,6 +19,7 @@ import re
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba import settings
+from snuba.clickhouse.escaping import escape_col, escape_string
 from snuba.query.parsing import ParsingContext
 from snuba.query.schema import CONDITION_OPERATORS
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -32,16 +32,8 @@ logger = logging.getLogger("snuba.util")
 # example partition name: "('2018-03-13 00:00:00', 90)"
 PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2})',\s*(\d+)\)")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
-ESCAPE_STRING_RE = re.compile(r"(['\\])")
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 TOPK_FUNCTION_RE = re.compile(r"^top([1-9]\d*)$")
-ESCAPE_COL_RE = re.compile(r"([`\\])")
-NEGATE_RE = re.compile(r"^(-?)(.*)$")
-SAFE_COL_RE = re.compile(r"^-?([a-zA-Z_][a-zA-Z0-9_\.]*)$")
-# Alias escaping is different than column names when we introduce table aliases.
-# Using the column escaping function would consider "." safe, which is not for
-# an alias.
-SAFE_ALIAS_RE = re.compile(r"^-?[a-zA-Z_][a-zA-Z0-9_]*$")
 APDEX_FUNCTION_RE = re.compile(r"^apdex\(\s*([^,]+)+\s*,\s*([\d]+)+\s*\)$")
 
 
@@ -59,29 +51,6 @@ def qualified_column(column_name: str, alias: str = "") -> str:
     empty. If the table is empty it returns the column itself.
     """
     return column_name if not alias else f"{alias}.{column_name}"
-
-
-def escape_expression(expr: Optional[str], regex: Pattern[str]) -> Optional[str]:
-    if not expr:
-        return expr
-    elif regex.match(expr):
-        # Column/Alias is safe to use without wrapping.
-        return expr
-    else:
-        # Column/Alias needs special characters escaped, and to be wrapped with
-        # backticks. If the column starts with a '-', keep that outside the
-        # backticks as it is not part of the column name, but used by the query
-        # generator to signify the sort order if we are sorting by this column.
-        col = ESCAPE_COL_RE.sub(r"\\\1", expr)
-        return "{}`{}`".format(*NEGATE_RE.match(col).groups())
-
-
-def escape_alias(alias: Optional[str]) -> Optional[str]:
-    return escape_expression(alias, SAFE_ALIAS_RE)
-
-
-def escape_col(col: Optional[str]) -> Optional[str]:
-    return escape_expression(col, SAFE_COL_RE)
 
 
 def parse_datetime(value: str, alignment: int = 1) -> datetime:
@@ -228,11 +197,6 @@ def tuplify(nested: Any) -> Any:
     if isinstance(nested, (list, tuple)):
         return tuple(tuplify(child) for child in nested)
     return nested
-
-
-def escape_string(str: str) -> str:
-    str = ESCAPE_STRING_RE.sub(r"\\\1", str)
-    return "'{}'".format(str)
 
 
 def escape_literal(

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -1,0 +1,116 @@
+import pytest
+
+from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
+from snuba.query.expressions import (
+    Column,
+    CurriedFunctionCall,
+    Expression,
+    FunctionCall,
+    Literal,
+)
+from snuba.query.parsing import ParsingContext
+
+test_expressions = [
+    (Literal(None, "test"), "'test'"),  # String literal
+    (Literal(None, 123), "123",),  # INT literal
+    (Literal(None, 123.321), "123.321",),  # FLOAT literal
+    (Literal(None, None), "NULL",),  # NULL
+    (Literal(None, True), "true",),  # True
+    (Literal(None, False), "false",),  # False
+    (Column(None, "column1", "table1"), "table1.column1"),  # Basic Column no alias
+    (Column(None, "column1", None), "column1"),  # Basic Column with no table
+    (
+        Column("alias", "column1", "table1"),
+        "(table1.column1 AS alias)",
+    ),  # Column with table and alias
+    (
+        FunctionCall(
+            None,
+            "f1",
+            [
+                Column(None, "param1", "table1"),
+                Column(None, "param2", "table1"),
+                Literal(None, None),
+                Literal(None, "test_string"),
+            ],
+        ),
+        "f1(table1.param1, table1.param2, NULL, 'test_string')",
+    ),  # Simple function call with columns and literals
+    (
+        FunctionCall(
+            "alias",
+            "f1",
+            [Column(None, "param1", "table1"), Column("alias1", "param2", "table1")],
+        ),
+        "(f1(table1.param1, (table1.param2 AS alias1)) AS alias)",
+    ),  # Function with alias
+    (
+        FunctionCall(
+            None,
+            "f1",
+            [
+                FunctionCall(None, "f2", [Column(None, "param1", "table1")]),
+                FunctionCall(None, "f3", [Column(None, "param2", "table1")]),
+            ],
+        ),
+        "f1(f2(table1.param1), f3(table1.param2))",
+    ),  # Hierarchical function call
+    (
+        FunctionCall(
+            None,
+            "f1",
+            [
+                FunctionCall("al1", "f2", [Column(None, "param1", "table1")]),
+                FunctionCall("al2", "f3", [Column(None, "param2", "table1")]),
+            ],
+        ),
+        "f1((f2(table1.param1) AS al1), (f3(table1.param2) AS al2))",
+    ),  # Hierarchical function call with aliases
+    (
+        CurriedFunctionCall(
+            None,
+            FunctionCall(None, "f0", [Column(None, "param1", "table1")]),
+            [
+                FunctionCall(None, "f1", [Column(None, "param2", "table1")]),
+                Column(None, "param3", "table1"),
+            ],
+        ),
+        "f0(table1.param1)(f1(table1.param2), table1.param3)",
+    ),  # Curried function call with hierarchy
+]
+
+
+@pytest.mark.parametrize("expression, expected", test_expressions)
+def test_format_expressions(expression: Expression, expected: str) -> None:
+    visitor = ClickhouseExpressionFormatter()
+    assert expression.accept(visitor) == expected
+
+
+def test_aliases() -> None:
+    # No context
+    col1 = Column("al1", "column1", "table1")
+    col2 = Column("al1", "column1", "table1")
+
+    assert col1.accept(ClickhouseExpressionFormatter()) == "(table1.column1 AS al1)"
+    assert col2.accept(ClickhouseExpressionFormatter()) == "(table1.column1 AS al1)"
+
+    # With Context
+    pc = ParsingContext()
+    assert col1.accept(ClickhouseExpressionFormatter(pc)) == "(table1.column1 AS al1)"
+    assert col2.accept(ClickhouseExpressionFormatter(pc)) == "al1"
+
+    # Hierarchical expression inherits parsing context and applies alaises
+    f = FunctionCall(
+        None,
+        "f1",
+        [
+            FunctionCall("tag[something]", "tag", [Column(None, "column1", "table1")]),
+            FunctionCall("tag[something]", "tag", [Column(None, "column1", "table1")]),
+            FunctionCall("tag[something]", "tag", [Column(None, "column1", "table1")]),
+        ],
+    )
+
+    expected = (
+        "f1((tag(table1.column1) AS tag[something]), tag[something], tag[something])"
+    )
+    assert f.accept(ClickhouseExpressionFormatter()) == expected

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -61,5 +61,5 @@ def test_visit_expression():
 
     # Tests the state changes on the Visitor
     assert visitor.get_visited_nodes() == expected
-    # Tests the retun value of the visitor
+    # Tests the return value of the visitor
     assert ret == expected

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -1,0 +1,54 @@
+from typing import List
+
+from snuba.query.expressions import (
+    Column,
+    CurriedFunctionCall,
+    Expression,
+    ExpressionVisitor,
+    FunctionCall,
+    Literal,
+)
+
+
+class DummyVisitor(ExpressionVisitor):
+    def __init__(self):
+        self.__visited_nodes: List[Expression] = []
+
+    def get_visited_nodes(self) -> List[Expression]:
+        return self.__visited_nodes
+
+    def visitLiteral(self, exp: Literal) -> None:
+        self.__visited_nodes.append(exp)
+
+    def visitColumn(self, exp: Column) -> None:
+        self.__visited_nodes.append(exp)
+
+    def visitFunctionCall(self, exp: FunctionCall) -> None:
+        self.__visited_nodes.append(exp)
+        for param in exp.parameters:
+            param.accept(self)
+
+    def visitCurriedFunctionCall(self, exp: CurriedFunctionCall) -> None:
+        self.__visited_nodes.append(exp)
+        exp.internal_function.accept(self)
+        for param in exp.parameters:
+            param.accept(self)
+
+
+def test_visit_expression():
+    col1 = Column("al", "c1", "t1")
+    literal1 = Literal("al2", "test")
+    f1 = FunctionCall("al3", "f1", [col1, literal1])
+
+    col2 = Column("al4", "c2", "t1")
+    literal2 = Literal("al5", "test2")
+    f2 = FunctionCall("al6", "f2", [col2, literal2])
+
+    curried = CurriedFunctionCall("al7", f2, [f1])
+
+    visitor = DummyVisitor()
+    curried.accept(visitor)
+
+    expected = [curried, f2, col2, literal2, f1, col1, literal1]
+
+    assert visitor.get_visited_nodes() == expected

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,7 @@ import pytest
 
 from tests.base import BaseTest
 
+from snuba.clickhouse.escaping import escape_col, escape_alias
 from snuba.datasets.factory import get_dataset
 from snuba import state
 from snuba.query.columns import (
@@ -14,8 +15,6 @@ from snuba.query.columns import (
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.util import (
-    escape_alias,
-    escape_col,
     escape_literal,
     tuplify,
 )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.base import BaseTest
 
-from snuba.clickhouse.escaping import escape_col, escape_alias
+from snuba.clickhouse.escaping import escape_identifier, escape_alias
 from snuba.datasets.factory import get_dataset
 from snuba import state
 from snuba.query.columns import (
@@ -38,18 +38,18 @@ class TestUtil(BaseTest):
             == "(1, 'a', toDate('2001-01-01'))"
         )
 
-    def test_escape_col(self):
-        assert escape_col(None) is None
-        assert escape_col("") == ""
-        assert escape_col("foo") == "foo"
-        assert escape_col("foo.bar") == "foo.bar"
-        assert escape_col("foo:bar") == "`foo:bar`"
+    def test_escape_identifier(self):
+        assert escape_identifier(None) is None
+        assert escape_identifier("") == ""
+        assert escape_identifier("foo") == "foo"
+        assert escape_identifier("foo.bar") == "foo.bar"
+        assert escape_identifier("foo:bar") == "`foo:bar`"
 
         # Even though backtick characters in columns should be
         # disallowed by the query schema, make sure we dont allow
         # injection anyway.
-        assert escape_col("`") == r"`\``"
-        assert escape_col("production`; --") == r"`production\`; --`"
+        assert escape_identifier("`") == r"`\``"
+        assert escape_identifier("production`; --") == r"`production\`; --`"
 
     def test_escape_alias(self):
         assert escape_alias(None) is None


### PR DESCRIPTION
This is the first step into the new Query AST formatting. This PR provides what we need to format Expressions. The next step will put them together into Query formatting.

In order to make formatting Clickhouse specific, this introduces a Visitor pattern (commonly used to evaluate asts) that is used to traverse the AST and format it node by node.
This formatter also manages escaping of each node type.

test plan:
- unit tests added