### PR TITLE
fix(migrations) Support all datasets in snuba migrate script

### DIFF
--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -4,25 +4,31 @@ import click
 from clickhouse_driver import Client
 
 from snuba import settings
-from snuba.datasets.factory import get_dataset
+from snuba.datasets.factory import get_dataset, DATASET_NAMES
 from snuba.util import local_dataset_mode
 
 
 @click.command()
 @click.option("--log-level", default=settings.LOG_LEVEL, help="Logging level to use.")
-def migrate(log_level):
+@click.option(
+    "--dataset", type=click.Choice(DATASET_NAMES), help="The dataset to target",
+)
+def migrate(log_level, dataset):
     from snuba.migrate import logger, run
 
-    # TODO: this only supports one dataset so far. More work is needed for the others.
-    dataset = get_dataset("events")
     logging.basicConfig(
         level=getattr(logging, log_level.upper()), format="%(asctime)s %(message)s"
     )
+    dataset_names = [dataset] if dataset else DATASET_NAMES
+    for dataset_name in dataset_names:
+        dataset = get_dataset(dataset_name)
+        logger.info("Migrating dataset %s", dataset_name)
+        if not local_dataset_mode():
+            logger.error("The migration tool can only work on local dataset mode.")
+            sys.exit(1)
 
-    if not local_dataset_mode():
-        logger.error("The migration tool can only work on local dataset mode.")
-        sys.exit(1)
+        clickhouse = Client(
+            host=settings.CLICKHOUSE_HOST, port=settings.CLICKHOUSE_PORT,
+        )
 
-    clickhouse = Client(host=settings.CLICKHOUSE_HOST, port=settings.CLICKHOUSE_PORT,)
-
-    run(clickhouse, dataset)
+        run(clickhouse, dataset)


### PR DESCRIPTION
The snuba migration script still has events hardcoded because, at the time we introduced datasets there was not a migration abstraction. Now there is one (still a very rudimentary one, but it kind of works for basic cases) so we can support the other datasets.

test
```
(snuba) ~/snuba  (fix/migrateScript *)$ snuba migrate
2019-11-25 11:15:53,577 Migrating dataset events
2019-11-25 11:15:53,597 Migrating dataset groupedmessage
2019-11-25 11:15:53,608 Migrating dataset discover
2019-11-25 11:15:53,608 Migrating dataset groupassignee
2019-11-25 11:15:53,618 Migrating dataset outcomes_raw
2019-11-25 11:15:53,624 Migrating dataset transactions
2019-11-25 11:15:53,629 Column 'transaction_hash' type differs between local ClickHouse and schema! (expected: UInt64 MATERIALIZED cityHash64(transaction_name), is: UInt64)
2019-11-25 11:15:53,629 Column 'user' type differs between local ClickHouse and schema! (expected: String DEFAULT '', is: String)
2019-11-25 11:15:53,629 Column 'sdk_name' type differs between local ClickHouse and schema! (expected: String DEFAULT '', is: String)
2019-11-25 11:15:53,629 Column 'sdk_version' type differs between local ClickHouse and schema! (expected: String DEFAULT '', is: String)
2019-11-25 11:15:53,633 Column 'transaction_hash' type differs between local ClickHouse and schema! (expected: UInt64 MATERIALIZED cityHash64(transaction_name), is: UInt64)
2019-11-25 11:15:53,633 Column 'user' type differs between local ClickHouse and schema! (expected: String DEFAULT '', is: String)
2019-11-25 11:15:53,634 Column 'sdk_name' type differs between local ClickHouse and schema! (expected: String DEFAULT '', is: String)
2019-11-25 11:15:53,634 Column 'sdk_version' type differs between local ClickHouse and schema! (expected: String DEFAULT '', is: String)
2019-11-25 11:15:53,634 Migrating dataset outcomes
```