### PR TITLE
fix: Fix double formatting datetimes when grouped

### DIFF
--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -67,28 +67,28 @@ def transform_columns(result: Result) -> Result:
         else:
             return iter(result["data"])
 
-    columns = set([col["name"] for col in result["meta"]])
-    for col in columns:
-        if DATETIME_TYPE_RE.match(col["type"]):
+    columns = {col["name"]: col['type'] for col in result["meta"]}
+    for col_name, col_type in columns.items():
+        if DATETIME_TYPE_RE.match(col_type):
             for row in iterate_rows():
                 if (
-                    row[col["name"]] is not None
+                    row[col_name] is not None
                 ):  # The column value can be null/None at times.
-                    row[col["name"]] = (
-                        row[col["name"]].replace(tzinfo=tz.tzutc()).isoformat()
+                    row[col_name] = (
+                        row[col_name].replace(tzinfo=tz.tzutc()).isoformat()
                     )
-        elif DATE_TYPE_RE.match(col["type"]):
+        elif DATE_TYPE_RE.match(col_type):
             for row in iterate_rows():
                 if (
-                    row[col["name"]] is not None
+                    row[col_name] is not None
                 ):  # The column value can be null/None at times.
-                    row[col["name"]] = (
-                        datetime(*(row[col["name"]].timetuple()[:6]))
+                    row[col_name] = (
+                        datetime(*(row[col_name].timetuple()[:6]))
                         .replace(tzinfo=tz.tzutc())
                         .isoformat()
                     )
-        elif UUID_TYPE_RE.match(col["type"]):
+        elif UUID_TYPE_RE.match(col_type):
             for row in iterate_rows():
-                row[col["name"]] = str(row[col["name"]])
+                row[col_name] = str(row[col_name])
 
     return result

--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -67,7 +67,7 @@ def transform_columns(result: Result) -> Result:
         else:
             return iter(result["data"])
 
-    columns = {col["name"]: col['type'] for col in result["meta"]}
+    columns = {col["name"]: col["type"] for col in result["meta"]}
     for col_name, col_type in columns.items():
         if DATETIME_TYPE_RE.match(col_type):
             for row in iterate_rows():

--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -67,7 +67,8 @@ def transform_columns(result: Result) -> Result:
         else:
             return iter(result["data"])
 
-    for col in result["meta"]:
+    columns = set([col["name"] for col in result["meta"]])
+    for col in columns:
         if DATETIME_TYPE_RE.match(col["type"]):
             for row in iterate_rows():
                 if (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1218,16 +1218,14 @@ class TestApi(BaseApiTest):
         }
         json.loads(self.app.post("/query", data=json.dumps(query)).data)
 
-    def test_aggregate_timestamp(self):
+    def test_duplicate_column(self):
         query = {
-            "project": 1,
-            "selected_columns": ["timestamp"],
-            "aggregations": [
-                ["count", "", "count"],
-                ["argMax", ["project_id", "timestamp"], "projectid"],
-                ["argMax", ["event_id", "timestamp"], "latest_event"],
-            ],
-            "groupby": ["timestamp"]
+            "selected_columns": ["timestamp", "timestamp"],
+            "limit": 3,
+            "project": [1],
+            "from_date": "2019-11-21T01:00:36",
+            "to_date": "2019-11-26T01:00:36",
+            "granularity": 3600,
         }
         result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
         assert "error" not in result

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1218,6 +1218,20 @@ class TestApi(BaseApiTest):
         }
         json.loads(self.app.post("/query", data=json.dumps(query)).data)
 
+    def test_aggregate_timestamp(self):
+        query = {
+            "project": 1,
+            "selected_columns": ["timestamp"],
+            "aggregations": [
+                ["count", "", "count"],
+                ["argMax", ["project_id", "timestamp"], "projectid"],
+                ["argMax", ["event_id", "timestamp"], "latest_event"],
+            ],
+            "groupby": ["timestamp"]
+        }
+        result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        assert "error" not in result
+
     def test_test_endpoints(self):
         project_id = 73
         group_id = 74


### PR DESCRIPTION
When grouping results by timestamp the result meta contains an additional timestamp value which causes result formatting to fail on the second pass. By getting the distinct column name list we don't double format any values.