### PR TITLE
feat(APM) Add transaction_status column to Snuba Transactions

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -77,6 +77,11 @@ def transactions_migrations(
             "ALTER TABLE %s ADD COLUMN sdk_version String DEFAULT ''" % clickhouse_table
         )
 
+    if "transaction_status" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT 0 AFTER transaction_op"
+        )
+
     return ret
 
 
@@ -94,6 +99,7 @@ class TransactionsDataset(TimeSeriesDataset):
                     Materialized(UInt(64), "cityHash64(transaction_name)",),
                 ),
                 ("transaction_op", LowCardinality(String())),
+                ("transaction_status", WithDefault(UInt(8), 0)),
                 ("start_ts", DateTime()),
                 ("start_ms", UInt(16)),
                 ("finish_ts", DateTime()),


### PR DESCRIPTION
Sentry is going to start passing the transaciton status soon. This adds the column in the transactions dataset.

test plan:
- snuba migrate -> created the column
- drop the dataset and run snuba bootstrap -> created the table with the column:

```
│ transaction_status │ UInt8                  │ DEFAULT      │ 0                            │
```