### PR TITLE
fix(discover) Enable the geo and sdk columns to be used

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -262,7 +262,6 @@ class DiscoverDataset(TimeSeriesDataset):
         table_alias: str = "",
     ):
         detected_dataset = detect_dataset(query, self.__transactions_columns)
-        dataset = get_dataset(detected_dataset)
 
         if detected_dataset == TRANSACTIONS:
             if column_name == "type":
@@ -278,15 +277,11 @@ class DiscoverDataset(TimeSeriesDataset):
             if column_name == "message":
                 return "transaction_name"
             if column_name == "geo_country_code":
-                return dataset.column_expr(
-                    "contexts[geo.country_code]", query, parsing_context
-                )
+                column_name = "contexts[geo.country_code]"
             if column_name == "geo_region":
-                return dataset.column_expr(
-                    "contexts[geo.region]", query, parsing_context
-                )
+                column_name = "contexts[geo.region]"
             if column_name == "geo_city":
-                return dataset.column_expr("contexts[geo.city]", query, parsing_context)
+                column_name = "contexts[geo.city]"
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:
@@ -299,7 +294,9 @@ class DiscoverDataset(TimeSeriesDataset):
             if self.__transactions_columns.get(column_name):
                 return "NULL"
 
-        return dataset.column_expr(column_name, query, parsing_context)
+        return get_dataset(detected_dataset).column_expr(
+            column_name, query, parsing_context
+        )
 
 
 class InvalidDataset(Exception):

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -154,6 +154,9 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("username", Nullable(String())),
                 ("email", Nullable(String())),
                 ("ip_address", Nullable(String())),
+                # SDK
+                ("sdk_name", Nullable(String())),
+                ("sdk_version", Nullable(String())),
                 # Other tags and context
                 ("tags", Nested([("key", String()), ("value", String())])),
                 ("contexts", Nested([("key", String()), ("value", String())])),
@@ -179,9 +182,7 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("geo_country_code", Nullable(String())),
                 ("geo_region", Nullable(String())),
                 ("geo_city", Nullable(String())),
-                ("sdk_name", Nullable(String())),
                 ("sdk_integrations", Nullable(Array(String()))),
-                ("sdk_version", Nullable(String())),
                 ("version", Nullable(String())),
                 ("http_method", Nullable(String())),
                 ("http_referer", Nullable(String())),
@@ -261,6 +262,7 @@ class DiscoverDataset(TimeSeriesDataset):
         table_alias: str = "",
     ):
         detected_dataset = detect_dataset(query, self.__transactions_columns)
+        dataset = get_dataset(detected_dataset)
 
         if detected_dataset == TRANSACTIONS:
             if column_name == "type":
@@ -275,6 +277,16 @@ class DiscoverDataset(TimeSeriesDataset):
                 return "transaction_name"
             if column_name == "message":
                 return "transaction_name"
+            if column_name == "geo_country_code":
+                return dataset.column_expr(
+                    "contexts[geo.country_code]", query, parsing_context
+                )
+            if column_name == "geo_region":
+                return dataset.column_expr(
+                    "contexts[geo.region]", query, parsing_context
+                )
+            if column_name == "geo_city":
+                return dataset.column_expr("contexts[geo.city]", query, parsing_context)
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:
@@ -287,9 +299,7 @@ class DiscoverDataset(TimeSeriesDataset):
             if self.__transactions_columns.get(column_name):
                 return "NULL"
 
-        return get_dataset(detected_dataset).column_expr(
-            column_name, query, parsing_context
-        )
+        return dataset.column_expr(column_name, query, parsing_context)
 
 
 class InvalidDataset(Exception):

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -157,6 +157,10 @@ class DiscoverDataset(TimeSeriesDataset):
                 # SDK
                 ("sdk_name", Nullable(String())),
                 ("sdk_version", Nullable(String())),
+                # geo location context
+                ("geo_country_code", Nullable(String())),
+                ("geo_region", Nullable(String())),
+                ("geo_city", Nullable(String())),
                 # Other tags and context
                 ("tags", Nested([("key", String()), ("value", String())])),
                 ("contexts", Nested([("key", String()), ("value", String())])),
@@ -179,9 +183,6 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("location", Nullable(String())),
                 ("culprit", Nullable(String())),
                 ("received", Nullable(DateTime())),
-                ("geo_country_code", Nullable(String())),
-                ("geo_region", Nullable(String())),
-                ("geo_city", Nullable(String())),
                 ("sdk_integrations", Nullable(Array(String()))),
                 ("version", Nullable(String())),
                 ("http_method", Nullable(String())),

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -74,6 +74,11 @@ class TestDiscoverApi(BaseApiTest):
                             "user": {
                                 "email": "sally@example.org",
                                 "ip_address": "8.8.8.8",
+                                "geo": {
+                                    "city": "San Francisco",
+                                    "region": "CA",
+                                    "country_code": "US",
+                                },
                             },
                             "contexts": {
                                 "trace": {
@@ -81,6 +86,11 @@ class TestDiscoverApi(BaseApiTest):
                                     "span_id": span_id,
                                     "op": "http",
                                 },
+                            },
+                            "sdk": {
+                                "name": "sentry.python",
+                                "version": "0.13.4",
+                                "integrations": ["django"],
                             },
                             "spans": [
                                 {
@@ -134,7 +144,14 @@ class TestDiscoverApi(BaseApiTest):
                 {
                     "dataset": "discover",
                     "project": 1,
-                    "selected_columns": ["type", "tags[foo]", "group_id", "release"],
+                    "selected_columns": [
+                        "type",
+                        "tags[foo]",
+                        "group_id",
+                        "release",
+                        "sdk_name",
+                        "geo_city",
+                    ],
                     "conditions": [["type", "=", "transaction"]],
                     "orderby": "timestamp",
                     "limit": 1,
@@ -149,6 +166,8 @@ class TestDiscoverApi(BaseApiTest):
             "tags[foo]": "baz",
             "group_id": None,
             "release": "1",
+            "geo_city": "San Francisco",
+            "sdk_name": "sentry.python",
         }
 
     def test_aggregations(self):
@@ -234,6 +253,49 @@ class TestDiscoverApi(BaseApiTest):
 
         assert response.status_code == 200
         assert data["data"] == [{"type": "error", "uniq_trace_id": 0}]
+
+    def test_geo_column_condition(self):
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [["count()", "", "count"]],
+                    "conditions": [
+                        ["type", "=", "transaction"],
+                        ["geo_country_code", "=", "MX"],
+                    ],
+                    "limit": 1000,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == [{"count": 0}]
+
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [["count()", "", "count"]],
+                    "conditions": [
+                        ["type", "=", "transaction"],
+                        ["geo_country_code", "=", "US"],
+                        ["geo_region", "=", "CA"],
+                        ["geo_city", "=", "San Francisco"],
+                    ],
+                    "limit": 1000,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == [{"count": 1}]
 
     def test_having(self):
         result = json.loads(


### PR DESCRIPTION
Previously these fields would not work on the discover dataset. This adds the required shims for geo fields and moves the  sdk_name and sdk_version fields into the list of shared fields.

Refs getsentry/sentry#15836