### PR TITLE
feat(discover): Add basic column validation

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -27,6 +27,8 @@ from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
 from snuba.util import is_condition
 
+from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
+
 EVENTS = "events"
 TRANSACTIONS = "transactions"
 
@@ -109,6 +111,35 @@ class DatasetSelector(QueryProcessor):
         source = query.get_data_source()
         assert isinstance(source, DiscoverSource)
         source.set_table_source(detected_dataset)
+
+
+class SimpleColumnValidator(QueryProcessor):
+    """
+    Checks that requested columns are present on the Discover schema. Prevents a column
+    that happens to be present on an underlying dataset being inadvertently exposed
+    on Discover.
+    """
+
+    def __init__(self, all_columns: ColumnSet) -> None:
+        self.__columns = all_columns
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        aliases = query.get_aliases()
+        columns = [
+            col for col in query.get_all_referenced_columns() if col not in aliases
+        ]
+        time_group_columns = [
+            "time",
+            "bucketed_end",
+        ]  # TODO: Remove when "time" column is correctly handled
+        for col in columns:
+            if (
+                col
+                and col not in self.__columns
+                and not NESTED_COL_EXPR_RE.match(col)
+                and col not in time_group_columns
+            ):
+                raise InvalidColumn(col)
 
 
 class DiscoverSchema(Schema):
@@ -237,6 +268,7 @@ class DiscoverDataset(TimeSeriesDataset):
         discover_source = self.get_dataset_schemas().get_read_schema().get_data_source()
 
         return [
+            SimpleColumnValidator(discover_source.get_columns()),
             DatasetSelector(discover_source, self.__transactions_columns),
             PrewhereProcessor(),
         ]
@@ -293,4 +325,8 @@ class DiscoverDataset(TimeSeriesDataset):
 
 
 class InvalidDataset(Exception):
+    pass
+
+
+class InvalidColumn(Exception):
     pass

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -329,6 +329,12 @@ class Query:
         # Return the set of all columns referenced in any expression
         return self.__get_referenced_columns(col_exprs)
 
+    def get_aliases(self) -> Sequence[str]:
+        if self.get_aggregations():
+            return [agg[2] for agg in self.get_aggregations()]
+
+        return []
+
     def get_columns_referenced_in_conditions(self) -> Sequence[Any]:
         col_exprs: MutableSequence[Any] = []
         self.__add_flat_conditions(col_exprs, self.get_conditions())

--- a/tests/query/test_query.py
+++ b/tests/query/test_query.py
@@ -178,3 +178,12 @@ def test_referenced_columns():
     query.set_prewhere([["pc6", "=", "10"]])
     assert query.get_all_referenced_columns() == set(["a", "b", "c", "d", "e", "pc6"])
     assert query.get_columns_referenced_in_having() == set(["b", "c", "d", "e"])
+
+    def test_get_aliases():
+        source = dataset.get_dataset_schemas().get_read_schema().get_data_source()
+
+        body = {"aggregations": [["uniq", "tags_value", "values_seen"]]}
+        assert Query(body, source).get_aliases() == ["values_seen"]
+
+        body = {"selected_columns": ["event_id", "project_id"]}
+        assert Query(body, source).get_aliases() == []

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -2,6 +2,7 @@ import calendar
 from datetime import datetime
 from functools import partial
 import simplejson as json
+import pytest
 import uuid
 
 from snuba import settings
@@ -285,3 +286,39 @@ class TestDiscoverApi(BaseApiTest):
             ).data
         )
         assert len(result["data"]) == 1
+
+    def test_invalid_column(self):
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "dataset": "discover",
+                        "project": self.project_id,
+                        "selected_columns": [
+                            "project_id",
+                            "time",
+                            "timestamp",
+                            "tags[some_custom_tag]",
+                        ],
+                    }
+                ),
+            ).data
+        )
+        assert len(result["data"]) == 1
+
+        with pytest.raises(Exception):
+            result = json.loads(
+                self.app.post(
+                    "/query",
+                    data=json.dumps(
+                        {
+                            "dataset": "discover",
+                            "project": self.project_id,
+                            "selected_columns": [
+                                "invalid_thing"
+                            ],
+                        }
+                    ),
+                ).data
+            )


### PR DESCRIPTION
Adds a simple validator that checks column names referenced in a query
against the Discover schema. This prevents columns that are defined on
the underlying events or transactions datasets but not intended to be
exposed in Discover being returned.

Test plan
- Run Sentry test suite