### PR TITLE
fix(discover): group_id defaults to 0 instead of NULL

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -162,7 +162,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
         self.__events_columns = ColumnSet(
             [
-                ("group_id", Nullable(UInt(64))),
+                ("group_id", UInt(64)),
                 ("primary_hash", Nullable(FixedString(32))),
                 ("type", Nullable(String())),
                 # Promoted tags
@@ -275,6 +275,8 @@ class DiscoverDataset(TimeSeriesDataset):
                 return "transaction_name"
             if column_name == "message":
                 return "transaction_name"
+            if column_name == "group_id":
+                return "0"
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -162,7 +162,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
         self.__events_columns = ColumnSet(
             [
-                ("group_id", UInt(64)),
+                ("group_id", Nullable(UInt(64))),
                 ("primary_hash", Nullable(FixedString(32))),
                 ("type", Nullable(String())),
                 # Promoted tags
@@ -276,6 +276,11 @@ class DiscoverDataset(TimeSeriesDataset):
             if column_name == "message":
                 return "transaction_name"
             if column_name == "group_id":
+                # TODO: We return 0 here instead of NULL so conditions like group_id
+                # in (1, 2, 3) will work, since Clickhouse won't run a query like:
+                # SELECT (NULL AS group_id) FROM transactions WHERE group_id IN (1, 2, 3)
+                # When we have the query AST, we should solve this by transforming the
+                # nonsensical conditions instead.
                 return "0"
             if self.__events_columns.get(column_name):
                 return "NULL"

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -147,7 +147,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"][0] == {
             "type": "transaction",
             "tags[foo]": "baz",
-            "group_id": None,
+            "group_id": 0,
             "release": "1",
         }
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -285,3 +285,44 @@ class TestDiscoverApi(BaseApiTest):
             ).data
         )
         assert len(result["data"]) == 1
+
+    def test_transaction_group_ids(self):
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "dataset": "discover",
+                        "project": self.project_id,
+                        "selected_columns": [
+                            "group_id",
+                        ],
+                        "conditions": [
+                            ["type", "=", "transaction"],
+                        ]
+                    }
+                ),
+            ).data
+        )
+        assert result["data"][0]["group_id"] == 0
+
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "dataset": "discover",
+                        "project": self.project_id,
+                        "selected_columns": [
+                            "group_id",
+                        ],
+                        "conditions": [
+                            ["type", "=", "transaction"],
+                            ["group_id", "IN", (1, 2, 3, 4)],
+                        ]
+                    }
+                ),
+            ).data
+        )
+
+        assert result["data"] == []


### PR DESCRIPTION
For the discover dataset, make group_id a non nullable column and default to 0
for transactions. This aligns group_id in Discover with the value of
transactions written to the events table.

The primary motivation for this is to prevent error like:
`DB::Exception: Type mismatch in IN or VALUES section. Expected: Nothing.
Got: UInt64.` occuring when a condition `type = "transaction" and
group_id in (1, 2, 3)` is sent to the Discover dataset.

This is an example of this error logged on Sentry.
https://sentry.io/organizations/sentry/issues/1235234594/events/2d859e6865504a36a32dc1886c381497/?project=300688

Whilst these conditions don't necessarily make sense (should always
yield an empty set since transactions have no group_id) they are
sometimes generated from Discover v2.

An alternative solution might be to strip the group_id condition
instead, however it might be more complex to implment correctly in
every case.