### PR TITLE
Fix: Missing unicodify on context key

### DIFF
--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -63,7 +63,8 @@ def extract_extra_contexts(output, contexts):
                 if isinstance(ctx_value, valid_types):
                     value = _unicodify(ctx_value)
                     if value:
-                        context_keys.append("%s.%s" % (ctx_name, inner_ctx_name))
+                        ctx_key = f"{ctx_name}.{inner_ctx_name}"
+                        context_keys.append(_unicodify(ctx_key))
                         context_values.append(_unicodify(ctx_value))
 
     output["contexts.key"] = context_keys

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -428,6 +428,7 @@ class TestEventsProcessor(BaseEventsTest):
                 "list": [1, 2, 3],
                 "dict": {"key": "value"},
                 "str": "string",
+                "\ud83c": "invalid utf-8 surrogate",
             },
         }
         orig_tags = {
@@ -483,6 +484,7 @@ class TestEventsProcessor(BaseEventsTest):
             "device": {},
             "extra": {
                 "dict": {"key": "value"},
+                "\ud83c": "invalid utf-8 surrogate",
                 "float": 1.3,
                 "int": 0,
                 "list": [1, 2, 3],
@@ -499,8 +501,8 @@ class TestEventsProcessor(BaseEventsTest):
         extract_extra_contexts(extra_output, contexts)
 
         assert extra_output == {
-            "contexts.key": ["extra.int", "extra.float", "extra.str"],
-            "contexts.value": [u"0", u"1.3", u"string"],
+            "contexts.key": ["extra.int", "extra.float", "extra.str", "extra.\\ud83c"],
+            "contexts.value": [u"0", u"1.3", u"string", u"invalid utf-8 surrogate"],
         }
 
     def test_extract_user(self):


### PR DESCRIPTION
Should fix this 
[25] DB::Exception: Incorrect surrogate pair of unicode escape sequences in JSON: (while read the value of key contexts.key) (version ######### (official build))