### PR TITLE
feat(apm) Fill in the transactions status field

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -24,7 +24,10 @@ from snuba.datasets.schemas.tables import (
     ReplacingMergeTreeSchema,
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.datasets.transactions_processor import TransactionsMessageProcessor
+from snuba.datasets.transactions_processor import (
+    TransactionsMessageProcessor,
+    UNKNOWN_SPAN_STATUS,
+)
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query_processor import QueryProcessor
@@ -79,7 +82,7 @@ def transactions_migrations(
 
     if "transaction_status" not in current_schema:
         ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT 2 AFTER transaction_op"
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT {UNKNOWN_SPAN_STATUS} AFTER transaction_op"
         )
 
     return ret
@@ -99,7 +102,7 @@ class TransactionsDataset(TimeSeriesDataset):
                     Materialized(UInt(64), "cityHash64(transaction_name)",),
                 ),
                 ("transaction_op", LowCardinality(String())),
-                ("transaction_status", WithDefault(UInt(8), 2)),
+                ("transaction_status", WithDefault(UInt(8), UNKNOWN_SPAN_STATUS)),
                 ("start_ts", DateTime()),
                 ("start_ms", UInt(16)),
                 ("finish_ts", DateTime()),

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -79,7 +79,7 @@ def transactions_migrations(
 
     if "transaction_status" not in current_schema:
         ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT 0 AFTER transaction_op"
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT 2 AFTER transaction_op"
         )
 
     return ret
@@ -99,7 +99,7 @@ class TransactionsDataset(TimeSeriesDataset):
                     Materialized(UInt(64), "cityHash64(transaction_name)",),
                 ),
                 ("transaction_op", LowCardinality(String())),
-                ("transaction_status", WithDefault(UInt(8), 0)),
+                ("transaction_status", WithDefault(UInt(8), 2)),
                 ("start_ts", DateTime()),
                 ("start_ms", UInt(16)),
                 ("finish_ts", DateTime()),

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -28,6 +28,9 @@ metrics = create_metrics(
 )
 
 
+UNKNOWN_SPAN_STATUS = 2
+
+
 class TransactionsMessageProcessor(MessageProcessor):
     PROMOTED_TAGS = {
         "environment",
@@ -77,7 +80,7 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
                 data["start_timestamp"],
             )
-            status = transaction_ctx.get("status", 2)
+            status = transaction_ctx.get("status", UNKNOWN_SPAN_STATUS)
             if (isinstance(status, str) and status.isdigit()) or isinstance(
                 status, int
             ):

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -77,6 +77,15 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
                 data["start_timestamp"],
             )
+            status = transaction_ctx.get("status", None)
+            if status is not None and (
+                (isinstance(status, str) and status.isdigit())
+                or isinstance(status, int)
+            ):
+                # This condition is complex because, at the time of writing, the status
+                # field is being migrated from a string to an integer and we should not
+                # throw if an old format event is received.
+                processed["transaction_status"] = int(status)
             if data["timestamp"] - data["start_timestamp"] < 0:
                 # Seems we have some negative durations in the DB
                 metrics.increment("negative_duration")

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -77,10 +77,9 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
                 data["start_timestamp"],
             )
-            status = transaction_ctx.get("status", None)
-            if status is not None and (
-                (isinstance(status, str) and status.isdigit())
-                or isinstance(status, int)
+            status = transaction_ctx.get("status", 2)
+            if (isinstance(status, str) and status.isdigit()) or isinstance(
+                status, int
             ):
                 # This condition is complex because, at the time of writing, the status
                 # field is being migrated from a string to an integer and we should not

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -33,6 +33,7 @@ class TransactionEvent:
     sdk_name: Optional[str]
     sdk_version: Optional[str]
     geo: Mapping[str, str]
+    status: int
 
     def serialize(self) -> Mapping[str, Any]:
         return (
@@ -108,6 +109,7 @@ class TransactionEvent:
                             "op": self.op,
                             "type": "trace",
                             "span_id": self.span_id,
+                            "status": str(self.status),
                         }
                     },
                     "tags": [
@@ -139,6 +141,7 @@ class TransactionEvent:
             "span_id": int(self.span_id, 16),
             "transaction_name": self.transaction_name,
             "transaction_op": self.op,
+            "transaction_status": self.status,
             "start_ts": start_timestamp,
             "start_ms": int(start_timestamp.microsecond / 1000),
             "finish_ts": finish_timestamp,
@@ -161,6 +164,7 @@ class TransactionEvent:
                 "trace.trace_id",
                 "trace.op",
                 "trace.span_id",
+                "trace.status",
                 "geo.country_code",
                 "geo.region",
                 "geo.city",
@@ -170,6 +174,7 @@ class TransactionEvent:
                 self.trace_id,
                 self.op,
                 self.span_id,
+                str(self.status),
                 self.geo["country_code"],
                 self.geo["region"],
                 self.geo["city"],
@@ -201,6 +206,7 @@ class TestTransactionsProcessor(BaseTest):
             trace_id="7400045b25c443b885914600aa83ad04",
             span_id="8841662216cc598b",
             transaction_name="/organizations/:orgId/issues/",
+            status=1,
             op="navigation",
             timestamp=finish,
             start_timestamp=start,
@@ -215,7 +221,7 @@ class TestTransactionsProcessor(BaseTest):
             release="34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a",
             sdk_name="sentry.python",
             sdk_version="0.9.0",
-            geo={"country_code": "XY", "region": "fake_region", "city": "fake_city",},
+            geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
         )
         payload = message.serialize()
         # Force an invalid event
@@ -232,6 +238,7 @@ class TestTransactionsProcessor(BaseTest):
             trace_id="7400045b25c443b885914600aa83ad04",
             span_id="8841662216cc598b",
             transaction_name="/organizations/:orgId/issues/",
+            status=1,
             op="navigation",
             timestamp=finish,
             start_timestamp=start,
@@ -246,7 +253,7 @@ class TestTransactionsProcessor(BaseTest):
             release="34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a",
             sdk_name="sentry.python",
             sdk_version="0.9.0",
-            geo={"country_code": "XY", "region": "fake_region", "city": "fake_city",},
+            geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
         )
         payload = message.serialize()
         # Force an invalid event
@@ -263,6 +270,7 @@ class TestTransactionsProcessor(BaseTest):
             trace_id="7400045b25c443b885914600aa83ad04",
             span_id="8841662216cc598b",
             transaction_name="/organizations/:orgId/issues/",
+            status=1,
             op="navigation",
             timestamp=finish,
             start_timestamp=start,
@@ -277,7 +285,7 @@ class TestTransactionsProcessor(BaseTest):
             release="34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a",
             sdk_name="sentry.python",
             sdk_version="0.9.0",
-            geo={"country_code": "XY", "region": "fake_region", "city": "fake_city",},
+            geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
         )
         meta = KafkaMessageMetadata(offset=1, partition=2,)
 

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -112,6 +112,7 @@ class TestTransactionsApi(BaseApiTest):
                                                 "trace_id": trace_id,
                                                 "span_id": span_id,
                                                 "op": "http",
+                                                "status": "0",
                                             },
                                         },
                                         "spans": [


### PR DESCRIPTION
https://github.com/getsentry/semaphore/pull/348 provides the value to put in the status field on the transaction table.
This PR starts populating the column.
https://github.com/getsentry/semaphore/pull/348 is also migrating the field from string to int so there is some complexity added to avoid casting issues.