### PR TITLE
feat(discover): Support "time" column in Discover

### DIFF
--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -150,7 +150,8 @@ class TimeSeriesDataset(Dataset):
         self.__time_group_columns = time_group_columns
         self.__time_parse_columns = time_parse_columns
 
-    def time_expr(self, column_name: str, granularity: int) -> str:
+    def time_expr(self, column_name: str, granularity: int, table_alias: str) -> str:
+        real_column = qualified_column(column_name, table_alias)
         template = {
             3600: "toStartOfHour({column})",
             60: "toStartOfMinute({column})",
@@ -159,7 +160,7 @@ class TimeSeriesDataset(Dataset):
             granularity,
             "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity})",
         )
-        return template.format(column=column_name, granularity=granularity)
+        return template.format(column=real_column, granularity=granularity)
 
     def column_expr(
         self,
@@ -170,8 +171,7 @@ class TimeSeriesDataset(Dataset):
     ):
         if column_name in self.__time_group_columns:
             real_column = self.__time_group_columns[column_name]
-            real_column = qualified_column(column_name, table_alias)
-            return self.time_expr(real_column, query.get_granularity())
+            return self.time_expr(real_column, query.get_granularity(), table_alias)
         else:
             return super().column_expr(column_name, query, parsing_context, table_alias)
 

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -150,11 +150,7 @@ class TimeSeriesDataset(Dataset):
         self.__time_group_columns = time_group_columns
         self.__time_parse_columns = time_parse_columns
 
-    def __time_expr(
-        self, column_name: str, granularity: int, table_alias: str = ""
-    ) -> str:
-        real_column = self.__time_group_columns[column_name]
-        real_column = qualified_column(real_column, table_alias)
+    def time_expr(self, column_name: str, granularity: int) -> str:
         template = {
             3600: "toStartOfHour({column})",
             60: "toStartOfMinute({column})",
@@ -163,7 +159,7 @@ class TimeSeriesDataset(Dataset):
             granularity,
             "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity})",
         )
-        return template.format(column=real_column, granularity=granularity)
+        return template.format(column=column_name, granularity=granularity)
 
     def column_expr(
         self,
@@ -173,7 +169,9 @@ class TimeSeriesDataset(Dataset):
         table_alias: str = "",
     ):
         if column_name in self.__time_group_columns:
-            return self.__time_expr(column_name, query.get_granularity(), table_alias)
+            real_column = self.__time_group_columns[column_name]
+            real_column = qualified_column(column_name, table_alias)
+            return self.time_expr(real_column, query.get_granularity())
         else:
             return super().column_expr(column_name, query, parsing_context, table_alias)
 

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -229,7 +229,7 @@ class DiscoverDataset(TimeSeriesDataset):
                 ),
                 write_schema=None,
             ),
-            time_group_columns={"time": "timestamp", "bucketed_end": "finish_ts"},
+            time_group_columns={},
             time_parse_columns=["timestamp", "start_ts", "finish_ts"],
         )
 
@@ -263,6 +263,8 @@ class DiscoverDataset(TimeSeriesDataset):
         detected_dataset = detect_dataset(query, self.__transactions_columns)
 
         if detected_dataset == TRANSACTIONS:
+            if column_name == "time":
+                return self.time_expr("finish_ts", query.get_granularity())
             if column_name == "type":
                 return "'transaction'"
             if column_name == "timestamp":
@@ -278,6 +280,8 @@ class DiscoverDataset(TimeSeriesDataset):
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:
+            if column_name == "time":
+                return self.time_expr("timestamp", query.get_granularity())
             if column_name == "release":
                 column_name = "tags[sentry:release]"
             if column_name == "dist":

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -264,7 +264,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
         if detected_dataset == TRANSACTIONS:
             if column_name == "time":
-                return self.time_expr("finish_ts", query.get_granularity())
+                return self.time_expr("finish_ts", query.get_granularity(), table_alias)
             if column_name == "type":
                 return "'transaction'"
             if column_name == "timestamp":
@@ -281,7 +281,7 @@ class DiscoverDataset(TimeSeriesDataset):
                 return "NULL"
         else:
             if column_name == "time":
-                return self.time_expr("timestamp", query.get_granularity())
+                return self.time_expr("timestamp", query.get_granularity(), table_alias)
             if column_name == "release":
                 column_name = "tags[sentry:release]"
             if column_name == "dist":

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -278,7 +278,7 @@ class TestDiscoverApi(BaseApiTest):
                         "dataset": "discover",
                         "project": self.project_id,
                         "selected_columns": ["project_id"],
-                        "groupby": ["bucketed_end", "project_id"],
+                        "groupby": ["time", "project_id"],
                         "conditions": [["type", "=", "transaction"]],
                     }
                 ),


### PR DESCRIPTION
Make "time" column work correctly regardless of whether we are reading
from the underlying events or transactions table. Remove references to
"bucketed_end" in Discover, which is not a column name we want to expose
any longer.

The time column is needed for generating the charts for Discover2. Queries
that reference this column currently generate errors in Sentry like this one:
https://sentry.io/organizations/sentry/issues/1235234594/events/88d70e31d42a4095b643dac519097595/
