### PR TITLE
Ensure we always populate the default value

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -88,6 +88,8 @@ class TransactionsMessageProcessor(MessageProcessor):
                 # field is being migrated from a string to an integer and we should not
                 # throw if an old format event is received.
                 processed["transaction_status"] = int(status)
+            else:
+                processed["transaction_status"] = UNKNOWN_SPAN_STATUS
             if data["timestamp"] - data["start_timestamp"] < 0:
                 # Seems we have some negative durations in the DB
                 metrics.increment("negative_duration")


### PR DESCRIPTION
Seems there is an issue when changing the default value of a table on Clickhouse.
This PR ensure we always populate the status field.