### PR TITLE
feat(subscriptions): Define scheduler interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,7 @@ simplejson==3.15.0
 singledispatch==3.4.0.3
 traceback2==1.4.0
 traitlets==4.3.2
+typing-extensions==3.7.4.1
 unittest2==1.1.0
 urllib3==1.25.3
 uWSGI==2.0.17

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+from typing import Generic, Iterator, Tuple, TypeVar
+
+from snuba.utils.types import Interval
+from snuba.subscriptions.types import TTimestamp
+
+
+TTask = TypeVar("TTask")
+
+
+class Scheduler(ABC, Generic[TTimestamp, TTask]):
+    @abstractmethod
+    def find(
+        self, interval: Interval[TTimestamp]
+    ) -> Iterator[Tuple[TTimestamp, TTask]]:
+        """
+        Return all of the tasks that were scheduled to be executed between
+        the lower bound (exclusive) and upper bound (inclusive) of the
+        provided interval.
+        """
+        raise NotImplementedError

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Generic, Iterator, Tuple, TypeVar
 
-from snuba.utils.types import Interval
 from snuba.subscriptions.types import TTimestamp
+from snuba.utils.types import Interval
 
 
 TTask = TypeVar("TTask")

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Generic, Iterator, Tuple, TypeVar
+from dataclasses import dataclass
+from typing import Generic, Iterator, TypeVar
 
 from snuba.subscriptions.types import TTimestamp
 from snuba.utils.types import Interval
@@ -8,11 +9,31 @@ from snuba.utils.types import Interval
 TTask = TypeVar("TTask")
 
 
+@dataclass(frozen=True)
+class ScheduledTask(Generic[TTimestamp, TTask]):
+    """
+    A scheduled task represents a unit of work (a task) that is intended to
+    be executed at (or around) a specific time.
+    """
+
+    # The time that this task was scheduled to execute.
+    timestamp: TTimestamp
+
+    # The task that should be executed.
+    task: TTask
+
+
 class Scheduler(ABC, Generic[TTimestamp, TTask]):
+    """
+    The scheduler maintains the scheduling state for various tasks and
+    provides the ability to query the schedule to find tasks that were
+    scheduled between a time interval.
+    """
+
     @abstractmethod
     def find(
         self, interval: Interval[TTimestamp]
-    ) -> Iterator[Tuple[TTimestamp, TTask]]:
+    ) -> Iterator[ScheduledTask[TTimestamp, TTask]]:
         """
         Return all of the tasks that were scheduled to be executed between
         the lower bound (exclusive) and upper bound (inclusive) of the

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -35,8 +35,9 @@ class Scheduler(ABC, Generic[TTimestamp, TTask]):
         self, interval: Interval[TTimestamp]
     ) -> Iterator[ScheduledTask[TTimestamp, TTask]]:
         """
-        Return all of the tasks that were scheduled to be executed between
-        the lower bound (exclusive) and upper bound (inclusive) of the
-        provided interval.
+        Find all of the tasks that were scheduled to be executed between the
+        lower bound (exclusive) and upper bound (inclusive) of the provided
+        interval. The tasks returned should be ordered by timestamp in
+        ascending order.
         """
         raise NotImplementedError

--- a/snuba/subscriptions/types.py
+++ b/snuba/subscriptions/types.py
@@ -1,0 +1,6 @@
+from typing import Any, TypeVar
+
+from snuba.utils.types import Comparable
+
+
+TTimestamp = TypeVar("TTimestamp", bound=Comparable[Any])

--- a/snuba/utils/types.py
+++ b/snuba/utils/types.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVar
+
+from typing_extensions import Protocol
+
+
+TComparable = TypeVar("TComparable", contravariant=True)
+
+
+class Comparable(Protocol[TComparable]):
+    """
+    Defines the protocol for comparable objects. Objects that satisfy this
+    protocol are assumed to have an ordering via the "rich comparison"
+    methods defined here.
+
+    "An ordering" does not necessarily imply a *total* ordering, or even that
+    the ordering itself is deterministic. The Python documentation provides a
+    more detailed explanation about the guarantees (or lack thereof) provided
+    by these methods: https://docs.python.org/3/reference/datamodel.html#object.__lt__
+
+    This class exists primarily to satisfy the type checker when dealing with
+    generics that will be directly compared, and secondarily to provide
+    documentation via type annotations.
+
+    In reality, this class provides little to no practical benefit, since all
+    of these methods defined in the protocol are part of the ``object`` class
+    definition (which is shared by all classes by default) but returns
+    ``NotImplemented`` rather than returning a valid result. (This protocol
+    is not defined as runtime checkable for that reason.)
+    """
+
+    def __lt__(self, other: TComparable) -> bool:
+        raise NotImplementedError
+
+    def __le__(self, other: TComparable) -> bool:
+        raise NotImplementedError
+
+    def __gt__(self, other: TComparable) -> bool:
+        raise NotImplementedError
+
+    def __ge__(self, other: TComparable) -> bool:
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> bool:
+        raise NotImplementedError
+
+    def __ne__(self, other: object) -> bool:
+        raise NotImplementedError
+
+
+T = TypeVar("T", bound=Comparable[Any])
+
+
+@dataclass(frozen=True)
+class Interval(Generic[T]):
+    lower: T
+    upper: T
+
+    def __post_init__(self) -> None:
+        assert self.upper >= self.lower

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -1,0 +1,10 @@
+import pytest
+
+from snuba.utils.types import Interval
+
+
+def test_interval_validation() -> None:
+    Interval(1, 1)
+    Interval(1, 10)
+    with pytest.raises(AssertionError):
+        Interval(10, 1)


### PR DESCRIPTION
This defines the abstract interface for the `Scheduler` that will be used by the subscribed queries consumer. This does not define or dictate the scheduler implementation.