### PR TITLE
fix: Add "issue" column to Discover schema

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -201,6 +201,9 @@ class DiscoverDataset(TimeSeriesDataset):
         self.__events_columns = ColumnSet(
             [
                 ("group_id", Nullable(UInt(64))),
+                # TODO: We should deprecate "issue" since it's just an alias
+                # for group_id but it's still being passed by Sentry.
+                ("issue", Nullable(UInt(64))),
                 ("primary_hash", Nullable(FixedString(32))),
                 ("type", Nullable(String())),
                 # Promoted tags


### PR DESCRIPTION
We need to add "issue" to the Discover schema as it's still being passed by Sentry in a number of cases