### PR TITLE
feat(datasets) Format the Clickhouse query from the Query AST

### DIFF
--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
+from snuba import settings
 from snuba.clickhouse.query import ClickhouseQuery
+from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
 from snuba.query.expressions import Expression
+from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.request.request_settings import RequestSettings
 
@@ -23,7 +26,7 @@ class AstClickhouseQuery(ClickhouseQuery):
         # to process this query independently from the Snuba Query
         # and there is no risk in doing so since they are immutable.
         self.__selected_columns = query.get_selected_columns_from_ast()
-        self.__condition = query.get_conditions_from_ast()
+        self.__condition = query.get_condition_from_ast()
         self.__groupby = query.get_groupby_from_ast()
         self.__having = query.get_having_from_ast()
         self.__orderby = query.get_orderby_from_ast()
@@ -36,15 +39,123 @@ class AstClickhouseQuery(ClickhouseQuery):
 
         # Clickhouse specific fields
         self.__prewhere: Optional[Expression] = None
-        self.__final = settings.get_turbo()
+        self.__turbo = settings.get_turbo()
+        self.__final = query.get_final()
 
         # Attributes that should be clickhouse specific that
         # have to be removed from the Snuba Query
         self.__sample = query.get_sample()
         self.__hastotals = query.has_totals()
 
+        self.__settings = settings
+
+        self.__formatted_query: Optional[str] = None
+
     def format_sql(self) -> str:
-        """
-        TODO: Do something interesting here.
-        """
-        raise NotImplementedError
+        if self.__formatted_query:
+            return self.__formatted_query
+
+        parsing_context = ParsingContext()
+
+        selected_cols = [
+            e.accept(ClickhouseExpressionFormatter(parsing_context))
+            for e in self.__selected_columns
+        ]
+        columns = ", ".join(selected_cols)
+        select_clause = f"SELECT {columns}"
+
+        from_clause = f"FROM {self.__data_source.format_from()}"
+
+        if self.__final:
+            from_clause = f"{from_clause} FINAL"
+
+        if not self.__data_source.supports_sample():
+            sample_rate = None
+        else:
+            if self.__sample:
+                sample_rate = self.__sample
+            elif self.__settings.get_turbo():
+                sample_rate = settings.TURBO_SAMPLE_RATE
+            else:
+                sample_rate = None
+        if sample_rate:
+            from_clause = f"{from_clause} SAMPLE {sample_rate}"
+
+        join_clause = ""
+        if self.__arrayjoin:
+            array_join = self.__arrayjoin.accept(
+                ClickhouseExpressionFormatter(parsing_context)
+            )
+            join_clause = f"ARRAY JOIN {array_join}"
+
+        where_clause = ""
+        if self.__condition:
+            formatted_condition = self.__condition.accept(
+                ClickhouseExpressionFormatter(parsing_context)
+            )
+            where_clause = f"WHERE {formatted_condition}"
+
+        prewhere_clause = ""
+        if self.__prewhere:
+            formatted_prewhere = self.__prewhere.accept(
+                ClickhouseExpressionFormatter(parsing_context)
+            )
+            prewhere_clause = f"PREWHERE {formatted_prewhere}"
+
+        group_clause = ""
+        if self.__groupby:
+            # reformat to use aliases generated during the select clause formatting.
+            groupby_expressions = [
+                e.accept(ClickhouseExpressionFormatter(parsing_context))
+                for e in self.__groupby
+            ]
+            formatted_groupby = ", ".join(groupby_expressions)
+            group_clause = f"GROUP BY ({formatted_groupby})"
+            if self.__hastotals:
+                group_clause = f"{group_clause} WITH TOTALS"
+
+        having_clause = ""
+        if self.__having:
+            assert self.__groupby, "found HAVING clause with no GROUP BY"
+            formatted_having = self.__having.accept(
+                ClickhouseExpressionFormatter(parsing_context)
+            )
+            having_clause = f"HAVING {formatted_having}"
+
+        order_clause = ""
+        if self.__orderby:
+            orderby = [
+                f"{e.node.accept(ClickhouseExpressionFormatter(parsing_context))} {e.direction.value}"
+                for e in self.__orderby
+            ]
+            formatted_orderby = ", ".join(orderby)
+            order_clause = f"ORDER BY {formatted_orderby}"
+
+        limitby_clause = ""
+        if self.__limitby is not None:
+            limitby_clause = "LIMIT {} BY {}".format(*self.__limitby)
+
+        limit_clause = ""
+        if self.__limit is not None:
+            limit_clause = f"LIMIT {self.__offset}, {self.__limit}"
+
+        self.__formatted_query = " ".join(
+            [
+                c
+                for c in [
+                    select_clause,
+                    from_clause,
+                    join_clause,
+                    prewhere_clause,
+                    where_clause,
+                    group_clause,
+                    having_clause,
+                    order_clause,
+                    limitby_clause,
+                    limit_clause,
+                ]
+                if c
+            ]
+        )
+
+        return self.__formatted_query

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -59,8 +59,8 @@ class AstClickhouseQuery(ClickhouseQuery):
             e.accept(ClickhouseExpressionFormatter(parsing_context))
             for e in self.__selected_columns
         ]
-        columns = ", ".join(selected_cols)
-        select_clause = f"SELECT {columns}"
+        formatted_columns = ", ".join(selected_cols)
+        select_clause = f"SELECT {formatted_columns}"
 
         # TODO: The visitor approach will be used for the FROM clause as well.
         from_clause = f"FROM {self.__data_source.format_from()}"
@@ -83,10 +83,10 @@ class AstClickhouseQuery(ClickhouseQuery):
 
         join_clause = ""
         if self.__arrayjoin:
-            array_join = self.__arrayjoin.accept(
+            formatted_array_join = self.__arrayjoin.accept(
                 ClickhouseExpressionFormatter(parsing_context)
             )
-            join_clause = f"ARRAY JOIN {array_join}"
+            join_clause = f"ARRAY JOIN {formatted_array_join}"
 
         where_clause = ""
         if self.__condition:

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -37,7 +37,7 @@ class AstClickhouseQuery(ClickhouseQuery):
         self.__offset = query.get_offset()
 
         # Clickhouse specific fields
-        self.__prewhere: query.get_prewhere_ast()
+        self.__prewhere = query.get_prewhere_ast()
         self.__turbo = settings.get_turbo()
         self.__final = query.get_final()
 

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from snuba.clickhouse.query import ClickhouseQuery
+from snuba.query.expressions import Expression
+from snuba.query.query import Query
+from snuba.request.request_settings import RequestSettings
+
+
+class AstClickhouseQuery(ClickhouseQuery):
+    """
+    Clickhouse query that takes the content from the Snuba Query
+    AST and can be processed (through query processors) for Clickhouse
+    specific customizations.
+
+    Here the process of formatting the query, is independent from
+    the query body dictionary and it is performed starting from the
+    AST.
+    """
+
+    def __init__(self, query: Query, settings: RequestSettings,) -> None:
+        # Snuba query structure
+        # Referencing them here directly since it makes it easier
+        # to process this query independently from the Snuba Query
+        # and there is no risk in doing so since they are immutable.
+        self.__selected_columns = query.get_selected_columns_from_ast()
+        self.__condition = query.get_conditions_from_ast()
+        self.__groupby = query.get_groupby_from_ast()
+        self.__having = query.get_having_from_ast()
+        self.__orderby = query.get_orderby_from_ast()
+        self.__data_source = query.get_data_source()
+        self.__arrayjoin = query.get_arrayjoin_from_ast()
+        self.__granularity = query.get_granularity()
+        self.__limit = query.get_limit()
+        self.__limitby = query.get_limitby()
+        self.__offset = query.get_offset()
+
+        # Clickhouse specific fields
+        self.__prewhere: Optional[Expression] = None
+        self.__final = settings.get_turbo()
+
+        # Attributes that should be clickhouse specific that
+        # have to be removed from the Snuba Query
+        self.__sample = query.get_sample()
+        self.__hastotals = query.has_totals()
+
+    def format_sql(self) -> str:
+        """
+        TODO: Do something interesting here.
+        """
+        raise NotImplementedError

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -60,8 +60,7 @@ class AstClickhouseQuery(ClickhouseQuery):
         formatter = ClickhouseExpressionFormatter(parsing_context)
 
         selected_cols = [e.accept(formatter) for e in self.__selected_columns]
-        formatted_columns = ", ".join(selected_cols)
-        select_clause = f"SELECT {formatted_columns}"
+        select_clause = f"SELECT {', '.join(selected_cols)}"
 
         # TODO: The visitor approach will be used for the FROM clause as well.
         from_clause = f"FROM {self.__data_source.format_from()}"
@@ -101,15 +100,13 @@ class AstClickhouseQuery(ClickhouseQuery):
         if self.__groupby:
             # reformat to use aliases generated during the select clause formatting.
             groupby_expressions = [e.accept(formatter) for e in self.__groupby]
-            formatted_groupby = ", ".join(groupby_expressions)
-            group_clause = f"GROUP BY ({formatted_groupby})"
+            group_clause = f"GROUP BY ({', '.join(groupby_expressions)})"
             if self.__hastotals:
                 group_clause = f"{group_clause} WITH TOTALS"
 
         having_clause = ""
         if self.__having:
-            formatted_having = self.__having.accept(formatter)
-            having_clause = f"HAVING {formatted_having}"
+            having_clause = f"HAVING {self.__having.accept(formatter)}"
 
         order_clause = ""
         if self.__orderby:
@@ -117,8 +114,7 @@ class AstClickhouseQuery(ClickhouseQuery):
                 f"{e.node.accept(formatter)} {e.direction.value}"
                 for e in self.__orderby
             ]
-            formatted_orderby = ", ".join(orderby)
-            order_clause = f"ORDER BY {formatted_orderby}"
+            order_clause = f"ORDER BY {', '.join(orderby)}"
 
         limitby_clause = ""
         if self.__limitby is not None:
@@ -126,7 +122,7 @@ class AstClickhouseQuery(ClickhouseQuery):
 
         limit_clause = ""
         if self.__limit is not None:
-            limit_clause = f"LIMIT {self.__offset}, {self.__limit}"
+            limit_clause = f"LIMIT {self.__limit} OFFSET {self.__offset}"
 
         self.__formatted_query = " ".join(
             [

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -7,7 +7,7 @@ from clickhouse_driver import Client, errors
 
 from snuba import settings
 from snuba.clickhouse.columns import Array
-from snuba.clickhouse.query import DictClickhouseQuery
+from snuba.clickhouse.query import ClickhouseQuery
 from snuba.reader import Reader, Result, transform_columns
 from snuba.writer import BatchWriter, WriterTableRow
 
@@ -127,7 +127,7 @@ class ClickhousePool(object):
             pass
 
 
-class NativeDriverReader(Reader[DictClickhouseQuery]):
+class NativeDriverReader(Reader[ClickhouseQuery]):
     def __init__(self, client):
         self.__client = client
 
@@ -152,7 +152,7 @@ class NativeDriverReader(Reader[DictClickhouseQuery]):
 
     def execute(
         self,
-        query: DictClickhouseQuery,
+        query: ClickhouseQuery,
         # TODO: move Clickhouse specific arguments into DictClickhouseQuery
         settings: Optional[Mapping[str, str]] = None,
         query_id: Optional[str] = None,

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 from snuba import settings as snuba_settings
 from snuba import util
@@ -10,7 +9,6 @@ from snuba.query.columns import (
 from snuba.datasets.dataset import Dataset
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
-from snuba.query.expressions import Expression
 from snuba.request.request_settings import RequestSettings
 
 
@@ -150,47 +148,3 @@ class DictClickhouseQuery(ClickhouseQuery):
     def format_sql(self) -> str:
         """Produces a SQL string from the parameters."""
         return self.__formatted_query
-
-
-class AstClickhouseQuery(ClickhouseQuery):
-    """
-    Clickhouse query that takes the content from the Snuba Query
-    AST and can be processed (through query processors) for Clickhouse
-    specific customizations.
-
-    Here the process of formatting the query, is independent from
-    the query body dictionary and it is performed starting from the
-    AST.
-    """
-
-    def __init__(self, query: Query, settings: RequestSettings,) -> None:
-        # Snuba query structure
-        # Referencing them here directly since it makes it easier
-        # to process this query independently from the Snuba Query
-        # and there is no risk in doing so since they are immutable.
-        self.__selected_columns = query.get_selected_columns_from_ast()
-        self.__condition = query.get_conditions_from_ast()
-        self.__groupby = query.get_groupby_from_ast()
-        self.__having = query.get_having_from_ast()
-        self.__orderby = query.get_orderby_from_ast()
-        self.__data_source = query.get_data_source()
-        self.__arrayjoin = query.get_arrayjoin_from_ast()
-        self.__granularity = query.get_granularity()
-        self.__limit = query.get_limit()
-        self.__limitby = query.get_limitby()
-        self.__offset = query.get_offset()
-
-        # Clickhouse specific fields
-        self.__prewhere: Optional[Expression] = None
-        self.__final = settings.get_turbo()
-
-        # Attributes that should be clickhouse specific that
-        # have to be removed from the Snuba Query
-        self.__sample = query.get_sample()
-        self.__hastotals = query.has_totals()
-
-    def format_sql(self) -> str:
-        """
-        TODO: Do something interesting here.
-        """
-        raise NotImplementedError

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -109,7 +109,7 @@ class Query:
         self.__selected_columns = selected_columns or []
         self.__array_join = array_join
         self.__condition = condition
-        self.__ast_prewhere = prewhere
+        self.__prewhere = prewhere
         self.__groupby = groupby or []
         self.__having = having
         self.__order_by = order_by or []
@@ -222,7 +222,7 @@ class Query:
         """
         Temporary method until pre where management is moved to Clickhouse query
         """
-        return self.__ast_prewhere
+        return self.__prewhere
 
     def set_prewhere(self, conditions: Sequence[Condition]) -> None:
         """

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -36,8 +36,8 @@ TElement = TypeVar("TElement")
 
 
 class OrderByDirection(Enum):
-    ASC = "asc"
-    DESC = "desc"
+    ASC = "ASC"
+    DESC = "DESC"
 
 
 @dataclass(frozen=True)
@@ -91,6 +91,7 @@ class Query:
         selected_columns: Optional[Sequence[Expression]] = None,
         array_join: Optional[Expression] = None,
         condition: Optional[Expression] = None,
+        prewhere: Optional[Expression] = None,
         groupby: Optional[Sequence[Expression]] = None,
         having: Optional[Expression] = None,
         order_by: Optional[Sequence[OrderBy]] = None,
@@ -108,6 +109,7 @@ class Query:
         self.__selected_columns = selected_columns or []
         self.__array_join = array_join
         self.__condition = condition
+        self.__ast_prewhere = prewhere
         self.__groupby = groupby or []
         self.__having = having
         self.__order_by = order_by or []
@@ -215,6 +217,12 @@ class Query:
         Temporary method until pre where management is moved to Clickhouse query
         """
         return self.__prewhere_conditions
+
+    def get_prewhere_ast(self) -> Optional[Expression]:
+        """
+        Temporary method until pre where management is moved to Clickhouse query
+        """
+        return self.__ast_prewhere
 
     def set_prewhere(self, conditions: Sequence[Condition]) -> None:
         """

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -1,0 +1,196 @@
+import pytest
+
+from snuba.clickhouse.astquery import AstClickhouseQuery
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.schemas.tables import TableSource
+from snuba.query.query import OrderBy, OrderByDirection, Query
+from snuba.query.expressions import (
+    Column,
+    CurriedFunctionCall,
+    FunctionCall,
+    Literal,
+)
+from snuba.query.conditions import binary_condition
+from snuba.request import RequestSettings
+
+test_cases = [
+    (
+        # Simple query with aliases and multiple tables
+        Query(
+            {},
+            TableSource("my_table", ColumnSet([])),
+            selected_columns=[
+                Column(None, "column1", None),
+                Column(None, "column2", "table1"),
+                Column("al", "column3", None),
+            ],
+            condition=binary_condition(
+                None,
+                "eq",
+                lhs=Column("al", "column3", None),
+                rhs=Literal(None, "blabla"),
+            ),
+            groupby=[
+                Column(None, "column1", None),
+                Column(None, "column2", "table1"),
+                Column("al", "column3", None),
+                Column(None, "column4", None),
+            ],
+            having=binary_condition(
+                None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+            ),
+            order_by=[
+                OrderBy(OrderByDirection.ASC, Column(None, "column1", None)),
+                OrderBy(OrderByDirection.DESC, Column(None, "column2", "table1")),
+            ],
+        ),
+        (
+            "SELECT column1, table1.column2, (column3 AS al) "
+            "FROM my_table "
+            "WHERE eq(al, 'blabla') "
+            "GROUP BY (column1, table1.column2, al, column4) "
+            "HAVING eq(column1, 123) "
+            "ORDER BY column1 ASC, table1.column2 DESC"
+        ),
+    ),
+    (
+        # Query with complex functions
+        Query(
+            {},
+            TableSource("my_table", ColumnSet([])),
+            selected_columns=[
+                CurriedFunctionCall(
+                    "my_complex_math",
+                    FunctionCall(
+                        None,
+                        "doSomething",
+                        [
+                            Column(None, "column1", None),
+                            Column(None, "column2", "table1"),
+                            Column("al", "column3", None),
+                        ],
+                    ),
+                    [Column(None, "column1", None)],
+                )
+            ],
+            condition=binary_condition(
+                None,
+                "and",
+                lhs=binary_condition(
+                    None,
+                    "eq",
+                    lhs=Column("al", "column3", None),
+                    rhs=Literal(None, "blabla"),
+                ),
+                rhs=binary_condition(
+                    None,
+                    "neq",  # yes, not very smart
+                    lhs=Column("al", "column3", None),
+                    rhs=Literal(None, "blabla"),
+                ),
+            ),
+            groupby=[
+                CurriedFunctionCall(
+                    "my_complex_math",
+                    FunctionCall(
+                        None,
+                        "doSomething",
+                        [
+                            Column(None, "column1", None),
+                            Column(None, "column2", "table1"),
+                            Column("al", "column3", None),
+                        ],
+                    ),
+                    [Column(None, "column1", None)],
+                )
+            ],
+            order_by=[
+                OrderBy(
+                    OrderByDirection.ASC,
+                    FunctionCall(None, "f", [Column(None, "column1", None)]),
+                )
+            ],
+        ),
+        (
+            "SELECT (doSomething(column1, table1.column2, (column3 AS al))(column1) AS my_complex_math) "
+            "FROM my_table "
+            "WHERE and(eq(al, 'blabla'), neq(al, 'blabla')) "
+            "GROUP BY (my_complex_math) "
+            "ORDER BY f(column1) ASC"
+        ),
+    ),
+    (
+        # Query with escaping
+        Query(
+            {},
+            TableSource("my_table", ColumnSet([])),
+            selected_columns=[
+                Column("al1", "field_##$$%", None),
+                Column("al2", "f@!@", "t&^%$"),
+            ],
+            groupby=[
+                Column("al1", "field_##$$%", None),
+                Column("al2", "f@!@", "t&^%$"),
+            ],
+            order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
+        ),
+        (
+            "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2) "
+            "FROM my_table "
+            "GROUP BY (al1, al2) "
+            "ORDER BY column1 ASC"
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("query, formatted", test_cases)
+def test_format_expressions(query: Query, formatted: str) -> None:
+    request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
+    clickhouse_query = AstClickhouseQuery(query, request_settings)
+    assert clickhouse_query.format_sql() == formatted
+
+
+def test_format_clickhouse_specific_query() -> None:
+    """
+    Adds a few of the Clickhosue specific fields to the query.
+    """
+
+    query = Query(
+        {"sample": 0.1, "totals": True, "limitby": (10, "environment")},
+        TableSource("my_table", ColumnSet([])),
+        selected_columns=[
+            Column(None, "column1", None),
+            Column(None, "column2", "table1"),
+        ],
+        condition=binary_condition(
+            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, "blabla"),
+        ),
+        groupby=[Column(None, "column1", None), Column(None, "column2", "table1")],
+        having=binary_condition(
+            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+        ),
+        order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
+        array_join=Column(None, "column1", None),
+    )
+
+    query.set_final(True)
+    query.set_offset(50)
+    query.set_limit(100)
+
+    request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
+    clickhouse_query = AstClickhouseQuery(query, request_settings)
+
+    expected = (
+        "SELECT column1, table1.column2 "
+        "FROM my_table FINAL SAMPLE 0.1 "
+        "ARRAY JOIN column1 "
+        "WHERE eq(column1, 'blabla') "
+        "GROUP BY (column1, table1.column2) WITH TOTALS "
+        "HAVING eq(column1, 123) "
+        "ORDER BY column1 ASC "
+        "LIMIT 10 BY environment "
+        "LIMIT 50, 100"
+    )
+
+    assert clickhouse_query.format_sql() == expected

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -190,7 +190,7 @@ def test_format_clickhouse_specific_query() -> None:
         "HAVING eq(column1, 123) "
         "ORDER BY column1 ASC "
         "LIMIT 10 BY environment "
-        "LIMIT 50, 100"
+        "LIMIT 100 OFFSET 50"
     )
 
     assert clickhouse_query.format_sql() == expected


### PR DESCRIPTION
This connects the Query AST PR with the Expression formatter, thus providing full formatting logic for the Clickhouse query.
There are some additional steps to be done to decouple Clickhouse query from the Snuba Query but I would like to get a basic parsing and formatting done first so we can validate it works.

Test plan:
See the unit test.