### PR TITLE
feat: Add "group_id" to the list of prewhere candidates for events

### DIFF
--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -243,6 +243,7 @@ class EventsDataset(TimeSeriesDataset):
             mandatory_conditions=[("deleted", "=", 0)],
             prewhere_candidates=[
                 "event_id",
+                "group_id",
                 "issue",
                 "tags[sentry:release]",
                 "message",


### PR DESCRIPTION
Since "issue" and "group_id" are aliases for the same thing, we should
also add group_id to the prewhere clause and treat them exactly the same.

We might want to deprecate "issue" long term and move towards
only supporting "group_id".