### PR TITLE
feat: Include timestamps equal to the end time

### DIFF
--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -43,7 +43,7 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
         query.add_conditions(
             [
                 (self.__timestamp_column, ">=", from_date.isoformat()),
-                (self.__timestamp_column, "<", to_date.isoformat()),
+                (self.__timestamp_column, "<=", to_date.isoformat()),
             ]
         )
 


### PR DESCRIPTION
There are scenarios where we insert then immediately attempt to fetch an
event. Since the default end time is utcnow() and we are rounding to 1
second, the event would be excluded from the results.

Alternative approach would be to add 1 second in Sentry https://github.com/getsentry/sentry/pull/15939