### PR TITLE
feat(datasets) Make complex_column_expr parametric to reuse it for the AST

### DIFF
--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -1,0 +1,73 @@
+import numbers
+from datetime import date, datetime
+from typing import Any, Callable, List, Optional, TypeVar, Tuple, Union
+
+from snuba.util import is_function
+
+TExpression = TypeVar("TExpression")
+
+
+def parse_function(
+    output_builder: Callable[[Optional[str], str, List[TExpression]], TExpression],
+    simple_expression_builder: Callable[[str], TExpression],
+    literal_builder: Callable[
+        [Optional[Union[str, datetime, date, List[Any], Tuple[Any], numbers.Number]]],
+        TExpression,
+    ],
+    expr,
+    depth=0,
+) -> TExpression:
+    """
+    Parses a function expression in the Snuba syntax and produces the expected data structure
+    to be used in the Query object.
+
+    It relies on three functions:
+    - output_builder, this puts alias, function name and parameters together
+    - simple_expression_builder, processes one column given the string name
+    - literal_builder, processes any individual type that represent a literal.
+
+    The goal of having these three functions is to preserve the parsing algorithm
+    but being able to either produce an AST or the old Clickhouse syntax.
+    """
+    function_tuple = is_function(expr, depth)
+    if function_tuple is None:
+        raise ValueError(
+            "complex_column_expr was given an expr %s that is not a function at depth %d."
+            % (expr, depth)
+        )
+
+    name, args, alias = function_tuple
+    out: List[TExpression] = []
+    i = 0
+    while i < len(args):
+        next_2 = args[i : i + 2]
+        if is_function(next_2, depth + 1):
+            out.append(
+                parse_function(
+                    output_builder,
+                    simple_expression_builder,
+                    literal_builder,
+                    next_2,
+                    depth + 1,
+                )
+            )
+            i += 2
+        else:
+            nxt = args[i]
+            if is_function(nxt, depth + 1):  # Embedded function
+                out.append(
+                    parse_function(
+                        output_builder,
+                        simple_expression_builder,
+                        literal_builder,
+                        nxt,
+                        depth + 1,
+                    )
+                )
+            elif isinstance(nxt, str):
+                out.append(simple_expression_builder(nxt))
+            else:
+                out.append(literal_builder(nxt))
+            i += 1
+
+    return output_builder(alias, name, out)

--- a/tests/query/parser/test_functions.py
+++ b/tests/query/parser/test_functions.py
@@ -1,0 +1,134 @@
+from snuba.query.conditions import binary_condition, BooleanFunctions
+from snuba.query.expressions import Column, Literal, FunctionCall
+from snuba.query.parser.functions import parse_function_to_expr
+from snuba.util import tuplify
+
+
+def test_complex_conditions_expr() -> None:
+    assert parse_function_to_expr(tuplify(["count", []]),) == FunctionCall(
+        None, "count", []
+    )
+    assert parse_function_to_expr(tuplify(["notEmpty", ["foo"]]),) == FunctionCall(
+        None, "notEmpty", [Column(None, "foo", None)]
+    )
+    assert parse_function_to_expr(
+        tuplify(["notEmpty", ["arrayElement", ["foo", 1]]]),
+    ) == FunctionCall(
+        None,
+        "notEmpty",
+        [
+            FunctionCall(
+                None, "arrayElement", [Column(None, "foo", None), Literal(None, 1)]
+            )
+        ],
+    )
+    assert parse_function_to_expr(
+        tuplify(["foo", ["bar", ["qux"], "baz"]]),
+    ) == FunctionCall(
+        None,
+        "foo",
+        [
+            FunctionCall(None, "bar", [Column(None, "qux", None)]),
+            Column(None, "baz", None),
+        ],
+    )
+    assert parse_function_to_expr(tuplify(["foo", [], "a"]),) == FunctionCall(
+        "a", "foo", []
+    )
+    assert parse_function_to_expr(tuplify(["foo", ["b", "c"], "d"]),) == FunctionCall(
+        "d", "foo", [Column(None, "b", None), Column(None, "c", None)]
+    )
+    assert parse_function_to_expr(tuplify(["foo", ["b", "c", ["d"]]]),) == FunctionCall(
+        None,
+        "foo",
+        [Column(None, "b", None), FunctionCall(None, "c", [Column(None, "d", None)])],
+    )
+
+    assert parse_function_to_expr(
+        tuplify(["emptyIfNull", ["project_id"]]),
+    ) == FunctionCall(None, "emptyIfNull", [Column(None, "project_id", None)])
+
+    assert parse_function_to_expr(
+        tuplify(["or", [["or", ["a", "b"]], "c"]]),
+    ) == binary_condition(
+        None,
+        BooleanFunctions.OR,
+        binary_condition(
+            None, BooleanFunctions.OR, Column(None, "a", None), Column(None, "b", None)
+        ),
+        Column(None, "c", None),
+    )
+    assert parse_function_to_expr(
+        tuplify(["and", [["and", ["a", "b"]], "c"]]),
+    ) == binary_condition(
+        None,
+        BooleanFunctions.AND,
+        binary_condition(
+            None, BooleanFunctions.AND, Column(None, "a", None), Column(None, "b", None)
+        ),
+        Column(None, "c", None),
+    )
+    # (A OR B) AND C
+    assert parse_function_to_expr(
+        tuplify(["and", [["or", ["a", "b"]], "c"]]),
+    ) == binary_condition(
+        None,
+        BooleanFunctions.AND,
+        binary_condition(
+            None, BooleanFunctions.OR, Column(None, "a", None), Column(None, "b", None)
+        ),
+        Column(None, "c", None),
+    )
+    # A OR B OR C OR D
+    assert parse_function_to_expr(
+        tuplify(["or", [["or", [["or", ["c", "d"]], "b"]], "a"]]),
+    ) == binary_condition(
+        None,
+        BooleanFunctions.OR,
+        binary_condition(
+            None,
+            BooleanFunctions.OR,
+            binary_condition(
+                None,
+                BooleanFunctions.OR,
+                Column(None, "c", None),
+                Column(None, "d", None),
+            ),
+            Column(None, "b", None),
+        ),
+        Column(None, "a", None),
+    )
+
+    assert parse_function_to_expr(
+        tuplify(
+            [
+                "if",
+                [["in", ["release", "tuple", ["'foo'"]]], "release", "'other'"],
+                "release",
+            ]
+        ),
+    ) == FunctionCall(
+        "release",
+        "if",
+        [
+            FunctionCall(
+                None,
+                "in",
+                [
+                    Column(None, "release", None),
+                    FunctionCall(None, "tuple", [Literal(None, "foo")]),
+                ],
+            ),
+            Column(None, "release", None),
+            Literal(None, "other"),
+        ],
+    )
+
+    # TODO once search_message is filled in everywhere, this can be just 'message' again.
+    assert parse_function_to_expr(
+        tuplify(["positionCaseInsensitive", ["message", "'lol 'single' quotes'"]]),
+    ) == FunctionCall(
+        None,
+        "positionCaseInsensitive",
+        [Column(None, "message", None), Literal(None, "lol 'single' quotes")],
+    )


### PR DESCRIPTION
complex_column_expr parses nested expressions in the current system. In the current system parsing and formatting happen together.
I think we should preserve the parsing part of it (that is dependent on the syntax) and change the outcome of that function. 

This PR makes complex_column_expr parametric, it now takes three functions as parameters that are used to produce the output. It also adds a rudimentary implementation to generate Expressions to prove the concept.

Test plan:
complex_column_expr is well covered. The tests still pass. A clone of that test is added for expressions.