### PR TITLE
fix(discover) Fix LIKE conditions on array fields

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -187,21 +187,35 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("version", Nullable(String())),
                 ("http_method", Nullable(String())),
                 ("http_referer", Nullable(String())),
-                ("exception_stacks.type", Nullable(String())),
-                ("exception_stacks.value", Nullable(String())),
-                ("exception_stacks.mechanism_type", Nullable(String())),
-                ("exception_stacks.mechanism_handled", Nullable(UInt(8))),
-                ("exception_frames.abs_path", Nullable(String())),
-                ("exception_frames.filename", Nullable(String())),
-                ("exception_frames.package", Nullable(String())),
-                ("exception_frames.module", Nullable(String())),
-                ("exception_frames.function", Nullable(String())),
-                ("exception_frames.in_app", Nullable(UInt(8))),
-                ("exception_frames.colno", Nullable(UInt(32))),
-                ("exception_frames.lineno", Nullable(UInt(32))),
-                ("exception_frames.stack_level", Nullable(UInt(16))),
-                ("modules.name", String()),
-                ("modules.version", String()),
+                # exception interface
+                (
+                    "exception_stacks",
+                    Nested(
+                        [
+                            ("type", Nullable(String())),
+                            ("value", Nullable(String())),
+                            ("mechanism_type", Nullable(String())),
+                            ("mechanism_handled", Nullable(UInt(8))),
+                        ]
+                    ),
+                ),
+                (
+                    "exception_frames",
+                    Nested(
+                        [
+                            ("abs_path", Nullable(String())),
+                            ("filename", Nullable(String())),
+                            ("package", Nullable(String())),
+                            ("module", Nullable(String())),
+                            ("function", Nullable(String())),
+                            ("in_app", Nullable(UInt(8))),
+                            ("colno", Nullable(UInt(32))),
+                            ("lineno", Nullable(UInt(32))),
+                            ("stack_level", UInt(16)),
+                        ]
+                    ),
+                ),
+                ("modules", Nested([("name", String()), ("version", String())])),
             ]
         )
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -297,6 +297,26 @@ class TestDiscoverApi(BaseApiTest):
         assert response.status_code == 200
         assert data["data"] == [{"count": 1}]
 
+    def test_exception_stack_column_condition(self):
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [["count()", "", "count"]],
+                    "conditions": [
+                        ["exception_stacks.type", "LIKE", "Arithmetic%"],
+                        ["exception_frames.filename", "LIKE", "%.java"],
+                    ],
+                    "limit": 1000,
+                }
+            ),
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data["data"] == [{"count": 1}]
+
     def test_having(self):
         result = json.loads(
             self.app.post(
@@ -356,12 +376,8 @@ class TestDiscoverApi(BaseApiTest):
                     {
                         "dataset": "discover",
                         "project": self.project_id,
-                        "selected_columns": [
-                            "group_id",
-                        ],
-                        "conditions": [
-                            ["type", "=", "transaction"],
-                        ]
+                        "selected_columns": ["group_id"],
+                        "conditions": [["type", "=", "transaction"]],
                     }
                 ),
             ).data
@@ -375,13 +391,11 @@ class TestDiscoverApi(BaseApiTest):
                     {
                         "dataset": "discover",
                         "project": self.project_id,
-                        "selected_columns": [
-                            "group_id",
-                        ],
+                        "selected_columns": ["group_id"],
                         "conditions": [
                             ["type", "=", "transaction"],
                             ["group_id", "IN", (1, 2, 3, 4)],
-                        ]
+                        ],
                     }
                 ),
             ).data


### PR DESCRIPTION
The discover dataset did not use the Nested() type helper which resulted in LIKE operators on the exception_frames and exception_stacks fields creating invalid SQL.