### PR TITLE
perf: Add _tags_flattened and _contexts_flattened columns

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -85,14 +85,14 @@ def transactions_migrations(
             f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT {UNKNOWN_SPAN_STATUS} AFTER transaction_op"
         )
 
-    if "tags_map" not in current_schema:
+    if "_tags_flattened" not in current_schema:
         ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN tags_map String DEFAULT ''"
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _tags_flattened String DEFAULT ''"
         )
 
-    if "contexts_map" not in current_schema:
+    if "_contexts_flattened" not in current_schema:
         ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN contexts_map String DEFAULT ''"
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _contexts_flattened String DEFAULT ''"
         )
 
     return ret
@@ -131,9 +131,9 @@ class TransactionsDataset(TimeSeriesDataset):
                 ("sdk_name", WithDefault(String(), "''")),
                 ("sdk_version", WithDefault(String(), "''")),
                 ("tags", Nested([("key", String()), ("value", String())])),
-                ("tags_map", String()),
+                ("_tags_flattened", String()),
                 ("contexts", Nested([("key", String()), ("value", String())])),
-                ("contexts_map", String()),
+                ("_contexts_flattened", String()),
                 ("partition", UInt(16)),
                 ("offset", UInt(64)),
                 ("retention_days", UInt(16)),

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -85,6 +85,16 @@ def transactions_migrations(
             f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT {UNKNOWN_SPAN_STATUS} AFTER transaction_op"
         )
 
+    if "tags_map" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN tags_map String DEFAULT ''"
+        )
+
+    if "contexts_map" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN contexts_map String DEFAULT ''"
+        )
+
     return ret
 
 
@@ -121,7 +131,9 @@ class TransactionsDataset(TimeSeriesDataset):
                 ("sdk_name", WithDefault(String(), "''")),
                 ("sdk_version", WithDefault(String(), "''")),
                 ("tags", Nested([("key", String()), ("value", String())])),
+                ("tags_map", String()),
                 ("contexts", Nested([("key", String()), ("value", String())])),
+                ("contexts_map", String()),
                 ("partition", UInt(16)),
                 ("offset", UInt(64)),
                 ("retention_days", UInt(16)),

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -31,7 +31,7 @@ metrics = create_metrics(
 
 UNKNOWN_SPAN_STATUS = 2
 
-ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", ":": "\:"})
+ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", "=": "\="})
 
 
 def escape_field(field: str) -> str:
@@ -57,7 +57,7 @@ class TransactionsMessageProcessor(MessageProcessor):
         # Tags are pre sorted, but it seems contexts are not, so to make this generic
         # we ensure the invariant is respected here.
         pairs = sorted(zip(keys, values))
-        pairs = [f"|{escape_field(k)}:{escape_field(v)}|" for k, v in pairs]
+        pairs = [f"|{escape_field(k)}={escape_field(v)}|" for k, v in pairs]
         # The result is going to be:
         # |tag:val||tag:val|
         # This gives the guarantee we will always have a delimiter on both side of the

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -35,10 +35,10 @@ ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", ":": "\:"})
 
 def escape_field(field: str) -> str:
     """
-            We have ':' in our tag names. Also we may have '|'. This escapes : and \ so
-            that we can always rebuild the tags from the map. When looking for tags with LIKE
-            there should be no issue. But there may be other cases.
-            """
+    We have ':' in our tag names. Also we may have '|'. This escapes : and \ so
+    that we can always rebuild the tags from the map. When looking for tags with LIKE
+    there should be no issue. But there may be other cases.
+    """
     return field.translate(ESCAPE_TRANSLATION)
 
 
@@ -133,7 +133,7 @@ class TransactionsMessageProcessor(MessageProcessor):
 
         tags = _as_dict_safe(data.get("tags", None))
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
-        processed["tags_map"] = self.__merge_nested_field(
+        processed["_tags_flattened"] = self.__merge_nested_field(
             processed["tags.key"], processed["tags.value"]
         )
 
@@ -153,7 +153,7 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(
             contexts
         )
-        processed["contexts_map"] = self.__merge_nested_field(
+        processed["_contexts_flattened"] = self.__merge_nested_field(
             processed["contexts.key"], processed["contexts.value"]
         )
 

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -372,7 +372,7 @@ class TestEventsProcessor(BaseEventsTest):
         assert tags == orig_tags
 
         extra_output = {}
-        extract_extra_tags(extra_output, tags)
+        extra_output["tags.key"], extra_output["tags.value"] = extract_extra_tags(tags)
 
         valid_items = [(k, v) for k, v in sorted(orig_tags.items()) if v]
         assert extra_output == {
@@ -498,7 +498,7 @@ class TestEventsProcessor(BaseEventsTest):
         assert tags == orig_tags
 
         extra_output = {}
-        extract_extra_contexts(extra_output, contexts)
+        extra_output["contexts.key"], extra_output["contexts.value"] = extract_extra_contexts(contexts)
 
         assert extra_output == {
             "contexts.key": ["extra.int", "extra.float", "extra.str", "extra.\\ud83c"],

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -185,11 +185,11 @@ class TransactionEvent:
             "offset": meta.offset,
             "partition": meta.partition,
             "retention_days": 90,
-            "tags_map": f"environment:{self.environment}|sentry\:release:{self.release}|sentry\:user:{self.user_id}|we\\\\\|r\:d:tag",
+            "tags_map": f"|environment:{self.environment}||sentry\:release:{self.release}||sentry\:user:{self.user_id}||we\\\\\|r\:d:tag|",
             "contexts_map": (
-                f"trace.sampled:True|trace.trace_id:{self.trace_id}|trace.op:{self.op}|trace.span_id:{self.span_id}|"
-                f"trace.status:{str(self.status)}|geo.country_code:{self.geo['country_code']}|"
-                f"geo.region:{self.geo['region']}|geo.city:{self.geo['city']}"
+                f"|geo.city:{self.geo['city']}||geo.country_code:{self.geo['country_code']}||geo.region:{self.geo['region']}|"
+                f"|trace.op:{self.op}||trace.sampled:True||trace.span_id:{self.span_id}||trace.status:{str(self.status)}|"
+                f"|trace.trace_id:{self.trace_id}|"
             ),
         }
 

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -116,7 +116,7 @@ class TransactionEvent:
                         ["sentry:release", self.release],
                         ["sentry:user", self.user_id],
                         ["environment", self.environment],
-                        ["we\|r:d", "tag"],
+                        ["we|r=d", "tag"],
                     ],
                     "user": {
                         "username": self.user_name,
@@ -158,7 +158,7 @@ class TransactionEvent:
             "user_id": self.user_id,
             "user_name": self.user_name,
             "user_email": self.user_email,
-            "tags.key": ["environment", "sentry:release", "sentry:user", "we\|r:d"],
+            "tags.key": ["environment", "sentry:release", "sentry:user", "we|r=d"],
             "tags.value": [self.environment, self.release, self.user_id, "tag"],
             "contexts.key": [
                 "trace.sampled",
@@ -185,11 +185,11 @@ class TransactionEvent:
             "offset": meta.offset,
             "partition": meta.partition,
             "retention_days": 90,
-            "_tags_flattened": f"|environment:{self.environment}||sentry\:release:{self.release}||sentry\:user:{self.user_id}||we\\\\\|r\:d:tag|",
+            "_tags_flattened": f"|environment={self.environment}||sentry:release={self.release}||sentry:user={self.user_id}||we\\|r\\=d=tag|",
             "_contexts_flattened": (
-                f"|geo.city:{self.geo['city']}||geo.country_code:{self.geo['country_code']}||geo.region:{self.geo['region']}|"
-                f"|trace.op:{self.op}||trace.sampled:True||trace.span_id:{self.span_id}||trace.status:{str(self.status)}|"
-                f"|trace.trace_id:{self.trace_id}|"
+                f"|geo.city={self.geo['city']}||geo.country_code={self.geo['country_code']}||geo.region={self.geo['region']}|"
+                f"|trace.op={self.op}||trace.sampled=True||trace.span_id={self.span_id}||trace.status={str(self.status)}|"
+                f"|trace.trace_id={self.trace_id}|"
             ),
         }
 

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -116,6 +116,7 @@ class TransactionEvent:
                         ["sentry:release", self.release],
                         ["sentry:user", self.user_id],
                         ["environment", self.environment],
+                        ["we\|r:d", "tag"],
                     ],
                     "user": {
                         "username": self.user_name,
@@ -157,8 +158,8 @@ class TransactionEvent:
             "user_id": self.user_id,
             "user_name": self.user_name,
             "user_email": self.user_email,
-            "tags.key": ["environment", "sentry:release", "sentry:user"],
-            "tags.value": [self.environment, self.release, self.user_id],
+            "tags.key": ["environment", "sentry:release", "sentry:user", "we\|r:d"],
+            "tags.value": [self.environment, self.release, self.user_id, "tag"],
             "contexts.key": [
                 "trace.sampled",
                 "trace.trace_id",
@@ -184,6 +185,12 @@ class TransactionEvent:
             "offset": meta.offset,
             "partition": meta.partition,
             "retention_days": 90,
+            "tags_map": f"environment:{self.environment}|sentry\:release:{self.release}|sentry\:user:{self.user_id}|we\\\\\|r\:d:tag",
+            "contexts_map": (
+                f"trace.sampled:True|trace.trace_id:{self.trace_id}|trace.op:{self.op}|trace.span_id:{self.span_id}|"
+                f"trace.status:{str(self.status)}|geo.country_code:{self.geo['country_code']}|"
+                f"geo.region:{self.geo['region']}|geo.city:{self.geo['city']}"
+            ),
         }
 
         if self.ipv4:

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -185,8 +185,8 @@ class TransactionEvent:
             "offset": meta.offset,
             "partition": meta.partition,
             "retention_days": 90,
-            "tags_map": f"|environment:{self.environment}||sentry\:release:{self.release}||sentry\:user:{self.user_id}||we\\\\\|r\:d:tag|",
-            "contexts_map": (
+            "_tags_flattened": f"|environment:{self.environment}||sentry\:release:{self.release}||sentry\:user:{self.user_id}||we\\\\\|r\:d:tag|",
+            "_contexts_flattened": (
                 f"|geo.city:{self.geo['city']}||geo.country_code:{self.geo['country_code']}||geo.region:{self.geo['region']}|"
                 f"|trace.op:{self.op}||trace.sampled:True||trace.span_id:{self.span_id}||trace.status:{str(self.status)}|"
                 f"|trace.trace_id:{self.trace_id}|"


### PR DESCRIPTION
The idea of these columns is to be able to run exact searches over tags and contexts through regex instead of having to unpack the nested columns for every row.

The query can be something like :
```
..... tags_map LIKE "%environment:prod%"
```

This is only adding the columns and filiing them in. Then next step will add a query processor to actually optimize the queries 