### PR TITLE
fix(transactions) Translate the transaction status from string to int (again)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ pytz==2018.4
 python-rapidjson==0.8.0
 redis==2.10.6
 redis-py-cluster==1.3.5
+semaphore>=0.4.64,<0.5.0
 sentry-sdk==0.13.1
 simplegeneric==0.8.1
 simplejson==3.15.0

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -81,12 +81,13 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
                 data["start_timestamp"],
             )
+
             status = transaction_ctx.get("status", None)
-            int_status = None
             if status:
-                int_status = SPAN_STATUS_NAME_TO_CODE.get(status)
-            if int_status is None:
+                int_status = SPAN_STATUS_NAME_TO_CODE.get(status, UNKNOWN_SPAN_STATUS)
+            else:
                 int_status = UNKNOWN_SPAN_STATUS
+
             processed["transaction_status"] = int_status
 
             if data["timestamp"] - data["start_timestamp"] < 0:

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from semaphore.consts import SPAN_STATUS_NAME_TO_CODE
 from typing import Optional
 
 import uuid
@@ -80,16 +81,14 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
                 data["start_timestamp"],
             )
-            status = transaction_ctx.get("status", UNKNOWN_SPAN_STATUS)
-            if (isinstance(status, str) and status.isdigit()) or isinstance(
-                status, int
-            ):
-                # This condition is complex because, at the time of writing, the status
-                # field is being migrated from a string to an integer and we should not
-                # throw if an old format event is received.
-                processed["transaction_status"] = int(status)
-            else:
-                processed["transaction_status"] = UNKNOWN_SPAN_STATUS
+            status = transaction_ctx.get("status", None)
+            int_status = None
+            if status:
+                int_status = SPAN_STATUS_NAME_TO_CODE.get(status)
+            if int_status is None:
+                int_status = UNKNOWN_SPAN_STATUS
+            processed["transaction_status"] = int_status
+
             if data["timestamp"] - data["start_timestamp"] < 0:
                 # Seems we have some negative durations in the DB
                 metrics.increment("negative_duration")

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -33,7 +33,7 @@ class TransactionEvent:
     sdk_name: Optional[str]
     sdk_version: Optional[str]
     geo: Mapping[str, str]
-    status: int
+    status: str
 
     def serialize(self) -> Mapping[str, Any]:
         return (
@@ -109,7 +109,7 @@ class TransactionEvent:
                             "op": self.op,
                             "type": "trace",
                             "span_id": self.span_id,
-                            "status": str(self.status),
+                            "status": self.status,
                         }
                     },
                     "tags": [
@@ -141,7 +141,7 @@ class TransactionEvent:
             "span_id": int(self.span_id, 16),
             "transaction_name": self.transaction_name,
             "transaction_op": self.op,
-            "transaction_status": self.status,
+            "transaction_status": 1 if self.status == "cancelled" else 2,
             "start_ts": start_timestamp,
             "start_ms": int(start_timestamp.microsecond / 1000),
             "finish_ts": finish_timestamp,
@@ -174,7 +174,7 @@ class TransactionEvent:
                 self.trace_id,
                 self.op,
                 self.span_id,
-                str(self.status),
+                self.status,
                 self.geo["country_code"],
                 self.geo["region"],
                 self.geo["city"],
@@ -206,7 +206,7 @@ class TestTransactionsProcessor(BaseTest):
             trace_id="7400045b25c443b885914600aa83ad04",
             span_id="8841662216cc598b",
             transaction_name="/organizations/:orgId/issues/",
-            status=1,
+            status="cancelled",
             op="navigation",
             timestamp=finish,
             start_timestamp=start,
@@ -238,7 +238,7 @@ class TestTransactionsProcessor(BaseTest):
             trace_id="7400045b25c443b885914600aa83ad04",
             span_id="8841662216cc598b",
             transaction_name="/organizations/:orgId/issues/",
-            status=1,
+            status="cancelled",
             op="navigation",
             timestamp=finish,
             start_timestamp=start,
@@ -270,7 +270,7 @@ class TestTransactionsProcessor(BaseTest):
             trace_id="7400045b25c443b885914600aa83ad04",
             span_id="8841662216cc598b",
             transaction_name="/organizations/:orgId/issues/",
-            status=1,
+            status="cancelled",
             op="navigation",
             timestamp=finish,
             start_timestamp=start,


### PR DESCRIPTION
The transaction status is coming from sentry as a string and, it seems, making the translation there would have impact beyond Snuba.
This translates it back to integer through the semaphore mapping in snuba.