### PR TITLE
perf: Add dataset and referrer as searchable tags in the main transaction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ python-rapidjson==0.8.0
 redis==2.10.6
 redis-py-cluster==1.3.5
 semaphore>=0.4.64,<0.5.0
-sentry-sdk==0.13.1
+sentry-sdk>=0.13.5
 simplegeneric==0.8.1
 simplejson==3.15.0
 singledispatch==3.4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ python-rapidjson==0.8.0
 redis==2.10.6
 redis-py-cluster==1.3.5
 semaphore>=0.4.64,<0.5.0
-sentry-sdk>=0.13.5
+sentry-sdk==0.13.5
 simplegeneric==0.8.1
 simplejson==3.15.0
 singledispatch==3.4.0.3

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -93,7 +93,6 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
     release=os.getenv("SNUBA_RELEASE"),
-    traces_sample_rate=1,
 )
 
 


### PR DESCRIPTION
Right now we have very little visibility over Snuba performance since we cannot break down the query time by dataset or by query type in APM.

This adds dataset and referrer to the main transaction as tags, which means we will be able to filter and group by them in APM. Referrer is useful to identify what the query is about since it corresponds (generally) to the Sentry feature that issued the query.

This requires us to upgrade the sdk.