### PR TITLE
perf(events): Swap issue and group_id for prewhere heuristics.

### DIFF
--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -243,8 +243,8 @@ class EventsDataset(TimeSeriesDataset):
             mandatory_conditions=[("deleted", "=", 0)],
             prewhere_candidates=[
                 "event_id",
-                "group_id",
                 "issue",
+                "group_id",
                 "tags[sentry:release]",
                 "message",
                 "environment",


### PR DESCRIPTION
No real test plan for heuristics.
We've identified that we've started issuing `issue IN (g1) AND group_id NOT IN (g2, g3)` and the `NOT` gets promoted first.