### PR TITLE
fix: Bring back sorting in conditions for flattened tags

### DIFF
--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -112,6 +112,7 @@ class NestedFieldConditionOptimizer(QueryProcessor):
 
         if positive_like_expression:
             # Positive conditions "=" are all merged together in one LIKE expression
+            positive_like_expression = sorted(positive_like_expression)
             like_formatted = f"%|{'|%|'.join(positive_like_expression)}|%"
             new_conditions.append([self.__flattened_col, "LIKE", like_formatted])
 

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -33,6 +33,20 @@ test_data = [
     (
         {
             "conditions": [
+                ["tags[test2.tag]", "=", "2"],
+                ["tags[test.tag]", "=", "1"],
+                ["c", "=", "3"],
+                ["tags[test3.tag]", "=", "3"],
+            ]
+        },
+        [
+            ["c", "=", "3"],
+            ["tags_map", "LIKE", "%|test.tag=1|%|test2.tag=2|%|test3.tag=3|%"],
+        ],
+    ),  # Multiple tags in the same merge and properly sorted
+    (
+        {
+            "conditions": [
                 ["tags[test.tag]", "!=", "1"],
                 ["c", "=", "3"],
                 ["tags[test2.tag]", "=", "2"],


### PR DESCRIPTION
Somewhere in the refactoring of the PR I even removed the sorting or forgot to add it.
Conditions in the LIKE clause must be sorted otherwise they would not match the same order of the flattened column itself.