### PR TITLE
ref(streams): Add `Topic` object, other domain object refinements

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -108,6 +108,7 @@ def replacer(
     from snuba.utils.streams.batching import BatchingConsumer
     from snuba.utils.streams.consumer import (
         KafkaConsumer,
+        Topic,
         TransportError,
         build_kafka_consumer_configuration,
     )
@@ -156,7 +157,7 @@ def replacer(
                 queued_min_messages=queued_min_messages,
             ),
         ),
-        replacements_topic,
+        Topic(replacements_topic),
         worker=ReplacerWorker(clickhouse, dataset, metrics=metrics),
         max_batch_size=max_batch_size,
         max_batch_time=max_batch_time_ms,

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -41,7 +41,7 @@ class ConsumerWorker(AbstractBatchWorker[ProcessedMessage]):
         # json.
         value = json.loads(message.value)
         metadata = KafkaMessageMetadata(
-            offset=message.offset, partition=message.stream.partition
+            offset=message.offset, partition=message.partition.index
         )
         processed = self._process_message_impl(value, metadata)
         if processed is None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -12,6 +12,7 @@ from snuba.utils.streams.batching import BatchingConsumer
 from snuba.utils.streams.consumer import (
     KafkaConsumer,
     KafkaConsumerWithCommitLog,
+    Topic,
     TransportError,
     build_kafka_consumer_configuration,
 )
@@ -122,13 +123,13 @@ class ConsumerBuilder:
             consumer = KafkaConsumerWithCommitLog(
                 configuration,
                 producer=self.producer,
-                commit_log_topic=self.commit_log_topic,
+                commit_log_topic=Topic(self.commit_log_topic),
                 commit_retry_policy=self.__commit_retry_policy,
             )
 
         return BatchingConsumer(
             consumer,
-            self.raw_topic,
+            Topic(self.raw_topic),
             worker=worker,
             max_batch_size=self.max_batch_size,
             max_batch_time=self.max_batch_time_ms,

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -7,7 +7,7 @@ from itertools import chain
 
 from snuba.util import settings_override
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.consumer import KafkaMessage, TopicPartition
+from snuba.utils.streams.consumer import KafkaMessage, Partition, Topic
 
 
 logger = logging.getLogger("snuba.perf")
@@ -23,7 +23,7 @@ def get_messages(events_file):
     raw_events = open(events_file).readlines()
     for raw_event in raw_events:
         messages.append(
-            KafkaMessage(TopicPartition("events", 1), 0, raw_event.encode("utf-8")),
+            KafkaMessage(Partition(Topic("events"), 1), 0, raw_event.encode("utf-8")),
         )
     return messages
 

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -36,7 +36,7 @@ from snuba.redis import redis_client
 from snuba.util import local_dataset_mode
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.metrics.timer import Timer
-from snuba.utils.streams.consumer import KafkaMessage, TopicPartition
+from snuba.utils.streams.consumer import KafkaMessage, Partition, Topic
 
 
 logger = logging.getLogger("snuba.api")
@@ -473,7 +473,7 @@ if application.debug or application.testing:
         if version != 2:
             raise RuntimeError("Unsupported protocol version: %s" % record)
 
-        message = KafkaMessage(TopicPartition("topic", 0), 0, http_request.data,)
+        message = KafkaMessage(Partition(Topic("topic"), 0), 0, http_request.data,)
 
         type_ = record[1]
         metrics = DummyMetricsBackend()

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -10,7 +10,7 @@ from snuba.datasets.factory import get_dataset
 from snuba.processor import ProcessorAction, ProcessedMessage
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.consumer import KafkaMessage, TopicPartition
+from snuba.utils.streams.consumer import KafkaMessage, Partition, Topic
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 
 
@@ -79,6 +79,6 @@ class TestSnapshotWorker:
         )
 
         ret = worker.process_message(
-            KafkaMessage(TopicPartition("topic", 0), 1, message.encode("utf-8"),)
+            KafkaMessage(Partition(Topic("topic"), 0), 1, message.encode("utf-8"),)
         )
         assert ret == expected

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -6,7 +6,7 @@ from snuba.consumer import ConsumerWorker
 from snuba.datasets.factory import enforce_table_writer
 from snuba.processor import ProcessedMessage, ProcessorAction
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.consumer import KafkaMessage, TopicPartition
+from snuba.utils.streams.consumer import KafkaMessage, Partition, Topic
 from tests.base import BaseEventsTest
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 
@@ -19,7 +19,7 @@ class TestConsumer(BaseEventsTest):
         event = self.event
 
         message = KafkaMessage(
-            TopicPartition("events", 456),
+            Partition(Topic("events"), 456),
             123,
             json.dumps((0, "insert", event)).encode(
                 "utf-8"
@@ -65,7 +65,7 @@ class TestConsumer(BaseEventsTest):
         event["data"]["received"] = int(calendar.timegm(old_timestamp.timetuple()))
 
         message = KafkaMessage(
-            TopicPartition("events", 1),
+            Partition(Topic("events"), 1),
             42,
             json.dumps((0, "insert", event)).encode("utf-8"),
         )

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -8,7 +8,7 @@ from snuba import replacer
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.consumer import KafkaMessage, TopicPartition
+from snuba.utils.streams.consumer import KafkaMessage, Partition, Topic
 from tests.base import BaseEventsTest
 
 
@@ -30,7 +30,7 @@ class TestReplacer(BaseEventsTest):
 
     def _wrap(self, msg: str) -> KafkaMessage:
         return KafkaMessage(
-            TopicPartition("replacements", 0), 0, json.dumps(msg).encode("utf-8"),
+            Partition(Topic("replacements"), 0), 0, json.dumps(msg).encode("utf-8"),
         )
 
     def _issue_count(self, project_id, group_id=None):
@@ -226,7 +226,7 @@ class TestReplacer(BaseEventsTest):
         project_id = self.project_id
 
         message = KafkaMessage(
-            TopicPartition("replacements", 1),
+            Partition(Topic("replacements"), 1),
             42,
             json.dumps(
                 (
@@ -258,7 +258,7 @@ class TestReplacer(BaseEventsTest):
         project_id = self.project_id
 
         message = KafkaMessage(
-            TopicPartition("replacements", 1),
+            Partition(Topic("replacements"), 1),
             42,
             json.dumps(
                 (
@@ -292,7 +292,7 @@ class TestReplacer(BaseEventsTest):
         project_id = self.project_id
 
         message = KafkaMessage(
-            TopicPartition("replacements", 1),
+            Partition(Topic("replacements"), 1),
             42,
             json.dumps(
                 (
@@ -346,7 +346,7 @@ class TestReplacer(BaseEventsTest):
         timestamp = datetime.now(tz=pytz.utc)
 
         message = KafkaMessage(
-            TopicPartition("replacements", 1),
+            Partition(Topic("replacements"), 1),
             42,
             json.dumps(
                 (


### PR DESCRIPTION
- Renames `TopicPartition` to just `Partition`
- Changes the type of `Partition.topic` from `str` to `Topic`
- Renames `Partition.partition` to `Partition.index`
- Changes the type of `topic` argument of `KafkaConsumer.subscribe` and `BatchingConsumer.subscribe` to `Sequence[Topic]` and `Topic` respectively
- Changes all references of `stream{,s}` to `partition{,s}`

This work is mostly motivated by the necessity of having a straightforward way to identify if a partition belongs to a topic in a subscription. The switch from `stream` back to `partition` was mostly because `stream` really is too generic — it is more specific to consider these as partitions of a topic, regardless of the backend implementation (which may not be solely Kafka in the future.)