### PR TITLE
feat(query processor) Support Lambda Expressions

### DIFF
--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -7,7 +7,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
-    Variable,
+    Argument,
 )
 from snuba.query.parsing import ParsingContext
 from snuba.clickhouse.escaping import escape_alias, escape_identifier, escape_string
@@ -85,10 +85,10 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         ret = f"{int_func}{self.__visit_params(exp.parameters)}"
         return self.__alias(ret, exp.alias)
 
-    def visitVariable(self, exp: Variable) -> str:
+    def visitArgument(self, exp: Argument) -> str:
         return escape_identifier(exp.name)
 
     def visitLambda(self, exp: Lambda) -> str:
-        variables = [escape_identifier(v) for v in exp.variables]
-        ret = f"({', '.join(variables)} -> {exp.transformation.accept(self)})"
+        parameters = [escape_identifier(v) for v in exp.parameters]
+        ret = f"({', '.join(parameters)} -> {exp.transformation.accept(self)})"
         return self.__alias(ret, exp.alias)

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -84,6 +84,14 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
     def visitCurriedFunctionCall(self, exp: CurriedFunctionCall) -> TVisited:
         raise NotImplementedError
 
+    @abstractmethod
+    def visitVariable(self, exp: Variable) -> TVisited:
+        raise NotImplementedError
+
+    @abstractmethod
+    def visitLambda(self, exp: Lambda) -> TVisited:
+        raise NotImplementedError
+
 
 @dataclass(frozen=True)
 class Literal(Expression):
@@ -214,3 +222,53 @@ class CurriedFunctionCall(Expression):
 
     def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
         return visitor.visitCurriedFunctionCall(self)
+
+
+@dataclass(frozen=True)
+class Variable(Expression):
+    """
+    A bound variable in a lambda expression. This is used to refer to variables
+    declared in the lambda expression
+    """
+
+    name: str
+
+    def transform(self, func: Callable[[Expression], Expression]) -> Expression:
+        return func(self)
+
+    def __iter__(self) -> Iterator[Expression]:
+        yield self
+
+    def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
+        return visitor.visitVariable(self)
+
+
+@dataclass(frozen=True)
+class Lambda(Expression):
+    """
+    A lambda expression in the form (x,y,z -> transform(x,y,z))
+    """
+
+    # the bound variables in the expressions. These are intentionally not expressions
+    # since they are variable names and cannot have aliases
+    variables: Sequence[str]
+    transformation: Expression
+
+    def transform(self, func: Callable[[Expression], Expression]) -> Expression:
+        """
+        Applies the transformation to the inner expression but not to the variables
+        declaration.
+        """
+        transformed = replace(self, transformation=self.transformation.transform(func),)
+        return func(transformed)
+
+    def __iter__(self) -> Iterator[Expression]:
+        """
+        Traverse the subtree in a postfix order.
+        """
+        for child in self.transformation:
+            yield child
+        yield self
+
+    def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
+        return visitor.visitLambda(self)

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -85,7 +85,7 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
         raise NotImplementedError
 
     @abstractmethod
-    def visitVariable(self, exp: Variable) -> TVisited:
+    def visitArgument(self, exp: Argument) -> TVisited:
         raise NotImplementedError
 
     @abstractmethod
@@ -225,7 +225,7 @@ class CurriedFunctionCall(Expression):
 
 
 @dataclass(frozen=True)
-class Variable(Expression):
+class Argument(Expression):
     """
     A bound variable in a lambda expression. This is used to refer to variables
     declared in the lambda expression
@@ -240,7 +240,7 @@ class Variable(Expression):
         yield self
 
     def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
-        return visitor.visitVariable(self)
+        return visitor.visitArgument(self)
 
 
 @dataclass(frozen=True)
@@ -249,17 +249,17 @@ class Lambda(Expression):
     A lambda expression in the form (x,y,z -> transform(x,y,z))
     """
 
-    # the bound variables in the expressions. These are intentionally not expressions
+    # the parameters in the expressions. These are intentionally not expressions
     # since they are variable names and cannot have aliases
-    variables: Sequence[str]
+    parameters: Sequence[str]
     transformation: Expression
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
-        Applies the transformation to the inner expression but not to the variables
+        Applies the transformation to the inner expression but not to the parameters
         declaration.
         """
-        transformed = replace(self, transformation=self.transformation.transform(func),)
+        transformed = replace(self, transformation=self.transformation.transform(func))
         return func(transformed)
 
     def __iter__(self) -> Iterator[Expression]:

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -17,6 +17,7 @@ test_expressions = [
     (Literal(None, 123), "123",),  # INT literal
     (Literal(None, 123.321), "123.321",),  # FLOAT literal
     (Literal(None, None), "NULL",),  # NULL
+    (Literal(None, True), "true",),  # True
     (Literal(None, False), "false",),  # False
     (Column(None, "column1", "table1"), "table1.column1"),  # Basic Column no alias
     (Column(None, "column1", None), "column1"),  # Basic Column with no table

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -6,7 +6,9 @@ from snuba.query.expressions import (
     CurriedFunctionCall,
     Expression,
     FunctionCall,
+    Lambda,
     Literal,
+    Variable,
 )
 from snuba.query.parsing import ParsingContext
 
@@ -15,7 +17,6 @@ test_expressions = [
     (Literal(None, 123), "123",),  # INT literal
     (Literal(None, 123.321), "123.321",),  # FLOAT literal
     (Literal(None, None), "NULL",),  # NULL
-    (Literal(None, True), "true",),  # True
     (Literal(None, False), "false",),  # False
     (Column(None, "column1", "table1"), "table1.column1"),  # Basic Column no alias
     (Column(None, "column1", None), "column1"),  # Basic Column with no table
@@ -77,6 +78,23 @@ test_expressions = [
         ),
         "f0(table1.param1)(f1(table1.param2), table1.param3)",
     ),  # Curried function call with hierarchy
+    (
+        FunctionCall(
+            None,
+            "arrayExists",
+            [
+                Lambda(
+                    None,
+                    ["x", "y"],
+                    FunctionCall(
+                        None, "testFunc", [Variable(None, "x"), Variable(None, "y")]
+                    ),
+                ),
+                Column(None, "test", None),
+            ],
+        ),
+        "arrayExists((x, y -> testFunc(x, y)), test)",
+    ),  # Lambda expression
 ]
 
 

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
-    Variable,
+    Argument,
 )
 from snuba.query.parsing import ParsingContext
 
@@ -88,7 +88,7 @@ test_expressions = [
                     None,
                     ["x", "y"],
                     FunctionCall(
-                        None, "testFunc", [Variable(None, "x"), Variable(None, "y")]
+                        None, "testFunc", [Argument(None, "x"), Argument(None, "y")]
                     ),
                 ),
                 Column(None, "test", None),

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
-    Variable,
+    Argument,
 )
 
 
@@ -44,7 +44,7 @@ class DummyVisitor(ExpressionVisitor[List[Expression]]):
             ret.extend(param.accept(self))
         return ret
 
-    def visitVariable(self, exp: Variable) -> List[Expression]:
+    def visitArgument(self, exp: Argument) -> List[Expression]:
         self.__visited_nodes.append(exp)
         return [exp]
 

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -6,7 +6,9 @@ from snuba.query.expressions import (
     Expression,
     ExpressionVisitor,
     FunctionCall,
+    Lambda,
     Literal,
+    Variable,
 )
 
 
@@ -40,6 +42,17 @@ class DummyVisitor(ExpressionVisitor[List[Expression]]):
         ret.extend(exp.internal_function.accept(self))
         for param in exp.parameters:
             ret.extend(param.accept(self))
+        return ret
+
+    def visitVariable(self, exp: Variable) -> List[Expression]:
+        self.__visited_nodes.append(exp)
+        return [exp]
+
+    def visitLambda(self, exp: Lambda) -> List[Expression]:
+        self.__visited_nodes.append(exp)
+        self.__visited_nodes.append(exp.transform.accept(self))
+        ret = [exp]
+        ret.extend(exp.transform.accept(self))
         return ret
 
 


### PR DESCRIPTION
Clickhouse supports lambda expressions and so should we.

This introduces a node in the ast that can be formatted into
```
arrayExists((x, y -> testFunc(x, y)), test)
```