### PR TITLE
perf(datasets) Track max_threads parameter as tag in snuba transactions

### DIFF
--- a/snuba/views.py
+++ b/snuba/views.py
@@ -93,7 +93,6 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
     release=os.getenv("SNUBA_RELEASE"),
-    traces_sample_rate=1,
 )
 
 

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -93,6 +93,7 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
     release=os.getenv("SNUBA_RELEASE"),
+    traces_sample_rate=1,
 )
 
 
@@ -349,7 +350,14 @@ def parse_and_run_query(dataset, request: Request, timer) -> QueryResult:
     with sentry_sdk.start_span(description=query.format_sql(), op="db") as span:
         span.set_tag("dataset", type(dataset).__name__)
         span.set_tag("table", source)
-        return raw_query(request, query, clickhouse_ro, timer, stats)
+        result = raw_query(request, query, clickhouse_ro, timer, stats)
+
+    with sentry_sdk.configure_scope() as scope:
+        if scope.span:
+            if "max_threads" in stats:
+                scope.span.set_tag("max_threads", stats["max_threads"])
+
+    return result
 
 
 # Special internal endpoints that compute global aggregate data that we want to


### PR DESCRIPTION
Trying to understand performance issues without knowing if Snuba decided to downgrade the number of threads for that query is not very useful.
This adds to the transaction the max_threads parameter we pass to Clickhouse.