### PR TITLE
Fix(query) Make expressions hashable

### DIFF
--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -85,17 +85,17 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         ret = f"{int_func}{self.__visit_params(exp.parameters)}"
         return self.__alias(ret, exp.alias)
 
-    def visitArgument(self, exp: Argument) -> str:
-        ret = escape_identifier(exp.name)
+    def __escape_identifier_enforce(self, expr: str) -> str:
+        ret = escape_identifier(expr)
         # This is for the type checker. escape_identifier can return
         # None if the input is None. Here the input is not None.
         assert ret is not None
         return ret
 
+    def visitArgument(self, exp: Argument) -> str:
+        return self.__escape_identifier_enforce(exp.name)
+
     def visitLambda(self, exp: Lambda) -> str:
-        parameters = [
-            escape_identifier(v) if escape_identifier(v) is not None else ""
-            for v in exp.parameters
-        ]
+        parameters = [self.__escape_identifier_enforce(v) for v in exp.parameters]
         ret = f"({', '.join(parameters)} -> {exp.transformation.accept(self)})"
         return self.__alias(ret, exp.alias)

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -86,9 +86,16 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         return self.__alias(ret, exp.alias)
 
     def visitArgument(self, exp: Argument) -> str:
-        return escape_identifier(exp.name)
+        ret = escape_identifier(exp.name)
+        # This is for the type checker. escape_identifier can return
+        # None if the input is None. Here the input is not None.
+        assert ret is not None
+        return ret
 
     def visitLambda(self, exp: Lambda) -> str:
-        parameters = [escape_identifier(v) for v in exp.parameters]
+        parameters = [
+            escape_identifier(v) if escape_identifier(v) is not None else ""
+            for v in exp.parameters
+        ]
         ret = f"({', '.join(parameters)} -> {exp.transformation.accept(self)})"
         return self.__alias(ret, exp.alias)

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -7,6 +7,7 @@ class ConditionFunctions:
     """
     Function names for comparison operations.
     """
+
     EQ = "equals"
     NEQ = "notEquals"
     LTE = "lessOrEquals"
@@ -20,14 +21,19 @@ class BooleanFunctions:
     """
     Same as comparison functions but for boolean operators.
     """
+
     NOT = "not"
     AND = "and"
     OR = "or"
 
 
-def binary_condition(alias: Optional[str], function_name: str, lhs: Expression, rhs: Expression) -> FunctionCall:
-    return FunctionCall(alias, function_name, [lhs, rhs])
+def binary_condition(
+    alias: Optional[str], function_name: str, lhs: Expression, rhs: Expression
+) -> FunctionCall:
+    return FunctionCall(alias, function_name, (lhs, rhs))
 
 
-def unary_condition(alias: Optional[str], function_name: str, operand: Expression) -> FunctionCall:
-    return FunctionCall(alias, function_name, [operand])
+def unary_condition(
+    alias: Optional[str], function_name: str, operand: Expression
+) -> FunctionCall:
+    return FunctionCall(alias, function_name, (operand,))

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
-from typing import Callable, Generic, Iterator, Optional, Sequence, TypeVar, Union
+from typing import (
+    Callable,
+    Generic,
+    Iterator,
+    Optional,
+    TypeVar,
+    Tuple,
+    Union,
+)
 
 TVisited = TypeVar("TVisited")
 
@@ -142,7 +150,7 @@ class FunctionCall(Expression):
     """
 
     function_name: str
-    parameters: Sequence[Expression]
+    parameters: Tuple[Expression]
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
@@ -159,7 +167,7 @@ class FunctionCall(Expression):
         """
         transformed = replace(
             self,
-            parameters=list(map(lambda child: child.transform(func), self.parameters)),
+            parameters=tuple(map(lambda child: child.transform(func), self.parameters)),
         )
         return func(transformed)
 
@@ -192,8 +200,8 @@ class CurriedFunctionCall(Expression):
     # The function on left side of the expression.
     # for topK this would be topK(5)
     internal_function: FunctionCall
-    # The list of parameters to apply to the result of internal_function.
-    parameters: Sequence[Expression]
+    # The parameters to apply to the result of internal_function.
+    parameters: Tuple[Expression]
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
@@ -205,7 +213,7 @@ class CurriedFunctionCall(Expression):
         transformed = replace(
             self,
             internal_function=self.internal_function.transform(func),
-            parameters=list(map(lambda child: child.transform(func), self.parameters)),
+            parameters=tuple(map(lambda child: child.transform(func), self.parameters)),
         )
         return func(transformed)
 
@@ -251,7 +259,7 @@ class Lambda(Expression):
 
     # the parameters in the expressions. These are intentionally not expressions
     # since they are variable names and cannot have aliases
-    parameters: Sequence[str]
+    parameters: Tuple[str]
     transformation: Expression
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -5,15 +5,12 @@ from dataclasses import dataclass, replace
 from typing import (
     Callable,
     Generic,
-    Hashable,
-    Iterable,
     Iterator,
     Optional,
-    Sequence,
     TypeVar,
+    Tuple,
     Union,
 )
-from typing_extensions import Protocol
 
 TVisited = TypeVar("TVisited")
 
@@ -141,20 +138,6 @@ class Column(Expression):
         return visitor.visitColumn(self)
 
 
-T = TypeVar("T", covariant=True)
-
-
-class HashableIterable(Protocol[T], Hashable, Iterable[T]):
-    """
-    Placeholder type for parameter lists that have to be hashable.
-    The only concrete type to achieve that is a Tuple, but we cannot
-    define the type of the collection as Tuple since the number of element
-    is not predetermined.
-    """
-
-    pass
-
-
 @dataclass(frozen=True)
 class FunctionCall(Expression):
     """
@@ -167,7 +150,8 @@ class FunctionCall(Expression):
     """
 
     function_name: str
-    parameters: HashableIterable[Expression]
+    # This is a tuple with variable size and not a Sequence to enforce it is hashable
+    parameters: Tuple[Expression, ...]
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
@@ -218,7 +202,8 @@ class CurriedFunctionCall(Expression):
     # for topK this would be topK(5)
     internal_function: FunctionCall
     # The parameters to apply to the result of internal_function.
-    parameters: HashableIterable[Expression]
+    # This is a tuple with variable size and not a Sequence to enforce it is hashable
+    parameters: Tuple[Expression, ...]
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
@@ -276,7 +261,8 @@ class Lambda(Expression):
 
     # the parameters in the expressions. These are intentionally not expressions
     # since they are variable names and cannot have aliases
-    parameters: HashableIterable[str]
+    # This is a tuple with variable size and not a Sequence to enforce it is hashable
+    parameters: Tuple[str, ...]
     transformation: Expression
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -5,12 +5,15 @@ from dataclasses import dataclass, replace
 from typing import (
     Callable,
     Generic,
+    Hashable,
+    Iterable,
     Iterator,
     Optional,
+    Sequence,
     TypeVar,
-    Tuple,
     Union,
 )
+from typing_extensions import Protocol
 
 TVisited = TypeVar("TVisited")
 
@@ -138,6 +141,20 @@ class Column(Expression):
         return visitor.visitColumn(self)
 
 
+T = TypeVar("T", covariant=True)
+
+
+class HashableIterable(Protocol[T], Hashable, Iterable[T]):
+    """
+    Placeholder type for parameter lists that have to be hashable.
+    The only concrete type to achieve that is a Tuple, but we cannot
+    define the type of the collection as Tuple since the number of element
+    is not predetermined.
+    """
+
+    pass
+
+
 @dataclass(frozen=True)
 class FunctionCall(Expression):
     """
@@ -150,7 +167,7 @@ class FunctionCall(Expression):
     """
 
     function_name: str
-    parameters: Tuple[Expression]
+    parameters: HashableIterable[Expression]
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
@@ -201,7 +218,7 @@ class CurriedFunctionCall(Expression):
     # for topK this would be topK(5)
     internal_function: FunctionCall
     # The parameters to apply to the result of internal_function.
-    parameters: Tuple[Expression]
+    parameters: HashableIterable[Expression]
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         """
@@ -259,7 +276,7 @@ class Lambda(Expression):
 
     # the parameters in the expressions. These are intentionally not expressions
     # since they are variable names and cannot have aliases
-    parameters: Tuple[str]
+    parameters: HashableIterable[str]
     transformation: Expression
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -98,7 +98,7 @@ def parse_function_to_expr(expr: Any) -> Expression:
     def output_builder(
         alias: Optional[str], name: str, params: List[Expression]
     ) -> Expression:
-        return FunctionCall(alias, name, params)
+        return FunctionCall(alias, name, tuple(params))
 
     return parse_function(
         output_builder, simple_expression_builder, literal_builder, expr, 0,

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -29,12 +29,12 @@ test_expressions = [
         FunctionCall(
             None,
             "f1",
-            [
+            (
                 Column(None, "param1", "table1"),
                 Column(None, "param2", "table1"),
                 Literal(None, None),
                 Literal(None, "test_string"),
-            ],
+            ),
         ),
         "f1(table1.param1, table1.param2, NULL, 'test_string')",
     ),  # Simple function call with columns and literals
@@ -42,7 +42,7 @@ test_expressions = [
         FunctionCall(
             "alias",
             "f1",
-            [Column(None, "param1", "table1"), Column("alias1", "param2", "table1")],
+            (Column(None, "param1", "table1"), Column("alias1", "param2", "table1")),
         ),
         "(f1(table1.param1, (table1.param2 AS alias1)) AS alias)",
     ),  # Function with alias
@@ -50,10 +50,10 @@ test_expressions = [
         FunctionCall(
             None,
             "f1",
-            [
-                FunctionCall(None, "f2", [Column(None, "param1", "table1")]),
-                FunctionCall(None, "f3", [Column(None, "param2", "table1")]),
-            ],
+            (
+                FunctionCall(None, "f2", (Column(None, "param1", "table1"))),
+                FunctionCall(None, "f3", (Column(None, "param2", "table1"))),
+            ),
         ),
         "f1(f2(table1.param1), f3(table1.param2))",
     ),  # Hierarchical function call
@@ -61,21 +61,21 @@ test_expressions = [
         FunctionCall(
             None,
             "f1",
-            [
-                FunctionCall("al1", "f2", [Column(None, "param1", "table1")]),
-                FunctionCall("al2", "f3", [Column(None, "param2", "table1")]),
-            ],
+            (
+                FunctionCall("al1", "f2", (Column(None, "param1", "table1"))),
+                FunctionCall("al2", "f3", (Column(None, "param2", "table1"))),
+            ),
         ),
         "f1((f2(table1.param1) AS al1), (f3(table1.param2) AS al2))",
     ),  # Hierarchical function call with aliases
     (
         CurriedFunctionCall(
             None,
-            FunctionCall(None, "f0", [Column(None, "param1", "table1")]),
-            [
-                FunctionCall(None, "f1", [Column(None, "param2", "table1")]),
+            FunctionCall(None, "f0", (Column(None, "param1", "table1"),)),
+            (
+                FunctionCall(None, "f1", (Column(None, "param2", "table1"),)),
                 Column(None, "param3", "table1"),
-            ],
+            ),
         ),
         "f0(table1.param1)(f1(table1.param2), table1.param3)",
     ),  # Curried function call with hierarchy
@@ -83,16 +83,16 @@ test_expressions = [
         FunctionCall(
             None,
             "arrayExists",
-            [
+            (
                 Lambda(
                     None,
-                    ["x", "y"],
+                    ("x", "y"),
                     FunctionCall(
-                        None, "testFunc", [Argument(None, "x"), Argument(None, "y")]
+                        None, "testFunc", (Argument(None, "x"), Argument(None, "y"))
                     ),
                 ),
                 Column(None, "test", None),
-            ],
+            ),
         ),
         "arrayExists((x, y -> testFunc(x, y)), test)",
     ),  # Lambda expression
@@ -122,11 +122,11 @@ def test_aliases() -> None:
     f = FunctionCall(
         None,
         "f1",
-        [
-            FunctionCall("tag[something]", "tag", [Column(None, "column1", "table1")]),
-            FunctionCall("tag[something]", "tag", [Column(None, "column1", "table1")]),
-            FunctionCall("tag[something]", "tag", [Column(None, "column1", "table1")]),
-        ],
+        (
+            FunctionCall("tag[something]", "tag", (Column(None, "column1", "table1"))),
+            FunctionCall("tag[something]", "tag", (Column(None, "column1", "table1"))),
+            FunctionCall("tag[something]", "tag", (Column(None, "column1", "table1"))),
+        ),
     )
 
     expected = "f1((tag(table1.column1) AS `tag[something]`), `tag[something]`, `tag[something]`)"
@@ -147,7 +147,7 @@ test_escaped = [
         "(table.columns.can AS `alias.cannot.have.dot`)",
     ),  # Escaping is different between columns and aliases
     (
-        FunctionCall(None, "f*&^%$#unction", [Column(None, "column", "table")]),
+        FunctionCall(None, "f*&^%$#unction", (Column(None, "column", "table"))),
         "`f*&^%$#unction`(table.column)",
     ),  # Function names can be escaped. Hopefully it will never happen
 ]

--- a/tests/query/parser/test_functions.py
+++ b/tests/query/parser/test_functions.py
@@ -9,7 +9,7 @@ def test_complex_conditions_expr() -> None:
         None, "count", ()
     )
     assert parse_function_to_expr(tuplify(["notEmpty", ["foo"]]),) == FunctionCall(
-        None, "notEmpty", (Column(None, "foo", None))
+        None, "notEmpty", (Column(None, "foo", None),)
     )
     assert parse_function_to_expr(
         tuplify(["notEmpty", ["arrayElement", ["foo", 1]]]),
@@ -19,7 +19,7 @@ def test_complex_conditions_expr() -> None:
         (
             FunctionCall(
                 None, "arrayElement", (Column(None, "foo", None), Literal(None, 1))
-            )
+            ),
         ),
     )
     assert parse_function_to_expr(
@@ -28,7 +28,7 @@ def test_complex_conditions_expr() -> None:
         None,
         "foo",
         (
-            FunctionCall(None, "bar", (Column(None, "qux", None))),
+            FunctionCall(None, "bar", (Column(None, "qux", None),)),
             Column(None, "baz", None),
         ),
     )
@@ -41,12 +41,12 @@ def test_complex_conditions_expr() -> None:
     assert parse_function_to_expr(tuplify(["foo", ["b", "c", ["d"]]]),) == FunctionCall(
         None,
         "foo",
-        (Column(None, "b", None), FunctionCall(None, "c", (Column(None, "d", None)))),
+        (Column(None, "b", None), FunctionCall(None, "c", (Column(None, "d", None),))),
     )
 
     assert parse_function_to_expr(
         tuplify(["emptyIfNull", ["project_id"]]),
-    ) == FunctionCall(None, "emptyIfNull", (Column(None, "project_id", None)))
+    ) == FunctionCall(None, "emptyIfNull", (Column(None, "project_id", None),))
 
     assert parse_function_to_expr(
         tuplify(["or", [["or", ["a", "b"]], "c"]]),
@@ -116,7 +116,7 @@ def test_complex_conditions_expr() -> None:
                 "in",
                 (
                     Column(None, "release", None),
-                    FunctionCall(None, "tuple", (Literal(None, "foo"))),
+                    FunctionCall(None, "tuple", (Literal(None, "foo"),)),
                 ),
             ),
             Column(None, "release", None),

--- a/tests/query/parser/test_functions.py
+++ b/tests/query/parser/test_functions.py
@@ -6,47 +6,47 @@ from snuba.util import tuplify
 
 def test_complex_conditions_expr() -> None:
     assert parse_function_to_expr(tuplify(["count", []]),) == FunctionCall(
-        None, "count", []
+        None, "count", ()
     )
     assert parse_function_to_expr(tuplify(["notEmpty", ["foo"]]),) == FunctionCall(
-        None, "notEmpty", [Column(None, "foo", None)]
+        None, "notEmpty", (Column(None, "foo", None))
     )
     assert parse_function_to_expr(
         tuplify(["notEmpty", ["arrayElement", ["foo", 1]]]),
     ) == FunctionCall(
         None,
         "notEmpty",
-        [
+        (
             FunctionCall(
-                None, "arrayElement", [Column(None, "foo", None), Literal(None, 1)]
+                None, "arrayElement", (Column(None, "foo", None), Literal(None, 1))
             )
-        ],
+        ),
     )
     assert parse_function_to_expr(
         tuplify(["foo", ["bar", ["qux"], "baz"]]),
     ) == FunctionCall(
         None,
         "foo",
-        [
-            FunctionCall(None, "bar", [Column(None, "qux", None)]),
+        (
+            FunctionCall(None, "bar", (Column(None, "qux", None))),
             Column(None, "baz", None),
-        ],
+        ),
     )
     assert parse_function_to_expr(tuplify(["foo", [], "a"]),) == FunctionCall(
-        "a", "foo", []
+        "a", "foo", ()
     )
     assert parse_function_to_expr(tuplify(["foo", ["b", "c"], "d"]),) == FunctionCall(
-        "d", "foo", [Column(None, "b", None), Column(None, "c", None)]
+        "d", "foo", (Column(None, "b", None), Column(None, "c", None))
     )
     assert parse_function_to_expr(tuplify(["foo", ["b", "c", ["d"]]]),) == FunctionCall(
         None,
         "foo",
-        [Column(None, "b", None), FunctionCall(None, "c", [Column(None, "d", None)])],
+        (Column(None, "b", None), FunctionCall(None, "c", (Column(None, "d", None)))),
     )
 
     assert parse_function_to_expr(
         tuplify(["emptyIfNull", ["project_id"]]),
-    ) == FunctionCall(None, "emptyIfNull", [Column(None, "project_id", None)])
+    ) == FunctionCall(None, "emptyIfNull", (Column(None, "project_id", None)))
 
     assert parse_function_to_expr(
         tuplify(["or", [["or", ["a", "b"]], "c"]]),
@@ -110,18 +110,18 @@ def test_complex_conditions_expr() -> None:
     ) == FunctionCall(
         "release",
         "if",
-        [
+        (
             FunctionCall(
                 None,
                 "in",
-                [
+                (
                     Column(None, "release", None),
-                    FunctionCall(None, "tuple", [Literal(None, "foo")]),
-                ],
+                    FunctionCall(None, "tuple", (Literal(None, "foo"))),
+                ),
             ),
             Column(None, "release", None),
             Literal(None, "other"),
-        ],
+        ),
     )
 
     # TODO once search_message is filled in everywhere, this can be just 'message' again.
@@ -130,5 +130,5 @@ def test_complex_conditions_expr() -> None:
     ) == FunctionCall(
         None,
         "positionCaseInsensitive",
-        [Column(None, "message", None), Literal(None, "lol 'single' quotes")],
+        (Column(None, "message", None), Literal(None, "lol 'single' quotes")),
     )

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -1,4 +1,8 @@
-from snuba.query.conditions import binary_condition, BooleanFunctions, ConditionFunctions
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
 from snuba.query.expressions import FunctionCall, Column, Expression
 
 
@@ -57,13 +61,10 @@ def test_map_expressions_in_basic_condition() -> None:
     condition = condition.transform(replace_col)
 
     condition_b = binary_condition(
-        None,
-        ConditionFunctions.EQ,
-        FunctionCall(None, "f", [c3]),
-        c2,
+        None, ConditionFunctions.EQ, FunctionCall(None, "f", (c3,)), c2,
     )
     ret = list(condition)
-    expected = [c3, FunctionCall(None, "f", [c3]), c2, condition_b]
+    expected = [c3, FunctionCall(None, "f", (c3,)), c2, condition_b]
 
     assert ret == expected
 
@@ -113,5 +114,21 @@ def test_nested_simple_condition() -> None:
 
     and1 = and1.transform(replace_col)
     ret = list(and1)
-    expected = [c1, cX, co1_b, c3, cX, co2_b, or1_b, c5, cX, co4_b, c7, cX, co5_b, or2_b, and1_b]
+    expected = [
+        c1,
+        cX,
+        co1_b,
+        c3,
+        cX,
+        co2_b,
+        or1_b,
+        c5,
+        cX,
+        co4_b,
+        c7,
+        cX,
+        co5_b,
+        or2_b,
+        and1_b,
+    ]
     assert ret == expected

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -17,7 +17,7 @@ def test_iterate_over_query():
     column1 = Column(None, "c1", "t1")
     column2 = Column(None, "c2", "t1")
     function_1 = FunctionCall("alias", "f1", (column1, column2))
-    function_2 = FunctionCall("alias", "f2", (column2))
+    function_2 = FunctionCall("alias", "f2", (column2,))
 
     condition = binary_condition(
         None, ConditionFunctions.EQ, column1, Literal(None, "1")
@@ -65,7 +65,7 @@ def test_replace_expression():
     column1 = Column(None, "c1", "t1")
     column2 = Column(None, "c2", "t1")
     function_1 = FunctionCall("alias", "f1", (column1, column2))
-    function_2 = FunctionCall("alias", "f2", (column2))
+    function_2 = FunctionCall("alias", "f2", (column2,))
 
     condition = binary_condition(
         None, ConditionFunctions.EQ, function_1, Literal(None, "1")
@@ -86,7 +86,7 @@ def test_replace_expression():
 
     def replace(exp: Expression) -> Expression:
         if isinstance(exp, FunctionCall) and exp.function_name == "f1":
-            return FunctionCall(exp.alias, "tag", (Literal(None, "f1")))
+            return FunctionCall(exp.alias, "tag", (Literal(None, "f1"),))
         return exp
 
     query.transform_expressions(replace)
@@ -94,7 +94,7 @@ def test_replace_expression():
     expected_query = Query(
         {},
         TableSource("my_table", ColumnSet([])),
-        selected_columns=[FunctionCall("alias", "tag", (Literal(None, "f1"),)),],
+        selected_columns=[FunctionCall("alias", "tag", (Literal(None, "f1"),))],
         array_join=None,
         condition=binary_condition(
             None,

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -16,10 +16,12 @@ def test_iterate_over_query():
     """
     column1 = Column(None, "c1", "t1")
     column2 = Column(None, "c2", "t1")
-    function_1 = FunctionCall("alias", "f1", [column1, column2])
-    function_2 = FunctionCall("alias", "f2", [column2])
+    function_1 = FunctionCall("alias", "f1", (column1, column2))
+    function_2 = FunctionCall("alias", "f2", (column2))
 
-    condition = binary_condition(None, ConditionFunctions.EQ, column1, Literal(None, "1"))
+    condition = binary_condition(
+        None, ConditionFunctions.EQ, column1, Literal(None, "1")
+    )
 
     orderby = OrderBy(OrderByDirection.ASC, function_2)
 
@@ -36,13 +38,20 @@ def test_iterate_over_query():
 
     expected_expressions = [
         # selected columns
-        column1, column2, function_1,
+        column1,
+        column2,
+        function_1,
         # condition
-        column1, Literal(None, "1"), condition,
+        column1,
+        Literal(None, "1"),
+        condition,
         # groupby
-        column1, column2, function_1,
+        column1,
+        column2,
+        function_1,
         # order by
-        column2, function_2,
+        column2,
+        function_2,
     ]
 
     assert list(query.get_all_expressions()) == expected_expressions
@@ -55,10 +64,12 @@ def test_replace_expression():
     """
     column1 = Column(None, "c1", "t1")
     column2 = Column(None, "c2", "t1")
-    function_1 = FunctionCall("alias", "f1", [column1, column2])
-    function_2 = FunctionCall("alias", "f2", [column2])
+    function_1 = FunctionCall("alias", "f1", (column1, column2))
+    function_2 = FunctionCall("alias", "f2", (column2))
 
-    condition = binary_condition(None, ConditionFunctions.EQ, function_1, Literal(None, "1"))
+    condition = binary_condition(
+        None, ConditionFunctions.EQ, function_1, Literal(None, "1")
+    )
 
     orderby = OrderBy(OrderByDirection.ASC, function_2)
 
@@ -75,7 +86,7 @@ def test_replace_expression():
 
     def replace(exp: Expression) -> Expression:
         if isinstance(exp, FunctionCall) and exp.function_name == "f1":
-            return FunctionCall(exp.alias, "tag", [Literal(None, "f1")])
+            return FunctionCall(exp.alias, "tag", (Literal(None, "f1")))
         return exp
 
     query.transform_expressions(replace)
@@ -83,25 +94,28 @@ def test_replace_expression():
     expected_query = Query(
         {},
         TableSource("my_table", ColumnSet([])),
-        selected_columns=[
-            FunctionCall("alias", "tag", [Literal(None, "f1")]),
-        ],
+        selected_columns=[FunctionCall("alias", "tag", (Literal(None, "f1"),)),],
         array_join=None,
         condition=binary_condition(
             None,
             ConditionFunctions.EQ,
-            FunctionCall("alias", "tag", [Literal(None, "f1")]),
+            FunctionCall("alias", "tag", (Literal(None, "f1"),)),
             Literal(None, "1"),
         ),
-        groupby=[FunctionCall("alias", "tag", [Literal(None, "f1")])],
+        groupby=[FunctionCall("alias", "tag", (Literal(None, "f1"),))],
         having=None,
         order_by=[orderby],
     )
 
-    assert query.get_selected_columns_from_ast() == expected_query.get_selected_columns_from_ast()
+    assert (
+        query.get_selected_columns_from_ast()
+        == expected_query.get_selected_columns_from_ast()
+    )
     assert query.get_condition_from_ast() == expected_query.get_condition_from_ast()
     assert query.get_groupby_from_ast() == expected_query.get_groupby_from_ast()
     assert query.get_having_from_ast() == expected_query.get_having_from_ast()
     assert query.get_orderby_from_ast() == expected_query.get_orderby_from_ast()
 
-    assert list(query.get_all_expressions()) == list(expected_query.get_all_expressions())
+    assert list(query.get_all_expressions()) == list(
+        expected_query.get_all_expressions()
+    )


### PR DESCRIPTION
The expression class is based on the idea of being immutable. Unfortunately it contains lists, that are not immutable and thus not hashable.
There are few places where expressions have to be used as dictionary keys (see conditions_expr), thus they have to be hashable.

This makes Expressions actually immutable and hashable by replacing Sequqnces with a custom Protocol in the expression interface. And we use tuples as implementation.