### PR TITLE
ref: Refactor `raw_query` to not return http status codes. Move `parse_and_run_query` to api/query

### DIFF
--- a/snuba/api/query.py
+++ b/snuba/api/query.py
@@ -28,7 +28,7 @@ metrics = create_metrics(settings.DOGSTATSD_HOST, settings.DOGSTATSD_PORT, "snub
 clickhouse_rw = ClickhousePool()
 clickhouse_ro = ClickhousePool(client_settings={"readonly": True})
 
-ClickHouseQueryResult = MutableMapping[str, MutableMapping[str, Any]]
+ClickhouseQueryResult = MutableMapping[str, MutableMapping[str, Any]]
 
 
 class RawQueryException(Exception):
@@ -47,7 +47,7 @@ def raw_query(
     client: ClickhousePool,
     timer: Timer,
     stats: MutableMapping[str, Any] = None,
-) -> ClickHouseQueryResult:
+) -> ClickhouseQueryResult:
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON
@@ -225,7 +225,7 @@ def log_query_and_update_stats(
 
 
 @split_query
-def parse_and_run_query(dataset: Dataset, request: Request, timer: Timer) -> ClickHouseQueryResult:
+def parse_and_run_query(dataset: Dataset, request: Request, timer: Timer) -> ClickhouseQueryResult:
     from_date, to_date = TimeSeriesExtensionProcessor.get_time_limit(
         request.extensions["timeseries"]
     )

--- a/snuba/api/query.py
+++ b/snuba/api/query.py
@@ -1,12 +1,17 @@
 import logging
 
-from clickhouse_driver.errors import Error as ClickHouseError
 from hashlib import md5
-from typing import Any, MutableMapping, NamedTuple
+from typing import Any, MutableMapping
+
+import sentry_sdk
+from clickhouse_driver.errors import Error as ClickHouseError
+from flask import request as http_request
 
 from snuba import settings, state
+from snuba.api.split import split_query
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clickhouse.query import DictClickhouseQuery
+from snuba.query.timeseries import TimeSeriesExtensionProcessor
 from snuba.request import Request
 from snuba.state.rate_limit import (
     RateLimitAggregator,
@@ -16,15 +21,23 @@ from snuba.state.rate_limit import (
 from snuba.util import create_metrics, force_bytes
 from snuba.utils.metrics.timer import Timer
 
-
 logger = logging.getLogger("snuba.query")
 metrics = create_metrics(settings.DOGSTATSD_HOST, settings.DOGSTATSD_PORT, "snuba.api")
 
+clickhouse_rw = ClickhousePool()
+clickhouse_ro = ClickhousePool(client_settings={"readonly": True})
 
-class QueryResult(NamedTuple):
-    # TODO: Give a better abstraction to QueryResult
-    result: MutableMapping[str, MutableMapping[str, Any]]
-    status: int
+ClickHouseQueryResult = MutableMapping[str, MutableMapping[str, Any]]
+
+
+class RawQueryException(Exception):
+    def __init__(self, type, message, stats, timer, sql, **meta):
+        self.type = type
+        self.message = message
+        self.stats = stats
+        self.timer = timer
+        self.sql = sql
+        self.meta = meta
 
 
 def raw_query(
@@ -33,7 +46,7 @@ def raw_query(
     client: ClickhousePool,
     timer: Timer,
     stats=None,
-) -> QueryResult:
+) -> ClickHouseQueryResult:
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON
@@ -77,9 +90,7 @@ def raw_query(
             }
         ),
 
-        if result:
-            status = 200
-        else:
+        if not result:
             try:
                 with RateLimitAggregator(
                     request.settings.get_rate_limit_params()
@@ -119,7 +130,6 @@ def raw_query(
                             query_id=query_id if use_deduper else None,
                             with_totals=request.query.has_totals(),
                         )
-                        status = 200
 
                         logger.debug(sql)
                         timer.mark("execute")
@@ -136,32 +146,59 @@ def raw_query(
 
                     except BaseException as ex:
                         error = str(ex)
-                        status = 500
                         logger.exception("Error running query: %s\n%s", sql, error)
+                        stats = log_query_and_update_stats(request, sql, timer, stats, 'error', query_settings)
+                        meta = {}
                         if isinstance(ex, ClickHouseError):
-                            result = {
-                                "error": {
-                                    "type": "clickhouse",
-                                    "code": ex.code,
-                                    "message": error,
-                                }
-                            }
+                            type = "clickhouse"
+                            meta["code"] = ex.code
                         else:
-                            result = {"error": {"type": "unknown", "message": error}}
-
+                            type = "unknown"
+                        raise RawQueryException(
+                            type=type,
+                            message=error,
+                            stats=stats,
+                            timer=timer,
+                            sql=sql,
+                            **meta,
+                        )
             except RateLimitExceeded as ex:
-                error = str(ex)
-                status = 429
-                result = {
-                    "error": {
-                        "type": "ratelimit",
-                        "message": "rate limit exceeded",
-                        "detail": error,
-                    }
-                }
+                stats = log_query_and_update_stats(request, sql, timer, stats, 'rate-limited', query_settings)
+                raise RawQueryException(
+                    type="rate-limited",
+                    message="rate limit exceeded",
+                    stats=stats,
+                    timer=timer,
+                    sql=sql,
+                    detail=str(ex)
+                )
+
+    stats = log_query_and_update_stats(request, sql, timer, stats, 'success', query_settings)
+
+    result["timing"] = timer
+
+    if settings.STATS_IN_RESPONSE or request.settings.get_debug():
+        result["stats"] = stats
+        result["sql"] = sql
+
+    return result
+
+
+def log_query_and_update_stats(
+    request: Request,
+    sql: str,
+    timer: Timer,
+    stats: MutableMapping,
+    status: str,
+    query_settings: MutableMapping,
+) -> MutableMapping:
+    """
+    If query logging is enabled then logs details about the query and its status, as
+    well as timing information.
+    Also updates stats with any relevant information and returns the updated dict.
+    """
 
     stats.update(query_settings)
-
     if settings.RECORD_QUERIES:
         # send to redis
         state.record_query(
@@ -183,11 +220,60 @@ def raw_query(
             },
             mark_tags={"final": str(stats.get("final", False))},
         )
+    return stats
 
-    result["timing"] = timer
 
-    if settings.STATS_IN_RESPONSE or request.settings.get_debug():
-        result["stats"] = stats
-        result["sql"] = sql
+@split_query
+def parse_and_run_query(dataset, request: Request, timer) -> ClickHouseQueryResult:
+    from_date, to_date = TimeSeriesExtensionProcessor.get_time_limit(
+        request.extensions["timeseries"]
+    )
 
-    return QueryResult(result, status)
+    extensions = dataset.get_extensions()
+    for name, extension in extensions.items():
+        extension.get_processor().process_query(
+            request.query, request.extensions[name], request.settings
+        )
+
+    request.query.add_conditions(dataset.default_conditions())
+
+    if request.settings.get_turbo():
+        request.query.set_final(False)
+
+    for processor in dataset.get_query_processors():
+        processor.process_query(request.query, request.settings)
+
+    relational_source = request.query.get_data_source()
+    request.query.add_conditions(relational_source.get_mandatory_conditions())
+
+    source = relational_source.format_from()
+    with sentry_sdk.start_span(description="create_query", op="db"):
+        # TODO: consider moving the performance logic and the pre_where generation into
+        # ClickhouseQuery since they are Clickhouse specific
+        query = DictClickhouseQuery(dataset, request.query, request.settings)
+    timer.mark("prepare_query")
+
+    stats = {
+        "clickhouse_table": source,
+        "final": request.query.get_final(),
+        "referrer": request.referrer,
+        "num_days": (to_date - from_date).days,
+        "sample": request.query.get_sample(),
+    }
+
+    with sentry_sdk.configure_scope() as scope:
+        if scope.span:
+            scope.span.set_tag("dataset", type(dataset).__name__)
+            scope.span.set_tag("referrer", http_request.referrer)
+
+    with sentry_sdk.start_span(description=query.format_sql(), op="db") as span:
+        span.set_tag("dataset", type(dataset).__name__)
+        span.set_tag("table", source)
+        result = raw_query(request, query, clickhouse_ro, timer, stats)
+
+    with sentry_sdk.configure_scope() as scope:
+        if scope.span:
+            if "max_threads" in stats:
+                scope.span.set_tag("max_threads", stats["max_threads"])
+
+    return result

--- a/snuba/api/split.py
+++ b/snuba/api/split.py
@@ -4,7 +4,6 @@ import math
 
 from snuba import state, util
 from snuba.datasets.dataset import ColumnSplitSpec
-from snuba.api.query import QueryResult
 from snuba.request import Request
 
 # Every time we find zero results for a given step, expand the search window by
@@ -77,7 +76,6 @@ def split_query(query_func):
         split_end = to_date
         split_start = max(split_end - timedelta(seconds=split_step), from_date)
         total_results = 0
-        status = 0
         while split_start < split_end and total_results < limit:
             request.extensions["timeseries"]["from_date"] = split_start.isoformat()
             request.extensions["timeseries"]["to_date"] = split_end.isoformat()
@@ -90,18 +88,12 @@ def split_query(query_func):
             # evaluation, so we need to copy the body to ensure that the query
             # has not been modified in between this call and the next loop
             # iteration, if needed.
-            query_result = query_func(dataset, copy.deepcopy(request), *args, **kwargs)
-            status = query_result.status
-
-            # If something failed, discard all progress and just return that
-            if status != 200:
-                overall_result = query_result.result
-                break
+            result = query_func(dataset, copy.deepcopy(request), *args, **kwargs)
 
             if overall_result is None:
-                overall_result = query_result.result
+                overall_result = result
             else:
-                overall_result["data"].extend(query_result.result["data"])
+                overall_result["data"].extend(result["data"])
 
             if remaining_offset > 0 and len(overall_result["data"]) > 0:
                 to_trim = min(remaining_offset, len(overall_result["data"]))
@@ -111,7 +103,7 @@ def split_query(query_func):
             total_results = len(overall_result["data"])
 
             if total_results < limit:
-                if len(query_result.result["data"]) == 0:
+                if len(result["data"]) == 0:
                     # If we got nothing from the last query, expand the range by a static factor
                     split_step = split_step * STEP_GROWTH
                 else:
@@ -120,7 +112,7 @@ def split_query(query_func):
                     # our last query and its time range, and how many we have left to fetch.
                     remaining = limit - total_results
                     split_step = split_step * math.ceil(
-                        remaining / float(len(query_result.result["data"]))
+                        remaining / float(len(result["data"]))
                     )
 
                 # Set the start and end of the next query based on the new range.
@@ -132,7 +124,7 @@ def split_query(query_func):
                 except OverflowError:
                     split_start = from_date
 
-        return QueryResult(overall_result, status)
+        return overall_result
 
     def col_split(
         dataset, request: Request, column_split_spec: ColumnSplitSpec, *args, **kwargs
@@ -148,21 +140,17 @@ def split_query(query_func):
         # not been modified by the time we're ready to run the full query.
         minimal_request = copy.deepcopy(request)
         minimal_request.query.set_selected_columns(column_split_spec.get_min_columns())
-        query_result = query_func(dataset, minimal_request, *args, **kwargs)
+        result = query_func(dataset, minimal_request, *args, **kwargs)
         del minimal_request
 
-        # If something failed, just return
-        if query_result.status != 200:
-            return QueryResult(query_result.result, query_result.status)
-
-        if query_result.result["data"]:
+        if result["data"]:
             request = copy.deepcopy(request)
 
             event_ids = list(
                 set(
                     [
                         event[column_split_spec.id_column]
-                        for event in query_result.result["data"]
+                        for event in result["data"]
                     ]
                 )
             )
@@ -176,16 +164,14 @@ def split_query(query_func):
                 set(
                     [
                         event[column_split_spec.project_column]
-                        for event in query_result.result["data"]
+                        for event in result["data"]
                     ]
                 )
             )
             request.extensions["project"]["project"] = project_ids
 
             timestamp_field = column_split_spec.timestamp_column
-            timestamps = [
-                event[timestamp_field] for event in query_result.result["data"]
-            ]
+            timestamps = [event[timestamp_field] for event in result["data"]]
             request.extensions["timeseries"]["from_date"] = util.parse_datetime(
                 min(timestamps)
             ).isoformat()

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import time
-
 from datetime import datetime
+from typing import NamedTuple
+
 from flask import Flask, redirect, render_template, request as http_request
 from markdown import markdown
 from uuid import uuid1
@@ -15,13 +16,15 @@ import jsonschema
 from uuid import UUID
 
 from snuba import schemas, settings, state, util
-from snuba.api.query import QueryResult, raw_query
-from snuba.api.split import split_query
-from snuba.clickhouse.native import ClickhousePool
-from snuba.clickhouse.query import DictClickhouseQuery
+from snuba.api.query import (
+    clickhouse_ro,
+    clickhouse_rw,
+    ClickHouseQueryResult,
+    parse_and_run_query,
+    RawQueryException,
+)
 from snuba.consumer import KafkaMessageMetadata
 from snuba.query.schema import SETTINGS_SCHEMA
-from snuba.query.timeseries import TimeSeriesExtensionProcessor
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import (
     InvalidDatasetError,
@@ -44,8 +47,11 @@ logging.basicConfig(
     level=getattr(logging, settings.LOG_LEVEL.upper()), format="%(asctime)s %(message)s"
 )
 
-clickhouse_rw = ClickhousePool()
-clickhouse_ro = ClickhousePool(client_settings={"readonly": True})
+
+class QueryResult(NamedTuple):
+    # TODO: Give a better abstraction to QueryResult
+    result: ClickHouseQueryResult
+    status: int
 
 
 try:
@@ -283,7 +289,7 @@ def dataset_query(dataset, body, timer):
     ensure_table_exists(dataset)
 
     schema = RequestSchema.build_with_extensions(dataset.get_extensions())
-    query_result = parse_and_run_query(
+    query_result = run_query(
         dataset,
         validate_request_content(body, schema, timer, dataset, http_request.referrer),
         timer,
@@ -303,60 +309,22 @@ def dataset_query(dataset, body, timer):
     )
 
 
-@split_query
-def parse_and_run_query(dataset, request: Request, timer) -> QueryResult:
-    from_date, to_date = TimeSeriesExtensionProcessor.get_time_limit(
-        request.extensions["timeseries"]
-    )
-
-    extensions = dataset.get_extensions()
-    for name, extension in extensions.items():
-        extension.get_processor().process_query(
-            request.query, request.extensions[name], request.settings
-        )
-
-    request.query.add_conditions(dataset.default_conditions())
-
-    if request.settings.get_turbo():
-        request.query.set_final(False)
-
-    for processor in dataset.get_query_processors():
-        processor.process_query(request.query, request.settings)
-
-    relational_source = request.query.get_data_source()
-    request.query.add_conditions(relational_source.get_mandatory_conditions())
-
-    source = relational_source.format_from()
-    with sentry_sdk.start_span(description="create_query", op="db"):
-        # TODO: consider moving the performance logic and the pre_where generation into
-        # ClickhouseQuery since they are Clickhouse specific
-        query = DictClickhouseQuery(dataset, request.query, request.settings)
-    timer.mark("prepare_query")
-
-    stats = {
-        "clickhouse_table": source,
-        "final": request.query.get_final(),
-        "referrer": request.referrer,
-        "num_days": (to_date - from_date).days,
-        "sample": request.query.get_sample(),
-    }
-
-    with sentry_sdk.configure_scope() as scope:
-        if scope.span:
-            scope.span.set_tag("dataset", type(dataset).__name__)
-            scope.span.set_tag("referrer", http_request.referrer)
-
-    with sentry_sdk.start_span(description=query.format_sql(), op="db") as span:
-        span.set_tag("dataset", type(dataset).__name__)
-        span.set_tag("table", source)
-        result = raw_query(request, query, clickhouse_ro, timer, stats)
-
-    with sentry_sdk.configure_scope() as scope:
-        if scope.span:
-            if "max_threads" in stats:
-                scope.span.set_tag("max_threads", stats["max_threads"])
-
-    return result
+def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
+    try:
+        return QueryResult(parse_and_run_query(dataset, request, timer), 200)
+    except RawQueryException as e:
+        error = {
+            "type": e.type,
+            "message": e.message,
+        }
+        error.update(e.meta)
+        result = {
+            "error": error,
+            "sql": e.sql,
+            "stats": e.stats,
+            "timing": e.timer,
+        }
+        return QueryResult(result, 429 if e.type == "rate-limited" else 500)
 
 
 # Special internal endpoints that compute global aggregate data that we want to
@@ -389,7 +357,7 @@ def sdk_distribution(*, timer: Timer):
 
     ensure_table_exists(dataset)
 
-    query_result = parse_and_run_query(dataset, request, timer)
+    query_result = run_query(dataset, request, timer)
     return (
         json.dumps(
             query_result.result,

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -19,7 +19,7 @@ from snuba import schemas, settings, state, util
 from snuba.api.query import (
     clickhouse_ro,
     clickhouse_rw,
-    ClickHouseQueryResult,
+    ClickhouseQueryResult,
     parse_and_run_query,
     RawQueryException,
 )
@@ -50,7 +50,7 @@ logging.basicConfig(
 
 class QueryResult(NamedTuple):
     # TODO: Give a better abstraction to QueryResult
-    result: ClickHouseQueryResult
+    result: ClickhouseQueryResult
     status: int
 
 

--- a/snuba/views.py
+++ b/snuba/views.py
@@ -314,7 +314,7 @@ def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
         return QueryResult(parse_and_run_query(dataset, request, timer), 200)
     except RawQueryException as e:
         error = {
-            "type": e.type,
+            "type": e.err_type,
             "message": e.message,
         }
         error.update(e.meta)
@@ -324,7 +324,7 @@ def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
             "stats": e.stats,
             "timing": e.timer,
         }
-        return QueryResult(result, 429 if e.type == "rate-limited" else 500)
+        return QueryResult(result, 429 if e.err_type == "rate-limited" else 500)
 
 
 # Special internal endpoints that compute global aggregate data that we want to

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -4,9 +4,9 @@ from unittest.mock import Mock
 import uuid
 
 from snuba import settings
+from snuba.api.query import parse_and_run_query
 from snuba.datasets.factory import enforce_table_writer
 from snuba.subscriptions.data import Subscription
-from snuba.views import parse_and_run_query
 from tests.base import BaseEventsTest
 
 
@@ -59,5 +59,5 @@ class TestApi(BaseEventsTest):
             resolution=timedelta(minutes=1),
         )
         request = subscription.build_request(self.dataset, datetime.utcnow(), 100, Mock())
-        query_result = parse_and_run_query(self.dataset, request, Mock())
-        assert query_result.result['data'][0]['count'] == 10
+        result = parse_and_run_query(self.dataset, request, Mock())
+        assert result['data'][0]['count'] == 10

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -6,7 +6,7 @@ from snuba.api.split import split_query
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset
 from snuba.query.query import Query
-from snuba.api.query import QueryResult
+from snuba.views import QueryResult
 from snuba.request import Request
 from snuba.request.request_settings import RequestSettings
 from snuba.utils.metrics.timer import Timer
@@ -93,9 +93,9 @@ def test_col_split(
     def do_query(dataset: Dataset, request: Request, timer: Timer):
         selected_cols = request.query.get_selected_columns()
         if selected_cols == list(first_query_data[0].keys()):
-            return QueryResult({"data": first_query_data}, 200)
+            return {"data": first_query_data}
         elif selected_cols == list(second_query_data[0].keys()):
-            return QueryResult({"data": second_query_data}, 200)
+            return {"data": second_query_data}
         else:
             raise ValueError(f"Unexpected selected columns: {selected_cols}")
 


### PR DESCRIPTION
This refactors `raw_query` to raise `RawQueryException` rather than return response dictionaries
with status codes.

We also move `parse_and_run_query` to api/query.py, and provide `run_query` which translates results
from `parse_and_run_query` into the response format that various views require.