### PR TITLE
perf(tagsmap): Run the flattened tags columns optimizer only for recent queries

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -239,4 +239,7 @@ class TransactionsDataset(TimeSeriesDataset):
         return [
             PrewhereProcessor(),
             NestedFieldConditionOptimizer("tags", "_tags_flattened", "start_ts"),
+            NestedFieldConditionOptimizer(
+                "contexts", "_contexts_flattened", "start_ts"
+            ),
         ]

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -238,5 +238,5 @@ class TransactionsDataset(TimeSeriesDataset):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             PrewhereProcessor(),
-            NestedFieldConditionOptimizer("tags", "_tags_flattened"),
+            NestedFieldConditionOptimizer("tags", "_tags_flattened", "start_ts"),
         ]

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -98,9 +98,6 @@ class NestedFieldConditionOptimizer(QueryProcessor):
         return None
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
-        enabled = state.get_config("optimize_nested_col_conditions", 0)
-        if not enabled:
-            return
         conditions = query.get_conditions()
         if not conditions:
             return

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -162,7 +162,6 @@ test_data = [
 
 @pytest.mark.parametrize("query_body, expected_condition", test_data)
 def test_nested_optimizer(query_body, expected_condition) -> None:
-    state.set_config("optimize_nested_col_conditions", 1)
     query = Query(query_body, TableSource("my_table", ColumnSet([]), None, []))
     request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
     processor = NestedFieldConditionOptimizer(

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -1,6 +1,7 @@
 import pytest
 
-from snuba import state
+from datetime import datetime
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
 from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
@@ -165,7 +166,10 @@ def test_nested_optimizer(query_body, expected_condition) -> None:
     query = Query(query_body, TableSource("my_table", ColumnSet([]), None, []))
     request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
     processor = NestedFieldConditionOptimizer(
-        nested_col="tags", flattened_col="tags_map", start_ts_col="start_ts"
+        nested_col="tags",
+        flattened_col="tags_map",
+        start_ts_col="start_ts",
+        beginning_of_time=datetime(2019, 12, 11, 0, 0, 0),
     )
     processor.process_query(query, request_settings)
 

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -52,6 +52,22 @@ test_data = [
             "conditions": [
                 ["tags[test.tag]", "=", "1"],
                 ["c", "=", "3"],
+                ["start_ts", ">", "2019-01-01T06:35:17"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
+            ]
+        },
+        [
+            ["c", "=", "3"],
+            ["start_ts", ">", "2019-01-01T06:35:17"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
+            ["tags_map", "LIKE", "%|test.tag=1|%"],
+        ],
+    ),  # Two start conditions: apply
+    (
+        {
+            "conditions": [
+                ["tags[test.tag]", "=", "1"],
+                ["c", "=", "3"],
                 ["tags[test2.tag]", "=", "2"],
                 ["tags[test3.tag]", "=", "3"],
                 ["start_ts", ">", "2019-12-18T06:35:17"],

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -9,13 +9,43 @@ from snuba.request.request_settings import RequestSettings
 
 test_data = [
     (
-        {"conditions": [["d", "=", "1"], ["c", "=", "3"]]},
-        [["d", "=", "1"], ["c", "=", "3"]],
+        {
+            "conditions": [
+                ["d", "=", "1"],
+                ["c", "=", "3"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
+            ]
+        },
+        [["d", "=", "1"], ["c", "=", "3"], ["start_ts", ">", "2019-12-18T06:35:17"]],
     ),  # No tags
     (
-        {"conditions": [["tags[test.tag]", "=", "1"], ["c", "=", "3"]]},
-        [["c", "=", "3"], ["tags_map", "LIKE", "%|test.tag=1|%"]],
+        {
+            "conditions": [
+                ["tags[test.tag]", "=", "1"],
+                ["c", "=", "3"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
+            ]
+        },
+        [
+            ["c", "=", "3"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
+            ["tags_map", "LIKE", "%|test.tag=1|%"],
+        ],
     ),  # One simple tag condition
+    (
+        {
+            "conditions": [
+                ["tags[test.tag]", "=", "1"],
+                ["c", "=", "3"],
+                ["start_ts", ">", "2019-01-01T06:35:17"],
+            ]
+        },
+        [
+            ["tags[test.tag]", "=", "1"],
+            ["c", "=", "3"],
+            ["start_ts", ">", "2019-01-01T06:35:17"],
+        ],
+    ),  # Query start from before the existence of tagsmap
     (
         {
             "conditions": [
@@ -23,10 +53,12 @@ test_data = [
                 ["c", "=", "3"],
                 ["tags[test2.tag]", "=", "2"],
                 ["tags[test3.tag]", "=", "3"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ]
         },
         [
             ["c", "=", "3"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
             ["tags_map", "LIKE", "%|test.tag=1|%|test2.tag=2|%|test3.tag=3|%"],
         ],
     ),  # Multiple tags in the same merge
@@ -37,10 +69,12 @@ test_data = [
                 ["tags[test.tag]", "=", "1"],
                 ["c", "=", "3"],
                 ["tags[test3.tag]", "=", "3"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ]
         },
         [
             ["c", "=", "3"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
             ["tags_map", "LIKE", "%|test.tag=1|%|test2.tag=2|%|test3.tag=3|%"],
         ],
     ),  # Multiple tags in the same merge and properly sorted
@@ -51,10 +85,12 @@ test_data = [
                 ["c", "=", "3"],
                 ["tags[test2.tag]", "=", "2"],
                 ["tags[test3.tag]", "!=", "3"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ]
         },
         [
             ["c", "=", "3"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
             ["tags_map", "LIKE", "%|test2.tag=2|%"],
             ["tags_map", "NOT LIKE", "%|test.tag=1|%"],
             ["tags_map", "NOT LIKE", "%|test3.tag=3|%"],
@@ -66,11 +102,13 @@ test_data = [
                 ["tags[test.tag]", "=", "1"],
                 ["c", "=", "3"],
                 [["func", ["tags[test2.tag]"]], "=", "2"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ]
         },
         [
             ["c", "=", "3"],
             [["func", ["tags[test2.tag]"]], "=", "2"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
             ["tags_map", "LIKE", "%|test.tag=1|%"],
         ],
     ),  # Nested condition. Only the external one is converted
@@ -80,9 +118,14 @@ test_data = [
                 ["tags[test.tag]", "=", "1"],
                 ["c", "=", "3"],
                 [["ifNull", ["tags[test2.tag]", ""]], "=", "2"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ]
         },
-        [["c", "=", "3"], ["tags_map", "LIKE", "%|test.tag=1|%|test2.tag=2|%"]],
+        [
+            ["c", "=", "3"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
+            ["tags_map", "LIKE", "%|test.tag=1|%|test2.tag=2|%"],
+        ],
     ),  # Nested conditions in ifNull. This is converted.
     (
         {
@@ -90,11 +133,13 @@ test_data = [
                 ["tags[test.tag]", "=", "1"],
                 ["c", "=", "3"],
                 ["contexts[test.context]", "=", "1"],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ]
         },
         [
             ["c", "=", "3"],
             ["contexts[test.context]", "=", "1"],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
             ["tags_map", "LIKE", "%|test.tag=1|%"],
         ],
     ),  # Both contexts and tags are present
@@ -103,11 +148,13 @@ test_data = [
             "conditions": [
                 [["tags[test.tag]", "=", "1"], ["c", "=", "3"]],
                 [["tags[test2.tag]", "=", "2"], ["tags[test3.tag]", "=", "3"]],
+                ["start_ts", ">", "2019-12-18T06:35:17"],
             ],
         },
         [
             [["tags[test.tag]", "=", "1"], ["c", "=", "3"]],
             [["tags[test2.tag]", "=", "2"], ["tags[test3.tag]", "=", "3"]],
+            ["start_ts", ">", "2019-12-18T06:35:17"],
         ],
     ),  # Nested conditions, ignored.
 ]
@@ -119,7 +166,8 @@ def test_nested_optimizer(query_body, expected_condition) -> None:
     query = Query(query_body, TableSource("my_table", ColumnSet([]), None, []))
     request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
     processor = NestedFieldConditionOptimizer(
-        nested_col="tags", flattened_col="tags_map"
+        nested_col="tags", flattened_col="tags_map", start_ts_col="start_ts"
     )
     processor.process_query(query, request_settings)
+
     assert query.get_conditions() == expected_condition


### PR DESCRIPTION
We introduced the flattened columns optimizer on dec 11. Which means we have valid data for the flattened columns since that day. 
This PR adds a condition to the optimizer so that we won't need 3 months of data to start using the optimizer. It automatically apply the optimizer only to queries that have start_date after dec 11.

It also adds the contexts optimizer to the transaction dataset.