### PR TITLE
ref(subscriptions): Make timestamp a concrete type

### DIFF
--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Generic, Iterator, TypeVar
 
-from snuba.subscriptions.types import TTimestamp
 from snuba.utils.types import Interval
 
 
@@ -10,20 +10,20 @@ TTask = TypeVar("TTask")
 
 
 @dataclass(frozen=True)
-class ScheduledTask(Generic[TTimestamp, TTask]):
+class ScheduledTask(Generic[TTask]):
     """
     A scheduled task represents a unit of work (a task) that is intended to
     be executed at (or around) a specific time.
     """
 
     # The time that this task was scheduled to execute.
-    timestamp: TTimestamp
+    timestamp: datetime
 
     # The task that should be executed.
     task: TTask
 
 
-class Scheduler(ABC, Generic[TTimestamp, TTask]):
+class Scheduler(ABC, Generic[TTask]):
     """
     The scheduler maintains the scheduling state for various tasks and
     provides the ability to query the schedule to find tasks that were
@@ -31,9 +31,7 @@ class Scheduler(ABC, Generic[TTimestamp, TTask]):
     """
 
     @abstractmethod
-    def find(
-        self, interval: Interval[TTimestamp]
-    ) -> Iterator[ScheduledTask[TTimestamp, TTask]]:
+    def find(self, interval: Interval[datetime]) -> Iterator[ScheduledTask[TTask]]:
         """
         Find all of the tasks that were scheduled to be executed between the
         lower bound (exclusive) and upper bound (inclusive) of the provided

--- a/snuba/subscriptions/types.py
+++ b/snuba/subscriptions/types.py
@@ -1,6 +1,0 @@
-from typing import Any, TypeVar
-
-from snuba.utils.types import Comparable
-
-
-TTimestamp = TypeVar("TTimestamp", bound=Comparable[Any])


### PR DESCRIPTION
Just trying to make life a little easier.