### PR TITLE
feat(query processor) Parse conditions

### DIFF
--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -121,10 +121,10 @@ def conditions_expr(
         res = " OR ".join(expressions)
         return "({})".format(res) if len(expressions) > 1 else res
 
-    def array_condition_builder(op: str, literals: Sequence[str], lhs: str) -> str:
+    def unpack_array_condition_builder(op: str, literal: Any, lhs: str) -> str:
         any_or_all = "arrayExists" if op in POSITIVE_OPERATORS else "arrayAll"
         return "{}(x -> assumeNotNull(x {} {}), {})".format(
-            any_or_all, op, escape_literal(literals), lhs,
+            any_or_all, op, escape_literal(literal), lhs,
         )
 
     def simple_condition_builder(lhs: str, op: str, literal: Any) -> str:
@@ -134,7 +134,7 @@ def conditions_expr(
         simple_expression_builder,
         and_builder,
         or_builder,
-        array_condition_builder,
+        unpack_array_condition_builder,
         simple_condition_builder,
         dataset,
         conditions,

--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -2,11 +2,12 @@ import numbers
 import re
 
 from datetime import date, datetime
-from typing import Any, List, Optional, OrderedDict, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba.clickhouse.escaping import escape_alias, NEGATE_RE
 from snuba.query.parser.functions import parse_function
+from snuba.query.parser.conditions import parse_conditions
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.schema import POSITIVE_OPERATORS
@@ -14,7 +15,6 @@ from snuba.util import (
     alias_expr,
     escape_literal,
     function_expr,
-    is_condition,
     is_function,
     QUOTED_LITERAL_RE,
 )
@@ -111,69 +111,33 @@ def complex_column_expr(
 def conditions_expr(
     dataset, conditions, query: Query, parsing_context: ParsingContext, depth=0
 ):
-    """
-    Return a boolean expression suitable for putting in the WHERE clause of the
-    query.  The expression is constructed by ANDing groups of OR expressions.
-    Expansion of columns is handled, as is replacement of columns with aliases,
-    if the column has already been expanded and aliased elsewhere.
-    """
-    from snuba.clickhouse.columns import Array
+    def simple_expression_builder(val: str) -> str:
+        return column_expr(dataset, val, query, parsing_context)
 
-    if not conditions:
-        return ""
+    def and_builder(expressions: Sequence[str]) -> str:
+        return " AND ".join(e for e in expressions if e)
 
-    if depth == 0:
-        # dedupe conditions at top level, but keep them in order
-        sub = OrderedDict(
-            (conditions_expr(dataset, cond, query, parsing_context, depth + 1), None)
-            for cond in conditions
+    def or_builder(expressions: Sequence[str]) -> str:
+        res = " OR ".join(expressions)
+        return "({})".format(res) if len(expressions) > 1 else res
+
+    def array_condition_builder(op: str, literals: Sequence[str], lhs: str) -> str:
+        any_or_all = "arrayExists" if op in POSITIVE_OPERATORS else "arrayAll"
+        return "{}(x -> assumeNotNull(x {} {}), {})".format(
+            any_or_all, op, escape_literal(literals), lhs,
         )
-        return " AND ".join(s for s in sub.keys() if s)
-    elif is_condition(conditions):
-        lhs, op, lit = dataset.process_condition(conditions)
 
-        # facilitate deduping IN conditions by sorting them.
-        if op in ("IN", "NOT IN") and isinstance(lit, tuple):
-            lit = tuple(sorted(lit))
+    def simple_condition_builder(lhs: str, op: str, literal: Any) -> str:
+        return "{} {} {}".format(lhs, op, escape_literal(literal))
 
-        # If the LHS is a simple column name that refers to an array column
-        # (and we are not arrayJoining on that column, which would make it
-        # scalar again) and the RHS is a scalar value, we assume that the user
-        # actually means to check if any (or all) items in the array match the
-        # predicate, so we return an `any(x == value for x in array_column)`
-        # type expression. We assume that operators looking for a specific value
-        # (IN, =, LIKE) are looking for rows where any array value matches, and
-        # exclusionary operators (NOT IN, NOT LIKE, !=) are looking for rows
-        # where all elements match (eg. all NOT LIKE 'foo').
-        columns = dataset.get_dataset_schemas().get_read_schema().get_columns()
-        if (
-            isinstance(lhs, str)
-            and lhs in columns
-            and isinstance(columns[lhs].type, Array)
-            and columns[lhs].base_name != query.get_arrayjoin()
-            and not isinstance(lit, (list, tuple))
-        ):
-            any_or_all = "arrayExists" if op in POSITIVE_OPERATORS else "arrayAll"
-            return "{}(x -> assumeNotNull(x {} {}), {})".format(
-                any_or_all,
-                op,
-                escape_literal(lit),
-                column_expr(dataset, lhs, query, parsing_context),
-            )
-        else:
-            return "{} {} {}".format(
-                column_expr(dataset, lhs, query, parsing_context),
-                op,
-                escape_literal(lit),
-            )
-
-    elif depth == 1:
-        sub = (
-            conditions_expr(dataset, cond, query, parsing_context, depth + 1)
-            for cond in conditions
-        )
-        sub = [s for s in sub if s]
-        res = " OR ".join(sub)
-        return "({})".format(res) if len(sub) > 1 else res
-    else:
-        raise InvalidConditionException(str(conditions))
+    return parse_conditions(
+        simple_expression_builder,
+        and_builder,
+        or_builder,
+        array_condition_builder,
+        simple_condition_builder,
+        dataset,
+        conditions,
+        query.get_arrayjoin(),
+        depth,
+    )

--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -6,8 +6,8 @@ from typing import Any, List, Optional, Sequence, Tuple, Union
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba.clickhouse.escaping import escape_alias, NEGATE_RE
-from snuba.query.parser.functions import parse_function
 from snuba.query.parser.conditions import parse_conditions
+from snuba.query.parser.functions import parse_function
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.query.schema import POSITIVE_OPERATORS

--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -111,7 +111,7 @@ def complex_column_expr(
 def conditions_expr(
     dataset, conditions, query: Query, parsing_context: ParsingContext, depth=0
 ):
-    def simple_expression_builder(val: str) -> str:
+    def simple_expression_builder(val: Any) -> str:
         return column_expr(dataset, val, query, parsing_context)
 
     def and_builder(expressions: Sequence[str]) -> str:

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Mapping, Optional
 
 from snuba.query.expressions import Expression, FunctionCall
 
@@ -7,6 +7,7 @@ class ConditionFunctions:
     """
     Function names for comparison operations.
     """
+
     EQ = "equals"
     NEQ = "notEquals"
     LTE = "lessOrEquals"
@@ -14,20 +15,46 @@ class ConditionFunctions:
     LT = "less"
     GT = "greater"
     IS_NULL = "isNull"
+    IS_NOT_NULL = "isNotNull"
+    LIKE = "like"
+    NOT_LIKE = "notLike"
+    IN = "in"
+    NOT_IN = "notIn"
+
+
+OPERATOR_TO_FUNCTION: Mapping[str, str] = {
+    ">": ConditionFunctions.GT,
+    "<": ConditionFunctions.LT,
+    ">=": ConditionFunctions.GTE,
+    "<=": ConditionFunctions.LTE,
+    "=": ConditionFunctions.EQ,
+    "!=": ConditionFunctions.NEQ,
+    "IN": ConditionFunctions.IN,
+    "NOT IN": ConditionFunctions.NOT_IN,
+    "IS NULL": ConditionFunctions.IS_NULL,
+    "IS NOT NULL": ConditionFunctions.IS_NOT_NULL,
+    "LIKE": ConditionFunctions.LIKE,
+    "NOT LIKE": ConditionFunctions.NOT_LIKE,
+}
 
 
 class BooleanFunctions:
     """
     Same as comparison functions but for boolean operators.
     """
+
     NOT = "not"
     AND = "and"
     OR = "or"
 
 
-def binary_condition(alias: Optional[str], function_name: str, lhs: Expression, rhs: Expression) -> FunctionCall:
+def binary_condition(
+    alias: Optional[str], function_name: str, lhs: Expression, rhs: Expression
+) -> FunctionCall:
     return FunctionCall(alias, function_name, [lhs, rhs])
 
 
-def unary_condition(alias: Optional[str], function_name: str, operand: Expression) -> FunctionCall:
+def unary_condition(
+    alias: Optional[str], function_name: str, operand: Expression
+) -> FunctionCall:
     return FunctionCall(alias, function_name, [operand])

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -1,0 +1,158 @@
+from typing import Any, Callable, Optional, OrderedDict, Sequence, TypeVar
+
+from snuba.datasets.dataset import Dataset
+from snuba.query.expressions import Column, Expression, Literal, FunctionCall
+from snuba.query.conditions import (
+    binary_condition,
+    ConditionFunctions,
+    BooleanFunctions,
+)
+from snuba.util import is_condition, QUOTED_LITERAL_RE
+
+
+TExpression = TypeVar("TExpression")
+
+
+class InvalidConditionException(Exception):
+    pass
+
+
+def parse_conditions(
+    simple_expression_builder: Callable[[str], TExpression],
+    and_builder: Callable[[Sequence[TExpression]], Optional[TExpression]],
+    or_builder: Callable[[Sequence[TExpression]], Optional[TExpression]],
+    array_condition_builder: Callable[[str, Sequence[str], TExpression], TExpression],
+    simple_condition_builder: Callable[[TExpression, str, Any], TExpression],
+    dataset: Dataset,
+    conditions: Any,
+    array_join: Optional[str],
+    depth: int = 0,
+) -> Optional[TExpression]:
+    """
+    Return a boolean expression suitable for putting in the WHERE clause of the
+    query.  The expression is constructed by ANDing groups of OR expressions.
+    Expansion of columns is handled, as is replacement of columns with aliases,
+    if the column has already been expanded and aliased elsewhere.
+    """
+    from snuba.clickhouse.columns import Array
+
+    if not conditions:
+        return ""
+
+    if depth == 0:
+        # dedupe conditions at top level, but keep them in order
+        sub = OrderedDict(
+            (
+                parse_conditions(
+                    simple_expression_builder,
+                    and_builder,
+                    or_builder,
+                    array_condition_builder,
+                    simple_condition_builder,
+                    dataset,
+                    cond,
+                    array_join,
+                    depth + 1,
+                ),
+                None,
+            )
+            for cond in conditions
+        )
+        return and_builder([s for s in sub.keys() if s])
+    elif is_condition(conditions):
+        lhs, op, lit = dataset.process_condition(conditions)
+
+        # facilitate deduping IN conditions by sorting them.
+        if op in ("IN", "NOT IN") and isinstance(lit, tuple):
+            lit = tuple(sorted(lit))
+
+        # If the LHS is a simple column name that refers to an array column
+        # (and we are not arrayJoining on that column, which would make it
+        # scalar again) and the RHS is a scalar value, we assume that the user
+        # actually means to check if any (or all) items in the array match the
+        # predicate, so we return an `any(x == value for x in array_column)`
+        # type expression. We assume that operators looking for a specific value
+        # (IN, =, LIKE) are looking for rows where any array value matches, and
+        # exclusionary operators (NOT IN, NOT LIKE, !=) are looking for rows
+        # where all elements match (eg. all NOT LIKE 'foo').
+        columns = dataset.get_dataset_schemas().get_read_schema().get_columns()
+        if (
+            isinstance(lhs, str)
+            and lhs in columns
+            and isinstance(columns[lhs].type, Array)
+            and columns[lhs].base_name != array_join
+            and not isinstance(lit, (list, tuple))
+        ):
+            return array_condition_builder(op, lit, simple_expression_builder(lhs))
+        else:
+            return simple_condition_builder(simple_expression_builder(lhs), op, lit)
+
+    elif depth == 1:
+        sub = (
+            parse_conditions(
+                simple_expression_builder,
+                and_builder,
+                or_builder,
+                array_condition_builder,
+                simple_condition_builder,
+                dataset,
+                cond,
+                array_join,
+                depth + 1,
+            )
+            for cond in conditions
+        )
+        return or_builder([s for s in sub if s])
+    else:
+        raise InvalidConditionException(str(conditions))
+
+
+def parse_conditions_to_expr(expr: Sequence[Any]) -> Expression:
+    def simple_expression_builder(val: str) -> Expression:
+        # TODO: This will use the schema of the dataset to decide
+        # if the expression is a column or a literal.
+        if QUOTED_LITERAL_RE.match(val):
+            return Literal(None, val[1:-1])
+        else:
+            return Column(None, val, None)
+
+    def multi_expression_builder(
+        expressions: Sequence[Expression], function: str
+    ) -> Optional[Expression]:
+        if len(expressions) == 0:
+            return None
+        if len(expressions) == 1:
+            return expressions[0]
+
+        return binary_condition(
+            None,
+            function,
+            expressions[0],
+            multi_expression_builder(function, expressions[1:]),
+        )
+
+    def and_builder(expressions: Sequence[Expression]) -> Optional[Expression]:
+        return multi_expression_builder(expressions, BooleanFunctions.AND)
+
+    def or_builder(expressions: Sequence[Expression]) -> Optional[Expression]:
+        return multi_expression_builder(expressions, BooleanFunctions.OR)
+
+    def array_condition_builder(
+        op: str, literals: Sequence[str], lhs: Expression
+    ) -> Expression:
+        pass
+
+    def simple_condition_builder(lhs: Expression, op: str, literal: Any) -> Expression:
+        pass
+
+    return parse_conditions(
+        simple_expression_builder,
+        and_builder,
+        or_builder,
+        array_condition_builder,
+        simple_condition_builder,
+        dataset,
+        conditions,
+        query.get_arrayjoin(),
+        depth,
+    )

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Optional, OrderedDict, Sequence, TypeVar
+from collections import OrderedDict
+from typing import Any, Callable, Optional, Sequence, TypeVar
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.expressions import (
@@ -105,7 +106,7 @@ def parse_conditions(
             return simple_condition_builder(operand_builder(lhs), op, lit)
 
     elif depth == 1:
-        sub = (
+        sub_expression = (
             parse_conditions(
                 operand_builder,
                 and_builder,
@@ -119,7 +120,7 @@ def parse_conditions(
             )
             for cond in conditions
         )
-        return or_builder([s for s in sub if s])
+        return or_builder([s for s in sub_expression if s])
     else:
         raise InvalidConditionException(str(conditions))
 

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -152,7 +152,7 @@ def parse_conditions_to_expr(
         op: str, literals: Sequence[str], lhs: Expression
     ) -> Expression:
         function_name = "arrayExists" if op in POSITIVE_OPERATORS else "arrayAll"
-        rhs = [Literal(None, s) for s in literals]
+        rhs = tuple(Literal(None, s) for s in literals)
 
         # Only IN and NOT IN can have a right hand side of the condition that is an
         # array of literals
@@ -162,24 +162,24 @@ def parse_conditions_to_expr(
         return FunctionCall(
             None,
             function_name,
-            [
+            (
                 Lambda(
                     None,
-                    ["x"],
+                    ("x",),
                     FunctionCall(
                         None,
                         "assumeNotNull",
-                        [
+                        (
                             FunctionCall(
                                 None,
                                 OPERATOR_TO_FUNCTION[op],
-                                [Argument(None, "x"), FunctionCall(None, "tuple", rhs)],
+                                (Argument(None, "x"), FunctionCall(None, "tuple", rhs)),
                             )
-                        ],
+                        ),
                     ),
                 ),
                 lhs,
-            ],
+            ),
         )
 
     def simple_condition_builder(lhs: Expression, op: str, literal: Any) -> Expression:

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -16,7 +16,7 @@ def parse_function(
         TExpression,
     ],
     expr: Any,
-    depth=0,
+    depth: int = 0,
 ) -> TExpression:
     """
     Parses a function expression in the Snuba syntax and produces the expected data structure

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -25,13 +25,13 @@ test_conditions = [
     (
         [["a", "=", 1]],
         FunctionCall(
-            None, ConditionFunctions.EQ, [Column(None, "a", None), Literal(None, 1)]
+            None, ConditionFunctions.EQ, (Column(None, "a", None), Literal(None, 1))
         ),
     ),
     (
         [[["a", "=", 1]]],
         FunctionCall(
-            None, ConditionFunctions.EQ, [Column(None, "a", None), Literal(None, 1)]
+            None, ConditionFunctions.EQ, (Column(None, "a", None), Literal(None, 1))
         ),
     ),
     (
@@ -39,18 +39,18 @@ test_conditions = [
         FunctionCall(
             None,
             BooleanFunctions.AND,
-            [
+            (
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "a", None), Literal(None, 1)],
+                    (Column(None, "a", None), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "b", None), Literal(None, 2)],
+                    (Column(None, "b", None), Literal(None, 2)),
                 ),
-            ],
+            ),
         ),
     ),
     (
@@ -58,18 +58,18 @@ test_conditions = [
         FunctionCall(
             None,
             BooleanFunctions.OR,
-            [
+            (
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "a", None), Literal(None, 1)],
+                    (Column(None, "a", None), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "b", None), Literal(None, 2)],
+                    (Column(None, "b", None), Literal(None, 2)),
                 ),
-            ],
+            ),
         ),
     ),
     (
@@ -77,29 +77,29 @@ test_conditions = [
         FunctionCall(
             None,
             BooleanFunctions.AND,
-            [
+            (
                 FunctionCall(
                     None,
                     BooleanFunctions.OR,
-                    [
+                    (
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            [Column(None, "a", None), Literal(None, 1)],
+                            (Column(None, "a", None), Literal(None, 1)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            [Column(None, "b", None), Literal(None, 2)],
+                            (Column(None, "b", None), Literal(None, 2)),
                         ),
-                    ],
+                    ),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "c", None), Literal(None, 3)],
+                    (Column(None, "c", None), Literal(None, 3)),
                 ),
-            ],
+            ),
         ),
     ),
     (
@@ -107,46 +107,46 @@ test_conditions = [
         FunctionCall(
             None,
             BooleanFunctions.AND,
-            [
+            (
                 FunctionCall(
                     None,
                     BooleanFunctions.OR,
-                    [
+                    (
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            [Column(None, "a", None), Literal(None, 1)],
+                            (Column(None, "a", None), Literal(None, 1)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            [Column(None, "b", None), Literal(None, 2)],
+                            (Column(None, "b", None), Literal(None, 2)),
                         ),
-                    ],
+                    ),
                 ),
                 FunctionCall(
                     None,
                     BooleanFunctions.OR,
-                    [
+                    (
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            [Column(None, "c", None), Literal(None, 3)],
+                            (Column(None, "c", None), Literal(None, 3)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            [Column(None, "d", None), Literal(None, 4)],
+                            (Column(None, "d", None), Literal(None, 4)),
                         ),
-                    ],
+                    ),
                 ),
-            ],
+            ),
         ),
     ),
     (
         [[["a", "=", 1], []]],
         FunctionCall(
-            None, ConditionFunctions.EQ, [Column(None, "a", None), Literal(None, 1)],
+            None, ConditionFunctions.EQ, (Column(None, "a", None), Literal(None, 1)),
         ),
     ),  # Malformed Condition Input
     (
@@ -154,18 +154,18 @@ test_conditions = [
         FunctionCall(
             None,
             BooleanFunctions.AND,
-            [
+            (
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [FunctionCall(None, "tag", ["foo"]), Literal(None, 1)],
+                    (FunctionCall(None, "tag", ("foo",)), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "b", None), Literal(None, 2)],
+                    (Column(None, "b", None), Literal(None, 2)),
                 ),
-            ],
+            ),
         ),
     ),  # Test functions in conditions
     (
@@ -173,18 +173,18 @@ test_conditions = [
         FunctionCall(
             None,
             BooleanFunctions.OR,
-            [
+            (
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [FunctionCall(None, "tag", ["foo"]), Literal(None, 1)],
+                    (FunctionCall(None, "tag", ("foo",)), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    [Column(None, "b", None), Literal(None, 2)],
+                    (Column(None, "b", None), Literal(None, 2)),
                 ),
-            ],
+            ),
         ),
     ),
     (
@@ -192,7 +192,7 @@ test_conditions = [
         FunctionCall(
             None,
             ConditionFunctions.LIKE,
-            [Column(None, "primary_hash", None), Literal(None, "%foo%")],
+            (Column(None, "primary_hash", None), Literal(None, "%foo%")),
         ),
     ),  # Test special output format of LIKE
     (
@@ -200,23 +200,23 @@ test_conditions = [
         FunctionCall(
             None,
             ConditionFunctions.EQ,
-            [
+            (
                 FunctionCall(
                     None,
                     "notEmpty",
-                    [
+                    (
                         FunctionCall(
                             None,
                             "arrayElement",
-                            [
+                            (
                                 Column(None, "exception_stacks.type", None),
                                 Literal(None, 1),
-                            ],
+                            ),
                         )
-                    ],
+                    ),
                 ),
                 Literal(None, 1),
-            ],
+            ),
         ),
     ),
     (
@@ -224,24 +224,24 @@ test_conditions = [
         FunctionCall(
             None,
             "arrayExists",
-            [
+            (
                 Lambda(
                     None,
-                    ["x"],
+                    ("x",),
                     FunctionCall(
                         None,
                         "assumeNotNull",
-                        [
+                        (
                             FunctionCall(
                                 None,
                                 ConditionFunctions.LIKE,
-                                [Argument(None, "x"), Literal(None, "%foo%")],
+                                (Argument(None, "x"), Literal(None, "%foo%")),
                             )
-                        ],
+                        ),
                     ),
                 ),
                 Column(None, "exception_frames.filename", None),
-            ],
+            ),
         ),
     ),  # Test scalar condition on array column is expanded as an iterator.
     (
@@ -249,24 +249,24 @@ test_conditions = [
         FunctionCall(
             None,
             "arrayAll",
-            [
+            (
                 Lambda(
                     None,
-                    ["x"],
+                    ("x",),
                     FunctionCall(
                         None,
                         "assumeNotNull",
-                        [
+                        (
                             FunctionCall(
                                 None,
                                 ConditionFunctions.NOT_LIKE,
-                                [Argument(None, "x"), Literal(None, "%foo%")],
+                                (Argument(None, "x"), Literal(None, "%foo%")),
                             )
-                        ],
+                        ),
                     ),
                 ),
                 Column(None, "exception_frames.filename", None),
-            ],
+            ),
         ),
     ),  # Test negative scalar condition on array column is expanded as an all() type iterator.
     (
@@ -276,14 +276,14 @@ test_conditions = [
         FunctionCall(
             None,
             ConditionFunctions.IN,
-            [
+            (
                 Column(None, "platform", None),
                 FunctionCall(
                     None,
                     "tuple",
-                    [Literal(None, "a"), Literal(None, "b"), Literal(None, "c")],
+                    (Literal(None, "a"), Literal(None, "b"), Literal(None, "c")),
                 ),
-            ],
+            ),
         ),
     ),  # Test that a duplicate IN condition is deduplicated even if the lists are in different orders.
 ]

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -5,7 +5,6 @@ from typing import Any, Sequence
 from snuba.datasets.factory import get_dataset
 from snuba.query.expressions import (
     Column,
-    CurriedFunctionCall,
     Expression,
     FunctionCall,
     Lambda,
@@ -13,10 +12,8 @@ from snuba.query.expressions import (
     Argument,
 )
 from snuba.query.conditions import (
-    binary_condition,
     ConditionFunctions,
     BooleanFunctions,
-    OPERATOR_TO_FUNCTION,
 )
 from snuba.query.parser.conditions import parse_conditions_to_expr
 from snuba.util import tuplify
@@ -196,7 +193,7 @@ test_conditions = [
                                 Column(None, "exception_stacks.type", None),
                                 Literal(None, 1),
                             ),
-                        )
+                        ),
                     ),
                 ),
                 Literal(None, 1),

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -237,7 +237,7 @@ test_conditions = [
             ConditionFunctions.LIKE,
             (Column(None, "primary_hash", None), Literal(None, "%foo%")),
         ),
-    ),  # Test special output format of LIKE
+    ),  # Test output format of LIKE
     (
         [[["notEmpty", ["arrayElement", ["exception_stacks.type", 1]]], "=", 1]],
         FunctionCall(

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -1,0 +1,295 @@
+import pytest
+
+from typing import Any, Sequence
+
+from snuba.datasets.factory import get_dataset
+from snuba.query.expressions import (
+    Column,
+    CurriedFunctionCall,
+    Expression,
+    FunctionCall,
+    Lambda,
+    Literal,
+    Argument,
+)
+from snuba.query.conditions import (
+    binary_condition,
+    ConditionFunctions,
+    BooleanFunctions,
+    OPERATOR_TO_FUNCTION,
+)
+from snuba.query.parser.conditions import parse_conditions_to_expr
+from snuba.util import tuplify
+
+test_conditions = [
+    (
+        [["a", "=", 1]],
+        FunctionCall(
+            None, ConditionFunctions.EQ, [Column(None, "a", None), Literal(None, 1)]
+        ),
+    ),
+    (
+        [[["a", "=", 1]]],
+        FunctionCall(
+            None, ConditionFunctions.EQ, [Column(None, "a", None), Literal(None, 1)]
+        ),
+    ),
+    (
+        [["a", "=", 1], ["b", "=", 2]],
+        FunctionCall(
+            None,
+            BooleanFunctions.AND,
+            [
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "a", None), Literal(None, 1)],
+                ),
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "b", None), Literal(None, 2)],
+                ),
+            ],
+        ),
+    ),
+    (
+        [[["a", "=", 1], ["b", "=", 2]]],
+        FunctionCall(
+            None,
+            BooleanFunctions.OR,
+            [
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "a", None), Literal(None, 1)],
+                ),
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "b", None), Literal(None, 2)],
+                ),
+            ],
+        ),
+    ),
+    (
+        [[["a", "=", 1], ["b", "=", 2]], ["c", "=", 3]],
+        FunctionCall(
+            None,
+            BooleanFunctions.AND,
+            [
+                FunctionCall(
+                    None,
+                    BooleanFunctions.OR,
+                    [
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            [Column(None, "a", None), Literal(None, 1)],
+                        ),
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            [Column(None, "b", None), Literal(None, 2)],
+                        ),
+                    ],
+                ),
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "c", None), Literal(None, 3)],
+                ),
+            ],
+        ),
+    ),
+    (
+        [[["a", "=", 1], ["b", "=", 2]], [["c", "=", 3], ["d", "=", 4]]],
+        FunctionCall(
+            None,
+            BooleanFunctions.AND,
+            [
+                FunctionCall(
+                    None,
+                    BooleanFunctions.OR,
+                    [
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            [Column(None, "a", None), Literal(None, 1)],
+                        ),
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            [Column(None, "b", None), Literal(None, 2)],
+                        ),
+                    ],
+                ),
+                FunctionCall(
+                    None,
+                    BooleanFunctions.OR,
+                    [
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            [Column(None, "c", None), Literal(None, 3)],
+                        ),
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            [Column(None, "d", None), Literal(None, 4)],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ),
+    (
+        [[["a", "=", 1], []]],
+        FunctionCall(
+            None, ConditionFunctions.EQ, [Column(None, "a", None), Literal(None, 1)],
+        ),
+    ),  # Malformed Condition Input
+    (
+        [[[["tag", ["foo"]], "=", 1], ["b", "=", 2]]],
+        FunctionCall(
+            None,
+            BooleanFunctions.AND,
+            [
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [FunctionCall(None, "tag", ["foo"]), Literal(None, 1)],
+                ),
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "b", None), Literal(None, 2)],
+                ),
+            ],
+        ),
+    ),  # Test functions in conditions
+    (
+        [[["tags[foo]", "=", 1], ["b", "=", 2]]],
+        FunctionCall(
+            None,
+            BooleanFunctions.OR,
+            [
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [FunctionCall(None, "tag", ["foo"]), Literal(None, 1)],
+                ),
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    [Column(None, "b", None), Literal(None, 2)],
+                ),
+            ],
+        ),
+    ),
+    (
+        [["primary_hash", "LIKE", "%foo%"]],
+        FunctionCall(
+            None,
+            ConditionFunctions.LIKE,
+            [Column(None, "primary_hash", None), Literal(None, "%foo%")],
+        ),
+    ),  # Test special output format of LIKE
+    (
+        [[["notEmpty", ["arrayElement", ["exception_stacks.type", 1]]], "=", 1]],
+        FunctionCall(
+            None,
+            ConditionFunctions.EQ,
+            [
+                FunctionCall(
+                    None,
+                    "notEmpty",
+                    [
+                        FunctionCall(
+                            None,
+                            "arrayElement",
+                            [
+                                Column(None, "exception_stacks.type", None),
+                                Literal(None, 1),
+                            ],
+                        )
+                    ],
+                ),
+                Literal(None, 1),
+            ],
+        ),
+    ),
+    (
+        [["exception_frames.filename", "LIKE", "%foo%"]],
+        FunctionCall(
+            None,
+            "arrayExists",
+            [
+                Lambda(
+                    None,
+                    ["x"],
+                    FunctionCall(
+                        None,
+                        "assumeNotNull",
+                        [
+                            FunctionCall(
+                                None,
+                                ConditionFunctions.LIKE,
+                                [Argument(None, "x"), Literal(None, "%foo%")],
+                            )
+                        ],
+                    ),
+                ),
+                Column(None, "exception_frames.filename", None),
+            ],
+        ),
+    ),  # Test scalar condition on array column is expanded as an iterator.
+    (
+        [["exception_frames.filename", "NOT LIKE", "%foo%"]],
+        FunctionCall(
+            None,
+            "arrayAll",
+            [
+                Lambda(
+                    None,
+                    ["x"],
+                    FunctionCall(
+                        None,
+                        "assumeNotNull",
+                        [
+                            FunctionCall(
+                                None,
+                                ConditionFunctions.NOT_LIKE,
+                                [Argument(None, "x"), Literal(None, "%foo%")],
+                            )
+                        ],
+                    ),
+                ),
+                Column(None, "exception_frames.filename", None),
+            ],
+        ),
+    ),  # Test negative scalar condition on array column is expanded as an all() type iterator.
+    (
+        tuplify(
+            [["platform", "IN", ["a", "b", "c"]], ["platform", "IN", ["c", "b", "a"]]]
+        ),
+        FunctionCall(
+            None,
+            ConditionFunctions.IN,
+            [
+                Column(None, "platform", None),
+                FunctionCall(
+                    None,
+                    "tuple",
+                    [Literal(None, "a"), Literal(None, "b"), Literal(None, "c")],
+                ),
+            ],
+        ),
+    ),  # Test that a duplicate IN condition is deduplicated even if the lists are in different orders.
+]
+
+
+@pytest.mark.parametrize("conditions, expected", test_conditions)
+def test_conditions_expr(conditions: Sequence[Any], expected: Expression) -> None:
+    dataset = get_dataset("events")
+    assert parse_conditions_to_expr(conditions, dataset, None) == expected

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -19,6 +19,8 @@ from snuba.query.parser.conditions import parse_conditions_to_expr
 from snuba.util import tuplify
 
 test_conditions = [
+    ([], None,),
+    ([[[]], []], None,),
     (
         [["a", "=", 1]],
         FunctionCall(
@@ -51,6 +53,36 @@ test_conditions = [
         ),
     ),
     (
+        [["a", "=", 1], ["b", "=", 2], ["c", "=", 3]],
+        FunctionCall(
+            None,
+            BooleanFunctions.AND,
+            (
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    (Column(None, "a", None), Literal(None, 1)),
+                ),
+                FunctionCall(
+                    None,
+                    BooleanFunctions.AND,
+                    (
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            (Column(None, "b", None), Literal(None, 2)),
+                        ),
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            (Column(None, "c", None), Literal(None, 3)),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),  # Odd number of conditions. Right associative expression
+    (
         [[["a", "=", 1], ["b", "=", 2]]],
         FunctionCall(
             None,
@@ -69,6 +101,36 @@ test_conditions = [
             ),
         ),
     ),
+    (
+        [[["a", "=", 1], ["b", "=", 2], ["c", "=", 3]]],
+        FunctionCall(
+            None,
+            BooleanFunctions.OR,
+            (
+                FunctionCall(
+                    None,
+                    ConditionFunctions.EQ,
+                    (Column(None, "a", None), Literal(None, 1)),
+                ),
+                FunctionCall(
+                    None,
+                    BooleanFunctions.OR,
+                    (
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            (Column(None, "b", None), Literal(None, 2)),
+                        ),
+                        FunctionCall(
+                            None,
+                            ConditionFunctions.EQ,
+                            (Column(None, "c", None), Literal(None, 3)),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    ),  # Odd number of conditions. Right associative expression
     (
         [[["a", "=", 1], ["b", "=", 2]], ["c", "=", 3]],
         FunctionCall(
@@ -217,7 +279,7 @@ test_conditions = [
                                 None,
                                 ConditionFunctions.LIKE,
                                 (Argument(None, "x"), Literal(None, "%foo%")),
-                            )
+                            ),
                         ),
                     ),
                 ),
@@ -242,7 +304,7 @@ test_conditions = [
                                 None,
                                 ConditionFunctions.NOT_LIKE,
                                 (Argument(None, "x"), Literal(None, "%foo%")),
-                            )
+                            ),
                         ),
                     ),
                 ),

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -153,12 +153,15 @@ test_conditions = [
         [[[["tag", ["foo"]], "=", 1], ["b", "=", 2]]],
         FunctionCall(
             None,
-            BooleanFunctions.AND,
+            BooleanFunctions.OR,
             (
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (FunctionCall(None, "tag", ("foo",)), Literal(None, 1)),
+                    (
+                        FunctionCall(None, "tag", (Column(None, "foo", None),)),
+                        Literal(None, 1),
+                    ),
                 ),
                 FunctionCall(
                     None,
@@ -168,25 +171,6 @@ test_conditions = [
             ),
         ),
     ),  # Test functions in conditions
-    (
-        [[["tags[foo]", "=", 1], ["b", "=", 2]]],
-        FunctionCall(
-            None,
-            BooleanFunctions.OR,
-            (
-                FunctionCall(
-                    None,
-                    ConditionFunctions.EQ,
-                    (FunctionCall(None, "tag", ("foo",)), Literal(None, 1)),
-                ),
-                FunctionCall(
-                    None,
-                    ConditionFunctions.EQ,
-                    (Column(None, "b", None), Literal(None, 2)),
-                ),
-            ),
-        ),
-    ),
     (
         [["primary_hash", "LIKE", "%foo%"]],
         FunctionCall(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,7 +71,7 @@ class TestUtil(BaseTest):
         conditions = []
         assert (
             conditions_expr(dataset, conditions, Query({}, source), ParsingContext())
-            is None
+            == ""
         )
 
         conditions = [[[]], []]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -68,6 +68,18 @@ class TestUtil(BaseTest):
             == "a = 1"
         )
 
+        conditions = []
+        assert (
+            conditions_expr(dataset, conditions, Query({}, source), ParsingContext())
+            is None
+        )
+
+        conditions = [[[]], []]
+        assert (
+            conditions_expr(dataset, conditions, Query({}, source), ParsingContext())
+            == ""
+        )
+
         conditions = [[["a", "=", 1]]]
         assert (
             conditions_expr(dataset, conditions, Query({}, source), ParsingContext())


### PR DESCRIPTION
This takes the same approach of complex_column_expr to preserve the current parser logic. It takes conditions_expr (that essentially defines lexing and parsing for conditions), it makes that function parametric so that it can be used to build any type of expressions.

It also provides a function `parse_conditions_to_expr` that parses the Snuba conditions into a FunctionCall. 

Limitation: it does not resolve columns yet. This is not a blocker, it will be useful later when processing joins.

test plan:
- added a test to mimic test_util, but for the new data model