### PR TITLE
ref(datasets): Improve type coverage

### DIFF
--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -37,7 +37,7 @@ class GroupedMessageDataset(CdcDataset):
 
     POSTGRES_TABLE = "sentry_groupedmessage"
 
-    def __init__(self):
+    def __init__(self) -> None:
         columns = ColumnSet(
             [
                 # columns to maintain the dataset

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -44,7 +44,7 @@ class Dataset(object):
         dataset_schemas: DatasetSchemas,
         *,
         table_writer: Optional[TableWriter] = None,
-    ):
+    ) -> None:
         self.__dataset_schemas = dataset_schemas
         self.__table_writer = table_writer
 
@@ -135,7 +135,7 @@ class TimeSeriesDataset(Dataset):
         time_group_columns: Mapping[str, str],
         time_parse_columns: Sequence[str],
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(*args, dataset_schemas=dataset_schemas, **kwargs)
         # Convenience columns that evaluate to a bucketed time. The bucketing
         # depends on the granularity parameter.

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -86,7 +86,7 @@ class EventsDataset(TimeSeriesDataset):
     and the particular quirks of storing and querying them.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         metadata_columns = ColumnSet(
             [
                 # optional stream related data

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -64,7 +64,7 @@ class OutcomesDataset(TimeSeriesDataset):
     Tracks event ingestion outcomes in Sentry.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         write_columns = ColumnSet(
             [
                 ("org_id", UInt(64)),

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -19,7 +19,7 @@ from snuba.query.timeseries import TimeSeriesExtension
 
 
 class OutcomesRawDataset(TimeSeriesDataset):
-    def __init__(self):
+    def __init__(self) -> None:
         read_columns = ColumnSet(
             [
                 ("org_id", UInt(64)),

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -107,7 +107,7 @@ def transactions_migrations(
 
 
 class TransactionsDataset(TimeSeriesDataset):
-    def __init__(self):
+    def __init__(self) -> None:
         columns = ColumnSet(
             [
                 ("project_id", UInt(64)),


### PR DESCRIPTION
This adds a return type to all dataset constructors (so that they are analyzed) and adds type annotations to `snuba.clickhouse.columns` where straightforward, since this directly impacts the level of coverage for the dataset itself.

This removes many noisy errors about functions missing annotations from `snuba/clickhouse/columns.py` and "Call to untyped function" errors from dataset constructors.

This brings the overall coverage of the `snuba` module from 79.92% to 83.17%, and removes many errors (and adds a few new ones):

```diff
-Found 747 errors in 78 files (checked 125 source files)
+Found 653 errors in 78 files (checked 125 source files)
```

<details>

```diff
diff before after
index 9624bc6..017ce16 100644
--- before
+++ after
@@ -26,7 +26,7 @@ Script: index
 | snuba.cli.replacer                             |  11.24% imprecise |   178 LOC |
 | snuba.clickhouse                               |   0.00% imprecise |     1 LOC |
 | snuba.clickhouse.astquery                      |   1.37% imprecise |   146 LOC |
-| snuba.clickhouse.columns                       |  49.21% imprecise |   317 LOC |
+| snuba.clickhouse.columns                       |  18.46% imprecise |   325 LOC |
 | snuba.clickhouse.escaping                      |   2.50% imprecise |    40 LOC |
 | snuba.clickhouse.formatter                     |   1.98% imprecise |   101 LOC |
 | snuba.clickhouse.http                          |  16.16% imprecise |    99 LOC |
@@ -40,25 +40,25 @@ Script: index
 | snuba.datasets                                 |   0.00% imprecise |     0 LOC |
 | snuba.datasets.cdc                             |   8.33% imprecise |    24 LOC |
 | snuba.datasets.cdc.cdcprocessors               |  16.15% imprecise |   161 LOC |
-| snuba.datasets.cdc.groupassignee               |  16.47% imprecise |    85 LOC |
+| snuba.datasets.cdc.groupassignee               |   7.06% imprecise |    85 LOC |
 | snuba.datasets.cdc.groupassignee_processor     |  22.00% imprecise |   100 LOC |
-| snuba.datasets.cdc.groupedmessage              |  43.96% imprecise |    91 LOC |
+| snuba.datasets.cdc.groupedmessage              |  12.09% imprecise |    91 LOC |
 | snuba.datasets.cdc.groupedmessage_processor    |  23.08% imprecise |   130 LOC |
 | snuba.datasets.dataset                         |   9.14% imprecise |   186 LOC |
 | snuba.datasets.dataset_schemas                 |   3.70% imprecise |    54 LOC |
-| snuba.datasets.discover                        |  31.52% imprecise |   330 LOC |
-| snuba.datasets.events                          |  43.80% imprecise |   395 LOC |
+| snuba.datasets.discover                        |  11.52% imprecise |   330 LOC |
+| snuba.datasets.events                          |  10.63% imprecise |   395 LOC |
 | snuba.datasets.events_processor                |  53.38% imprecise |   429 LOC |
 | snuba.datasets.factory                         |   2.90% imprecise |    69 LOC |
 | snuba.datasets.groups                          |   3.39% imprecise |   177 LOC |
-| snuba.datasets.outcomes                        |  33.70% imprecise |   184 LOC |
-| snuba.datasets.outcomes_raw                    |  33.85% imprecise |    65 LOC |
+| snuba.datasets.outcomes                        |   3.80% imprecise |   184 LOC |
+| snuba.datasets.outcomes_raw                    |   0.00% imprecise |    65 LOC |
 | snuba.datasets.schemas                         |   2.59% imprecise |   116 LOC |
 | snuba.datasets.schemas.join                    |   0.59% imprecise |   169 LOC |
-| snuba.datasets.schemas.tables                  |   0.94% imprecise |   318 LOC |
+| snuba.datasets.schemas.tables                  |   0.31% imprecise |   318 LOC |
 | snuba.datasets.table_storage                   |  14.60% imprecise |   137 LOC |
 | snuba.datasets.tags_column_processor           |   8.61% imprecise |   151 LOC |
-| snuba.datasets.transactions                    |  33.46% imprecise |   254 LOC |
+| snuba.datasets.transactions                    |  12.99% imprecise |   254 LOC |
 | snuba.datasets.transactions_processor          |  24.08% imprecise |   191 LOC |
 | snuba.migrate                                  |  48.00% imprecise |    50 LOC |
 | snuba.optimize                                 |  34.41% imprecise |    93 LOC |
@@ -132,5 +132,5 @@ Script: index
 | snuba.views                                    |  42.66% imprecise |   497 LOC |
 | snuba.writer                                   |  19.15% imprecise |    47 LOC |
 +------------------------------------------------+-------------------+-----------+
-| Total                                          |  20.08% imprecise | 14241 LOC |
+| Total                                          |  16.83% imprecise | 14249 LOC |
 +------------------------------------------------+-------------------+-----------+

```
</details>