### PR TITLE
ref(cli): Allow running snuba via `python -m`

### DIFF
--- a/snuba/__main__.py
+++ b/snuba/__main__.py
@@ -1,0 +1,4 @@
+if __name__ == "__main__":
+    from snuba.cli import main
+
+    main()


### PR DESCRIPTION
I keep forgetting to do this and I finally remembered. This allows doing things like running `python -m pdb -m snuba` which will automatically drop into PDB on an uncaught exception.