### PR TITLE
feat: Improve Discover column selection

### DIFF
--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -1,9 +1,9 @@
 import pytest
-from typing import Sequence
+from typing import Any, MutableMapping
 from tests.base import BaseDatasetTest
 
 from snuba.datasets.factory import get_dataset
-from snuba.query.query import Condition, Query
+from snuba.query.query import Query
 from snuba.request.request_settings import RequestSettings
 
 
@@ -17,17 +17,22 @@ def get_dataset_source(dataset_name):
 
 
 test_data = [
-    ([["type", "=", "transaction"]], "transactions",),
-    ([["type", "!=", "transaction"]], "events",),
-    ([], "events",),
-    ([["duration", "=", 0]], "transactions",),
+    ({"conditions": [["type", "=", "transaction"]]}, "transactions",),
+    ({"conditions": [["type", "!=", "transaction"]]}, "events",),
+    ({"conditions": []}, "events",),
+    ({"conditions": [["duration", "=", 0]]}, "transactions",),
+    # No conditions, other referenced columns
+    ({"selected_columns": ["group_id"]}, "events"),
+    ({"selected_columns": ["trace_id"]}, "transactions"),
+    ({"selected_columns": ["group_id", "trace_id"]}, "events"),
+    ({"aggregations": [["max", "duration", "max_duration"]]}, "transactions"),
 ]
 
 
 class TestDiscover(BaseDatasetTest):
-    @pytest.mark.parametrize("conditions, expected_dataset", test_data)
-    def test_data_source(self, conditions: Sequence[Condition], expected_dataset: str):
-        query = Query({"conditions": conditions}, get_dataset_source("discover"))
+    @pytest.mark.parametrize("query_body, expected_dataset", test_data)
+    def test_data_source(self, query_body: MutableMapping[str, Any], expected_dataset: str):
+        query = Query(query_body, get_dataset_source("discover"))
 
         request_settings = RequestSettings(turbo=False, consistent=False, debug=False)
         for processor in get_dataset("discover").get_query_processors():


### PR DESCRIPTION
If no dataset specific condition exists on a query use the other
referenced columns to help choose the dataset.

This helps ensure we return more meaningful results when the detected
dataset is ambiguous. This comes up on the organization_events_stats
endpoint in Sentry where no stats would be displayed if "duration",
or "p95" was selected as the y Axis (and no conditions were provided),
as the transactions dataset would not otherwise be selected.