### PR TITLE
perf: Support flattened tags in the discover dataset

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -289,12 +289,15 @@ class DiscoverDataset(TimeSeriesDataset):
                 post_processors={
                     TRANSACTIONS: [
                         NestedFieldConditionOptimizer(
-                            "tags", "_tags_flattened", "timestamp", BEGINNING_OF_TIME
+                            "tags",
+                            "_tags_flattened",
+                            {"start_ts", "finish_ts", "timestamp"},
+                            BEGINNING_OF_TIME,
                         ),
                         NestedFieldConditionOptimizer(
                             "contexts",
                             "_contexts_flattened",
-                            "timestamp",
+                            {"start_ts", "finish_ts", "timestamp"},
                             BEGINNING_OF_TIME,
                         ),
                     ]

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -16,12 +16,14 @@ from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.schemas import Schema, RelationalSource
+from snuba.datasets.transactions import BEGINNING_OF_TIME
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
@@ -31,7 +33,9 @@ EVENTS = "events"
 TRANSACTIONS = "transactions"
 
 
-def detect_dataset(query: Query, events_columns: ColumnSet, transactions_columns: ColumnSet) -> str:
+def detect_dataset(
+    query: Query, events_columns: ColumnSet, transactions_columns: ColumnSet
+) -> str:
     """
     Given a query, we attempt to guess whether it is better to fetch data from the
     "events" or "transactions" dataset. This is going to be wrong in some cases.
@@ -66,6 +70,10 @@ def detect_dataset(query: Query, events_columns: ColumnSet, transactions_columns
 
 
 class DiscoverSource(RelationalSource):
+    # TODO: Make this generic. It does not need to be discover specific.
+    # A mutable RelationalSource that switches between multiple datasets
+    # can be used in other scenarios.
+
     def __init__(self, columns: ColumnSet, table_source: RelationalSource) -> None:
         self.__columns = columns
         self.__table_source = table_source
@@ -103,22 +111,32 @@ class DatasetSelector(QueryProcessor):
     the detected dataset.
     """
 
+    # TODO: Make this generic. It does not need to be discover specific.
+
     def __init__(
-        self, discover_source: RelationalSource, events_columns: ColumnSet, transactions_columns: ColumnSet
+        self,
+        discover_source: RelationalSource,
+        events_columns: ColumnSet,
+        transactions_columns: ColumnSet,
+        followup_processors: Mapping[str, Sequence[QueryProcessor]],
     ) -> None:
         self.__discover_source = discover_source
         self.__events_columns = events_columns
         self.__transactions_columns = transactions_columns
+        # These are the processors that need to run depending on the selected dataset.
+        # Adding them here instead of as top level processors running their own conditions
+        # to make the coupling explicit.
+        self.__followup_processors = followup_processors
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         detected_dataset = detect_dataset(
-            query,
-            self.__events_columns,
-            self.__transactions_columns
+            query, self.__events_columns, self.__transactions_columns
         )
         source = query.get_data_source()
         assert isinstance(source, DiscoverSource)
         source.set_table_source(detected_dataset)
+        for processor in self.__followup_processors.get(detected_dataset, []):
+            processor.process_query(query, request_settings)
 
 
 class DiscoverSchema(Schema):
@@ -264,7 +282,24 @@ class DiscoverDataset(TimeSeriesDataset):
         discover_source = self.get_dataset_schemas().get_read_schema().get_data_source()
 
         return [
-            DatasetSelector(discover_source, self.__events_columns, self.__transactions_columns),
+            DatasetSelector(
+                discover_source=discover_source,
+                events_columns=self.__events_columns,
+                transactions_columns=self.__transactions_columns,
+                followup_processors={
+                    TRANSACTIONS: [
+                        NestedFieldConditionOptimizer(
+                            "tags", "_tags_flattened", "timestamp", BEGINNING_OF_TIME
+                        ),
+                        NestedFieldConditionOptimizer(
+                            "contexts",
+                            "_contexts_flattened",
+                            "timestamp",
+                            BEGINNING_OF_TIME,
+                        ),
+                    ]
+                },
+            ),
             PrewhereProcessor(),
         ]
 
@@ -287,7 +322,9 @@ class DiscoverDataset(TimeSeriesDataset):
         parsing_context: ParsingContext,
         table_alias: str = "",
     ):
-        detected_dataset = detect_dataset(query, self.__events_columns, self.__transactions_columns)
+        detected_dataset = detect_dataset(
+            query, self.__events_columns, self.__transactions_columns
+        )
 
         if detected_dataset == TRANSACTIONS:
             if column_name == "time":

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -246,9 +246,12 @@ class TransactionsDataset(TimeSeriesDataset):
         return [
             PrewhereProcessor(),
             NestedFieldConditionOptimizer(
-                "tags", "_tags_flattened", "start_ts", BEGINNING_OF_TIME
+                "tags", "_tags_flattened", {"start_ts", "finish_ts"}, BEGINNING_OF_TIME
             ),
             NestedFieldConditionOptimizer(
-                "contexts", "_contexts_flattened", "start_ts", BEGINNING_OF_TIME
+                "contexts",
+                "_contexts_flattened",
+                {"start_ts", "finish_ts"},
+                BEGINNING_OF_TIME,
             ),
         ]

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -107,6 +107,7 @@ class NestedFieldConditionOptimizer(QueryProcessor):
         conditions = query.get_conditions()
         if not conditions:
             return
+
         # Enable the processor only if we have enough data in the flattened
         # columns. Which have been deployed at BEGINNING_OF_TIME. If the query
         # starts earlier than that we do not apply the optimization.
@@ -133,6 +134,7 @@ class NestedFieldConditionOptimizer(QueryProcessor):
                         return
             if not apply_optimization:
                 return
+
         new_conditions = []
         positive_like_expression: List[str] = []
         negative_like_expression: List[str] = []

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -107,7 +107,6 @@ class NestedFieldConditionOptimizer(QueryProcessor):
         conditions = query.get_conditions()
         if not conditions:
             return
-
         # Enable the processor only if we have enough data in the flattened
         # columns. Which have been deployed at BEGINNING_OF_TIME. If the query
         # starts earlier than that we do not apply the optimization.
@@ -134,7 +133,6 @@ class NestedFieldConditionOptimizer(QueryProcessor):
                         return
             if not apply_optimization:
                 return
-
         new_conditions = []
         positive_like_expression: List[str] = []
         negative_like_expression: List[str] = []

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -38,6 +38,20 @@ test_data = [
             "conditions": [
                 ["tags[test.tag]", "=", "1"],
                 ["c", "=", "3"],
+                ["finish_ts", ">", "2019-12-18T06:35:17"],
+            ]
+        },
+        [
+            ["c", "=", "3"],
+            ["finish_ts", ">", "2019-12-18T06:35:17"],
+            ["tags_map", "LIKE", "%|test.tag=1|%"],
+        ],
+    ),  # One simple tag condition, different timestamp
+    (
+        {
+            "conditions": [
+                ["tags[test.tag]", "=", "1"],
+                ["c", "=", "3"],
                 ["start_ts", ">", "2019-01-01T06:35:17"],
             ]
         },
@@ -184,7 +198,7 @@ def test_nested_optimizer(query_body, expected_condition) -> None:
     processor = NestedFieldConditionOptimizer(
         nested_col="tags",
         flattened_col="tags_map",
-        start_ts_col="start_ts",
+        timestamp_cols={"start_ts", "finish_ts"},
         beginning_of_time=datetime(2019, 12, 11, 0, 0, 0),
     )
     processor.process_query(query, request_settings)


### PR DESCRIPTION
The flattened tags column has been used in the transactions dataset for a while. This adds the support to the discover dataset.

Specifically what this PR introduces is the ability of a query processor to delegate further processing to followup processors to make the dependency explicit instead of making it hidden.
Now this support is in the discover dataset, making it generic is a TODO and requires the DatasetSelector to be made generic first.