### PR TITLE
feat(streams): Add `tell` and `seek` to public consumer API

### DIFF
--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -122,6 +122,24 @@ class TickConsumer(Consumer[Tick]):
 
         return result
 
+    def tell(self) -> Mapping[Partition, int]:
+        # If there is no previous message for a partition, return the current
+        # consumer offset, otherwise return the previous message offset (which
+        # will be the next offset returned for that partition) to make the
+        # behavior of the consumer consistent with what would typically be
+        # expected by the caller.
+        return {
+            partition: (
+                self.__previous_messages[partition].offset
+                if partition in self.__previous_messages
+                else offset
+            )
+            for partition, offset in self.__consumer.tell().items()
+        }
+
+    def seek(self, offsets: Mapping[Partition, int]) -> None:
+        raise NotImplementedError
+
     def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         return self.__consumer.stage_offsets(offsets)
 

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -71,6 +71,13 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def tell(self) -> Mapping[Partition, int]:
+        """
+        Return the working offsets for all currently assigned positions.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         """
         Stage offsets to be committed. If an offset has already been staged

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -78,6 +78,26 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def seek(self, offsets: Mapping[Partition, int]) -> None:
+        """
+        Update the working offsets for the provided partitions.
+
+        When using this method, it is possible to set a partition to an
+        invalid offset without an immediate error. (Examples of invalid
+        offsets include an offset that is too low and has already been
+        dropped by the broker due to data retention policies, or an offset
+        that is too high which is not yet associated with a message.) Since
+        this method only updates the local working offset (and does not
+        communicate with the broker), setting an invalid offset will cause a
+        subsequent ``poll`` call to raise an exception, even though the call
+        to ``seek`` succeeded.
+
+        If any provided partitions are not in the assignment set, an
+        exception will be raised and no offsets will be modified.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         """
         Stage offsets to be committed. If an offset has already been staged

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -86,6 +86,9 @@ class DummyConsumer(Consumer[TPayload]):
 
         return None
 
+    def tell(self) -> Mapping[Partition, int]:
+        return self.__offsets
+
     def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         assert not self.__closed
 

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -9,7 +9,7 @@ from typing import (
 )
 
 from snuba.utils.streams.consumer import Consumer
-from snuba.utils.streams.types import Message, Partition, Topic, TPayload
+from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic, TPayload
 
 
 epoch = datetime(2019, 12, 19)
@@ -75,10 +75,12 @@ class DummyConsumer(Consumer[TPayload]):
 
         # TODO: Throw ``EndOfPartition`` errors.
         for partition, offset in sorted(self.__offsets.items()):
+            messages = self.__messages[partition]
             try:
-                payload = self.__messages[partition][offset]
+                payload = messages[offset]
             except IndexError:
-                pass
+                if not offset == len(messages):
+                    raise ConsumerError("invalid offset")
             else:
                 message = Message(partition, offset, payload, epoch)
                 self.__offsets[partition] = message.get_next_offset()
@@ -88,6 +90,12 @@ class DummyConsumer(Consumer[TPayload]):
 
     def tell(self) -> Mapping[Partition, int]:
         return self.__offsets
+
+    def seek(self, offsets: Mapping[Partition, int]) -> None:
+        if offsets.keys() - self.__offsets.keys():
+            raise ConsumerError("cannot seek on unassigned partitions")
+
+        self.__offsets.update(offsets)
 
     def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
         assert not self.__closed

--- a/tests/subscriptions/test_consumer.py
+++ b/tests/subscriptions/test_consumer.py
@@ -1,7 +1,9 @@
+import pytest
+
 from snuba.subscriptions.consumer import Tick, TickConsumer
 from snuba.utils.streams.consumer import Consumer
 from snuba.utils.streams.dummy import DummyConsumer, epoch
-from snuba.utils.streams.types import Message, Partition, Topic
+from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic
 from snuba.utils.types import Interval
 
 
@@ -100,3 +102,49 @@ def test_tick_consumer() -> None:
         Partition(topic, 0): 3,
         Partition(topic, 1): 1,
     }
+
+    consumer.seek({Partition(topic, 0): 1})
+
+    assert consumer.tell() == {
+        Partition(topic, 0): 1,
+        Partition(topic, 1): 0,
+    }
+
+    assert inner_consumer.tell() == {
+        Partition(topic, 0): 1,
+        Partition(topic, 1): 1,
+    }
+
+    # consume 0, 1
+    assert consumer.poll() is None
+
+    assert consumer.tell() == {
+        Partition(topic, 0): 1,
+        Partition(topic, 1): 0,
+    }
+
+    assert inner_consumer.tell() == {
+        Partition(topic, 0): 2,
+        Partition(topic, 1): 1,
+    }
+
+    # consume 0, 2
+    assert consumer.poll() == Message(
+        Partition(topic, 0),
+        1,
+        Tick(offsets=Interval(1, 2), timestamps=Interval(epoch, epoch)),
+        epoch,
+    )
+
+    assert consumer.tell() == {
+        Partition(topic, 0): 2,
+        Partition(topic, 1): 0,
+    }
+
+    assert inner_consumer.tell() == {
+        Partition(topic, 0): 3,
+        Partition(topic, 1): 1,
+    }
+
+    with pytest.raises(ConsumerError):
+        consumer.seek({Partition(topic, -1): 0})

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -1,0 +1,51 @@
+import pytest
+
+from snuba.utils.streams.dummy import DummyConsumer
+from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic
+
+
+def test_working_offsets() -> None:
+    topic = Topic("example")
+    partition = Partition(topic, 0)
+
+    consumer = DummyConsumer({partition: [0]})
+    consumer.subscribe([topic])
+
+    # NOTE: This will eventually need to be controlled by a generalized
+    # consumer auto offset reset setting.
+    assert consumer.tell() == {partition: 0}
+
+    message = consumer.poll()
+    assert isinstance(message, Message)
+    assert message.offset == 0
+    assert consumer.tell() == {partition: 1}
+
+    # It should be safe to try to read the first missing offset (index) in the
+    # partition.
+    assert consumer.poll() is None
+
+    consumer.seek({partition: 0})
+    assert consumer.tell() == {partition: 0}
+
+    message = consumer.poll()
+    assert isinstance(message, Message)
+    assert message.offset == 0
+    assert consumer.tell() == {partition: 1}
+
+    # Seeking beyond the first missing index should work, but subsequent reads
+    # should error.
+    consumer.seek({partition: 2})
+    assert consumer.tell() == {partition: 2}
+
+    with pytest.raises(ConsumerError):
+        consumer.poll()
+
+    # Offsets should not be advanced after a failed poll.
+    assert consumer.tell() == {partition: 2}
+
+    # Trying to seek on an unassigned partition should error.
+    with pytest.raises(ConsumerError):
+        consumer.seek({partition: 0, Partition(topic, -1): 0})
+
+    # ``seek`` should be atomic -- either all updates are applied or none are.
+    assert consumer.tell() == {partition: 2}


### PR DESCRIPTION
This is required for the next steps of the synchronous consumer, which will need to be able to roll back offsets for the wrapped consumer if it observes the consumer skipping ahead in the stream (further than the remote offset.)

As far as reviewing, this change is probably easiest to read and understand by:

1. starting with `snuba/utils/streams/consumer.py` for interface definition and documentation,
2. moving to `snuba/utils/streams/dummy.py` (and its tests) for a contrived example,
3. moving to `snuba/subscriptions/consumer.py` (and its tests) for a more complex usage example.