### PR TITLE
fix(parser): Fix parsing of groupby and orderby

### DIFF
--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -9,7 +9,7 @@ from snuba.query.expressions import Expression
 from snuba.query.parser.conditions import parse_conditions_to_expr
 from snuba.query.parser.expressions import parse_aggregation, parse_expression
 from snuba.query.query import OrderBy, OrderByDirection, Query
-from snuba.util import is_function, tuplify
+from snuba.util import is_function, to_list, tuplify
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,8 @@ def _parse_query_impl(body: MutableMapping[str, Any], dataset: Dataset) -> Query
         )
 
     groupby_exprs = [
-        parse_expression(tuplify(group_by)) for group_by in body.get("groupby", [])
+        parse_expression(tuplify(group_by))
+        for group_by in to_list(body.get("groupby", []))
     ]
     select_exprs = [
         parse_expression(tuplify(select)) for select in body.get("selected_columns", [])
@@ -72,7 +73,7 @@ def _parse_query_impl(body: MutableMapping[str, Any], dataset: Dataset) -> Query
     having_expr = parse_conditions_to_expr(body.get("having", []), dataset, arrayjoin)
 
     orderby_exprs = []
-    for orderby in body.get("orderby", []):
+    for orderby in to_list(body.get("orderby", [])):
         if isinstance(orderby, str):
             match = NEGATE_RE.match(orderby)
             assert match is not None, f"Invalid Order By clause {orderby}"

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -108,6 +108,18 @@ test_cases = [
             ],
         ),
     ),  # Order by with functions
+    (
+        {"selected_columns": [], "groupby": "column1", "orderby": "-column1"},
+        Query(
+            {},
+            TableSource("events", ColumnSet([])),
+            selected_columns=[Column(None, "column1", None)],
+            condition=None,
+            groupby=[Column(None, "column1", None)],
+            having=None,
+            order_by=[OrderBy(OrderByDirection.DESC, Column(None, "column1", None))],
+        ),
+    ),  # Order and group by provided as string
 ]
 
 


### PR DESCRIPTION
The query can provide groupby and orderby as string instead of list.
Thus if we iterate on the orderby elements we end up with this beautiful result:
```
SELECT tags_key, (`count()`() AS count) FROM sentry_dist SAMPLE 1 WHERE in(project_id, tuple(300688)) GROUP BY (tags_key) ORDER BY  DESC, c ASC, o ASC, u ASC, n ASC, t ASC LIMIT 1000 OFFSET 0"
```

This fixes it