### PR TITLE
ref(streams): Move `ConsumerError` to streams.consumer

### DIFF
--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -9,8 +9,8 @@ from typing import (
     Sequence,
 )
 
-from snuba.utils.streams.consumer import Consumer
-from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic
+from snuba.utils.streams.consumer import Consumer, ConsumerError
+from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.utils.types import Interval
 
 

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -14,8 +14,8 @@ from typing import (
 )
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
-from snuba.utils.streams.consumer import Consumer
-from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic, TPayload
+from snuba.utils.streams.consumer import Consumer, ConsumerError
+from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -19,6 +19,29 @@ from snuba.utils.streams.types import (
 logger = logging.getLogger(__name__)
 
 
+class ConsumerError(Exception):
+    """
+    Base class for exceptions that are raised during consumption.
+
+    Subclasses may extend this class to disambiguate errors that are specific
+    to their implementation.
+    """
+
+
+class EndOfPartition(ConsumerError):
+    """
+    Raised when there are no more messages to consume from the partition.
+    """
+
+    def __init__(self, partition: Partition, offset: int):
+        # The partition that the consumer has reached the end of.
+        self.partition = partition
+
+        # The next unconsumed offset in the partition (where there is currently
+        # no message.)
+        self.offset = offset
+
+
 class Consumer(Generic[TPayload], ABC):
     """
     This abstract class provides an interface for consuming messages from a

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -8,8 +8,8 @@ from typing import (
     Sequence,
 )
 
-from snuba.utils.streams.consumer import Consumer
-from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic, TPayload
+from snuba.utils.streams.consumer import Consumer, ConsumerError
+from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 
 
 epoch = datetime(2019, 12, 19)

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -21,15 +21,8 @@ from confluent_kafka import TopicPartition as ConfluentTopicPartition
 
 from snuba.utils.retries import NoRetryPolicy, RetryPolicy
 from snuba.utils.streams.codecs import Codec
-from snuba.utils.streams.consumer import Consumer
-from snuba.utils.streams.types import (
-    ConsumerError,
-    EndOfPartition,
-    Message,
-    Partition,
-    Topic,
-    TPayload,
-)
+from snuba.utils.streams.consumer import Consumer, ConsumerError, EndOfPartition
+from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 
 logger = logging.getLogger(__name__)
 

--- a/snuba/utils/streams/types.py
+++ b/snuba/utils/streams/types.py
@@ -41,26 +41,3 @@ class Message(Generic[TPayload]):
 
     def get_next_offset(self) -> int:
         return self.offset + 1
-
-
-class ConsumerError(Exception):
-    """
-    Base class for exceptions that are raised during consumption.
-
-    Subclasses may extend this class to disambiguate errors that are specific
-    to their implementation.
-    """
-
-
-class EndOfPartition(ConsumerError):
-    """
-    Raised when there are no more messages to consume from the partition.
-    """
-
-    def __init__(self, partition: Partition, offset: int):
-        # The partition that the consumer has reached the end of.
-        self.partition = partition
-
-        # The next unconsumed offset in the partition (where there is currently
-        # no message.)
-        self.offset = offset

--- a/tests/subscriptions/test_consumer.py
+++ b/tests/subscriptions/test_consumer.py
@@ -1,9 +1,9 @@
 import pytest
 
 from snuba.subscriptions.consumer import Tick, TickConsumer
-from snuba.utils.streams.consumer import Consumer
+from snuba.utils.streams.consumer import Consumer, ConsumerError
 from snuba.utils.streams.dummy import DummyConsumer, epoch
-from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic
+from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.utils.types import Interval
 
 

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -1,14 +1,15 @@
 import pytest
 
+from snuba.utils.streams.consumer import Consumer, ConsumerError
 from snuba.utils.streams.dummy import DummyConsumer
-from snuba.utils.streams.types import ConsumerError, Message, Partition, Topic
+from snuba.utils.streams.types import Message, Partition, Topic
 
 
 def test_working_offsets() -> None:
     topic = Topic("example")
     partition = Partition(topic, 0)
 
-    consumer = DummyConsumer({partition: [0]})
+    consumer: Consumer[int] = DummyConsumer({partition: [0]})
     consumer.subscribe([topic])
 
     # NOTE: This will eventually need to be controlled by a generalized

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -5,6 +5,7 @@ import pytest
 from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka.admin import AdminClient, NewTopic
 
+from snuba.utils.streams.consumer import Consumer, ConsumerError, EndOfPartition
 from snuba.utils.streams.codecs import PassthroughCodec
 from snuba.utils.streams.kafka import (
     Commit,
@@ -15,8 +16,6 @@ from snuba.utils.streams.kafka import (
     as_kafka_configuration_bool,
 )
 from snuba.utils.streams.types import (
-    ConsumerError,
-    EndOfPartition,
     Message,
     Partition,
     Topic,
@@ -45,7 +44,7 @@ def topic() -> Iterator[Topic]:
 
 
 def test_consumer_backend(topic: Topic) -> None:
-    def build_consumer() -> KafkaConsumer[KafkaPayload]:
+    def build_consumer() -> Consumer[KafkaPayload]:
         codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
         return KafkaConsumer(
             {
@@ -194,7 +193,7 @@ def test_auto_offset_reset_earliest(topic: Topic) -> None:
     assert producer.flush(5.0) == 0
 
     codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
-    consumer = KafkaConsumer(
+    consumer: Consumer[KafkaPayload] = KafkaConsumer(
         {
             **configuration,
             "auto.offset.reset": "earliest",
@@ -222,7 +221,7 @@ def test_auto_offset_reset_latest(topic: Topic) -> None:
     assert producer.flush(5.0) == 0
 
     codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
-    consumer = KafkaConsumer(
+    consumer: Consumer[KafkaPayload] = KafkaConsumer(
         {
             **configuration,
             "auto.offset.reset": "latest",
@@ -254,7 +253,7 @@ def test_auto_offset_reset_error(topic: Topic) -> None:
     assert producer.flush(5.0) == 0
 
     codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
-    consumer = KafkaConsumer(
+    consumer: Consumer[KafkaPayload] = KafkaConsumer(
         {
             **configuration,
             "auto.offset.reset": "error",
@@ -287,7 +286,7 @@ def test_commit_log_consumer(topic: Topic) -> None:
     commit_log_producer = FakeConfluentKafkaProducer()
 
     codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
-    consumer = KafkaConsumerWithCommitLog(
+    consumer: Consumer[KafkaPayload] = KafkaConsumerWithCommitLog(
         {
             **configuration,
             "auto.offset.reset": "earliest",


### PR DESCRIPTION
Just following up on https://github.com/getsentry/snuba/pull/663#discussion_r363524133.

This also includes a minor type tweak to `tests/utils/streams/test_kafka.py`.