### PR TITLE
feat(query) Support AST in extensions (project and timeseries)

### DIFF
--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -1,6 +1,6 @@
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Sequence
 
-from snuba.query.expressions import Expression, FunctionCall
+from snuba.query.expressions import Expression, Literal, FunctionCall
 
 
 class ConditionFunctions:
@@ -46,6 +46,26 @@ class BooleanFunctions:
     NOT = "not"
     AND = "and"
     OR = "or"
+
+
+def __set_condition(
+    alias: Optional[str], function: str, lhs: Expression, rhs: Sequence[Literal]
+) -> Expression:
+    return binary_condition(
+        alias, function, lhs, FunctionCall(None, "tuple", tuple(rhs)),
+    )
+
+
+def in_condition(
+    alias: Optional[str], lhs: Expression, rhs: Sequence[Literal],
+) -> Expression:
+    return __set_condition(alias, ConditionFunctions.IN, lhs, rhs,)
+
+
+def not_in_condition(
+    alias: Optional[str], lhs: Expression, rhs: Sequence[Literal],
+) -> Expression:
+    return __set_condition(alias, ConditionFunctions.NOT_IN, lhs, rhs,)
 
 
 def binary_condition(

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -1,5 +1,6 @@
 from typing import Mapping, Optional, Sequence
 
+from snuba.query.dsl import literals_tuple
 from snuba.query.expressions import Expression, Literal, FunctionCall
 
 
@@ -51,9 +52,7 @@ class BooleanFunctions:
 def __set_condition(
     alias: Optional[str], function: str, lhs: Expression, rhs: Sequence[Literal]
 ) -> Expression:
-    return binary_condition(
-        alias, function, lhs, FunctionCall(None, "tuple", tuple(rhs)),
-    )
+    return binary_condition(alias, function, lhs, literals_tuple(None, rhs))
 
 
 def in_condition(

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -1,0 +1,10 @@
+from typing import Optional, Sequence
+
+from snuba.query.expressions import FunctionCall, Literal
+
+# Add here functions (only stateless stuff) used to make the AST less
+# verbose to build.
+
+
+def literals_tuple(alias: Optional[str], literals: Sequence[Literal]):
+    return FunctionCall(alias, "tuple", tuple(literals))

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -8,6 +8,7 @@ from typing import (
     Generic,
     Iterator,
     Optional,
+    Sequence,
     TypeVar,
     Tuple,
     Union,

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -8,7 +8,6 @@ from typing import (
     Generic,
     Iterator,
     Optional,
-    Sequence,
     TypeVar,
     Tuple,
     Union,

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -20,6 +20,7 @@ from typing import (
 
 from snuba.clickhouse.escaping import SAFE_COL_RE
 from snuba.datasets.schemas import RelationalSource
+from snuba.query.conditions import binary_condition, BooleanFunctions
 from snuba.query.expressions import Expression
 from snuba.query.types import Condition
 from snuba.util import columns_in_expr, is_condition, to_list
@@ -211,6 +212,14 @@ class Query:
 
     def add_conditions(self, conditions: Sequence[Condition],) -> None:
         self.__extend_sequence("conditions", conditions)
+
+    def add_condition_to_ast(self, condition: Expression) -> None:
+        if not self.__condition:
+            self.__condition = condition
+        else:
+            self.__condition = binary_condition(
+                None, BooleanFunctions.AND, condition, self.__condition
+            )
 
     def get_prewhere(self) -> Sequence[Condition]:
         """

--- a/snuba/query/timeseries.py
+++ b/snuba/query/timeseries.py
@@ -3,6 +3,12 @@ from typing import Any, Mapping, Tuple
 
 from snuba import state
 from snuba.util import parse_datetime
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
+from snuba.query.expressions import Column, Literal
 from snuba.query.extensions import QueryExtension
 from snuba.query.query_processor import ExtensionQueryProcessor
 from snuba.query.query import Query
@@ -45,6 +51,24 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
                 (self.__timestamp_column, ">=", from_date.isoformat()),
                 (self.__timestamp_column, "<", to_date.isoformat()),
             ]
+        )
+        query.add_condition_to_ast(
+            binary_condition(
+                None,
+                BooleanFunctions.AND,
+                binary_condition(
+                    None,
+                    ConditionFunctions.GTE,
+                    Column(None, self.__timestamp_column, None),
+                    Literal(None, from_date),
+                ),
+                binary_condition(
+                    None,
+                    ConditionFunctions.LT,
+                    Column(None, self.__timestamp_column, None),
+                    Literal(None, to_date),
+                ),
+            )
         )
 
 

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -5,6 +5,8 @@ from tests.base import BaseTest
 from snuba import replacer, state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
+from snuba.query.conditions import FunctionCall, BooleanFunctions
+from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.project_extension import (
     ProjectExtension,
     ProjectExtensionProcessor,
@@ -15,15 +17,32 @@ from snuba.query.types import Condition
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.schemas import validate_jsonschema
 
+
+def build_in(projects: Sequence[int]) -> Expression:
+    return FunctionCall(
+        None,
+        "in",
+        (
+            Column(None, "project_id", None),
+            FunctionCall(None, "tuple", tuple([Literal(None, p) for p in projects])),
+        ),
+    )
+
+
 project_extension_test_data = [
-    ({"project": 2}, [("project_id", "IN", [2])]),
-    ({"project": [2, 3]}, [("project_id", "IN", [2, 3])]),
+    ({"project": 2}, [("project_id", "IN", [2])], build_in([2]),),
+    ({"project": [2, 3]}, [("project_id", "IN", [2, 3])], build_in([2, 3]),),
 ]
 
 
-@pytest.mark.parametrize("raw_data, expected_conditions", project_extension_test_data)
+@pytest.mark.parametrize(
+    "raw_data, expected_conditions, expected_ast_conditions",
+    project_extension_test_data,
+)
 def test_project_extension_query_processing(
-    raw_data: dict, expected_conditions: Sequence[Condition]
+    raw_data: dict,
+    expected_conditions: Sequence[Condition],
+    expected_ast_conditions: Expression,
 ):
     extension = ProjectExtension(
         processor=ProjectExtensionProcessor(project_column="project_id")
@@ -35,6 +54,7 @@ def test_project_extension_query_processing(
     extension.get_processor().process_query(query, valid_data, request_settings)
 
     assert query.get_conditions() == expected_conditions
+    assert query.get_condition_from_ast() == expected_ast_conditions
 
 
 def test_project_extension_query_adds_rate_limits():
@@ -99,6 +119,7 @@ class TestProjectExtensionWithGroups(BaseTest):
         )
 
         assert self.query.get_conditions() == [("project_id", "IN", [2])]
+        assert self.query.get_condition_from_ast() == build_in([2])
 
     def test_without_turbo_with_projects_needing_final(self):
         request_settings = HTTPRequestSettings()
@@ -109,6 +130,7 @@ class TestProjectExtensionWithGroups(BaseTest):
         )
 
         assert self.query.get_conditions() == [("project_id", "IN", [2])]
+        assert self.query.get_condition_from_ast() == build_in([2])
         assert self.query.get_final()
 
     def test_without_turbo_without_projects_needing_final(self):
@@ -119,6 +141,7 @@ class TestProjectExtensionWithGroups(BaseTest):
         )
 
         assert self.query.get_conditions() == [("project_id", "IN", [2])]
+        assert self.query.get_condition_from_ast() == build_in([2])
         assert not self.query.get_final()
 
     def test_when_there_are_not_many_groups_to_exclude(self):
@@ -135,6 +158,31 @@ class TestProjectExtensionWithGroups(BaseTest):
             (["assumeNotNull", ["group_id"]], "NOT IN", [100, 101, 102]),
         ]
         assert self.query.get_conditions() == expected
+        assert self.query.get_condition_from_ast() == FunctionCall(
+            None,
+            BooleanFunctions.AND,
+            (
+                FunctionCall(
+                    None,
+                    "notIn",
+                    (
+                        FunctionCall(
+                            None, "assumeNotNull", (Column(None, "group_id", None),)
+                        ),
+                        FunctionCall(
+                            None,
+                            "tuple",
+                            (
+                                Literal(None, 100),
+                                Literal(None, 101),
+                                Literal(None, 102),
+                            ),
+                        ),
+                    ),
+                ),
+                build_in([2]),
+            ),
+        )
         assert not self.query.get_final()
 
     def test_when_there_are_too_many_groups_to_exclude(self):
@@ -147,4 +195,5 @@ class TestProjectExtensionWithGroups(BaseTest):
         )
 
         assert self.query.get_conditions() == [("project_id", "IN", [2])]
+        assert self.query.get_condition_from_ast() == build_in([2])
         assert self.query.get_final()

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -18,20 +18,22 @@ from snuba.request.request_settings import HTTPRequestSettings
 from snuba.schemas import validate_jsonschema
 
 
-def build_time_condition(from_date: datetime, to_date: datetime) -> Expression:
+def build_time_condition(
+    time_columns: str, from_date: datetime, to_date: datetime
+) -> Expression:
     return binary_condition(
         None,
         BooleanFunctions.AND,
         binary_condition(
             None,
             ConditionFunctions.GTE,
-            Column(None, "timestamp", None),
+            Column(None, time_columns, None),
             Literal(None, from_date),
         ),
         binary_condition(
             None,
             ConditionFunctions.LT,
-            Column(None, "timestamp", None),
+            Column(None, time_columns, None),
             Literal(None, to_date),
         ),
     )
@@ -48,7 +50,9 @@ test_data = [
             ("timestamp", ">=", "2019-09-19T10:00:00"),
             ("timestamp", "<", "2019-09-19T12:00:00"),
         ],
-        build_time_condition(datetime(2019, 9, 19, 10), datetime(2019, 9, 19, 12)),
+        build_time_condition(
+            "timestamp", datetime(2019, 9, 19, 10), datetime(2019, 9, 19, 12)
+        ),
         3600,
     ),
     (
@@ -61,7 +65,9 @@ test_data = [
             ("timestamp", ">=", "2019-09-18T12:00:00"),
             ("timestamp", "<", "2019-09-19T12:00:00"),
         ],
-        build_time_condition(datetime(2019, 9, 18, 12), datetime(2019, 9, 19, 12)),
+        build_time_condition(
+            "timestamp", datetime(2019, 9, 18, 12), datetime(2019, 9, 19, 12)
+        ),
         3600,
     ),
     (
@@ -74,7 +80,9 @@ test_data = [
             ("timestamp", "<", "2019-09-19T12:00:34"),
         ],
         build_time_condition(
-            datetime(2019, 9, 19, 10, 5, 30), datetime(2019, 9, 19, 12, 0, 34)
+            "timestamp",
+            datetime(2019, 9, 19, 10, 5, 30),
+            datetime(2019, 9, 19, 12, 0, 34),
         ),
         60,
     ),

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -1,15 +1,40 @@
 import pytest
-import datetime
+from datetime import datetime, timedelta
 from typing import Sequence
 
 from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
+from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.query import Query
 from snuba.query.types import Condition
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.schemas import validate_jsonschema
+
+
+def build_time_condition(from_date: datetime, to_date: datetime) -> Expression:
+    return binary_condition(
+        None,
+        BooleanFunctions.AND,
+        binary_condition(
+            None,
+            ConditionFunctions.GTE,
+            Column(None, "timestamp", None),
+            Literal(None, from_date),
+        ),
+        binary_condition(
+            None,
+            ConditionFunctions.LT,
+            Column(None, "timestamp", None),
+            Literal(None, to_date),
+        ),
+    )
 
 
 test_data = [
@@ -23,6 +48,7 @@ test_data = [
             ("timestamp", ">=", "2019-09-19T10:00:00"),
             ("timestamp", "<", "2019-09-19T12:00:00"),
         ],
+        build_time_condition(datetime(2019, 9, 19, 10), datetime(2019, 9, 19, 12)),
         3600,
     ),
     (
@@ -35,6 +61,7 @@ test_data = [
             ("timestamp", ">=", "2019-09-18T12:00:00"),
             ("timestamp", "<", "2019-09-19T12:00:00"),
         ],
+        build_time_condition(datetime(2019, 9, 18, 12), datetime(2019, 9, 19, 12)),
         3600,
     ),
     (
@@ -46,21 +73,28 @@ test_data = [
             ("timestamp", ">=", "2019-09-19T10:05:30"),
             ("timestamp", "<", "2019-09-19T12:00:34"),
         ],
+        build_time_condition(
+            datetime(2019, 9, 19, 10, 5, 30), datetime(2019, 9, 19, 12, 0, 34)
+        ),
         60,
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "raw_data, expected_conditions, expected_granularity", test_data
+    "raw_data, expected_conditions, expected_ast_condition, expected_granularity",
+    test_data,
 )
 def test_query_extension_processing(
-    raw_data: dict, expected_conditions: Sequence[Condition], expected_granularity: int,
+    raw_data: dict,
+    expected_conditions: Sequence[Condition],
+    expected_ast_condition: Expression,
+    expected_granularity: int,
 ):
     state.set_config("max_days", 1)
     extension = TimeSeriesExtension(
         default_granularity=60,
-        default_window=datetime.timedelta(days=5),
+        default_window=timedelta(days=5),
         timestamp_column="timestamp",
     )
     valid_data = validate_jsonschema(raw_data, extension.get_schema())
@@ -70,4 +104,5 @@ def test_query_extension_processing(
 
     extension.get_processor().process_query(query, valid_data, request_settings)
     assert query.get_conditions() == expected_conditions
+    assert query.get_condition_from_ast() == expected_ast_condition
     assert query.get_granularity() == expected_granularity


### PR DESCRIPTION
Ports two query extensions (timeseries and project) to the new query AST.  In this PR we run the old system and the new one in parallel