### PR TITLE
ref(web): Various improvements to query API

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -38,18 +38,11 @@ ClickhouseQueryResult = MutableMapping[str, MutableMapping[str, Any]]
 
 class RawQueryException(Exception):
     def __init__(
-        self,
-        err_type: str,
-        message: str,
-        stats: Mapping[str, Any],
-        timer: Timer,
-        sql: str,
-        **meta
+        self, err_type: str, message: str, stats: Mapping[str, Any], sql: str, **meta
     ):
         self.err_type = err_type
         self.message = message
         self.stats = stats
-        self.timer = timer
         self.sql = sql
         self.meta = meta
 
@@ -176,7 +169,6 @@ def raw_query(
                             err_type=err_type,
                             message=error,
                             stats=stats,
-                            timer=timer,
                             sql=sql,
                             **meta,
                         )
@@ -188,7 +180,6 @@ def raw_query(
                     err_type="rate-limited",
                     message="rate limit exceeded",
                     stats=stats,
-                    timer=timer,
                     sql=sql,
                     detail=str(ex),
                 )
@@ -196,8 +187,6 @@ def raw_query(
     stats = log_query_and_update_stats(
         request, sql, timer, stats, "success", query_settings
     )
-
-    result["timing"] = timer
 
     if settings.STATS_IN_RESPONSE or request.settings.get_debug():
         result["stats"] = stats

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -285,7 +285,7 @@ def dataset_query_view(*, dataset_name: str, timer: Timer):
         assert False, "unexpected fallthrough"
 
 
-def dataset_query(dataset, body, timer: Timer) -> Response:
+def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
     assert http_request.method == "POST"
     ensure_table_exists(dataset)
     return format_result(

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -308,7 +308,11 @@ def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
 def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
     try:
         return QueryResult(
-            {**parse_and_run_query(dataset, request, timer), "timing": timer}, 200
+            {
+                **parse_and_run_query(dataset, request, timer),
+                "timing": timer.for_json(),
+            },
+            200,
         )
     except RawQueryException as e:
         return QueryResult(
@@ -316,7 +320,7 @@ def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
                 "error": {"type": e.err_type, "message": e.message, **e.meta},
                 "sql": e.sql,
                 "stats": e.stats,
-                "timing": timer,
+                "timing": timer.for_json(),
             },
             429 if e.err_type == "rate-limited" else 500,
         )
@@ -331,7 +335,7 @@ def format_result(result: QueryResult) -> Response:
         return obj
 
     return Response(
-        json.dumps(result.result, for_json=True, default=json_default),
+        json.dumps(result.result, default=json_default),
         result.status,
         {"Content-Type": "application/json"},
     )

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -318,18 +318,15 @@ def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
             {**parse_and_run_query(dataset, request, timer), "timing": timer}, 200
         )
     except RawQueryException as e:
-        error = {
-            "type": e.err_type,
-            "message": e.message,
-        }
-        error.update(e.meta)
-        result = {
-            "error": error,
-            "sql": e.sql,
-            "stats": e.stats,
-            "timing": timer,
-        }
-        return QueryResult(result, 429 if e.err_type == "rate-limited" else 500)
+        return QueryResult(
+            {
+                "error": {"type": e.err_type, "message": e.message, **e.meta},
+                "sql": e.sql,
+                "stats": e.stats,
+                "timing": timer,
+            },
+            429 if e.err_type == "rate-limited" else 500,
+        )
 
 
 # Special internal endpoints that compute global aggregate data that we want to

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -397,7 +397,7 @@ if application.debug or application.testing:
 
     _ensured = {}
 
-    def ensure_table_exists(dataset, force=False):
+    def ensure_table_exists(dataset: Dataset, force: bool = False) -> None:
         if not force and _ensured.get(dataset, False):
             return
 
@@ -495,5 +495,5 @@ if application.debug or application.testing:
 
 else:
 
-    def ensure_table_exists(dataset, force=False):
+    def ensure_table_exists(dataset: Dataset, force: bool = False) -> None:
         pass


### PR DESCRIPTION
More progress towards returning the `Result` from the `Reader` from `raw_query`.

- Avoids passing `timer` back the stack during query processing as part of the result or error
- Consolidates response encoding for `dataset_query` and `sdk_distribution` endpoints
- Removes use of proprietary simplejson `for_json` parameter
- Adds several type annotations