### PR TITLE
feat: Remove time fields from Discover dataset

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -255,12 +255,6 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("transaction_hash", Nullable(UInt(64))),
                 ("transaction_op", Nullable(String())),
                 ("transaction_status", Nullable(UInt(8))),
-                # TODO: Time columns below will need to be aligned more closely to the
-                # names in events once we figure out how timeseries queries will work
-                ("start_ts", Nullable(DateTime())),
-                ("start_ms", Nullable(UInt(16))),
-                ("finish_ts", Nullable(DateTime())),
-                ("finish_ms", Nullable(UInt(16))),
                 ("duration", Nullable(UInt(32))),
             ]
         )
@@ -276,7 +270,7 @@ class DiscoverDataset(TimeSeriesDataset):
                 write_schema=None,
             ),
             time_group_columns={},
-            time_parse_columns=["timestamp", "start_ts", "finish_ts"],
+            time_parse_columns=["timestamp"],
         )
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
@@ -293,13 +287,13 @@ class DiscoverDataset(TimeSeriesDataset):
                         NestedFieldConditionOptimizer(
                             "tags",
                             "_tags_flattened",
-                            {"start_ts", "finish_ts", "timestamp"},
+                            {"timestamp"},
                             BEGINNING_OF_TIME,
                         ),
                         NestedFieldConditionOptimizer(
                             "contexts",
                             "_contexts_flattened",
-                            {"start_ts", "finish_ts", "timestamp"},
+                            {"timestamp"},
                             BEGINNING_OF_TIME,
                         ),
                     ]


### PR DESCRIPTION
Remove access to start_ts, start_ms, finish_ts and finish_ms in the
Discover dataset as we only want to expose the timestamp (finish_ts)
field in Discover.