### PR TITLE
ref(streams): Unify `Topic` abstractions between streams and table storage

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -63,12 +63,12 @@ def bootstrap(
             table_writer = dataset.get_table_writer()
             if table_writer:
                 stream_loader = table_writer.get_stream_loader()
-                for topic_spec in stream_loader.get_all_topic_specs():
+                for topic in stream_loader.get_all_topics():
                     topics.append(
                         NewTopic(
-                            topic_spec.topic_name,
-                            num_partitions=topic_spec.partitions_number,
-                            replication_factor=topic_spec.replication_factor,
+                            topic.name,
+                            num_partitions=topic.partitions_number,
+                            replication_factor=topic.replication_factor,
                         )
                     )
 

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -123,11 +123,11 @@ def replacer(
     )
 
     stream_loader = enforce_table_writer(dataset).get_stream_loader()
-    default_replacement_topic_spec = stream_loader.get_replacement_topic_spec()
+    default_replacement_topic = stream_loader.get_replacement_topic()
     assert (
-        default_replacement_topic_spec is not None
+        default_replacement_topic is not None
     ), f"Dataset {dataset} does not have a replacement topic."
-    replacements_topic = replacements_topic or default_replacement_topic_spec.topic_name
+    replacements_topic = replacements_topic or default_replacement_topic.name
 
     metrics = util.create_metrics(
         dogstatsd_host, dogstatsd_port, "snuba.replacer", tags={"group": consumer_group}

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -31,13 +31,13 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         self,
         dataset,
         producer,
-        replacements_topic: Optional[Topic],
         metrics: MetricsBackend,
+        replacements_topic: Optional[Topic] = None,
     ):
         self.__dataset = dataset
         self.producer = producer
-        self.replacements_topic = replacements_topic
         self.metrics = metrics
+        self.replacements_topic = replacements_topic
         self.__writer = enforce_table_writer(dataset).get_writer(
             {"load_balancing": "in_order", "insert_distributed_sync": 1}
         )

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -12,7 +12,7 @@ from snuba.processor import (
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker
 from snuba.utils.streams.kafka import KafkaPayload
-from snuba.utils.streams.types import Message
+from snuba.utils.streams.types import Message, Topic
 
 
 logger = logging.getLogger("snuba.consumer")
@@ -27,7 +27,13 @@ class InvalidActionType(Exception):
 
 
 class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
-    def __init__(self, dataset, producer, replacements_topic, metrics: MetricsBackend):
+    def __init__(
+        self,
+        dataset,
+        producer,
+        replacements_topic: Optional[Topic],
+        metrics: MetricsBackend,
+    ):
         self.__dataset = dataset
         self.producer = producer
         self.replacements_topic = replacements_topic
@@ -90,7 +96,7 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         if replacements:
             for key, replacement in replacements:
                 self.producer.produce(
-                    self.replacements_topic,
+                    self.replacements_topic.name,
                     key=str(key).encode("utf-8"),
                     value=json.dumps(replacement).encode("utf-8"),
                     on_delivery=self.delivery_callback,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -55,16 +55,16 @@ class ConsumerBuilder:
             self.bootstrap_servers = bootstrap_servers
 
         stream_loader = enforce_table_writer(self.dataset).get_stream_loader()
-        self.raw_topic = raw_topic or stream_loader.get_default_topic_spec().topic_name
+        self.raw_topic = raw_topic or stream_loader.get_default_topic().name
         default_replacement_topic_name = (
-            stream_loader.get_replacement_topic_spec().topic_name
-            if stream_loader.get_replacement_topic_spec()
+            stream_loader.get_replacement_topic().name
+            if stream_loader.get_replacement_topic()
             else None
         )
         self.replacements_topic = replacements_topic or default_replacement_topic_name
         default_commit_log_topic_name = (
-            stream_loader.get_commit_log_topic_spec().topic_name
-            if stream_loader.get_commit_log_topic_spec()
+            stream_loader.get_commit_log_topic().topic_name
+            if stream_loader.get_commit_log_topic()
             else None
         )
         self.commit_log_topic = commit_log_topic or default_commit_log_topic_name

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -155,8 +155,8 @@ class ConsumerBuilder:
             ConsumerWorker(
                 self.dataset,
                 producer=self.producer,
-                replacements_topic=self.replacements_topic,
                 metrics=self.metrics,
+                replacements_topic=self.replacements_topic,
             )
         )
 

--- a/snuba/consumers/snapshot_worker.py
+++ b/snuba/consumers/snapshot_worker.py
@@ -8,6 +8,7 @@ from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.datasets.dataset import Dataset
 from snuba.snapshots import SnapshotId
 from snuba.utils.metrics.backends.abstract import MetricsBackend
+from snuba.utils.streams.types import Topic
 
 logger = logging.getLogger("snuba.snapshot-consumer")
 
@@ -38,7 +39,7 @@ class SnapshotAwareWorker(ConsumerWorker):
         snapshot_id: SnapshotId,
         transaction_data: TransactionData,
         metrics: MetricsBackend,
-        replacements_topic: Optional[str] = None,
+        replacements_topic: Optional[Topic] = None,
     ) -> None:
         super().__init__(
             dataset=dataset,

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -8,7 +8,7 @@ from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeRow,
 )
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader, KafkaTopic
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query_processor import QueryProcessor
@@ -76,7 +76,7 @@ class GroupAssigneeDataset(CdcDataset):
                 write_schema=schema,
                 stream_loader=KafkaStreamLoader(
                     processor=GroupAssigneeProcessor(self.POSTGRES_TABLE),
-                    default_topic="cdc",
+                    default_topic=KafkaTopic("cdc"),
                 ),
                 postgres_table=self.POSTGRES_TABLE,
             ),

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -9,7 +9,7 @@ from snuba.datasets.cdc.groupedmessage_processor import (
     GroupedMessageRow,
 )
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader, KafkaTopic
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query_processor import QueryProcessor
@@ -82,7 +82,7 @@ class GroupedMessageDataset(CdcDataset):
                 write_schema=schema,
                 stream_loader=KafkaStreamLoader(
                     processor=GroupedMessageProcessor(self.POSTGRES_TABLE),
-                    default_topic="cdc",
+                    default_topic=KafkaTopic("cdc"),
                 ),
                 postgres_table=self.POSTGRES_TABLE,
             ),

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -14,7 +14,7 @@ from snuba.clickhouse.columns import (
 )
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.dataset_schemas import DatasetSchemas
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader, KafkaTopic
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import (
     MigrationSchemaColumn,
@@ -263,9 +263,9 @@ class EventsDataset(TimeSeriesDataset):
             write_schema=schema,
             stream_loader=KafkaStreamLoader(
                 processor=EventsProcessor(promoted_tag_columns),
-                default_topic="events",
-                replacement_topic="event-replacements",
-                commit_log_topic="snuba-commit-log",
+                default_topic=KafkaTopic("events"),
+                replacement_topic=KafkaTopic("event-replacements"),
+                commit_log_topic=KafkaTopic("snuba-commit-log"),
             ),
         )
 

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -25,7 +25,7 @@ from snuba.datasets.schemas.tables import (
     SummingMergeTreeSchema,
     MaterializedViewSchema,
 )
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader, KafkaTopic
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
@@ -158,7 +158,7 @@ class OutcomesDataset(TimeSeriesDataset):
         table_writer = TableWriter(
             write_schema=write_schema,
             stream_loader=KafkaStreamLoader(
-                processor=OutcomesProcessor(), default_topic="outcomes",
+                processor=OutcomesProcessor(), default_topic=KafkaTopic("outcomes"),
             ),
         )
 

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -17,7 +17,7 @@ from snuba.clickhouse.columns import (
 )
 from snuba.writer import BatchWriter
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader, KafkaTopic
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.datasets.schemas.tables import (
     MigrationSchemaColumn,
@@ -176,7 +176,8 @@ class TransactionsDataset(TimeSeriesDataset):
             table_writer=TransactionsTableWriter(
                 write_schema=schema,
                 stream_loader=KafkaStreamLoader(
-                    processor=TransactionsMessageProcessor(), default_topic="events",
+                    processor=TransactionsMessageProcessor(),
+                    default_topic=KafkaTopic("events"),
                 ),
             ),
             time_group_columns={

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -48,10 +48,7 @@ def run(events_file, dataset, repeat=1, profile_process=False, profile_write=Fal
         ClickhousePool().execute(statement)
 
     consumer = ConsumerWorker(
-        dataset=dataset,
-        producer=None,
-        replacements_topic=None,
-        metrics=DummyMetricsBackend(),
+        dataset=dataset, producer=None, metrics=DummyMetricsBackend(),
     )
 
     messages = get_messages(events_file)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -464,9 +464,7 @@ if application.debug or application.testing:
         if type_ == "insert":
             from snuba.consumer import ConsumerWorker
 
-            worker = ConsumerWorker(
-                dataset, producer=None, replacements_topic=None, metrics=metrics
-            )
+            worker = ConsumerWorker(dataset, producer=None, metrics=metrics)
         else:
             from snuba.replacer import ReplacerWorker
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -34,10 +34,7 @@ class TestConsumer(BaseEventsTest):
             .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset,
-            FakeConfluentKafkaProducer(),
-            replacement_topic.name,
-            self.metrics,
+            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
         )
         batch = [test_worker.process_message(message)]
         test_worker.flush_batch(batch)
@@ -53,10 +50,7 @@ class TestConsumer(BaseEventsTest):
             .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset,
-            FakeConfluentKafkaProducer(),
-            replacement_topic.name,
-            self.metrics,
+            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
         )
 
         event = self.event
@@ -83,7 +77,7 @@ class TestConsumer(BaseEventsTest):
             .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset, producer, replacement_topic.name, self.metrics
+            self.dataset, producer, replacement_topic, self.metrics
         )
 
         test_worker.flush_batch(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -31,12 +31,12 @@ class TestConsumer(BaseEventsTest):
         replacement_topic = (
             enforce_table_writer(self.dataset)
             .get_stream_loader()
-            .get_replacement_topic_spec()
+            .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
             self.dataset,
             FakeConfluentKafkaProducer(),
-            replacement_topic.topic_name,
+            replacement_topic.name,
             self.metrics,
         )
         batch = [test_worker.process_message(message)]
@@ -50,12 +50,12 @@ class TestConsumer(BaseEventsTest):
         replacement_topic = (
             enforce_table_writer(self.dataset)
             .get_stream_loader()
-            .get_replacement_topic_spec()
+            .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
             self.dataset,
             FakeConfluentKafkaProducer(),
-            replacement_topic.topic_name,
+            replacement_topic.name,
             self.metrics,
         )
 
@@ -80,10 +80,10 @@ class TestConsumer(BaseEventsTest):
         replacement_topic = (
             enforce_table_writer(self.dataset)
             .get_stream_loader()
-            .get_replacement_topic_spec()
+            .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset, producer, replacement_topic.topic_name, self.metrics
+            self.dataset, producer, replacement_topic.name, self.metrics
         )
 
         test_worker.flush_batch(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -34,7 +34,7 @@ class TestConsumer(BaseEventsTest):
             .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
+            self.dataset, FakeConfluentKafkaProducer(), self.metrics, replacement_topic,
         )
         batch = [test_worker.process_message(message)]
         test_worker.flush_batch(batch)
@@ -50,7 +50,7 @@ class TestConsumer(BaseEventsTest):
             .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
+            self.dataset, FakeConfluentKafkaProducer(), self.metrics, replacement_topic,
         )
 
         event = self.event
@@ -77,7 +77,7 @@ class TestConsumer(BaseEventsTest):
             .get_replacement_topic()
         )
         test_worker = ConsumerWorker(
-            self.dataset, producer, replacement_topic, self.metrics
+            self.dataset, producer, self.metrics, replacement_topic,
         )
 
         test_worker.flush_batch(


### PR DESCRIPTION
This replaces the `KafkaTopicSpec` object from `snuba.datasets.table_storage` with a subclass of `snuba.utils.streams.types.Topic` that includes the topic configuration data. This allows the table storage types to be used directly as arguments to the new streams tooling with minimal type transformations.