### PR TITLE
ref(processor): Improve type annotations

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -23,13 +23,13 @@ class ProcessedMessage(NamedTuple):
     data: Sequence[Any]
 
 
-class MessageProcessor(object):
+class MessageProcessor:
     """
     The Processor is responsible for converting an incoming message body from the
     event stream into a row or statement to be inserted or executed against clickhouse.
     """
 
-    def process_message(self, message, metadata=None,) -> Optional[ProcessedMessage]:
+    def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
         raise NotImplementedError
 
 

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -59,11 +59,11 @@ def _collapse_uint32(n) -> Optional[int]:
     if n is None:
         return None
 
-    n = int(n)
-    if (n < 0) or (n > MAX_UINT32):
+    i = int(n)
+    if (i < 0) or (i > MAX_UINT32):
         return None
 
-    return n
+    return i
 
 
 def _boolify(s) -> Optional[bool]:

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -1,5 +1,6 @@
 import ipaddress
 import re
+from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from hashlib import md5
@@ -23,12 +24,13 @@ class ProcessedMessage(NamedTuple):
     data: Sequence[Any]
 
 
-class MessageProcessor:
+class MessageProcessor(ABC):
     """
     The Processor is responsible for converting an incoming message body from the
     event stream into a row or statement to be inserted or executed against clickhouse.
     """
 
+    @abstractmethod
     def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
         raise NotImplementedError
 

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -1,11 +1,11 @@
 import ipaddress
 import re
-
 from datetime import datetime
 from enum import Enum
 from hashlib import md5
-import simplejson as json
 from typing import Any, NamedTuple, Optional, Sequence, Union
+
+import simplejson as json
 
 from snuba.util import force_bytes
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -253,10 +253,13 @@ def decode_part_str(part_str: str) -> Part:
     return Part(date, int(retention_days))
 
 
-def force_bytes(s: Any) -> Any:
+def force_bytes(s: Union[bytes, str]) -> bytes:
     if isinstance(s, bytes):
         return s
-    return s.encode("utf-8", "replace")
+    elif isinstance(s, str):
+        return s.encode("utf-8", "replace")
+    else:
+        raise TypeError(f"cannot convert {type(s).__name__} to bytes")
 
 
 @contextmanager


### PR DESCRIPTION
This also fixes a bug in `_floatify` where zero values would be converted to `None`.

This fixes many type errors (due to untyped functions), and converts several others to valid type errors:

```diff
-Found 653 errors in 81 files (checked 138 source files)
+Found 583 errors in 81 files (checked 138 source files)
```