### PR TITLE
ref(web): Create separate WSGI entrypoint from views

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -15,11 +15,11 @@ fi
 if [ "$1" = 'api' ]; then
   if [ "$#" -gt 1 ]; then
     echo "Running Snuba API server with arguments:" "${@:2}"
-    set -- uwsgi --master --manage-script-name --wsgi-file snuba/web/views.py --die-on-term "${@:2}"
+    set -- uwsgi --master --manage-script-name --wsgi-file snuba/web/wsgi.py --die-on-term "${@:2}"
   else
     _default_args="--socket /tmp/snuba.sock --http 0.0.0.0:1218 --http-keepalive"
     echo "Running Snuba API server with default arguments: $_default_args"
-    set -- uwsgi --master --manage-script-name --wsgi-file snuba/web/views.py --die-on-term $_default_args
+    set -- uwsgi --master --manage-script-name --wsgi-file snuba/web/wsgi.py --die-on-term $_default_args
   fi
   set -- "$@"
 fi

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -29,7 +29,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--master",
                 "--manage-script-name",
                 "--wsgi-file",
-                "snuba/web/views.py",
+                "snuba/web/wsgi.py",
                 "--http",
                 "0.0.0.0:1218",
                 "--http-keepalive",

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -8,8 +8,6 @@ from flask import Flask, Response, redirect, render_template, request as http_re
 from markdown import markdown
 from uuid import uuid1
 import sentry_sdk
-from sentry_sdk.integrations.flask import FlaskIntegration
-from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
 import simplejson as json
 from werkzeug.exceptions import BadRequest
 import jsonschema
@@ -43,9 +41,6 @@ from snuba.web.query import (
 
 
 logger = logging.getLogger("snuba.api")
-logging.basicConfig(
-    level=getattr(logging, settings.LOG_LEVEL.upper()), format="%(asctime)s %(message)s"
-)
 
 
 class QueryResult(NamedTuple):
@@ -94,12 +89,6 @@ def check_clickhouse():
 application = Flask(__name__, static_url_path="")
 application.testing = settings.TESTING
 application.debug = settings.DEBUG
-
-sentry_sdk.init(
-    dsn=settings.SENTRY_DSN,
-    integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
-    release=os.getenv("SNUBA_RELEASE"),
-)
 
 
 @application.errorhandler(BadRequest)

--- a/snuba/web/wsgi.py
+++ b/snuba/web/wsgi.py
@@ -1,0 +1,25 @@
+def configure() -> None:
+    import logging
+    import os
+
+    from snuba import settings
+
+    logging.basicConfig(
+        level=getattr(logging, settings.LOG_LEVEL.upper()),
+        format="%(asctime)s %(message)s",
+    )
+
+    import sentry_sdk
+    from sentry_sdk.integrations.flask import FlaskIntegration
+    from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
+
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
+        release=os.getenv("SNUBA_RELEASE"),
+    )
+
+
+configure()
+
+from snuba.web.views import application  # noqa


### PR DESCRIPTION
This removes the implicit module-level initialization for logging and Sentry to a path where it will only be invoked by the uwsgi entrypoint. This prevents conflicts with the CLI where the effective log level was dependent on import ordering (importing views could override the desired log level.)

This is a redo of #673 as noted here: https://github.com/getsentry/snuba/pull/673#issuecomment-573240034