### PR TITLE
ref(subscriptions): Include partition ID in ID returned from stub API endpoints

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -366,8 +366,10 @@ def sdk_distribution(*, timer: Timer) -> Response:
 
 @application.route("/<dataset:dataset>/subscriptions", methods=["POST"])
 def create_subscription(*, dataset: Dataset):
+    partition = 0
+    key = uuid1().hex
     return (
-        json.dumps({"subscription_id": uuid1().hex}),
+        json.dumps({"subscription_id": f"{partition}/{key}"}),
         202,
         {"Content-Type": "application/json"},
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1699,7 +1699,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
 
         assert resp.status_code == 202
         data = json.loads(resp.data)
-        assert data == {"subscription_id": expected_uuid.hex}  # TODO
+        assert data == {"subscription_id": f"0/{expected_uuid.hex}"}  # TODO
 
 
 class TestDeleteSubscriptionApi(BaseApiTest):


### PR DESCRIPTION
This is required to finish fixing getsentry/sentry#16471.