### PR TITLE
Update Subscription creation API stub to actually create Subscriptions

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -44,7 +44,7 @@ class Subscription:
         )
         extra_conditions = []
         if offset is not None:
-            extra_conditions = [["ifnull", ["offset", 0]], "<=", offset]
+            extra_conditions = [[["ifnull", ["offset", 0]], "<=", offset]]
         return validate_request_content(
             {
                 "project": self.project_id,

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -29,7 +29,7 @@ class Subscription:
     time_window: timedelta
     resolution: timedelta
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.time_window < timedelta(minutes=1):
             raise InvalidSubscriptionError(
                 "Time window must be greater than or equal to 1 minute"

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -1,0 +1,28 @@
+from abc import abstractmethod, ABC
+from binascii import crc32
+
+from snuba.datasets.dataset import Dataset
+from snuba.subscriptions.data import Subscription
+
+
+class SubscriptionPartitioner(ABC):
+    @abstractmethod
+    def build_partition_id(self, subscription: Subscription):
+        pass
+
+
+class DatasetSubscriptionPartitioner(SubscriptionPartitioner):
+    """
+    Partitions a subscription based on the Dataset that we're going to store it in.
+    """
+
+    SHARD_COUNT = 64
+
+    def __init__(self, dataset: Dataset):
+        self.dataset = dataset
+
+    def build_partition_id(self, subscription: Subscription) -> str:
+        # TODO: Use something from the dataset to determine the number of shards
+        return str(
+            crc32(str(subscription.project_id).encode("utf-8")) % self.SHARD_COUNT
+        )

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -7,7 +7,7 @@ from snuba.subscriptions.data import Subscription
 
 class SubscriptionPartitioner(ABC):
     @abstractmethod
-    def build_partition_id(self, subscription: Subscription):
+    def build_partition_id(self, subscription: Subscription) -> int:
         pass
 
 
@@ -16,13 +16,13 @@ class DatasetSubscriptionPartitioner(SubscriptionPartitioner):
     Partitions a subscription based on the Dataset that we're going to store it in.
     """
 
-    SHARD_COUNT = 64
+    PARTITION_COUNT = 64
 
     def __init__(self, dataset: Dataset):
         self.dataset = dataset
 
-    def build_partition_id(self, subscription: Subscription) -> str:
-        # TODO: Use something from the dataset to determine the number of shards
-        return str(
-            crc32(str(subscription.project_id).encode("utf-8")) % self.SHARD_COUNT
+    def build_partition_id(self, subscription: Subscription) -> int:
+        # TODO: Use something from the dataset to determine the number of partitions
+        return (
+            crc32(str(subscription.project_id).encode("utf-8")) % self.PARTITION_COUNT
         )

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -19,7 +19,7 @@ class DatasetSubscriptionPartitioner(SubscriptionPartitioner):
     PARTITION_COUNT = 64
 
     def __init__(self, dataset: Dataset):
-        self.dataset = dataset
+        self.__dataset = dataset
 
     def build_partition_id(self, subscription: Subscription) -> int:
         # TODO: Use something from the dataset to determine the number of partitions

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -1,10 +1,8 @@
-from datetime import datetime, timedelta
-from typing import Sequence, Tuple
+from dataclasses import dataclass
+from datetime import datetime
 from uuid import uuid1
 
 from snuba.datasets.dataset import Dataset
-from snuba.query.query import Aggregation
-from snuba.query.types import Condition
 from snuba.redis import redis_client
 from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
@@ -13,8 +11,10 @@ from snuba.utils.metrics.timer import Timer
 from snuba.web.query import parse_and_run_query
 
 
-class InvalidSubscriptionError(Exception):
-    pass
+@dataclass(frozen=True)
+class SubscriptionIdentifier:
+    partition_id: int
+    subscription_id: str
 
 
 class SubscriptionCreator:
@@ -27,39 +27,16 @@ class SubscriptionCreator:
         self.dataset = dataset
 
     def create(
-        self,
-        project_id: int,
-        conditions: Sequence[Condition],
-        aggregations: Sequence[Aggregation],
-        time_window: timedelta,
-        resolution: timedelta,
-        timer: Timer,
-    ) -> Tuple[str, str]:
-        if time_window < timedelta(minutes=1):
-            raise InvalidSubscriptionError(
-                "Time window must be greater than or equal to 1 minute"
-            )
-        if resolution < timedelta(minutes=1):
-            raise InvalidSubscriptionError(
-                "Resolution must be greater than or equal to 1 minute"
-            )
-
-        subscription = Subscription(
-            str(uuid1().hex),
-            project_id,
-            conditions,
-            aggregations,
-            time_window,
-            resolution,
-        )
-
+        self, subscription: Subscription, timer: Timer
+    ) -> SubscriptionIdentifier:
         # We want to test the query out here to make sure it's valid and can run
-        request = subscription.build_request(
-            self.dataset, datetime.now() - subscription.time_window, None, timer,
-        )
+        request = subscription.build_request(self.dataset, datetime.now(), None, timer,)
         parse_and_run_query(self.dataset, request, timer)
         partition_id = DatasetSubscriptionPartitioner(self.dataset).build_partition_id(
             subscription
         )
-        RedisSubscriptionStore(redis_client, partition_id).create(subscription)
-        return partition_id, subscription
+        subscription_id = uuid1().hex
+        RedisSubscriptionStore(redis_client, self.dataset, str(partition_id)).create(
+            subscription_id, subscription,
+        )
+        return SubscriptionIdentifier(partition_id, subscription_id)

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timedelta
+from typing import Sequence, Tuple
+from uuid import uuid1
+
+from snuba.datasets.dataset import Dataset
+from snuba.query.query import Aggregation
+from snuba.query.types import Condition
+from snuba.redis import redis_client
+from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
+from snuba.subscriptions.store import RedisSubscriptionStore
+from snuba.utils.metrics.timer import Timer
+from snuba.web.query import parse_and_run_query
+
+
+class InvalidSubscriptionError(Exception):
+    pass
+
+
+class SubscriptionCreator:
+    """
+    Handles creation of a `Subscription`, including assigning an ID and validating that
+    the resulting query is valid.
+    """
+
+    def __init__(self, dataset: Dataset):
+        self.dataset = dataset
+
+    def create(
+        self,
+        project_id: int,
+        conditions: Sequence[Condition],
+        aggregations: Sequence[Aggregation],
+        time_window: timedelta,
+        resolution: timedelta,
+        timer: Timer,
+    ) -> Tuple[str, str]:
+        if time_window < timedelta(minutes=1):
+            raise InvalidSubscriptionError(
+                "Time window must be greater than or equal to 1 minute"
+            )
+        if resolution < timedelta(minutes=1):
+            raise InvalidSubscriptionError(
+                "Resolution must be greater than or equal to 1 minute"
+            )
+
+        subscription = Subscription(
+            str(uuid1().hex),
+            project_id,
+            conditions,
+            aggregations,
+            time_window,
+            resolution,
+        )
+
+        # We want to test the query out here to make sure it's valid and can run
+        request = subscription.build_request(
+            self.dataset, datetime.now() - subscription.time_window, None, timer,
+        )
+        parse_and_run_query(self.dataset, request, timer)
+        partition_id = DatasetSubscriptionPartitioner(self.dataset).build_partition_id(
+            subscription
+        )
+        RedisSubscriptionStore(redis_client, partition_id).create(subscription)
+        return partition_id, subscription

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -30,7 +30,9 @@ class SubscriptionCreator:
         self, subscription: Subscription, timer: Timer
     ) -> SubscriptionIdentifier:
         # We want to test the query out here to make sure it's valid and can run
-        request = subscription.build_request(self.dataset, datetime.now(), None, timer,)
+        request = subscription.build_request(
+            self.dataset, datetime.utcnow(), None, timer,
+        )
         parse_and_run_query(self.dataset, request, timer)
         partition_id = DatasetSubscriptionPartitioner(self.dataset).build_partition_id(
             subscription

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -9,7 +9,6 @@ from tests.subscriptions import BaseSubscriptionTest
 class TestBuildRequest(BaseSubscriptionTest):
     def test_conditions(self):
         subscription = Subscription(
-            id="hello",
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -21,7 +21,6 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             ),
         )
         subscription = Subscription(
-            id="hello",
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -1,0 +1,14 @@
+from datetime import timedelta
+
+from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
+from tests.subscriptions import BaseSubscriptionTest
+
+
+class TestBuildRequest(BaseSubscriptionTest):
+    def test(self):
+        subscription = Subscription(
+            "test", 123, [], [], timedelta(minutes=10), timedelta(minutes=1)
+        )
+        partitioner = DatasetSubscriptionPartitioner(self.dataset)
+        assert partitioner.build_partition_id(subscription) == "18"

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -8,7 +8,7 @@ from tests.subscriptions import BaseSubscriptionTest
 class TestBuildRequest(BaseSubscriptionTest):
     def test(self):
         subscription = Subscription(
-            "test", 123, [], [], timedelta(minutes=10), timedelta(minutes=1)
+            123, [], [], timedelta(minutes=10), timedelta(minutes=1)
         )
         partitioner = DatasetSubscriptionPartitioner(self.dataset)
-        assert partitioner.build_partition_id(subscription) == "18"
+        assert partitioner.build_partition_id(subscription) == 18

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -1,0 +1,82 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+from pytest import raises
+
+from snuba.redis import redis_client
+from snuba.subscriptions.store import RedisSubscriptionStore
+from snuba.subscriptions.subscription import (
+    InvalidSubscriptionError,
+    SubscriptionCreator,
+)
+from snuba.web.query import RawQueryException
+from tests.subscriptions import BaseSubscriptionTest
+
+
+class TestSubscriptionCreator(BaseSubscriptionTest):
+    def test(self):
+        creator = SubscriptionCreator(self.dataset)
+        project_id = 123
+        conditions = [["platform", "IN", ["a"]]]
+        aggregations = [["count()", "", "count"]]
+        time_window = timedelta(minutes=10)
+        resolution = timedelta(minutes=1)
+        partition_id, subscription = creator.create(
+            project_id, conditions, aggregations, time_window, resolution, Mock(),
+        )
+        assert subscription.project_id == project_id
+        assert subscription.conditions == conditions
+        assert subscription.aggregations == aggregations
+        assert subscription.time_window == time_window
+        assert subscription.resolution == resolution
+        assert RedisSubscriptionStore(redis_client, partition_id).all() == [
+            subscription
+        ]
+
+    def test_invalid_condition_column(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(RawQueryException):
+            creator.create(
+                123,
+                [["platfo", "IN", ["a"]]],
+                [["count()", "", "count"]],
+                timedelta(minutes=10),
+                timedelta(minutes=1),
+                Mock(),
+            )
+
+    def test_invalid_aggregation(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(RawQueryException):
+            creator.create(
+                123,
+                [["platform", "IN", ["a"]]],
+                [["cout()", "", "count"]],
+                timedelta(minutes=10),
+                timedelta(minutes=1),
+                Mock(),
+            )
+
+    def test_invalid_time_window(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(InvalidSubscriptionError):
+            creator.create(
+                123,
+                [["platfo", "IN", ["a"]]],
+                [["count()", "", "count"]],
+                timedelta(),
+                timedelta(minutes=1),
+                Mock(),
+            )
+
+    def test_invalid_resolution(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(InvalidSubscriptionError):
+            creator.create(
+                123,
+                [["platfo", "IN", ["a"]]],
+                [["count()", "", "count"]],
+                timedelta(minutes=1),
+                timedelta(),
+                Mock(),
+            )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1702,10 +1702,10 @@ class TestCreateSubscriptionApi(BaseApiTest):
                         "project_id": 1,
                         "conditions": [["platform", "IN", ["a"]]],
                         "aggregations": [["count()", "", "count"]],
-                        "time_window": 10,
-                        "resolution": 1,
+                        "time_window": int(timedelta(minutes=10).total_seconds()),
+                        "resolution": int(timedelta(minutes=1).total_seconds()),
                     }
-                ),
+                ).encode("utf-8"),
             )
 
         assert resp.status_code == 202

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ import uuid
 from snuba import settings, state
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.redis import redis_client
-
+from snuba.web.views import SUBSCRIPTION_SEPARATOR
 from tests.base import BaseApiTest
 
 
@@ -24,7 +24,7 @@ class TestApi(BaseApiTest):
 
         # values for test data
         self.project_ids = [1, 2, 3]  # 3 projects
-        self.environments = [u"prød", "test"]  # 2 environments
+        self.environments = ["prød", "test"]  # 2 environments
         self.platforms = ["a", "b", "c", "d", "e", "f"]  # 6 platforms
         self.hashes = [x * 32 for x in "0123456789ab"]  # 12 hashes
         self.group_ids = [int(hsh[:16], 16) for hsh in self.hashes]
@@ -1084,12 +1084,12 @@ class TestApi(BaseApiTest):
                         "granularity": 3600,
                         "groupby": ["environment"],
                         "aggregations": [["count()", "", "count"]],
-                        "conditions": [["environment", "IN", [u"prød"]]],
+                        "conditions": [["environment", "IN", ["prød"]]],
                     }
                 ),
             ).data
         )
-        assert result["data"][0] == {"environment": u"prød", "count": 90}
+        assert result["data"][0] == {"environment": "prød", "count": 90}
 
     def test_query_timing(self):
         result = json.loads(
@@ -1204,7 +1204,7 @@ class TestApi(BaseApiTest):
 
         # all `test` events first as we sorted DESC by (the prefix of) environment
         assert all(d["environment"] == "test" for d in result["data"][:90])
-        assert all(d["environment"] == u"prød" for d in result["data"][90:])
+        assert all(d["environment"] == "prød" for d in result["data"][90:])
 
         # within a value of environment, timestamps should be sorted ascending
         test_timestamps = [d["time"] for d in result["data"][:90]]
@@ -1693,16 +1693,57 @@ class TestCreateSubscriptionApi(BaseApiTest):
     def test(self):
         expected_uuid = uuid.uuid1()
 
-        with patch("snuba.web.views.uuid1") as uuid4:
+        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
             uuid4.return_value = expected_uuid
-            resp = self.app.post("/events/subscriptions")
+            resp = self.app.post(
+                "{}/subscriptions".format(self.dataset_name),
+                data=json.dumps(
+                    {
+                        "project_id": 1,
+                        "conditions": [["platform", "IN", ["a"]]],
+                        "aggregations": [["count()", "", "count"]],
+                        "time_window": 10,
+                        "resolution": 1,
+                    }
+                ),
+            )
 
         assert resp.status_code == 202
         data = json.loads(resp.data)
-        assert data == {"subscription_id": f"0/{expected_uuid.hex}"}  # TODO
+        assert data == {
+            "subscription_id": "{}{}{}".format(
+                55, SUBSCRIPTION_SEPARATOR, expected_uuid.hex
+            )
+        }
+
+    def test_time_error(self):
+        resp = self.app.post(
+            "{}/subscriptions".format(self.dataset_name),
+            data=json.dumps(
+                {
+                    "project_id": 1,
+                    "conditions": [["platform", "IN", ["a"]]],
+                    "aggregations": [["count()", "", "count"]],
+                    "time_window": 0,
+                    "resolution": 1,
+                }
+            ),
+        )
+
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data == {
+            "error": {
+                "message": "Time window must be greater than or equal to 1 minute",
+                "type": "subscription",
+            }
+        }
 
 
 class TestDeleteSubscriptionApi(BaseApiTest):
     def test(self):
-        resp = self.app.delete(f"/events/subscriptions/1/{uuid.uuid4().hex}")
-        assert resp.status_code == 202
+        resp = self.app.delete(
+            f"{self.dataset_name}/subscriptions/1/{uuid.uuid4().hex}"
+        )
+        print(f"{self.dataset_name}/subscriptions/1/{uuid.uuid4().hex}")
+        assert resp.status_code == 202, resp


### PR DESCRIPTION
This adds a `SubscriptionCreator` class that handles the domain logic of validating and creating a
subscription. Updates the endpoint to use this and return the id.

Adds a Partitioner to determine where we'll store a given subscription. At the moment this is
hardcoded, but in the future we can update it to fetch from the dataset.

I'll add a json schema for the API and do extra validation in a follow-up pr.