### PR TITLE
feat(query parsing) Apdex query processor

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -22,6 +22,7 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
@@ -284,6 +285,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
         return [
             BasicFunctionsProcessor(),
+            ApdexProcessor(),
             DatasetSelector(
                 discover_source=discover_source,
                 events_columns=self.__events_columns,

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -285,13 +285,13 @@ class DiscoverDataset(TimeSeriesDataset):
 
         return [
             BasicFunctionsProcessor(),
-            ApdexProcessor(),
             DatasetSelector(
                 discover_source=discover_source,
                 events_columns=self.__events_columns,
                 transactions_columns=self.__transactions_columns,
                 post_processors={
                     TRANSACTIONS: [
+                        ApdexProcessor(),
                         NestedFieldConditionOptimizer(
                             "tags",
                             "_tags_flattened",

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -21,7 +21,6 @@ from snuba.datasets.schemas.tables import (
     ReplacingMergeTreeSchema,
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -21,6 +21,7 @@ from snuba.datasets.schemas.tables import (
     ReplacingMergeTreeSchema,
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
+from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
@@ -392,4 +393,4 @@ class EventsDataset(TimeSeriesDataset):
         }
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [BasicFunctionsProcessor(), PrewhereProcessor()]
+        return [BasicFunctionsProcessor(), ApdexProcessor(), PrewhereProcessor()]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -393,4 +393,4 @@ class EventsDataset(TimeSeriesDataset):
         }
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [BasicFunctionsProcessor(), ApdexProcessor(), PrewhereProcessor()]
+        return [BasicFunctionsProcessor(), PrewhereProcessor()]

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -31,6 +31,7 @@ from snuba.datasets.transactions_processor import (
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query_processor import QueryProcessor
+from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
@@ -246,6 +247,7 @@ class TransactionsDataset(TimeSeriesDataset):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             BasicFunctionsProcessor(),
+            ApdexProcessor(),
             PrewhereProcessor(),
             NestedFieldConditionOptimizer(
                 "tags", "_tags_flattened", {"start_ts", "finish_ts"}, BEGINNING_OF_TIME

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence
 
-from snuba.query.expressions import FunctionCall, Literal
+from snuba.query.expressions import Expression, FunctionCall, Literal
 
 # Add here functions (only stateless stuff) used to make the AST less
 # verbose to build.
@@ -8,3 +8,20 @@ from snuba.query.expressions import FunctionCall, Literal
 
 def literals_tuple(alias: Optional[str], literals: Sequence[Literal]):
     return FunctionCall(alias, "tuple", tuple(literals))
+
+
+# arithmetic function
+def plus(lhs: Expression, rhs: Expression, alias: Optional[str]):
+    return FunctionCall(alias, "plus", (lhs, rhs))
+
+
+def minus(lhs: Expression, rhs: Expression, alias: Optional[str]):
+    return FunctionCall(alias, "minus", (lhs, rhs))
+
+
+def multiply(lhs: Expression, rhs: Expression, alias: Optional[str]):
+    return FunctionCall(alias, "multiply", (lhs, rhs))
+
+
+def div(lhs: Expression, rhs: Expression, alias: Optional[str]):
+    return FunctionCall(alias, "div", (lhs, rhs))

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -11,17 +11,17 @@ def literals_tuple(alias: Optional[str], literals: Sequence[Literal]):
 
 
 # arithmetic function
-def plus(lhs: Expression, rhs: Expression, alias: Optional[str]):
+def plus(lhs: Expression, rhs: Expression, alias: Optional[str] = None):
     return FunctionCall(alias, "plus", (lhs, rhs))
 
 
-def minus(lhs: Expression, rhs: Expression, alias: Optional[str]):
+def minus(lhs: Expression, rhs: Expression, alias: Optional[str] = None):
     return FunctionCall(alias, "minus", (lhs, rhs))
 
 
-def multiply(lhs: Expression, rhs: Expression, alias: Optional[str]):
+def multiply(lhs: Expression, rhs: Expression, alias: Optional[str] = None):
     return FunctionCall(alias, "multiply", (lhs, rhs))
 
 
-def div(lhs: Expression, rhs: Expression, alias: Optional[str]):
+def div(lhs: Expression, rhs: Expression, alias: Optional[str] = None):
     return FunctionCall(alias, "div", (lhs, rhs))

--- a/snuba/query/processors/apdex_processor.py
+++ b/snuba/query/processors/apdex_processor.py
@@ -1,0 +1,74 @@
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
+from snuba.query.expressions import (
+    Expression,
+    FunctionCall,
+    Literal,
+)
+from snuba.query.dsl import div, multiply, plus
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+class ApdexProcessor(QueryProcessor):
+    """
+    Resolves the apdex function call into
+    countIf({col} <= {satisfied}) + (countIf(({col} > {satisfied}) AND ({col} <= {tolerated})) / 2)) / count()
+    according to the definition of apdex index: https://en.wikipedia.org/wiki/Apdex
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def process_functions(exp: Expression) -> Expression:
+            if isinstance(exp, FunctionCall) and exp.function_name == "apdex":
+                assert len(exp.parameters) == 2
+                column = exp.parameters[0]
+                satisfied = exp.parameters[1]
+                tolerated = multiply(satisfied, Literal(None, 4))
+
+                return div(
+                    plus(
+                        FunctionCall(
+                            None,
+                            "countIf",
+                            (
+                                binary_condition(
+                                    None, ConditionFunctions.LTE, column, satisfied,
+                                ),
+                            ),
+                        ),
+                        div(
+                            FunctionCall(
+                                None,
+                                "countIf",
+                                (
+                                    binary_condition(
+                                        None,
+                                        BooleanFunctions.AND,
+                                        binary_condition(
+                                            None,
+                                            ConditionFunctions.GT,
+                                            column,
+                                            satisfied,
+                                        ),
+                                        binary_condition(
+                                            None,
+                                            ConditionFunctions.LTE,
+                                            column,
+                                            tolerated,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            Literal(None, 2),
+                        ),
+                    ),
+                    FunctionCall(None, "count", ()),
+                )
+
+            return exp
+
+        query.transform_expressions(process_functions)

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -1,0 +1,90 @@
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
+from snuba.datasets.schemas.tables import TableSource
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
+from snuba.query.dsl import div, multiply, plus
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.processors.apdex_processor import ApdexProcessor
+from snuba.query.query import Query
+from snuba.request.request_settings import HTTPRequestSettings
+
+
+def test_format_expressions() -> None:
+    unprocessed = Query(
+        {},
+        TableSource("events", ColumnSet([])),
+        selected_columns=[
+            Column(None, "column2", None),
+            FunctionCall(
+                "perf", "apdex", (Column(None, "column1", None), Literal(None, 300))
+            ),
+        ],
+    )
+    expected = Query(
+        {},
+        TableSource("events", ColumnSet([])),
+        selected_columns=[
+            Column(None, "column2", None),
+            div(
+                plus(
+                    FunctionCall(
+                        None,
+                        "countIf",
+                        (
+                            binary_condition(
+                                None,
+                                ConditionFunctions.LTE,
+                                Column(None, "column1", None),
+                                Literal(None, 300),
+                            ),
+                        ),
+                    ),
+                    div(
+                        FunctionCall(
+                            None,
+                            "countIf",
+                            (
+                                binary_condition(
+                                    None,
+                                    BooleanFunctions.AND,
+                                    binary_condition(
+                                        None,
+                                        ConditionFunctions.GT,
+                                        Column(None, "column1", None),
+                                        Literal(None, 300),
+                                    ),
+                                    binary_condition(
+                                        None,
+                                        ConditionFunctions.LTE,
+                                        Column(None, "column1", None),
+                                        multiply(Literal(None, 300), Literal(None, 4)),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Literal(None, 2),
+                    ),
+                ),
+                FunctionCall(None, "count", (),),
+            ),
+        ],
+    )
+
+    ApdexProcessor().process_query(unprocessed, HTTPRequestSettings())
+    assert (
+        expected.get_selected_columns_from_ast()
+        == unprocessed.get_selected_columns_from_ast()
+    )
+
+    ret = unprocessed.get_selected_columns_from_ast()[1].accept(
+        ClickhouseExpressionFormatter()
+    )
+    assert ret == (
+        "div(plus(countIf(lessOrEquals(column1, 300)), "
+        "div(countIf(and(greater(column1, 300), "
+        "lessOrEquals(column1, multiply(300, 4)))), 2)), count())"
+    )


### PR DESCRIPTION
This reimplement apdex as a query processor to deal with the new AST.
Features we inherit by doing it this way instead of hacking aggregations:
- apdex works in every field of the query (please don't try to group by apdex)
- works both when passed through the clickhouse syntax (please stop using it) and the snuba syntax
- a query processor can introduce an apdex function in the query that is processed by this one 
- we can reprocess the content of the processed apdex in following processors (like changing table and columns)

Unit test added. We cannot test it directly through test_api still because the query processing is not complete.