### PR TITLE
fix(outcomes) Fix outcomes migration

### DIFF
--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -48,7 +48,7 @@ def outcomes_write_migrations(
     # Add/remove known migrations
     ret = []
     if "size" not in current_schema:
-        ret.append(f"ALTER TABLE {clickhouse_table} ADD COLUMN size UInt32")
+        ret.append(f"ALTER TABLE {clickhouse_table} ADD COLUMN size Nullable(UInt32)")
 
     return ret
 
@@ -59,7 +59,9 @@ def outcomes_read_migrations(
     # Add/remove known migrations
     ret = []
     if "bytes_received" not in current_schema:
-        ret.append(f"ALTER TABLE {clickhouse_table} ADD COLUMN bytes_received UInt64")
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN bytes_received Nullable(UInt64)"
+        )
 
     return ret
 

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -11,7 +11,7 @@ from snuba.clickhouse.columns import (
     UInt,
     UUID,
 )
-from snuba.datasets.schemas.tables import MergeTreeSchema
+from snuba.datasets.schemas.tables import MergeTreeSchema, MigrationSchemaColumn
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
@@ -19,6 +19,18 @@ from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
+
+
+def outcomes_raw_migrations(
+    clickhouse_table: str, current_schema: Mapping[str, MigrationSchemaColumn]
+) -> Sequence[str]:
+    # Add/remove known migrations
+    ret = []
+    if "size" not in current_schema:
+        ret.append(f"ALTER TABLE {clickhouse_table} ADD COLUMN size Nullable(UInt32)")
+        pass
+
+    return ret
 
 
 class OutcomesRawDataset(TimeSeriesDataset):
@@ -43,6 +55,7 @@ class OutcomesRawDataset(TimeSeriesDataset):
             order_by="(org_id, project_id, timestamp)",
             partition_by="(toMonday(timestamp))",
             settings={"index_granularity": 16384},
+            migration_function=outcomes_raw_migrations,
         )
 
         dataset_schemas = DatasetSchemas(


### PR DESCRIPTION
The migration to add the `size` column was missing two parts:
1) it misses the migration for the outcomes_raw dataset
2) it creates non nullable columns.