### PR TITLE
feature(outcomes): Add event size and bytes columns

### DIFF
--- a/snuba/datasets/dataset_schemas.py
+++ b/snuba/datasets/dataset_schemas.py
@@ -25,6 +25,9 @@ class DatasetSchemas(object):
     def get_read_schema(self) -> Schema:
         return self.__read_schema
 
+    def get_intermediary_schemas(self) -> Sequence[Schema]:
+        return self.__intermediary_schemas
+
     def __get_unique_schemas(self) -> Sequence[Schema]:
         unique_schemas: List[Schema] = []
 

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -165,6 +165,7 @@ class OutcomesDataset(TimeSeriesDataset):
                 ("outcome", UInt(8)),
                 ("reason", String()),
                 ("times_seen", UInt(64)),
+                ("bytes_received", UInt(64)),
             ]
         )
 

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -28,7 +28,6 @@ def outcomes_raw_migrations(
     ret = []
     if "size" not in current_schema:
         ret.append(f"ALTER TABLE {clickhouse_table} ADD COLUMN size Nullable(UInt32)")
-        pass
 
     return ret
 
@@ -44,6 +43,7 @@ class OutcomesRawDataset(TimeSeriesDataset):
                 ("outcome", UInt(8)),
                 ("reason", LowCardinality(Nullable(String()))),
                 ("event_id", Nullable(UUID())),
+                ("size", Nullable(UInt(32))),
             ]
         )
 

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -9,6 +9,8 @@ from snuba.datasets.schemas import RelationalSource, Schema
 from snuba.query.types import Condition
 from snuba.util import local_dataset_mode
 
+import functools
+
 
 class TableSource(RelationalSource):
     """
@@ -329,4 +331,12 @@ class MaterializedViewSchema(TableSchema):
                 self.__get_local_source_table_name(),
                 self.__get_local_destination_table_name(),
             ),
+        )
+
+    def get_migration_statements(
+        self,
+    ) -> Callable[[str, Mapping[str, MigrationSchemaColumn], str], Sequence[str]]:
+        return functools.partial(
+            super().get_migration_statements(),
+            table_definition=self.get_local_table_definition().statement,
         )

--- a/snuba/migrate.py
+++ b/snuba/migrate.py
@@ -45,7 +45,8 @@ def run(conn, dataset):
     schemas = []
     if dataset.get_table_writer():
         schemas.append(dataset.get_table_writer().get_schema())
-    schemas.append(dataset.get_dataset_schemas().get_read_schema())
+    schemas = [dataset.get_dataset_schemas().get_read_schema()]
+    schemas.extend(dataset.get_dataset_schemas().get_intermediary_schemas())
 
     for schema in schemas:
         _run_schema(conn, schema)


### PR DESCRIPTION
As part of our new pricing model, we want to capture the amount of bytes we are processing for events. This branch adds event_size and bytes columns to the outcomes data set so that we can track this metric.