### PR TITLE
perf(flattened tags) Support flattened tags on the events table

### DIFF
--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -78,6 +78,11 @@ def events_migrations(
             "ALTER TABLE %s ADD COLUMN location Nullable(String)" % clickhouse_table
         )
 
+    if "_tags_flattened" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _tags_flattened String DEFAULT '' AFTER tags"
+        )
+
     return ret
 
 
@@ -193,6 +198,7 @@ class EventsDataset(TimeSeriesDataset):
             + [
                 # other tags
                 ("tags", Nested([("key", String()), ("value", String())])),
+                ("_tags_flattened", String()),
                 # other context
                 ("contexts", Nested([("key", String()), ("value", String())])),
                 # http interface

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -1,0 +1,107 @@
+from datetime import datetime, timedelta
+from typing import Sequence, Tuple
+
+from snuba import settings
+from snuba.processor import (
+    _ensure_valid_date,
+    _ensure_valid_ip,
+    _unicodify,
+)
+
+
+def extract_base(output, message):
+    output["event_id"] = message["event_id"]
+    project_id = message["project_id"]
+    output["project_id"] = project_id
+    return output
+
+
+def extract_user(output, user):
+    output["user_id"] = _unicodify(user.get("id", None))
+    output["username"] = _unicodify(user.get("username", None))
+    output["email"] = _unicodify(user.get("email", None))
+    ip_addr = _ensure_valid_ip(user.get("ip_address", None))
+    output["ip_address"] = str(ip_addr) if ip_addr is not None else None
+
+
+def extract_extra_tags(tags) -> Tuple[Sequence[str], Sequence[str]]:
+    tag_keys = []
+    tag_values = []
+    for tag_key, tag_value in sorted(tags.items()):
+        value = _unicodify(tag_value)
+        if value:
+            tag_keys.append(_unicodify(tag_key))
+            tag_values.append(value)
+
+    return (tag_keys, tag_values)
+
+
+def extract_extra_contexts(contexts) -> Tuple[Sequence[str], Sequence[str]]:
+    context_keys = []
+    context_values = []
+    valid_types = (int, float, str)
+    for ctx_name, ctx_obj in contexts.items():
+        if isinstance(ctx_obj, dict):
+            ctx_obj.pop("type", None)  # ignore type alias
+            for inner_ctx_name, ctx_value in ctx_obj.items():
+                if isinstance(ctx_value, valid_types):
+                    value = _unicodify(ctx_value)
+                    if value:
+                        ctx_key = f"{ctx_name}.{inner_ctx_name}"
+                        context_keys.append(_unicodify(ctx_key))
+                        context_values.append(_unicodify(ctx_value))
+
+    return (context_keys, context_values)
+
+
+def enforce_retention(message, timestamp):
+    project_id = message["project_id"]
+    retention_days = settings.RETENTION_OVERRIDES.get(project_id)
+    if retention_days is None:
+        retention_days = int(
+            message.get("retention_days") or settings.DEFAULT_RETENTION_DAYS
+        )
+
+    # This is not ideal but it should never happen anyways
+    timestamp = _ensure_valid_date(timestamp)
+    if timestamp is None:
+        timestamp = datetime.utcnow()
+    # TODO: We may need to allow for older events in the future when post
+    # processing triggers are based off of Snuba. Or this branch could be put
+    # behind a "backfill-only" optional switch.
+    if settings.DISCARD_OLD_EVENTS and timestamp < (
+        datetime.utcnow() - timedelta(days=retention_days)
+    ):
+        raise EventTooOld
+    return retention_days
+
+
+ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", "=": "\="})
+
+
+def escape_field(field: str) -> str:
+    """
+    We have ':' in our tag names. Also we may have '|'. This escapes : and \ so
+    that we can always rebuild the tags from the map. When looking for tags with LIKE
+    there should be no issue. But there may be other cases.
+    """
+    return field.translate(ESCAPE_TRANSLATION)
+
+
+def flatten_nested_field(keys: Sequence[str], values: Sequence[str]) -> str:
+    # We need to guarantee the content of the merged string is sorted otherwise we
+    # will not be able to run a LIKE operation over multiple fields at the same time.
+    # Tags are pre sorted, but it seems contexts are not, so to make this generic
+    # we ensure the invariant is respected here.
+    pairs = sorted(zip(keys, values))
+    str_pairs = [f"|{escape_field(k)}={escape_field(v)}|" for k, v in pairs]
+    # The result is going to be:
+    # |tag:val||tag:val|
+    # This gives the guarantee we will always have a delimiter on both side of the
+    # tag pair, thus we can unequivocally identify a tag with a LIKE expression even if
+    # the value or the tag name in the query is a substring of a real tag.
+    return "".join(str_pairs)
+
+
+class EventTooOld(Exception):
+    pass

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -1,16 +1,24 @@
-from datetime import datetime, timedelta
-from typing import Optional, Sequence, Tuple
+from datetime import datetime
+from typing import Optional
 
 import logging
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba import settings
+from snuba.datasets.events_format import (
+    enforce_retention,
+    extract_base,
+    extract_extra_contexts,
+    extract_extra_tags,
+    extract_user,
+    flatten_nested_field,
+    EventTooOld,
+)
 from snuba.processor import (
     _as_dict_safe,
     _boolify,
     _collapse_uint32,
     _ensure_valid_date,
-    _ensure_valid_ip,
     _floatify,
     _hashify,
     _unicodify,
@@ -21,101 +29,8 @@ from snuba.processor import (
     ProcessedMessage,
 )
 
+
 logger = logging.getLogger("snuba.processor")
-
-
-def extract_base(output, message):
-    output["event_id"] = message["event_id"]
-    project_id = message["project_id"]
-    output["project_id"] = project_id
-    return output
-
-
-def extract_user(output, user):
-    output["user_id"] = _unicodify(user.get("id", None))
-    output["username"] = _unicodify(user.get("username", None))
-    output["email"] = _unicodify(user.get("email", None))
-    ip_addr = _ensure_valid_ip(user.get("ip_address", None))
-    output["ip_address"] = str(ip_addr) if ip_addr is not None else None
-
-
-def extract_extra_tags(tags) -> Tuple[Sequence[str], Sequence[str]]:
-    tag_keys = []
-    tag_values = []
-    for tag_key, tag_value in sorted(tags.items()):
-        value = _unicodify(tag_value)
-        if value:
-            tag_keys.append(_unicodify(tag_key))
-            tag_values.append(value)
-
-    return (tag_keys, tag_values)
-
-
-def extract_extra_contexts(contexts) -> Tuple[Sequence[str], Sequence[str]]:
-    context_keys = []
-    context_values = []
-    valid_types = (int, float, str)
-    for ctx_name, ctx_obj in contexts.items():
-        if isinstance(ctx_obj, dict):
-            ctx_obj.pop("type", None)  # ignore type alias
-            for inner_ctx_name, ctx_value in ctx_obj.items():
-                if isinstance(ctx_value, valid_types):
-                    value = _unicodify(ctx_value)
-                    if value:
-                        ctx_key = f"{ctx_name}.{inner_ctx_name}"
-                        context_keys.append(_unicodify(ctx_key))
-                        context_values.append(_unicodify(ctx_value))
-
-    return (context_keys, context_values)
-
-
-def enforce_retention(message, timestamp):
-    project_id = message["project_id"]
-    retention_days = settings.RETENTION_OVERRIDES.get(project_id)
-    if retention_days is None:
-        retention_days = int(
-            message.get("retention_days") or settings.DEFAULT_RETENTION_DAYS
-        )
-
-    # This is not ideal but it should never happen anyways
-    timestamp = _ensure_valid_date(timestamp)
-    if timestamp is None:
-        timestamp = datetime.utcnow()
-    # TODO: We may need to allow for older events in the future when post
-    # processing triggers are based off of Snuba. Or this branch could be put
-    # behind a "backfill-only" optional switch.
-    if settings.DISCARD_OLD_EVENTS and timestamp < (
-        datetime.utcnow() - timedelta(days=retention_days)
-    ):
-        raise EventTooOld
-    return retention_days
-
-
-ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", "=": "\="})
-
-
-def escape_field(field: str) -> str:
-    """
-    We have ':' in our tag names. Also we may have '|'. This escapes : and \ so
-    that we can always rebuild the tags from the map. When looking for tags with LIKE
-    there should be no issue. But there may be other cases.
-    """
-    return field.translate(ESCAPE_TRANSLATION)
-
-
-def flatten_nested_field(keys: Sequence[str], values: Sequence[str]) -> str:
-    # We need to guarantee the content of the merged string is sorted otherwise we
-    # will not be able to run a LIKE operation over multiple fields at the same time.
-    # Tags are pre sorted, but it seems contexts are not, so to make this generic
-    # we ensure the invariant is respected here.
-    pairs = sorted(zip(keys, values))
-    str_pairs = [f"|{escape_field(k)}={escape_field(v)}|" for k, v in pairs]
-    # The result is going to be:
-    # |tag:val||tag:val|
-    # This gives the guarantee we will always have a delimiter on both side of the
-    # tag pair, thus we can unequivocally identify a tag with a LIKE expression even if
-    # the value or the tag name in the query is a substring of a real tag.
-    return "".join(str_pairs)
 
 
 class EventsProcessor(MessageProcessor):
@@ -454,7 +369,3 @@ class EventsProcessor(MessageProcessor):
         output["exception_frames.colno"] = frame_colnos
         output["exception_frames.lineno"] = frame_linenos
         output["exception_frames.stack_level"] = frame_stack_levels
-
-
-class EventTooOld(Exception):
-    pass

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -108,13 +108,13 @@ def merge_nested_field(keys: Sequence[str], values: Sequence[str]) -> str:
     # Tags are pre sorted, but it seems contexts are not, so to make this generic
     # we ensure the invariant is respected here.
     pairs = sorted(zip(keys, values))
-    pairs = [f"|{escape_field(k)}={escape_field(v)}|" for k, v in pairs]
+    str_pairs = [f"|{escape_field(k)}={escape_field(v)}|" for k, v in pairs]
     # The result is going to be:
     # |tag:val||tag:val|
     # This gives the guarantee we will always have a delimiter on both side of the
     # tag pair, thus we can univocally identify a tag with a LIKE expression even if
     # the value or the tag name in the query is a substring of a real tag.
-    return "".join(pairs)
+    return "".join(str_pairs)
 
 
 class EventsProcessor(MessageProcessor):

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from semaphore.consts import SPAN_STATUS_NAME_TO_CODE
-from typing import Optional, Sequence
+from typing import Optional
 
 import uuid
 
@@ -20,6 +20,7 @@ from snuba.datasets.events_processor import (
     extract_extra_contexts,
     extract_extra_tags,
     extract_user,
+    merge_nested_field,
 )
 from snuba.util import create_metrics
 
@@ -31,17 +32,6 @@ metrics = create_metrics(
 
 UNKNOWN_SPAN_STATUS = 2
 
-ESCAPE_TRANSLATION = str.maketrans({"\\": "\\\\", "|": "\|", "=": "\="})
-
-
-def escape_field(field: str) -> str:
-    """
-    We have ':' in our tag names. Also we may have '|'. This escapes : and \ so
-    that we can always rebuild the tags from the map. When looking for tags with LIKE
-    there should be no issue. But there may be other cases.
-    """
-    return field.translate(ESCAPE_TRANSLATION)
-
 
 class TransactionsMessageProcessor(MessageProcessor):
     PROMOTED_TAGS = {
@@ -50,20 +40,6 @@ class TransactionsMessageProcessor(MessageProcessor):
         "sentry:user",
         "sentry:dist",
     }
-
-    def __merge_nested_field(self, keys: Sequence[str], values: Sequence[str]) -> str:
-        # We need to guarantee the content of the merged string is sorted otherwise we
-        # will not be able to run a LIKE operation over multiple fields at the same time.
-        # Tags are pre sorted, but it seems contexts are not, so to make this generic
-        # we ensure the invariant is respected here.
-        pairs = sorted(zip(keys, values))
-        pairs = [f"|{escape_field(k)}={escape_field(v)}|" for k, v in pairs]
-        # The result is going to be:
-        # |tag:val||tag:val|
-        # This gives the guarantee we will always have a delimiter on both side of the
-        # tag pair, thus we can univocally identify a tag with a LIKE expression even if
-        # the value or the tag name in the query is a substring of a real tag.
-        return "".join(pairs)
 
     def __extract_timestamp(self, field):
         timestamp = _ensure_valid_date(datetime.fromtimestamp(field))
@@ -133,7 +109,7 @@ class TransactionsMessageProcessor(MessageProcessor):
 
         tags = _as_dict_safe(data.get("tags", None))
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
-        processed["_tags_flattened"] = self.__merge_nested_field(
+        processed["_tags_flattened"] = merge_nested_field(
             processed["tags.key"], processed["tags.value"]
         )
 
@@ -153,7 +129,7 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(
             contexts
         )
-        processed["_contexts_flattened"] = self.__merge_nested_field(
+        processed["_contexts_flattened"] = merge_nested_field(
             processed["contexts.key"], processed["contexts.value"]
         )
 

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -20,7 +20,7 @@ from snuba.datasets.events_processor import (
     extract_extra_contexts,
     extract_extra_tags,
     extract_user,
-    merge_nested_field,
+    flatten_nested_field,
 )
 from snuba.util import create_metrics
 
@@ -107,7 +107,7 @@ class TransactionsMessageProcessor(MessageProcessor):
 
         tags = _as_dict_safe(data.get("tags", None))
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
-        processed["_tags_flattened"] = merge_nested_field(
+        processed["_tags_flattened"] = flatten_nested_field(
             processed["tags.key"], processed["tags.value"]
         )
 
@@ -127,7 +127,7 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(
             contexts
         )
-        processed["_contexts_flattened"] = merge_nested_field(
+        processed["_contexts_flattened"] = flatten_nested_field(
             processed["contexts.key"], processed["contexts.value"]
         )
 

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -4,7 +4,15 @@ from typing import Optional
 
 import uuid
 
-from snuba import settings
+from snuba.datasets.events_format import (
+    enforce_retention,
+    extract_base,
+    extract_extra_contexts,
+    extract_extra_tags,
+    extract_user,
+    flatten_nested_field,
+)
+
 from snuba.processor import (
     _as_dict_safe,
     MessageProcessor,
@@ -13,14 +21,6 @@ from snuba.processor import (
     _ensure_valid_date,
     _ensure_valid_ip,
     _unicodify,
-)
-from snuba.datasets.events_processor import (
-    enforce_retention,
-    extract_base,
-    extract_extra_contexts,
-    extract_extra_tags,
-    extract_user,
-    flatten_nested_field,
 )
 from snuba.util import create_metrics
 

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -8,7 +8,7 @@ from typing import Optional, List, NamedTuple, Set
 from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
-from snuba.datasets.transactions_processor import escape_field
+from snuba.datasets.events_processor import escape_field
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
 from snuba.util import is_condition, is_function, parse_datetime

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -8,7 +8,7 @@ from typing import Optional, List, NamedTuple, Set
 from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
-from snuba.datasets.events_processor import escape_field
+from snuba.datasets.events_format import escape_field
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
 from snuba.util import is_condition, is_function, parse_datetime

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -6,33 +6,12 @@ import simplejson as json
 
 from snuba import replacer
 from snuba.clickhouse import DATETIME_FORMAT
+from snuba.replacer import FLATTENED_COLUMN_TEMPLATE
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.base import BaseEventsTest
-
-FLATTENED_COLUMN_TEMPLATE = """
-concat(
-    '|',
-    arrayStringConcat(
-        arrayMap(tuple -> concat(
-                replaceRegexpAll(tuple.1, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'),
-                '=',
-                replaceRegexpAll(tuple.2, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1')
-            ),
-            arraySort(
-                arrayFilter(
-                    tuple -> tuple.1 != %s,
-                    arrayMap((k, v) -> tuple(k, v), `tags.key`, `tags.value`)
-                )
-            )
-        ),
-        '||'
-    ),
-    '|'
-)
-"""
 
 
 class TestReplacer(BaseEventsTest):

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -12,6 +12,28 @@ from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.base import BaseEventsTest
 
+FLATTENED_COLUMN_TEMPLATE = """
+concat(
+    '|',
+    arrayStringConcat(
+        arrayMap(tuple -> concat(
+                replaceRegexpAll(tuple.1, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'),
+                '=',
+                replaceRegexpAll(tuple.2, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1')
+            ),
+            arraySort(
+                arrayFilter(
+                    tuple -> tuple.1 != %s,
+                    arrayMap((k, v) -> tuple(k, v), `tags.key`, `tags.value`)
+                )
+            )
+        ),
+        '||'
+    ),
+    '|'
+)
+"""
+
 
 class TestReplacer(BaseEventsTest):
     def setup_method(self, test_method):
@@ -108,8 +130,8 @@ class TestReplacer(BaseEventsTest):
             == "INSERT INTO %(dist_write_table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(dist_read_table_name)s FINAL PREWHERE group_id IN (%(previous_group_ids)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
         )
         assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
             "previous_group_ids": ", ".join(str(gid) for gid in [1, 2]),
             "project_id": self.project_id,
             "timestamp": timestamp.strftime(DATETIME_FORMAT),
@@ -145,8 +167,8 @@ class TestReplacer(BaseEventsTest):
             == "INSERT INTO %(dist_write_table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(dist_read_table_name)s FINAL PREWHERE group_id = %(previous_group_id)s WHERE project_id = %(project_id)s AND primary_hash IN (%(hashes)s) AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
         )
         assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
             "hashes": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
             "previous_group_id": 1,
             "project_id": self.project_id,
@@ -176,9 +198,10 @@ class TestReplacer(BaseEventsTest):
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
             == "INSERT INTO %(dist_write_table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(dist_read_table_name)s FINAL WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted AND %(tag_column)s IS NOT NULL"
         )
+        flattened_column = FLATTENED_COLUMN_TEMPLATE % "'sentry:user'"
         assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, NULL, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'sentry:user')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'sentry:user'), arrayEnumerate(`tags.value`))), contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "select_columns": f"event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, NULL, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'sentry:user')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'sentry:user'), arrayEnumerate(`tags.value`))), {flattened_column}, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
             "tag_column": "`sentry:user`",
             "tag_str": "'sentry:user'",
             "project_id": self.project_id,
@@ -208,9 +231,11 @@ class TestReplacer(BaseEventsTest):
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
             == "INSERT INTO %(dist_write_table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(dist_read_table_name)s FINAL WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted AND has(`tags.key`, %(tag_str)s)"
         )
+
+        flattened_column = FLATTENED_COLUMN_TEMPLATE % "'foo:bar'"
         assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'foo:bar')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'foo:bar'), arrayEnumerate(`tags.value`))), contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
+            "select_columns": f"event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'foo:bar')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'foo:bar'), arrayEnumerate(`tags.value`))), {flattened_column}, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
             "tag_column": "`foo:bar`",
             "tag_str": "'foo:bar'",
             "project_id": self.project_id,
@@ -386,6 +411,84 @@ class TestReplacer(BaseEventsTest):
 
         assert _issue_count() == []
         assert _issue_count(total=True) == [{"count": 1, "group_id": 1}]
+
+    def test_flattened_tags(self):
+        self.event["project_id"] = self.project_id
+        self.event["group_id"] = 1
+        # | and = are intentional to test the escaping logic when computing the
+        # flattened_tags on tag deletions
+        self.event["data"]["tags"] = []
+        self.event["data"]["tags"].append(["browser|name", "foo=1"])
+        self.event["data"]["tags"].append(["browser|to_delete", "foo=2"])
+        self.event["data"]["tags"].append(["notbrowser", "foo\\3"])
+        self.event["data"]["tags"].append(["notbrowser2", "foo4"])
+        self.write_raw_events(self.event)
+
+        project_id = self.project_id
+
+        def _fetch_flattened_tags():
+            return json.loads(
+                self.app.post(
+                    "/query",
+                    data=json.dumps(
+                        {
+                            "project": [project_id],
+                            "selected_columns": [
+                                "_tags_flattened",
+                                "tags.key",
+                                "tags.value",
+                            ],
+                        }
+                    ),
+                ).data
+            )["data"]
+
+        assert _fetch_flattened_tags() == [
+            {
+                "tags.key": [
+                    "browser|name",
+                    "browser|to_delete",
+                    "notbrowser",
+                    "notbrowser2",
+                ],
+                "tags.value": ["foo=1", "foo=2", "foo\\3", "foo4"],
+                "_tags_flattened": "|browser\\|name=foo\\=1||browser\\|to_delete=foo\\=2||notbrowser=foo\\\\3||notbrowser2=foo4|",
+            }
+        ]
+
+        timestamp = datetime.now(tz=pytz.utc)
+
+        message: Message[KafkaPayload] = Message(
+            Partition(Topic("replacements"), 1),
+            42,
+            KafkaPayload(
+                None,
+                json.dumps(
+                    (
+                        2,
+                        "end_delete_tag",
+                        {
+                            "project_id": project_id,
+                            "tag": "browser|to_delete",
+                            "datetime": timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
+                        },
+                    )
+                ).encode("utf-8"),
+            ),
+            datetime.now(),
+        )
+
+        processed = self.replacer.process_message(message)
+        self.replacer.flush_batch([processed])
+
+        print(_fetch_flattened_tags())
+        assert _fetch_flattened_tags() == [
+            {
+                "tags.key": ["browser|name", "notbrowser", "notbrowser2"],
+                "tags.value": ["foo=1", "foo\\3", "foo4"],
+                "_tags_flattened": "|browser\\|name=foo\\=1||notbrowser=foo\\\\3||notbrowser2=foo4|",
+            }
+        ]
 
     def test_query_time_flags(self):
         project_ids = [1, 2]

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -460,7 +460,6 @@ class TestReplacer(BaseEventsTest):
         processed = self.replacer.process_message(message)
         self.replacer.flush_batch([processed])
 
-        print(_fetch_flattened_tags())
         assert _fetch_flattened_tags() == [
             {
                 "tags.key": ["browser|name", "notbrowser", "notbrowser2"],


### PR DESCRIPTION
We are adding the tags_flattened column on the events table as on the transactions table.
Here it is more complex because we have to recalculate it during replacements if the user deletes tags.

Unit test added to verify clickhouse recalculate the flattened tags correctly even when it needs to escape characters.