### PR TITLE
ref(streams): Use `Topic` object consistently

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -3,7 +3,9 @@ import logging
 from typing import Any, Mapping, Optional, Sequence
 
 import simplejson as json
+from confluent_kafka import Producer as ConfluentKafkaProducer
 
+from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import enforce_table_writer
 from snuba.processor import ProcessedMessage, ProcessorAction
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -25,11 +27,11 @@ class InvalidActionType(Exception):
 class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
     def __init__(
         self,
-        dataset,
-        producer,
+        dataset: Dataset,
+        producer: Optional[ConfluentKafkaProducer],
         replacements_topic: Optional[Topic],
         metrics: MetricsBackend,
-    ):
+    ) -> None:
         self.__dataset = dataset
         self.producer = producer
         self.replacements_topic = replacements_topic

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -28,9 +28,9 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
     def __init__(
         self,
         dataset: Dataset,
-        producer: Optional[ConfluentKafkaProducer],
-        replacements_topic: Optional[Topic],
         metrics: MetricsBackend,
+        producer: Optional[ConfluentKafkaProducer] = None,
+        replacements_topic: Optional[Topic] = None,
     ) -> None:
         self.__dataset = dataset
         self.producer = producer

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -1,5 +1,6 @@
-from confluent_kafka import KafkaError, KafkaException, Producer
 from typing import Optional, Sequence
+
+from confluent_kafka import KafkaError, KafkaException, Producer
 
 from snuba import settings, util
 from snuba.consumer import ConsumerWorker
@@ -55,19 +56,32 @@ class ConsumerBuilder:
             self.bootstrap_servers = bootstrap_servers
 
         stream_loader = enforce_table_writer(self.dataset).get_stream_loader()
-        self.raw_topic = raw_topic or stream_loader.get_default_topic_spec().topic_name
-        default_replacement_topic_name = (
-            stream_loader.get_replacement_topic_spec().topic_name
-            if stream_loader.get_replacement_topic_spec()
-            else None
-        )
-        self.replacements_topic = replacements_topic or default_replacement_topic_name
-        default_commit_log_topic_name = (
-            stream_loader.get_commit_log_topic_spec().topic_name
-            if stream_loader.get_commit_log_topic_spec()
-            else None
-        )
-        self.commit_log_topic = commit_log_topic or default_commit_log_topic_name
+
+        self.raw_topic: Topic
+        if raw_topic is not None:
+            self.raw_topic = Topic(raw_topic)
+        else:
+            self.raw_topic = Topic(stream_loader.get_default_topic_spec().topic_name)
+
+        self.replacements_topic: Optional[Topic]
+        if replacements_topic is not None:
+            self.replacements_topic = Topic(replacements_topic)
+        else:
+            replacement_topic_spec = stream_loader.get_replacement_topic_spec()
+            if replacement_topic_spec is not None:
+                self.replacements_topic = Topic(replacement_topic_spec.topic_name)
+            else:
+                self.replacements_topic = None
+
+        self.commit_log_topic: Optional[Topic]
+        if commit_log_topic is not None:
+            self.commit_log_topic = Topic(commit_log_topic)
+        else:
+            commit_log_topic_spec = stream_loader.get_commit_log_topic_spec()
+            if commit_log_topic_spec is not None:
+                self.commit_log_topic = Topic(commit_log_topic_spec.topic_name)
+            else:
+                self.commit_log_topic = None
 
         # XXX: This can result in a producer being built in cases where it's
         # not actually required.
@@ -131,13 +145,13 @@ class ConsumerBuilder:
                 configuration,
                 codec=codec,
                 producer=self.producer,
-                commit_log_topic=Topic(self.commit_log_topic),
+                commit_log_topic=self.commit_log_topic,
                 commit_retry_policy=self.__commit_retry_policy,
             )
 
         return BatchingConsumer(
             consumer,
-            Topic(self.raw_topic),
+            self.raw_topic,
             worker=worker,
             max_batch_size=self.max_batch_size,
             max_batch_time=self.max_batch_time_ms,

--- a/snuba/consumers/snapshot_worker.py
+++ b/snuba/consumers/snapshot_worker.py
@@ -1,13 +1,14 @@
 import logging
+from typing import Any, Mapping, Optional, Set
 
 from confluent_kafka import Producer
-from typing import Any, Optional, Mapping, Set
 
 from snuba.consumer import ConsumerWorker, KafkaMessageMetadata
-from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.datasets.dataset import Dataset
 from snuba.snapshots import SnapshotId
+from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.abstract import MetricsBackend
+from snuba.utils.streams.types import Topic
 
 logger = logging.getLogger("snuba.snapshot-consumer")
 
@@ -38,7 +39,7 @@ class SnapshotAwareWorker(ConsumerWorker):
         snapshot_id: SnapshotId,
         transaction_data: TransactionData,
         metrics: MetricsBackend,
-        replacements_topic: Optional[str] = None,
+        replacements_topic: Optional[Topic] = None,
     ) -> None:
         super().__init__(
             dataset=dataset,

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -47,12 +47,7 @@ def run(events_file, dataset, repeat=1, profile_process=False, profile_write=Fal
     for statement in dataset.get_dataset_schemas().get_create_statements():
         ClickhousePool().execute(statement)
 
-    consumer = ConsumerWorker(
-        dataset=dataset,
-        producer=None,
-        replacements_topic=None,
-        metrics=DummyMetricsBackend(),
-    )
+    consumer = ConsumerWorker(dataset, metrics=DummyMetricsBackend())
 
     messages = get_messages(events_file)
     messages = chain(*([messages] * repeat))

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -451,9 +451,7 @@ if application.debug or application.testing:
         if type_ == "insert":
             from snuba.consumer import ConsumerWorker
 
-            worker = ConsumerWorker(
-                dataset, producer=None, replacements_topic=None, metrics=metrics
-            )
+            worker = ConsumerWorker(dataset, metrics=metrics)
         else:
             from snuba.replacer import ReplacerWorker
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -28,14 +28,16 @@ class TestConsumer(BaseEventsTest):
             datetime.now(),
         )
 
-        replacement_topic = Topic(
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_replacement_topic_spec()
-            .topic_name
-        )
         test_worker = ConsumerWorker(
-            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
+            self.dataset,
+            producer=FakeConfluentKafkaProducer(),
+            replacements_topic=Topic(
+                enforce_table_writer(self.dataset)
+                .get_stream_loader()
+                .get_replacement_topic_spec()
+                .topic_name
+            ),
+            metrics=self.metrics,
         )
         batch = [test_worker.process_message(message)]
         test_worker.flush_batch(batch)
@@ -45,14 +47,16 @@ class TestConsumer(BaseEventsTest):
         ) == [(self.event["project_id"], self.event["event_id"], 123, 456)]
 
     def test_skip_too_old(self):
-        replacement_topic = Topic(
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_replacement_topic_spec()
-            .topic_name
-        )
         test_worker = ConsumerWorker(
-            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
+            self.dataset,
+            producer=FakeConfluentKafkaProducer(),
+            replacements_topic=Topic(
+                enforce_table_writer(self.dataset)
+                .get_stream_loader()
+                .get_replacement_topic_spec()
+                .topic_name
+            ),
+            metrics=self.metrics,
         )
 
         event = self.event
@@ -73,14 +77,16 @@ class TestConsumer(BaseEventsTest):
 
     def test_produce_replacement_messages(self):
         producer = FakeConfluentKafkaProducer()
-        replacement_topic = Topic(
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_replacement_topic_spec()
-            .topic_name
-        )
         test_worker = ConsumerWorker(
-            self.dataset, producer, replacement_topic, self.metrics
+            self.dataset,
+            producer=producer,
+            replacements_topic=Topic(
+                enforce_table_writer(self.dataset)
+                .get_stream_loader()
+                .get_replacement_topic_spec()
+                .topic_name
+            ),
+            metrics=self.metrics,
         )
 
         test_worker.flush_batch(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -28,16 +28,14 @@ class TestConsumer(BaseEventsTest):
             datetime.now(),
         )
 
-        replacement_topic = (
+        replacement_topic = Topic(
             enforce_table_writer(self.dataset)
             .get_stream_loader()
             .get_replacement_topic_spec()
+            .topic_name
         )
         test_worker = ConsumerWorker(
-            self.dataset,
-            FakeConfluentKafkaProducer(),
-            replacement_topic.topic_name,
-            self.metrics,
+            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
         )
         batch = [test_worker.process_message(message)]
         test_worker.flush_batch(batch)
@@ -47,16 +45,14 @@ class TestConsumer(BaseEventsTest):
         ) == [(self.event["project_id"], self.event["event_id"], 123, 456)]
 
     def test_skip_too_old(self):
-        replacement_topic = (
+        replacement_topic = Topic(
             enforce_table_writer(self.dataset)
             .get_stream_loader()
             .get_replacement_topic_spec()
+            .topic_name
         )
         test_worker = ConsumerWorker(
-            self.dataset,
-            FakeConfluentKafkaProducer(),
-            replacement_topic.topic_name,
-            self.metrics,
+            self.dataset, FakeConfluentKafkaProducer(), replacement_topic, self.metrics,
         )
 
         event = self.event
@@ -77,13 +73,14 @@ class TestConsumer(BaseEventsTest):
 
     def test_produce_replacement_messages(self):
         producer = FakeConfluentKafkaProducer()
-        replacement_topic = (
+        replacement_topic = Topic(
             enforce_table_writer(self.dataset)
             .get_stream_loader()
             .get_replacement_topic_spec()
+            .topic_name
         )
         test_worker = ConsumerWorker(
-            self.dataset, producer, replacement_topic.topic_name, self.metrics
+            self.dataset, producer, replacement_topic, self.metrics
         )
 
         test_worker.flush_batch(


### PR DESCRIPTION
This is half of what was previously #686.

This change consistently uses the `Topic` object instead of the topic name downstream of the `ConsumerBuilder`. This also expands type annotations in several places around the consumer.