### PR TITLE
refs(requests): Move `validate_request_content` into the `request` module

### DIFF
--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -1,0 +1,25 @@
+import jsonschema
+import sentry_sdk
+from werkzeug.exceptions import BadRequest
+
+from snuba.datasets.dataset import Dataset
+from snuba.request import Request
+from snuba.request.schema import RequestSchema
+from snuba.utils.metrics.timer import Timer
+
+
+def validate_request_content(
+    body, schema: RequestSchema, timer: Timer, dataset: Dataset, referrer: str
+) -> Request:
+    with sentry_sdk.start_span(
+        description="validate_request_content", op="validate"
+    ) as span:
+        try:
+            request = schema.validate(body, dataset, referrer)
+            span.set_data("snuba_query", request.body)
+        except jsonschema.ValidationError as error:
+            raise BadRequest(str(error)) from error
+
+        timer.mark("validate_schema")
+
+    return request

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -8,6 +8,7 @@ from snuba.query.types import Condition
 from snuba.request import Request
 from snuba.request.request_settings import SubscriptionRequestSettings
 from snuba.request.schema import RequestSchema
+from snuba.request.validation import validate_request_content
 from snuba.utils.metrics.timer import Timer
 
 SUBSCRIPTION_REFERRER = "subscription"
@@ -48,10 +49,6 @@ class Subscription:
         :param timestamp: Date that the query should run up until
         :param offset: Maximum offset we should query for
         """
-        # XXX: We should move this somewhere better so that we don't need to import from
-        # web.views here.
-        from snuba.web.views import validate_request_content
-
         schema = RequestSchema.build_with_extensions(
             dataset.get_extensions(), SubscriptionRequestSettings,
         )


### PR DESCRIPTION
This allows `validate_request_content` to be used in subscriptions without circular import issues.