### PR TITLE
ref(subscriptions): Package layout and data model refinements

### DIFF
--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -1,0 +1,28 @@
+import json
+from datetime import timedelta
+
+from snuba.subscriptions.data import Subscription
+from snuba.utils.codecs import Codec
+
+
+class SubscriptionCodec(Codec[bytes, Subscription]):
+    def encode(self, value: Subscription) -> bytes:
+        return json.dumps(
+            {
+                "project_id": value.project_id,
+                "conditions": value.conditions,
+                "aggregations": value.aggregations,
+                "time_window": int(value.time_window.total_seconds()),
+                "resolution": int(value.resolution.total_seconds()),
+            }
+        ).encode("utf-8")
+
+    def decode(self, value: bytes) -> Subscription:
+        data = json.loads(value.decode("utf-8"))
+        return Subscription(
+            project_id=data["project_id"],
+            conditions=data["conditions"],
+            aggregations=data["aggregations"],
+            time_window=timedelta(seconds=data["time_window"]),
+            resolution=timedelta(seconds=data["resolution"]),
+        )

--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -1,12 +1,12 @@
 import json
 from datetime import timedelta
 
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.data import SubscriptionData
 from snuba.utils.codecs import Codec
 
 
-class SubscriptionCodec(Codec[bytes, Subscription]):
-    def encode(self, value: Subscription) -> bytes:
+class SubscriptionDataCodec(Codec[bytes, SubscriptionData]):
+    def encode(self, value: SubscriptionData) -> bytes:
         return json.dumps(
             {
                 "project_id": value.project_id,
@@ -17,9 +17,9 @@ class SubscriptionCodec(Codec[bytes, Subscription]):
             }
         ).encode("utf-8")
 
-    def decode(self, value: bytes) -> Subscription:
+    def decode(self, value: bytes) -> SubscriptionData:
         data = json.loads(value.decode("utf-8"))
-        return Subscription(
+        return SubscriptionData(
             project_id=data["project_id"],
             conditions=data["conditions"],
             aggregations=data["aggregations"],

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Optional, Sequence
+from typing import NewType, Optional, Sequence
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.query import Aggregation
@@ -18,10 +18,14 @@ class InvalidSubscriptionError(Exception):
     pass
 
 
+PartitionId = NewType("PartitionId", int)
+SubscriptionKey = NewType("SubscriptionKey", str)
+
+
 @dataclass(frozen=True)
 class SubscriptionIdentifier:
-    partition_id: int
-    subscription_id: str
+    partition: PartitionId
+    key: SubscriptionKey
 
 
 @dataclass(frozen=True)

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import NamedTuple, NewType, Optional, Sequence
+from uuid import UUID
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.query import Aggregation
@@ -19,13 +20,12 @@ class InvalidSubscriptionError(Exception):
 
 
 PartitionId = NewType("PartitionId", int)
-SubscriptionKey = NewType("SubscriptionKey", str)
 
 
 @dataclass(frozen=True)
 class SubscriptionIdentifier:
     partition: PartitionId
-    key: SubscriptionKey
+    key: UUID
 
 
 @dataclass(frozen=True)

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -19,6 +19,12 @@ class InvalidSubscriptionError(Exception):
 
 
 @dataclass(frozen=True)
+class SubscriptionIdentifier:
+    partition_id: int
+    subscription_id: str
+
+
+@dataclass(frozen=True)
 class Subscription:
     """
     Represents the state of a subscription.

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -25,7 +25,7 @@ PartitionId = NewType("PartitionId", int)
 @dataclass(frozen=True)
 class SubscriptionIdentifier:
     partition: PartitionId
-    key: UUID
+    uuid: UUID
 
 
 @dataclass(frozen=True)

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import NewType, Optional, Sequence
+from typing import NamedTuple, NewType, Optional, Sequence
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.query import Aggregation
@@ -78,3 +78,8 @@ class SubscriptionData:
             dataset,
             SUBSCRIPTION_REFERRER,
         )
+
+
+class Subscription(NamedTuple):
+    identifier: SubscriptionIdentifier
+    data: SubscriptionData

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -25,7 +25,7 @@ class SubscriptionIdentifier:
 
 
 @dataclass(frozen=True)
-class Subscription:
+class SubscriptionData:
     """
     Represents the state of a subscription.
     """

--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -4,7 +4,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 
 from snuba.datasets.dataset import Dataset
 from snuba.subscriptions.consumer import Tick
-from snuba.subscriptions.data import SubscriptionData
+from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.scheduler import ScheduledTask
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import ClickhouseQueryResult, parse_and_run_query
@@ -23,10 +23,10 @@ class SubscriptionExecutor:
         self.__executor_pool = executor_pool
 
     def execute(
-        self, task: ScheduledTask[SubscriptionData], tick: Tick, timer: Timer
+        self, task: ScheduledTask[Subscription], tick: Tick, timer: Timer
     ) -> Future[ClickhouseQueryResult]:
         try:
-            request = task.task.build_request(
+            request = task.task.data.build_request(
                 self.__dataset, tick.timestamps.upper, tick.offsets.upper, timer,
             )
         except Exception as e:

--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -4,7 +4,7 @@ from concurrent.futures import Future, ThreadPoolExecutor
 
 from snuba.datasets.dataset import Dataset
 from snuba.subscriptions.consumer import Tick
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.data import SubscriptionData
 from snuba.subscriptions.scheduler import ScheduledTask
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import ClickhouseQueryResult, parse_and_run_query
@@ -23,7 +23,7 @@ class SubscriptionExecutor:
         self.__executor_pool = executor_pool
 
     def execute(
-        self, task: ScheduledTask[Subscription], tick: Tick, timer: Timer
+        self, task: ScheduledTask[SubscriptionData], tick: Tick, timer: Timer
     ) -> Future[ClickhouseQueryResult]:
         try:
             request = task.task.build_request(

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -2,16 +2,16 @@ from abc import abstractmethod, ABC
 from binascii import crc32
 
 from snuba.datasets.dataset import Dataset
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.data import SubscriptionData
 
 
-class SubscriptionPartitioner(ABC):
+class SubscriptionDataPartitioner(ABC):
     @abstractmethod
-    def build_partition_id(self, subscription: Subscription) -> int:
+    def build_partition_id(self, data: SubscriptionData) -> int:
         pass
 
 
-class DatasetSubscriptionPartitioner(SubscriptionPartitioner):
+class DatasetSubscriptionDataPartitioner(SubscriptionDataPartitioner):
     """
     Partitions a subscription based on the Dataset that we're going to store it in.
     """
@@ -21,8 +21,6 @@ class DatasetSubscriptionPartitioner(SubscriptionPartitioner):
     def __init__(self, dataset: Dataset):
         self.__dataset = dataset
 
-    def build_partition_id(self, subscription: Subscription) -> int:
+    def build_partition_id(self, data: SubscriptionData) -> int:
         # TODO: Use something from the dataset to determine the number of partitions
-        return (
-            crc32(str(subscription.project_id).encode("utf-8")) % self.PARTITION_COUNT
-        )
+        return crc32(str(data.project_id).encode("utf-8")) % self.PARTITION_COUNT

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -2,12 +2,12 @@ from abc import abstractmethod, ABC
 from binascii import crc32
 
 from snuba.datasets.dataset import Dataset
-from snuba.subscriptions.data import SubscriptionData
+from snuba.subscriptions.data import PartitionId, SubscriptionData
 
 
 class SubscriptionDataPartitioner(ABC):
     @abstractmethod
-    def build_partition_id(self, data: SubscriptionData) -> int:
+    def build_partition_id(self, data: SubscriptionData) -> PartitionId:
         pass
 
 
@@ -21,6 +21,8 @@ class DatasetSubscriptionDataPartitioner(SubscriptionDataPartitioner):
     def __init__(self, dataset: Dataset):
         self.__dataset = dataset
 
-    def build_partition_id(self, data: SubscriptionData) -> int:
+    def build_partition_id(self, data: SubscriptionData) -> PartitionId:
         # TODO: Use something from the dataset to determine the number of partitions
-        return crc32(str(data.project_id).encode("utf-8")) % self.PARTITION_COUNT
+        return PartitionId(
+            crc32(str(data.project_id).encode("utf-8")) % self.PARTITION_COUNT
+        )

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -3,15 +3,15 @@ from typing import Collection, Tuple
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset_name
 from snuba.redis import RedisClientType
-from snuba.subscriptions.codecs import SubscriptionCodec
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.codecs import SubscriptionDataCodec
+from snuba.subscriptions.data import SubscriptionData
 
 
-class RedisSubscriptionStore:
+class RedisSubscriptionDataStore:
     """
-    A Redis backed store for Subscriptions. Stores subscriptions using
-    `SubscriptionCodec`. Each instance of the store operates on a partition of data,
-    defined by the `key` constructor param.
+    A Redis backed store for subscription data. Stores subscriptions using
+    `SubscriptionDataCodec`. Each instance of the store operates on a
+    partition of data, defined by the `key` constructor param.
     """
 
     KEY_TEMPLATE = "subscriptions:{}:{}"
@@ -20,29 +20,29 @@ class RedisSubscriptionStore:
         self.client = client
         self.dataset = dataset
         self.key = key
-        self.codec = SubscriptionCodec()
+        self.codec = SubscriptionDataCodec()
 
     @property
     def _key(self) -> str:
         return self.KEY_TEMPLATE.format(get_dataset_name(self.dataset), self.key)
 
-    def create(self, subscription_id: str, subscription: Subscription) -> None:
+    def create(self, subscription_id: str, data: SubscriptionData) -> None:
         """
-        Stores a `Subscription` in Redis. Will overwrite any existing `Subscriptions`
-        with the same id.
+        Stores subscription data in Redis. Will overwrite any existing
+        subscriptions with the same id.
         """
-        payload = self.codec.encode(subscription)
+        payload = self.codec.encode(data)
         self.client.hset(self._key, subscription_id.encode("utf-8"), payload)
 
     def delete(self, subscription_id: str) -> None:
         """
-        Removes a `Subscription` from the Redis store.
+        Removes a subscription from the Redis store.
         """
         self.client.hdel(self._key, subscription_id)
 
-    def all(self) -> Collection[Tuple[str, Subscription]]:
+    def all(self) -> Collection[Tuple[str, SubscriptionData]]:
         """
-        Fetches all `Subscriptions` from the store
+        Fetches all subscriptions from the store.
         :return: A collection of `Subscriptions`.
         """
         return [

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -1,35 +1,10 @@
-import json
-from datetime import timedelta
 from typing import Collection, Tuple
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset_name
 from snuba.redis import RedisClientType
+from snuba.subscriptions.codecs import SubscriptionCodec
 from snuba.subscriptions.data import Subscription
-from snuba.utils.codecs import Codec
-
-
-class SubscriptionCodec(Codec[bytes, Subscription]):
-    def encode(self, value: Subscription) -> bytes:
-        return json.dumps(
-            {
-                "project_id": value.project_id,
-                "conditions": value.conditions,
-                "aggregations": value.aggregations,
-                "time_window": int(value.time_window.total_seconds()),
-                "resolution": int(value.resolution.total_seconds()),
-            }
-        ).encode("utf-8")
-
-    def decode(self, value: bytes) -> Subscription:
-        data = json.loads(value.decode("utf-8"))
-        return Subscription(
-            project_id=data["project_id"],
-            conditions=data["conditions"],
-            aggregations=data["aggregations"],
-            time_window=timedelta(seconds=data["time_window"]),
-            resolution=timedelta(seconds=data["resolution"]),
-        )
 
 
 class RedisSubscriptionStore:

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -6,7 +6,6 @@ from snuba.redis import redis_client
 from snuba.subscriptions.data import (
     SubscriptionData,
     SubscriptionIdentifier,
-    SubscriptionKey,
 )
 from snuba.subscriptions.partitioner import DatasetSubscriptionDataPartitioner
 from snuba.subscriptions.store import RedisSubscriptionDataStore
@@ -29,7 +28,7 @@ class SubscriptionCreator:
         parse_and_run_query(self.dataset, request, timer)
         identifier = SubscriptionIdentifier(
             DatasetSubscriptionDataPartitioner(self.dataset).build_partition_id(data),
-            SubscriptionKey(uuid1().hex),
+            uuid1(),
         )
         RedisSubscriptionDataStore(
             redis_client, self.dataset, identifier.partition

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -33,6 +33,6 @@ class SubscriptionCreator:
         RedisSubscriptionDataStore(
             redis_client, self.dataset, identifier.partition
         ).create(
-            identifier.key, data,
+            identifier.uuid, data,
         )
         return identifier

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -1,20 +1,13 @@
-from dataclasses import dataclass
 from datetime import datetime
 from uuid import uuid1
 
 from snuba.datasets.dataset import Dataset
 from snuba.redis import redis_client
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.data import Subscription, SubscriptionIdentifier
 from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
 from snuba.subscriptions.store import RedisSubscriptionStore
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import parse_and_run_query
-
-
-@dataclass(frozen=True)
-class SubscriptionIdentifier:
-    partition_id: int
-    subscription_id: str
 
 
 class SubscriptionCreator:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -367,7 +367,9 @@ def create_subscription(*, dataset: Dataset, timer: Timer):
     # example date fields and aggregates.
     identifier = SubscriptionCreator(dataset).create(subscription, timer)
     return (
-        json.dumps({"subscription_id": f"{identifier.partition}/{identifier.key.hex}"}),
+        json.dumps(
+            {"subscription_id": f"{identifier.partition}/{identifier.uuid.hex}"}
+        ),
         202,
         {"Content-Type": "application/json"},
     )

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -367,7 +367,7 @@ def create_subscription(*, dataset: Dataset, timer: Timer):
     # example date fields and aggregates.
     identifier = SubscriptionCreator(dataset).create(subscription, timer)
     return (
-        json.dumps({"subscription_id": f"{identifier.partition}/{identifier.key}"}),
+        json.dumps({"subscription_id": f"{identifier.partition}/{identifier.key.hex}"}),
         202,
         {"Content-Type": "application/json"},
     )

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -26,7 +26,7 @@ from snuba.request import Request
 from snuba.request.schema import HTTPRequestSettings, RequestSchema, SETTINGS_SCHEMAS
 from snuba.redis import redis_client
 from snuba.request.validation import validate_request_content
-from snuba.subscriptions.codecs import SubscriptionCodec
+from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import InvalidSubscriptionError, SubscriptionIdentifier
 from snuba.subscriptions.subscription import SubscriptionCreator
 from snuba.util import local_dataset_mode
@@ -371,7 +371,7 @@ def build_external_subscription_id(identifier: SubscriptionIdentifier) -> str:
 @application.route("/<dataset:dataset>/subscriptions", methods=["POST"])
 @util.time_request("subscription")
 def create_subscription(*, dataset: Dataset, timer: Timer):
-    subscription = SubscriptionCodec().decode(http_request.data)
+    subscription = SubscriptionDataCodec().decode(http_request.data)
     # TODO: Check for valid queries with fields that are invalid for subscriptions. For
     # example date fields and aggregates.
     subscription_identifier = SubscriptionCreator(dataset).create(subscription, timer,)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -26,8 +26,8 @@ from snuba.request import Request
 from snuba.request.schema import HTTPRequestSettings, RequestSchema, SETTINGS_SCHEMAS
 from snuba.redis import redis_client
 from snuba.request.validation import validate_request_content
+from snuba.subscriptions.codecs import SubscriptionCodec
 from snuba.subscriptions.data import InvalidSubscriptionError, SubscriptionIdentifier
-from snuba.subscriptions.store import SubscriptionCodec
 from snuba.subscriptions.subscription import SubscriptionCreator
 from snuba.util import local_dataset_mode
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -26,9 +26,9 @@ from snuba.request import Request
 from snuba.request.schema import HTTPRequestSettings, RequestSchema, SETTINGS_SCHEMAS
 from snuba.redis import redis_client
 from snuba.request.validation import validate_request_content
-from snuba.subscriptions.data import InvalidSubscriptionError
+from snuba.subscriptions.data import InvalidSubscriptionError, SubscriptionIdentifier
 from snuba.subscriptions.store import SubscriptionCodec
-from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionIdentifier
+from snuba.subscriptions.subscription import SubscriptionCreator
 from snuba.util import local_dataset_mode
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.metrics.timer import Timer

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -1,0 +1,47 @@
+import json
+from datetime import timedelta
+
+from snuba.subscriptions.codecs import SubscriptionCodec
+from snuba.subscriptions.data import Subscription
+from tests.base import BaseTest
+
+
+class TestSubscriptionCodec(BaseTest):
+    def build_subscription(self) -> Subscription:
+        return Subscription(
+            project_id=5,
+            conditions=[["platform", "IN", ["a"]]],
+            aggregations=[["count()", "", "count"]],
+            time_window=timedelta(minutes=500),
+            resolution=timedelta(minutes=1),
+        )
+
+    def test_basic(self):
+        subscription = self.build_subscription()
+        codec = SubscriptionCodec()
+        assert codec.decode(codec.encode(subscription)) == subscription
+
+    def test_encode(self):
+        codec = SubscriptionCodec()
+        subscription = self.build_subscription()
+
+        payload = codec.encode(subscription)
+        data = json.loads(payload.decode("utf-8"))
+        assert data["project_id"] == subscription.project_id
+        assert data["conditions"] == subscription.conditions
+        assert data["aggregations"] == subscription.aggregations
+        assert data["time_window"] == int(subscription.time_window.total_seconds())
+        assert data["resolution"] == int(subscription.resolution.total_seconds())
+
+    def test_decode(self):
+        codec = SubscriptionCodec()
+        subscription = self.build_subscription()
+        data = {
+            "project_id": subscription.project_id,
+            "conditions": subscription.conditions,
+            "aggregations": subscription.aggregations,
+            "time_window": int(subscription.time_window.total_seconds()),
+            "resolution": int(subscription.resolution.total_seconds()),
+        }
+        payload = json.dumps(data).encode("utf-8")
+        assert codec.decode(payload) == subscription

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -1,14 +1,14 @@
 import json
 from datetime import timedelta
 
-from snuba.subscriptions.codecs import SubscriptionCodec
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.codecs import SubscriptionDataCodec
+from snuba.subscriptions.data import SubscriptionData
 from tests.base import BaseTest
 
 
 class TestSubscriptionCodec(BaseTest):
-    def build_subscription(self) -> Subscription:
-        return Subscription(
+    def build_subscription_data(self) -> SubscriptionData:
+        return SubscriptionData(
             project_id=5,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],
@@ -17,13 +17,13 @@ class TestSubscriptionCodec(BaseTest):
         )
 
     def test_basic(self):
-        subscription = self.build_subscription()
-        codec = SubscriptionCodec()
-        assert codec.decode(codec.encode(subscription)) == subscription
+        data = self.build_subscription_data()
+        codec = SubscriptionDataCodec()
+        assert codec.decode(codec.encode(data)) == data
 
     def test_encode(self):
-        codec = SubscriptionCodec()
-        subscription = self.build_subscription()
+        codec = SubscriptionDataCodec()
+        subscription = self.build_subscription_data()
 
         payload = codec.encode(subscription)
         data = json.loads(payload.decode("utf-8"))
@@ -34,8 +34,8 @@ class TestSubscriptionCodec(BaseTest):
         assert data["resolution"] == int(subscription.resolution.total_seconds())
 
     def test_decode(self):
-        codec = SubscriptionCodec()
-        subscription = self.build_subscription()
+        codec = SubscriptionDataCodec()
+        subscription = self.build_subscription_data()
         data = {
             "project_id": subscription.project_id,
             "conditions": subscription.conditions,

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -1,14 +1,14 @@
 from datetime import datetime, timedelta
 from unittest.mock import Mock
 
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.data import SubscriptionData
 from snuba.web.query import parse_and_run_query
 from tests.subscriptions import BaseSubscriptionTest
 
 
 class TestBuildRequest(BaseSubscriptionTest):
     def test_conditions(self):
-        subscription = Subscription(
+        subscription = SubscriptionData(
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -5,7 +5,13 @@ from concurrent.futures import ThreadPoolExecutor
 
 from snuba import settings
 from snuba.subscriptions.consumer import Tick
-from snuba.subscriptions.data import SubscriptionData
+from snuba.subscriptions.data import (
+    PartitionId,
+    Subscription,
+    SubscriptionData,
+    SubscriptionIdentifier,
+    SubscriptionKey,
+)
 from snuba.subscriptions.executor import SubscriptionExecutor
 from snuba.subscriptions.scheduler import ScheduledTask
 from snuba.utils.types import Interval
@@ -20,12 +26,15 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
                 max_workers=settings.SUBSCRIPTIONS_MAX_CONCURRENT_QUERIES
             ),
         )
-        subscription = SubscriptionData(
-            project_id=self.project_id,
-            conditions=[["platform", "IN", ["a"]]],
-            aggregations=[["count()", "", "count"]],
-            time_window=timedelta(minutes=500),
-            resolution=timedelta(minutes=1),
+        subscription = Subscription(
+            SubscriptionIdentifier(PartitionId(0), SubscriptionKey("key")),
+            SubscriptionData(
+                project_id=self.project_id,
+                conditions=[["platform", "IN", ["a"]]],
+                aggregations=[["count()", "", "count"]],
+                time_window=timedelta(minutes=500),
+                resolution=timedelta(minutes=1),
+            ),
         )
         now = datetime.utcnow()
         task = ScheduledTask(now, subscription)

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from unittest.mock import Mock
+from uuid import uuid1
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -10,7 +11,6 @@ from snuba.subscriptions.data import (
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
-    SubscriptionKey,
 )
 from snuba.subscriptions.executor import SubscriptionExecutor
 from snuba.subscriptions.scheduler import ScheduledTask
@@ -27,7 +27,7 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             ),
         )
         subscription = Subscription(
-            SubscriptionIdentifier(PartitionId(0), SubscriptionKey("key")),
+            SubscriptionIdentifier(PartitionId(0), uuid1()),
             SubscriptionData(
                 project_id=self.project_id,
                 conditions=[["platform", "IN", ["a"]]],

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from snuba import settings
 from snuba.subscriptions.consumer import Tick
-from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.data import SubscriptionData
 from snuba.subscriptions.executor import SubscriptionExecutor
 from snuba.subscriptions.scheduler import ScheduledTask
 from snuba.utils.types import Interval
@@ -20,7 +20,7 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
                 max_workers=settings.SUBSCRIPTIONS_MAX_CONCURRENT_QUERIES
             ),
         )
-        subscription = Subscription(
+        subscription = SubscriptionData(
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -1,14 +1,14 @@
 from datetime import timedelta
 
-from snuba.subscriptions.data import Subscription
-from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
+from snuba.subscriptions.data import SubscriptionData
+from snuba.subscriptions.partitioner import DatasetSubscriptionDataPartitioner
 from tests.subscriptions import BaseSubscriptionTest
 
 
 class TestBuildRequest(BaseSubscriptionTest):
     def test(self):
-        subscription = Subscription(
+        data = SubscriptionData(
             123, [], [], timedelta(minutes=10), timedelta(minutes=1)
         )
-        partitioner = DatasetSubscriptionPartitioner(self.dataset)
-        assert partitioner.build_partition_id(subscription) == 18
+        partitioner = DatasetSubscriptionDataPartitioner(self.dataset)
+        assert partitioner.build_partition_id(data) == 18

--- a/tests/subscriptions/test_store.py
+++ b/tests/subscriptions/test_store.py
@@ -1,13 +1,8 @@
-import json
 from datetime import timedelta
 
 from snuba.redis import redis_client
 from snuba.subscriptions.data import Subscription
-from snuba.subscriptions.store import (
-    RedisSubscriptionStore,
-    SubscriptionCodec,
-)
-from tests.base import BaseTest
+from snuba.subscriptions.store import RedisSubscriptionStore
 from tests.subscriptions import BaseSubscriptionTest
 
 
@@ -78,44 +73,3 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
         store_2.create(new_subscription_id, new_subscription)
         assert store_1.all() == [(subscription_id, self.subscription)]
         assert store_2.all() == [(new_subscription_id, new_subscription)]
-
-
-class TestSubscriptionCodec(BaseTest):
-    def build_subscription(self) -> Subscription:
-        return Subscription(
-            project_id=5,
-            conditions=[["platform", "IN", ["a"]]],
-            aggregations=[["count()", "", "count"]],
-            time_window=timedelta(minutes=500),
-            resolution=timedelta(minutes=1),
-        )
-
-    def test_basic(self):
-        subscription = self.build_subscription()
-        codec = SubscriptionCodec()
-        assert codec.decode(codec.encode(subscription)) == subscription
-
-    def test_encode(self):
-        codec = SubscriptionCodec()
-        subscription = self.build_subscription()
-
-        payload = codec.encode(subscription)
-        data = json.loads(payload.decode("utf-8"))
-        assert data["project_id"] == subscription.project_id
-        assert data["conditions"] == subscription.conditions
-        assert data["aggregations"] == subscription.aggregations
-        assert data["time_window"] == int(subscription.time_window.total_seconds())
-        assert data["resolution"] == int(subscription.resolution.total_seconds())
-
-    def test_decode(self):
-        codec = SubscriptionCodec()
-        subscription = self.build_subscription()
-        data = {
-            "project_id": subscription.project_id,
-            "conditions": subscription.conditions,
-            "aggregations": subscription.aggregations,
-            "time_window": int(subscription.time_window.total_seconds()),
-            "resolution": int(subscription.resolution.total_seconds()),
-        }
-        payload = json.dumps(data).encode("utf-8")
-        assert codec.decode(payload) == subscription

--- a/tests/subscriptions/test_store.py
+++ b/tests/subscriptions/test_store.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from uuid import uuid1
 
 from snuba.redis import redis_client
 from snuba.subscriptions.data import SubscriptionData
@@ -22,13 +23,13 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
 
     def test_create(self):
         store = self.build_store()
-        subscription_id = "something"
+        subscription_id = uuid1()
         store.create(subscription_id, self.subscription)
         assert store.all() == [(subscription_id, self.subscription)]
 
     def test_delete(self):
         store = self.build_store()
-        subscription_id = "something"
+        subscription_id = uuid1()
         store.create(subscription_id, self.subscription)
         assert store.all() == [(subscription_id, self.subscription)]
         store.delete(subscription_id)
@@ -37,7 +38,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
     def test_all(self):
         store = self.build_store()
         assert store.all() == []
-        subscription_id = "something"
+        subscription_id = uuid1()
         store.create(subscription_id, self.subscription)
         assert store.all() == [(subscription_id, self.subscription)]
         new_subscription = SubscriptionData(
@@ -47,7 +48,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
             time_window=timedelta(minutes=400),
             resolution=timedelta(minutes=2),
         )
-        new_subscription_id = "what"
+        new_subscription_id = uuid1()
         store.create(new_subscription_id, new_subscription)
         assert sorted(store.all(), key=lambda row: row[0]) == [
             (subscription_id, self.subscription),
@@ -57,7 +58,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
     def test_partitions(self):
         store_1 = self.build_store("1")
         store_2 = self.build_store("2")
-        subscription_id = "something"
+        subscription_id = uuid1()
         store_1.create(subscription_id, self.subscription)
         assert store_2.all() == []
         assert store_1.all() == [(subscription_id, self.subscription)]
@@ -69,7 +70,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
             time_window=timedelta(minutes=400),
             resolution=timedelta(minutes=2),
         )
-        new_subscription_id = "what"
+        new_subscription_id = uuid1()
         store_2.create(new_subscription_id, new_subscription)
         assert store_1.all() == [(subscription_id, self.subscription)]
         assert store_2.all() == [(new_subscription_id, new_subscription)]

--- a/tests/subscriptions/test_store.py
+++ b/tests/subscriptions/test_store.py
@@ -1,15 +1,15 @@
 from datetime import timedelta
 
 from snuba.redis import redis_client
-from snuba.subscriptions.data import Subscription
-from snuba.subscriptions.store import RedisSubscriptionStore
+from snuba.subscriptions.data import SubscriptionData
+from snuba.subscriptions.store import RedisSubscriptionDataStore
 from tests.subscriptions import BaseSubscriptionTest
 
 
 class TestRedisSubscriptionStore(BaseSubscriptionTest):
     @property
-    def subscription(self) -> Subscription:
-        return Subscription(
+    def subscription(self) -> SubscriptionData:
+        return SubscriptionData(
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],
@@ -17,8 +17,8 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
             resolution=timedelta(minutes=1),
         )
 
-    def build_store(self, key="1") -> RedisSubscriptionStore:
-        return RedisSubscriptionStore(redis_client, self.dataset, key)
+    def build_store(self, key="1") -> RedisSubscriptionDataStore:
+        return RedisSubscriptionDataStore(redis_client, self.dataset, key)
 
     def test_create(self):
         store = self.build_store()
@@ -40,7 +40,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
         subscription_id = "something"
         store.create(subscription_id, self.subscription)
         assert store.all() == [(subscription_id, self.subscription)]
-        new_subscription = Subscription(
+        new_subscription = SubscriptionData(
             project_id=self.project_id,
             conditions=[["platform", "IN", ["b"]]],
             aggregations=[["count()", "", "something"]],
@@ -62,7 +62,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
         assert store_2.all() == []
         assert store_1.all() == [(subscription_id, self.subscription)]
 
-        new_subscription = Subscription(
+        new_subscription = SubscriptionData(
             project_id=self.project_id,
             conditions=[["platform", "IN", ["b"]]],
             aggregations=[["count()", "", "something"]],

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -4,8 +4,8 @@ from unittest.mock import Mock
 from pytest import raises
 
 from snuba.redis import redis_client
-from snuba.subscriptions.store import RedisSubscriptionStore
-from snuba.subscriptions.data import InvalidSubscriptionError, Subscription
+from snuba.subscriptions.store import RedisSubscriptionDataStore
+from snuba.subscriptions.data import InvalidSubscriptionError, SubscriptionData
 from snuba.subscriptions.subscription import SubscriptionCreator
 from snuba.web.query import RawQueryException
 from tests.subscriptions import BaseSubscriptionTest
@@ -14,7 +14,7 @@ from tests.subscriptions import BaseSubscriptionTest
 class TestSubscriptionCreator(BaseSubscriptionTest):
     def test(self):
         creator = SubscriptionCreator(self.dataset)
-        subscription = Subscription(
+        subscription = SubscriptionData(
             project_id=123,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],
@@ -22,7 +22,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             resolution=timedelta(minutes=1),
         )
         identifier = creator.create(subscription, Mock())
-        RedisSubscriptionStore(
+        RedisSubscriptionDataStore(
             redis_client, self.dataset, str(identifier.partition_id),
         ).all()[0][1] == subscription
 
@@ -30,7 +30,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset)
         with raises(RawQueryException):
             creator.create(
-                Subscription(
+                SubscriptionData(
                     123,
                     [["platfo", "IN", ["a"]]],
                     [["count()", "", "count"]],
@@ -44,7 +44,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset)
         with raises(RawQueryException):
             creator.create(
-                Subscription(
+                SubscriptionData(
                     123,
                     [["platform", "IN", ["a"]]],
                     [["cout()", "", "count"]],
@@ -58,7 +58,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset)
         with raises(InvalidSubscriptionError):
             creator.create(
-                Subscription(
+                SubscriptionData(
                     123,
                     [["platfo", "IN", ["a"]]],
                     [["count()", "", "count"]],
@@ -72,7 +72,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset)
         with raises(InvalidSubscriptionError):
             creator.create(
-                Subscription(
+                SubscriptionData(
                     123,
                     [["platfo", "IN", ["a"]]],
                     [["count()", "", "count"]],

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -70,7 +70,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
         with raises(InvalidSubscriptionError):
             creator.create(
-                Subscription(
+                SubscriptionData(
                     123,
                     [["platfo", "IN", ["a"]]],
                     [["count()", "", "count"]],

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -23,7 +23,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         )
         identifier = creator.create(subscription, Mock())
         RedisSubscriptionDataStore(
-            redis_client, self.dataset, str(identifier.partition_id),
+            redis_client, self.dataset, identifier.partition,
         ).all()[0][1] == subscription
 
     def test_invalid_condition_column(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,6 @@ import uuid
 from snuba import settings, state
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.redis import redis_client
-from snuba.web.views import SUBSCRIPTION_SEPARATOR
 from tests.base import BaseApiTest
 
 
@@ -1711,9 +1710,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         assert resp.status_code == 202
         data = json.loads(resp.data)
         assert data == {
-            "subscription_id": "{}{}{}".format(
-                55, SUBSCRIPTION_SEPARATOR, expected_uuid.hex
-            )
+            "subscription_id": f"55/{expected_uuid.hex}",
         }
 
     def test_time_error(self):


### PR DESCRIPTION
- Moves the codec to `subscriptions.codecs`.
- Moves `SubscriptionIdentifier` to `subscriptions.data`.
- Changes the identifier `partition_id` to a `PartitionId` [`NewType`](https://docs.python.org/3/library/typing.html#newtype) of `int`.
- Changes the identifier `subscription_id` to a UUID type.
- Renames `Subscription` to `SubscriptionData` (and updates other class names that deal solely with `SubscriptionData` to reflect this) and adds `Subscription` class that contains both the identifier and the data values.
- Minor stylistic or simplification changes related to the other changes (mostly collapsing some `format` calls into f-strings.)