### PR TITLE
perf: Skip flattened optimization if we unpack tags anyway

### DIFF
--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -111,7 +111,7 @@ class AstClickhouseQuery(ClickhouseQuery):
         order_clause = ""
         if self.__orderby:
             orderby = [
-                f"{e.node.accept(formatter)} {e.direction.value}"
+                f"{e.expression.accept(formatter)} {e.direction.value}"
                 for e in self.__orderby
             ]
             order_clause = f"ORDER BY {', '.join(orderby)}"

--- a/snuba/query/query.py
+++ b/snuba/query/query.py
@@ -44,7 +44,7 @@ class OrderByDirection(Enum):
 @dataclass(frozen=True)
 class OrderBy:
     direction: OrderByDirection
-    node: Expression
+    expression: Expression
 
 
 class Query:
@@ -128,7 +128,9 @@ class Query:
             self.__condition or [],
             chain.from_iterable(self.__groupby),
             self.__having or [],
-            chain.from_iterable(map(lambda orderby: orderby.node, self.__order_by)),
+            chain.from_iterable(
+                map(lambda orderby: orderby.expression, self.__order_by)
+            ),
         )
 
     def transform_expressions(self, func: Callable[[Expression], Expression],) -> None:
@@ -158,7 +160,9 @@ class Query:
         self.__having = self.__having.transform(func) if self.__having else None
         self.__order_by = list(
             map(
-                lambda clause: replace(clause, node=clause.node.transform(func)),
+                lambda clause: replace(
+                    clause, expression=clause.expression.transform(func)
+                ),
                 self.__order_by,
             )
         )


### PR DESCRIPTION
This is the perf of a massive query with tags filtering and group by a tag
> 51 rows in set. Elapsed: 110.565 sec. Processed 126.04 million rows, 217.14 GB (1.14 million rows/s., 1.96 GB/s.)

Same query without flattened tags

> 51 rows in set. Elapsed: 81.081 sec. Processed 126.08 million rows, 133.23 GB (1.55 million rows/s., 1.64 GB/s.)

If we are already unpacking the tags (for the group by), loading an additional big column (the flattened tags) makes things worse since that column is not needed otherwise for the query.