### PR TITLE
fix(cloudbuild): Remove the priveate log bucket

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,7 +33,6 @@ images: [
   'us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA',
   ]
 timeout: 3600s
-logsBucket: 'gs://sentryio-cloudbuild-logs'
 secrets:
 - kmsKeyName: projects/sentryio/locations/global/keyRings/service-credentials/cryptoKeys/cloudbuild
   secretEnv:


### PR DESCRIPTION
Unbreaks GCB builds for now. Follow up to #700.