### PR TITLE
feat(streams): Add `pause` and `resume` to `Consumer` API

### DIFF
--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -125,6 +125,12 @@ class TickConsumer(Consumer[Tick]):
 
         return result
 
+    def pause(self, partitions: Sequence[Partition]) -> None:
+        self.__consumer.pause(partitions)
+
+    def resume(self, partitions: Sequence[Partition]) -> None:
+        self.__consumer.resume(partitions)
+
     def tell(self) -> Mapping[Partition, int]:
         # If there is no previous message for a partition, return the current
         # consumer offset, otherwise return the previous message offset (which

--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -131,6 +131,9 @@ class TickConsumer(Consumer[Tick]):
     def resume(self, partitions: Sequence[Partition]) -> None:
         self.__consumer.resume(partitions)
 
+    def paused(self) -> Sequence[Partition]:
+        return self.__consumer.paused()
+
     def tell(self) -> Mapping[Partition, int]:
         # If there is no previous message for a partition, return the current
         # consumer offset, otherwise return the previous message offset (which

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -106,8 +106,8 @@ class Consumer(Generic[TPayload], ABC):
         reassignment. If partitions should remain paused across rebalances,
         this should be implemented in the assignment callback.
 
-        If any provided partitions are not in the assignment set, an
-        exception will be raised and no parittions will be paused.
+        If any of the provided partitions are not in the assignment set, an
+        exception will be raised and no partitions will be paused.
         """
         raise NotImplementedError
 
@@ -116,8 +116,8 @@ class Consumer(Generic[TPayload], ABC):
         """
         Resume consuming from the provided partitions.
 
-        If any provided partitions are not in the assignment set, an
-        exception will be raised and no parittions will be resumed.
+        If any of the provided partitions are not in the assignment set, an
+        exception will be raised and no partitions will be resumed.
         """
         raise NotImplementedError
 

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -98,6 +98,26 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def pause(self, partitions: Sequence[Partition]) -> None:
+        """
+        Pause consuming from the provided partitions.
+
+        If any provided partitions are not in the assignment set, an
+        exception will be raised and no parittions will be paused.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def resume(self, partitions: Sequence[Partition]) -> None:
+        """
+        Resume consuming from the provided partitions.
+
+        If any provided partitions are not in the assignment set, an
+        exception will be raised and no parittions will be resumed.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def tell(self) -> Mapping[Partition, int]:
         """
         Return the working offsets for all currently assigned positions.

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -102,6 +102,10 @@ class Consumer(Generic[TPayload], ABC):
         """
         Pause consuming from the provided partitions.
 
+        A partition that is paused will be automatically resumed during
+        reassignment. If partitions should remain paused across rebalances,
+        this should be implemented in the assignment callback.
+
         If any provided partitions are not in the assignment set, an
         exception will be raised and no parittions will be paused.
         """

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -122,6 +122,13 @@ class Consumer(Generic[TPayload], ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def paused(self) -> Sequence[Partition]:
+        """
+        Return the currently paused partitions.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def tell(self) -> Mapping[Partition, int]:
         """
         Return the working offsets for all currently assigned positions.

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -103,8 +103,14 @@ class Consumer(Generic[TPayload], ABC):
         Pause consuming from the provided partitions.
 
         A partition that is paused will be automatically resumed during
-        reassignment. If partitions should remain paused across rebalances,
-        this should be implemented in the assignment callback.
+        reassignment. This ensures that the behavior is consistent during
+        rebalances, regardless of whether or not this consumer retains
+        ownership of the partition. (If this partition was assigned to a
+        different consumer in the consumer group during a rebalance, that
+        consumer would not have knowledge of whether or not the partition was
+        previously paused and would start consuming from the partition.) If
+        partitions should remain paused across rebalances, this should be
+        implemented in the assignment callback.
 
         If any of the provided partitions are not in the assignment set, an
         exception will be raised and no partitions will be paused.

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -41,7 +41,7 @@ class DummyBroker(Generic[TPayload]):
     ) -> Sequence[Partition]:
         if self.subscriptions[consumer.group]:
             # XXX: Consumer group balancing is not currently implemented.
-            if consumer not in self.subcriptions[consumer.group]:
+            if consumer not in self.subscriptions[consumer.group]:
                 raise NotImplementedError
 
             # XXX: Updating an existing subscription is currently not implemented.

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -24,7 +24,7 @@ epoch = datetime(2019, 12, 19)
 
 class DummyBroker(Generic[TPayload]):
     def __init__(
-        self, topics: Mapping[Topic, Sequence[MutableSequence[TPayload]]]
+        self, topics: MutableMapping[Topic, Sequence[MutableSequence[TPayload]]]
     ) -> None:
         self.topics = topics
         self.offsets: MutableMapping[str, MutableMapping[Partition, int]] = defaultdict(

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -175,6 +175,12 @@ class DummyConsumer(Consumer[TPayload]):
         for partition in partitions:
             self.__paused.discard(partition)
 
+    def paused(self) -> Sequence[Partition]:
+        if self.__closed:
+            raise RuntimeError("consumer is closed")
+
+        return [*self.__paused]
+
     def tell(self) -> Mapping[Partition, int]:
         if self.__closed:
             raise RuntimeError("consumer is closed")

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -251,6 +251,17 @@ class KafkaConsumer(Consumer[TPayload]):
                     Partition(Topic(i.topic), i.partition): i.offset for i in assignment
                 }
                 self.__seek(offsets)
+
+                # Ensure that all partitions are resumed on assignment to avoid
+                # carrying over state from a previous assignment.
+                self.__consumer.resume(
+                    [
+                        ConfluentTopicPartition(
+                            partition.topic.name, partition.index, offset
+                        )
+                        for partition, offset in offsets.items()
+                    ]
+                )
             except Exception:
                 self.__state = KafkaConsumerState.ERROR
                 raise

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -441,6 +441,9 @@ class KafkaConsumer(Consumer[TPayload]):
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:
             raise InvalidState(self.__state)
 
+        if set(partitions) - self.__offsets.keys():
+            raise ConsumerError("cannot pause unassigned partitions")
+
         self.__consumer.pause(
             [
                 ConfluentTopicPartition(partition.topic.name, partition.index)
@@ -466,6 +469,9 @@ class KafkaConsumer(Consumer[TPayload]):
         """
         if self.__state in {KafkaConsumerState.CLOSED, KafkaConsumerState.ERROR}:
             raise InvalidState(self.__state)
+
+        if set(partitions) - self.__offsets.keys():
+            raise ConsumerError("cannot resume unassigned partitions")
 
         self.__consumer.resume(
             [

--- a/tests/utils/streams/mixins.py
+++ b/tests/utils/streams/mixins.py
@@ -341,6 +341,9 @@ class StreamsTestMixin(ABC):
 
             # Pause all partitions.
             consumer_a.pause([Partition(topic, 0), Partition(topic, 1)])
+            assert set(consumer_a.paused()) == set(
+                [Partition(topic, 0), Partition(topic, 1)]
+            )
 
             consumer_b.subscribe([topic])
             for i in range(10):
@@ -353,6 +356,7 @@ class StreamsTestMixin(ABC):
             # The first consumer should have had its offsets rolled back, as
             # well as should have had it's partition resumed during
             # rebalancing.
+            assert consumer_a.paused() == []
             assert consumer_a.poll(10.0) is not None
 
             assert len(consumer_a.tell()) == 1

--- a/tests/utils/streams/mixins.py
+++ b/tests/utils/streams/mixins.py
@@ -14,7 +14,7 @@ from tests.assertions import assert_changes, assert_does_not_change
 
 class StreamsTestMixin(ABC):
     @abstractmethod
-    def get_topic(self) -> ContextManager[Topic]:
+    def get_topic(self, partitions: int = 1) -> ContextManager[Topic]:
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/utils/streams/mixins.py
+++ b/tests/utils/streams/mixins.py
@@ -18,7 +18,9 @@ class StreamsTestMixin(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_consumer(self, group: str) -> Consumer[int]:
+    def get_consumer(
+        self, group: str, enable_end_of_partition: bool = True
+    ) -> Consumer[int]:
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/utils/streams/mixins.py
+++ b/tests/utils/streams/mixins.py
@@ -285,9 +285,6 @@ class StreamsTestMixin(ABC):
             consumer.resume([Partition(topic, 0)])
             assert consumer.poll(5.0) == messages[0]
 
-            # TODO: Test that partitions are resumed after rebalance or
-            # resetting subscriptions.
-
             with pytest.raises(ConsumerError):
                 consumer.resume([Partition(topic, 1)])
 

--- a/tests/utils/streams/mixins.py
+++ b/tests/utils/streams/mixins.py
@@ -312,15 +312,15 @@ class StreamsTestMixin(ABC):
                 consumer_a.poll(10.0) in messages
             )  # XXX: getting the subcription is slow
 
+            assert len(consumer_a.tell()) == 2
+            assert len(consumer_b.tell()) == 0
+
             # Pause all partitions.
             consumer_a.pause([Partition(topic, 0), Partition(topic, 1)])
 
-            # with (assert_changes(lambda: len(consumer_a.tell()), 2, 1)), (
-            #     assert_changes(lambda: len(consumer_b.tell()), 0, 2)
-            # ):
             consumer_b.subscribe([topic])
             for i in range(10):
-                consumer_a.poll(0)  # attempt to force session timeout
+                assert consumer_a.poll(0) is None  # attempt to force session timeout
                 if consumer_b.poll(1.0) is not None:
                     break
             else:
@@ -330,3 +330,6 @@ class StreamsTestMixin(ABC):
             # well as should have had it's partition resumed during
             # rebalancing.
             assert consumer_a.poll(10.0) is not None
+
+            assert len(consumer_a.tell()) == 1
+            assert len(consumer_b.tell()) == 1

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -1,4 +1,5 @@
 import contextlib
+import uuid
 from typing import Iterator
 from unittest import TestCase
 
@@ -13,11 +14,13 @@ from tests.utils.streams.mixins import StreamsTestMixin
 
 class DummyStreamsTestCase(StreamsTestMixin, TestCase):
     def setUp(self) -> None:
-        self.broker: DummyBroker[int] = DummyBroker({Topic("test"): [[]]})
+        self.broker: DummyBroker[int] = DummyBroker({})
 
     @contextlib.contextmanager
-    def get_topic(self) -> Iterator[Topic]:
-        yield Topic("test")
+    def get_topic(self, partitions: int = 1) -> Iterator[Topic]:
+        topic = Topic(uuid.uuid1().hex)
+        self.broker.topics[topic] = [[] for i in range(partitions)]
+        yield topic
 
     def get_consumer(self, group: str) -> DummyConsumer[int]:
         return DummyConsumer(self.broker, group, enable_end_of_partition=True)

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -22,8 +22,12 @@ class DummyStreamsTestCase(StreamsTestMixin, TestCase):
         self.broker.topics[topic] = [[] for i in range(partitions)]
         yield topic
 
-    def get_consumer(self, group: str) -> DummyConsumer[int]:
-        return DummyConsumer(self.broker, group, enable_end_of_partition=True)
+    def get_consumer(
+        self, group: str, enable_end_of_partition: bool = True
+    ) -> DummyConsumer[int]:
+        return DummyConsumer(
+            self.broker, group, enable_end_of_partition=enable_end_of_partition
+        )
 
     def get_producer(self) -> DummyProducer[int]:
         return DummyProducer(self.broker)

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -3,6 +3,8 @@ import uuid
 from typing import Iterator
 from unittest import TestCase
 
+import pytest
+
 from snuba.utils.streams.dummy import (
     DummyBroker,
     DummyConsumer,
@@ -31,3 +33,9 @@ class DummyStreamsTestCase(StreamsTestMixin, TestCase):
 
     def get_producer(self) -> DummyProducer[int]:
         return DummyProducer(self.broker)
+
+    @pytest.mark.xfail(
+        strict=True, reason="rebalancing not implemented", raises=NotImplementedError
+    )
+    def test_pause_resume_rebalancing(self) -> None:
+        return super().test_pause_resume_rebalancing()

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -53,7 +53,10 @@ class KafkaStreamsTestCase(StreamsTestMixin, TestCase):
             assert future.result() is None
 
     def get_consumer(
-        self, group: str, auto_offset_reset: str = "earliest"
+        self,
+        group: str,
+        enable_end_of_partition: bool = True,
+        auto_offset_reset: str = "earliest",
     ) -> KafkaConsumer[int]:
         return KafkaConsumer(
             {
@@ -61,7 +64,7 @@ class KafkaStreamsTestCase(StreamsTestMixin, TestCase):
                 "auto.offset.reset": auto_offset_reset,
                 "enable.auto.commit": "false",
                 "enable.auto.offset.store": "false",
-                "enable.partition.eof": "true",
+                "enable.partition.eof": enable_end_of_partition,
                 "group.id": group,
                 "session.timeout.ms": 10000,
             },

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -37,11 +37,11 @@ class KafkaStreamsTestCase(StreamsTestMixin, TestCase):
     codec = TestCodec()
 
     @contextlib.contextmanager
-    def get_topic(self) -> Iterator[Topic]:
+    def get_topic(self, partitions: int = 1) -> Iterator[Topic]:
         name = f"test-{uuid.uuid1().hex}"
         client = AdminClient(self.configuration)
         [[key, future]] = client.create_topics(
-            [NewTopic(name, num_partitions=1, replication_factor=1)]
+            [NewTopic(name, num_partitions=partitions, replication_factor=1)]
         ).items()
         assert key == name
         assert future.result() is None


### PR DESCRIPTION
This adds the `pause` and `resume` methods to the `Consumer` API (and all subclasses) as well as adding it to the stream test mixin.