### PR TITLE
fix(metrics): Allow not having dogstatsd

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -68,17 +68,6 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
 )
 @click.option("--log-level", default=settings.LOG_LEVEL, help="Logging level to use.")
 @click.option(
-    "--dogstatsd-host",
-    default=settings.DOGSTATSD_HOST,
-    help="Host to send DogStatsD metrics to.",
-)
-@click.option(
-    "--dogstatsd-port",
-    default=settings.DOGSTATSD_PORT,
-    type=int,
-    help="Port to send DogStatsD metrics to.",
-)
-@click.option(
     "--stateful-consumer",
     default=False,
     type=bool,
@@ -99,8 +88,6 @@ def consumer(
     queued_max_messages_kbytes: int,
     queued_min_messages: int,
     log_level: str,
-    dogstatsd_host: str,
-    dogstatsd_port: int,
     stateful_consumer: bool,
 ) -> None:
 
@@ -125,8 +112,6 @@ def consumer(
         auto_offset_reset=auto_offset_reset,
         queued_max_messages_kbytes=queued_max_messages_kbytes,
         queued_min_messages=queued_min_messages,
-        dogstatsd_host=dogstatsd_host,
-        dogstatsd_port=dogstatsd_port,
     )
 
     if stateful_consumer:

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -72,17 +72,6 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option("--log-level", default=settings.LOG_LEVEL, help="Logging level to use.")
-@click.option(
-    "--dogstatsd-host",
-    default=settings.DOGSTATSD_HOST,
-    help="Host to send DogStatsD metrics to.",
-)
-@click.option(
-    "--dogstatsd-port",
-    default=settings.DOGSTATSD_PORT,
-    type=int,
-    help="Port to send DogStatsD metrics to.",
-)
 def replacer(
     *,
     replacements_topic: Optional[str],
@@ -97,8 +86,6 @@ def replacer(
     queued_max_messages_kbytes: int,
     queued_min_messages: int,
     log_level: str,
-    dogstatsd_host: str,
-    dogstatsd_port: int,
 ) -> None:
 
     import sentry_sdk
@@ -129,9 +116,7 @@ def replacer(
     ), f"Dataset {dataset} does not have a replacement topic."
     replacements_topic = replacements_topic or default_replacement_topic_spec.topic_name
 
-    metrics = util.create_metrics(
-        dogstatsd_host, dogstatsd_port, "snuba.replacer", tags={"group": consumer_group}
-    )
+    metrics = util.create_metrics("snuba.replacer", tags={"group": consumer_group})
 
     client_settings = {
         # Replacing existing rows requires reconstructing the entire tuple for each

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -42,8 +42,6 @@ class ConsumerBuilder:
         auto_offset_reset: str,
         queued_max_messages_kbytes: int,
         queued_min_messages: int,
-        dogstatsd_host: str,
-        dogstatsd_port: int,
         commit_retry_policy: Optional[RetryPolicy] = None,
     ) -> None:
         self.dataset = get_dataset(dataset_name)
@@ -94,10 +92,7 @@ class ConsumerBuilder:
         )
 
         self.metrics = util.create_metrics(
-            dogstatsd_host,
-            dogstatsd_port,
-            "snuba.consumer",
-            tags={"group": group_id, "dataset": self.dataset_name},
+            "snuba.consumer", tags={"group": group_id, "dataset": self.dataset_name},
         )
 
         self.max_batch_size = max_batch_size

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -24,9 +24,7 @@ from snuba.datasets.events_processor import (
 from snuba.util import create_metrics
 
 
-metrics = create_metrics(
-    settings.DOGSTATSD_HOST, settings.DOGSTATSD_PORT, "snuba.transactions.processor"
-)
+metrics = create_metrics("snuba.transactions.processor")
 
 
 UNKNOWN_SPAN_STATUS = 2

--- a/snuba/settings_docker.py
+++ b/snuba/settings_docker.py
@@ -12,3 +12,7 @@ REDIS_PORT = int(env("REDIS_PORT", 6379))
 REDIS_PASSWORD = env("REDIS_PASSWORD")
 REDIS_DB = int(env("REDIS_DB", 1))
 USE_REDIS_CLUSTER = False
+
+# Dogstatsd Options
+DOGSTATSD_HOST = None
+DOGSTATSD_PORT = None

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -276,18 +276,26 @@ def settings_override(overrides: Mapping[str, Any]) -> Iterator[None]:
             setattr(settings, k, v)
 
 
-def create_metrics(
-    host: str, port: int, prefix: str, tags: Optional[Tags] = None
-) -> MetricsBackend:
-    """Create a DogStatsd object with the specified prefix and tags. Prefixes
-    must start with `snuba.<category>`, for example: `snuba.processor`."""
-    from datadog import DogStatsd
-    from snuba.utils.metrics.backends.datadog import DatadogMetricsBackend
-
+def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
+    """Create a DogStatsd object if DOGSTATSD_HOST and DOGSTATSD_PORT are defined,
+    with the specified prefix and tags. Return a DummyMetricsBackend otherwise.
+    Prefixes must start with `snuba.<category>`, for example: `snuba.processor`.
+    """
     bits = prefix.split(".", 2)
     assert (
         len(bits) >= 2 and bits[0] == "snuba"
     ), "prefix must be like `snuba.<category>`"
+
+    host = settings.DOGSTATSD_HOST
+    port = settings.DOGSTATSD_PORT
+
+    if host is None or port is None:
+        from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
+
+        return DummyMetricsBackend()
+
+    from datadog import DogStatsd
+    from snuba.utils.metrics.backends.datadog import DatadogMetricsBackend
 
     return DatadogMetricsBackend(
         DogStatsd(

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -289,10 +289,14 @@ def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
     host = settings.DOGSTATSD_HOST
     port = settings.DOGSTATSD_PORT
 
-    if host is None or port is None:
+    if host is None and port is None:
         from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 
         return DummyMetricsBackend()
+    elif host is None or port is None:
+        raise ValueError(
+            f"DOGSTATSD_HOST and DOGSTATSD_PORT should both be None or not None. Found DOGSTATSD_HOST: {host}, DOGSTATSD_PORT: {port} instead."
+        )
 
     from datadog import DogStatsd
     from snuba.utils.metrics.backends.datadog import DatadogMetricsBackend

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -28,7 +28,7 @@ from snuba.utils.metrics.timer import Timer
 from snuba.web.split import split_query
 
 logger = logging.getLogger("snuba.query")
-metrics = create_metrics(settings.DOGSTATSD_HOST, settings.DOGSTATSD_PORT, "snuba.api")
+metrics = create_metrics("snuba.api")
 
 clickhouse_rw = ClickhousePool()
 clickhouse_ro = ClickhousePool(client_settings={"readonly": True})

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -432,8 +432,7 @@ if application.debug or application.testing:
 
     @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])
     def eventstream(*, dataset: Dataset):
-        ensure_table_exists(dataset)
-        record = json.loads(http_request.data)
+        ensure_table_exists(dataset)        record = json.loads(http_request.data)
 
         version = record[0]
         if version != 2:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -432,7 +432,8 @@ if application.debug or application.testing:
 
     @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])
     def eventstream(*, dataset: Dataset):
-        ensure_table_exists(dataset)        record = json.loads(http_request.data)
+        ensure_table_exists(dataset)
+        record = json.loads(http_request.data)
 
         version = record[0]
         if version != 2:


### PR DESCRIPTION
All the code assumed a valid and running dogstatsd instance which was causing issues when running without it, especially with the bare Docker image over at getsentry/onpremise. This patch adds the option to have `se
ttings.DOGSTATSD_HOST` and `settings.DOGSTATSD_PORT` as `None`, sets these to `None` by default in the Docker settings and refactors some code to use the settings values for dogstatsd at all times.

**BREAKING:** This removes the `--dogstatsd-host` and `--dogstatsd-port` CLI arguments, which doesn't seem to be used anywhere (checked getsentry/single-tenant and getsentry/ops).