### PR TITLE
build(requirements): Bump Jinja2 to 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ isodate==0.6.0
 isort==4.3.4
 itsdangerous==0.24
 jedi==0.12.0
-Jinja2==2.10
 jsonschema==3.0.1
 lazy-object-proxy==1.3.1
 linecache2==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ isodate==0.6.0
 isort==4.3.4
 itsdangerous==0.24
 jedi==0.12.0
+Jinja2==2.10.1
 jsonschema==3.0.1
 lazy-object-proxy==1.3.1
 linecache2==1.0.0


### PR DESCRIPTION
The Jinja2 version we are using has a security issue. This PR updates it to a known secure version.