### PR TITLE
Revert "fix(subscriptions): Revert subscriptions API implementation (#710)"

### DIFF
--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -1,0 +1,25 @@
+import jsonschema
+import sentry_sdk
+from werkzeug.exceptions import BadRequest
+
+from snuba.datasets.dataset import Dataset
+from snuba.request import Request
+from snuba.request.schema import RequestSchema
+from snuba.utils.metrics.timer import Timer
+
+
+def validate_request_content(
+    body, schema: RequestSchema, timer: Timer, dataset: Dataset, referrer: str
+) -> Request:
+    with sentry_sdk.start_span(
+        description="validate_request_content", op="validate"
+    ) as span:
+        try:
+            request = schema.validate(body, dataset, referrer)
+            span.set_data("snuba_query", request.body)
+        except jsonschema.ValidationError as error:
+            raise BadRequest(str(error)) from error
+
+        timer.mark("validate_schema")
+
+    return request

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Sequence
+from typing import Optional, Sequence
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.query import Aggregation
@@ -8,10 +8,14 @@ from snuba.query.types import Condition
 from snuba.request import Request
 from snuba.request.request_settings import SubscriptionRequestSettings
 from snuba.request.schema import RequestSchema
+from snuba.request.validation import validate_request_content
 from snuba.utils.metrics.timer import Timer
-from snuba.web.views import validate_request_content
 
 SUBSCRIPTION_REFERRER = "subscription"
+
+
+class InvalidSubscriptionError(Exception):
+    pass
 
 
 @dataclass(frozen=True)
@@ -20,15 +24,24 @@ class Subscription:
     Represents the state of a subscription.
     """
 
-    id: str
     project_id: int
     conditions: Sequence[Condition]
     aggregations: Sequence[Aggregation]
     time_window: timedelta
     resolution: timedelta
 
+    def __post_init__(self) -> None:
+        if self.time_window < timedelta(minutes=1):
+            raise InvalidSubscriptionError(
+                "Time window must be greater than or equal to 1 minute"
+            )
+        if self.resolution < timedelta(minutes=1):
+            raise InvalidSubscriptionError(
+                "Resolution must be greater than or equal to 1 minute"
+            )
+
     def build_request(
-        self, dataset: Dataset, timestamp: datetime, offset: int, timer: Timer
+        self, dataset: Dataset, timestamp: datetime, offset: Optional[int], timer: Timer
     ) -> Request:
         """
         Returns a Request that can be used to run a query via `parse_and_run_query`.
@@ -39,12 +52,13 @@ class Subscription:
         schema = RequestSchema.build_with_extensions(
             dataset.get_extensions(), SubscriptionRequestSettings,
         )
+        extra_conditions: Sequence[Condition] = []
+        if offset is not None:
+            extra_conditions = [[["ifnull", ["offset", 0]], "<=", offset]]
         return validate_request_content(
             {
                 "project": self.project_id,
-                "conditions": (
-                    self.conditions + [[["ifnull", ["offset", 0]], "<=", offset]]
-                ),
+                "conditions": [*self.conditions, *extra_conditions],
                 "aggregations": self.aggregations,
                 "from_date": (timestamp - self.time_window).isoformat(),
                 "to_date": timestamp.isoformat(),

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -1,0 +1,28 @@
+from abc import abstractmethod, ABC
+from binascii import crc32
+
+from snuba.datasets.dataset import Dataset
+from snuba.subscriptions.data import Subscription
+
+
+class SubscriptionPartitioner(ABC):
+    @abstractmethod
+    def build_partition_id(self, subscription: Subscription) -> int:
+        pass
+
+
+class DatasetSubscriptionPartitioner(SubscriptionPartitioner):
+    """
+    Partitions a subscription based on the Dataset that we're going to store it in.
+    """
+
+    PARTITION_COUNT = 64
+
+    def __init__(self, dataset: Dataset):
+        self.__dataset = dataset
+
+    def build_partition_id(self, subscription: Subscription) -> int:
+        # TODO: Use something from the dataset to determine the number of partitions
+        return (
+            crc32(str(subscription.project_id).encode("utf-8")) % self.PARTITION_COUNT
+        )

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import uuid1
+
+from snuba.datasets.dataset import Dataset
+from snuba.redis import redis_client
+from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
+from snuba.subscriptions.store import RedisSubscriptionStore
+from snuba.utils.metrics.timer import Timer
+from snuba.web.query import parse_and_run_query
+
+
+@dataclass(frozen=True)
+class SubscriptionIdentifier:
+    partition_id: int
+    subscription_id: str
+
+
+class SubscriptionCreator:
+    """
+    Handles creation of a `Subscription`, including assigning an ID and validating that
+    the resulting query is valid.
+    """
+
+    def __init__(self, dataset: Dataset):
+        self.dataset = dataset
+
+    def create(
+        self, subscription: Subscription, timer: Timer
+    ) -> SubscriptionIdentifier:
+        # We want to test the query out here to make sure it's valid and can run
+        request = subscription.build_request(
+            self.dataset, datetime.utcnow(), None, timer,
+        )
+        parse_and_run_query(self.dataset, request, timer)
+        partition_id = DatasetSubscriptionPartitioner(self.dataset).build_partition_id(
+            subscription
+        )
+        subscription_id = uuid1().hex
+        RedisSubscriptionStore(redis_client, self.dataset, str(partition_id)).create(
+            subscription_id, subscription,
+        )
+        return SubscriptionIdentifier(partition_id, subscription_id)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -6,7 +6,6 @@ from typing import NamedTuple
 
 from flask import Flask, Response, redirect, render_template, request as http_request
 from markdown import markdown
-from uuid import uuid1
 import sentry_sdk
 import simplejson as json
 from werkzeug.exceptions import BadRequest
@@ -26,6 +25,10 @@ from snuba.datasets.schemas.tables import TableSchema
 from snuba.request import Request
 from snuba.request.schema import HTTPRequestSettings, RequestSchema, SETTINGS_SCHEMAS
 from snuba.redis import redis_client
+from snuba.request.validation import validate_request_content
+from snuba.subscriptions.data import InvalidSubscriptionError
+from snuba.subscriptions.store import SubscriptionCodec
+from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionIdentifier
 from snuba.util import local_dataset_mode
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -227,23 +230,6 @@ def parse_request_body(http_request):
             raise BadRequest(str(error)) from error
 
 
-def validate_request_content(
-    body, schema: RequestSchema, timer: Timer, dataset: Dataset, referrer: str
-) -> Request:
-    with sentry_sdk.start_span(
-        description="validate_request_content", op="validate"
-    ) as span:
-        try:
-            request = schema.validate(body, dataset, referrer)
-            span.set_data("snuba_query", request.body)
-        except jsonschema.ValidationError as error:
-            raise BadRequest(str(error)) from error
-
-        timer.mark("validate_schema")
-
-    return request
-
-
 @application.route("/query", methods=["GET", "POST"])
 @util.time_request("query")
 def unqualified_query_view(*, timer: Timer):
@@ -363,12 +349,36 @@ def sdk_distribution(*, timer: Timer) -> Response:
     return format_result(run_query(dataset, request, timer))
 
 
-@application.route("/<dataset:dataset>/subscriptions", methods=["POST"])
-def create_subscription(*, dataset: Dataset):
-    partition = 0
-    key = uuid1().hex
+SUBSCRIPTION_SEPARATOR = "/"
+
+
+@application.errorhandler(InvalidSubscriptionError)
+def handle_subscription_error(exception: InvalidSubscriptionError):
+    data = {"error": {"type": "subscription", "message": str(exception)}}
     return (
-        json.dumps({"subscription_id": f"{partition}/{key}"}),
+        json.dumps(data, indent=4),
+        400,
+        {"Content-Type": "application/json"},
+    )
+
+
+def build_external_subscription_id(identifier: SubscriptionIdentifier) -> str:
+    return "{}{}{}".format(
+        identifier.partition_id, SUBSCRIPTION_SEPARATOR, identifier.subscription_id
+    )
+
+
+@application.route("/<dataset:dataset>/subscriptions", methods=["POST"])
+@util.time_request("subscription")
+def create_subscription(*, dataset: Dataset, timer: Timer):
+    subscription = SubscriptionCodec().decode(http_request.data)
+    # TODO: Check for valid queries with fields that are invalid for subscriptions. For
+    # example date fields and aggregates.
+    subscription_identifier = SubscriptionCreator(dataset).create(subscription, timer,)
+    return (
+        json.dumps(
+            {"subscription_id": build_external_subscription_id(subscription_identifier)}
+        ),
         202,
         {"Content-Type": "application/json"},
     )

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -9,7 +9,6 @@ from tests.subscriptions import BaseSubscriptionTest
 class TestBuildRequest(BaseSubscriptionTest):
     def test_conditions(self):
         subscription = Subscription(
-            id="hello",
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -21,7 +21,6 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             ),
         )
         subscription = Subscription(
-            id="hello",
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],
             aggregations=[["count()", "", "count"]],

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -1,0 +1,14 @@
+from datetime import timedelta
+
+from snuba.subscriptions.data import Subscription
+from snuba.subscriptions.partitioner import DatasetSubscriptionPartitioner
+from tests.subscriptions import BaseSubscriptionTest
+
+
+class TestBuildRequest(BaseSubscriptionTest):
+    def test(self):
+        subscription = Subscription(
+            123, [], [], timedelta(minutes=10), timedelta(minutes=1)
+        )
+        partitioner = DatasetSubscriptionPartitioner(self.dataset)
+        assert partitioner.build_partition_id(subscription) == 18

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -1,0 +1,83 @@
+from datetime import timedelta
+from unittest.mock import Mock
+
+from pytest import raises
+
+from snuba.redis import redis_client
+from snuba.subscriptions.store import RedisSubscriptionStore
+from snuba.subscriptions.data import InvalidSubscriptionError, Subscription
+from snuba.subscriptions.subscription import SubscriptionCreator
+from snuba.web.query import RawQueryException
+from tests.subscriptions import BaseSubscriptionTest
+
+
+class TestSubscriptionCreator(BaseSubscriptionTest):
+    def test(self):
+        creator = SubscriptionCreator(self.dataset)
+        subscription = Subscription(
+            project_id=123,
+            conditions=[["platform", "IN", ["a"]]],
+            aggregations=[["count()", "", "count"]],
+            time_window=timedelta(minutes=10),
+            resolution=timedelta(minutes=1),
+        )
+        identifier = creator.create(subscription, Mock())
+        RedisSubscriptionStore(
+            redis_client, self.dataset, str(identifier.partition_id),
+        ).all()[0][1] == subscription
+
+    def test_invalid_condition_column(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(RawQueryException):
+            creator.create(
+                Subscription(
+                    123,
+                    [["platfo", "IN", ["a"]]],
+                    [["count()", "", "count"]],
+                    timedelta(minutes=10),
+                    timedelta(minutes=1),
+                ),
+                Mock(),
+            )
+
+    def test_invalid_aggregation(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(RawQueryException):
+            creator.create(
+                Subscription(
+                    123,
+                    [["platform", "IN", ["a"]]],
+                    [["cout()", "", "count"]],
+                    timedelta(minutes=10),
+                    timedelta(minutes=1),
+                ),
+                Mock(),
+            )
+
+    def test_invalid_time_window(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(InvalidSubscriptionError):
+            creator.create(
+                Subscription(
+                    123,
+                    [["platfo", "IN", ["a"]]],
+                    [["count()", "", "count"]],
+                    timedelta(),
+                    timedelta(minutes=1),
+                ),
+                Mock(),
+            )
+
+    def test_invalid_resolution(self):
+        creator = SubscriptionCreator(self.dataset)
+        with raises(InvalidSubscriptionError):
+            creator.create(
+                Subscription(
+                    123,
+                    [["platfo", "IN", ["a"]]],
+                    [["count()", "", "count"]],
+                    timedelta(minutes=1),
+                    timedelta(),
+                ),
+                Mock(),
+            )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,7 @@ import uuid
 from snuba import settings, state
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.redis import redis_client
-
+from snuba.web.views import SUBSCRIPTION_SEPARATOR
 from tests.base import BaseApiTest
 
 
@@ -1693,16 +1693,57 @@ class TestCreateSubscriptionApi(BaseApiTest):
     def test(self):
         expected_uuid = uuid.uuid1()
 
-        with patch("snuba.web.views.uuid1") as uuid4:
+        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
             uuid4.return_value = expected_uuid
-            resp = self.app.post("/events/subscriptions")
+            resp = self.app.post(
+                "{}/subscriptions".format(self.dataset_name),
+                data=json.dumps(
+                    {
+                        "project_id": 1,
+                        "conditions": [["platform", "IN", ["a"]]],
+                        "aggregations": [["count()", "", "count"]],
+                        "time_window": int(timedelta(minutes=10).total_seconds()),
+                        "resolution": int(timedelta(minutes=1).total_seconds()),
+                    }
+                ).encode("utf-8"),
+            )
 
         assert resp.status_code == 202
         data = json.loads(resp.data)
-        assert data == {"subscription_id": f"0/{expected_uuid.hex}"}  # TODO
+        assert data == {
+            "subscription_id": "{}{}{}".format(
+                55, SUBSCRIPTION_SEPARATOR, expected_uuid.hex
+            )
+        }
+
+    def test_time_error(self):
+        resp = self.app.post(
+            "{}/subscriptions".format(self.dataset_name),
+            data=json.dumps(
+                {
+                    "project_id": 1,
+                    "conditions": [["platform", "IN", ["a"]]],
+                    "aggregations": [["count()", "", "count"]],
+                    "time_window": 0,
+                    "resolution": 1,
+                }
+            ),
+        )
+
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data == {
+            "error": {
+                "message": "Time window must be greater than or equal to 1 minute",
+                "type": "subscription",
+            }
+        }
 
 
 class TestDeleteSubscriptionApi(BaseApiTest):
     def test(self):
-        resp = self.app.delete(f"/events/subscriptions/1/{uuid.uuid4().hex}")
-        assert resp.status_code == 202
+        resp = self.app.delete(
+            f"{self.dataset_name}/subscriptions/1/{uuid.uuid4().hex}"
+        )
+        print(f"{self.dataset_name}/subscriptions/1/{uuid.uuid4().hex}")
+        assert resp.status_code == 202, resp


### PR DESCRIPTION
I've removed the calls in sentry temporarily in https://github.com/getsentry/sentry/pull/16565. Once
that is merged we can merge this and I'll update sentry to use the api correctly.

This reverts commit ab0ca24f2aa1058fcf6df036617f765a23275d86.