### PR TITLE
fix(subscriptions): Disallow window sizes of > 24h

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -35,6 +35,11 @@ class Subscription:
             raise InvalidSubscriptionError(
                 "Time window must be greater than or equal to 1 minute"
             )
+        elif self.time_window > timedelta(hours=24):
+            raise InvalidSubscriptionError(
+                "Time window must be less than or equal to 24 hours"
+            )
+
         if self.resolution < timedelta(minutes=1):
             raise InvalidSubscriptionError(
                 "Resolution must be greater than or equal to 1 minute"

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -68,6 +68,18 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
                 Mock(),
             )
 
+        with raises(InvalidSubscriptionError):
+            creator.create(
+                Subscription(
+                    123,
+                    [["platfo", "IN", ["a"]]],
+                    [["count()", "", "count"]],
+                    timedelta(hours=48),
+                    timedelta(minutes=1),
+                ),
+                Mock(),
+            )
+
     def test_invalid_resolution(self):
         creator = SubscriptionCreator(self.dataset)
         with raises(InvalidSubscriptionError):


### PR DESCRIPTION
Smaller time windows equals less bytes read equals faster queries equals better throughput.