### PR TITLE
perf(json) Test rapid json test

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -74,13 +74,13 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
     help="Runs a stateful consumer (that manages snapshots) instead of a basic one.",
 )
 @click.option(
-    "--rapid-json-deserialize",
+    "--rapidjson-deserialize",
     default=False,
     type=bool,
     help="Uses rapidjson to deserialize messages",
 )
 @click.option(
-    "--rapid-json-serialize",
+    "--rapidjson-serialize",
     default=False,
     type=bool,
     help="Uses rapidjson to serialize messages",
@@ -101,8 +101,8 @@ def consumer(
     queued_min_messages: int,
     log_level: str,
     stateful_consumer: bool,
-    rapid_json_deserialize: bool,
-    rapid_json_serialize: bool,
+    rapidjson_deserialize: bool,
+    rapidjson_serialize: bool,
 ) -> None:
 
     import sentry_sdk
@@ -126,8 +126,8 @@ def consumer(
         auto_offset_reset=auto_offset_reset,
         queued_max_messages_kbytes=queued_max_messages_kbytes,
         queued_min_messages=queued_min_messages,
-        rapid_json_deserialize=rapid_json_deserialize,
-        rapid_json_serialize=rapid_json_serialize,
+        rapidjson_deserialize=rapidjson_deserialize,
+        rapidjson_serialize=rapidjson_serialize,
     )
 
     if stateful_consumer:

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -73,6 +73,18 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
     type=bool,
     help="Runs a stateful consumer (that manages snapshots) instead of a basic one.",
 )
+@click.option(
+    "--rapid-json-deserialize",
+    default=False,
+    type=bool,
+    help="Uses rapidjson to deserialize messages",
+)
+@click.option(
+    "--rapid-json-serialize",
+    default=False,
+    type=bool,
+    help="Uses rapidjson to serialize messages",
+)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -89,6 +101,8 @@ def consumer(
     queued_min_messages: int,
     log_level: str,
     stateful_consumer: bool,
+    rapid_json_deserialize: bool,
+    rapid_json_serialize: bool,
 ) -> None:
 
     import sentry_sdk
@@ -112,6 +126,8 @@ def consumer(
         auto_offset_reset=auto_offset_reset,
         queued_max_messages_kbytes=queued_max_messages_kbytes,
         queued_min_messages=queued_min_messages,
+        rapid_json_deserialize=rapid_json_deserialize,
+        rapid_json_serialize=rapid_json_serialize,
     )
 
     if stateful_consumer:

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, Mapping, Optional, Sequence
 
 import simplejson as json
+import rapidjson
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from snuba.datasets.dataset import Dataset
@@ -31,14 +32,18 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         metrics: MetricsBackend,
         producer: Optional[ConfluentKafkaProducer] = None,
         replacements_topic: Optional[Topic] = None,
+        rapid_json_deserialize: bool = False,
+        rapid_json_serialize: bool = False,
     ) -> None:
         self.__dataset = dataset
         self.producer = producer
         self.replacements_topic = replacements_topic
         self.metrics = metrics
         self.__writer = enforce_table_writer(dataset).get_writer(
-            {"load_balancing": "in_order", "insert_distributed_sync": 1}
+            {"load_balancing": "in_order", "insert_distributed_sync": 1},
+            rapid_json_serialize=rapid_json_serialize,
         )
+        self.__rapid_json_deserialize = rapid_json_deserialize
 
     def process_message(
         self, message: Message[KafkaPayload]
@@ -46,7 +51,10 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         # TODO: consider moving this inside the processor so we can do a quick
         # processing of messages we want to filter out without fully parsing the
         # json.
-        value = json.loads(message.payload.value)
+        if self.__rapid_json_deserialize:
+            value = rapidjson.loads(message.payload.value)
+        else:
+            value = json.loads(message.payload.value)
         metadata = KafkaMessageMetadata(
             offset=message.offset, partition=message.partition.index
         )

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -32,8 +32,8 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         metrics: MetricsBackend,
         producer: Optional[ConfluentKafkaProducer] = None,
         replacements_topic: Optional[Topic] = None,
-        rapid_json_deserialize: bool = False,
-        rapid_json_serialize: bool = False,
+        rapidjson_deserialize: bool = False,
+        rapidjson_serialize: bool = False,
     ) -> None:
         self.__dataset = dataset
         self.producer = producer
@@ -41,9 +41,9 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         self.metrics = metrics
         self.__writer = enforce_table_writer(dataset).get_writer(
             {"load_balancing": "in_order", "insert_distributed_sync": 1},
-            rapid_json_serialize=rapid_json_serialize,
+            rapidjson_serialize=rapidjson_serialize,
         )
-        self.__rapid_json_deserialize = rapid_json_deserialize
+        self.__rapidjson_deserialize = rapidjson_deserialize
 
     def process_message(
         self, message: Message[KafkaPayload]
@@ -51,7 +51,7 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         # TODO: consider moving this inside the processor so we can do a quick
         # processing of messages we want to filter out without fully parsing the
         # json.
-        if self.__rapid_json_deserialize:
+        if self.__rapidjson_deserialize:
             value = rapidjson.loads(message.payload.value)
         else:
             value = json.loads(message.payload.value)

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -42,6 +42,8 @@ class ConsumerBuilder:
         auto_offset_reset: str,
         queued_max_messages_kbytes: int,
         queued_min_messages: int,
+        rapid_json_deserialize: bool,
+        rapid_json_serialize: bool,
         commit_retry_policy: Optional[RetryPolicy] = None,
     ) -> None:
         self.dataset = get_dataset(dataset_name)
@@ -116,6 +118,8 @@ class ConsumerBuilder:
             )
 
         self.__commit_retry_policy = commit_retry_policy
+        self.__rapid_json_deserialize = rapid_json_deserialize
+        self.__rapid_json_serialize = rapid_json_serialize
 
     def __build_consumer(
         self, worker: ConsumerWorker
@@ -164,6 +168,8 @@ class ConsumerBuilder:
                 producer=self.producer,
                 replacements_topic=self.replacements_topic,
                 metrics=self.metrics,
+                rapid_json_deserialize=self.__rapid_json_deserialize,
+                rapid_json_serialize=self.__rapid_json_serialize,
             )
         )
 

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -42,8 +42,8 @@ class ConsumerBuilder:
         auto_offset_reset: str,
         queued_max_messages_kbytes: int,
         queued_min_messages: int,
-        rapid_json_deserialize: bool,
-        rapid_json_serialize: bool,
+        rapidjson_deserialize: bool,
+        rapidjson_serialize: bool,
         commit_retry_policy: Optional[RetryPolicy] = None,
     ) -> None:
         self.dataset = get_dataset(dataset_name)
@@ -118,8 +118,8 @@ class ConsumerBuilder:
             )
 
         self.__commit_retry_policy = commit_retry_policy
-        self.__rapid_json_deserialize = rapid_json_deserialize
-        self.__rapid_json_serialize = rapid_json_serialize
+        self.__rapidjson_deserialize = rapidjson_deserialize
+        self.__rapidjson_serialize = rapidjson_serialize
 
     def __build_consumer(
         self, worker: ConsumerWorker
@@ -168,8 +168,8 @@ class ConsumerBuilder:
                 producer=self.producer,
                 replacements_topic=self.replacements_topic,
                 metrics=self.metrics,
-                rapid_json_deserialize=self.__rapid_json_deserialize,
-                rapid_json_serialize=self.__rapid_json_serialize,
+                rapidjson_deserialize=self.__rapidjson_deserialize,
+                rapidjson_serialize=self.__rapidjson_serialize,
             )
         )
 

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -87,7 +87,7 @@ class TableWriter:
         return self.__table_schema
 
     def get_writer(
-        self, options=None, table_name=None, rapid_json_serialize=False
+        self, options=None, table_name=None, rapidjson_serialize=False
     ) -> BatchWriter:
         from snuba import settings
         from snuba.clickhouse.http import HTTPBatchWriter
@@ -104,7 +104,7 @@ class TableWriter:
             settings.CLICKHOUSE_HTTP_PORT,
             lambda row: (
                 rapidjson.dumps(row, default=default)
-                if rapid_json_serialize
+                if rapidjson_serialize
                 else json.dumps(row, default=default)
             ).encode("utf-8"),
             options,

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -86,7 +86,9 @@ class TableWriter:
     def get_schema(self) -> WritableTableSchema:
         return self.__table_schema
 
-    def get_writer(self, options=None, table_name=None) -> BatchWriter:
+    def get_writer(
+        self, options=None, table_name=None, rapid_json_serialize=False
+    ) -> BatchWriter:
         from snuba import settings
         from snuba.clickhouse.http import HTTPBatchWriter
 
@@ -100,7 +102,11 @@ class TableWriter:
             self.__table_schema,
             settings.CLICKHOUSE_HOST,
             settings.CLICKHOUSE_HTTP_PORT,
-            lambda row: json.dumps(row, default=default).encode("utf-8"),
+            lambda row: (
+                rapidjson.dumps(row, default=default)
+                if rapid_json_serialize
+                else json.dumps(row, default=default)
+            ).encode("utf-8"),
             options,
             table_name,
             chunk_size=settings.CLICKHOUSE_HTTP_CHUNK_SIZE,

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -60,8 +60,11 @@ class TransactionsTableWriter(TableWriter):
         self,
         options: Optional[MutableMapping[str, Any]] = None,
         table_name: Optional[str] = None,
+        rapid_json_serialize=False,
     ) -> BatchWriter:
-        return super().get_writer(self.__update_options(options), table_name,)
+        return super().get_writer(
+            self.__update_options(options), table_name, rapid_json_serialize
+        )
 
     def get_bulk_writer(
         self,

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -60,10 +60,10 @@ class TransactionsTableWriter(TableWriter):
         self,
         options: Optional[MutableMapping[str, Any]] = None,
         table_name: Optional[str] = None,
-        rapid_json_serialize=False,
+        rapidjson_serialize=False,
     ) -> BatchWriter:
         return super().get_writer(
-            self.__update_options(options), table_name, rapid_json_serialize
+            self.__update_options(options), table_name, rapidjson_serialize
         )
 
     def get_bulk_writer(


### PR DESCRIPTION
This allows us to replace the simplejson library with rapidjson during either deserialization in the consumer or serialization in the writer.

This is just a test to run it on specific instances of a consumer, we would never pass the option as a CLI parameter. The PR will be reverted after the test.

Turned it on and ran all the sentry test-snuba suite to validate.