### PR TITLE
feat(subscriptions): Implement SubscriptionScheduler

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -55,6 +55,9 @@ class SubscriptionData:
                 "Resolution must be greater than or equal to 1 minute"
             )
 
+        if self.resolution.microseconds > 0:
+            raise InvalidSubscriptionError("Resolution does not support microseconds")
+
     def build_request(
         self, dataset: Dataset, timestamp: datetime, offset: Optional[int], timer: Timer
     ) -> Request:

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -73,11 +73,11 @@ class SubscriptionScheduler(Scheduler[Subscription]):
         self, interval: Interval[datetime]
     ) -> Iterator[ScheduledTask[Subscription]]:
         subscriptions = self.__get_subscriptions(interval.lower)
-        for i in range(
+        for timestamp in range(
             math.ceil(interval.lower.timestamp()),
             math.ceil(interval.upper.timestamp()),
         ):
             for subscription in subscriptions:
                 resolution = int(subscription.data.resolution.total_seconds())
-                if i % resolution == 0:
-                    yield ScheduledTask(datetime.fromtimestamp(i), subscription)
+                if timestamp % resolution == 0:
+                    yield ScheduledTask(datetime.fromtimestamp(timestamp), subscription)

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -2,7 +2,7 @@ import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Generic, Iterator, List, TypeVar
+from typing import Generic, Iterator, List, Optional, TypeVar
 
 from snuba.subscriptions.data import PartitionId, Subscription, SubscriptionIdentifier
 from snuba.subscriptions.store import SubscriptionDataStore
@@ -55,9 +55,9 @@ class SubscriptionScheduler(Scheduler[Subscription]):
         self.__cache_ttl = cache_ttl
         self.__partition_id = partition_id
         self.__subscriptions: List[Subscription] = []
-        self.__last_refresh = None
+        self.__last_refresh: Optional[datetime] = None
 
-    def __get_subscriptions(self, current_time) -> List[Subscription]:
+    def __get_subscriptions(self, current_time: datetime) -> List[Subscription]:
         if (
             self.__last_refresh is None
             or (current_time - self.__last_refresh) > self.__cache_ttl

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -1,3 +1,4 @@
+import abc
 import json
 from datetime import timedelta
 from typing import Collection, Tuple
@@ -32,7 +33,32 @@ class SubscriptionCodec(Codec[bytes, Subscription]):
         )
 
 
-class RedisSubscriptionStore:
+class SubscriptionStore(abc.ABC):
+    @abc.abstractmethod
+    def create(self, subscription_id: str, subscription: Subscription) -> None:
+        """
+        Creates a `Subscription` in the store. Will overwrite any existing `Subscriptions`
+        with the same id.
+        """
+        pass
+
+    @abc.abstractmethod
+    def delete(self, subscription_id: str) -> None:
+        """
+        Removes a `Subscription` from the store.
+        """
+        pass
+
+    @abc.abstractmethod
+    def all(self) -> Collection[Tuple[str, Subscription]]:
+        """
+        Fetches all `Subscriptions` from the store
+        :return: A collection of `Subscriptions`.
+        """
+        pass
+
+
+class RedisSubscriptionStore(SubscriptionStore):
     """
     A Redis backed store for Subscriptions. Stores subscriptions using
     `SubscriptionCodec`. Each instance of the store operates on a partition of data,

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -11,7 +11,7 @@ from snuba.subscriptions.data import PartitionId, SubscriptionData
 
 class SubscriptionDataStore(abc.ABC):
     @abc.abstractmethod
-    def create(self, subscription_id: UUID, subscription: SubscriptionData) -> None:
+    def create(self, key: UUID, data: SubscriptionData) -> None:
         """
         Creates a `Subscription` in the store. Will overwrite any existing `Subscriptions`
         with the same id.
@@ -19,7 +19,7 @@ class SubscriptionDataStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete(self, subscription_id: UUID) -> None:
+    def delete(self, key: UUID) -> None:
         """
         Removes a `Subscription` from the store.
         """

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -11,7 +11,7 @@ from snuba.subscriptions.data import PartitionId, SubscriptionData
 
 class SubscriptionDataStore(abc.ABC):
     @abc.abstractmethod
-    def create(self, subscription_id: str, subscription: SubscriptionData) -> None:
+    def create(self, subscription_id: UUID, subscription: SubscriptionData) -> None:
         """
         Creates a `Subscription` in the store. Will overwrite any existing `Subscriptions`
         with the same id.
@@ -19,14 +19,14 @@ class SubscriptionDataStore(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def delete(self, subscription_id: str) -> None:
+    def delete(self, subscription_id: UUID) -> None:
         """
         Removes a `Subscription` from the store.
         """
         pass
 
     @abc.abstractmethod
-    def all(self) -> Collection[Tuple[str, SubscriptionData]]:
+    def all(self) -> Collection[Tuple[UUID, SubscriptionData]]:
         """
         Fetches all `Subscriptions` from the store
         :return: A collection of `Subscriptions`.

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -9,7 +9,7 @@ from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import PartitionId, SubscriptionData
 
 
-class SubscriptionStore(abc.ABC):
+class SubscriptionDataStore(abc.ABC):
     @abc.abstractmethod
     def create(self, subscription_id: str, subscription: SubscriptionData) -> None:
         """
@@ -34,7 +34,7 @@ class SubscriptionStore(abc.ABC):
         pass
 
 
-class RedisSubscriptionDataStore(SubscriptionStore):
+class RedisSubscriptionDataStore(SubscriptionDataStore):
     """
     A Redis backed store for subscription data. Stores subscriptions using
     `SubscriptionDataCodec`. Each instance of the store operates on a

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -4,12 +4,12 @@ from typing import Collection, Tuple
 
 from snuba.redis import redis_client
 from snuba.subscriptions.data import (
+    PartitionId,
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
 )
 from snuba.subscriptions.scheduler import (
-    PartitionId,
     ScheduledTask,
     SubscriptionScheduler,
 )
@@ -45,7 +45,7 @@ class TestSubscriptionScheduler(BaseTest):
         sort_key=None,
     ) -> None:
         store = RedisSubscriptionDataStore(
-            redis_client, self.dataset, str(self.partition_id),
+            redis_client, self.dataset, self.partition_id,
         )
         for subscription in subscriptions:
             store.create(subscription.identifier.uuid, subscription.data)

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -3,15 +3,17 @@ from datetime import datetime, timedelta
 from typing import Collection, Tuple
 
 from snuba.redis import redis_client
-from snuba.subscriptions.scheduler import (
-    PartitionId,
-    ScheduledTask,
-    SubscriptionScheduler,
+from snuba.subscriptions.data import (
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
 )
-from snuba.subscriptions.store import RedisSubscriptionStore
+from snuba.subscriptions.scheduler import (
+    PartitionId,
+    ScheduledTask,
+    SubscriptionScheduler,
+)
+from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.utils.types import Interval
 from tests.base import BaseTest
 
@@ -42,11 +44,11 @@ class TestSubscriptionScheduler(BaseTest):
         expected: Collection[ScheduledTask[Subscription]],
         sort_key=None,
     ) -> None:
-        store = RedisSubscriptionStore(
+        store = RedisSubscriptionDataStore(
             redis_client, self.dataset, str(self.partition_id),
         )
         for subscription in subscriptions:
-            store.create(subscription.identifier.uuid.hex, subscription.data)
+            store.create(subscription.identifier.uuid, subscription.data)
 
         scheduler = SubscriptionScheduler(
             store, self.partition_id, timedelta(minutes=1)

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -1,0 +1,128 @@
+import uuid
+from datetime import datetime, timedelta
+from typing import Collection, Tuple
+
+from snuba.subscriptions.scheduler import (
+    PartitionId,
+    ScheduledTask,
+    SubscriptionScheduler,
+    Subscription,
+    SubscriptionData,
+    SubscriptionIdentifier,
+)
+from snuba.utils.types import Interval
+from tests.base import BaseTest
+
+
+class TestSubscriptionScheduler(BaseTest):
+    def setup_method(self, test_method, dataset_name=None) -> None:
+        super().setup_method(test_method, dataset_name)
+        self.now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+
+    def build_subscription(self, resolution: timedelta) -> Subscription:
+        return Subscription(
+            SubscriptionIdentifier(PartitionId(1), uuid.uuid4()),
+            SubscriptionData(1, [], [], timedelta(minutes=1), resolution),
+        )
+
+    def build_interval(self, lower: timedelta, upper: timedelta) -> Interval[datetime]:
+        return Interval(self.now + lower, self.now + upper)
+
+    def sort_key(self, task: ScheduledTask[Subscription]) -> Tuple[datetime, uuid.UUID]:
+        return task.timestamp, task.task.identifier.uuid
+
+    def test_delete(self) -> None:
+        scheduler = SubscriptionScheduler()
+        subscription = self.build_subscription(timedelta(minutes=1))
+        scheduler.set(subscription)
+        expected = [ScheduledTask(self.now, subscription)]
+
+        assert (
+            list(
+                scheduler.find(
+                    self.build_interval(timedelta(minutes=0), timedelta(minutes=1))
+                )
+            )
+            == expected
+        )
+        scheduler.delete(subscription.identifier.uuid)
+        assert (
+            list(
+                scheduler.find(
+                    self.build_interval(timedelta(minutes=0), timedelta(minutes=1))
+                )
+            )
+            == []
+        )
+
+    def run_test(
+        self,
+        subscriptions: Collection[Subscription],
+        start: timedelta,
+        end: timedelta,
+        expected: Collection[ScheduledTask[Subscription]],
+    ) -> None:
+        scheduler = SubscriptionScheduler()
+        for subscription in subscriptions:
+            scheduler.set(subscription)
+
+        assert (
+            sorted(
+                list(scheduler.find(self.build_interval(start, end))), key=self.sort_key
+            )
+            == expected
+        )
+
+    def test_simple(self) -> None:
+        subscription = self.build_subscription(timedelta(minutes=1))
+        self.run_test(
+            [subscription],
+            start=timedelta(minutes=-10),
+            end=timedelta(minutes=0),
+            expected=[
+                ScheduledTask(self.now + timedelta(minutes=-10 + i), subscription)
+                for i in range(10)
+            ],
+        )
+
+    def test_subscription_not_running(self) -> None:
+        self.run_test(
+            [self.build_subscription(timedelta(minutes=3))],
+            start=timedelta(minutes=-2),
+            end=timedelta(minutes=0),
+            expected=[],
+        )
+
+    def test_subscription_resolution_larger_than_interval(self) -> None:
+        subscription = self.build_subscription(timedelta(minutes=3))
+        self.run_test(
+            [subscription],
+            start=timedelta(minutes=-1),
+            end=timedelta(minutes=1),
+            expected=[ScheduledTask(self.now, subscription)],
+        )
+        subscription = self.build_subscription(timedelta(minutes=1))
+        self.run_test(
+            [subscription],
+            start=timedelta(seconds=-1),
+            end=timedelta(seconds=1),
+            expected=[ScheduledTask(self.now, subscription)],
+        )
+
+    def test_multiple_subscriptions(self) -> None:
+        subscription = self.build_subscription(timedelta(minutes=1))
+        other_subscription = self.build_subscription(timedelta(minutes=2))
+        expected = [
+            ScheduledTask(self.now + timedelta(minutes=-10 + i), subscription)
+            for i in range(10)
+        ] + [
+            ScheduledTask(self.now + timedelta(minutes=-10 + i), other_subscription)
+            for i in range(0, 10, 2)
+        ]
+        expected.sort(key=self.sort_key)
+        self.run_test(
+            [subscription, other_subscription],
+            start=timedelta(minutes=-10),
+            end=timedelta(minutes=0),
+            expected=expected,
+        )


### PR DESCRIPTION
The `SubscriptionScheduler` keeps a dict of `Subscription` objects that it manages. When `find` is
passed an `Interval[datetime]`, return all `ScheduledTask[Subscription]` objects that should be
run within that interval.