### PR TITLE
build(docker): Force pip version 20.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*; \
     \
     # Temporary fix until a version of python:3.7-slim with pip 20.0.2 is out
-    pip install pip>=20.0.2; \
+    pip install "pip>=20.0.2"; \
     make install-python-dependencies; \
     mkdir /tmp/uwsgi-dogstatsd; \
     wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*; \
     \
     # Temporary fix until a version of python:3.7-slim with pip 20.0.2 is out
-    pip install pip>=20.0.2
+    pip install pip>=20.0.2; \
     make install-python-dependencies; \
     mkdir /tmp/uwsgi-dogstatsd; \
     wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,8 @@ RUN set -ex; \
     apt-get install -y $buildDeps --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*; \
     \
+    # Temporary fix until a version of python:3.7-slim with pip 20.0.2 is out
+    pip install pip>=20.0.2
     make install-python-dependencies; \
     mkdir /tmp/uwsgi-dogstatsd; \
     wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \


### PR DESCRIPTION
pip 20 broke binary wheel detection so now `semaphore`, one of our dependencies try to compile from its source, which is rust, and fails. This patch forces pip version to be 20.0.2 which is supposed to have a fix for this.