### PR TITLE
ref(streams): Make dummy consumer and producer thread-safe

### DIFF
--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -153,7 +153,7 @@ class DummyConsumer(Consumer[TPayload]):
             if self.__closed:
                 raise RuntimeError("consumer is closed")
 
-            self.__offsets = self.__broker.subscribe(self, topics)
+            self.__offsets = {**self.__broker.subscribe(self, topics)}
 
             self.__staged_offsets.clear()
             self.__last_eof_at.clear()

--- a/tests/subscriptions/test_consumer.py
+++ b/tests/subscriptions/test_consumer.py
@@ -2,7 +2,7 @@ import pytest
 
 from snuba.subscriptions.consumer import Tick, TickConsumer
 from snuba.utils.streams.consumer import Consumer, ConsumerError
-from snuba.utils.streams.dummy import DummyBroker, DummyConsumer, epoch
+from snuba.utils.streams.dummy import DummyBroker, DummyConsumer, DummyProducer, epoch
 from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.utils.types import Interval
 
@@ -10,9 +10,15 @@ from snuba.utils.types import Interval
 def test_tick_consumer() -> None:
     topic = Topic("messages")
 
-    inner_consumer: Consumer[int] = DummyConsumer(
-        DummyBroker({topic: [[0, 1, 2], [0]]}), "group",
-    )
+    broker: DummyBroker[int] = DummyBroker()
+    broker.create_topic(topic, partitions=2)
+
+    producer: DummyProducer[int] = DummyProducer(broker)
+    for partition, payloads in enumerate([[0, 1, 2], [0]]):
+        for payload in payloads:
+            producer.produce(Partition(topic, partition), payload).result()
+
+    inner_consumer: Consumer[int] = DummyConsumer(broker, "group")
 
     consumer = TickConsumer(inner_consumer)
 

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -16,12 +16,12 @@ from tests.utils.streams.mixins import StreamsTestMixin
 
 class DummyStreamsTestCase(StreamsTestMixin, TestCase):
     def setUp(self) -> None:
-        self.broker: DummyBroker[int] = DummyBroker({})
+        self.broker: DummyBroker[int] = DummyBroker()
 
     @contextlib.contextmanager
     def get_topic(self, partitions: int = 1) -> Iterator[Topic]:
         topic = Topic(uuid.uuid1().hex)
-        self.broker.topics[topic] = [[] for i in range(partitions)]
+        self.broker.create_topic(topic, partitions)
         yield topic
 
     def get_consumer(


### PR DESCRIPTION
The synchronized consumer tests will require a thread-safe consumer to make deterministic assertions, since the commit log consumer runs in a separate thread.

This change moves all shared state between the `DummyConsumer` and `DummyProducer` to methods on the `DummyBroker` which are synchronized, rather than exposing them as attributes on dataclasses. This also synchronizes all methods that get or set mutable state on the `DummyConsumer` and `DummyProducer`.