### PR TITLE
Revert "build(docker): Force pip version 20.0.2 (#724)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,8 +87,6 @@ RUN set -ex; \
     apt-get install -y $buildDeps --no-install-recommends; \
     rm -rf /var/lib/apt/lists/*; \
     \
-    # Temporary fix until a version of python:3.7-slim with pip 20.0.2 is out
-    pip install "pip>=20.0.2"; \
     make install-python-dependencies; \
     mkdir /tmp/uwsgi-dogstatsd; \
     wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \


### PR DESCRIPTION
This reverts commit b9167fbca1a2d901202f423f2a4192415c9c63dd as
`pip` `20.0.2` is the default now.