### PR TITLE
feat(streams): Implement `SynchronizedConsumer`

### DIFF
--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -167,3 +167,7 @@ class TickConsumer(Consumer[Tick]):
 
     def close(self, timeout: Optional[float] = None) -> None:
         return self.__consumer.close(timeout)
+
+    @property
+    def closed(self) -> bool:
+        return self.__consumer.closed

--- a/snuba/utils/streams/consumer.py
+++ b/snuba/utils/streams/consumer.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from typing import (
     Callable,
     Generic,
@@ -180,4 +180,8 @@ class Consumer(Generic[TPayload], ABC):
 
     @abstractmethod
     def close(self, timeout: Optional[float] = None) -> None:
+        raise NotImplementedError
+
+    @abstractproperty
+    def closed(self) -> bool:
         raise NotImplementedError

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -283,6 +283,10 @@ class DummyConsumer(Consumer[TPayload]):
             self.__closed = True
             self.close_calls += 1
 
+    @property
+    def closed(self) -> bool:
+        return self.__closed
+
 
 class DummyProducer(Producer[TPayload]):
     def __init__(self, broker: DummyBroker[TPayload]) -> None:

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -589,6 +589,10 @@ class KafkaConsumer(Consumer[TPayload]):
 
         self.__state = KafkaConsumerState.CLOSED
 
+    @property
+    def closed(self) -> bool:
+        return self.__state is KafkaConsumerState.CLOSED
+
 
 DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 10000

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -37,7 +37,9 @@ from snuba.utils.concurrent import execute
 from snuba.utils.retries import NoRetryPolicy, RetryPolicy
 from snuba.utils.streams.consumer import Consumer, ConsumerError, EndOfPartition
 from snuba.utils.streams.producer import Producer
+from snuba.utils.streams.synchronized import Commit
 from snuba.utils.streams.types import Message, Partition, Topic, TPayload
+
 
 logger = logging.getLogger(__name__)
 
@@ -616,15 +618,6 @@ def build_kafka_consumer_configuration(
         "queued.min.messages": queued_min_messages,
         "enable.partition.eof": False,
     }
-
-
-@dataclass(frozen=True)
-class Commit:
-    __slots__ = ["group", "partition", "offset"]
-
-    group: str
-    partition: Partition
-    offset: int
 
 
 class CommitCodec(Codec[KafkaPayload, Commit]):

--- a/snuba/utils/streams/synchronized.py
+++ b/snuba/utils/streams/synchronized.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+from snuba.utils.streams.types import Partition
+
+
+@dataclass(frozen=True)
+class Commit:
+    __slots__ = ["group", "partition", "offset"]
+
+    group: str
+    partition: Partition
+    offset: int

--- a/snuba/utils/streams/synchronized.py
+++ b/snuba/utils/streams/synchronized.py
@@ -17,6 +17,29 @@ class Commit:
 
 
 class SynchronizedConsumer(Consumer[TPayload]):
+    """
+    This class implements a consumer that is can only consume messages that
+    have already been consumed and committed by one or more other consumer
+    groups.
+
+    The consumer groups that are being "followed" are required to publish
+    their offsets to a shared commit log topic. The advancement of the
+    offsets for these consumer groups in the commit log topic controls
+    whether or not the local consumer is allowed to consume messages from its
+    assigned partitions. (This commit log topic works similarly to/was
+    inspired by/essentially duplicates the contents of the Kafka built-in
+    ``__consumer_offsets`` topic, which seems to be intended to be a private
+    API of the Kafka system based on the lack of external documentation.)
+
+    It is important to note that the since the local consumer is only allowed
+    to consume messages that have been consumed and committed by all of the
+    members of the referenced consumer groups, this consumer can only consume
+    messages as fast as the slowest consumer (or in other words, the most
+    latent or lagging consumer) for each partition. If one of these consumers
+    stops consuming messages entirely, this consumer will also stop making
+    progress in those partitions.
+    """
+
     def __init__(
         self,
         consumer: Consumer[TPayload],

--- a/snuba/utils/streams/synchronized.py
+++ b/snuba/utils/streams/synchronized.py
@@ -146,7 +146,11 @@ class SynchronizedConsumer(Consumer[TPayload]):
             with self.__remote_offsets.get() as remote_offsets:
                 for partition in resume_candidates:
                     remote_offset = min(
-                        offsets.get(partition, 0) for offsets in remote_offsets.values()
+                        (
+                            offsets.get(partition, 0)
+                            for offsets in remote_offsets.values()
+                        ),
+                        default=0,
                     )
                     if remote_offset > local_offsets[partition]:
                         resume_partitions.append(partition)
@@ -163,7 +167,11 @@ class SynchronizedConsumer(Consumer[TPayload]):
 
         with self.__remote_offsets.get() as remote_offsets:
             remote_offset = min(
-                offsets.get(message.partition, 0) for offsets in remote_offsets.values()
+                (
+                    offsets.get(message.partition, 0)
+                    for offsets in remote_offsets.values()
+                ),
+                default=0,
             )
 
         # Check to make sure the message does not exceed the remote offset. If

--- a/snuba/utils/streams/synchronized.py
+++ b/snuba/utils/streams/synchronized.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
+from threading import Event
+from typing import Callable, Mapping, MutableMapping, Optional, Sequence, Set
 
-from snuba.utils.streams.types import Partition
+from snuba.utils.concurrent import Synchronized, execute
+from snuba.utils.streams.consumer import Consumer, ConsumerError, EndOfPartition
+from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 
 
 @dataclass(frozen=True)
@@ -10,3 +14,183 @@ class Commit:
     group: str
     partition: Partition
     offset: int
+
+
+class SynchronizedConsumer(Consumer[TPayload]):
+    def __init__(
+        self,
+        consumer: Consumer[TPayload],
+        commit_log_consumer: Consumer[Commit],
+        commit_log_topic: Topic,
+        commit_log_groups: Set[str],
+    ) -> None:
+        self.__consumer = consumer
+
+        self.__commit_log_consumer = commit_log_consumer
+        self.__commit_log_topic = commit_log_topic
+        self.__commit_log_groups = commit_log_groups
+
+        self.__remote_offsets: Synchronized[
+            Mapping[str, MutableMapping[Partition, int]]
+        ] = Synchronized({group: {} for group in commit_log_groups})
+
+        self.__commit_log_worker_stop_requested = Event()
+
+        # TODO: We need to be able to deal with this consumer crashing -- it
+        # should then cause the synchronized consumer to be put in an invalid
+        # state.
+        self.__commit_log_worker = execute(self.__run_commit_log_worker)
+
+        # The set of partitions that have been paused by the caller/user. This
+        # takes precedence over whether or not the partition should be paused
+        # due to offset synchronization.
+        self.__paused: Set[Partition] = set()
+
+    def __run_commit_log_worker(self) -> None:
+        # TODO: This needs to roll back to the initial offset.
+
+        # TODO: This needs to ensure that it is subscribed to all partitions.
+
+        self.__commit_log_consumer.subscribe([self.__commit_log_topic])
+
+        while not self.__commit_log_worker_stop_requested.is_set():
+            try:
+                message = self.__commit_log_consumer.poll(0.1)
+            except EndOfPartition:
+                continue
+
+            if message is None:
+                continue
+
+            commit = message.payload
+            if commit.group not in self.__commit_log_groups:
+                continue
+
+            with self.__remote_offsets.get() as remote_offsets:
+                # NOTE: This will store data about partitions that are not
+                # actually part of the subscription or assignment. This
+                # approach (potentially) requires more memory and locking
+                # overhead (due to writing state for partitions that are not
+                # subscribed or assigned), but amortizes the cost of the
+                # initial load of the topic and makes the implementation
+                # quite a bit simpler.
+                remote_offsets[commit.group][commit.partition] = commit.offset
+
+        self.__commit_log_consumer.close()
+
+    def subscribe(
+        self,
+        topics: Sequence[Topic],
+        on_assign: Optional[Callable[[Mapping[Partition, int]], None]] = None,
+        on_revoke: Optional[Callable[[Sequence[Partition]], None]] = None,
+    ) -> None:
+        def assignment_callback(offsets: Mapping[Partition, int]) -> None:
+            for partition in offsets:
+                self.__paused.discard(partition)
+
+            if on_assign is not None:
+                on_assign(offsets)
+
+        def revocation_callback(partitions: Sequence[Partition]) -> None:
+            for partition in partitions:
+                self.__paused.discard(partition)
+
+            if on_revoke is not None:
+                on_revoke(partitions)
+
+        return self.__consumer.subscribe(
+            topics, on_assign=assignment_callback, on_revoke=revocation_callback
+        )
+
+    def unsubscribe(self) -> None:
+        return self.__consumer.unsubscribe()
+
+    def poll(self, timeout: Optional[float] = None) -> Optional[Message[TPayload]]:
+        # Resume any partitions that can be resumed (where the local
+        # offset is less than the remote offset.)
+        resume_candidates = set(self.__consumer.paused()) - self.__paused
+        if resume_candidates:
+            local_offsets = self.tell()
+            resume_partitions = []
+
+            with self.__remote_offsets.get() as remote_offsets:
+                for partition in resume_candidates:
+                    remote_offset = min(
+                        offsets.get(partition, 0) for offsets in remote_offsets.values()
+                    )
+                    if remote_offset > local_offsets[partition]:
+                        resume_partitions.append(partition)
+
+            if resume_partitions:
+                self.__consumer.resume(resume_partitions)
+
+        # We don't need to explicitly handle ``EndOfPartition`` here -- even if
+        # we receive the next message before the leader, we will roll back our
+        # offsets and wait for the leader to advance.
+        message = self.__consumer.poll(timeout)
+        if message is None:
+            return None
+
+        with self.__remote_offsets.get() as remote_offsets:
+            remote_offset = min(
+                offsets.get(message.partition, 0) for offsets in remote_offsets.values()
+            )
+
+        # Check to make sure the message does not exceed the remote offset. If
+        # it does, pause the partition and seek back to the message offset.
+        if message.offset >= remote_offset:
+            self.__consumer.pause([message.partition])
+            self.__consumer.seek({message.partition: message.offset})
+            return None
+
+        return message
+
+    def pause(self, partitions: Sequence[Partition]) -> None:
+        if self.closed:
+            raise RuntimeError("consumer is closed")
+
+        if set(partitions) - self.tell().keys():
+            raise ConsumerError("cannot pause unassigned partitions")
+
+        for partition in partitions:
+            self.__paused.add(partition)
+
+        self.__consumer.pause(partitions)
+
+    def resume(self, partitions: Sequence[Partition]) -> None:
+        if self.closed:
+            raise RuntimeError("consumer is closed")
+
+        if set(partitions) - self.tell().keys():
+            raise ConsumerError("cannot resume unassigned partitions")
+
+        # Partitions are not actually resumed by the inner consumer immediately
+        # upon calling this method. Instead, any partitions that are able to be
+        # resumed will be resumed at the start of the next ``poll`` call.
+        for partition in partitions:
+            self.__paused.discard(partition)
+
+    def paused(self) -> Sequence[Partition]:
+        return [*self.__paused]
+
+    def tell(self) -> Mapping[Partition, int]:
+        return self.__consumer.tell()
+
+    def seek(self, offsets: Mapping[Partition, int]) -> None:
+        return self.__consumer.seek(offsets)
+
+    def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
+        return self.__consumer.stage_offsets(offsets)
+
+    def commit_offsets(self) -> Mapping[Partition, int]:
+        return self.__consumer.commit_offsets()
+
+    def close(self, timeout: Optional[float] = None) -> None:
+        # TODO: Be careful to ensure there are not any deadlock conditions
+        # here. Should this actually wait for the commit log worker?
+        self.__commit_log_worker_stop_requested.set()
+        return self.__consumer.close(timeout)
+
+    @property
+    def closed(self) -> bool:
+        return self.__consumer.closed

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -12,15 +12,31 @@ def assert_changes(
     after: T,
     operator: Callable[[T, T], bool] = operator.eq,
 ) -> Iterator[None]:
-    assert operator(callable(), before)
+    actual = callable()
+    assert operator(
+        actual, before
+    ), f"precondition ({operator}) on {callable} failed: expected: {before!r}, actual: {actual!r}"
+
     yield
-    assert operator(callable(), after)
+
+    actual = callable()
+    assert operator(
+        actual, after
+    ), f"postcondition ({operator}) on {callable} failed: expected: {after!r}, actual: {actual!r}"
 
 
 @contextmanager
 def assert_does_not_change(
     callable: Callable[[], T], value: T, operator: Callable[[T, T], bool] = operator.eq,
 ) -> Iterator[None]:
-    assert operator(callable(), value)
+    actual = callable()
+    assert operator(
+        actual, value
+    ), f"precondition ({operator}) on {callable} failed: expected: {value!r}, actual: {actual!r}"
+
     yield
-    assert operator(callable(), value)
+
+    actual = callable()
+    assert operator(
+        actual, value
+    ), f"postcondition ({operator}) on {callable} failed: expected: {value!r}, actual: {actual!r}"

--- a/tests/utils/streams/mixins.py
+++ b/tests/utils/streams/mixins.py
@@ -112,7 +112,8 @@ class StreamsTestMixin(ABC):
             with pytest.raises(ConsumerError):
                 consumer.seek({Partition(topic, 0): messages[0].offset})
 
-            consumer.close()
+            with assert_changes(lambda: consumer.closed, False, True):
+                consumer.close()
 
             # Make sure all public methods (except ``close```) error if called
             # after the consumer has been closed.

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -10,7 +10,6 @@ from confluent_kafka.admin import AdminClient, NewTopic
 from snuba.utils.codecs import Codec
 from snuba.utils.streams.consumer import ConsumerError, EndOfPartition
 from snuba.utils.streams.kafka import (
-    Commit,
     CommitCodec,
     KafkaConsumer,
     KafkaConsumerWithCommitLog,
@@ -18,6 +17,7 @@ from snuba.utils.streams.kafka import (
     KafkaProducer,
     as_kafka_configuration_bool,
 )
+from snuba.utils.streams.synchronized import Commit
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.utils.streams.mixins import StreamsTestMixin
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer

--- a/tests/utils/streams/test_synchronized.py
+++ b/tests/utils/streams/test_synchronized.py
@@ -1,0 +1,298 @@
+import time
+from contextlib import closing
+from typing import TypeVar
+
+from snuba.utils.streams.consumer import Consumer
+from snuba.utils.streams.dummy import DummyBroker, DummyConsumer, DummyProducer
+from snuba.utils.streams.producer import Producer
+from snuba.utils.streams.synchronized import Commit, SynchronizedConsumer
+from snuba.utils.streams.types import Message, Partition, Topic
+from tests.assertions import assert_changes, assert_does_not_change
+
+
+T = TypeVar("T")
+
+
+def wait_for_consumer(consumer: Consumer[T], message: Message[T], attempts: int = 10):
+    """Block until the provided consumer has received the provided message."""
+    for i in range(attempts):
+        if consumer.tell().get(message.partition) >= message.get_next_offset():
+            return
+
+        time.sleep(0.1)
+
+    raise Exception(
+        f"{message} was not received by {consumer} within {attempts} attempts"
+    )
+
+
+def test_synchronized_consumer() -> None:
+    topic = Topic("topic")
+    commit_log_topic = Topic("commit-log")
+
+    broker: DummyBroker[int] = DummyBroker()
+    broker.create_topic(topic, partitions=1)
+    consumer: Consumer[int] = DummyConsumer(broker, "consumer")
+    producer: Producer[int] = DummyProducer(broker)
+    messages = [producer.produce(topic, i).result(1.0) for i in range(6)]
+
+    commit_log_broker: DummyBroker[Commit] = DummyBroker()
+    commit_log_broker.create_topic(commit_log_topic, partitions=1)
+    commit_log_consumer: Consumer[Commit] = DummyConsumer(
+        commit_log_broker, "commit-log-consumer"
+    )
+    commit_log_producer: Producer[Commit] = DummyProducer(commit_log_broker)
+
+    synchronized_consumer: Consumer[int] = SynchronizedConsumer(
+        consumer,
+        commit_log_consumer,
+        commit_log_topic=commit_log_topic,
+        commit_log_groups={"leader-a", "leader-b"},
+    )
+
+    with closing(synchronized_consumer):
+        synchronized_consumer.subscribe([topic])
+
+        # The consumer should not consume any messages until it receives a
+        # commit from both groups that are being followed.
+        # TODO: This test is not ideal -- there are no guarantees that the
+        # commit log worker has subscribed and started polling yet.
+        with assert_changes(
+            consumer.paused, [], [Partition(topic, 0)]
+        ), assert_does_not_change(
+            consumer.tell, {Partition(topic, 0): messages[0].offset}
+        ):
+            assert synchronized_consumer.poll(0.0) is None
+
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader-a", Partition(topic, 0), messages[0].get_next_offset()),
+            ).result(),
+        )
+
+        # The consumer should remain paused, since it needs both groups to
+        # advance before it may continue.
+        with assert_does_not_change(
+            consumer.paused, [Partition(topic, 0)]
+        ), assert_does_not_change(
+            consumer.tell, {Partition(topic, 0): messages[0].offset}
+        ):
+            assert synchronized_consumer.poll(0.0) is None
+
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader-b", Partition(topic, 0), messages[0].get_next_offset()),
+            ).result(),
+        )
+
+        # The consumer should be able to resume consuming, since both consumers
+        # have processed the first message.
+        with assert_changes(consumer.paused, [Partition(topic, 0)], []), assert_changes(
+            consumer.tell,
+            {Partition(topic, 0): messages[0].offset},
+            {Partition(topic, 0): messages[0].get_next_offset()},
+        ):
+            assert synchronized_consumer.poll(0.0) == messages[0]
+
+        # After consuming the one available message, the consumer should be
+        # paused again until the remote offsets advance.
+        with assert_changes(
+            consumer.paused, [], [Partition(topic, 0)]
+        ), assert_does_not_change(
+            consumer.tell, {Partition(topic, 0): messages[1].offset}
+        ):
+            assert synchronized_consumer.poll(0.0) is None
+
+        # Emulate the unlikely (but possible) scenario of the leader offsets
+        # being within a series of compacted (deleted) messages by:
+        # 1. moving the remote offsets forward, so that the partition is resumed
+        # 2. seeking the consumer beyond the remote offsets
+
+        commit_log_producer.produce(
+            commit_log_topic,
+            Commit("leader-a", Partition(topic, 0), messages[3].offset),
+        ).result()
+
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader-b", Partition(topic, 0), messages[5].offset),
+            ).result(),
+        )
+
+        # The consumer should be able to resume consuming, since both consumers
+        # have processed the first message.
+        with assert_changes(consumer.paused, [Partition(topic, 0)], []), assert_changes(
+            consumer.tell,
+            {Partition(topic, 0): messages[1].offset},
+            {Partition(topic, 0): messages[1].get_next_offset()},
+        ):
+            assert synchronized_consumer.poll(0.0) == messages[1]
+
+        # At this point, we manually seek the consumer offset, to emulate messages being skipped.
+        with assert_changes(
+            consumer.tell,
+            {Partition(topic, 0): messages[2].offset},
+            {Partition(topic, 0): messages[4].offset},
+        ):
+            consumer.seek({Partition(topic, 0): messages[4].offset})
+
+        # Since the (effective) remote offset is the offset for message #3 (via
+        # ``leader-a``), and the local offset is the offset of message #4, when
+        # message #4 is consumed, it should be discarded and the offset should
+        # be rolled back to wait for the commit log to advance.
+        with assert_changes(
+            consumer.paused, [], [Partition(topic, 0)]
+        ), assert_does_not_change(
+            consumer.tell, {Partition(topic, 0): messages[4].offset}
+        ):
+            assert synchronized_consumer.poll(0.0) is None
+
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader-a", Partition(topic, 0), messages[5].offset),
+            ).result(),
+        )
+
+        # The consumer should be able to resume consuming.
+        with assert_changes(consumer.paused, [Partition(topic, 0)], []), assert_changes(
+            consumer.tell,
+            {Partition(topic, 0): messages[4].offset},
+            {Partition(topic, 0): messages[4].get_next_offset()},
+        ):
+            assert synchronized_consumer.poll(0.0) == messages[4]
+
+
+def test_synchronized_consumer_pause_resume() -> None:
+    topic = Topic("topic")
+    commit_log_topic = Topic("commit-log")
+
+    broker: DummyBroker[int] = DummyBroker()
+    broker.create_topic(topic, partitions=1)
+    consumer: Consumer[int] = DummyConsumer(broker, "consumer")
+    producer: Producer[int] = DummyProducer(broker)
+    messages = [producer.produce(topic, i).result(1.0) for i in range(2)]
+
+    commit_log_broker: DummyBroker[Commit] = DummyBroker()
+    commit_log_broker.create_topic(commit_log_topic, partitions=1)
+    commit_log_consumer: Consumer[Commit] = DummyConsumer(
+        commit_log_broker, "commit-log-consumer"
+    )
+    commit_log_producer: Producer[Commit] = DummyProducer(commit_log_broker)
+
+    synchronized_consumer: Consumer[int] = SynchronizedConsumer(
+        consumer,
+        commit_log_consumer,
+        commit_log_topic=commit_log_topic,
+        commit_log_groups={"leader"},
+    )
+
+    with closing(synchronized_consumer):
+        synchronized_consumer.subscribe([topic])
+
+        # TODO: This test is not ideal -- there are no guarantees that the
+        # commit log worker has subscribed and started polling yet.
+        with assert_changes(
+            synchronized_consumer.paused, [], [Partition(topic, 0)]
+        ), assert_changes(consumer.paused, [], [Partition(topic, 0)]):
+            synchronized_consumer.pause([Partition(topic, 0)])
+
+        # Advancing the commit log offset should not cause the consumer to
+        # resume, since it has been explicitly paused.
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader", Partition(topic, 0), messages[0].get_next_offset()),
+            ).result(),
+        )
+
+        with assert_does_not_change(consumer.paused, [Partition(topic, 0)]):
+            assert synchronized_consumer.poll(0) is None
+
+        # Resuming the partition does not immediately cause the partition to
+        # resume, but it should look as if it is resumed to the caller.
+        with assert_changes(
+            synchronized_consumer.paused, [Partition(topic, 0)], []
+        ), assert_does_not_change(consumer.paused, [Partition(topic, 0)]):
+            synchronized_consumer.resume([Partition(topic, 0)])
+
+        # The partition should be resumed on the next poll call, however.
+        with assert_changes(consumer.paused, [Partition(topic, 0)], []):
+            assert synchronized_consumer.poll(0) == messages[0]
+
+        # Pausing due to hitting the offset fence should not appear as a paused
+        # partition to the caller.
+        with assert_does_not_change(synchronized_consumer.paused, []), assert_changes(
+            consumer.paused, [], [Partition(topic, 0)]
+        ):
+            assert synchronized_consumer.poll(0) is None
+
+        # Other pause and resume actions should not cause the inner consumer to
+        # change its state while up against the fence.
+        with assert_changes(
+            synchronized_consumer.paused, [], [Partition(topic, 0)]
+        ), assert_does_not_change(consumer.paused, [Partition(topic, 0)]):
+            synchronized_consumer.pause([Partition(topic, 0)])
+
+        with assert_changes(
+            synchronized_consumer.paused, [Partition(topic, 0)], []
+        ), assert_does_not_change(consumer.paused, [Partition(topic, 0)]):
+            synchronized_consumer.resume([Partition(topic, 0)])
+
+
+def test_synchronized_consumer_handles_end_of_partition() -> None:
+    topic = Topic("topic")
+    commit_log_topic = Topic("commit-log")
+
+    broker: DummyBroker[int] = DummyBroker()
+    broker.create_topic(topic, partitions=1)
+    consumer: Consumer[int] = DummyConsumer(broker, "consumer")
+    producer: Producer[int] = DummyProducer(broker)
+    messages = [producer.produce(topic, i).result(1.0) for i in range(2)]
+
+    commit_log_broker: DummyBroker[Commit] = DummyBroker()
+    commit_log_broker.create_topic(commit_log_topic, partitions=1)
+    commit_log_consumer: Consumer[Commit] = DummyConsumer(
+        commit_log_broker, "commit-log-consumer", enable_end_of_partition=True
+    )
+    commit_log_producer: Producer[Commit] = DummyProducer(commit_log_broker)
+
+    synchronized_consumer: Consumer[int] = SynchronizedConsumer(
+        consumer,
+        commit_log_consumer,
+        commit_log_topic=commit_log_topic,
+        commit_log_groups={"leader"},
+    )
+
+    with closing(synchronized_consumer):
+        synchronized_consumer.subscribe([topic])
+
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader", Partition(topic, 0), messages[0].get_next_offset()),
+            ).result(),
+        )
+
+        assert synchronized_consumer.poll(0) == messages[0]
+
+        # If the commit log consumer does not handle EOF, it will have crashed
+        # here and will never return the next message.
+        wait_for_consumer(
+            commit_log_consumer,
+            commit_log_producer.produce(
+                commit_log_topic,
+                Commit("leader", Partition(topic, 0), messages[1].get_next_offset()),
+            ).result(),
+        )
+
+        assert synchronized_consumer.poll(0) == messages[1]


### PR DESCRIPTION
This implements a consumer that fences its offsets based on the progress of one or more other consumers which produce `Commit` messages to a commit log topic.