### PR TITLE
ref(subscriptions): Remove `Timer` from Executor parameters

### DIFF
--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -23,8 +23,9 @@ class SubscriptionExecutor:
         self.__executor_pool = executor_pool
 
     def execute(
-        self, task: ScheduledTask[Subscription], tick: Tick, timer: Timer
+        self, task: ScheduledTask[Subscription], tick: Tick
     ) -> Future[ClickhouseQueryResult]:
+        timer = Timer()
         try:
             request = task.task.data.build_request(
                 self.__dataset, tick.timestamps.upper, tick.offsets.upper, timer,

--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -25,7 +25,7 @@ class SubscriptionExecutor:
     def execute(
         self, task: ScheduledTask[Subscription], tick: Tick
     ) -> Future[ClickhouseQueryResult]:
-        timer = Timer()
+        timer = Timer("query")
         try:
             request = task.task.data.build_request(
                 self.__dataset, tick.timestamps.upper, tick.offsets.upper, timer,

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 from uuid import uuid1
 
 from concurrent.futures import ThreadPoolExecutor
@@ -43,7 +42,7 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             timestamps=Interval(now - timedelta(minutes=1), now),
         )
 
-        future = executor.execute(task, tick, Mock())
+        future = executor.execute(task, tick)
         result = future.result()
 
         assert result["data"][0]["count"] == 10
@@ -52,7 +51,7 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             offsets=Interval(5000, 5001),
             timestamps=Interval(now + timedelta(hours=10), now + timedelta(hours=11)),
         )
-        future = executor.execute(task, tick, Mock())
+        future = executor.execute(task, tick)
         result = future.result()
 
         assert result["data"][0]["count"] == 0


### PR DESCRIPTION
These objects aren't thread safe, and only really make sense as implemented to be used with one query at a time. Instantiating it in the `SubscriptionExecutor` is safer, because it decreases the likelihood of reuse across multiple queries and although the timer is passed between the main (consumer) thread and the worker (executor) thread, there is no potential for concurrent access.