### PR TITLE
hack: Workaround for bug in rediscluster

### DIFF
--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -39,6 +39,8 @@ if settings.USE_REDIS_CLUSTER:
         startup_nodes=startup_nodes,
         socket_keepalive=True,
         password=settings.REDIS_PASSWORD,
+        # HACK(mattrobenolt): See https://github.com/Grokzen/redis-py-cluster/pull/353
+        max_connections_per_node=True,
     )
 else:
     redis_client = StrictRedis(


### PR DESCRIPTION
Internally in redis-py-cluster, within
ClusterConnectionPool.count_all_num_connections, this function is not
thread safe, only under python3.

Setting this flag skips the buggy code path by not needing to iterate
the _created_connections_per_node dictionary to count total connections.

For snuba, we don't set a `max_connections` value anyhow, so the default
was effectively infinite.

See: https://github.com/Grokzen/redis-py-cluster/pull/353

Fixes SNUBA-1PR