### PR TITLE
perf(prewhere) Tests adding type in the prewhere clause for selected projects

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -24,7 +24,7 @@ from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.prewhere import CustomPrewhereProcessor, PrewhereProcessor
 from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
@@ -295,10 +295,11 @@ class DiscoverDataset(TimeSeriesDataset):
                             {"timestamp"},
                             BEGINNING_OF_TIME,
                         ),
-                    ]
+                        PrewhereProcessor(),
+                    ],
+                    EVENTS: [CustomPrewhereProcessor(custom_candidates=["type"])],
                 },
             ),
-            PrewhereProcessor(),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -22,7 +22,7 @@ from snuba.datasets.schemas.tables import (
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.processors.prewhere import CustomPrewhereProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
@@ -400,5 +400,5 @@ class EventsDataset(TimeSeriesDataset):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             BasicFunctionsProcessor(),
-            CustomPrewhereProcessor(custom_candidates=["type"]),
+            PrewhereProcessor(),
         ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -22,7 +22,7 @@ from snuba.datasets.schemas.tables import (
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.prewhere import CustomPrewhereProcessor
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
@@ -398,4 +398,7 @@ class EventsDataset(TimeSeriesDataset):
         }
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [BasicFunctionsProcessor(), PrewhereProcessor()]
+        return [
+            BasicFunctionsProcessor(),
+            CustomPrewhereProcessor(custom_candidates=["type"]),
+        ]

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -1,6 +1,9 @@
-from typing import Optional, Sequence
+import json
+from typing import Optional, Sequence, Set
 
-from snuba import settings, util
+from snuba import settings, state, util
+from snuba.query.conditions import is_in_condition
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.types import Condition
@@ -22,8 +25,11 @@ class PrewhereProcessor(QueryProcessor):
     def __init__(self, max_prewhere_conditions: Optional[int] = None) -> None:
         self.__max_prewhere_conditions: int = max_prewhere_conditions if max_prewhere_conditions is not None else settings.MAX_PREWHERE_CONDITIONS
 
+    def _get_prewhere_keys(self, query: Query) -> Sequence[str]:
+        return query.get_data_source().get_prewhere_candidates()
+
     def process_query(self, query: Query, request_settings: RequestSettings,) -> None:
-        prewhere_keys = query.get_data_source().get_prewhere_candidates()
+        prewhere_keys = self._get_prewhere_keys(query)
         if not prewhere_keys:
             return
         prewhere_conditions: Sequence[Condition] = []
@@ -61,3 +67,51 @@ class PrewhereProcessor(QueryProcessor):
                 list(filter(lambda cond: cond not in prewhere_conditions, conditions))
             )
         query.set_prewhere(prewhere_conditions)
+
+
+class CustomPrewhereProcessor(PrewhereProcessor):
+    def __init__(
+        self,
+        custom_candidates: Sequence[str],
+        max_prewhere_conditions: Optional[int] = None,
+    ) -> None:
+        super().__init__(max_prewhere_conditions)
+        self.__custom_candidates = custom_candidates
+
+    def _get_prewhere_keys(self, query: Query) -> Sequence[str]:
+        candidates = query.get_data_source().get_prewhere_candidates()
+
+        custom_projects_config = state.get_config("prewhere_custom_key_projects", "[]")
+        custom_projects = json.loads(custom_projects_config)
+
+        condition = query.get_condition_from_ast()
+
+        def is_project_condition(node: Expression) -> bool:
+            return (
+                is_in_condition(node)
+                and isinstance(node, FunctionCall)
+                and node.parameters[0] == Column(None, "project_id", None)
+            )
+
+        project_conditions = filter(lambda node: is_project_condition(node), condition)
+
+        def extract_project_ids(node: Expression) -> Set[int]:
+            assert isinstance(condition.parameters[1], FunctionCall)
+            literals = node.parameters[1].parameters
+            return {
+                int(literal.value)
+                for literal in literals
+                if isinstance(literal, Literal)
+            }
+
+        projects_lists_in_query = map(
+            lambda node: extract_project_ids(node), project_conditions
+        )
+        projects_in_query = set()
+        for projects in projects_lists_in_query:
+            projects_in_query = projects_in_query | projects
+
+        if any(p in custom_projects for p in projects_in_query):
+            return self.__custom_candidates + candidates
+        else:
+            return candidates

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -2,8 +2,9 @@ import pytest
 from typing import Any, MutableMapping
 from tests.base import BaseDatasetTest
 
+from snuba import settings, state
 from snuba.datasets.factory import get_dataset
-from snuba.query.query import Query
+from snuba.query.parser import parse_query
 from snuba.request.request_settings import HTTPRequestSettings
 
 
@@ -17,15 +18,42 @@ def get_dataset_source(dataset_name):
 
 
 test_data = [
-    ({"conditions": [["type", "=", "transaction"]]}, "transactions",),
-    ({"conditions": [["type", "!=", "transaction"]]}, "events",),
-    ({"conditions": []}, "events",),
-    ({"conditions": [["duration", "=", 0]]}, "transactions",),
+    (
+        {"conditions": [["project_id", "IN", [1]], ["type", "=", "transaction"]]},
+        "transactions",
+    ),
+    (
+        {"conditions": [["project_id", "IN", [1]], ["type", "!=", "transaction"]]},
+        "events",
+    ),
+    ({"conditions": [["project_id", "IN", [1]]]}, "events",),
+    (
+        {"conditions": [["project_id", "IN", [1]], ["duration", "=", 0]]},
+        "transactions",
+    ),
     # No conditions, other referenced columns
-    ({"selected_columns": ["group_id"]}, "events"),
-    ({"selected_columns": ["trace_id"]}, "transactions"),
-    ({"selected_columns": ["group_id", "trace_id"]}, "events"),
-    ({"aggregations": [["max", "duration", "max_duration"]]}, "transactions"),
+    (
+        {"selected_columns": ["group_id"], "conditions": [["project_id", "IN", [1]]]},
+        "events",
+    ),
+    (
+        {"selected_columns": ["trace_id"], "conditions": [["project_id", "IN", [1]]]},
+        "transactions",
+    ),
+    (
+        {
+            "selected_columns": ["group_id", "trace_id"],
+            "conditions": [["project_id", "IN", [1]]],
+        },
+        "events",
+    ),
+    (
+        {
+            "conditions": [["project_id", "IN", [1]]],
+            "aggregations": [["max", "duration", "max_duration"]],
+        },
+        "transactions",
+    ),
 ]
 
 
@@ -34,9 +62,13 @@ class TestDiscover(BaseDatasetTest):
     def test_data_source(
         self, query_body: MutableMapping[str, Any], expected_dataset: str
     ):
-        query = Query(query_body, get_dataset_source("discover"))
+        settings.MAX_PREWHERE_CONDITIONS = 3
+        state.set_config("prewhere_custom_key_projects", "[1,3]")
 
+        dataset = get_dataset("discover")
+        query = parse_query(query_body, dataset)
         request_settings = HTTPRequestSettings()
+
         for processor in get_dataset("discover").get_query_processors():
             processor.process_query(query, request_settings)
 

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -100,7 +100,7 @@ def test_custom_prewhere(query_body, new_conditions, prewhere_conditions) -> Non
     settings.MAX_PREWHERE_CONDITIONS = 3
     state.set_config("prewhere_custom_key_projects", "[1,3]")
 
-    dataset = get_dataset("transactions")
+    dataset = get_dataset("events")
     query = parse_query(query_body, dataset)
     request_settings = HTTPRequestSettings()
 

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -1,9 +1,11 @@
 import pytest
 
-from snuba import settings
+from snuba import settings, state
 from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.factory import get_dataset
 from snuba.datasets.schemas.tables import TableSource
-from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.parser import parse_query
+from snuba.query.processors.prewhere import CustomPrewhereProcessor, PrewhereProcessor
 from snuba.query.query import Query
 from snuba.request.request_settings import HTTPRequestSettings
 
@@ -55,6 +57,54 @@ def test_prewhere(query_body, keys, new_conditions, prewhere_conditions) -> None
 
     request_settings = HTTPRequestSettings()
     processor = PrewhereProcessor()
+    processor.process_query(query, request_settings)
+
+    assert query.get_conditions() == new_conditions
+    assert query.get_prewhere() == prewhere_conditions
+
+
+test_custom_prewhere = [
+    (
+        {
+            "conditions": [
+                ["project_id", "IN", [4]],
+                ["d", "=", "3"],
+                ["type", "=", "error"],
+                ["event_id", "=", "1"],
+                ["b", "=", "2"],
+            ],
+        },
+        [["d", "=", "3"], ["type", "=", "error"], ["b", "=", "2"]],
+        [["event_id", "=", "1"], ["project_id", "IN", [4]]],
+    ),
+    (
+        {
+            "conditions": [
+                ["project_id", "IN", [1, 3]],
+                ["d", "=", "3"],
+                ["type", "=", "error"],
+                ["event_id", "=", "1"],
+                ["b", "=", "2"],
+            ],
+        },
+        [["d", "=", "3"], ["b", "=", "2"]],
+        [["type", "=", "error"], ["event_id", "=", "1"], ["project_id", "IN", [1, 3]]],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "query_body, new_conditions, prewhere_conditions", test_custom_prewhere
+)
+def test_custom_prewhere(query_body, new_conditions, prewhere_conditions) -> None:
+    settings.MAX_PREWHERE_CONDITIONS = 3
+    state.set_config("prewhere_custom_key_projects", "[1,3]")
+
+    dataset = get_dataset("transactions")
+    query = parse_query(query_body, dataset)
+    request_settings = HTTPRequestSettings()
+
+    processor = CustomPrewhereProcessor(custom_candidates=["type"])
     processor.process_query(query, request_settings)
 
     assert query.get_conditions() == new_conditions


### PR DESCRIPTION
This is a test to see the results of using type in the prewhere clause. In order to do that we keep a list of suitable projects in state.
We parse the query to find project_id conditions, if at least one matches we add the custom key to the prewhere clauses.