### PR TITLE
ref(subscriptions): Use the topic specification in partitioner

### DIFF
--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod, ABC
 from binascii import crc32
 
-from snuba.datasets.dataset import Dataset
+from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.subscriptions.data import PartitionId, SubscriptionData
 
 
@@ -11,18 +11,15 @@ class SubscriptionDataPartitioner(ABC):
         pass
 
 
-class DatasetSubscriptionDataPartitioner(SubscriptionDataPartitioner):
+class TopicSubscriptionDataPartitioner(SubscriptionDataPartitioner):
     """
-    Partitions a subscription based on the Dataset that we're going to store it in.
+    Identifies the partition index that contains the source data for a subscription.
     """
 
-    PARTITION_COUNT = 64
-
-    def __init__(self, dataset: Dataset):
-        self.__dataset = dataset
+    def __init__(self, topic: KafkaTopicSpec):
+        self.__topic = topic
 
     def build_partition_id(self, data: SubscriptionData) -> PartitionId:
-        # TODO: Use something from the dataset to determine the number of partitions
         return PartitionId(
-            crc32(str(data.project_id).encode("utf-8")) % self.PARTITION_COUNT
+            crc32(str(data.project_id).encode("utf-8")) % self.__topic.partitions_number
         )

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -11,9 +11,7 @@ class TestBuildRequest(BaseSubscriptionTest):
         data = SubscriptionData(
             123, [], [], timedelta(minutes=10), timedelta(minutes=1)
         )
-        assert (
-            TopicSubscriptionDataPartitioner(
-                KafkaTopicSpec("topic", partitions_number=64)
-            ).build_partition_id(data)
-            == 18
+        partitioner = TopicSubscriptionDataPartitioner(
+            KafkaTopicSpec("topic", partitions_number=64)
         )
+        assert partitioner.build_partition_id(data) == 18

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -1,7 +1,8 @@
 from datetime import timedelta
 
+from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.subscriptions.data import SubscriptionData
-from snuba.subscriptions.partitioner import DatasetSubscriptionDataPartitioner
+from snuba.subscriptions.partitioner import TopicSubscriptionDataPartitioner
 from tests.subscriptions import BaseSubscriptionTest
 
 
@@ -10,5 +11,9 @@ class TestBuildRequest(BaseSubscriptionTest):
         data = SubscriptionData(
             123, [], [], timedelta(minutes=10), timedelta(minutes=1)
         )
-        partitioner = DatasetSubscriptionDataPartitioner(self.dataset)
-        assert partitioner.build_partition_id(data) == 18
+        assert (
+            TopicSubscriptionDataPartitioner(
+                KafkaTopicSpec("topic", partitions_number=64)
+            ).build_partition_id(data)
+            == 18
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1711,7 +1711,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         assert resp.status_code == 202
         data = json.loads(resp.data)
         assert data == {
-            "subscription_id": f"55/{expected_uuid.hex}",
+            "subscription_id": f"0/{expected_uuid.hex}",
         }
 
     def test_time_error(self):


### PR DESCRIPTION
This uses the partition number defined on the topic specification object instead of a magic number to determine the partition routing.