### PR TITLE
ref(query): Remove redundant query log call

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -140,7 +140,6 @@ def raw_query(
                             with_totals=request.query.has_totals(),
                         )
 
-                        logger.debug(sql)
                         timer.mark("execute")
                         stats.update(
                             {


### PR DESCRIPTION
This is already logged by the ClickHouse driver at the same level, I don't think we need to log it twice:

```
2020-02-03 17:23:42,798 DEBUG    snuba.query: SELECT (count() AS count) FROM sentry_local PREWHERE project_id IN (1) WHERE ifnull(offset, 0) <= 87694 AND timestamp >= toDateTime('2020-02-04T01:17:00') AND timestamp < toDateTime('2020-02-04T01:22:00') AND deleted = 0 LIMIT 0, 1000
2020-02-03 17:23:42,873 DEBUG    clickhouse_driver.connection: Query: SELECT (count() AS count) FROM sentry_local PREWHERE project_id IN (1) WHERE ifnull(offset, 0) <= 87694 AND timestamp >= toDateTime('2020-02-04T01:18:00') AND timestamp < toDateTime('2020-02-04T01:23:00') AND deleted = 0 LIMIT 0, 1000
```