### PR TITLE
ref(datasets): Add the ability to provide configuration to topic creation

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -79,6 +79,7 @@ def bootstrap(
                         topic_spec.topic_name,
                         num_partitions=topic_spec.partitions_number,
                         replication_factor=topic_spec.replication_factor,
+                        config=topic_spec.configuration,
                     )
 
         logger.debug("Initiating topic creation")

--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -88,3 +88,8 @@ PROJECT_STACKTRACE_BLACKLIST = set()
 SUBSCRIPTIONS_MAX_CONCURRENT_QUERIES = 10
 
 TOPIC_PARTITION_COUNTS: MutableMapping[str, int] = {}  # (topic name, # of partitions)
+
+TOPIC_PARTITION_CONFIGURATIONS: MutableMapping[str, MutableMapping[str, str]] = {
+    "events": {"message.timestamp.type": "LogAppendTime"},
+    "snuba-commit-log": {"cleanup.policy": "compact"},
+}


### PR DESCRIPTION
This allows specifying Kafka configuration parameters for topics at creation time. Similar to #747. This does not alter existing topics.