### PR TITLE
build(docker): Use redis-cluster for compose, consolidate Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ notifications:
     on_error: always
 after_script:
   - npm install -g @zeus-ci/cli
-  - $(npm bin -g)/zeus upload -t "application/x-junit+xml" ~/.artifacts/*.junit.xml
-  - $(npm bin -g)/zeus upload -t "application/x-cobertura+xml" ~/.artifacts/coverage.xml
+  - $(npm bin -g)/zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
+  - $(npm bin -g)/zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 services:
   - docker
-  - redis-server
 
 dist: xenial
 
 before_install:
-  - docker run -d --network host --name zookeeper -e ZOOKEEPER_CLIENT_PORT=2181 confluentinc/cp-zookeeper:4.1.0
-  - docker run -d --network host --name kafka -e KAFKA_ZOOKEEPER_CONNECT=localhost:2181 -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092 -e KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1 confluentinc/cp-kafka:4.1.0
-  - docker run -d --net host --name clickhouse-server --ulimit nofile=262144:262144 yandex/clickhouse-server:19.11
-  - make travis-start-redis-cluster
+  - docker network create --attachable cloudbuild
   - docker build -t getsentry/snuba .
-  - docker ps -a
 
 script:
-  - docker run -v ~/.artifacts:/.artifacts --net host -e SNUBA_SETTINGS=ci --entrypoint python getsentry/snuba -m pytest -vv --cov . --cov-report="xml:/.artifacts/coverage.xml" --junit-xml="/.artifacts/pytest.junit.xml"
+  - SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ services:
 dist: xenial
 
 before_install:
+  - docker pull getsentry/sentry:latest || true
+  - docker build -t getsentry/snuba . --cache-from getsentry/sentry:latest
   - docker network create --attachable cloudbuild
-  - docker build -t getsentry/snuba .
 
 script:
   - SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: xenial
 
 before_install:
   - docker pull getsentry/snuba:latest || true
-  - docker build -t getsentry/snuba . --cache-from getsentry/sentry:latest
+  - docker build -t getsentry/snuba . --cache-from getsentry/snuba:latest
   - docker network create --attachable cloudbuild
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 dist: xenial
 
 before_install:
-  - docker pull getsentry/sentry:latest || true
+  - docker pull getsentry/snuba:latest || true
   - docker build -t getsentry/snuba . --cache-from getsentry/sentry:latest
   - docker network create --attachable cloudbuild
 

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -3,7 +3,7 @@ version: '3.4'
 services:
   snuba-test:
     depends_on:
-      - redis
+      - redis_cluster
       - kafka
       - clickhouse
     image: '$SNUBA_IMAGE'
@@ -22,8 +22,7 @@ services:
     environment:
       SNUBA_SETTINGS: 'ci'
       CLICKHOUSE_HOST: clickhouse
-      USE_REDIS_CLUSTER: 0
-      REDIS_HOST: 'redis'
+      REDIS_HOST: 'redis1'
       REDIS_PORT: 6379
       DEFAULT_BROKERS: 'kafka:9092'
     entrypoint: python
@@ -52,8 +51,35 @@ services:
       nofile:
         soft: 262144
         hard: 262144
-  redis:
+  redis1: &redis_config
     image: redis:5.0-alpine
+    command:
+      - redis-server
+      - '--appendonly'
+      - 'no'
+      - '--cluster-enabled'
+      - 'yes'
+      - '--cluster-config-file'
+      - '/data/redis_cluster.conf'
+  redis2:
+    << : *redis_config
+  redis3:
+    << : *redis_config
+  redis_cluster:
+    << : *redis_config
+    command:
+     - '/bin/sh'
+     - '-c'
+     - >-
+      echo yes |
+      redis-cli --cluster create
+      $$(getent hosts redis1 | awk '{ print $$1 }'):6379
+      $$(getent hosts redis2 | awk '{ print $$1 }'):6379
+      $$(getent hosts redis3 | awk '{ print $$1 }'):6379
+    depends_on:
+     - redis1
+     - redis2
+     - redis3
 
 networks:
   default:


### PR DESCRIPTION
Enables redis-cluster for the Docker Compose test setup on GCB and removes the custom logic from TravisCI to use the same setup.

This is a follow up to #727. A logical next step would be to stop building a docker image inside Travis and trigger the Travis builds from GCB once the image is built. That said a better option would be to simply moving everything to GCB for efficiency.