### PR TITLE
meta: ignore .venv file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,6 @@ conftest.py
 .coverage
 .mypy_cache/
 .pytest_cache/
+.venv/
 htmlcov/
 snuba.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 .coverage
 .mypy_cache/
 .pytest_cache/
+.venv/
 htmlcov/
 snuba.egg-info/


### PR DESCRIPTION
Makes it consistent with the rest of sentry.