### PR TITLE
feat(streams): Record wall clock latency for receiving messages in batching consumer

### DIFF
--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -114,7 +114,7 @@ class TickConsumer(Consumer[Tick]):
                     Interval(previous_message.offset, message.offset),
                     Interval(previous_message.timestamp, message.timestamp),
                 ),
-                previous_message.timestamp,
+                message.timestamp,
             )
         else:
             result = None

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -161,6 +161,15 @@ class BatchingConsumer(Generic[TPayload]):
     def _handle_message(self, msg: Message[TPayload]) -> None:
         start = time.time()
 
+        self.__metrics.timing(
+            "receive_latency",
+            (start - msg.timestamp.timestamp()) * 1000,
+            tags={
+                "topic": msg.partition.topic.name,
+                "partition": str(msg.partition.index),
+            },
+        )
+
         # set the deadline only after the first message for this batch is seen
         if not self.__batch_deadline:
             self.__batch_deadline = self.max_batch_time / 1000.0 + start


### PR DESCRIPTION
This adds the `receive_latency` timing to the batching consumer, which represents the duration of time it takes between a message being written by the broker and the message being received (but not processed) by the batching consumer.

This is subject to clock drift between different hosts, but should provide a reasonable approximation of how far the consumer is lagging in wall clock time on a per partition basis.