### PR TITLE
fix(errors) Disable replacements in errors dataset

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -24,6 +24,9 @@ class ErrorsProcessor(EventsProcessorBase):
     def __init__(self, promoted_tag_columns: Mapping[str, str]):
         self._promoted_tag_columns = promoted_tag_columns
 
+    def _replacements_enabled(self) -> bool:
+        return False
+
     def extract_promoted_tags(
         self, output: MutableMapping[str, Any], tags: Mapping[str, Any],
     ) -> None:


### PR DESCRIPTION
The replacement topic still does not exists for the errors dataset so we need to skip this phase fir now.