### PR TITLE
feat(parser) Resolve tags/contexts in the AST query

### DIFF
--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -9,6 +9,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
+    NestedColumn,
     Argument,
 )
 from snuba.query.parsing import ParsingContext
@@ -77,6 +78,11 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             ret.append(".")
         ret.append(escape_identifier(exp.column_name) or "")
         return self.__alias("".join(ret), exp.alias)
+
+    def visitNestedColumn(self, exp: NestedColumn) -> str:
+        raise ValueError(
+            f"Clickhouse does not support a dictionary style accessor for nested columns: {exp.column_name}"
+        )
 
     def __visit_params(self, parameters: Sequence[Expression]) -> str:
         ret = [p.accept(self) for p in parameters]

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -9,7 +9,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
-    NestedColumn,
+    MappingColumn,
     Argument,
 )
 from snuba.query.parsing import ParsingContext
@@ -79,7 +79,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         ret.append(escape_identifier(exp.column_name) or "")
         return self.__alias("".join(ret), exp.alias)
 
-    def visitNestedColumn(self, exp: NestedColumn) -> str:
+    def visitMappingColumn(self, exp: MappingColumn) -> str:
         raise ValueError(
             f"Clickhouse does not support a dictionary style accessor for nested columns: {exp.column_name}"
         )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -339,6 +339,9 @@ class EventsDataset(TimeSeriesDataset):
     def get_required_columns(self):
         return self.__required_columns
 
+    def get_all_columns(self) -> ColumnSet:
+        return self.__all_columns
+
     def _get_promoted_columns(self):
         # The set of columns, and associated keys that have been promoted
         # to the top level table namespace.

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Mapping, Sequence, Union
+from typing import FrozenSet, Mapping, Sequence, Union
 
 from snuba.clickhouse.columns import (
     Array,
@@ -327,22 +327,22 @@ class EventsDataset(TimeSeriesDataset):
         else:
             return super().column_expr(column_name, query, parsing_context, table_alias)
 
-    def get_promoted_tag_columns(self):
+    def get_promoted_tag_columns(self) -> ColumnSet:
         return self.__promoted_tag_columns
 
-    def _get_promoted_context_tag_columns(self):
+    def _get_promoted_context_tag_columns(self) -> ColumnSet:
         return self.__promoted_context_tag_columns
 
-    def _get_promoted_context_columns(self):
+    def _get_promoted_context_columns(self) -> ColumnSet:
         return self.__promoted_context_columns
 
-    def get_required_columns(self):
+    def get_required_columns(self) -> ColumnSet:
         return self.__required_columns
 
     def get_all_columns(self) -> ColumnSet:
         return self.__all_columns
 
-    def _get_promoted_columns(self):
+    def _get_promoted_columns(self) -> Mapping[str, FrozenSet[str]]:
         # The set of columns, and associated keys that have been promoted
         # to the top level table namespace.
         return {
@@ -358,7 +358,7 @@ class EventsDataset(TimeSeriesDataset):
             ),
         }
 
-    def _get_column_tag_map(self):
+    def _get_column_tag_map(self) -> Mapping[str, Mapping[str, str]]:
         # For every applicable promoted column,  a map of translations from the column
         # name  we save in the database to the tag we receive in the query.
         promoted_context_tag_columns = self._get_promoted_context_tag_columns()
@@ -371,14 +371,14 @@ class EventsDataset(TimeSeriesDataset):
             "contexts": {},
         }
 
-    def get_tag_column_map(self):
+    def get_tag_column_map(self) -> Mapping[str, Mapping[str, str]]:
         # And a reverse map from the tags the client expects to the database columns
         return {
             col: dict(map(reversed, trans.items()))
             for col, trans in self._get_column_tag_map().items()
         }
 
-    def get_promoted_tags(self):
+    def get_promoted_tags(self) -> Mapping[str, Sequence[str]]:
         # The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
         # and they can/will use a promoted column.
         return {
@@ -409,6 +409,6 @@ class EventsDataset(TimeSeriesDataset):
                 nested_column_names={"tags", "contexts"},
                 columns=self.__all_columns,
                 promoted_columns=self._get_promoted_columns(),
-                tags_column_map=self.get_tag_column_map(),
+                key_column_map=self.get_tag_column_map(),
             ),
         ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -14,22 +14,22 @@ from snuba.clickhouse.columns import (
 )
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.dataset_schemas import DatasetSchemas
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import (
     MigrationSchemaColumn,
     ReplacingMergeTreeSchema,
 )
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
-from snuba.query.query_processor import QueryProcessor
-from snuba.query.timeseries import TimeSeriesExtension
+from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.single_tag_expr import SingleTagProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.query.timeseries import TimeSeriesExtension
 from snuba.util import qualified_column
 
 

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 
-from typing import Any, Iterable, List, Mapping, Optional, Union
+from typing import Any, List, Mapping, Optional, Union
 
 from dataclasses import dataclass
 from snuba import state

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 
-from typing import Any, List, Mapping, Optional, Set, Union
+from typing import Any, Iterable, List, Mapping, Optional, Union
 
 from dataclasses import dataclass
 from snuba import state
@@ -77,7 +77,7 @@ class TagColumnProcessor:
     def __init__(
         self,
         columns: ColumnSet,
-        promoted_columns: Mapping[str, Set[str]],
+        promoted_columns: Mapping[str, Iterable[str]],
         column_tag_map: Mapping[str, Mapping[str, str]],
     ) -> None:
         # The ColumnSet of the dataset. Used to format promoted

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta
-from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
+from typing import Any, FrozenSet, Mapping, MutableMapping, Optional, Sequence, Union
 
 from snuba.clickhouse.columns import (
     ColumnSet,
@@ -231,14 +231,14 @@ class TransactionsDataset(TimeSeriesDataset):
     def get_all_columns(self) -> ColumnSet:
         return self.__columns
 
-    def _get_promoted_columns(self):
+    def _get_promoted_columns(self) -> Mapping[str, FrozenSet[str]]:
         # TODO: Support promoted tags
         return {
             "tags": frozenset(),
             "contexts": frozenset(),
         }
 
-    def _get_column_tag_map(self):
+    def _get_column_tag_map(self) -> Mapping[str, Mapping[str, str]]:
         # TODO: Support promoted tags
         return {
             "tags": {},
@@ -313,6 +313,6 @@ class TransactionsDataset(TimeSeriesDataset):
                 nested_column_names={"tags", "contexts"},
                 columns=self.__columns,
                 promoted_columns=self._get_promoted_columns(),
-                tags_column_map=self.get_tag_column_map(),
+                key_column_map=self.get_tag_column_map(),
             ),
         ]

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -194,7 +194,7 @@ class TransactionsDataset(TimeSeriesDataset):
             ]
         )
 
-        promoted_columns_specs = {
+        self.__promoted_columns_specs = {
             "tags": PromotedColumnSpec({}),
             "contexts": PromotedColumnSpec({}),
         }
@@ -215,7 +215,7 @@ class TransactionsDataset(TimeSeriesDataset):
         dataset_schemas = DatasetSchemas(read_schema=schema, write_schema=schema,)
 
         self.__tags_processor = TagColumnProcessor(
-            columns=columns, promoted_columns_spec=promoted_columns_specs,
+            columns=self.__columns, promoted_columns_spec=self.__promoted_columns_specs,
         )
 
         super().__init__(
@@ -294,6 +294,6 @@ class TransactionsDataset(TimeSeriesDataset):
             SingleTagProcessor(
                 nested_column_names={"tags", "contexts"},
                 columns=self.__columns,
-                promoted_columns_spec=promoted_columns_specs,
+                promoted_columns_spec=self.__promoted_columns_specs,
             ),
         ]

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence
 
-from snuba.query.expressions import Expression, FunctionCall, Literal
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 
 # Add here functions (only stateless stuff) used to make the AST less
 # verbose to build.
@@ -8,6 +8,13 @@ from snuba.query.expressions import Expression, FunctionCall, Literal
 
 def literals_tuple(alias: Optional[str], literals: Sequence[Literal]) -> FunctionCall:
     return FunctionCall(alias, "tuple", tuple(literals))
+
+
+# Array functions
+def array_element(
+    alias: Optional[str], array_col: Column, index: Expression
+) -> FunctionCall:
+    return FunctionCall(alias, "arrayElement", (index,))
 
 
 # arithmetic function

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -14,7 +14,7 @@ def literals_tuple(alias: Optional[str], literals: Sequence[Literal]) -> Functio
 def array_element(
     alias: Optional[str], array_col: Column, index: Expression
 ) -> FunctionCall:
-    return FunctionCall(alias, "arrayElement", (index,))
+    return FunctionCall(alias, "arrayElement", (array_col, index))
 
 
 # arithmetic function

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -86,6 +86,10 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
         raise NotImplementedError
 
     @abstractmethod
+    def visitNestedColumn(self, exp: NestedColumn) -> TVisited:
+        raise NotImplementedError
+
+    @abstractmethod
     def visitFunctionCall(self, exp: FunctionCall) -> TVisited:
         raise NotImplementedError
 
@@ -137,6 +141,21 @@ class Column(Expression):
 
     def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
         return visitor.visitColumn(self)
+
+
+@dataclass(frozen=True)
+class NestedColumn(Column):
+    """
+    Represents a structured column in our query like tag[something].
+    Our query language supports accessing elements of a nested column by key, so,
+    having a specific AST construct, allows for a cleaner query processing of these
+    columns.
+    """
+
+    key: str
+
+    def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
+        return visitor.visitNestedColumn(self)
 
 
 @dataclass(frozen=True)

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -86,7 +86,7 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
         raise NotImplementedError
 
     @abstractmethod
-    def visitNestedColumn(self, exp: NestedColumn) -> TVisited:
+    def visitMappingColumn(self, exp: MappingColumn) -> TVisited:
         raise NotImplementedError
 
     @abstractmethod
@@ -144,7 +144,7 @@ class Column(Expression):
 
 
 @dataclass(frozen=True)
-class NestedColumn(Column):
+class MappingColumn(Column):
     """
     Represents a structured column in our query like tag[something].
     Our query language supports accessing elements of a nested column by key, so,
@@ -155,7 +155,7 @@ class NestedColumn(Column):
     key: str
 
     def accept(self, visitor: ExpressionVisitor[TVisited]) -> TVisited:
-        return visitor.visitNestedColumn(self)
+        return visitor.visitMappingColumn(self)
 
 
 @dataclass(frozen=True)

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -2,8 +2,13 @@ import numbers
 from datetime import date, datetime
 from typing import Any, Callable, List, Optional, TypeVar, Tuple, Union
 
-from snuba.query.expressions import Column, Expression, Literal, FunctionCall
-from snuba.util import is_function, QUOTED_LITERAL_RE
+from snuba.query.expressions import (
+    Expression,
+    FunctionCall,
+    Literal,
+)
+from snuba.query.parser.strings import parse_string
+from snuba.util import is_function
 
 TExpression = TypeVar("TExpression")
 
@@ -81,14 +86,6 @@ def parse_function_to_expr(expr: Any) -> Expression:
     The real parser will be in a different data structure.
     """
 
-    def simple_expression_builder(val: str) -> Expression:
-        # TODO: This will use the schema of the dataset to decide
-        # if the expression is a column or a literal.
-        if QUOTED_LITERAL_RE.match(val):
-            return Literal(None, val[1:-1])
-        else:
-            return Column(None, val, None)
-
     def literal_builder(
         val: Optional[Union[str, datetime, date, List[Any], Tuple[Any], numbers.Number]]
     ) -> Expression:
@@ -100,6 +97,4 @@ def parse_function_to_expr(expr: Any) -> Expression:
     ) -> Expression:
         return FunctionCall(alias, name, tuple(params))
 
-    return parse_function(
-        output_builder, simple_expression_builder, literal_builder, expr, 0,
-    )
+    return parse_function(output_builder, parse_string, literal_builder, expr, 0,)

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -1,0 +1,32 @@
+from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
+from snuba.query.expressions import Column, Expression, NestedColumn, Literal
+from snuba.util import QUOTED_LITERAL_RE
+
+
+def parse_string(val: str) -> Expression:
+    if isinstance(val, str):
+        match = NESTED_COL_EXPR_RE.match(val)
+        if match:
+            col_name = match[1]
+            key_name = match[2]
+            return NestedColumn(
+                # We pass the original expression as alias so that the query processors
+                # know what the client expects as column name.
+                # TODO: apply alias on all AST nodes created during parsing to make the original
+                # name visible to the query processors.
+                alias=val,
+                column_name=col_name,
+                table_name=None,
+                key=key_name,
+            )
+
+    if val.isdigit():
+        return Literal(None, int(val))
+    else:
+        try:
+            return Literal(None, float(val))
+        except Exception:
+            if QUOTED_LITERAL_RE.match(val):
+                return Literal(None, val[1:-1])
+            else:
+                return Column(None, val, None)

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -1,5 +1,5 @@
 from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
-from snuba.query.expressions import Column, Expression, NestedColumn, Literal
+from snuba.query.expressions import Column, Expression, MappingColumn, Literal
 from snuba.util import QUOTED_LITERAL_RE
 
 
@@ -9,7 +9,7 @@ def parse_string(val: str) -> Expression:
         if match:
             col_name = match[1]
             key_name = match[2]
-            return NestedColumn(
+            return MappingColumn(
                 # We pass the original expression as alias so that the query processors
                 # know what the client expects as column name.
                 # TODO: apply alias on all AST nodes created during parsing to make the original

--- a/snuba/query/processors/single_tag_expr.py
+++ b/snuba/query/processors/single_tag_expr.py
@@ -1,0 +1,74 @@
+from typing import Mapping, Set
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.query.expressions import (
+    Column,
+    Expression,
+    FunctionCall,
+    Literal,
+    NestedColumn,
+)
+from snuba.query.dsl import array_element
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+class SingleTagProcessor(QueryProcessor):
+    def __init__(
+        self,
+        nested_column_names: Set[str],
+        columns: ColumnSet,
+        promoted_columns: Mapping[str, Set[str]],
+    ) -> None:
+        # Keeps the names of the nested columns to expand
+        self.__nested_column_names = nested_column_names
+        # The ColumnSet of the dataset. Used to format promoted
+        # columns with the right type.
+        self.__columns = columns
+        # Keeps a dictionary of promoted columns. The key of the mapping
+        # can be 'tags' or 'contexts'. The values is a set of flattened
+        # columns.
+        self.__promoted_columns = promoted_columns
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def process_column(exp: Expression) -> Expression:
+            if not isinstance(
+                exp, NestedColumn or exp.column_name not in self.__nested_column_names
+            ):
+                return exp
+
+            alias = exp.alias
+            key_name = exp.key
+            col_name = exp.column_name
+            if col_name in self.__promoted_columns:
+                actual_key = self.__get_tag_column_map()[col_name].get(
+                    key_name, key_name
+                )
+                if actual_key in self.__promoted_columns[col_name]:
+                    col_type = self.__columns.get(actual_key, None)
+                    col_type = str(col_type) if col_type else None
+
+                    if (
+                        col_type
+                        and "String" in col_type
+                        and "FixedString" not in col_type
+                    ):
+                        Column(alias, actual_key, None)
+                    else:
+                        return FunctionCall(
+                            alias, "toString", Column(None, actual_key, None)
+                        )
+
+            # For the rest, return an expression that looks it up in the nested tags.
+            return array_element(
+                alias,
+                Column(None, col_name, None),
+                FunctionCall(
+                    None,
+                    "indexOf",
+                    (Column(None, col_name, None), Literal(None, key_name)),
+                ),
+            )
+
+        query.transform_expressions(process_column)

--- a/snuba/query/processors/single_tag_expr.py
+++ b/snuba/query/processors/single_tag_expr.py
@@ -7,7 +7,7 @@ from snuba.query.expressions import (
     Expression,
     FunctionCall,
     Literal,
-    NestedColumn,
+    MappingColumn,
 )
 from snuba.query.dsl import array_element
 from snuba.query.query import Query
@@ -17,7 +17,7 @@ from snuba.request.request_settings import RequestSettings
 
 class SingleTagProcessor(QueryProcessor):
     """
-    Processes NestedColumns that represent tags or contexts (or any dictionary style
+    Processes MappingColumns that represent tags or contexts (or any dictionary style
     nested column) into an expression clickhouse understands.
     The nested column must be defined in the form of:
     `Nested([("key", String()), ("value", String())])`
@@ -43,7 +43,7 @@ class SingleTagProcessor(QueryProcessor):
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         def process_column(exp: Expression) -> Expression:
             if (
-                not isinstance(exp, NestedColumn)
+                not isinstance(exp, MappingColumn)
                 or exp.column_name not in self.__nested_column_names
             ):
                 return exp

--- a/snuba/query/processors/single_tag_expr.py
+++ b/snuba/query/processors/single_tag_expr.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Set
+from typing import Mapping, Iterable
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.query.expressions import (
@@ -15,12 +15,21 @@ from snuba.request.request_settings import RequestSettings
 
 
 class SingleTagProcessor(QueryProcessor):
+    """
+    Processes NestedColumns that represent tags or contexts (or any dictionary style
+    nested column) into an expression clickhouse understands.
+    The nested column must be defined in the form of:
+    `Nested([("key", String()), ("value", String())])`
+    With a key called `key` and a value called `value`.
+    It supports promoted tags/contexts as well.
+    """
+
     def __init__(
         self,
-        nested_column_names: Set[str],
+        nested_column_names: Iterable[str],
         columns: ColumnSet,
-        promoted_columns: Mapping[str, Set[str]],
-        tags_column_map: Mapping[str, Mapping[str, str]],
+        promoted_columns: Mapping[str, Iterable[str]],
+        key_column_map: Mapping[str, Mapping[str, str]],
     ) -> None:
         # Keeps the names of the nested columns to expand
         self.__nested_column_names = nested_column_names
@@ -28,17 +37,18 @@ class SingleTagProcessor(QueryProcessor):
         # columns with the right type.
         self.__columns = columns
         # Keeps a dictionary of promoted columns. The key of the mapping
-        # can be 'tags' or 'contexts'. The values is a set of flattened
-        # columns.
+        # can be any of the nested column names above. The values is a set
+        # of flattened columns.
         self.__promoted_columns = promoted_columns
-        # Keeps a dictionary of the mapping between promoted tags and the
-        # columns that represent them
-        self.__tags_column_map = tags_column_map
+        # Keeps a dictionary of the mapping between promoted keys in the
+        # nested columns and the related promoted column
+        self.__key_column_map = key_column_map
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         def process_column(exp: Expression) -> Expression:
-            if not isinstance(
-                exp, NestedColumn or exp.column_name not in self.__nested_column_names
+            if (
+                not isinstance(exp, NestedColumn)
+                or exp.column_name not in self.__nested_column_names
             ):
                 return exp
 
@@ -46,9 +56,11 @@ class SingleTagProcessor(QueryProcessor):
             key_name = exp.key
             col_name = exp.column_name
             if col_name in self.__promoted_columns:
-                actual_key = self.__tags_column_map[col_name].get(key_name, key_name)
-                if actual_key in self.__promoted_columns[col_name]:
-                    col_type = self.__columns.get(actual_key, None)
+                promoted_column_name = self.__key_column_map[col_name].get(
+                    key_name, key_name
+                )
+                if promoted_column_name in self.__promoted_columns[col_name]:
+                    col_type = self.__columns.get(promoted_column_name, None)
                     col_type = str(col_type) if col_type else None
 
                     if (
@@ -56,13 +68,15 @@ class SingleTagProcessor(QueryProcessor):
                         and "String" in col_type
                         and "FixedString" not in col_type
                     ):
-                        return Column(alias, actual_key, None)
+                        return Column(alias, promoted_column_name, None)
                     else:
                         return FunctionCall(
-                            alias, "toString", Column(None, actual_key, None)
+                            alias,
+                            "toString",
+                            (Column(None, promoted_column_name, None),),
                         )
 
-            # For the rest, return an expression that looks it up in the nested tags.
+            # For the rest, return an expression that looks it up in the nested column itself.
             return array_element(
                 alias,
                 Column(None, f"{col_name}.value", None),

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Optional, List, NamedTuple, Set
 
 from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
-from snuba.query.expressions import Column, Expression
+from snuba.query.expressions import Expression, NestedColumn
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.datasets.events_format import escape_field
@@ -108,9 +108,8 @@ class NestedFieldConditionOptimizer(QueryProcessor):
         if not expression:
             return False
         for node in expression:
-            if isinstance(node, Column):
-                tag = NESTED_COL_EXPR_RE.match(node.column_name)
-                if tag and tag[1] == self.__nested_col:
+            if isinstance(node, NestedColumn):
+                if node.column_name == self.__nested_col:
                     return True
         return False
 

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Optional, List, NamedTuple, Set
 
 from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
-from snuba.query.expressions import Expression, NestedColumn
+from snuba.query.expressions import Expression, MappingColumn
 from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.datasets.events_format import escape_field
@@ -108,7 +108,7 @@ class NestedFieldConditionOptimizer(QueryProcessor):
         if not expression:
             return False
         for node in expression:
-            if isinstance(node, NestedColumn):
+            if isinstance(node, MappingColumn):
                 if node.column_name == self.__nested_col:
                     return True
         return False

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -6,7 +6,7 @@ from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.schemas.tables import TableSource
 from snuba.query.conditions import binary_condition
-from snuba.query.expressions import Column, FunctionCall, Literal, NestedColumn
+from snuba.query.expressions import Column, FunctionCall, Literal, MappingColumn
 from snuba.query.parser import parse_query
 from snuba.query.query import OrderBy, OrderByDirection, Query
 
@@ -70,7 +70,7 @@ test_cases = [
             condition=binary_condition(
                 None,
                 "in",
-                NestedColumn("tags[sentry:dist]", "tags", None, "sentry:dist"),
+                MappingColumn("tags[sentry:dist]", "tags", None, "sentry:dist"),
                 FunctionCall(
                     None, "tuple", (Literal(None, "dist1"), Literal(None, "dist2"),),
                 ),
@@ -130,14 +130,14 @@ test_cases = [
             TableSource("events", ColumnSet([])),
             selected_columns=[
                 FunctionCall(
-                    None, "f", (NestedColumn("tags[test2]", "tags", None, "test2"),)
+                    None, "f", (MappingColumn("tags[test2]", "tags", None, "test2"),)
                 ),
                 Column(None, "column1", None),
-                NestedColumn("tags[test]", "tags", None, "test"),
+                MappingColumn("tags[test]", "tags", None, "test"),
             ],
             groupby=[
                 FunctionCall(
-                    None, "f", (NestedColumn("tags[test2]", "tags", None, "test2"),)
+                    None, "f", (MappingColumn("tags[test2]", "tags", None, "test2"),)
                 )
             ],
         ),

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -6,7 +6,7 @@ from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.schemas.tables import TableSource
 from snuba.query.conditions import binary_condition
-from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.expressions import Column, FunctionCall, Literal, NestedColumn
 from snuba.query.parser import parse_query
 from snuba.query.query import OrderBy, OrderByDirection, Query
 
@@ -70,7 +70,7 @@ test_cases = [
             condition=binary_condition(
                 None,
                 "in",
-                Column(None, "tags[sentry:dist]", None),
+                NestedColumn("tags[sentry:dist]", "tags", None, "sentry:dist"),
                 FunctionCall(
                     None, "tuple", (Literal(None, "dist1"), Literal(None, "dist2"),),
                 ),
@@ -120,6 +120,28 @@ test_cases = [
             order_by=[OrderBy(OrderByDirection.DESC, Column(None, "column1", None))],
         ),
     ),  # Order and group by provided as string
+    (
+        {
+            "selected_columns": ["column1", "tags[test]"],
+            "groupby": [["f", ["tags[test2]"]]],
+        },
+        Query(
+            {},
+            TableSource("events", ColumnSet([])),
+            selected_columns=[
+                FunctionCall(
+                    None, "f", (NestedColumn("tags[test2]", "tags", None, "test2"),)
+                ),
+                Column(None, "column1", None),
+                NestedColumn("tags[test]", "tags", None, "test"),
+            ],
+            groupby=[
+                FunctionCall(
+                    None, "f", (NestedColumn("tags[test2]", "tags", None, "test2"),)
+                )
+            ],
+        ),
+    ),  # Unpack nested column both in a simple expression and in a function call.
 ]
 
 

--- a/tests/query/processors/test_single_tag_expr.py
+++ b/tests/query/processors/test_single_tag_expr.py
@@ -1,0 +1,146 @@
+import pytest
+
+from snuba.clickhouse.columns import (
+    ColumnSet,
+    String,
+    UInt,
+)
+from snuba.clickhouse.astquery import AstClickhouseQuery
+from snuba.datasets.factory import get_dataset
+from snuba.query.conditions import binary_condition, ConditionFunctions, in_condition
+from snuba.query.dsl import array_element
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.parser import parse_query
+from snuba.query.processors.single_tag_expr import SingleTagProcessor
+from snuba.request.request_settings import HTTPRequestSettings
+
+test_data = [
+    (
+        {
+            "selected_columns": ["c1", "c2", "c3"],
+            "aggregations": [],
+            "groupby": [],
+            "conditions": [["c3", "IN", ["t1", "t2"]]],
+        },
+        [Column(None, "c1", None), Column(None, "c2", None), Column(None, "c3", None)],
+        [],
+        in_condition(
+            None, Column(None, "c3", None), [Literal(None, "t1"), Literal(None, "t2")],
+        ),
+        "SELECT c1, c2, c3 FROM test_sentry_local WHERE in(c3, tuple('t1', 't2'))",
+    ),  # No tags, nothing explodes
+    (
+        {
+            "selected_columns": ["tags[myTag]"],
+            "aggregations": [],
+            "groupby": [],
+            "conditions": [],
+        },
+        [
+            array_element(
+                "tags[myTag]",
+                Column(None, "tags.value", None),
+                FunctionCall(
+                    None,
+                    "indexOf",
+                    (Column(None, "tags.key", None), Literal(None, "myTag")),
+                ),
+            )
+        ],
+        [],
+        None,
+        "SELECT (arrayElement(tags.value, indexOf(tags.key, 'myTag')) AS `tags[myTag]`) FROM test_sentry_local",
+    ),  # One single not promoted tag
+    (
+        {
+            "selected_columns": ["tags[myTag]"],
+            "aggregations": [],
+            "conditions": [["tags[myTag]", "=", "a"]],
+        },
+        [
+            array_element(
+                "tags[myTag]",
+                Column(None, "tags.value", None),
+                FunctionCall(
+                    None,
+                    "indexOf",
+                    (Column(None, "tags.key", None), Literal(None, "myTag")),
+                ),
+            )
+        ],
+        [],
+        binary_condition(
+            None,
+            ConditionFunctions.EQ,
+            array_element(
+                "tags[myTag]",
+                Column(None, "tags.value", None),
+                FunctionCall(
+                    None,
+                    "indexOf",
+                    (Column(None, "tags.key", None), Literal(None, "myTag")),
+                ),
+            ),
+            Literal(None, "a"),
+        ),
+        "SELECT (arrayElement(tags.value, indexOf(tags.key, 'myTag')) AS `tags[myTag]`) FROM test_sentry_local WHERE equals(`tags[myTag]`, 'a')",
+    ),  # Tag requested twice, use alias
+    (
+        {"selected_columns": ["tags[app.device]", "contexts[device.family]"]},
+        [
+            Column("tags[app.device]", "app_device", None),
+            Column("contexts[device.family]", "device_family", None),
+        ],
+        [],
+        None,
+        "SELECT (app_device AS `tags[app.device]`), (device_family AS `contexts[device.family]`) FROM test_sentry_local",
+    ),  # Promoted tag and promoted context
+]
+
+
+@pytest.mark.parametrize(
+    "query_body, expect_select, expect_groupby, expect_condition, formatted_query",
+    test_data,
+)
+def test_tags_processor(
+    query_body, expect_select, expect_groupby, expect_condition, formatted_query
+) -> None:
+    dataset = get_dataset("events")
+    query = parse_query(query_body, dataset)
+    request_settings = HTTPRequestSettings()
+
+    all_columns = ColumnSet(
+        [
+            ("app_device", String()),
+            ("device", String()),
+            ("device_family", String()),
+            ("runtime", String()),
+            ("runtime_name", String()),
+            ("browser", String()),
+            ("browser_name", String()),
+            ("os", String()),
+            ("os_name", String()),
+            ("os_rooted", UInt(8)),
+        ]
+    )
+
+    promoted_cols = {
+        "tags": {"app_device", "device"},
+        "contexts": {"device_family", "runtime"},
+    }
+
+    tags_column_map = {
+        "tags": {"app.device": "app_device", "device": "device"},
+        "contexts": {"device.family": "device_family", "runtime": "runtime"},
+    }
+
+    processor = SingleTagProcessor(
+        {"tags", "contexts"}, all_columns, promoted_cols, tags_column_map
+    )
+    processor.process_query(query, request_settings)
+
+    assert query.get_selected_columns_from_ast() == expect_select
+    assert query.get_groupby_from_ast() == expect_groupby
+    assert query.get_condition_from_ast() == expect_condition
+
+    assert AstClickhouseQuery(query, request_settings).format_sql() == formatted_query

--- a/tests/query/processors/test_single_tag_expr.py
+++ b/tests/query/processors/test_single_tag_expr.py
@@ -7,6 +7,7 @@ from snuba.clickhouse.columns import (
 )
 from snuba.clickhouse.astquery import AstClickhouseQuery
 from snuba.datasets.factory import get_dataset
+from snuba.datasets.promoted_columns import PromotedColumnSpec
 from snuba.query.conditions import binary_condition, ConditionFunctions, in_condition
 from snuba.query.dsl import array_element
 from snuba.query.expressions import Column, FunctionCall, Literal
@@ -124,19 +125,14 @@ def test_tags_processor(
         ]
     )
 
-    promoted_cols = {
-        "tags": {"app_device", "device"},
-        "contexts": {"device_family", "runtime"},
-    }
-
     tags_column_map = {
-        "tags": {"app.device": "app_device", "device": "device"},
-        "contexts": {"device.family": "device_family", "runtime": "runtime"},
+        "tags": PromotedColumnSpec({"app.device": "app_device", "device": "device"}),
+        "contexts": PromotedColumnSpec(
+            {"device.family": "device_family", "runtime": "runtime"}
+        ),
     }
 
-    processor = SingleTagProcessor(
-        {"tags", "contexts"}, all_columns, promoted_cols, tags_column_map
-    )
+    processor = SingleTagProcessor({"tags", "contexts"}, all_columns, tags_column_map)
     processor.process_query(query, request_settings)
 
     assert query.get_selected_columns_from_ast() == expect_select

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
-    NestedColumn,
+    MappingColumn,
     Argument,
 )
 
@@ -28,7 +28,7 @@ class DummyVisitor(ExpressionVisitor[List[Expression]]):
         self.__visited_nodes.append(exp)
         return [exp]
 
-    def visitNestedColumn(self, exp: NestedColumn) -> List[Expression]:
+    def visitMappingColumn(self, exp: MappingColumn) -> List[Expression]:
         self.__visited_nodes.append(exp)
         return [exp]
 
@@ -66,7 +66,7 @@ def test_visit_expression():
     literal1 = Literal("al2", "test")
     f1 = FunctionCall("al3", "f1", [col1, literal1])
 
-    col2 = NestedColumn("al4", "c2", "t1", "k1")
+    col2 = MappingColumn("al4", "c2", "t1", "k1")
     literal2 = Literal("al5", "test2")
     f2 = FunctionCall("al6", "f2", [col2, literal2])
 

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -8,6 +8,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Lambda,
     Literal,
+    NestedColumn,
     Argument,
 )
 
@@ -24,6 +25,10 @@ class DummyVisitor(ExpressionVisitor[List[Expression]]):
         return [exp]
 
     def visitColumn(self, exp: Column) -> List[Expression]:
+        self.__visited_nodes.append(exp)
+        return [exp]
+
+    def visitNestedColumn(self, exp: NestedColumn) -> List[Expression]:
         self.__visited_nodes.append(exp)
         return [exp]
 
@@ -61,7 +66,7 @@ def test_visit_expression():
     literal1 = Literal("al2", "test")
     f1 = FunctionCall("al3", "f1", [col1, literal1])
 
-    col2 = Column("al4", "c2", "t1")
+    col2 = NestedColumn("al4", "c2", "t1", "k1")
     literal2 = Literal("al5", "test2")
     f2 = FunctionCall("al6", "f2", [col2, literal2])
 


### PR DESCRIPTION
This is the first step to properly support tags in when parsing the query into the AST.
This addresses tags[key] and contexts[key] cases for simple datasets (events and transactions). A followup PR will take care of composite datasets like groups and discover.

These are the principles:
- since tags[aaa] is allowed by the general syntax, we will have a NestedColumn AST type.
- A query processor turns that into the clickhouse manageable expression
- There is no reason to conflate tags[] and tags_keys/tags_value in the same processor.

Depends on https://github.com/getsentry/snuba/pull/774