### PR TITLE
ref(streams): Use abstract `Producer` with `KafkaConsumerWithCommitLog`

### DIFF
--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -662,9 +662,11 @@ class KafkaConsumerWithCommitLog(KafkaConsumer[TPayload]):
         self, commit: Commit, future: Future[Commit]
     ) -> None:
         try:
-            future.result()
+            message = future.result()
         except Exception:
             logger.warning("Failed to produce commit record: %r", commit, exc_info=True)
+        else:
+            logger.debug("Produced commit record: %r", message)
 
     def commit_offsets(self) -> Mapping[Partition, int]:
         offsets = super().commit_offsets()

--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -677,6 +677,10 @@ class KafkaConsumerWithCommitLog(KafkaConsumer[TPayload]):
 
         return offsets
 
+    def close(self, timeout: Optional[float] = None) -> None:
+        super().close()
+        self.__producer.close().result(timeout)
+
 
 class KafkaProducer(Producer[TPayload]):
     def __init__(

--- a/snuba/utils/streams/producer.py
+++ b/snuba/utils/streams/producer.py
@@ -21,5 +21,8 @@ class Producer(Generic[TPayload], ABC):
     def close(self) -> Future[None]:
         """
         Close the producer.
+
+        This method returns a ``Future`` that will have its result set when
+        there are no more messages in flight.
         """
         raise NotImplementedError


### PR DESCRIPTION
This reduces the coupling with the Confluent Kafka client slightly, and removes one use of the `FakeConfluentKafkaProducer`. This also improves the logging for the `KafkaProducer`.