### PR TITLE
ref(subscriptions): Enable concurrent query execution

### DIFF
--- a/snuba/settings_base.py
+++ b/snuba/settings_base.py
@@ -85,7 +85,4 @@ TURBO_SAMPLE_RATE = 0.1
 
 PROJECT_STACKTRACE_BLACKLIST = set()
 
-# Number of queries each subscription consumer can run concurrently.
-SUBSCRIPTIONS_MAX_CONCURRENT_QUERIES = 10
-
 TOPIC_PARTITION_COUNTS: MutableMapping[str, int] = {}  # (topic name, # of partitions)

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -3,7 +3,6 @@ from uuid import uuid1
 
 from concurrent.futures import ThreadPoolExecutor
 
-from snuba import settings
 from snuba.subscriptions.consumer import Tick
 from snuba.subscriptions.data import (
     PartitionId,
@@ -19,12 +18,7 @@ from tests.subscriptions import BaseSubscriptionTest
 
 class TestSubscriptionExecutor(BaseSubscriptionTest):
     def test(self):
-        executor = SubscriptionExecutor(
-            self.dataset,
-            ThreadPoolExecutor(
-                max_workers=settings.SUBSCRIPTIONS_MAX_CONCURRENT_QUERIES
-            ),
-        )
+        executor = SubscriptionExecutor(self.dataset, ThreadPoolExecutor())
 
         subscription = Subscription(
             SubscriptionIdentifier(PartitionId(0), uuid1()),


### PR DESCRIPTION
This updates the `SubscriptionWorker` so that it can execute subscriptions queries concurrently.