### PR TITLE
Record who is passing sample without turbo

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -241,6 +241,11 @@ def parse_and_run_query(
         request.extensions["timeseries"]
     )
 
+    if (
+        request.query.get_sample() is not None and request.query.get_sample() != 1.0
+    ) and not request.settings.get_turbo():
+        metrics.increment("sample_without_turbo", tags={"referrer": request.referrer})
+
     extensions = dataset.get_extensions()
     for name, extension in extensions.items():
         extension.get_processor().process_query(


### PR DESCRIPTION
We are considering enforcing TURBO is set to True if the client provides a sampling rate to ensure snuba will never apply final and turbo together. 
To do that we need to know what has to be fixed first.