### PR TITLE
ref(clickhouse): Move ClickHouse pool instantiation to `snuba.environment`

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -24,17 +24,6 @@ from snuba.environment import setup_logging, setup_sentry
     help="Kafka bootstrap server to use.",
 )
 @click.option(
-    "--clickhouse-host",
-    default=settings.CLICKHOUSE_HOST,
-    help="Clickhouse server to write to.",
-)
-@click.option(
-    "--clickhouse-port",
-    default=settings.CLICKHOUSE_PORT,
-    type=int,
-    help="Clickhouse native port to write to.",
-)
-@click.option(
     "--dataset",
     "dataset_name",
     default="events",
@@ -77,8 +66,6 @@ def replacer(
     replacements_topic: Optional[str],
     consumer_group: str,
     bootstrap_server: Sequence[str],
-    clickhouse_host: str,
-    clickhouse_port: int,
     dataset_name: str,
     max_batch_size: int,
     max_batch_time_ms: int,
@@ -128,7 +115,9 @@ def replacer(
     }
 
     clickhouse = ClickhousePool(
-        host=clickhouse_host, port=clickhouse_port, client_settings=client_settings,
+        settings.CLICKHOUSE_HOST,
+        settings.CLICKHOUSE_PORT,
+        client_settings=client_settings,
     )
 
     codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -18,8 +18,8 @@ logger = logging.getLogger("snuba.clickhouse")
 class ClickhousePool(object):
     def __init__(
         self,
-        host=settings.CLICKHOUSE_HOST,
-        port=settings.CLICKHOUSE_PORT,
+        host: str,
+        port: int,
         connect_timeout=1,
         send_receive_timeout=300,
         max_pool_size=settings.CLICKHOUSE_MAX_POOL_SIZE,

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
 
 from snuba import settings
+from snuba.clickhouse.native import ClickhousePool
 
 
 def setup_logging(level: Optional[str] = None) -> None:
@@ -26,3 +27,7 @@ def setup_sentry() -> None:
         integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
         release=os.getenv("SNUBA_RELEASE"),
     )
+
+
+clickhouse_rw = ClickhousePool()
+clickhouse_ro = ClickhousePool(client_settings={"readonly": True})

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -29,5 +29,9 @@ def setup_sentry() -> None:
     )
 
 
-clickhouse_rw = ClickhousePool()
-clickhouse_ro = ClickhousePool(client_settings={"readonly": True})
+clickhouse_rw = ClickhousePool(settings.CLICKHOUSE_HOST, settings.CLICKHOUSE_PORT)
+clickhouse_ro = ClickhousePool(
+    settings.CLICKHOUSE_HOST,
+    settings.CLICKHOUSE_PORT,
+    client_settings={"readonly": True},
+)

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from itertools import chain
 from typing import MutableSequence, Sequence
 
+from snuba.environment import clickhouse_rw
 from snuba.util import settings_override
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.kafka import KafkaPayload
@@ -42,10 +43,9 @@ def run(events_file, dataset, repeat=1, profile_process=False, profile_write=Fal
     """
 
     from snuba.consumer import ConsumerWorker
-    from snuba.clickhouse.native import ClickhousePool
 
     for statement in dataset.get_dataset_schemas().get_create_statements():
-        ClickhousePool().execute(statement.statement)
+        clickhouse_rw.execute(statement.statement)
 
     consumer = ConsumerWorker(dataset, metrics=DummyMetricsBackend())
 

--- a/snuba/snapshots/loaders/single_table.py
+++ b/snuba/snapshots/loaders/single_table.py
@@ -1,12 +1,10 @@
+import logging
 from typing import Callable
 
-import logging
-
-from snuba.clickhouse.native import ClickhousePool
-from snuba.snapshots import BulkLoadSource
-from snuba.writer import BufferedWriterWrapper, WriterTableRow
-from snuba.snapshots import SnapshotTableRow
+from snuba.environment import clickhouse_ro
+from snuba.snapshots import BulkLoadSource, SnapshotTableRow
 from snuba.snapshots.loaders import BulkLoader
+from snuba.writer import BufferedWriterWrapper, WriterTableRow
 
 
 class SingleTableBulkLoader(BulkLoader):
@@ -29,7 +27,6 @@ class SingleTableBulkLoader(BulkLoader):
     def load(self, writer: BufferedWriterWrapper) -> None:
         logger = logging.getLogger("snuba.bulk-loader")
 
-        clickhouse_ro = ClickhousePool(client_settings={"readonly": True})
         clickhouse_tables = clickhouse_ro.execute("show tables")
         if (self.__dest_table,) not in clickhouse_tables:
             raise ValueError("Destination table %s does not exists" % self.__dest_table)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -1,5 +1,4 @@
 import logging
-
 from hashlib import md5
 from typing import Any, Mapping, MutableMapping, Optional
 
@@ -9,29 +8,29 @@ from flask import request as http_request
 
 from snuba import settings, state
 from snuba.clickhouse.astquery import AstClickhouseQuery
-from snuba.clickhouse.native import ClickhousePool, NativeDriverReader
+from snuba.clickhouse.native import NativeDriverReader
 from snuba.clickhouse.query import ClickhouseQuery, DictClickhouseQuery
 from snuba.datasets.dataset import Dataset
+from snuba.environment import clickhouse_ro
 from snuba.query.timeseries import TimeSeriesExtensionProcessor
 from snuba.reader import Reader
-from snuba.request import Request
 from snuba.redis import redis_client
+from snuba.request import Request
 from snuba.state.cache import Cache, RedisCache
 from snuba.state.rate_limit import (
+    PROJECT_RATE_LIMIT_NAME,
     RateLimitAggregator,
     RateLimitExceeded,
-    PROJECT_RATE_LIMIT_NAME,
 )
 from snuba.util import create_metrics, force_bytes
 from snuba.utils.codecs import JSONCodec
 from snuba.utils.metrics.timer import Timer
 from snuba.web.split import split_query
 
+
 logger = logging.getLogger("snuba.query")
 metrics = create_metrics("snuba.api")
 
-clickhouse_rw = ClickhousePool()
-clickhouse_ro = ClickhousePool(client_settings={"readonly": True})
 
 ClickhouseQueryResult = MutableMapping[str, MutableMapping[str, Any]]
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -3,14 +3,15 @@ import os
 import time
 from datetime import datetime
 from typing import NamedTuple
+from uuid import UUID
 
-from flask import Flask, Response, redirect, render_template, request as http_request
-from markdown import markdown
+import jsonschema
 import sentry_sdk
 import simplejson as json
+from flask import Flask, Response, redirect, render_template
+from flask import request as http_request
+from markdown import markdown
 from werkzeug.exceptions import BadRequest
-import jsonschema
-from uuid import UUID
 
 from snuba import settings, state, util
 from snuba.consumer import KafkaMessageMetadata
@@ -22,17 +23,15 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.datasets.schemas.tables import TableSchema
+from snuba.environment import clickhouse_ro, clickhouse_rw
+from snuba.redis import redis_client
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.request.schema import RequestSchema
-from snuba.redis import redis_client
 from snuba.request.validation import validate_request_content
 from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import InvalidSubscriptionError, PartitionId
-from snuba.subscriptions.subscription import (
-    SubscriptionCreator,
-    SubscriptionDeleter,
-)
+from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDeleter
 from snuba.util import local_dataset_mode
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -40,11 +39,9 @@ from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.web.converters import DatasetConverter
 from snuba.web.query import (
-    clickhouse_ro,
-    clickhouse_rw,
     ClickhouseQueryResult,
-    parse_and_run_query,
     RawQueryException,
+    parse_and_run_query,
 )
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,8 +4,8 @@ from datetime import datetime, timedelta
 import uuid
 
 from snuba import settings
+from snuba.environment import clickhouse_rw
 from snuba.datasets.factory import enforce_table_writer, get_dataset
-from snuba.clickhouse.native import ClickhousePool
 from snuba.redis import redis_client
 
 
@@ -51,7 +51,7 @@ class BaseTest(object):
 
         if self.dataset_name:
             self.dataset = get_dataset(self.dataset_name)
-            self.clickhouse = ClickhousePool()
+            self.clickhouse = clickhouse_rw
 
             for statement in self.dataset.get_dataset_schemas().get_drop_statements():
                 self.clickhouse.execute(statement.statement)

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -3,12 +3,12 @@ import simplejson as json
 from datetime import datetime
 
 from tests.base import BaseDatasetTest
-from snuba.clickhouse.native import ClickhousePool
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeProcessor,
     GroupAssigneeRow,
 )
+from snuba.environment import clickhouse_ro
 
 
 class TestGroupassignee(BaseDatasetTest):
@@ -92,8 +92,7 @@ class TestGroupassignee(BaseDatasetTest):
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
         self.write_processed_records(ret.data)
-        cp = ClickhousePool()
-        ret = cp.execute("SELECT * FROM test_groupassignee_local;")
+        ret = clickhouse_ro.execute("SELECT * FROM test_groupassignee_local;")
         assert ret[0] == (
             42,  # offset
             0,  # deleted
@@ -129,8 +128,7 @@ class TestGroupassignee(BaseDatasetTest):
             }
         )
         self.write_processed_records(row.to_clickhouse())
-        cp = ClickhousePool()
-        ret = cp.execute("SELECT * FROM test_groupassignee_local;")
+        ret = clickhouse_ro.execute("SELECT * FROM test_groupassignee_local;")
         assert ret[0] == (
             0,  # offset
             0,  # deleted

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -1,11 +1,12 @@
-from tests.base import BaseEventsTest
+from unittest.mock import call, patch
 
 from clickhouse_driver import errors
-from unittest.mock import patch, call
 
+from snuba import settings
 from snuba.clickhouse.columns import Array, ColumnSet, Nested, Nullable, String, UInt
-from snuba.datasets.factory import enforce_table_writer
 from snuba.clickhouse.native import ClickhousePool
+from snuba.datasets.factory import enforce_table_writer
+from tests.base import BaseEventsTest
 
 
 class TestClickhouse(BaseEventsTest):
@@ -35,7 +36,7 @@ class TestClickhouse(BaseEventsTest):
             errors.NetworkError,
             '{"data": "to my face"}',
         ]
-        cp = ClickhousePool()
+        cp = ClickhousePool(settings.CLICKHOUSE_HOST, settings.CLICKHOUSE_PORT)
         cp.execute("SHOW TABLES")
         assert FakeClient.return_value.execute.mock_calls == [
             call("SHOW TABLES"),

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -3,12 +3,12 @@ import simplejson as json
 from datetime import datetime
 
 from tests.base import BaseDatasetTest
-from snuba.clickhouse.native import ClickhousePool
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.cdc.groupedmessage_processor import (
     GroupedMessageProcessor,
     GroupedMessageRow,
 )
+from snuba.environment import clickhouse_ro
 
 
 class TestGroupedMessage(BaseDatasetTest):
@@ -102,8 +102,7 @@ class TestGroupedMessage(BaseDatasetTest):
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
         self.write_processed_records(ret.data)
-        cp = ClickhousePool()
-        ret = cp.execute("SELECT * FROM test_groupedmessage_local;")
+        ret = clickhouse_ro.execute("SELECT * FROM test_groupedmessage_local;")
         assert ret[0] == (
             42,  # offset
             0,  # deleted
@@ -137,8 +136,7 @@ class TestGroupedMessage(BaseDatasetTest):
             }
         )
         self.write_processed_records(row.to_clickhouse())
-        cp = ClickhousePool()
-        ret = cp.execute("SELECT * FROM test_groupedmessage_local;")
+        ret = clickhouse_ro.execute("SELECT * FROM test_groupedmessage_local;")
         assert ret[0] == (
             0,  # offset
             0,  # deleted


### PR DESCRIPTION
- Moves ClickHouse native driver pool instantiation out of `snuba.web.query` and into `snuba.environment`.
- Ensures that references to `ClickhousePool` that do not override the host and port use the global pool.
- Removes the default host and port arguments from `ClickhousePool` so that it is more difficult to unintentionally instantiate a new pool by mistake.