### PR TITLE
ref(reader): Move reader instantiation to `snuba.environment`

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -128,7 +128,7 @@ class ClickhousePool(object):
 
 
 class NativeDriverReader(Reader[ClickhouseQuery]):
-    def __init__(self, client) -> None:
+    def __init__(self, client: ClickhousePool) -> None:
         self.__client = client
 
     def __transform_result(self, result, with_totals: bool) -> Result:

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -9,7 +9,9 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
 
 from snuba import settings
-from snuba.clickhouse.native import ClickhousePool
+from snuba.clickhouse.native import ClickhousePool, NativeDriverReader
+from snuba.clickhouse.query import ClickhouseQuery
+from snuba.reader import Reader
 
 
 def setup_logging(level: Optional[str] = None) -> None:
@@ -35,3 +37,5 @@ clickhouse_ro = ClickhousePool(
     settings.CLICKHOUSE_PORT,
     client_settings={"readonly": True},
 )
+
+reader: Reader[ClickhouseQuery] = NativeDriverReader(clickhouse_ro)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -8,12 +8,10 @@ from flask import request as http_request
 
 from snuba import settings, state
 from snuba.clickhouse.astquery import AstClickhouseQuery
-from snuba.clickhouse.native import NativeDriverReader
-from snuba.clickhouse.query import ClickhouseQuery, DictClickhouseQuery
+from snuba.clickhouse.query import DictClickhouseQuery
 from snuba.datasets.dataset import Dataset
-from snuba.environment import clickhouse_ro
+from snuba.environment import reader
 from snuba.query.timeseries import TimeSeriesExtensionProcessor
-from snuba.reader import Reader
 from snuba.redis import redis_client
 from snuba.request import Request
 from snuba.state.cache import Cache, RedisCache
@@ -52,7 +50,6 @@ cache: Cache[Any] = RedisCache(redis_client, "snuba-query-cache:", JSONCodec())
 def raw_query(
     request: Request,
     query: DictClickhouseQuery,
-    reader: Reader[ClickhouseQuery],
     timer: Timer,
     stats: Optional[MutableMapping[str, Any]] = None,
 ) -> ClickhouseQueryResult:
@@ -294,9 +291,7 @@ def parse_and_run_query(
             )
         except Exception:
             logger.exception("Failed to format ast query")
-        result = raw_query(
-            request, query, NativeDriverReader(clickhouse_ro), timer, stats
-        )
+        result = raw_query(request, query, timer, stats)
 
     with sentry_sdk.configure_scope() as scope:
         if scope.span:


### PR DESCRIPTION
This removes the `reader` parameter from `raw_query`, since there is no way to actually set it without modifications to `parse_and_run_query` and correspondingly `split_query` and it's inner functions.

The HTTP reader will have state (the HTTP connection pool), so reinstantiating it on each call to `parse_and_run_query` isn't ideal — it will be better to instantiate a `Reader` instance and reuse it. Since the ClickHouse cluster address is a global setting, it (unfortunately) seems appropriate to make this global state, similar to the native driver pool.

I think that in the future, we'll want the table storages themselves to provide the writer and reader interfaces (since I assume we'll want table storages to be able to reference different ClickHouse clusters) but that seems like a reasonably far future.