### PR TITLE
feat(replacers) Split replacer into ReplacementWorker and ReplacementProcessor

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -1,8 +1,8 @@
 import logging
+import time
 
 from collections import deque
 from datetime import datetime
-import time
 from typing import FrozenSet, Mapping, Optional, Sequence
 
 from snuba import settings

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -1,0 +1,421 @@
+import logging
+
+from collections import deque
+from datetime import datetime
+import time
+from typing import FrozenSet, Mapping, Optional, Sequence
+
+from snuba import settings
+from snuba.clickhouse import DATETIME_FORMAT
+from snuba.clickhouse.escaping import escape_identifier, escape_string
+from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
+from snuba.processor import InvalidMessageType, _hashify
+from snuba.redis import redis_client
+from snuba.replacers.replacer_processor import (
+    Replacement,
+    ReplacementMessage,
+    ReplacerProcessor,
+)
+
+
+logger = logging.getLogger(__name__)
+
+EXCLUDE_GROUPS = object()
+NEEDS_FINAL = object()
+
+
+def get_project_exclude_groups_key(project_id):
+    return "project_exclude_groups:%s" % project_id
+
+
+def set_project_exclude_groups(project_id, group_ids):
+    """Add {group_id: now, ...} to the ZSET for each `group_id` to exclude,
+    remove outdated entries based on `settings.REPLACER_KEY_TTL`, and expire
+    the entire ZSET incase it's rarely touched."""
+
+    now = time.time()
+    key = get_project_exclude_groups_key(project_id)
+    p = redis_client.pipeline()
+
+    p.zadd(key, **{str(group_id): now for group_id in group_ids})
+    p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
+    p.expire(key, int(settings.REPLACER_KEY_TTL))
+
+    p.execute()
+
+
+def get_project_needs_final_key(project_id):
+    return "project_needs_final:%s" % project_id
+
+
+def set_project_needs_final(project_id):
+    return redis_client.set(
+        get_project_needs_final_key(project_id), True, ex=settings.REPLACER_KEY_TTL
+    )
+
+
+def get_projects_query_flags(project_ids):
+    """\
+    1. Fetch `needs_final` for each Project
+    2. Fetch groups to exclude for each Project
+    3. Trim groups to exclude ZSET for each Project
+
+    Returns (needs_final, group_ids_to_exclude)
+    """
+
+    project_ids = set(project_ids)
+    now = time.time()
+    p = redis_client.pipeline()
+
+    needs_final_keys = [
+        get_project_needs_final_key(project_id) for project_id in project_ids
+    ]
+    for needs_final_key in needs_final_keys:
+        p.get(needs_final_key)
+
+    exclude_groups_keys = [
+        get_project_exclude_groups_key(project_id) for project_id in project_ids
+    ]
+    for exclude_groups_key in exclude_groups_keys:
+        p.zremrangebyscore(
+            exclude_groups_key, float("-inf"), now - settings.REPLACER_KEY_TTL
+        )
+        p.zrevrangebyscore(
+            exclude_groups_key, float("inf"), now - settings.REPLACER_KEY_TTL
+        )
+
+    results = p.execute()
+
+    needs_final = any(results[: len(project_ids)])
+    exclude_groups = sorted(
+        {int(group_id) for group_id in sum(results[(len(project_ids) + 1) :: 2], [])}
+    )
+
+    return (needs_final, exclude_groups)
+
+
+class ErrorsReplacer(ReplacerProcessor):
+    def __init__(
+        self,
+        write_schema: WritableTableSchema,
+        read_schema: TableSchema,
+        required_columns: Sequence[str],
+        tag_column_map: Mapping[str, Mapping[str, str]],
+        promoted_tags: Mapping[str, FrozenSet[str]],
+    ) -> None:
+        super().__init__(write_schema=write_schema, read_schema=read_schema)
+        self.__required_columns = required_columns
+        self.__all_column_names = [col.escaped for col in write_schema.get_columns()]
+        self.__tag_column_map = tag_column_map
+        self.__promoted_tags = promoted_tags
+
+    def process_message(self, message: ReplacementMessage) -> Optional[Replacement]:
+        type_ = message.action_type
+        event = message.data
+
+        if type_ in (
+            "start_delete_groups",
+            "start_merge",
+            "start_unmerge",
+            "start_delete_tag",
+        ):
+            return None
+        elif type_ == "end_delete_groups":
+            processed = process_delete_groups(event, self.__required_columns)
+        elif type_ == "end_merge":
+            processed = process_merge(event, self.__all_column_names)
+        elif type_ == "end_unmerge":
+            processed = process_unmerge(event, self.__all_column_names)
+        elif type_ == "end_delete_tag":
+            processed = process_delete_tag(
+                event,
+                self.get_write_schema(),
+                self.__tag_column_map,
+                self.__promoted_tags,
+            )
+        else:
+            raise InvalidMessageType("Invalid message type: {}".format(type_))
+
+        return processed
+
+    def pre_replacement(self, replacement: Replacement, matching_records: int) -> None:
+        # query_time_flags == (type, project_id, [...data...])
+        flag_type, project_id = replacement.query_time_flags[:2]
+        if flag_type == NEEDS_FINAL:
+            set_project_needs_final(project_id)
+        elif flag_type == EXCLUDE_GROUPS:
+            group_ids = replacement.query_time_flags[2]
+            set_project_exclude_groups(project_id, group_ids)
+
+
+def process_delete_groups(message, required_columns) -> Optional[Replacement]:
+    group_ids = message["group_ids"]
+    if not group_ids:
+        return None
+
+    assert all(isinstance(gid, int) for gid in group_ids)
+    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
+    select_columns = map(lambda i: i if i != "deleted" else "1", required_columns)
+
+    where = """\
+        PREWHERE group_id IN (%(group_ids)s)
+        WHERE project_id = %(project_id)s
+        AND received <= CAST('%(timestamp)s' AS DateTime)
+        AND NOT deleted
+    """
+
+    count_query_template = (
+        """\
+        SELECT count()
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    insert_query_template = (
+        """\
+        INSERT INTO %(dist_write_table_name)s (%(required_columns)s)
+        SELECT %(select_columns)s
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    query_args = {
+        "required_columns": ", ".join(required_columns),
+        "select_columns": ", ".join(select_columns),
+        "project_id": message["project_id"],
+        "group_ids": ", ".join(str(gid) for gid in group_ids),
+        "timestamp": timestamp.strftime(DATETIME_FORMAT),
+    }
+
+    query_time_flags = (EXCLUDE_GROUPS, message["project_id"], group_ids)
+
+    return Replacement(
+        count_query_template, insert_query_template, query_args, query_time_flags
+    )
+
+
+SEEN_MERGE_TXN_CACHE = deque(maxlen=100)
+
+
+def process_merge(message, all_column_names) -> Optional[Replacement]:
+    # HACK: We were sending duplicates of the `end_merge` message from Sentry,
+    # this is only for performance of the backlog.
+    txn = message.get("transaction_id")
+    if txn:
+        if txn in SEEN_MERGE_TXN_CACHE:
+            return None
+        else:
+            SEEN_MERGE_TXN_CACHE.append(txn)
+
+    previous_group_ids = message["previous_group_ids"]
+    if not previous_group_ids:
+        return None
+
+    assert all(isinstance(gid, int) for gid in previous_group_ids)
+    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
+    select_columns = map(
+        lambda i: i if i != "group_id" else str(message["new_group_id"]),
+        all_column_names,
+    )
+
+    where = """\
+        PREWHERE group_id IN (%(previous_group_ids)s)
+        WHERE project_id = %(project_id)s
+        AND received <= CAST('%(timestamp)s' AS DateTime)
+        AND NOT deleted
+    """
+
+    count_query_template = (
+        """\
+        SELECT count()
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    insert_query_template = (
+        """\
+        INSERT INTO %(dist_write_table_name)s (%(all_columns)s)
+        SELECT %(select_columns)s
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    query_args = {
+        "all_columns": ", ".join(all_column_names),
+        "select_columns": ", ".join(select_columns),
+        "project_id": message["project_id"],
+        "previous_group_ids": ", ".join(str(gid) for gid in previous_group_ids),
+        "timestamp": timestamp.strftime(DATETIME_FORMAT),
+    }
+
+    query_time_flags = (EXCLUDE_GROUPS, message["project_id"], previous_group_ids)
+
+    return Replacement(
+        count_query_template, insert_query_template, query_args, query_time_flags
+    )
+
+
+def process_unmerge(message, all_column_names) -> Optional[Replacement]:
+    hashes = message["hashes"]
+    if not hashes:
+        return None
+
+    assert all(isinstance(h, str) for h in hashes)
+    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
+    select_columns = map(
+        lambda i: i if i != "group_id" else str(message["new_group_id"]),
+        all_column_names,
+    )
+
+    where = """\
+        PREWHERE group_id = %(previous_group_id)s
+        WHERE project_id = %(project_id)s
+        AND primary_hash IN (%(hashes)s)
+        AND received <= CAST('%(timestamp)s' AS DateTime)
+        AND NOT deleted
+    """
+
+    count_query_template = (
+        """\
+        SELECT count()
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    insert_query_template = (
+        """\
+        INSERT INTO %(dist_write_table_name)s (%(all_columns)s)
+        SELECT %(select_columns)s
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    query_args = {
+        "all_columns": ", ".join(all_column_names),
+        "select_columns": ", ".join(select_columns),
+        "previous_group_id": message["previous_group_id"],
+        "project_id": message["project_id"],
+        "hashes": ", ".join("'%s'" % _hashify(h) for h in hashes),
+        "timestamp": timestamp.strftime(DATETIME_FORMAT),
+    }
+
+    query_time_flags = (NEEDS_FINAL, message["project_id"])
+
+    return Replacement(
+        count_query_template, insert_query_template, query_args, query_time_flags
+    )
+
+
+# This obnoxious amount backslashes is sadly required.
+# replaceRegexpAll(tuple.1, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1')
+# means running this on Clickhouse:
+# replaceRegexpAll(tuple.1, '(\\||\\=|\\\\)', '\\\\\\1')
+# The (\\||\\=|\\\\) pattern should be actually this: (\||\=|\\). The additional
+# backslashes are because of Clickhouse escaping.
+FLATTENED_COLUMN_TEMPLATE = """
+concat(
+    '|',
+    arrayStringConcat(
+        arrayMap(tuple -> concat(
+                replaceRegexpAll(tuple.1, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'),
+                '=',
+                replaceRegexpAll(tuple.2, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1')
+            ),
+            arraySort(
+                arrayFilter(
+                    tuple -> tuple.1 != %s,
+                    arrayMap((k, v) -> tuple(k, v), `tags.key`, `tags.value`)
+                )
+            )
+        ),
+        '||'
+    ),
+    '|'
+)
+"""
+
+
+def process_delete_tag(
+    message,
+    schema: TableSchema,
+    tag_column_map: Mapping[str, Mapping[str, str]],
+    promoted_tags: Mapping[str, FrozenSet[str]],
+) -> Optional[Replacement]:
+    tag = message["tag"]
+    if not tag:
+        return None
+
+    assert isinstance(tag, str)
+    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
+    tag_column_name = tag_column_map["tags"].get(tag, tag)
+    is_promoted = tag in promoted_tags["tags"]
+
+    where = """\
+        WHERE project_id = %(project_id)s
+        AND received <= CAST('%(timestamp)s' AS DateTime)
+        AND NOT deleted
+    """
+
+    if is_promoted:
+        where += "AND %(tag_column)s IS NOT NULL"
+    else:
+        where += "AND has(`tags.key`, %(tag_str)s)"
+
+    insert_query_template = (
+        """\
+        INSERT INTO %(dist_write_table_name)s (%(all_columns)s)
+        SELECT %(select_columns)s
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    all_columns = schema.get_columns()
+    select_columns = []
+    for col in all_columns:
+        if is_promoted and col.flattened == tag_column_name:
+            select_columns.append("NULL")
+        elif col.flattened == "tags.key":
+            select_columns.append(
+                "arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, %s)), `tags.key`)"
+                % escape_string(tag)
+            )
+        elif col.flattened == "tags.value":
+            select_columns.append(
+                "arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, %s), arrayEnumerate(`tags.value`)))"
+                % escape_string(tag)
+            )
+        elif col.flattened == "_tags_flattened":
+            select_columns.append(FLATTENED_COLUMN_TEMPLATE % escape_string(tag))
+        else:
+            select_columns.append(col.escaped)
+
+    all_column_names = [col.escaped for col in all_columns]
+    query_args = {
+        "all_columns": ", ".join(all_column_names),
+        "select_columns": ", ".join(select_columns),
+        "project_id": message["project_id"],
+        "tag_str": escape_string(tag),
+        "tag_column": escape_identifier(tag_column_name),
+        "timestamp": timestamp.strftime(DATETIME_FORMAT),
+    }
+
+    count_query_template = (
+        """\
+        SELECT count()
+        FROM %(dist_read_table_name)s FINAL
+    """
+        + where
+    )
+
+    query_time_flags = (NEEDS_FINAL, message["project_id"])
+
+    return Replacement(
+        count_query_template, insert_query_template, query_args, query_time_flags
+    )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import Mapping, Sequence, Union
+from typing import FrozenSet, Mapping, Sequence, Union
 
 from snuba.clickhouse.columns import (
     Array,
@@ -334,19 +334,19 @@ class EventsDataset(TimeSeriesDataset):
         else:
             return super().column_expr(column_name, query, parsing_context, table_alias)
 
-    def get_promoted_tag_columns(self):
+    def get_promoted_tag_columns(self) -> ColumnSet:
         return self.__promoted_tag_columns
 
-    def _get_promoted_context_tag_columns(self):
+    def _get_promoted_context_tag_columns(self) -> ColumnSet:
         return self.__promoted_context_tag_columns
 
-    def _get_promoted_context_columns(self):
+    def _get_promoted_context_columns(self) -> ColumnSet:
         return self.__promoted_context_columns
 
-    def get_required_columns(self):
+    def get_required_columns(self) -> ColumnSet:
         return self.__required_columns
 
-    def _get_promoted_columns(self):
+    def _get_promoted_columns(self) -> Mapping[str, FrozenSet[str]]:
         # The set of columns, and associated keys that have been promoted
         # to the top level table namespace.
         return {
@@ -362,7 +362,7 @@ class EventsDataset(TimeSeriesDataset):
             ),
         }
 
-    def _get_column_tag_map(self):
+    def _get_column_tag_map(self) -> Mapping[str, Mapping[str, str]]:
         # For every applicable promoted column,  a map of translations from the column
         # name  we save in the database to the tag we receive in the query.
         promoted_context_tag_columns = self._get_promoted_context_tag_columns()
@@ -375,14 +375,14 @@ class EventsDataset(TimeSeriesDataset):
             "contexts": {},
         }
 
-    def get_tag_column_map(self):
+    def get_tag_column_map(self) -> Mapping[str, Mapping[str, str]]:
         # And a reverse map from the tags the client expects to the database columns
         return {
             col: dict(map(reversed, trans.items()))
             for col, trans in self._get_column_tag_map().items()
         }
 
-    def get_promoted_tags(self):
+    def get_promoted_tags(self) -> Mapping[str, Sequence[str]]:
         # The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
         # and they can/will use a promoted column.
         return {

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -9,6 +9,7 @@ from snuba import settings
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.processor import MessageProcessor
+from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.snapshots.loaders import BulkLoader
 from snuba.writer import BatchWriter
 
@@ -96,10 +97,14 @@ class TableWriter:
     """
 
     def __init__(
-        self, write_schema: WritableTableSchema, stream_loader: KafkaStreamLoader,
+        self,
+        write_schema: WritableTableSchema,
+        stream_loader: KafkaStreamLoader,
+        replacer_processor: Optional[ReplacerProcessor] = None,
     ) -> None:
         self.__table_schema = write_schema
         self.__stream_loader = stream_loader
+        self.__replacer_processor = replacer_processor
 
     def get_schema(self) -> WritableTableSchema:
         return self.__table_schema
@@ -160,3 +165,10 @@ class TableWriter:
 
     def get_stream_loader(self) -> KafkaStreamLoader:
         return self.__stream_loader
+
+    def get_replacer_processor(self) -> Optional[ReplacerProcessor]:
+        """
+        Returns a replacer processor if this table writer knows how to do
+        replacements on the table it manages.
+        """
+        return self.__replacer_processor

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -168,7 +168,7 @@ class TableWriter:
 
     def get_replacer_processor(self) -> Optional[ReplacerProcessor]:
         """
-        Returns a replacer processor if this table writer knows how to do
+        Returns a replacement processor if this table writer knows how to do
         replacements on the table it manages.
         """
         return self.__replacer_processor

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -9,7 +9,7 @@ from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.extensions import QueryExtension
 from snuba.query.query import Query
 from snuba.query.query_processor import ExtensionData, ExtensionQueryProcessor
-from snuba.replacer import get_projects_query_flags
+from snuba.datasets.errors_replacer import get_projects_query_flags
 from snuba.request.request_settings import RequestSettings
 from snuba.state import get_config, get_configs
 from snuba.state.rate_limit import RateLimitParameters, PROJECT_RATE_LIMIT_NAME

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -1,110 +1,21 @@
 import logging
 import time
-from collections import deque
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Any, Mapping, Optional, Sequence
-
 import simplejson as json
 
-from snuba.clickhouse import DATETIME_FORMAT
-from snuba.clickhouse.escaping import escape_identifier, escape_string
+from typing import Optional, Sequence
+
 from snuba.clickhouse.native import ClickhousePool
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.factory import enforce_table_writer
-from snuba.processor import InvalidMessageType, InvalidMessageVersion, _hashify
-from snuba.redis import redis_client
+from snuba.datasets.factory import enforce_table_writer, get_dataset_name
+from snuba.processor import InvalidMessageVersion
+from snuba.replacers.replacer_processor import Replacement, ReplacementMessage
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message
 
-from . import settings
-
 
 logger = logging.getLogger("snuba.replacer")
-
-
-EXCLUDE_GROUPS = object()
-NEEDS_FINAL = object()
-
-
-def get_project_exclude_groups_key(project_id):
-    return "project_exclude_groups:%s" % project_id
-
-
-def set_project_exclude_groups(project_id, group_ids):
-    """Add {group_id: now, ...} to the ZSET for each `group_id` to exclude,
-    remove outdated entries based on `settings.REPLACER_KEY_TTL`, and expire
-    the entire ZSET incase it's rarely touched."""
-
-    now = time.time()
-    key = get_project_exclude_groups_key(project_id)
-    p = redis_client.pipeline()
-
-    p.zadd(key, **{str(group_id): now for group_id in group_ids})
-    p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
-    p.expire(key, int(settings.REPLACER_KEY_TTL))
-
-    p.execute()
-
-
-def get_project_needs_final_key(project_id):
-    return "project_needs_final:%s" % project_id
-
-
-def set_project_needs_final(project_id):
-    return redis_client.set(
-        get_project_needs_final_key(project_id), True, ex=settings.REPLACER_KEY_TTL
-    )
-
-
-def get_projects_query_flags(project_ids):
-    """\
-    1. Fetch `needs_final` for each Project
-    2. Fetch groups to exclude for each Project
-    3. Trim groups to exclude ZSET for each Project
-
-    Returns (needs_final, group_ids_to_exclude)
-    """
-
-    project_ids = set(project_ids)
-    now = time.time()
-    p = redis_client.pipeline()
-
-    needs_final_keys = [
-        get_project_needs_final_key(project_id) for project_id in project_ids
-    ]
-    for needs_final_key in needs_final_keys:
-        p.get(needs_final_key)
-
-    exclude_groups_keys = [
-        get_project_exclude_groups_key(project_id) for project_id in project_ids
-    ]
-    for exclude_groups_key in exclude_groups_keys:
-        p.zremrangebyscore(
-            exclude_groups_key, float("-inf"), now - settings.REPLACER_KEY_TTL
-        )
-        p.zrevrangebyscore(
-            exclude_groups_key, float("inf"), now - settings.REPLACER_KEY_TTL
-        )
-
-    results = p.execute()
-
-    needs_final = any(results[: len(project_ids)])
-    exclude_groups = sorted(
-        {int(group_id) for group_id in sum(results[(len(project_ids) + 1) :: 2], [])}
-    )
-
-    return (needs_final, exclude_groups)
-
-
-@dataclass(frozen=True)
-class Replacement:
-    count_query_template: str
-    insert_query_template: str
-    query_args: Mapping[str, Any]
-    query_time_flags: Any
 
 
 class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
@@ -112,56 +23,32 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
         self, clickhouse: ClickhousePool, dataset: Dataset, metrics: MetricsBackend
     ) -> None:
         self.clickhouse = clickhouse
-        self.dataset = dataset
         self.metrics = metrics
-        self.__all_column_names = [
-            col.escaped
-            for col in enforce_table_writer(dataset).get_schema().get_columns()
-        ]
-        self.__required_columns = [
-            col.escaped for col in dataset.get_required_columns()
-        ]
+        self.__replacer_processor = enforce_table_writer(
+            dataset
+        ).get_replacer_processor()
+        dataset_name = get_dataset_name(dataset)
+        assert (
+            self.__replacer_processor
+        ), f"This dataset writer does not support a replacer {dataset_name}"
 
     def process_message(self, message: Message[KafkaPayload]) -> Optional[Replacement]:
         message = json.loads(message.payload.value)
         version = message[0]
 
         if version == 2:
-            type_, event = message[1:3]
-
-            if type_ in (
-                "start_delete_groups",
-                "start_merge",
-                "start_unmerge",
-                "start_delete_tag",
-            ):
-                return None
-            elif type_ == "end_delete_groups":
-                processed = process_delete_groups(event, self.__required_columns)
-            elif type_ == "end_merge":
-                processed = process_merge(event, self.__all_column_names)
-            elif type_ == "end_unmerge":
-                processed = process_unmerge(event, self.__all_column_names)
-            elif type_ == "end_delete_tag":
-                processed = process_delete_tag(event, self.dataset)
-            else:
-                raise InvalidMessageType("Invalid message type: {}".format(type_))
+            return self.__replacer_processor.process_message(
+                ReplacementMessage(message[1], message[2])
+            )
         else:
             raise InvalidMessageVersion("Unknown message format: " + str(message))
-
-        return processed
 
     def flush_batch(self, batch: Sequence[Replacement]) -> None:
         for replacement in batch:
             query_args = {
                 **replacement.query_args,
-                "dist_read_table_name": self.dataset.get_dataset_schemas()
-                .get_read_schema()
-                .get_data_source()
-                .format_from(),
-                "dist_write_table_name": enforce_table_writer(self.dataset)
-                .get_schema()
-                .get_table_name(),
+                "dist_read_table_name": self.__replacer_processor.get_read_schema().get_table_name(),
+                "dist_write_table_name": self.__replacer_processor.get_write_schema().get_table_name(),
             }
             count = self.clickhouse.execute_robust(
                 replacement.count_query_template % query_args
@@ -169,287 +56,15 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
             if count == 0:
                 continue
 
-            # query_time_flags == (type, project_id, [...data...])
-            flag_type, project_id = replacement.query_time_flags[:2]
-            if flag_type == NEEDS_FINAL:
-                set_project_needs_final(project_id)
-            elif flag_type == EXCLUDE_GROUPS:
-                group_ids = replacement.query_time_flags[2]
-                set_project_exclude_groups(project_id, group_ids)
+            self.__replacer_processor.pre_replacement(replacement, count)
 
             t = time.time()
             query = replacement.insert_query_template % query_args
             logger.debug("Executing replace query: %s" % query)
             self.clickhouse.execute_robust(query)
             duration = int((time.time() - t) * 1000)
+
+            self.__replacer_processor.post_replacement(replacement, duration, count)
             logger.info("Replacing %s rows took %sms" % (count, duration))
             self.metrics.timing("replacements.count", count)
             self.metrics.timing("replacements.duration", duration)
-
-
-def process_delete_groups(message, required_columns) -> Optional[Replacement]:
-    group_ids = message["group_ids"]
-    if not group_ids:
-        return None
-
-    assert all(isinstance(gid, int) for gid in group_ids)
-    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
-    select_columns = map(lambda i: i if i != "deleted" else "1", required_columns)
-
-    where = """\
-        PREWHERE group_id IN (%(group_ids)s)
-        WHERE project_id = %(project_id)s
-        AND received <= CAST('%(timestamp)s' AS DateTime)
-        AND NOT deleted
-    """
-
-    count_query_template = (
-        """\
-        SELECT count()
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    insert_query_template = (
-        """\
-        INSERT INTO %(dist_write_table_name)s (%(required_columns)s)
-        SELECT %(select_columns)s
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    query_args = {
-        "required_columns": ", ".join(required_columns),
-        "select_columns": ", ".join(select_columns),
-        "project_id": message["project_id"],
-        "group_ids": ", ".join(str(gid) for gid in group_ids),
-        "timestamp": timestamp.strftime(DATETIME_FORMAT),
-    }
-
-    query_time_flags = (EXCLUDE_GROUPS, message["project_id"], group_ids)
-
-    return Replacement(
-        count_query_template, insert_query_template, query_args, query_time_flags
-    )
-
-
-SEEN_MERGE_TXN_CACHE = deque(maxlen=100)
-
-
-def process_merge(message, all_column_names) -> Optional[Replacement]:
-    # HACK: We were sending duplicates of the `end_merge` message from Sentry,
-    # this is only for performance of the backlog.
-    txn = message.get("transaction_id")
-    if txn:
-        if txn in SEEN_MERGE_TXN_CACHE:
-            return None
-        else:
-            SEEN_MERGE_TXN_CACHE.append(txn)
-
-    previous_group_ids = message["previous_group_ids"]
-    if not previous_group_ids:
-        return None
-
-    assert all(isinstance(gid, int) for gid in previous_group_ids)
-    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
-    select_columns = map(
-        lambda i: i if i != "group_id" else str(message["new_group_id"]),
-        all_column_names,
-    )
-
-    where = """\
-        PREWHERE group_id IN (%(previous_group_ids)s)
-        WHERE project_id = %(project_id)s
-        AND received <= CAST('%(timestamp)s' AS DateTime)
-        AND NOT deleted
-    """
-
-    count_query_template = (
-        """\
-        SELECT count()
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    insert_query_template = (
-        """\
-        INSERT INTO %(dist_write_table_name)s (%(all_columns)s)
-        SELECT %(select_columns)s
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    query_args = {
-        "all_columns": ", ".join(all_column_names),
-        "select_columns": ", ".join(select_columns),
-        "project_id": message["project_id"],
-        "previous_group_ids": ", ".join(str(gid) for gid in previous_group_ids),
-        "timestamp": timestamp.strftime(DATETIME_FORMAT),
-    }
-
-    query_time_flags = (EXCLUDE_GROUPS, message["project_id"], previous_group_ids)
-
-    return Replacement(
-        count_query_template, insert_query_template, query_args, query_time_flags
-    )
-
-
-def process_unmerge(message, all_column_names) -> Optional[Replacement]:
-    hashes = message["hashes"]
-    if not hashes:
-        return None
-
-    assert all(isinstance(h, str) for h in hashes)
-    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
-    select_columns = map(
-        lambda i: i if i != "group_id" else str(message["new_group_id"]),
-        all_column_names,
-    )
-
-    where = """\
-        PREWHERE group_id = %(previous_group_id)s
-        WHERE project_id = %(project_id)s
-        AND primary_hash IN (%(hashes)s)
-        AND received <= CAST('%(timestamp)s' AS DateTime)
-        AND NOT deleted
-    """
-
-    count_query_template = (
-        """\
-        SELECT count()
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    insert_query_template = (
-        """\
-        INSERT INTO %(dist_write_table_name)s (%(all_columns)s)
-        SELECT %(select_columns)s
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    query_args = {
-        "all_columns": ", ".join(all_column_names),
-        "select_columns": ", ".join(select_columns),
-        "previous_group_id": message["previous_group_id"],
-        "project_id": message["project_id"],
-        "hashes": ", ".join("'%s'" % _hashify(h) for h in hashes),
-        "timestamp": timestamp.strftime(DATETIME_FORMAT),
-    }
-
-    query_time_flags = (NEEDS_FINAL, message["project_id"])
-
-    return Replacement(
-        count_query_template, insert_query_template, query_args, query_time_flags
-    )
-
-
-# This obnoxious amount backslashes is sadly required.
-# replaceRegexpAll(tuple.1, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1')
-# means running this on Clickhouse:
-# replaceRegexpAll(tuple.1, '(\\||\\=|\\\\)', '\\\\\\1')
-# The (\\||\\=|\\\\) pattern should be actually this: (\||\=|\\). The additional
-# backslashes are because of Clickhouse escaping.
-FLATTENED_COLUMN_TEMPLATE = """
-concat(
-    '|',
-    arrayStringConcat(
-        arrayMap(tuple -> concat(
-                replaceRegexpAll(tuple.1, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'),
-                '=',
-                replaceRegexpAll(tuple.2, '(\\\\||\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1')
-            ),
-            arraySort(
-                arrayFilter(
-                    tuple -> tuple.1 != %s,
-                    arrayMap((k, v) -> tuple(k, v), `tags.key`, `tags.value`)
-                )
-            )
-        ),
-        '||'
-    ),
-    '|'
-)
-"""
-
-
-def process_delete_tag(message, dataset) -> Optional[Replacement]:
-    tag = message["tag"]
-    if not tag:
-        return None
-
-    assert isinstance(tag, str)
-    timestamp = datetime.strptime(message["datetime"], settings.PAYLOAD_DATETIME_FORMAT)
-    tag_column_name = dataset.get_tag_column_map()["tags"].get(tag, tag)
-    is_promoted = tag in dataset.get_promoted_tags()["tags"]
-
-    where = """\
-        WHERE project_id = %(project_id)s
-        AND received <= CAST('%(timestamp)s' AS DateTime)
-        AND NOT deleted
-    """
-
-    if is_promoted:
-        where += "AND %(tag_column)s IS NOT NULL"
-    else:
-        where += "AND has(`tags.key`, %(tag_str)s)"
-
-    insert_query_template = (
-        """\
-        INSERT INTO %(dist_write_table_name)s (%(all_columns)s)
-        SELECT %(select_columns)s
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    select_columns = []
-    all_columns = dataset.get_dataset_schemas().get_read_schema().get_columns()
-    for col in all_columns:
-        if is_promoted and col.flattened == tag_column_name:
-            select_columns.append("NULL")
-        elif col.flattened == "tags.key":
-            select_columns.append(
-                "arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, %s)), `tags.key`)"
-                % escape_string(tag)
-            )
-        elif col.flattened == "tags.value":
-            select_columns.append(
-                "arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, %s), arrayEnumerate(`tags.value`)))"
-                % escape_string(tag)
-            )
-        elif col.flattened == "_tags_flattened":
-            select_columns.append(FLATTENED_COLUMN_TEMPLATE % escape_string(tag))
-        else:
-            select_columns.append(col.escaped)
-
-    all_column_names = [col.escaped for col in all_columns]
-    query_args = {
-        "all_columns": ", ".join(all_column_names),
-        "select_columns": ", ".join(select_columns),
-        "project_id": message["project_id"],
-        "tag_str": escape_string(tag),
-        "tag_column": escape_identifier(tag_column_name),
-        "timestamp": timestamp.strftime(DATETIME_FORMAT),
-    }
-
-    count_query_template = (
-        """\
-        SELECT count()
-        FROM %(dist_read_table_name)s FINAL
-    """
-        + where
-    )
-
-    query_time_flags = (NEEDS_FINAL, message["project_id"])
-
-    return Replacement(
-        count_query_template, insert_query_template, query_args, query_time_flags
-    )

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -30,7 +30,7 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
         dataset_name = get_dataset_name(dataset)
         assert (
             self.__replacer_processor
-        ), f"This dataset writer does not support a replacer {dataset_name}"
+        ), f"This dataset writer does not support replacements {dataset_name}"
 
     def process_message(self, message: Message[KafkaPayload]) -> Optional[Replacement]:
         message = json.loads(message.payload.value)

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -1,0 +1,61 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Mapping, NamedTuple, Optional
+
+from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
+
+
+class ReplacementMessage(NamedTuple):
+    action_type: str  # This is a string to make this class agnostic to the dataset
+    data: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class Replacement:
+    count_query_template: str
+    insert_query_template: str
+    query_args: Mapping[str, Any]
+    query_time_flags: Any
+
+
+class ReplacerProcessor(ABC):
+    """
+    Processes one message from the replacer topic into a data structure that contains
+    the query to apply the replacement.
+    Every dataset/storage that needs to implement replacements, needs to provide an
+    instance of this class that will be used by the ReplacementWorker.
+    """
+
+    def __init__(
+        self, write_schema: WritableTableSchema, read_schema: TableSchema
+    ) -> None:
+        self.__write_schema = write_schema
+        self.__read_schema = read_schema
+
+    @abstractmethod
+    def process_message(self, message: ReplacementMessage) -> Optional[Replacement]:
+        """
+        Processes one message from the topic.
+        """
+        raise NotImplementedError
+
+    def get_write_schema(self) -> WritableTableSchema:
+        return self.__write_schema
+
+    def get_read_schema(self) -> TableSchema:
+        return self.__write_schema
+
+    def pre_replacement(self, replacement: Replacement, matching_records: int) -> None:
+        """
+        Custom actions to run before the replacements when we already know how
+        many rows will be impacted.
+        """
+        pass
+
+    def post_replacement(
+        self, replacement: Replacement, duration: int, matching_records: int
+    ) -> None:
+        """
+        Custom actions to run after the replacement was executed.
+        """
+        pass

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -6,6 +6,12 @@ from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
 
 
 class ReplacementMessage(NamedTuple):
+    """
+    Represent a generic replacement message (version 2 in our protocol) that we
+    find on the replacement topic.
+    TODO: We should use codecs to encode/decode kafka replacements messages.
+    """
+
     action_type: str  # This is a string to make this class agnostic to the dataset
     data: Mapping[str, Any]
 

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -2,9 +2,13 @@ import pytest
 from typing import Sequence
 
 from tests.base import BaseTest
-from snuba import replacer, state
+from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
+from snuba.datasets.errors_replacer import (
+    set_project_exclude_groups,
+    set_project_needs_final,
+)
 from snuba.query.conditions import FunctionCall, BooleanFunctions
 from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.project_extension import (
@@ -127,7 +131,7 @@ class TestProjectExtensionWithGroups(BaseTest):
 
     def test_without_turbo_with_projects_needing_final(self):
         request_settings = HTTPRequestSettings()
-        replacer.set_project_needs_final(2)
+        set_project_needs_final(2)
 
         self.extension.get_processor().process_query(
             self.query, self.valid_data, request_settings
@@ -151,7 +155,7 @@ class TestProjectExtensionWithGroups(BaseTest):
     def test_when_there_are_not_many_groups_to_exclude(self):
         request_settings = HTTPRequestSettings()
         state.set_config("max_group_ids_exclude", 5)
-        replacer.set_project_exclude_groups(2, [100, 101, 102])
+        set_project_exclude_groups(2, [100, 101, 102])
 
         self.extension.get_processor().process_query(
             self.query, self.valid_data, request_settings
@@ -192,7 +196,7 @@ class TestProjectExtensionWithGroups(BaseTest):
     def test_when_there_are_too_many_groups_to_exclude(self):
         request_settings = HTTPRequestSettings()
         state.set_config("max_group_ids_exclude", 2)
-        replacer.set_project_exclude_groups(2, [100, 101, 102])
+        set_project_exclude_groups(2, [100, 101, 102])
 
         self.extension.get_processor().process_query(
             self.query, self.valid_data, request_settings


### PR DESCRIPTION
I should probably have started from here for supporting the errors dataset instead of keeping this aside. 
Rationale:
Replacers today are strictly dependent on Events dataset. This dependency is actually two-folds: there is a direct code dependency on the Events dataset, and there is a conceptual dependency on the events/errors data model.
Thus making replacers generic requires two different approaches:
1) breaking the code dependency from replacer to dataset by inverting it (like we did for message processors). The dataset defines the processor (through the table writer) and the script instantiates the worker
2) Building a more generic concept of replacement that could work datasets other than errors and events.

What we need to make errors work is only step 1. Step 2 is a way more complex redesign. I don't think there is any urgency to focus on that now considering we do not have any meaningful use case to run replacers other than events and errors (which are 98% the same logic).

So this PR splits replacer.py into worker and processor as we did for message processors long ago. This way we can associate the replacer processor to the table writer (the storage layer). This is declared in the dataset. Which can instantiate it with all the schema specific parameters that are needed. 
If/when we will build a generic replacer, we will be able to build on top of this.

Most of the code in this PR is just cut and paste from one place to another.