### PR TITLE
fix(replacer) Return the right schema from get_read_schema

### DIFF
--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -49,7 +49,7 @@ class ReplacerProcessor(ABC):
         return self.__write_schema
 
     def get_read_schema(self) -> TableSchema:
-        return self.__write_schema
+        return self.__read_schema
 
     def pre_replacement(self, replacement: Replacement, matching_records: int) -> None:
         """


### PR DESCRIPTION
Apparently get_read_schema and get_write_schema are not supposed to do the same thing, who could have told that. This was dumb.

(nothing is broken since the only dataset that supports replacement uses the same schema for reads and writes).