### PR TITLE
feat(errors) Split replacer metrics like for consumers

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -100,7 +100,9 @@ def replacer(
     ), f"Dataset {dataset} does not have a replacement topic."
     replacements_topic = replacements_topic or default_replacement_topic_spec.topic_name
 
-    metrics = util.create_metrics("snuba.replacer", tags={"group": consumer_group})
+    metrics = util.create_metrics(
+        "snuba.replacer", tags={"group": consumer_group, "dataset": dataset_name}
+    )
 
     client_settings = {
         # Replacing existing rows requires reconstructing the entire tuple for each


### PR DESCRIPTION
Consumers metrics are split by dataset (passing the dataset as tag).
https://github.com/getsentry/snuba/blob/master/snuba/consumers/consumer_builder.py#L97

Replacers were not.