### PR TITLE
ref(subscriptions): Add metrics for schedule size, staleness, task latency and concurrent queries

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -124,6 +124,10 @@ def subscriptions(
 
     loader = enforce_table_writer(dataset).get_stream_loader()
 
+    metrics = create_metrics(
+        "snuba.subscriptions", tags={"group": consumer_group, "dataset": dataset_name},
+    )
+
     consumer = TickConsumer(
         SynchronizedConsumer(
             KafkaConsumer(
@@ -192,10 +196,7 @@ def subscriptions(
             ),
             max_batch_size,
             max_batch_time_ms,
-            create_metrics(
-                "snuba.subscriptions",
-                tags={"group": consumer_group, "dataset": dataset_name},
-            ),
+            metrics,
         )
 
         def handler(signum, frame) -> None:

--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import time
 from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime
 
 from snuba.datasets.dataset import Dataset
+from snuba.request import Request
 from snuba.subscriptions.consumer import Tick
 from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.scheduler import ScheduledTask
+from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import ClickhouseQueryResult, parse_and_run_query
 
@@ -18,9 +22,23 @@ class SubscriptionExecutor:
     to make the query, and the result is then returned as a `Future`.
     """
 
-    def __init__(self, dataset: Dataset, executor_pool: ThreadPoolExecutor):
+    def __init__(
+        self,
+        dataset: Dataset,
+        executor_pool: ThreadPoolExecutor,
+        metrics: MetricsBackend,
+    ):
         self.__dataset = dataset
         self.__executor_pool = executor_pool
+        self.__metrics = metrics
+
+    def __run_query(
+        self, scheduled_at: datetime, request: Request, timer: Timer
+    ) -> ClickhouseQueryResult:
+        self.__metrics.timing(
+            "executor.latency", (time.time() - scheduled_at.timestamp()) * 1000,
+        )
+        return parse_and_run_query(self.__dataset, request, timer)
 
     def execute(
         self, task: ScheduledTask[Subscription], tick: Tick
@@ -35,7 +53,7 @@ class SubscriptionExecutor:
             future.set_exception(e)
         else:
             future = self.__executor_pool.submit(
-                parse_and_run_query, self.__dataset, request, timer
+                self.__run_query, task.timestamp, request, timer
             )
         return future
 

--- a/snuba/utils/metrics/gauge.py
+++ b/snuba/utils/metrics/gauge.py
@@ -1,0 +1,49 @@
+from threading import Lock
+from typing import Any, Optional
+
+from snuba.utils.metrics.backends.abstract import MetricsBackend
+from snuba.utils.metrics.types import Tags
+
+
+class Gauge:
+    """
+    Implements a thread-safe gauge as a context manager. This can be used to
+    track how many threads are concurrently executing a code block.
+    """
+
+    def __init__(
+        self,
+        metrics: MetricsBackend,
+        name: str,
+        tags: Optional[Tags] = None,
+        lock: Optional[Lock] = None,
+    ) -> None:
+        if lock is None:
+            lock = Lock()
+
+        self.__metrics = metrics
+        self.__name = name
+        self.__tags = tags
+
+        self.__lock = lock
+        self.__value = 0
+
+        self.__report()
+
+    def __report(self) -> None:
+        self.__metrics.gauge(self.__name, self.__value, self.__tags)
+
+    def __enter__(self) -> None:
+        with self.__lock:
+            self.__value += 1
+            self.__report()
+
+    def __exit__(
+        self,
+        type: Optional[Any] = None,
+        value: Optional[Any] = None,
+        traceback: Optional[Any] = None,
+    ) -> None:
+        with self.__lock:
+            self.__value -= 1
+            self.__report()

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -12,13 +12,16 @@ from snuba.subscriptions.data import (
 )
 from snuba.subscriptions.executor import SubscriptionExecutor
 from snuba.subscriptions.scheduler import ScheduledTask
+from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.types import Interval
 from tests.subscriptions import BaseSubscriptionTest
 
 
 class TestSubscriptionExecutor(BaseSubscriptionTest):
     def test(self):
-        executor = SubscriptionExecutor(self.dataset, ThreadPoolExecutor())
+        executor = SubscriptionExecutor(
+            self.dataset, ThreadPoolExecutor(), DummyMetricsBackend(strict=True)
+        )
 
         subscription = Subscription(
             SubscriptionIdentifier(PartitionId(0), uuid1()),

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -11,6 +11,7 @@ from snuba.subscriptions.data import (
 )
 from snuba.subscriptions.scheduler import ScheduledTask, SubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
+from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.types import Interval
 from tests.base import BaseTest
 
@@ -48,7 +49,10 @@ class TestSubscriptionScheduler(BaseTest):
             store.create(subscription.identifier.uuid, subscription.data)
 
         scheduler = SubscriptionScheduler(
-            store, self.partition_id, timedelta(minutes=1)
+            store,
+            self.partition_id,
+            timedelta(minutes=1),
+            DummyMetricsBackend(strict=True),
         )
 
         result = list(scheduler.find(self.build_interval(start, end)))

--- a/tests/utils/metrics/test_gauge.py
+++ b/tests/utils/metrics/test_gauge.py
@@ -1,0 +1,54 @@
+from concurrent.futures import wait
+from threading import Event
+from snuba.utils.concurrent import execute
+from snuba.utils.metrics.gauge import Gauge
+from tests.backends.metrics import TestingMetricsBackend, Gauge as GaugeCall
+
+
+def test_gauge_simple() -> None:
+    backend = TestingMetricsBackend()
+
+    name = "name"
+    tags = {"tag": "value"}
+    gauge = Gauge(backend, name, tags)
+
+    with gauge:
+        pass
+
+    assert backend.calls == [
+        GaugeCall(name, 0, tags),
+        GaugeCall(name, 1, tags),
+        GaugeCall(name, 0, tags),
+    ]
+
+
+def test_gauge_concurrent() -> None:
+    backend = TestingMetricsBackend()
+
+    name = "name"
+    tags = {"tag": "value"}
+    gauge = Gauge(backend, name, tags)
+
+    event = Event()
+
+    def waiter() -> None:
+        with gauge:
+            event.wait()
+
+    futures = [execute(waiter) for i in range(4)]
+
+    event.set()
+
+    wait(futures)
+
+    assert backend.calls == [
+        GaugeCall(name, 0, tags),
+        GaugeCall(name, 1, tags),
+        GaugeCall(name, 2, tags),
+        GaugeCall(name, 3, tags),
+        GaugeCall(name, 4, tags),
+        GaugeCall(name, 3, tags),
+        GaugeCall(name, 2, tags),
+        GaugeCall(name, 1, tags),
+        GaugeCall(name, 0, tags),
+    ]


### PR DESCRIPTION
This adds four metrics:

1. `schedule.size`: how many subscriptions are in a schedule for a partition
2. `schedule.staleness`: how many milliseconds since the last schedule refresh for a partition
3. `executor.latency`: how many milliseconds behind schedule is a query when it starts to run
4. `executor.concurrent`: how many queries are running concurrently