### PR TITLE
ref(query): Add optional `format` parameter to `ClickhouseQuery.format_sql`

### DIFF
--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -52,7 +52,7 @@ class AstClickhouseQuery(ClickhouseQuery):
         self.__settings = settings
         self.__formatted_query: Optional[str] = None
 
-    def format_sql(self) -> str:
+    def __get_formatted_query(self) -> str:
         if self.__formatted_query:
             return self.__formatted_query
 
@@ -144,3 +144,9 @@ class AstClickhouseQuery(ClickhouseQuery):
         )
 
         return self.__formatted_query
+
+    def format_sql(self, format: Optional[str] = None) -> str:
+        query = self.__get_formatted_query()
+        if format is not None:
+            query = f"{query} FORMAT {format}"
+        return query

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -52,7 +52,7 @@ class AstClickhouseQuery(ClickhouseQuery):
         self.__settings = settings
         self.__formatted_query: Optional[str] = None
 
-    def __get_formatted_query(self) -> str:
+    def _format_query_impl(self) -> str:
         if self.__formatted_query:
             return self.__formatted_query
 
@@ -144,9 +144,3 @@ class AstClickhouseQuery(ClickhouseQuery):
         )
 
         return self.__formatted_query
-
-    def format_sql(self, format: Optional[str] = None) -> str:
-        query = self.__get_formatted_query()
-        if format is not None:
-            query = f"{query} FORMAT {format}"
-        return query

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from snuba import settings as snuba_settings
 from snuba import util
-from snuba.query.columns import (
-    column_expr,
-    conditions_expr,
-)
 from snuba.datasets.dataset import Dataset
+from snuba.query.columns import column_expr, conditions_expr
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
 from snuba.request.request_settings import RequestSettings
@@ -19,7 +17,7 @@ class ClickhouseQuery(ABC):
     """
 
     @abstractmethod
-    def format_sql(self) -> str:
+    def format_sql(self, format: Optional[str] = None) -> str:
         raise NotImplementedError
 
 
@@ -145,6 +143,9 @@ class DictClickhouseQuery(ClickhouseQuery):
             ]
         )
 
-    def format_sql(self) -> str:
+    def format_sql(self, format: Optional[str] = None) -> str:
         """Produces a SQL string from the parameters."""
-        return self.__formatted_query
+        query = self.__formatted_query
+        if format is not None:
+            query = f"{query} FORMAT {format}"
+        return query


### PR DESCRIPTION
This allows the `Reader[ClickhouseQuery]` to change the formatter used by ClickHouse by adding the 
`FORMAT` clause to the query. This is required for the HTTP reader, since it expects data in the `JSON` format.

This is kind of clunky, but seemed better than the alternatives that I considered:

1. Just tacking this onto the end of the string in the `Reader` when necessary. Seemed like a bad idea, since it splits the query formatting across two classes and relies on the assumption that the `FORMAT` clause is always the last one in the `SELECT` grammar.
2. Adding the format to the `Query` object. This would mean introducing an API for updating the format to `ClickhouseQuery` for this special case. Seemed like a bad idea, since it would set the precedent for the `Reader` to actually mutate the `ClickhouseQuery` object (and also is just a lot of work.)
3. Always adding `FORMAT JSON` to the formatted query, as in the original draft implementation of the HTTP reader (#406.) Seemed like a bad idea, since though the native driver ignores it as of today, there are no guarantees that it will ignore it forever. It would also require changing a lot of (unrelated, in my opinion) tests.