### PR TITLE
fix(subscriptions): Actually pass metrics to the things that need it now

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -176,7 +176,7 @@ def subscriptions(
                 else Topic(loader.get_default_topic_spec().topic_name)
             ),
             SubscriptionWorker(
-                SubscriptionExecutor(dataset, executor),
+                SubscriptionExecutor(dataset, executor, metrics),
                 {
                     index: SubscriptionScheduler(
                         RedisSubscriptionDataStore(
@@ -184,6 +184,7 @@ def subscriptions(
                         ),
                         PartitionId(index),
                         cache_ttl=timedelta(seconds=schedule_ttl),
+                        metrics=metrics,
                     )
                     for index in range(
                         partitions


### PR DESCRIPTION
I did everything in #789 except actually make it work, apparently.

```diff
--- a/tmp/before.txt
+++ b/tmp/after.txt
@@ -1,4 +1,4 @@
-Found 540 errors in 90 files (checked 160 source files)
+Found 538 errors in 90 files (checked 160 source files)
 snuba/cleanup.py:10: error: Function is missing a type annotation
 snuba/cleanup.py:11: error: Call to untyped function "get_active_partitions" in typed context
 snuba/cleanup.py:12: error: Call to untyped function "filter_stale_partitions" in typed context
@@ -58,9 +58,7 @@ snuba/cli/subscriptions.py:121: error: Module has no attribute "DEFAULT_DATASET_
 snuba/cli/subscriptions.py:122: error: Module has no attribute "DEFAULT_BROKERS"
 snuba/cli/subscriptions.py:152: error: Item "None" of "Optional[KafkaTopicSpec]" has no attribute "topic_name"
 snuba/cli/subscriptions.py:168: error: "ThreadPoolExecutor" has no attribute "_max_workers"
-snuba/cli/subscriptions.py:179: error: Too few arguments for "SubscriptionExecutor"
-snuba/cli/subscriptions.py:181: error: Missing positional argument "metrics" in call to "SubscriptionScheduler"
-snuba/cli/subscriptions.py:202: error: Function is missing a type annotation for one or more arguments
+snuba/cli/subscriptions.py:203: error: Function is missing a type annotation for one or more arguments
 snuba/cli/subscriptions.py:76: error: Module has no attribute "DEFAULT_MAX_BATCH_SIZE"
 snuba/cli/subscriptions.py:82: error: Module has no attribute "DEFAULT_MAX_BATCH_TIME_MS"
 snuba/clickhouse/astquery.py:78: error: Module has no attribute "TURBO_SAMPLE_RATE"
```