### PR TITLE
ref(query): Improve(?) return type of `raw_query`

### DIFF
--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -12,7 +12,7 @@ from snuba.subscriptions.scheduler import ScheduledTask
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge
 from snuba.utils.metrics.timer import Timer
-from snuba.web.query import ClickhouseQueryResult, parse_and_run_query
+from snuba.web.query import RawQueryResult, parse_and_run_query
 
 
 class SubscriptionExecutor:
@@ -45,14 +45,14 @@ class SubscriptionExecutor:
 
     def execute(
         self, task: ScheduledTask[Subscription], tick: Tick
-    ) -> Future[ClickhouseQueryResult]:
+    ) -> Future[RawQueryResult]:
         timer = Timer("query")
         try:
             request = task.task.data.build_request(
                 self.__dataset, task.timestamp, tick.offsets.upper, timer,
             )
         except Exception as e:
-            future: Future[ClickhouseQueryResult] = Future()
+            future: Future[RawQueryResult] = Future()
             future.set_exception(e)
         else:
             future = self.__executor_pool.submit(

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -5,6 +5,7 @@ import json
 from concurrent.futures import Future, as_completed
 from typing import Mapping, NamedTuple, Optional, Sequence
 
+from snuba.reader import Result
 from snuba.subscriptions.consumer import Tick
 from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.executor import SubscriptionExecutor
@@ -14,17 +15,16 @@ from snuba.utils.streams.batching import AbstractBatchWorker
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.producer import Producer
 from snuba.utils.streams.types import Message, Topic
-from snuba.web.query import RawQueryResult
 
 
 class SubscriptionResultFuture(NamedTuple):
     task: ScheduledTask[Subscription]
-    future: Future[RawQueryResult]
+    future: Future[Result]
 
 
 class SubscriptionResult(NamedTuple):
     task: ScheduledTask[Subscription]
-    result: RawQueryResult
+    result: Result
 
 
 class SubscriptionWorker(AbstractBatchWorker[Tick, Sequence[SubscriptionResultFuture]]):

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -14,17 +14,17 @@ from snuba.utils.streams.batching import AbstractBatchWorker
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.producer import Producer
 from snuba.utils.streams.types import Message, Topic
-from snuba.web.query import ClickhouseQueryResult
+from snuba.web.query import RawQueryResult
 
 
 class SubscriptionResultFuture(NamedTuple):
     task: ScheduledTask[Subscription]
-    future: Future[ClickhouseQueryResult]
+    future: Future[RawQueryResult]
 
 
 class SubscriptionResult(NamedTuple):
     task: ScheduledTask[Subscription]
-    result: ClickhouseQueryResult
+    result: RawQueryResult
 
 
 class SubscriptionWorker(AbstractBatchWorker[Tick, Sequence[SubscriptionResultFuture]]):

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -1,6 +1,6 @@
 import logging
 from hashlib import md5
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping
 
 import sentry_sdk
 from clickhouse_driver.errors import Error as ClickHouseError
@@ -51,14 +51,13 @@ def raw_query(
     request: Request,
     query: DictClickhouseQuery,
     timer: Timer,
-    stats: Optional[MutableMapping[str, Any]] = None,
+    stats: MutableMapping[str, Any],
 ) -> ClickhouseQueryResult:
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
     fix some of the formatting issues in the result JSON
     """
 
-    stats = stats or {}
     use_cache, use_deduper, uc_max = state.get_configs(
         [("use_cache", 0), ("use_deduper", 1), ("uncompressed_cache_max_cols", 5)]
     )

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -224,7 +224,7 @@ def update_query_metadata_and_stats(
     stats.update(query_settings)
 
     query_metadata.query_list.append(
-        ClickhouseQueryMetadata(sql=sql, stats=stats, status=status, trace_id=trace_id,)
+        ClickhouseQueryMetadata(sql=sql, stats=stats, status=status, trace_id=trace_id)
     )
 
     return stats
@@ -346,7 +346,7 @@ def _run_query(
         except Exception:
             logger.exception("Failed to format ast query")
 
-        result = raw_query(request, query, timer, query_metadata, stats, span.trace_id,)
+        result = raw_query(request, query, timer, query_metadata, stats, span.trace_id)
 
     with sentry_sdk.configure_scope() as scope:
         if scope.span:

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -65,7 +65,7 @@ def raw_query(
     query: DictClickhouseQuery,
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
-    stats: Optional[MutableMapping[str, Any]] = None,
+    stats: MutableMapping[str, Any],
     trace_id: Optional[str] = None,
 ) -> RawQueryResult:
     """

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -88,22 +88,24 @@ def split_query(query_func):
             # evaluation, so we need to copy the body to ensure that the query
             # has not been modified in between this call and the next loop
             # iteration, if needed.
+            # XXX: The extra data is carried across from the initial response
+            # and never updated.
             result = query_func(dataset, copy.deepcopy(request), *args, **kwargs)
 
             if overall_result is None:
                 overall_result = result
             else:
-                overall_result["data"].extend(result["data"])
+                overall_result.result["data"].extend(result.result["data"])
 
-            if remaining_offset > 0 and len(overall_result["data"]) > 0:
-                to_trim = min(remaining_offset, len(overall_result["data"]))
-                overall_result["data"] = overall_result["data"][to_trim:]
+            if remaining_offset > 0 and len(overall_result.result["data"]) > 0:
+                to_trim = min(remaining_offset, len(overall_result.result["data"]))
+                overall_result.result["data"] = overall_result.result["data"][to_trim:]
                 remaining_offset -= to_trim
 
-            total_results = len(overall_result["data"])
+            total_results = len(overall_result.result["data"])
 
             if total_results < limit:
-                if len(result["data"]) == 0:
+                if len(result.result["data"]) == 0:
                     # If we got nothing from the last query, expand the range by a static factor
                     split_step = split_step * STEP_GROWTH
                 else:
@@ -112,7 +114,7 @@ def split_query(query_func):
                     # our last query and its time range, and how many we have left to fetch.
                     remaining = limit - total_results
                     split_step = split_step * math.ceil(
-                        remaining / float(len(result["data"]))
+                        remaining / float(len(result.result["data"]))
                     )
 
                 # Set the start and end of the next query based on the new range.
@@ -143,11 +145,16 @@ def split_query(query_func):
         result = query_func(dataset, minimal_request, *args, **kwargs)
         del minimal_request
 
-        if result["data"]:
+        if result.result["data"]:
             request = copy.deepcopy(request)
 
             event_ids = list(
-                set([event[column_split_spec.id_column] for event in result["data"]])
+                set(
+                    [
+                        event[column_split_spec.id_column]
+                        for event in result.result["data"]
+                    ]
+                )
             )
             request.query.add_conditions(
                 [(column_split_spec.id_column, "IN", event_ids)]
@@ -159,14 +166,14 @@ def split_query(query_func):
                 set(
                     [
                         event[column_split_spec.project_column]
-                        for event in result["data"]
+                        for event in result.result["data"]
                     ]
                 )
             )
             request.extensions["project"]["project"] = project_ids
 
             timestamp_field = column_split_spec.timestamp_column
-            timestamps = [event[timestamp_field] for event in result["data"]]
+            timestamps = [event[timestamp_field] for event in result.result["data"]]
             request.extensions["timeseries"]["from_date"] = util.parse_datetime(
                 min(timestamps)
             ).isoformat()

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import NamedTuple
+from typing import Any, Mapping, NamedTuple
 from uuid import UUID
 
 import jsonschema
@@ -40,7 +40,6 @@ from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.web.converters import DatasetConverter
 from snuba.web.query import (
     RawQueryException,
-    RawQueryResult,
     parse_and_run_query,
 )
 
@@ -50,7 +49,7 @@ logger = logging.getLogger("snuba.api")
 
 class WebQueryResult(NamedTuple):
     # TODO: Give a better abstraction to QueryResult
-    result: RawQueryResult
+    payload: Mapping[str, Any]
     status: int
 
 
@@ -310,7 +309,7 @@ def format_result(result: WebQueryResult) -> Response:
         return obj
 
     return Response(
-        json.dumps(result.result, default=json_default),
+        json.dumps(result.payload, default=json_default),
         result.status,
         {"Content-Type": "application/json"},
     )

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -48,7 +48,7 @@ from snuba.web.query import (
 logger = logging.getLogger("snuba.api")
 
 
-class QueryResult(NamedTuple):
+class WebQueryResult(NamedTuple):
     # TODO: Give a better abstraction to QueryResult
     result: RawQueryResult
     status: int
@@ -282,15 +282,15 @@ def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
     )
 
 
-def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
+def run_query(dataset: Dataset, request: Request, timer: Timer) -> WebQueryResult:
     try:
         result = parse_and_run_query(dataset, request, timer)
         payload = {**result.result, "timing": timer.for_json()}
         if settings.STATS_IN_RESPONSE or request.settings.get_debug():
             payload.update(result.extra)
-        return QueryResult(payload, 200)
+        return WebQueryResult(payload, 200)
     except RawQueryException as e:
-        return QueryResult(
+        return WebQueryResult(
             {
                 "error": {"type": e.err_type, "message": e.message, **e.meta},
                 "sql": e.sql,
@@ -301,7 +301,7 @@ def run_query(dataset: Dataset, request: Request, timer: Timer) -> QueryResult:
         )
 
 
-def format_result(result: QueryResult) -> Response:
+def format_result(result: WebQueryResult) -> Response:
     def json_default(obj):
         if isinstance(obj, datetime):
             return obj.isoformat()

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -19,4 +19,4 @@ class TestBuildRequest(BaseSubscriptionTest):
             self.dataset, datetime.utcnow(), 100, Mock()
         )
         result = parse_and_run_query(self.dataset, request, Mock())
-        assert result["data"][0]["count"] == 10
+        assert result.result["data"][0]["count"] == 10

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -41,7 +41,7 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
         )
 
         result = executor.execute(ScheduledTask(now, subscription), tick).result()
-        assert result["data"][0]["count"] == 10
+        assert result.result["data"][0]["count"] == 10
 
         result = executor.execute(
             ScheduledTask(
@@ -51,4 +51,4 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             tick,
         ).result()
 
-        assert result["data"][0]["count"] == 0
+        assert result.result["data"][0]["count"] == 0

--- a/tests/subscriptions/test_executor.py
+++ b/tests/subscriptions/test_executor.py
@@ -41,7 +41,7 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
         )
 
         result = executor.execute(ScheduledTask(now, subscription), tick).result()
-        assert result.result["data"][0]["count"] == 10
+        assert result["data"][0]["count"] == 10
 
         result = executor.execute(
             ScheduledTask(
@@ -51,4 +51,4 @@ class TestSubscriptionExecutor(BaseSubscriptionTest):
             tick,
         ).result()
 
-        assert result.result["data"][0]["count"] == 0
+        assert result["data"][0]["count"] == 0

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,5 +1,6 @@
-import pytest
 from typing import Any, Mapping
+
+import pytest
 
 from snuba import state
 from snuba.datasets.dataset import Dataset
@@ -8,6 +9,7 @@ from snuba.query.query import Query
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.metrics.timer import Timer
+from snuba.web.query import RawQueryResult
 from snuba.web.split import split_query
 
 
@@ -92,9 +94,9 @@ def test_col_split(
     def do_query(dataset: Dataset, request: Request, timer: Timer):
         selected_cols = request.query.get_selected_columns()
         if selected_cols == list(first_query_data[0].keys()):
-            return {"data": first_query_data}
+            return RawQueryResult({"data": first_query_data}, {})
         elif selected_cols == list(second_query_data[0].keys()):
-            return {"data": second_query_data}
+            return RawQueryResult({"data": second_query_data}, {})
         else:
             raise ValueError(f"Unexpected selected columns: {selected_cols}")
 


### PR DESCRIPTION
This changes the return type of `raw_query` from `ClickhouseQueryResult` (a mapping that contained essentially arbitrary data) to `RawQueryResult`, a new type that contains the `Result` (directly as returned by the `Reader`) and arbitrary (stats, SQL, debug information) data in an `extra` attribute. This design change does not impact the external API or require test changes.

This has several benefits:

1. moves forward along the path of enabling the `Result` type to be immutable (and allows it to be converted from a `TypedDict` in the future to something more appropriate)
2. continues to separate the concerns of query evaluation and response formatting
3. allows more reliable type checking of code that deals with the `Result` type
4. removes implied ClickHouse coupling by removing a type (`ClickhouseQueryResult`) that is not actually coupled to ClickHouse

This also highlights some design issues (that already existed), like how the splitter takes the extra data from the initial query and never updates it as additional queries are executed.