### PR TITLE
feat(errors) Remove clutter remaining from redis key migration

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -308,7 +308,8 @@ class DiscoverDataset(TimeSeriesDataset):
         return {
             "project": ProjectExtension(
                 processor=ProjectWithGroupsProcessor(
-                    project_column="project_id", replacer_state_name=None,
+                    project_column="project_id",
+                    replacer_state_name=ReplacerState.EVENTS,
                 )
             ),
             "timeseries": TimeSeriesExtension(

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -401,7 +401,7 @@ class EventsDataset(TimeSeriesDataset):
                     project_column="project_id",
                     # key migration is on going. As soon as all the keys we are interested
                     # into in redis are stored with "EVENTS" in the name, we can change this.
-                    replacer_state_name=None,
+                    replacer_state_name=ReplacerState.EVENTS,
                 )
             ),
             "timeseries": TimeSeriesExtension(

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -151,7 +151,8 @@ class Groups(TimeSeriesDataset):
         return {
             "project": ProjectExtension(
                 processor=ProjectWithGroupsProcessor(
-                    project_column="events.project_id", replacer_state_name=None,
+                    project_column="events.project_id",
+                    replacer_state_name=ReplacerState.EVENTS,
                 )
             ),
             "timeseries": TimeSeriesExtension(

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -107,9 +107,7 @@ class ProjectWithGroupsProcessor(ProjectExtensionProcessor):
     2. Taking into consideration groups that should be excluded (groups are excluded because of replacement).
     """
 
-    def __init__(
-        self, project_column: str, replacer_state_name: Optional[ReplacerState]
-    ) -> None:
+    def __init__(self, project_column: str, replacer_state_name: ReplacerState) -> None:
         super().__init__(project_column)
         # This is used to allow us to keep the replacement state in redis for multiple
         # replacer on multiple tables. replacer_state_name is part of the redis key.


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/781 left some migration clutter in the errors_replacer file in the code that generates the redis key to store groups that are pending replacement.
We added a string to identify which dataset the list of groups was belonging to. In order to ensure a safe migration we double wrote the keys in the old and new format.

Those old keys are not relevant anymore so this PR cleans up the clutter.