### PR TITLE
ref(subscriptions): Add metric for number of workers per consumer

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -166,6 +166,7 @@ def subscriptions(
 
     executor = ThreadPoolExecutor(max_workers=max_query_workers)
     logger.debug("Starting %r with %s workers...", executor, executor._max_workers)
+    metrics.gauge("executor.workers", executor._max_workers)
 
     with closing(consumer), executor, closing(producer):
         batching_consumer = BatchingConsumer(


### PR DESCRIPTION
This will allow us to calculate on a per-dataset or per-host (consumer) basis what percentage of available threads are actually being used to run queries at a given point in time. In other words, it adds context to `executor.concurrent` introduced in #789, and will let us know if we need to add more executor threads without cross-referencing configuration files.