### PR TITLE
fix(outcomes): Remove invalid migration

### DIFF
--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -11,7 +11,7 @@ from snuba.clickhouse.columns import (
     UInt,
     UUID,
 )
-from snuba.datasets.schemas.tables import MergeTreeSchema, MigrationSchemaColumn
+from snuba.datasets.schemas.tables import MergeTreeSchema
 from snuba.datasets.dataset_schemas import DatasetSchemas
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
@@ -19,18 +19,6 @@ from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
-
-
-def outcomes_raw_migrations(
-    clickhouse_table: str, current_schema: Mapping[str, MigrationSchemaColumn]
-) -> Sequence[str]:
-    # Add/remove known migrations
-    ret = []
-    if "size" not in current_schema:
-        ret.append(f"ALTER TABLE {clickhouse_table} ADD COLUMN size Nullable(UInt32)")
-        pass
-
-    return ret
 
 
 class OutcomesRawDataset(TimeSeriesDataset):
@@ -54,7 +42,6 @@ class OutcomesRawDataset(TimeSeriesDataset):
             order_by="(org_id, project_id, timestamp)",
             partition_by="(toMonday(timestamp))",
             settings={"index_granularity": 16384},
-            migration_function=outcomes_raw_migrations,
         )
 
         dataset_schemas = DatasetSchemas(


### PR DESCRIPTION
We don't have a size column on the outcomes_raw dataset so we shouldn't
run the migration to add this column unnecessarily.