### PR TITLE
ref(query): Use explicit `None` instead of empty strings for missing values

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -62,7 +62,7 @@ def raw_query(
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
     stats: Optional[MutableMapping[str, Any]] = None,
-    trace_id: str = "",
+    trace_id: Optional[str] = None,
 ) -> ClickhouseQueryResult:
     """
     Submit a raw SQL query to clickhouse and do some post-processing on it to
@@ -213,7 +213,7 @@ def update_query_metadata_and_stats(
     stats: MutableMapping[str, Any],
     query_metadata: SnubaQueryMetadata,
     query_settings: Mapping[str, Any],
-    trace_id: str,
+    trace_id: Optional[str],
     status: str,
 ) -> MutableMapping:
     """

--- a/snuba/web/query_metadata.py
+++ b/snuba/web/query_metadata.py
@@ -10,7 +10,7 @@ class ClickhouseQueryMetadata:
     sql: str
     stats: Mapping[str, Any]
     status: str
-    trace_id: str
+    trace_id: Optional[str] = None
 
     def to_dict(self) -> Mapping[str, Any]:
         return {
@@ -31,7 +31,7 @@ class SnubaQueryMetadata:
     dataset: str
     timer: Timer
     query_list: MutableSequence[ClickhouseQueryMetadata]
-    referrer: Optional[str] = ""
+    referrer: Optional[str] = None
 
     def to_dict(self) -> Mapping[str, Any]:
         return {


### PR DESCRIPTION
Noticed this while rebasing #792 on top of aa74dc1e5952c465a0d61f4899be9ac7560c6c17.