### PR TITLE
test(readonly_events) Test the readonly table optimization for events

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -27,6 +27,7 @@ from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.impact_processor import ImpactProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.readonly_events import ReadOnlyTableSelector
 from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.types import Condition
@@ -298,7 +299,8 @@ class DiscoverDataset(TimeSeriesDataset):
                             {"timestamp"},
                             BEGINNING_OF_TIME,
                         ),
-                    ]
+                    ],
+                    EVENTS: [ReadOnlyTableSelector("sentry_dist", "sentry_dist_ro")],
                 },
             ),
             PrewhereProcessor(),

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -24,6 +24,7 @@ from snuba.datasets.schemas.tables import (
 from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.readonly_events import ReadOnlyTableSelector
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
@@ -412,4 +413,8 @@ class EventsDataset(TimeSeriesDataset):
         }
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return [BasicFunctionsProcessor(), PrewhereProcessor()]
+        return [
+            ReadOnlyTableSelector("sentry_dist", "sentry_dist_ro"),
+            BasicFunctionsProcessor(),
+            PrewhereProcessor(),
+        ]

--- a/snuba/query/processors/readonly_events.py
+++ b/snuba/query/processors/readonly_events.py
@@ -1,0 +1,36 @@
+from snuba import state
+from snuba.datasets.schemas.tables import TableSource
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+class ReadOnlyTableSelector(QueryProcessor):
+    """
+    Replaces the
+    """
+
+    def __init__(self, table_to_replace: str, read_only_table: str) -> None:
+        self.__table_to_replace = table_to_replace
+        self.__read_only_table = read_only_table
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        readonly_enabled = state.get_config("enable_events_readonly_table", False)
+        if not readonly_enabled:
+            return
+
+        if request_settings.get_consistent():
+            return
+
+        data_source = query.get_data_source()
+
+        if data_source.format_from() != self.__table_to_replace:
+            return
+
+        new_source = TableSource(
+            table_name=self.__read_only_table,
+            columns=data_source.get_columns(),
+            mandatory_conditions=data_source.get_mandatory_conditions(),
+            prewhere_candidates=data_source.get_prewhere_candidates(),
+        )
+        query.set_data_source(new_source)

--- a/snuba/query/processors/readonly_events.py
+++ b/snuba/query/processors/readonly_events.py
@@ -8,7 +8,8 @@ from snuba.request.request_settings import RequestSettings
 class ReadOnlyTableSelector(QueryProcessor):
     """
     Replaces the data source in the query with a TableSource if the table
-    name of the original datasource is the one provided to the constructor.
+    name of the original datasource is the one provided to the constructor,
+    the query is not consistent, and this processor is enabled.
     """
 
     def __init__(self, table_to_replace: str, read_only_table: str) -> None:

--- a/snuba/query/processors/readonly_events.py
+++ b/snuba/query/processors/readonly_events.py
@@ -7,7 +7,8 @@ from snuba.request.request_settings import RequestSettings
 
 class ReadOnlyTableSelector(QueryProcessor):
     """
-    Replaces the
+    Replaces the data source in the query with a TableSource if the table
+    name of the original datasource is the one provided to the constructor.
     """
 
     def __init__(self, table_to_replace: str, read_only_table: str) -> None:

--- a/tests/query/processors/test_readonly.py
+++ b/tests/query/processors/test_readonly.py
@@ -1,0 +1,40 @@
+import pytest
+
+from snuba import state
+from snuba.clickhouse.columns import ColumnSet, String
+from snuba.datasets.schemas.tables import TableSource
+from snuba.query.processors.readonly_events import ReadOnlyTableSelector
+from snuba.query.query import Query
+from snuba.request.request_settings import HTTPRequestSettings
+
+test_data = [
+    ("sentry_dist", True, "sentry_dist"),
+    ("sentry_dist", False, "sentry_ro"),
+    ("bla", False, "bla"),
+]
+
+
+@pytest.mark.parametrize("initial_table, consistent, expected_table", test_data)
+def test_prewhere(initial_table, consistent, expected_table) -> None:
+    state.set_config("enable_events_readonly_table", True)
+    body = {
+        "conditions": [
+            ["d", "=", "1"],
+            ["c", "=", "3"],
+            ["a", "=", "1"],
+            ["b", "=", "2"],
+        ],
+    }
+    cols = ColumnSet([("col", String())])
+    query = Query(body, TableSource(initial_table, cols, [["time", "=", "1"]], ["c1"]),)
+
+    request_settings = HTTPRequestSettings(consistent=consistent)
+    processor = ReadOnlyTableSelector("sentry_dist", "sentry_ro")
+    processor.process_query(query, request_settings)
+
+    source = query.get_data_source()
+    assert isinstance(source, TableSource)
+    assert source.format_from() == expected_table
+    assert source.get_columns() == cols
+    assert source.get_prewhere_candidates() == ["c1"]
+    assert source.get_mandatory_conditions() == [["time", "=", "1"]]


### PR DESCRIPTION
This is the quickest possible way to test using a dedicated table for non consistent queries on Clickhouse.
It just replaces the table storage in the query in place if needed. If the test is successful we will register the read only table as a proper schema in the datasets, otherwise we will revert.