### PR TITLE
ref(reader): Improve abstractions around column transformation

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -1,14 +1,17 @@
 import logging
 import queue
 import time
-from typing import Iterable, Mapping, Optional
+from datetime import date, datetime
+from typing import Callable, Iterable, Mapping, Optional, TypeVar
+from uuid import UUID
 
 from clickhouse_driver import Client, errors
+from dateutil.tz import tz
 
 from snuba import settings
 from snuba.clickhouse.columns import Array
 from snuba.clickhouse.query import ClickhouseQuery
-from snuba.reader import Reader, Result, transform_columns
+from snuba.reader import Reader, Result, build_result_transformer
 from snuba.writer import BatchWriter, WriterTableRow
 
 
@@ -127,6 +130,57 @@ class ClickhousePool(object):
             pass
 
 
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+def transform_nullable(
+    function: Callable[[T], R]
+) -> Callable[[Optional[T]], Optional[R]]:
+    def transform_column(value: Optional[T]) -> Optional[R]:
+        if value is None:
+            return value
+        else:
+            return function(value)
+
+    return transform_column
+
+
+def transform_date(value: date) -> str:
+    """
+    Convert a timezone-naive date object into an ISO 8601 formatted date and
+    time string respresentation.
+    """
+    return datetime(*value.timetuple()[:6]).replace(tzinfo=tz.tzutc()).isoformat()
+
+
+def transform_datetime(value: datetime) -> str:
+    """
+    Convert a timezone-naive datetime object into an ISO 8601 formatted date
+    and time string representation.
+    """
+    return value.replace(tzinfo=tz.tzutc()).isoformat()
+
+
+def transform_uuid(value: UUID) -> str:
+    """
+    Convert a UUID object into a string representation.
+    """
+    return str(value)
+
+
+transform_result = build_result_transformer(
+    {
+        "Date": transform_date,
+        "Nullable(Date)": transform_nullable(transform_date),
+        "DateTime": transform_datetime,
+        "Nullable(DateTime)": transform_nullable(transform_datetime),
+        "UUID": transform_uuid,
+        "Nullable(UUID)": transform_nullable(transform_uuid),
+    }
+)
+
+
 class NativeDriverReader(Reader[ClickhouseQuery]):
     def __init__(self, client: ClickhousePool) -> None:
         self.__client = client
@@ -148,7 +202,9 @@ class NativeDriverReader(Reader[ClickhouseQuery]):
         else:
             result = {"data": data, "meta": meta}
 
-        return transform_columns(result)
+        transform_result(result)
+
+        return result
 
     def execute(
         self,

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -169,7 +169,7 @@ def transform_uuid(value: UUID) -> str:
     return str(value)
 
 
-transform_result = build_result_transformer(
+transform_column_types = build_result_transformer(
     {
         "Date": transform_date,
         "Nullable(Date)": transform_nullable(transform_date),
@@ -213,7 +213,7 @@ class NativeDriverReader(Reader[ClickhouseQuery]):
         else:
             result = {"data": data, "meta": meta}
 
-        transform_result(result)
+        transform_column_types(result)
 
         return result
 


### PR DESCRIPTION
This transformation logic is going to need to be shared between the native reader and the HTTP reader, but the actual transformation logic for these types will be different since the native reader is dealing with Python objects, and the HTTP reader will be dealing with strings. This splits the transformation functions themselves from the code that manages the result mutation.
