### PR TITLE
ref(reader): Remove duplicate columns from result

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1228,7 +1228,7 @@ class TestApi(BaseApiTest):
             "granularity": 3600,
         }
         result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
-        assert "error" not in result
+        assert result["meta"] == [{"name": "timestamp", "type": "DateTime"}]
 
     def test_test_endpoints(self):
         project_id = 73


### PR DESCRIPTION
As noted in [this comment thread](https://github.com/getsentry/snuba/pull/800#discussion_r386654402), column names or aliases can be listed multiple times in `result.meta`.

However, since each row is returned as a mapping of name to value, columns that share names or aliases will only appear once per row. Including the result set column definition in the response multiple times can lead to confusing behavior for both internal and external users (see #596, #800.)

This change, while not a total fix, makes the behavior consistent between `meta` (columns) and `data` (rows) so that the lengths of the two data structures are equal in all cases and no columns are duplicated.

Alternative solutions for future work could include one of:

1. rejecting queries that have duplicate names
2. discarding duplicate names before running the query (this can be done safely as the query language and result set format do not preserve ordering)
3. converting the result set row format from maps to sequences to preserve ordering between the column definitions (`meta[i]`) and column values (`data[i]`) (…and if the user zips column names and values back into a map, that's their problem)