### PR TITLE
Revert "ref(reader): Improve abstractions around column transformation (#800)"

### DIFF
--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 import itertools
+import re
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Generic,
-    Iterator,
     Mapping,
     MutableMapping,
     Optional,
     Sequence,
     TypeVar,
 )
+
+from dateutil.tz import tz
+
 
 if TYPE_CHECKING:
     from mypy_extensions import TypedDict
@@ -27,36 +30,6 @@ if TYPE_CHECKING:
     )
 else:
     Result = MutableMapping[str, Any]
-
-
-def iterate_rows(result: Result) -> Iterator[Row]:
-    if "totals" in result:
-        return itertools.chain(result["data"], [result["totals"]])
-    else:
-        return iter(result["data"])
-
-
-def build_result_transformer(
-    column_transformations: Mapping[str, Callable[[Any], Any]],
-) -> Callable[[Result], None]:
-    """
-    Builds and returns a function that can be used to mutate a ``Result``
-    instance in-place by transforming all values for columns that have a
-    transformation function specified for their data type.
-    """
-
-    def transform_result(result: Result) -> None:
-        for column in result["meta"]:
-            transformer = column_transformations.get(column["type"])
-            if transformer is None:
-                continue
-
-            name = column["name"]
-            for row in iterate_rows(result):
-                row[name] = transformer(row[name])
-
-    return transform_result
-
 
 TQuery = TypeVar("TQuery")
 
@@ -72,3 +45,48 @@ class Reader(ABC, Generic[TQuery]):
     ) -> Result:
         """Execute a query."""
         raise NotImplementedError
+
+
+DATE_TYPE_RE = re.compile(r"(Nullable\()?Date\b")
+DATETIME_TYPE_RE = re.compile(r"(Nullable\()?DateTime\b")
+
+UUID_TYPE_RE = re.compile(r"(Nullable\()?UUID\b")
+
+
+def transform_columns(result: Result) -> Result:
+    """
+    Converts Clickhouse results into formatted strings. Specifically:
+    - timezone-naive date and datetime values returned by ClickHouse
+       into ISO 8601 formatted strings (including the UTC offset.)
+    - UUID objects into strings
+    """
+
+    def iterate_rows():
+        if "totals" in result:
+            return itertools.chain(result["data"], [result["totals"]])
+        else:
+            return iter(result["data"])
+
+    columns = {col["name"]: col["type"] for col in result["meta"]}
+    for col_name, col_type in columns.items():
+        if DATETIME_TYPE_RE.match(col_type):
+            for row in iterate_rows():
+                if (
+                    row[col_name] is not None
+                ):  # The column value can be null/None at times.
+                    row[col_name] = row[col_name].replace(tzinfo=tz.tzutc()).isoformat()
+        elif DATE_TYPE_RE.match(col_type):
+            for row in iterate_rows():
+                if (
+                    row[col_name] is not None
+                ):  # The column value can be null/None at times.
+                    row[col_name] = (
+                        datetime(*(row[col_name].timetuple()[:6]))
+                        .replace(tzinfo=tz.tzutc())
+                        .isoformat()
+                    )
+        elif UUID_TYPE_RE.match(col_type):
+            for row in iterate_rows():
+                row[col_name] = str(row[col_name])
+
+    return result


### PR DESCRIPTION
ClickHouse sometimes returns `DateTime` objects (and possibly `Date`) objects with timezone parameters. I have not been able to track down when or why this happens — it happens for me in some tests but not others, so there should be some kind of pattern to it. (I assume it has something to do with the way the DDL is applied, but I have not verified this.)

The presence of the timezone in the column type causes the type transformer not to be used (and it is now apparent to me why [these patterns](https://github.com/getsentry/snuba/blob/356af728b4036567cb483111c8ca47d1b70d7e5a/snuba/reader.py#L50-L51) were structured as they were, tracing their lineage all the way back to #76 which changed but did not test this behavior.)

The existing tests did not fail, since [this function on the web query path](https://github.com/getsentry/snuba/blob/ec59f9c89ca84d9bda65e79111a3abe6b8d24eb2/snuba/web/views.py#L304-L309) acts as a safety rail if any types make it through the remainder of the execution pipeline without being properly encoded. This function is never actually hit in production, since [the `cache.set` call during query execution](https://github.com/getsentry/snuba/blob/ec59f9c89ca84d9bda65e79111a3abe6b8d24eb2/snuba/web/query.py#L172-L173) will throw if any values are not serializable. This cache is not enabled in tests.

I still think the fundamental approach of this original PR (#800) is a good one, but it will take some time to fix, and the tests should also be made more robust before attempting that change again.

This reverts commit ec59f9c89ca84d9bda65e79111a3abe6b8d24eb2.