### PR TITLE
fix(tests): Fix slow tests caused by infinite recursion during Mock serialization

### DIFF
--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
-from unittest.mock import Mock
 
 from snuba.subscriptions.data import SubscriptionData
 from snuba.web.query import parse_and_run_query
+from snuba.utils.metrics.timer import Timer
 from tests.subscriptions import BaseSubscriptionTest
 
 
@@ -15,8 +15,9 @@ class TestBuildRequest(BaseSubscriptionTest):
             time_window=timedelta(minutes=500),
             resolution=timedelta(minutes=1),
         )
+        timer = Timer("test")
         request = subscription.build_request(
-            self.dataset, datetime.utcnow(), 100, Mock()
+            self.dataset, datetime.utcnow(), 100, timer,
         )
-        result = parse_and_run_query(self.dataset, request, Mock())
+        result = parse_and_run_query(self.dataset, request, timer)
         assert result.result["data"][0]["count"] == 10


### PR DESCRIPTION
#807 turned on `RECORD_QUERIES` during tests, which caused a `RecursionError` when serializing the query metadata — which includes the `Timer`, which in the case of these tests was not a timer, but a `Mock`. These tests did not fail (they instead became very slow) since the block where the serialization occurred is in a `try`/`except` block.

Another reason to avoid using `Mock` objects.