### PR TITLE
chore: Ignore `.venv` files as well as directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,6 @@ conftest.py
 .coverage
 .mypy_cache/
 .pytest_cache/
-.venv/
+.venv
 htmlcov/
 snuba.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 .coverage
 .mypy_cache/
 .pytest_cache/
-.venv/
+.venv
 htmlcov/
 snuba.egg-info/


### PR DESCRIPTION
This allows `.venv` to be a symlink on the local filesystem rather than requiring it to be an actual directory. This is required due to the changes to `.vscode/settings.json` in #770.