### PR TITLE
fix(subscriptions): Gracefully handle non-monotonic clock movement in `TickConsumer`

### DIFF
--- a/snuba/utils/clock.py
+++ b/snuba/utils/clock.py
@@ -34,8 +34,8 @@ class TestingClock(Clock):
     the time, use the ``sleep`` method.
     """
 
-    def __init__(self) -> None:
-        self.__time = 0.0
+    def __init__(self, epoch: float = 0.0) -> None:
+        self.__time = epoch
 
     def time(self) -> float:
         return self.__time

--- a/snuba/utils/streams/types.py
+++ b/snuba/utils/streams/types.py
@@ -39,5 +39,10 @@ class Message(Generic[TPayload]):
     payload: TPayload
     timestamp: datetime
 
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(partition={self.partition}, offset={self.offset})"
+        )
+
     def get_next_offset(self) -> int:
         return self.offset + 1

--- a/snuba/utils/types.py
+++ b/snuba/utils/types.py
@@ -52,9 +52,16 @@ T = TypeVar("T", bound=Comparable[Any])
 
 
 @dataclass(frozen=True)
+class InvalidRangeError(ValueError, Generic[T]):
+    lower: T
+    upper: T
+
+
+@dataclass(frozen=True)
 class Interval(Generic[T]):
     lower: T
     upper: T
 
     def __post_init__(self) -> None:
-        assert self.upper >= self.lower
+        if not self.upper >= self.lower:
+            raise InvalidRangeError(self.lower, self.upper)

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -1,10 +1,14 @@
 import pytest
 
-from snuba.utils.types import Interval
+from snuba.utils.types import Interval, InvalidRangeError
 
 
 def test_interval_validation() -> None:
     Interval(1, 1)
     Interval(1, 10)
-    with pytest.raises(AssertionError):
+
+    with pytest.raises(InvalidRangeError) as e:
         Interval(10, 1)
+
+    assert e.value.lower == 10
+    assert e.value.upper == 1


### PR DESCRIPTION
This changes the behavior of the tick consumer to ignore messages that would otherwise be exposed as non-monotonic clock movement. This can happen when a broker clock is adjusted non-monotonically, or when a partition primary changes from one broker to another broker with significant clock drift between the two. The discarded messages are not exposed via `poll` or via `tell` so they should appear as gaps in the consumption stream (as if they never occurred at all, or were deleted via log compaction) and consequently they should never be committed.

The potential drawback with this approach is that if it takes a large number of messages to reach the previous high watermark timestamp after a clock adjustment, none of those messages will be committed to preserve the ordering invariant. If the consumer crashes or the consumer group is rebalanced before it reaches the previous high watermark position, all of those messages will have to be processed again by the next consumer since none of them will have been able to be committed.

This also adds a clock to  the `DummyBroker` for testing purposes, an `InvalidRangeError` exception for identifying this case when constructing intervals, and changes the `__repr__` of the `Message` object for more useful logging.