### PR TITLE
feat(datasets) Extract Storage classes from Dataset for reuse

### DIFF
--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,37 +1,15 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
-
 from snuba.datasets.cdc import CdcDataset
-from snuba.datasets.dataset_schemas import StorageSchemas
-from snuba.datasets.cdc.groupedmessage_processor import (
-    GroupedMessageProcessor,
-    GroupedMessageRow,
+from snuba.datasets.storages.groupedmessages import (
+    POSTGRES_TABLE,
+    schema,
+    storage,
 )
-from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.plans.single_table import SingleTableQueryPlanBuilder
-from snuba.datasets.storage import TableStorage
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.query_processor import QueryProcessor
-from snuba.snapshots.loaders.single_table import SingleTableBulkLoader
-
-
-class GroupedMessageTableWriter(TableWriter):
-    def __init__(
-        self, postgres_table: str, **kwargs,
-    ):
-        super().__init__(**kwargs)
-        self.__postgres_table = postgres_table
-
-    def get_bulk_loader(self, source, dest_table):
-        return SingleTableBulkLoader(
-            source=source,
-            source_table=self.__postgres_table,
-            dest_table=dest_table,
-            row_processor=lambda row: GroupedMessageRow.from_bulk(row).to_clickhouse(),
-        )
 
 
 class GroupedMessageDataset(CdcDataset):
@@ -40,54 +18,7 @@ class GroupedMessageDataset(CdcDataset):
     to replace such a table in event search.
     """
 
-    POSTGRES_TABLE = "sentry_groupedmessage"
-
     def __init__(self) -> None:
-        columns = ColumnSet(
-            [
-                # columns to maintain the dataset
-                # Kafka topic offset
-                ("offset", UInt(64)),
-                # GroupStatus in Sentry does not have a 'DELETED' state that reflects the deletion
-                # of the record. Having a dedicated clickhouse-only flag to identify this case seems
-                # more consistent than add an additional value into the status field below that does not
-                # exists on the Sentry side.
-                ("record_deleted", UInt(8)),
-                # PG columns
-                ("project_id", UInt(64)),
-                ("id", UInt(64)),
-                ("status", Nullable(UInt(8))),
-                ("last_seen", Nullable(DateTime())),
-                ("first_seen", Nullable(DateTime())),
-                ("active_at", Nullable(DateTime())),
-                ("first_release_id", Nullable(UInt(64))),
-            ]
-        )
-
-        schema = ReplacingMergeTreeSchema(
-            columns=columns,
-            local_table_name="groupedmessage_local",
-            dist_table_name="groupedmessage_dist",
-            mandatory_conditions=[("record_deleted", "=", 0)],
-            prewhere_candidates=["project_id", "id"],
-            order_by="(project_id, id)",
-            partition_by=None,
-            version_column="offset",
-            sample_expr="id",
-        )
-
-        storage = TableStorage(
-            schemas=StorageSchemas(read_schema=schema, write_schema=schema),
-            table_writer=GroupedMessageTableWriter(
-                write_schema=schema,
-                stream_loader=KafkaStreamLoader(
-                    processor=GroupedMessageProcessor(self.POSTGRES_TABLE),
-                    default_topic="cdc",
-                ),
-                postgres_table=self.POSTGRES_TABLE,
-            ),
-            query_processors=[],
-        )
 
         super().__init__(
             storages=[storage],
@@ -97,7 +28,7 @@ class GroupedMessageDataset(CdcDataset):
             abstract_column_set=schema.get_columns(),
             writable_storage=storage,
             default_control_topic="cdc_control",
-            postgres_table=self.POSTGRES_TABLE,
+            postgres_table=POSTGRES_TABLE,
         )
 
     def get_prewhere_keys(self) -> Sequence[str]:

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,12 +1,12 @@
 from typing import Sequence
 
 from snuba.datasets.cdc import CdcDataset
+from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.groupedmessages import (
     POSTGRES_TABLE,
     schema,
     storage,
 )
-from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.query_processor import QueryProcessor
 

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -199,17 +199,15 @@ class DiscoverDataset(TimeSeriesDataset):
             ]
         )
 
-        storage_selector = DiscoverQueryStorageSelector(
-            events_table=events_storage,
-            abstract_events_columns=self.__events_columns,
-            transactions_table=transactions_storage,
-            abstract_transactions_columns=self.__transactions_columns,
-        )
-
         super().__init__(
             storages=[events_storage, transactions_storage],
             query_plan_builder=SelectedStorageQueryPlanBuilder(
-                selector=storage_selector,
+                selector=DiscoverQueryStorageSelector(
+                    events_table=events_storage,
+                    abstract_events_columns=self.__events_columns,
+                    transactions_table=transactions_storage,
+                    abstract_transactions_columns=self.__transactions_columns,
+                ),
             ),
             abstract_column_set=(
                 self.__common_columns

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,27 +1,24 @@
 from datetime import timedelta
 from typing import FrozenSet, Mapping, Sequence, Union
 
-from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.events import (
     all_columns,
-    metadata_columns,
-    promoted_tag_columns,
-    promoted_context_tag_columns,
     promoted_context_columns,
-    required_columns,
+    promoted_context_tag_columns,
+    promoted_tag_columns,
     schema,
     storage,
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
+from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
+from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
-from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.util import qualified_column
 
 
@@ -32,12 +29,6 @@ class EventsDataset(TimeSeriesDataset):
     """
 
     def __init__(self) -> None:
-
-        self.__metadata_columns = metadata_columns
-        self.__promoted_tag_columns = promoted_tag_columns
-        self.__promoted_context_tag_columns = promoted_context_tag_columns
-        self.__promoted_context_columns = promoted_context_columns
-        self.__required_columns = required_columns
 
         super(EventsDataset, self).__init__(
             storages=[storage],
@@ -86,38 +77,20 @@ class EventsDataset(TimeSeriesDataset):
         else:
             return super().column_expr(column_name, query, parsing_context, table_alias)
 
-    def get_promoted_tag_columns(self) -> ColumnSet:
-        return self.__promoted_tag_columns
-
-    def _get_promoted_context_tag_columns(self) -> ColumnSet:
-        return self.__promoted_context_tag_columns
-
-    def _get_promoted_context_columns(self) -> ColumnSet:
-        return self.__promoted_context_columns
-
-    def get_required_columns(self) -> ColumnSet:
-        return self.__required_columns
-
     def _get_promoted_columns(self) -> Mapping[str, FrozenSet[str]]:
         # The set of columns, and associated keys that have been promoted
         # to the top level table namespace.
         return {
             "tags": frozenset(
                 col.flattened
-                for col in (
-                    self.get_promoted_tag_columns()
-                    + self._get_promoted_context_tag_columns()
-                )
+                for col in (promoted_tag_columns + promoted_context_tag_columns)
             ),
-            "contexts": frozenset(
-                col.flattened for col in self._get_promoted_context_columns()
-            ),
+            "contexts": frozenset(col.flattened for col in promoted_context_columns),
         }
 
     def _get_column_tag_map(self) -> Mapping[str, Mapping[str, str]]:
         # For every applicable promoted column,  a map of translations from the column
         # name  we save in the database to the tag we receive in the query.
-        promoted_context_tag_columns = self._get_promoted_context_tag_columns()
 
         return {
             "tags": {
@@ -125,24 +98,6 @@ class EventsDataset(TimeSeriesDataset):
                 for col in promoted_context_tag_columns
             },
             "contexts": {},
-        }
-
-    def get_tag_column_map(self) -> Mapping[str, Mapping[str, str]]:
-        # And a reverse map from the tags the client expects to the database columns
-        return {
-            col: dict(map(reversed, trans.items()))
-            for col, trans in self._get_column_tag_map().items()
-        }
-
-    def get_promoted_tags(self) -> Mapping[str, Sequence[str]]:
-        # The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
-        # and they can/will use a promoted column.
-        return {
-            col: [
-                self._get_column_tag_map()[col].get(x, x)
-                for x in self._get_promoted_columns()[col]
-            ]
-            for col in self._get_promoted_columns()
         }
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,32 +1,22 @@
 from datetime import timedelta
 from typing import FrozenSet, Mapping, Sequence, Union
 
-from snuba.clickhouse.columns import (
-    Array,
-    ColumnSet,
-    DateTime,
-    FixedString,
-    Float,
-    Nested,
-    Nullable,
-    String,
-    UInt,
-)
+from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
-from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.plans.single_table import SingleTableQueryPlanBuilder
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
-from snuba.datasets.errors_replacer import ErrorsReplacer, ReplacerState
-from snuba.datasets.events_processor import EventsProcessor
-from snuba.datasets.storage import TableStorage
-from snuba.datasets.schemas.tables import (
-    MigrationSchemaColumn,
-    ReplacingMergeTreeSchema,
+from snuba.datasets.storages.events import (
+    all_columns,
+    metadata_columns,
+    promoted_tag_columns,
+    promoted_context_tag_columns,
+    promoted_context_columns,
+    required_columns,
+    schema,
+    storage,
 )
 from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.processors.readonly_events import ReadOnlyTableSelector
 from snuba.query.query import Query
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
@@ -36,60 +26,6 @@ from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsPro
 from snuba.util import qualified_column
 
 
-def events_migrations(
-    clickhouse_table: str, current_schema: Mapping[str, MigrationSchemaColumn]
-) -> Sequence[str]:
-    # Add/remove known migrations
-    ret = []
-    if "group_id" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN group_id UInt64 DEFAULT 0" % clickhouse_table
-        )
-
-    if "device_model" in current_schema:
-        ret.append("ALTER TABLE %s DROP COLUMN device_model" % clickhouse_table)
-
-    if "sdk_integrations" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN sdk_integrations Array(String)"
-            % clickhouse_table
-        )
-
-    if "modules.name" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN modules Nested(name String, version String)"
-            % clickhouse_table
-        )
-
-    if "culprit" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN culprit Nullable(String)" % clickhouse_table
-        )
-
-    if "search_message" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN search_message Nullable(String)"
-            % clickhouse_table
-        )
-
-    if "title" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN title Nullable(String)" % clickhouse_table
-        )
-
-    if "location" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN location Nullable(String)" % clickhouse_table
-        )
-
-    if "_tags_flattened" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN _tags_flattened String DEFAULT '' AFTER tags"
-        )
-
-    return ret
-
-
 class EventsDataset(TimeSeriesDataset):
     """
     Represents the collection of classic sentry "error" type events
@@ -97,175 +33,6 @@ class EventsDataset(TimeSeriesDataset):
     """
 
     def __init__(self) -> None:
-        metadata_columns = ColumnSet(
-            [
-                # optional stream related data
-                ("offset", Nullable(UInt(64))),
-                ("partition", Nullable(UInt(16))),
-            ]
-        )
-
-        promoted_tag_columns = ColumnSet(
-            [
-                # These are the classic tags, they are saved in Snuba exactly as they
-                # appear in the event body.
-                ("level", Nullable(String())),
-                ("logger", Nullable(String())),
-                ("server_name", Nullable(String())),  # future name: device_id?
-                ("transaction", Nullable(String())),
-                ("environment", Nullable(String())),
-                ("sentry:release", Nullable(String())),
-                ("sentry:dist", Nullable(String())),
-                ("sentry:user", Nullable(String())),
-                ("site", Nullable(String())),
-                ("url", Nullable(String())),
-            ]
-        )
-
-        promoted_context_tag_columns = ColumnSet(
-            [
-                # These are promoted tags that come in in `tags`, but are more closely
-                # related to contexts.  To avoid naming confusion with Clickhouse nested
-                # columns, they are stored in the database with s/./_/
-                # promoted tags
-                ("app_device", Nullable(String())),
-                ("device", Nullable(String())),
-                ("device_family", Nullable(String())),
-                ("runtime", Nullable(String())),
-                ("runtime_name", Nullable(String())),
-                ("browser", Nullable(String())),
-                ("browser_name", Nullable(String())),
-                ("os", Nullable(String())),
-                ("os_name", Nullable(String())),
-                ("os_rooted", Nullable(UInt(8))),
-            ]
-        )
-
-        promoted_context_columns = ColumnSet(
-            [
-                ("os_build", Nullable(String())),
-                ("os_kernel_version", Nullable(String())),
-                ("device_name", Nullable(String())),
-                ("device_brand", Nullable(String())),
-                ("device_locale", Nullable(String())),
-                ("device_uuid", Nullable(String())),
-                ("device_model_id", Nullable(String())),
-                ("device_arch", Nullable(String())),
-                ("device_battery_level", Nullable(Float(32))),
-                ("device_orientation", Nullable(String())),
-                ("device_simulator", Nullable(UInt(8))),
-                ("device_online", Nullable(UInt(8))),
-                ("device_charging", Nullable(UInt(8))),
-            ]
-        )
-
-        required_columns = ColumnSet(
-            [
-                ("event_id", FixedString(32)),
-                ("project_id", UInt(64)),
-                ("group_id", UInt(64)),
-                ("timestamp", DateTime()),
-                ("deleted", UInt(8)),
-                ("retention_days", UInt(16)),
-            ]
-        )
-
-        all_columns = (
-            required_columns
-            + [
-                # required for non-deleted
-                ("platform", Nullable(String())),
-                ("message", Nullable(String())),
-                ("primary_hash", Nullable(FixedString(32))),
-                ("received", Nullable(DateTime())),
-                ("search_message", Nullable(String())),
-                ("title", Nullable(String())),
-                ("location", Nullable(String())),
-                # optional user
-                ("user_id", Nullable(String())),
-                ("username", Nullable(String())),
-                ("email", Nullable(String())),
-                ("ip_address", Nullable(String())),
-                # optional geo
-                ("geo_country_code", Nullable(String())),
-                ("geo_region", Nullable(String())),
-                ("geo_city", Nullable(String())),
-                ("sdk_name", Nullable(String())),
-                ("sdk_version", Nullable(String())),
-                ("type", Nullable(String())),
-                ("version", Nullable(String())),
-            ]
-            + metadata_columns
-            + promoted_context_columns
-            + promoted_tag_columns
-            + promoted_context_tag_columns
-            + [
-                # other tags
-                ("tags", Nested([("key", String()), ("value", String())])),
-                ("_tags_flattened", String()),
-                # other context
-                ("contexts", Nested([("key", String()), ("value", String())])),
-                # http interface
-                ("http_method", Nullable(String())),
-                ("http_referer", Nullable(String())),
-                # exception interface
-                (
-                    "exception_stacks",
-                    Nested(
-                        [
-                            ("type", Nullable(String())),
-                            ("value", Nullable(String())),
-                            ("mechanism_type", Nullable(String())),
-                            ("mechanism_handled", Nullable(UInt(8))),
-                        ]
-                    ),
-                ),
-                (
-                    "exception_frames",
-                    Nested(
-                        [
-                            ("abs_path", Nullable(String())),
-                            ("filename", Nullable(String())),
-                            ("package", Nullable(String())),
-                            ("module", Nullable(String())),
-                            ("function", Nullable(String())),
-                            ("in_app", Nullable(UInt(8))),
-                            ("colno", Nullable(UInt(32))),
-                            ("lineno", Nullable(UInt(32))),
-                            ("stack_level", UInt(16)),
-                        ]
-                    ),
-                ),
-                # These are columns we added later in the life of the (current) production
-                # database. They don't necessarily belong here in a logical/readability sense
-                # but they are here to match the order of columns in production becase
-                # `insert_distributed_sync` is very sensitive to column existence and ordering.
-                ("culprit", Nullable(String())),
-                ("sdk_integrations", Array(String())),
-                ("modules", Nested([("name", String()), ("version", String())])),
-            ]
-        )
-
-        sample_expr = "cityHash64(toString(event_id))"
-        schema = ReplacingMergeTreeSchema(
-            columns=all_columns,
-            local_table_name="sentry_local",
-            dist_table_name="sentry_dist",
-            mandatory_conditions=[("deleted", "=", 0)],
-            prewhere_candidates=[
-                "event_id",
-                "group_id",
-                "tags[sentry:release]",
-                "message",
-                "environment",
-                "project_id",
-            ],
-            order_by="(project_id, toStartOfDay(timestamp), %s)" % sample_expr,
-            partition_by="(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))",
-            version_column="deleted",
-            sample_expr=sample_expr,
-            migration_function=events_migrations,
-        )
 
         self.__metadata_columns = metadata_columns
         self.__promoted_tag_columns = promoted_tag_columns
@@ -273,39 +40,13 @@ class EventsDataset(TimeSeriesDataset):
         self.__promoted_context_columns = promoted_context_columns
         self.__required_columns = required_columns
 
-        self.__storage = TableStorage(
-            schemas=StorageSchemas(read_schema=schema, write_schema=schema),
-            table_writer=TableWriter(
-                write_schema=schema,
-                stream_loader=KafkaStreamLoader(
-                    processor=EventsProcessor(promoted_tag_columns),
-                    default_topic="events",
-                    replacement_topic="event-replacements",
-                    commit_log_topic="snuba-commit-log",
-                ),
-                replacer_processor=ErrorsReplacer(
-                    write_schema=schema,
-                    read_schema=schema,
-                    required_columns=[col.escaped for col in required_columns],
-                    tag_column_map=self.get_tag_column_map(),
-                    promoted_tags=self.get_promoted_tags(),
-                    state_name=ReplacerState.EVENTS,
-                ),
-            ),
-            query_processors=[
-                # TODO: This one should become an entirely separate storage and picked
-                # in the storage selector.
-                ReadOnlyTableSelector("sentry_dist", "sentry_dist_ro"),
-            ],
-        )
-
         super(EventsDataset, self).__init__(
-            storages=[self.__storage],
+            storages=[storage],
             query_plan_builder=SingleTableQueryPlanBuilder(
-                storage=self.__storage, post_processors=[PrewhereProcessor()],
+                storage=storage, post_processors=[PrewhereProcessor()],
             ),
             abstract_column_set=schema.get_columns(),
-            writable_storage=self.__storage,
+            writable_storage=storage,
             time_group_columns={"time": "timestamp", "rtime": "received"},
             time_parse_columns=("timestamp", "received"),
         )
@@ -315,9 +56,6 @@ class EventsDataset(TimeSeriesDataset):
             promoted_columns=self._get_promoted_columns(),
             column_tag_map=self._get_column_tag_map(),
         )
-
-    def get_storage(self) -> TableStorage:
-        return self.__storage
 
     def get_split_query_spec(self) -> Union[None, ColumnSplitSpec]:
         return ColumnSplitSpec(

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -5,8 +5,8 @@ from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.events import (
     all_columns,
-    get_promoted_columns,
     get_column_tag_map,
+    get_promoted_columns,
     schema,
     storage,
 )

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -4,6 +4,8 @@ from typing import Mapping, Optional, Sequence, Union
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.factory import get_dataset
+from snuba.datasets.storages.events import storage as events_storage
+from snuba.datasets.storages.groupedmessages import storage as groupedmessages_storage
 from snuba.datasets.schemas.join import (
     JoinConditionExpression,
     JoinCondition,
@@ -58,19 +60,11 @@ class Groups(TimeSeriesDataset):
     def __init__(self) -> None:
         self.__grouped_message = get_dataset("groupedmessage")
         groupedmessage_source = (
-            self.__grouped_message.get_all_storages()[0]
-            .get_schemas()
-            .get_read_schema()
-            .get_data_source()
+            groupedmessages_storage.get_schemas().get_read_schema().get_data_source()
         )
 
         self.__events = get_dataset("events")
-        events_source = (
-            self.__events.get_all_storages()[0]
-            .get_schemas()
-            .get_read_schema()
-            .get_data_source()
-        )
+        events_source = events_storage.get_schemas().get_read_schema().get_data_source()
 
         join_structure = JoinClause(
             left_node=TableJoinNode(

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -1,0 +1,319 @@
+from typing import FrozenSet, Mapping, Sequence
+
+from snuba.clickhouse.columns import (
+    Array,
+    ColumnSet,
+    DateTime,
+    FixedString,
+    Float,
+    Nested,
+    Nullable,
+    String,
+    UInt,
+)
+from snuba.datasets.dataset_schemas import StorageSchemas
+from snuba.datasets.errors_replacer import ErrorsReplacer, ReplacerState
+from snuba.datasets.events_processor import EventsProcessor
+from snuba.datasets.schemas.tables import (
+    MigrationSchemaColumn,
+    ReplacingMergeTreeSchema,
+)
+from snuba.datasets.storage import TableStorage
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.query.processors.readonly_events import ReadOnlyTableSelector
+
+
+def events_migrations(
+    clickhouse_table: str, current_schema: Mapping[str, MigrationSchemaColumn]
+) -> Sequence[str]:
+    # Add/remove known migrations
+    ret = []
+    if "group_id" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN group_id UInt64 DEFAULT 0" % clickhouse_table
+        )
+
+    if "device_model" in current_schema:
+        ret.append("ALTER TABLE %s DROP COLUMN device_model" % clickhouse_table)
+
+    if "sdk_integrations" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN sdk_integrations Array(String)"
+            % clickhouse_table
+        )
+
+    if "modules.name" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN modules Nested(name String, version String)"
+            % clickhouse_table
+        )
+
+    if "culprit" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN culprit Nullable(String)" % clickhouse_table
+        )
+
+    if "search_message" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN search_message Nullable(String)"
+            % clickhouse_table
+        )
+
+    if "title" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN title Nullable(String)" % clickhouse_table
+        )
+
+    if "location" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN location Nullable(String)" % clickhouse_table
+        )
+
+    if "_tags_flattened" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _tags_flattened String DEFAULT '' AFTER tags"
+        )
+
+    return ret
+
+
+metadata_columns = ColumnSet(
+    [
+        # optional stream related data
+        ("offset", Nullable(UInt(64))),
+        ("partition", Nullable(UInt(16))),
+    ]
+)
+
+promoted_tag_columns = ColumnSet(
+    [
+        # These are the classic tags, they are saved in Snuba exactly as they
+        # appear in the event body.
+        ("level", Nullable(String())),
+        ("logger", Nullable(String())),
+        ("server_name", Nullable(String())),  # future name: device_id?
+        ("transaction", Nullable(String())),
+        ("environment", Nullable(String())),
+        ("sentry:release", Nullable(String())),
+        ("sentry:dist", Nullable(String())),
+        ("sentry:user", Nullable(String())),
+        ("site", Nullable(String())),
+        ("url", Nullable(String())),
+    ]
+)
+
+promoted_context_tag_columns = ColumnSet(
+    [
+        # These are promoted tags that come in in `tags`, but are more closely
+        # related to contexts.  To avoid naming confusion with Clickhouse nested
+        # columns, they are stored in the database with s/./_/
+        # promoted tags
+        ("app_device", Nullable(String())),
+        ("device", Nullable(String())),
+        ("device_family", Nullable(String())),
+        ("runtime", Nullable(String())),
+        ("runtime_name", Nullable(String())),
+        ("browser", Nullable(String())),
+        ("browser_name", Nullable(String())),
+        ("os", Nullable(String())),
+        ("os_name", Nullable(String())),
+        ("os_rooted", Nullable(UInt(8))),
+    ]
+)
+
+promoted_context_columns = ColumnSet(
+    [
+        ("os_build", Nullable(String())),
+        ("os_kernel_version", Nullable(String())),
+        ("device_name", Nullable(String())),
+        ("device_brand", Nullable(String())),
+        ("device_locale", Nullable(String())),
+        ("device_uuid", Nullable(String())),
+        ("device_model_id", Nullable(String())),
+        ("device_arch", Nullable(String())),
+        ("device_battery_level", Nullable(Float(32))),
+        ("device_orientation", Nullable(String())),
+        ("device_simulator", Nullable(UInt(8))),
+        ("device_online", Nullable(UInt(8))),
+        ("device_charging", Nullable(UInt(8))),
+    ]
+)
+
+required_columns = ColumnSet(
+    [
+        ("event_id", FixedString(32)),
+        ("project_id", UInt(64)),
+        ("group_id", UInt(64)),
+        ("timestamp", DateTime()),
+        ("deleted", UInt(8)),
+        ("retention_days", UInt(16)),
+    ]
+)
+
+all_columns = (
+    required_columns
+    + [
+        # required for non-deleted
+        ("platform", Nullable(String())),
+        ("message", Nullable(String())),
+        ("primary_hash", Nullable(FixedString(32))),
+        ("received", Nullable(DateTime())),
+        ("search_message", Nullable(String())),
+        ("title", Nullable(String())),
+        ("location", Nullable(String())),
+        # optional user
+        ("user_id", Nullable(String())),
+        ("username", Nullable(String())),
+        ("email", Nullable(String())),
+        ("ip_address", Nullable(String())),
+        # optional geo
+        ("geo_country_code", Nullable(String())),
+        ("geo_region", Nullable(String())),
+        ("geo_city", Nullable(String())),
+        ("sdk_name", Nullable(String())),
+        ("sdk_version", Nullable(String())),
+        ("type", Nullable(String())),
+        ("version", Nullable(String())),
+    ]
+    + metadata_columns
+    + promoted_context_columns
+    + promoted_tag_columns
+    + promoted_context_tag_columns
+    + [
+        # other tags
+        ("tags", Nested([("key", String()), ("value", String())])),
+        ("_tags_flattened", String()),
+        # other context
+        ("contexts", Nested([("key", String()), ("value", String())])),
+        # http interface
+        ("http_method", Nullable(String())),
+        ("http_referer", Nullable(String())),
+        # exception interface
+        (
+            "exception_stacks",
+            Nested(
+                [
+                    ("type", Nullable(String())),
+                    ("value", Nullable(String())),
+                    ("mechanism_type", Nullable(String())),
+                    ("mechanism_handled", Nullable(UInt(8))),
+                ]
+            ),
+        ),
+        (
+            "exception_frames",
+            Nested(
+                [
+                    ("abs_path", Nullable(String())),
+                    ("filename", Nullable(String())),
+                    ("package", Nullable(String())),
+                    ("module", Nullable(String())),
+                    ("function", Nullable(String())),
+                    ("in_app", Nullable(UInt(8))),
+                    ("colno", Nullable(UInt(32))),
+                    ("lineno", Nullable(UInt(32))),
+                    ("stack_level", UInt(16)),
+                ]
+            ),
+        ),
+        # These are columns we added later in the life of the (current) production
+        # database. They don't necessarily belong here in a logical/readability sense
+        # but they are here to match the order of columns in production becase
+        # `insert_distributed_sync` is very sensitive to column existence and ordering.
+        ("culprit", Nullable(String())),
+        ("sdk_integrations", Array(String())),
+        ("modules", Nested([("name", String()), ("version", String())])),
+    ]
+)
+
+sample_expr = "cityHash64(toString(event_id))"
+schema = ReplacingMergeTreeSchema(
+    columns=all_columns,
+    local_table_name="sentry_local",
+    dist_table_name="sentry_dist",
+    mandatory_conditions=[("deleted", "=", 0)],
+    prewhere_candidates=[
+        "event_id",
+        "group_id",
+        "tags[sentry:release]",
+        "message",
+        "environment",
+        "project_id",
+    ],
+    order_by="(project_id, toStartOfDay(timestamp), %s)" % sample_expr,
+    partition_by="(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))",
+    version_column="deleted",
+    sample_expr=sample_expr,
+    migration_function=events_migrations,
+)
+
+
+def _get_promoted_columns() -> Mapping[str, FrozenSet[str]]:
+    # The set of columns, and associated keys that have been promoted
+    # to the top level table namespace.
+    return {
+        "tags": frozenset(
+            col.flattened
+            for col in (promoted_tag_columns + promoted_context_tag_columns)
+        ),
+        "contexts": frozenset(col.flattened for col in promoted_context_columns),
+    }
+
+
+def _get_column_tag_map() -> Mapping[str, Mapping[str, str]]:
+    # For every applicable promoted column,  a map of translations from the column
+    # name  we save in the database to the tag we receive in the query.
+
+    return {
+        "tags": {
+            col.flattened: col.flattened.replace("_", ".")
+            for col in promoted_context_tag_columns
+        },
+        "contexts": {},
+    }
+
+
+def get_tag_column_map() -> Mapping[str, Mapping[str, str]]:
+    # And a reverse map from the tags the client expects to the database columns
+    return {
+        col: dict(map(reversed, trans.items()))
+        for col, trans in _get_column_tag_map().items()
+    }
+
+
+def get_promoted_tags() -> Mapping[str, Sequence[str]]:
+    # The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
+    # and they can/will use a promoted column.
+    return {
+        col: [
+            _get_column_tag_map()[col].get(x, x) for x in _get_promoted_columns()[col]
+        ]
+        for col in _get_promoted_columns()
+    }
+
+
+storage = TableStorage(
+    schemas=StorageSchemas(read_schema=schema, write_schema=schema),
+    table_writer=TableWriter(
+        write_schema=schema,
+        stream_loader=KafkaStreamLoader(
+            processor=EventsProcessor(promoted_tag_columns),
+            default_topic="events",
+            replacement_topic="event-replacements",
+            commit_log_topic="snuba-commit-log",
+        ),
+        replacer_processor=ErrorsReplacer(
+            write_schema=schema,
+            read_schema=schema,
+            required_columns=[col.escaped for col in required_columns],
+            tag_column_map=get_tag_column_map(),
+            promoted_tags=get_promoted_tags(),
+            state_name=ReplacerState.EVENTS,
+        ),
+    ),
+    query_processors=[
+        # TODO: This one should become an entirely separate storage and picked
+        # in the storage selector.
+        ReadOnlyTableSelector("sentry_dist", "sentry_dist_ro"),
+    ],
+)

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -247,7 +247,7 @@ schema = ReplacingMergeTreeSchema(
 )
 
 
-def _get_promoted_columns() -> Mapping[str, FrozenSet[str]]:
+def get_promoted_columns() -> Mapping[str, FrozenSet[str]]:
     # The set of columns, and associated keys that have been promoted
     # to the top level table namespace.
     return {
@@ -259,7 +259,7 @@ def _get_promoted_columns() -> Mapping[str, FrozenSet[str]]:
     }
 
 
-def _get_column_tag_map() -> Mapping[str, Mapping[str, str]]:
+def get_column_tag_map() -> Mapping[str, Mapping[str, str]]:
     # For every applicable promoted column,  a map of translations from the column
     # name  we save in the database to the tag we receive in the query.
 
@@ -276,7 +276,7 @@ def get_tag_column_map() -> Mapping[str, Mapping[str, str]]:
     # And a reverse map from the tags the client expects to the database columns
     return {
         col: dict(map(reversed, trans.items()))
-        for col, trans in _get_column_tag_map().items()
+        for col, trans in get_column_tag_map().items()
     }
 
 
@@ -284,10 +284,8 @@ def get_promoted_tags() -> Mapping[str, Sequence[str]]:
     # The canonical list of foo.bar strings that you can send as a `tags[foo.bar]` query
     # and they can/will use a promoted column.
     return {
-        col: [
-            _get_column_tag_map()[col].get(x, x) for x in _get_promoted_columns()[col]
-        ]
-        for col in _get_promoted_columns()
+        col: [get_column_tag_map()[col].get(x, x) for x in get_promoted_columns()[col]]
+        for col in get_promoted_columns()
     }
 
 

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -1,0 +1,75 @@
+from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
+
+from snuba.datasets.cdc.groupedmessage_processor import (
+    GroupedMessageProcessor,
+    GroupedMessageRow,
+)
+from snuba.datasets.dataset_schemas import StorageSchemas
+from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
+from snuba.datasets.storage import TableStorage
+from snuba.datasets.table_storage import KafkaStreamLoader, TableWriter
+from snuba.snapshots.loaders.single_table import SingleTableBulkLoader
+
+
+class GroupedMessageTableWriter(TableWriter):
+    def __init__(
+        self, postgres_table: str, **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.__postgres_table = postgres_table
+
+    def get_bulk_loader(self, source, dest_table):
+        return SingleTableBulkLoader(
+            source=source,
+            source_table=self.__postgres_table,
+            dest_table=dest_table,
+            row_processor=lambda row: GroupedMessageRow.from_bulk(row).to_clickhouse(),
+        )
+
+
+columns = ColumnSet(
+    [
+        # columns to maintain the dataset
+        # Kafka topic offset
+        ("offset", UInt(64)),
+        # GroupStatus in Sentry does not have a 'DELETED' state that reflects the deletion
+        # of the record. Having a dedicated clickhouse-only flag to identify this case seems
+        # more consistent than add an additional value into the status field below that does not
+        # exists on the Sentry side.
+        ("record_deleted", UInt(8)),
+        # PG columns
+        ("project_id", UInt(64)),
+        ("id", UInt(64)),
+        ("status", Nullable(UInt(8))),
+        ("last_seen", Nullable(DateTime())),
+        ("first_seen", Nullable(DateTime())),
+        ("active_at", Nullable(DateTime())),
+        ("first_release_id", Nullable(UInt(64))),
+    ]
+)
+
+schema = ReplacingMergeTreeSchema(
+    columns=columns,
+    local_table_name="groupedmessage_local",
+    dist_table_name="groupedmessage_dist",
+    mandatory_conditions=[("record_deleted", "=", 0)],
+    prewhere_candidates=["project_id", "id"],
+    order_by="(project_id, id)",
+    partition_by=None,
+    version_column="offset",
+    sample_expr="id",
+)
+
+POSTGRES_TABLE = "sentry_groupedmessage"
+
+storage = TableStorage(
+    schemas=StorageSchemas(read_schema=schema, write_schema=schema),
+    table_writer=GroupedMessageTableWriter(
+        write_schema=schema,
+        stream_loader=KafkaStreamLoader(
+            processor=GroupedMessageProcessor(POSTGRES_TABLE), default_topic="cdc",
+        ),
+        postgres_table=POSTGRES_TABLE,
+    ),
+    query_processors=[],
+)

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -1,0 +1,210 @@
+from datetime import datetime
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
+
+from snuba.clickhouse.columns import (
+    ColumnSet,
+    Date,
+    DateTime,
+    IPv4,
+    IPv6,
+    LowCardinality,
+    Materialized,
+    Nested,
+    Nullable,
+    String,
+    UInt,
+    UUID,
+    WithDefault,
+)
+from snuba.datasets.dataset_schemas import StorageSchemas
+from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
+from snuba.datasets.schemas.tables import (
+    MigrationSchemaColumn,
+    ReplacingMergeTreeSchema,
+)
+from snuba.datasets.storage import TableStorage
+from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
+from snuba.datasets.transactions_processor import (
+    TransactionsMessageProcessor,
+    UNKNOWN_SPAN_STATUS,
+)
+from snuba.writer import BatchWriter
+
+# This is the moment in time we started filling in flattened_tags and flattened_contexts
+# columns. It is captured to use the flattened tags optimization only for queries that
+# do not go back this much in time.
+# Will be removed in february.
+BEGINNING_OF_TIME = datetime(2019, 12, 11, 0, 0, 0)
+
+
+class TransactionsTableWriter(TableWriter):
+    def __update_options(
+        self, options: Optional[MutableMapping[str, Any]] = None,
+    ) -> MutableMapping[str, Any]:
+        if options is None:
+            options = {}
+        if "insert_allow_materialized_columns" not in options:
+            options["insert_allow_materialized_columns"] = 1
+        return options
+
+    def get_writer(
+        self,
+        options: Optional[MutableMapping[str, Any]] = None,
+        table_name: Optional[str] = None,
+        rapidjson_serialize=False,
+    ) -> BatchWriter:
+        return super().get_writer(
+            self.__update_options(options), table_name, rapidjson_serialize
+        )
+
+    def get_bulk_writer(
+        self,
+        options: Optional[MutableMapping[str, Any]] = None,
+        table_name: Optional[str] = None,
+    ) -> BatchWriter:
+        return super().get_bulk_writer(self.__update_options(options), table_name,)
+
+
+def transactions_migrations(
+    clickhouse_table: str, current_schema: Mapping[str, MigrationSchemaColumn]
+) -> Sequence[str]:
+    ret = []
+    duration_col = current_schema.get("duration")
+    if duration_col and duration_col.default_type == "MATERIALIZED":
+        ret.append("ALTER TABLE %s MODIFY COLUMN duration UInt32" % clickhouse_table)
+
+    if "sdk_name" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN sdk_name LowCardinality(String) DEFAULT ''"
+            % clickhouse_table
+        )
+
+    if "sdk_version" not in current_schema:
+        ret.append(
+            "ALTER TABLE %s ADD COLUMN sdk_version LowCardinality(String) DEFAULT ''"
+            % clickhouse_table
+        )
+
+    if "transaction_status" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT {UNKNOWN_SPAN_STATUS} AFTER transaction_op"
+        )
+
+    if "_tags_flattened" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _tags_flattened String DEFAULT ''"
+        )
+
+    if "_contexts_flattened" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _contexts_flattened String DEFAULT ''"
+        )
+
+    if "_start_date" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _start_date Date MATERIALIZED toDate(start_ts) AFTER start_ms"
+        )
+
+    if "_finish_date" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN _finish_date Date MATERIALIZED toDate(finish_ts) AFTER finish_ms"
+        )
+
+    if "user_hash" not in current_schema:
+        ret.append(
+            f"ALTER TABLE {clickhouse_table} ADD COLUMN user_hash UInt64 MATERIALIZED cityHash64(user) AFTER user"
+        )
+
+    low_cardinality_cols = [
+        "transaction_name",
+        "release",
+        "dist",
+        "sdk_name",
+        "sdk_version",
+        "environment",
+    ]
+    for col_name in low_cardinality_cols:
+        col = current_schema.get(col_name)
+        if col and not col.column_type.startswith("LowCardinality"):
+            new_type = f"LowCardinality({col.column_type})"
+            ret.append(
+                f"ALTER TABLE {clickhouse_table} MODIFY COLUMN {col_name} {new_type} {col.default_type} {col.default_expr}"
+            )
+
+    return ret
+
+
+columns = ColumnSet(
+    [
+        ("project_id", UInt(64)),
+        ("event_id", UUID()),
+        ("trace_id", UUID()),
+        ("span_id", UInt(64)),
+        ("transaction_name", LowCardinality(String())),
+        ("transaction_hash", Materialized(UInt(64), "cityHash64(transaction_name)",),),
+        ("transaction_op", LowCardinality(String())),
+        ("transaction_status", WithDefault(UInt(8), UNKNOWN_SPAN_STATUS)),
+        ("start_ts", DateTime()),
+        ("start_ms", UInt(16)),
+        ("_start_date", Materialized(Date(), "toDate(start_ts)"),),
+        ("finish_ts", DateTime()),
+        ("finish_ms", UInt(16)),
+        ("_finish_date", Materialized(Date(), "toDate(finish_ts)"),),
+        ("duration", UInt(32)),
+        ("platform", LowCardinality(String())),
+        ("environment", LowCardinality(Nullable(String()))),
+        ("release", LowCardinality(Nullable(String()))),
+        ("dist", LowCardinality(Nullable(String()))),
+        ("ip_address_v4", Nullable(IPv4())),
+        ("ip_address_v6", Nullable(IPv6())),
+        ("user", WithDefault(String(), "''",)),
+        ("user_hash", Materialized(UInt(64), "cityHash64(user)"),),
+        ("user_id", Nullable(String())),
+        ("user_name", Nullable(String())),
+        ("user_email", Nullable(String())),
+        ("sdk_name", WithDefault(LowCardinality(String()), "''")),
+        ("sdk_version", WithDefault(LowCardinality(String()), "''")),
+        ("tags", Nested([("key", String()), ("value", String())])),
+        ("_tags_flattened", String()),
+        ("contexts", Nested([("key", String()), ("value", String())])),
+        ("_contexts_flattened", String()),
+        ("partition", UInt(16)),
+        ("offset", UInt(64)),
+        ("retention_days", UInt(16)),
+        ("deleted", UInt(8)),
+    ]
+)
+
+schema = ReplacingMergeTreeSchema(
+    columns=columns,
+    local_table_name="transactions_local",
+    dist_table_name="transactions_dist",
+    mandatory_conditions=[],
+    prewhere_candidates=["event_id", "project_id"],
+    order_by="(project_id, _finish_date, transaction_name, cityHash64(span_id))",
+    partition_by="(retention_days, toMonday(_finish_date))",
+    version_column="deleted",
+    sample_expr=None,
+    migration_function=transactions_migrations,
+)
+
+storage = TableStorage(
+    schemas=StorageSchemas(read_schema=schema, write_schema=schema),
+    table_writer=TransactionsTableWriter(
+        write_schema=schema,
+        stream_loader=KafkaStreamLoader(
+            processor=TransactionsMessageProcessor(), default_topic="events",
+        ),
+    ),
+    query_processors=[
+        NestedFieldConditionOptimizer(
+            "tags", "_tags_flattened", {"start_ts", "finish_ts"}, BEGINNING_OF_TIME,
+        ),
+        NestedFieldConditionOptimizer(
+            "contexts",
+            "_contexts_flattened",
+            {"start_ts", "finish_ts"},
+            BEGINNING_OF_TIME,
+        ),
+    ],
+)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -11,13 +11,13 @@ from snuba.datasets.storages.transactions import (
 from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
-from snuba.query.query_processor import QueryProcessor
 from snuba.query.processors.apdex_processor import ApdexProcessor
-from snuba.query.processors.impact_processor import ImpactProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.query import Query
-from snuba.query.timeseries import TimeSeriesExtension
+from snuba.query.processors.impact_processor import ImpactProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.query.timeseries import TimeSeriesExtension
 
 
 class TransactionsDataset(TimeSeriesDataset):

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,36 +1,14 @@
-from datetime import datetime, timedelta
-from typing import Any, Mapping, MutableMapping, Optional, Sequence, Union
+from datetime import timedelta
+from typing import Mapping, Sequence, Union
 
-from snuba.clickhouse.columns import (
-    ColumnSet,
-    Date,
-    DateTime,
-    IPv4,
-    IPv6,
-    LowCardinality,
-    Materialized,
-    Nested,
-    Nullable,
-    String,
-    UInt,
-    UUID,
-    WithDefault,
-)
-from snuba.writer import BatchWriter
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
-from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.plans.single_table import SingleTableQueryPlanBuilder
-from snuba.datasets.schemas.tables import (
-    MigrationSchemaColumn,
-    ReplacingMergeTreeSchema,
+from snuba.datasets.storages.transactions import (
+    columns,
+    schema,
+    storage,
 )
-from snuba.datasets.storage import TableStorage
-from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
 from snuba.datasets.tags_column_processor import TagColumnProcessor
-from snuba.datasets.transactions_processor import (
-    TransactionsMessageProcessor,
-    UNKNOWN_SPAN_STATUS,
-)
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query_processor import QueryProcessor
@@ -38,221 +16,32 @@ from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.impact_processor import ImpactProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
 from snuba.query.query import Query
 from snuba.query.timeseries import TimeSeriesExtension
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
 
 
-# This is the moment in time we started filling in flattened_tags and flattened_contexts
-# columns. It is captured to use the flattened tags optimization only for queries that
-# do not go back this much in time.
-# Will be removed in february.
-BEGINNING_OF_TIME = datetime(2019, 12, 11, 0, 0, 0)
-
-
-class TransactionsTableWriter(TableWriter):
-    def __update_options(
-        self, options: Optional[MutableMapping[str, Any]] = None,
-    ) -> MutableMapping[str, Any]:
-        if options is None:
-            options = {}
-        if "insert_allow_materialized_columns" not in options:
-            options["insert_allow_materialized_columns"] = 1
-        return options
-
-    def get_writer(
-        self,
-        options: Optional[MutableMapping[str, Any]] = None,
-        table_name: Optional[str] = None,
-        rapidjson_serialize=False,
-    ) -> BatchWriter:
-        return super().get_writer(
-            self.__update_options(options), table_name, rapidjson_serialize
-        )
-
-    def get_bulk_writer(
-        self,
-        options: Optional[MutableMapping[str, Any]] = None,
-        table_name: Optional[str] = None,
-    ) -> BatchWriter:
-        return super().get_bulk_writer(self.__update_options(options), table_name,)
-
-
-def transactions_migrations(
-    clickhouse_table: str, current_schema: Mapping[str, MigrationSchemaColumn]
-) -> Sequence[str]:
-    ret = []
-    duration_col = current_schema.get("duration")
-    if duration_col and duration_col.default_type == "MATERIALIZED":
-        ret.append("ALTER TABLE %s MODIFY COLUMN duration UInt32" % clickhouse_table)
-
-    if "sdk_name" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN sdk_name LowCardinality(String) DEFAULT ''"
-            % clickhouse_table
-        )
-
-    if "sdk_version" not in current_schema:
-        ret.append(
-            "ALTER TABLE %s ADD COLUMN sdk_version LowCardinality(String) DEFAULT ''"
-            % clickhouse_table
-        )
-
-    if "transaction_status" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN transaction_status UInt8 DEFAULT {UNKNOWN_SPAN_STATUS} AFTER transaction_op"
-        )
-
-    if "_tags_flattened" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN _tags_flattened String DEFAULT ''"
-        )
-
-    if "_contexts_flattened" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN _contexts_flattened String DEFAULT ''"
-        )
-
-    if "_start_date" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN _start_date Date MATERIALIZED toDate(start_ts) AFTER start_ms"
-        )
-
-    if "_finish_date" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN _finish_date Date MATERIALIZED toDate(finish_ts) AFTER finish_ms"
-        )
-
-    if "user_hash" not in current_schema:
-        ret.append(
-            f"ALTER TABLE {clickhouse_table} ADD COLUMN user_hash UInt64 MATERIALIZED cityHash64(user) AFTER user"
-        )
-
-    low_cardinality_cols = [
-        "transaction_name",
-        "release",
-        "dist",
-        "sdk_name",
-        "sdk_version",
-        "environment",
-    ]
-    for col_name in low_cardinality_cols:
-        col = current_schema.get(col_name)
-        if col and not col.column_type.startswith("LowCardinality"):
-            new_type = f"LowCardinality({col.column_type})"
-            ret.append(
-                f"ALTER TABLE {clickhouse_table} MODIFY COLUMN {col_name} {new_type} {col.default_type} {col.default_expr}"
-            )
-
-    return ret
-
-
 class TransactionsDataset(TimeSeriesDataset):
     def __init__(self) -> None:
-        columns = ColumnSet(
-            [
-                ("project_id", UInt(64)),
-                ("event_id", UUID()),
-                ("trace_id", UUID()),
-                ("span_id", UInt(64)),
-                ("transaction_name", LowCardinality(String())),
-                (
-                    "transaction_hash",
-                    Materialized(UInt(64), "cityHash64(transaction_name)",),
-                ),
-                ("transaction_op", LowCardinality(String())),
-                ("transaction_status", WithDefault(UInt(8), UNKNOWN_SPAN_STATUS)),
-                ("start_ts", DateTime()),
-                ("start_ms", UInt(16)),
-                ("_start_date", Materialized(Date(), "toDate(start_ts)"),),
-                ("finish_ts", DateTime()),
-                ("finish_ms", UInt(16)),
-                ("_finish_date", Materialized(Date(), "toDate(finish_ts)"),),
-                ("duration", UInt(32)),
-                ("platform", LowCardinality(String())),
-                ("environment", LowCardinality(Nullable(String()))),
-                ("release", LowCardinality(Nullable(String()))),
-                ("dist", LowCardinality(Nullable(String()))),
-                ("ip_address_v4", Nullable(IPv4())),
-                ("ip_address_v6", Nullable(IPv6())),
-                ("user", WithDefault(String(), "''",)),
-                ("user_hash", Materialized(UInt(64), "cityHash64(user)"),),
-                ("user_id", Nullable(String())),
-                ("user_name", Nullable(String())),
-                ("user_email", Nullable(String())),
-                ("sdk_name", WithDefault(LowCardinality(String()), "''")),
-                ("sdk_version", WithDefault(LowCardinality(String()), "''")),
-                ("tags", Nested([("key", String()), ("value", String())])),
-                ("_tags_flattened", String()),
-                ("contexts", Nested([("key", String()), ("value", String())])),
-                ("_contexts_flattened", String()),
-                ("partition", UInt(16)),
-                ("offset", UInt(64)),
-                ("retention_days", UInt(16)),
-                ("deleted", UInt(8)),
-            ]
-        )
-
-        schema = ReplacingMergeTreeSchema(
-            columns=columns,
-            local_table_name="transactions_local",
-            dist_table_name="transactions_dist",
-            mandatory_conditions=[],
-            prewhere_candidates=["event_id", "project_id"],
-            order_by="(project_id, _finish_date, transaction_name, cityHash64(span_id))",
-            partition_by="(retention_days, toMonday(_finish_date))",
-            version_column="deleted",
-            sample_expr=None,
-            migration_function=transactions_migrations,
-        )
-
         self.__tags_processor = TagColumnProcessor(
             columns=columns,
             promoted_columns=self._get_promoted_columns(),
             column_tag_map=self._get_column_tag_map(),
         )
 
-        self.__storage = TableStorage(
-            schemas=StorageSchemas(read_schema=schema, write_schema=schema),
-            table_writer=TransactionsTableWriter(
-                write_schema=schema,
-                stream_loader=KafkaStreamLoader(
-                    processor=TransactionsMessageProcessor(), default_topic="events",
-                ),
-            ),
-            query_processors=[
-                NestedFieldConditionOptimizer(
-                    "tags",
-                    "_tags_flattened",
-                    {"start_ts", "finish_ts"},
-                    BEGINNING_OF_TIME,
-                ),
-                NestedFieldConditionOptimizer(
-                    "contexts",
-                    "_contexts_flattened",
-                    {"start_ts", "finish_ts"},
-                    BEGINNING_OF_TIME,
-                ),
-            ],
-        )
-
         super().__init__(
-            storages=[self.__storage],
+            storages=[storage],
             query_plan_builder=SingleTableQueryPlanBuilder(
-                storage=self.__storage, post_processors=[PrewhereProcessor()],
+                storage=storage, post_processors=[PrewhereProcessor()],
             ),
             abstract_column_set=schema.get_columns(),
-            writable_storage=self.__storage,
+            writable_storage=storage,
             time_group_columns={
                 "bucketed_start": "start_ts",
                 "bucketed_end": "finish_ts",
             },
             time_parse_columns=("start_ts", "finish_ts"),
         )
-
-    def get_storage(self) -> TableStorage:
-        return self.__storage
 
     def _get_promoted_columns(self):
         # TODO: Support promoted tags


### PR DESCRIPTION
This should be a no brainer. Now that we have a class that represents the Storage in a dataset we can reuse them instead of having weird cross references between datasets.
This moves the Storage objects out of the dataset objects so they can be reused.

Depends on #840 