### PR TITLE
dev: mypy error messages in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,8 @@
   },
 
   "python.linting.pylintEnabled": false,
+  "python.linting.mypyEnabled": true,
+  "python.linting.mypyArgs": ["--strict"],
   "python.linting.flake8Enabled": true,
   "python.formatting.provider": "black",
   // https://github.com/DonJayamanne/pythonVSCode/issues/992

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ MarkupSafe==1.0
 mccabe==0.6.1
 mywsgi==1.0.3
 more-itertools==4.2.0
+mypy>=0.761
 packaging==17.1
 parsimonious==0.8.1
 parso==0.2.1


### PR DESCRIPTION
We can have mypy errors in vscode by enabling the related linter. 