### PR TITLE
ref: Keep consistent structure of request in SnubaQueryMetadata

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -271,7 +271,6 @@ def parse_and_run_query(
         dataset=get_dataset_name(dataset),
         timer=timer,
         query_list=[],
-        referrer=request.referrer,
     )
 
     try:

--- a/snuba/web/query_metadata.py
+++ b/snuba/web/query_metadata.py
@@ -31,15 +31,16 @@ class SnubaQueryMetadata:
     dataset: str
     timer: Timer
     query_list: MutableSequence[ClickhouseQueryMetadata]
-    referrer: Optional[str] = None
 
     def to_dict(self) -> Mapping[str, Any]:
         return {
-            "request_id": self.request.id,
-            "referrer": self.referrer,
+            "request": {
+                "id": self.request.id,
+                "body": self.request.body,
+                "referrer": self.request.referrer,
+            },
             "dataset": self.dataset,
             "query_list": [q.to_dict() for q in self.query_list],
-            "request": self.request.body,
             "status": self.status,
             "timing": self.timer.for_json(),
         }

--- a/snuba/web/static/dashboard.html
+++ b/snuba/web/static/dashboard.html
@@ -273,7 +273,7 @@
                         Header: 'project',
                         width: 120,
                         id: 'project',
-                        accessor: row => Array.isArray(row.request.project) ? row.request.project.join(',') : row.request.project
+                        accessor: row => Array.isArray(row.request.body.project) ? row.request.body.project.join(',') : row.request.body.project
                       },{
                         Header: 'dataset',
                         width: 120,
@@ -281,7 +281,7 @@
                       },{
                         Header: 'referrer',
                         width: 400,
-                        accessor: 'referrer'
+                        accessor: 'request.referrer'
                       },{
                         Header: 'ms',
                         width: 70,
@@ -290,7 +290,7 @@
                         Header: 'days',
                         width:70,
                         id: 'days',
-                        accessor: row => (new Date(row.request.to_date).getTime() - new Date(row.request.from_date).getTime()) / (1000 * 3600 * 24)
+                        accessor: row => (new Date(row.request.body.to_date).getTime() - new Date(row.request.body.from_date).getTime()) / (1000 * 3600 * 24)
                       },{
                         Header: 'groupby',
                         width:200,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1707,7 +1707,7 @@ class TestApi(BaseApiTest):
             assert record_query_mock.call_count == 1
             metadata = record_query_mock.call_args[0][0]
             assert metadata["dataset"] == "events"
-            assert metadata["referrer"] == "test"
+            assert metadata["request"]["referrer"] == "test"
             assert len(metadata["query_list"]) == expected_query_count
 
 


### PR DESCRIPTION
SnubaQueryMetadata.to_dict() method maintains the structure of request