### PR TITLE
fix: Default expressions on column should always be strings

### DIFF
--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -150,9 +150,9 @@ class WithCodecs(ColumnTypeWithModifier):
 
 
 class WithDefault(ColumnTypeWithModifier):
-    def __init__(self, inner_type: ColumnType, default) -> None:
+    def __init__(self, inner_type: ColumnType, default: str) -> None:
         super().__init__(inner_type)
-        self.default = default  # XXX: this is problematic for typing
+        self.default = default
 
     def __repr__(self) -> str:
         return "WithDefault({}, {})".format(repr(self.inner_type), self.default)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -160,7 +160,7 @@ class TransactionsDataset(TimeSeriesDataset):
                     Materialized(UInt(64), "cityHash64(transaction_name)",),
                 ),
                 ("transaction_op", LowCardinality(String())),
-                ("transaction_status", WithDefault(UInt(8), UNKNOWN_SPAN_STATUS)),
+                ("transaction_status", WithDefault(UInt(8), str(UNKNOWN_SPAN_STATUS))),
                 ("start_ts", DateTime()),
                 ("start_ms", UInt(16)),
                 ("_start_date", Materialized(Date(), "toDate(start_ts)"),),


### PR DESCRIPTION
Default expressions are always strings, Clickhouse will cast values to
the appropriate type for that column.

This caused issues when comparing default values in https://github.com/getsentry/snuba/pull/794