### PR TITLE
fix(typing) Fix most types hints in columns.py

### DIFF
--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -7,6 +7,7 @@ from typing import (
     Iterator,
     Mapping,
     MutableMapping,
+    MutableSequence,
     List,
     Optional,
     Sequence,
@@ -53,6 +54,7 @@ class FlattenedColumn:
             "{}.{}".format(self.base_name, self.name) if self.base_name else self.name
         )
         self.escaped: str = escape_identifier(self.flattened)
+        assert self.escaped is not None
 
     def __repr__(self) -> str:
         return "FlattenedColumn({}, {}, {})".format(
@@ -80,7 +82,7 @@ class ColumnType:
     def flatten(self, name: str) -> Sequence[FlattenedColumn]:
         return [FlattenedColumn(None, name, self)]
 
-    def get_all_modifiers(self) -> List[Type[ColumnTypeWithModifier]]:
+    def get_all_modifiers(self) -> MutableSequence[Type[ColumnTypeWithModifier]]:
         """
         Basic column types never have any modifiers, since modifiers wrap a basic
         column type in order to modify it in some way.
@@ -92,10 +94,10 @@ class ColumnTypeWithModifier(ABC, ColumnType):
     def __init__(self, inner_type: ColumnType) -> None:
         self.inner_type = inner_type
 
-    def get_all_modifiers(self) -> List[Type[ColumnTypeWithModifier]]:
+    def get_all_modifiers(self) -> MutableSequence[Type[ColumnTypeWithModifier]]:
         def get_nested_modifiers(
             obj: ColumnType,
-        ) -> List[Type[ColumnTypeWithModifier]]:
+        ) -> MutableSequence[Type[ColumnTypeWithModifier]]:
             if not isinstance(obj, ColumnTypeWithModifier):
                 return obj.get_all_modifiers()
             else:

--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 from itertools import chain
 from abc import ABC
-from typing import Mapping, Iterable, Optional, Sequence, Type, Tuple, Union
+from typing import (
+    cast,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    Tuple,
+    Union,
+)
 
 from snuba.clickhouse.escaping import escape_identifier
 
@@ -15,11 +26,11 @@ class Column:
     def __repr__(self) -> str:
         return "Column({}, {})".format(repr(self.name), repr(self.type))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.name == other.name
-            and self.type == other.type
+            and self.name == cast(Column, other).name
+            and self.type == cast(Column, other).type
         )
 
     def for_schema(self) -> str:
@@ -28,7 +39,7 @@ class Column:
     @staticmethod
     def to_columns(
         columns: Sequence[Union[Column, Tuple[str, ColumnType]]]
-    ) -> Sequence[Column]:
+    ) -> List[Column]:
         return [Column(*col) if not isinstance(col, Column) else col for col in columns]
 
 
@@ -41,18 +52,18 @@ class FlattenedColumn:
         self.flattened = (
             "{}.{}".format(self.base_name, self.name) if self.base_name else self.name
         )
-        self.escaped = escape_identifier(self.flattened)
+        self.escaped: str = escape_identifier(self.flattened)
 
     def __repr__(self) -> str:
         return "FlattenedColumn({}, {}, {})".format(
             repr(self.base_name), repr(self.name), repr(self.type)
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.flattened == other.flattened
-            and self.type == other.type
+            and self.flattened == cast(FlattenedColumn, other).flattened
+            and self.type == cast(FlattenedColumn, other).type
         )
 
 
@@ -60,7 +71,7 @@ class ColumnType:
     def __repr__(self) -> str:
         return self.__class__.__name__ + "()"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return self.__class__ == other.__class__
 
     def for_schema(self) -> str:
@@ -69,7 +80,7 @@ class ColumnType:
     def flatten(self, name: str) -> Sequence[FlattenedColumn]:
         return [FlattenedColumn(None, name, self)]
 
-    def get_all_modifiers(self) -> Iterable[Type[ColumnTypeWithModifier]]:
+    def get_all_modifiers(self) -> List[Type[ColumnTypeWithModifier]]:
         """
         Basic column types never have any modifiers, since modifiers wrap a basic
         column type in order to modify it in some way.
@@ -81,10 +92,10 @@ class ColumnTypeWithModifier(ABC, ColumnType):
     def __init__(self, inner_type: ColumnType) -> None:
         self.inner_type = inner_type
 
-    def get_all_modifiers(self) -> Iterable[Type[ColumnTypeWithModifier]]:
+    def get_all_modifiers(self) -> List[Type[ColumnTypeWithModifier]]:
         def get_nested_modifiers(
             obj: ColumnType,
-        ) -> Iterable[Type[ColumnTypeWithModifier]]:
+        ) -> List[Type[ColumnTypeWithModifier]]:
             if not isinstance(obj, ColumnTypeWithModifier):
                 return obj.get_all_modifiers()
             else:
@@ -102,8 +113,11 @@ class Nullable(ColumnTypeWithModifier):
     def __repr__(self) -> str:
         return "Nullable({})".format(repr(self.inner_type))
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.inner_type == other.inner_type
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self.inner_type == cast(Nullable, other).inner_type
+        )
 
     def for_schema(self) -> str:
         return "Nullable({})".format(self.inner_type.for_schema())
@@ -117,11 +131,11 @@ class Materialized(ColumnTypeWithModifier):
     def __repr__(self) -> str:
         return "Materialized({}, {})".format(repr(self.inner_type), self.expression)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.expression == other.expression
-            and self.inner_type == other.inner_type
+            and self.expression == cast(Materialized, other).expression
+            and self.inner_type == cast(Materialized, other).inner_type
         )
 
     def for_schema(self) -> str:
@@ -138,11 +152,11 @@ class WithCodecs(ColumnTypeWithModifier):
     def __repr__(self) -> str:
         return f"WithCodecs({repr(self.inner_type)}, {', '.join(self.__codecs)})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.__codecs == other.__codecs
-            and self.inner_type == other.inner_type
+            and self.__codecs == cast(WithCodecs, other).__codecs
+            and self.inner_type == cast(WithCodecs, other).inner_type
         )
 
     def for_schema(self) -> str:
@@ -157,11 +171,11 @@ class WithDefault(ColumnTypeWithModifier):
     def __repr__(self) -> str:
         return "WithDefault({}, {})".format(repr(self.inner_type), self.default)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.default == other.default
-            and self.inner_type == other.inner_type
+            and self.default == cast(WithDefault, other).default
+            and self.inner_type == cast(WithDefault, other).inner_type
         )
 
     def for_schema(self) -> str:
@@ -175,8 +189,11 @@ class Array(ColumnType):
     def __repr__(self) -> str:
         return "Array({})".format(repr(self.inner_type))
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.inner_type == other.inner_type
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self.inner_type == cast(Array, other).inner_type
+        )
 
     def for_schema(self) -> str:
         return "Array({})".format(self.inner_type.for_schema())
@@ -191,10 +208,10 @@ class Nested(ColumnType):
     def __repr__(self) -> str:
         return "Nested({})".format(repr(self.nested_columns))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.nested_columns == other.nested_columns
+            and self.nested_columns == cast(Nested, other).nested_columns
         )
 
     def for_schema(self) -> str:
@@ -216,15 +233,18 @@ class LowCardinality(ColumnTypeWithModifier):
     def __repr__(self) -> str:
         return "LowCardinality({})".format(repr(self.inner_type))
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.inner_type == other.inner_type
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self.inner_type == cast(Array, other).inner_type
+        )
 
     def for_schema(self) -> str:
         return "LowCardinality({})".format(self.inner_type.for_schema())
 
 
 class AggregateFunction(ColumnType):
-    def __init__(self, func: str, *arg_types: Tuple[ColumnType]) -> None:
+    def __init__(self, func: str, *arg_types: ColumnType) -> None:
         self.func = func
         self.arg_types = arg_types
 
@@ -233,11 +253,11 @@ class AggregateFunction(ColumnType):
             ", ".join(repr(x) for x in chain([self.func], self.arg_types)),
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.func == other.func
-            and self.arg_types == other.arg_types
+            and self.func == cast(AggregateFunction, other).func
+            and self.arg_types == cast(AggregateFunction, other).arg_types
         )
 
     def for_schema(self) -> str:
@@ -269,8 +289,11 @@ class FixedString(ColumnType):
     def __repr__(self) -> str:
         return "FixedString({})".format(self.length)
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.length == other.length
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self.length == cast(FixedString, other).length
+        )
 
     def for_schema(self) -> str:
         return "FixedString({})".format(self.length)
@@ -284,8 +307,8 @@ class UInt(ColumnType):
     def __repr__(self) -> str:
         return "UInt({})".format(self.size)
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.size == other.size
+    def __eq__(self, other: object) -> bool:
+        return self.__class__ == other.__class__ and self.size == cast(UInt, other).size
 
     def for_schema(self) -> str:
         return "UInt{}".format(self.size)
@@ -299,8 +322,10 @@ class Float(ColumnType):
     def __repr__(self) -> str:
         return "Float({})".format(self.size)
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.size == other.size
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__ and self.size == cast(Float, other).size
+        )
 
     def for_schema(self) -> str:
         return "Float{}".format(self.size)
@@ -323,8 +348,11 @@ class Enum(ColumnType):
             ", ".join("'{}' = {}".format(v[0], v[1]) for v in self.values)
         )
 
-    def __eq__(self, other) -> bool:
-        return self.__class__ == other.__class__ and self.values == other.values
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self.values == cast(Enum, other).values
+        )
 
     def for_schema(self) -> str:
         return "Enum({})".format(
@@ -349,8 +377,8 @@ class ColumnSet:
     ) -> None:
         self.columns = Column.to_columns(columns)
 
-        self._lookup = {}
-        self._flattened = []
+        self._lookup: MutableMapping[str, FlattenedColumn] = {}
+        self._flattened: List[FlattenedColumn] = []
         for column in self.columns:
             self._flattened.extend(column.type.flatten(column.name))
 
@@ -365,27 +393,32 @@ class ColumnSet:
     def __repr__(self) -> str:
         return "ColumnSet({})".format(repr(self.columns))
 
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self._flattened == other._flattened
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self._flattened == cast(ColumnSet, other)._flattened
+        )
 
     def __len__(self) -> int:
         return len(self._flattened)
 
-    def __add__(self, other) -> ColumnSet:
+    def __add__(self, other: Union[ColumnSet, List[Column]]) -> ColumnSet:
         if isinstance(other, ColumnSet):
             return ColumnSet(self.columns + other.columns)
         return ColumnSet(self.columns + other)
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         return key in self._lookup
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> FlattenedColumn:
         return self._lookup[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[FlattenedColumn]:
         return iter(self._flattened)
 
-    def get(self, key, default=None):
+    def get(
+        self, key: str, default: Optional[FlattenedColumn] = None
+    ) -> Optional[FlattenedColumn]:
         try:
             return self[key]
         except KeyError:

--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -402,7 +402,7 @@ class ColumnSet:
     def __len__(self) -> int:
         return len(self._flattened)
 
-    def __add__(self, other: Union[ColumnSet, List[Column]]) -> ColumnSet:
+    def __add__(self, other) -> ColumnSet:
         if isinstance(other, ColumnSet):
             return ColumnSet(self.columns + other.columns)
         return ColumnSet(self.columns + other)

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -125,9 +125,13 @@ class TagColumnProcessor:
 
     def __string_col(self, col: str) -> str:
         col_type = self.__columns.get(col, None)
-        col_type = str(col_type) if col_type else None
+        col_type_name = str(col_type) if col_type else None
 
-        if col_type and "String" in col_type and "FixedString" not in col_type:
+        if (
+            col_type_name
+            and "String" in col_type_name
+            and "FixedString" not in col_type_name
+        ):
             return escape_identifier(col)
         else:
             return "toString({})".format(escape_identifier(col))


### PR DESCRIPTION
Now that I see mypy errors in vscode, all that red is unbearable so I had to fix a few of them.
There are a couple of types in columns.py I did not fix because they require a bigger refactoring since some parts of ColumnSet are more permissive by design.

```
412c462
< Found 400 errors in 82 files (checked 165 source files)
---
> Found 450 errors in 82 files (checked 165 source files)
```