### PR TITLE
fix: Upgrade `MarkupSafe`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ lazy-object-proxy==1.3.1
 linecache2==1.0.0
 lz4==2.0.0
 Markdown==2.6.11
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mccabe==0.6.1
 mywsgi==1.0.3
 more-itertools==4.2.0


### PR DESCRIPTION
The build was broken as a side effect of docker-library/python@695bd3c10cdf1692a2af9abdc51f0eff99731e78, this fixes it.