### PR TITLE
fix(errors) Ensure we write a string as user

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -96,7 +96,14 @@ class ErrorsProcessor(EventsProcessorBase):
     ) -> None:
         output["release"] = tags.get("sentry:release")
         output["dist"] = tags.get("sentry:dist")
-        output["user"] = tags.get("sentry:user", "")
+        user_to_write = tags.get("sentry:user", "") or ""
+        if not isinstance(user_to_write, str):
+            logger.error(
+                "User key has the wrong format: %r %r",
+                user_to_write,
+                type(user_to_write),
+            )
+        output["user"] = tags.get("sentry:user", str(user_to_write))
         # The table has an empty string default, but the events coming from eventstream
         # often have transaction_name set to NULL, so we need to replace that with
         # an empty string.


### PR DESCRIPTION
We are seeing production errors in which it seems we are not writing a string in the user field. It is probably None or something other than a string.
Add some log when this happens, avoid None, and force anything else to string.