### PR TITLE
fix(contexts) Fix the return type of promoted contexts

### DIFF
--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -348,7 +348,7 @@ class EventsDataset(TimeSeriesDataset):
 
             # This conversion must not be ported to the errors dataset. We should
             # not support promoting tags/contexts with boolean values. There is
-            # no way to convert them back consistentyl to the value provided by
+            # no way to convert them back consistently to the value provided by
             # the client when the event is ingested, in all ways to access
             # tags/contexts. Once the errors dataset is in use, we will not have
             # boolean promoted tags/contexts so this constraint will be easy to enforce.

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -86,6 +86,7 @@ class TestDiscoverApi(BaseApiTest):
                                     "span_id": span_id,
                                     "op": "http",
                                 },
+                                "device": {"online": True},
                             },
                             "sdk": {
                                 "name": "sentry.python",
@@ -402,3 +403,20 @@ class TestDiscoverApi(BaseApiTest):
         )
 
         assert result["data"] == []
+
+    def test_contexts(self):
+        # TODO: Add the same test for errors after PR #820 is merged.
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "dataset": "discover",
+                        "project": self.project_id,
+                        "conditions": [["type", "=", "transaction"]],
+                        "selected_columns": ["contexts[device.online]"],
+                    }
+                ),
+            ).data
+        )
+        assert result["data"] == [{"contexts[device.online]": "True"}]


### PR DESCRIPTION
PR #820 uncovered that if we return promoted contexts through the `contexts[...]` syntax we have an inconsistency between errors and transactions, and this basically breaks discover, since the common columns should behave consistently there.
Specifically `contexts[device.simulator]` would return `'True'` from the transactions table and `'1'` from the events table since the context is promoted in the events table (thus stored in a UInt8) but not in the transactions table where the context is only in the contexts column as a string.

I don't think there is a way to properly support contexts/tag promotions for columns that are not Strings or Numbers, or for any column that require some non reversible data transformation when stored in a column (we do transform `'True'` into `True` this way https://github.com/getsentry/snuba/blob/master/snuba/processor.py#L90-L93).
We cannot reconstruct the exact user input from the column we stored, which is wrong, since tag promotion should be an optimization transparent to the client.

Moreover, there is no way to support tags/contexts properly if we remove the column from the contexts field when promoting it (https://github.com/getsentry/snuba/blob/master/snuba/datasets/events_processor.py#L102) since then, the result of `tags[context]` would be inconsistent  with the result of . `tags_key` / `tags_value`. The first come from the promoted column, the second comes from the tags column. Now we do not have that problem because this impacts only contexts and the arrayJoin operations only support tags, not contexts and we are not removing anything from the tags field. That's a coincidence, though.

The bright side of all this is that the errors dataset does not promote any non string context, thus this type of context promotion will disappear there and we will be able to stop supporting it.