### PR TITLE
feat(cdc) Pre filter cdc messages based on table header [take 2]

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -44,14 +44,15 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
             rapidjson_serialize=rapidjson_serialize,
         )
         self.__rapidjson_deserialize = rapidjson_deserialize
+        self.__pre_filter = (
+            enforce_table_writer(self.__dataset).get_stream_loader().get_pre_filter()
+        )
 
     def process_message(
         self, message: Message[KafkaPayload]
     ) -> Optional[ProcessedMessage]:
-        pre_filter = (
-            enforce_table_writer(self.__dataset).get_stream_loader().get_pre_filter()
-        )
-        if pre_filter and pre_filter.should_drop(message):
+
+        if self.__pre_filter and self.__pre_filter.should_drop(message):
             return None
 
         if self.__rapidjson_deserialize:

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -39,14 +39,13 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         self.producer = producer
         self.replacements_topic = replacements_topic
         self.metrics = metrics
-        self.__writer = enforce_table_writer(dataset).get_writer(
+        table_writer = enforce_table_writer(dataset)
+        self.__writer = table_writer.get_writer(
             {"load_balancing": "in_order", "insert_distributed_sync": 1},
             rapidjson_serialize=rapidjson_serialize,
         )
         self.__rapidjson_deserialize = rapidjson_deserialize
-        self.__pre_filter = (
-            enforce_table_writer(self.__dataset).get_stream_loader().get_pre_filter()
-        )
+        self.__pre_filter = table_writer.get_stream_loader().get_pre_filter()
 
     def process_message(
         self, message: Message[KafkaPayload]

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -8,10 +8,6 @@ from typing import Any, Mapping, Optional, Sequence, Type
 from snuba.processor import MessageProcessor, ProcessorAction, ProcessedMessage
 from snuba.writer import WriterTableRow
 
-KAFKA_ONLY_PARTITION = (
-    0  # CDC only works with single partition topics. So partition must be 0
-)
-
 POSTGRES_DATE_FORMAT_WITH_NS = "%Y-%m-%d %H:%M:%S.%f%z"
 POSTGRES_DATE_FORMAT_WITHOUT_NS = "%Y-%m-%d %H:%M:%S%z"
 
@@ -115,11 +111,6 @@ class CdcProcessor(MessageProcessor):
 
     def process_message(self, value, metadata) -> Optional[ProcessedMessage]:
         assert isinstance(value, dict)
-
-        partition = metadata.partition
-        assert (
-            partition == KAFKA_ONLY_PARTITION
-        ), "CDC can only work with single partition topics for consistency"
 
         offset = metadata.offset
         event = value["event"]

--- a/snuba/datasets/cdc/message_filters.py
+++ b/snuba/datasets/cdc/message_filters.py
@@ -26,14 +26,14 @@ class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
             message.partition.index == KAFKA_ONLY_PARTITION
         ), "CDC can only work with single partition topics for consistency"
 
-        table_header = next(
-            (header for header in message.payload.headers if header[0] == "table"), None
+        table_name = next(
+            (value for key, value in message.payload.headers if key == "table"), None
         )
 
-        if table_header:
-            table_name = table_header[1].decode("utf-8")
+        if table_name:
+            table_name = table_name.decode("utf-8")
             if table_name != self.__postgres_table:
-                metrics.increment("CDC Message Dropped", tags={"table": table_name})
+                metrics.increment("cdc_message_dropped", tags={"table": table_name})
                 return True
 
         return False

--- a/snuba/datasets/cdc/message_filters.py
+++ b/snuba/datasets/cdc/message_filters.py
@@ -1,0 +1,32 @@
+from snuba import environment
+from snuba.datasets.message_filters import StreamMessageFilter
+from snuba.utils.metrics.backends.wrapper import MetricsWrapper
+from snuba.utils.streams.kafka import KafkaPayload
+from snuba.utils.streams.types import Message
+
+metrics = MetricsWrapper(environment.metrics, "cdc.consumer")
+
+KAFKA_ONLY_PARTITION = (
+    0  # CDC only works with single partition topics. So partition must be 0
+)
+
+
+class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
+    def __init__(self, postgres_table: str) -> None:
+        self.__postgres_table = postgres_table
+
+    def should_drop(self, message: Message[KafkaPayload]) -> bool:
+        assert (
+            message.partition.index == KAFKA_ONLY_PARTITION
+        ), "CDC can only work with single partition topics for consistency"
+
+        table_header = [
+            header for header in message.payload.headers if header[0] == "table"
+        ]
+        if table_header:
+            table_name = table_header[0][1].decode("utf-8")
+            if table_name != self.__postgres_table:
+                metrics.increment("CDC Message Dropped", tags={"table": table_name})
+                return True
+
+        return False

--- a/snuba/datasets/message_filters.py
+++ b/snuba/datasets/message_filters.py
@@ -6,6 +6,11 @@ from snuba.utils.streams.types import Message, TPayload
 
 
 class StreamMessageFilter(ABC, Generic[TPayload]):
+    """
+    A filter over messages coming from a stream. Can be used to pre filter
+    messages during consumption but potentially for other use cases as well.
+    """
+
     @abstractmethod
     def should_drop(self, message: Message[TPayload]) -> bool:
         raise NotImplementedError

--- a/snuba/datasets/message_filters.py
+++ b/snuba/datasets/message_filters.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Generic
+
+from snuba.utils.streams.kafka import KafkaPayload
+from snuba.utils.streams.types import Message, TPayload
+
+
+class StreamMessageFilter(ABC, Generic[TPayload]):
+    @abstractmethod
+    def should_drop(self, message: Message[TPayload]) -> bool:
+        raise NotImplementedError
+
+
+class PassthroughKafkaFilter(StreamMessageFilter[KafkaPayload]):
+    def should_drop(self, message: Message[KafkaPayload]) -> bool:
+        return True

--- a/snuba/datasets/message_filters.py
+++ b/snuba/datasets/message_filters.py
@@ -18,4 +18,4 @@ class StreamMessageFilter(ABC, Generic[TPayload]):
 
 class PassthroughKafkaFilter(StreamMessageFilter[KafkaPayload]):
     def should_drop(self, message: Message[KafkaPayload]) -> bool:
-        return True
+        return False

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -1,10 +1,10 @@
-
 from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
 from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeProcessor,
     GroupAssigneeRow,
 )
+from snuba.datasets.cdc.message_filters import CdcTableNameMessageFilter
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.table_storage import TableWriter, KafkaStreamLoader
@@ -62,6 +62,7 @@ storage = WritableTableStorage(
         stream_loader=KafkaStreamLoader(
             processor=GroupAssigneeProcessor(POSTGRES_TABLE),
             default_topic="cdc",
+            pre_filter=CdcTableNameMessageFilter(POSTGRES_TABLE),
         ),
         postgres_table=POSTGRES_TABLE,
     ),

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -4,6 +4,7 @@ from snuba.datasets.cdc.groupedmessage_processor import (
     GroupedMessageProcessor,
     GroupedMessageRow,
 )
+from snuba.datasets.cdc.message_filters import CdcTableNameMessageFilter
 from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
 from snuba.datasets.storage import WritableTableStorage
@@ -67,7 +68,9 @@ storage = WritableTableStorage(
     table_writer=GroupedMessageTableWriter(
         write_schema=schema,
         stream_loader=KafkaStreamLoader(
-            processor=GroupedMessageProcessor(POSTGRES_TABLE), default_topic="cdc",
+            processor=GroupedMessageProcessor(POSTGRES_TABLE),
+            default_topic="cdc",
+            pre_filter=CdcTableNameMessageFilter(POSTGRES_TABLE),
         ),
         postgres_table=POSTGRES_TABLE,
     ),

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence
 
 from snuba import settings
 from snuba.clickhouse import DATETIME_FORMAT
-from snuba.datasets.message_filters import PassthroughKafkaFilter, StreamMessageFilter
+from snuba.datasets.message_filters import StreamMessageFilter
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.processor import MessageProcessor
 from snuba.replacers.replacer_processor import ReplacerProcessor
@@ -68,6 +68,10 @@ class KafkaStreamLoader:
         return self.__processor
 
     def get_pre_filter(self) -> Optional[StreamMessageFilter[KafkaPayload]]:
+        """
+        Returns a filter (or none if none is defined) to be applied to the messages
+        coming from the Kafka stream before parsing the content of the message.
+        """
         return self.__pre_filter
 
     def get_default_topic_spec(self) -> KafkaTopicSpec:

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -7,10 +7,12 @@ from typing import Optional, Sequence
 
 from snuba import settings
 from snuba.clickhouse import DATETIME_FORMAT
+from snuba.datasets.message_filters import PassthroughKafkaFilter, StreamMessageFilter
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.processor import MessageProcessor
 from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.snapshots.loaders import BulkLoader
+from snuba.utils.streams.kafka import KafkaPayload
 from snuba.writer import BatchWriter
 
 
@@ -31,6 +33,7 @@ class KafkaStreamLoader:
         self,
         processor: MessageProcessor,
         default_topic: str,
+        pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
         replacement_topic: Optional[str] = None,
         commit_log_topic: Optional[str] = None,
     ) -> None:
@@ -59,9 +62,13 @@ class KafkaStreamLoader:
             if commit_log_topic
             else None
         )
+        self.__pre_filter = pre_filter
 
     def get_processor(self) -> MessageProcessor:
         return self.__processor
+
+    def get_pre_filter(self) -> Optional[StreamMessageFilter[KafkaPayload]]:
+        return self.__pre_filter
 
     def get_default_topic_spec(self) -> KafkaTopicSpec:
         return self.__default_topic_spec

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -1,5 +1,5 @@
 import pytz
-import simplejson as json
+import rapidjson
 from datetime import datetime
 
 from tests.base import BaseDatasetTest
@@ -8,7 +8,11 @@ from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeProcessor,
     GroupAssigneeRow,
 )
+from snuba.datasets.cdc.message_filters import CdcTableNameMessageFilter
+from snuba.datasets.storages.groupassignees import POSTGRES_TABLE
 from snuba.environment import clickhouse_ro
+from snuba.utils.streams.kafka import Headers, KafkaPayload
+from snuba.utils.streams.types import Message, Partition, Topic
 
 
 class TestGroupassignee(BaseDatasetTest):
@@ -75,20 +79,42 @@ class TestGroupassignee(BaseDatasetTest):
         "date_added": None,
     }
 
+    def __make_msg(
+        self, partition: int, offset: int, payload: str, headers: Headers
+    ) -> Message[KafkaPayload]:
+        return Message(
+            partition=Partition(Topic("topic"), partition),
+            offset=offset,
+            payload=KafkaPayload(b"key", payload.encode(), headers),
+            timestamp=datetime(2019, 6, 19, 6, 46, 28),
+        )
+
     def test_messages(self):
         processor = GroupAssigneeProcessor("sentry_groupasignee")
+        message_filter = CdcTableNameMessageFilter(postgres_table=POSTGRES_TABLE)
 
         metadata = KafkaMessageMetadata(offset=42, partition=0,)
 
-        begin_msg = json.loads(self.BEGIN_MSG)
+        assert not message_filter.should_drop(
+            self.__make_msg(0, 42, self.BEGIN_MSG, [])
+        )
+        begin_msg = rapidjson.loads(self.BEGIN_MSG)
         ret = processor.process_message(begin_msg, metadata)
         assert ret is None
 
-        commit_msg = json.loads(self.COMMIT_MSG)
+        assert not message_filter.should_drop(
+            self.__make_msg(0, 42, self.COMMIT_MSG, [])
+        )
+        commit_msg = rapidjson.loads(self.COMMIT_MSG)
         ret = processor.process_message(commit_msg, metadata)
         assert ret is None
 
-        insert_msg = json.loads(self.INSERT_MSG)
+        assert not message_filter.should_drop(
+            self.__make_msg(
+                0, 42, self.INSERT_MSG, [("table", POSTGRES_TABLE.encode())]
+            )
+        )
+        insert_msg = rapidjson.loads(self.INSERT_MSG)
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
         self.write_processed_records(ret.data)
@@ -103,17 +129,36 @@ class TestGroupassignee(BaseDatasetTest):
             None,  # team_id
         )
 
-        update_msg = json.loads(self.UPDATE_MSG_NO_KEY_CHANGE)
+        assert not message_filter.should_drop(
+            self.__make_msg(
+                0,
+                42,
+                self.UPDATE_MSG_NO_KEY_CHANGE,
+                [("table", POSTGRES_TABLE.encode())],
+            )
+        )
+        update_msg = rapidjson.loads(self.UPDATE_MSG_NO_KEY_CHANGE)
         ret = processor.process_message(update_msg, metadata)
         assert ret.data == [self.PROCESSED]
 
         # Tests an update with key change which becomes a two inserts:
         # one deletion and the insertion of the new row.
-        update_msg = json.loads(self.UPDATE_MSG_WITH_KEY_CHANGE)
+        assert not message_filter.should_drop(
+            self.__make_msg(
+                0,
+                42,
+                self.UPDATE_MSG_WITH_KEY_CHANGE,
+                [("table", POSTGRES_TABLE.encode())],
+            )
+        )
+        update_msg = rapidjson.loads(self.UPDATE_MSG_WITH_KEY_CHANGE)
         ret = processor.process_message(update_msg, metadata)
         assert ret.data == [self.DELETED, self.PROCESSED_UPDATE]
 
-        delete_msg = json.loads(self.DELETE_MSG)
+        assert not message_filter.should_drop(
+            self.__make_msg(0, 42, self.DELETE_MSG, [])
+        )
+        delete_msg = rapidjson.loads(self.DELETE_MSG)
         ret = processor.process_message(delete_msg, metadata)
         assert ret.data == [self.DELETED]
 

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -1,5 +1,5 @@
 import pytz
-import rapidjson
+import simplejson as json
 from datetime import datetime
 
 from tests.base import BaseDatasetTest
@@ -98,14 +98,14 @@ class TestGroupassignee(BaseDatasetTest):
         assert not message_filter.should_drop(
             self.__make_msg(0, 42, self.BEGIN_MSG, [])
         )
-        begin_msg = rapidjson.loads(self.BEGIN_MSG)
+        begin_msg = json.loads(self.BEGIN_MSG)
         ret = processor.process_message(begin_msg, metadata)
         assert ret is None
 
         assert not message_filter.should_drop(
             self.__make_msg(0, 42, self.COMMIT_MSG, [])
         )
-        commit_msg = rapidjson.loads(self.COMMIT_MSG)
+        commit_msg = json.loads(self.COMMIT_MSG)
         ret = processor.process_message(commit_msg, metadata)
         assert ret is None
 
@@ -114,7 +114,7 @@ class TestGroupassignee(BaseDatasetTest):
                 0, 42, self.INSERT_MSG, [("table", POSTGRES_TABLE.encode())]
             )
         )
-        insert_msg = rapidjson.loads(self.INSERT_MSG)
+        insert_msg = json.loads(self.INSERT_MSG)
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
         self.write_processed_records(ret.data)
@@ -137,7 +137,7 @@ class TestGroupassignee(BaseDatasetTest):
                 [("table", POSTGRES_TABLE.encode())],
             )
         )
-        update_msg = rapidjson.loads(self.UPDATE_MSG_NO_KEY_CHANGE)
+        update_msg = json.loads(self.UPDATE_MSG_NO_KEY_CHANGE)
         ret = processor.process_message(update_msg, metadata)
         assert ret.data == [self.PROCESSED]
 
@@ -151,14 +151,14 @@ class TestGroupassignee(BaseDatasetTest):
                 [("table", POSTGRES_TABLE.encode())],
             )
         )
-        update_msg = rapidjson.loads(self.UPDATE_MSG_WITH_KEY_CHANGE)
+        update_msg = json.loads(self.UPDATE_MSG_WITH_KEY_CHANGE)
         ret = processor.process_message(update_msg, metadata)
         assert ret.data == [self.DELETED, self.PROCESSED_UPDATE]
 
         assert not message_filter.should_drop(
             self.__make_msg(0, 42, self.DELETE_MSG, [])
         )
-        delete_msg = rapidjson.loads(self.DELETE_MSG)
+        delete_msg = json.loads(self.DELETE_MSG)
         ret = processor.process_message(delete_msg, metadata)
         assert ret.data == [self.DELETED]
 

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -82,7 +82,11 @@ class TestSnapshotWorker:
         message: Message[KafkaPayload] = Message(
             Partition(Topic("topic"), 0),
             1,
-            KafkaPayload(None, value.encode("utf-8")),
+            KafkaPayload(
+                None,
+                value.encode("utf-8"),
+                [("table", "sentry_groupedmessage".encode())],
+            ),
             datetime.now(),
         )
 

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -1,5 +1,5 @@
 import pytz
-import rapidjson
+import simplejson as json
 
 from datetime import datetime
 
@@ -109,14 +109,14 @@ class TestGroupedMessage(BaseDatasetTest):
         assert not message_filter.should_drop(
             self.__make_msg(0, 42, self.BEGIN_MSG, [])
         )
-        begin_msg = rapidjson.loads(self.BEGIN_MSG)
+        begin_msg = json.loads(self.BEGIN_MSG)
         ret = processor.process_message(begin_msg, metadata)
         assert ret is None
 
         assert not message_filter.should_drop(
             self.__make_msg(0, 42, self.COMMIT_MSG, [])
         )
-        commit_msg = rapidjson.loads(self.COMMIT_MSG)
+        commit_msg = json.loads(self.COMMIT_MSG)
         ret = processor.process_message(commit_msg, metadata)
         assert ret is None
 
@@ -125,7 +125,7 @@ class TestGroupedMessage(BaseDatasetTest):
                 0, 42, self.INSERT_MSG, [("table", "sentry_groupedmessage".encode())]
             )
         )
-        insert_msg = rapidjson.loads(self.INSERT_MSG)
+        insert_msg = json.loads(self.INSERT_MSG)
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
         self.write_processed_records(ret.data)
@@ -147,14 +147,14 @@ class TestGroupedMessage(BaseDatasetTest):
                 0, 42, self.UPDATE_MSG, [("table", "sentry_groupedmessage".encode())]
             )
         )
-        update_msg = rapidjson.loads(self.UPDATE_MSG)
+        update_msg = json.loads(self.UPDATE_MSG)
         ret = processor.process_message(update_msg, metadata)
         assert ret.data == [self.PROCESSED]
 
         assert not message_filter.should_drop(
             self.__make_msg(0, 42, self.DELETE_MSG, [])
         )
-        delete_msg = rapidjson.loads(self.DELETE_MSG)
+        delete_msg = json.loads(self.DELETE_MSG)
         ret = processor.process_message(delete_msg, metadata)
         assert ret.data == [self.DELETED]
 


### PR DESCRIPTION
The goal is to drop cdc messages before the json payload gets parsed if the Kafka headers contain a table the consumer is not interested into.

The current  Consumer is not doing any dataset specific operation before json parsing and I would not want to move parsing into the MessageProcessor (since this would make the processor Kafka specific while now they are fairly agnostic to the stream type).
I added, instead, a pre-filter component (provided by the StreamLoader (which is provided by the Table Writer) together with the MessageProcessor). This is Kafka specific, if the stream is a Kafka stream, and it makes a step in making the MessageProcessor fully agnostic to the stream type.