### PR TITLE
ref(util): Tighten up type annotations on `to_list`

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    TypeVar,
     Union,
 )
 import logging
@@ -29,6 +30,9 @@ from snuba.utils.metrics.types import Tags
 logger = logging.getLogger("snuba.util")
 
 
+T = TypeVar("T")
+
+
 # example partition name: "('2018-03-13 00:00:00', 90)"
 PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2})',\s*(\d+)\)")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
@@ -44,7 +48,7 @@ def local_dataset_mode() -> bool:
     return settings.DATASET_MODE == "local"
 
 
-def to_list(value: Any) -> List[Any]:
+def to_list(value: Union[T, List[T]]) -> List[T]:
     return value if isinstance(value, list) else [value]
 
 


### PR DESCRIPTION
Probably the world's most pedantic pull request, but something I noticed wasn't specified quite right while reviewing #865.

If `to_list` is provided with `None`, it will return `List[None]`, so this makes the type signature reflect that. This in theory would also catch any places where `to_list` was being used incorrectly to do something like turn a `Tuple[T]` into `List[T]`, as it would actually return `List[Tuple[T]]` in this case.

In general, I think this function is diminishing in utility as type constraints around `Query` improve, so hopefully this ends up being that gets deleted in the near future. 