### PR TITLE
ref: Bump semaphore to sentry_relay

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -49,7 +49,7 @@ ignore_missing_imports = True
 [mypy-rediscluster]
 ignore_missing_imports = True
 
-[mypy-semaphore.consts]
+[mypy-sentry_relay.consts]
 ignore_missing_imports = True
 
 [mypy-setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ pytz==2018.4
 python-rapidjson==0.8.0
 redis==2.10.6
 redis-py-cluster==1.3.5
-semaphore>=0.4.64,<0.5.0
+sentry-relay>=0.5.7,<0.6.0
 sentry-sdk==0.13.5
 simplegeneric==0.8.1
 simplejson==3.15.0

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from semaphore.consts import SPAN_STATUS_NAME_TO_CODE
+from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from typing import Optional
 
 import uuid


### PR DESCRIPTION
This causes Snuba to accept `unknown` in addition to `unknown_error`. We
want to eventually rename `unknown_error` to `unknown`.