### PR TITLE
fix(timeseries) Always use the Universal time zone in timeseries

### DIFF
--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -65,9 +65,9 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             return str(exp.value)
         elif isinstance(exp.value, datetime):
             value = exp.value.replace(tzinfo=None, microsecond=0)
-            return "toDateTime('{}')".format(value.isoformat())
+            return "toDateTime('{}', 'Universal')".format(value.isoformat())
         elif isinstance(exp.value, date):
-            return "toDate('{}')".format(exp.value.isoformat())
+            return "toDate('{}', 'Universal')".format(exp.value.isoformat())
         else:
             raise ValueError(f"Unexpected literal type {type(exp.value)}")
 

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -165,12 +165,12 @@ class TimeSeriesDataset(Dataset):
     def time_expr(self, column_name: str, granularity: int, table_alias: str) -> str:
         real_column = qualified_column(column_name, table_alias)
         template = {
-            3600: "toStartOfHour({column})",
-            60: "toStartOfMinute({column})",
-            86400: "toDate({column})",
+            3600: "toStartOfHour({column}, 'Universal')",
+            60: "toStartOfMinute({column}, 'Universal')",
+            86400: "toDate({column}, 'Universal')",
         }.get(
             granularity,
-            "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity})",
+            "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity}, 'Universal')",
         )
         return template.format(column=real_column, granularity=granularity)
 

--- a/snuba/query/processors/timeseries_column_processor.py
+++ b/snuba/query/processors/timeseries_column_processor.py
@@ -20,12 +20,20 @@ class TimeSeriesColumnProcessor(QueryProcessor):
     ) -> str:
         function_call = {
             3600: FunctionCall(
-                alias, "toStartOfHour", (Column(None, column_name, None),)
+                alias,
+                "toStartOfHour",
+                (Column(None, column_name, None), Literal(None, "Universal")),
             ),
             60: FunctionCall(
-                alias, "toStartOfMinute", (Column(None, column_name, None),)
+                alias,
+                "toStartOfMinute",
+                (Column(None, column_name, None), Literal(None, "Universal")),
             ),
-            86400: FunctionCall(alias, "toDate", (Column(None, column_name, None),)),
+            86400: FunctionCall(
+                alias,
+                "toDate",
+                (Column(None, column_name, None), Literal(None, "Universal")),
+            ),
         }.get(granularity)
         if not function_call:
             # "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity})",
@@ -48,6 +56,7 @@ class TimeSeriesColumnProcessor(QueryProcessor):
                         ),
                         Literal(None, granularity),
                     ),
+                    Literal(None, "Universal"),
                 ),
             )
 

--- a/snuba/query/processors/timeseries_column_processor.py
+++ b/snuba/query/processors/timeseries_column_processor.py
@@ -36,7 +36,6 @@ class TimeSeriesColumnProcessor(QueryProcessor):
             ),
         }.get(granularity)
         if not function_call:
-            # "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity})",
             function_call = FunctionCall(
                 alias,
                 "toDateTime",

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -231,9 +231,9 @@ def escape_literal(
         return escape_string(value)
     elif isinstance(value, datetime):
         value = value.replace(tzinfo=None, microsecond=0)
-        return "toDateTime('{}')".format(value.isoformat())
+        return "toDateTime('{}', 'Universal')".format(value.isoformat())
     elif isinstance(value, date):
-        return "toDate('{}')".format(value.isoformat())
+        return "toDate('{}', 'Universal')".format(value.isoformat())
     elif isinstance(value, (list, tuple)):
         return "({})".format(", ".join(escape_literal(v) for v in value))
     elif isinstance(value, numbers.Number):

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -67,12 +67,12 @@ class TestEventsDataset(BaseEventsTest):
 
         assert (
             column_expr(self.dataset, "time", deepcopy(query), ParsingContext())
-            == "(toDate(timestamp) AS time)"
+            == "(toDate(timestamp, 'Universal') AS time)"
         )
 
         assert (
             column_expr(self.dataset, "rtime", deepcopy(query), ParsingContext())
-            == "(toDate(received) AS rtime)"
+            == "(toDate(received, 'Universal') AS rtime)"
         )
 
         assert (

--- a/tests/datasets/test_join_columns.py
+++ b/tests/datasets/test_join_columns.py
@@ -69,7 +69,7 @@ def test_simple_column_expr():
 
     assert (
         column_expr(dataset, "events.time", deepcopy(query), ParsingContext())
-        == "(toDate(events.timestamp) AS `events.time`)"
+        == "(toDate(events.timestamp, 'Universal') AS `events.time`)"
     )
 
     assert (

--- a/tests/query/processors/test_timeseries_column_processor.py
+++ b/tests/query/processors/test_timeseries_column_processor.py
@@ -14,18 +14,30 @@ from snuba.request.request_settings import HTTPRequestSettings
 tests = [
     (
         3600,
-        FunctionCall("my_start", "toStartOfHour", (Column(None, "start_ts", None),)),
-        "(toStartOfHour(start_ts) AS my_start)",
+        FunctionCall(
+            "my_start",
+            "toStartOfHour",
+            (Column(None, "start_ts", None), Literal(None, "Universal")),
+        ),
+        "(toStartOfHour(start_ts, 'Universal') AS my_start)",
     ),
     (
         60,
-        FunctionCall("my_start", "toStartOfMinute", (Column(None, "start_ts", None),)),
-        "(toStartOfMinute(start_ts) AS my_start)",
+        FunctionCall(
+            "my_start",
+            "toStartOfMinute",
+            (Column(None, "start_ts", None), Literal(None, "Universal")),
+        ),
+        "(toStartOfMinute(start_ts, 'Universal') AS my_start)",
     ),
     (
         86400,
-        FunctionCall("my_start", "toDate", (Column(None, "start_ts", None),)),
-        "(toDate(start_ts) AS my_start)",
+        FunctionCall(
+            "my_start",
+            "toDate",
+            (Column(None, "start_ts", None), Literal(None, "Universal")),
+        ),
+        "(toDate(start_ts, 'Universal') AS my_start)",
     ),
     (
         1440,
@@ -46,9 +58,10 @@ tests = [
                     ),
                     Literal(None, 1440),
                 ),
+                Literal(None, "Universal"),
             ),
         ),
-        "(toDateTime(multiply(intDiv(toUInt32(start_ts), 1440), 1440)) AS my_start)",
+        "(toDateTime(multiply(intDiv(toUInt32(start_ts), 1440), 1440), 'Universal') AS my_start)",
     ),
 ]
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -28,14 +28,14 @@ class TestUtil(BaseTest):
     def test_escape(self):
         assert escape_literal(r"'") == r"'\''"
         assert escape_literal(r"\'") == r"'\\\''"
-        assert escape_literal(date(2001, 1, 1)) == "toDate('2001-01-01')"
+        assert escape_literal(date(2001, 1, 1)) == "toDate('2001-01-01', 'Universal')"
         assert (
             escape_literal(datetime(2001, 1, 1, 1, 1, 1))
-            == "toDateTime('2001-01-01T01:01:01')"
+            == "toDateTime('2001-01-01T01:01:01', 'Universal')"
         )
         assert (
             escape_literal([1, "a", date(2001, 1, 1)])
-            == "(1, 'a', toDate('2001-01-01'))"
+            == "(1, 'a', toDate('2001-01-01', 'Universal'))"
         )
 
     def test_escape_identifier(self):


### PR DESCRIPTION
Always use the Universal timezone to avoid timezone mismatch errors.