### PR TITLE
perf(metrics) Remove a useless metric

### DIFF
--- a/snuba/datasets/cdc/message_filters.py
+++ b/snuba/datasets/cdc/message_filters.py
@@ -4,7 +4,6 @@ from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message
 
-metrics = MetricsWrapper(environment.metrics, "cdc.consumer")
 
 KAFKA_ONLY_PARTITION = (
     0  # CDC only works with single partition topics. So partition must be 0
@@ -33,7 +32,6 @@ class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
         if table_name:
             table_name = table_name.decode("utf-8")
             if table_name != self.__postgres_table:
-                metrics.increment("cdc_message_dropped", tags={"table": table_name})
                 return True
 
         return False


### PR DESCRIPTION
This metric is almost useless and takes almost 10% of the message processing time on cdc.