### PR TITLE
feat(ast) Add query processor for discover column_expr

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -24,6 +24,7 @@ from snuba.query.query import Query
 from snuba.query.query_processor import QueryProcessor
 from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.discover_column_processor import DiscoverColumnProcessor
 from snuba.query.processors.impact_processor import ImpactProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.timeseries import TimeSeriesExtension
@@ -225,12 +226,17 @@ class DiscoverDataset(TimeSeriesDataset):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             BasicFunctionsProcessor(),
+            DiscoverColumnProcessor(
+                self.__events_columns, self.__transactions_columns, detect_table,
+            ),
             # Apdex and Impact seem very good candidates for
             # being defined by the Transaction entity when it will
             # exist, so it would run before Storage selection.
             ApdexProcessor(),
             ImpactProcessor(),
-            TimeSeriesColumnProcessor({}),
+            TimeSeriesColumnProcessor(
+                {"finish_ts": "finish_ts", "timestamp": "timestamp"}
+            ),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/query/processors/discover_column_processor.py
+++ b/snuba/query/processors/discover_column_processor.py
@@ -1,0 +1,91 @@
+from typing import Callable, Mapping, Optional
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.query.dsl import multiply
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.query import Query
+from snuba.query.query_processor import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+EVENTS = "events"
+TRANSACTIONS = "transactions"
+
+
+class DiscoverColumnProcessor(QueryProcessor):
+    """
+    Translate the time group columns of the dataset to use the correct granularity rounding.
+    """
+
+    def __init__(
+        self,
+        events_columns: ColumnSet,
+        transactions_columns: ColumnSet,
+        detect_table_fn: Callable[[Query, ColumnSet, ColumnSet], str],
+    ) -> None:
+        self.detect_table = detect_table_fn
+        self.__events_columns = events_columns
+        self.__transactions_columns = transactions_columns
+
+    def get_new_column_name(self, detected_dataset: str, column_name: str) -> str:
+        if detected_dataset == TRANSACTIONS:
+            if column_name == "time":
+                return "finish_ts"
+            if column_name == "type":
+                return "'transaction'"
+            if column_name == "timestamp":
+                return "finish_ts"
+            if column_name == "username":
+                return "user_name"
+            if column_name == "email":
+                return "user_email"
+            if column_name == "transaction":
+                return "transaction_name"
+            if column_name == "message":
+                return "transaction_name"
+            if column_name == "title":
+                return "transaction_name"
+            if column_name == "group_id":
+                # TODO: We return 0 here instead of NULL so conditions like group_id
+                # in (1, 2, 3) will work, since Clickhouse won't run a query like:
+                # SELECT (NULL AS group_id) FROM transactions WHERE group_id IN (1, 2, 3)
+                # When we have the query AST, we should solve this by transforming the
+                # nonsensical conditions instead.
+                return "0"
+            if column_name == "geo_country_code":
+                column_name = "contexts[geo.country_code]"
+            if column_name == "geo_region":
+                column_name = "contexts[geo.region]"
+            if column_name == "geo_city":
+                column_name = "contexts[geo.city]"
+            if self.__events_columns.get(column_name):
+                return "NULL"
+        else:
+            if column_name == "time":
+                return "timestamp"
+            if column_name == "release":
+                column_name = "tags[sentry:release]"
+            if column_name == "dist":
+                column_name = "tags[sentry:dist]"
+            if column_name == "user":
+                column_name = "tags[sentry:user]"
+            if self.__transactions_columns.get(column_name):
+                return "NULL"
+
+        return column_name
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def process_column(exp: Expression) -> Expression:
+            if isinstance(exp, Column):
+                detected_dataset = self.detect_table(
+                    query, self.__events_columns, self.__transactions_columns
+                )
+                column_name = exp.column_name
+                new_column_name = self.get_new_column_name(
+                    detected_dataset, column_name
+                )
+                return Column(exp.alias, new_column_name, exp.table_name)
+
+            return exp
+
+        query.transform_expressions(process_column)

--- a/tests/query/processors/test_discover_column_processor.py
+++ b/tests/query/processors/test_discover_column_processor.py
@@ -1,0 +1,122 @@
+import pytest
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
+from snuba.datasets.schemas.tables import TableSource
+from snuba.datasets.discover import DiscoverDataset
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
+from snuba.query.dsl import div, multiply, plus
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.processors.discover_column_processor import DiscoverColumnProcessor
+from snuba.query.query import Query
+from snuba.request.request_settings import HTTPRequestSettings
+
+
+def test_discover_column_format_events_expressions() -> None:
+    unprocessed = Query(
+        {},
+        TableSource("events", ColumnSet([])),
+        selected_columns=[
+            Column("t_time", "time", None),
+            Column("t_release", "release", None),
+            Column("t_dist", "dist", None),
+            Column("t_user", "user", None),
+            Column("t_transaction_hash", "transaction_hash", None),
+        ],
+    )
+    expected = Query(
+        {},
+        TableSource("events", ColumnSet([])),
+        selected_columns=[
+            Column("t_time", "timestamp", None),
+            Column("t_release", "tags[sentry:release]", None),
+            Column("t_dist", "tags[sentry:dist]", None),
+            Column("t_user", "tags[sentry:user]", None),
+            Column("t_transaction_hash", "NULL", None),
+        ],
+    )
+
+    def mock_detect_table(*args, **kwargs):
+        return "events"
+
+    dataset = DiscoverDataset()
+    DiscoverColumnProcessor(
+        dataset._DiscoverDataset__events_columns,
+        dataset._DiscoverDataset__transactions_columns,
+        mock_detect_table,
+    ).process_query(unprocessed, HTTPRequestSettings())
+    assert (
+        expected.get_selected_columns_from_ast()
+        == unprocessed.get_selected_columns_from_ast()
+    )
+
+    expected = [
+        "(timestamp AS t_time)",
+        "(`tags[sentry:release]` AS t_release)",
+        "(`tags[sentry:dist]` AS t_dist)",
+        "(`tags[sentry:user]` AS t_user)",
+        "(NULL AS t_transaction_hash)",
+    ]
+    columns = unprocessed.get_selected_columns_from_ast()
+    for idx, col in enumerate(columns):
+        ret = col.accept(ClickhouseExpressionFormatter())
+        assert ret == expected[idx]
+
+
+def test_discover_column_format_transactions_expressions() -> None:
+    unprocessed = Query(
+        {},
+        TableSource("transactions", ColumnSet([])),
+        selected_columns=[
+            Column(None, "time", None),
+            Column(None, "type", None),
+            Column(None, "timestamp", None),
+            Column(None, "username", None),
+            Column(None, "email", None),
+            Column(None, "transaction", None),
+            Column(None, "message", None),
+            Column(None, "title", None),
+            Column(None, "group_id", None),
+            Column(None, "geo_country_code", None),
+            Column(None, "geo_region", None),
+            Column(None, "geo_city", None),
+            Column(None, "server_name", None),
+        ],
+    )
+    expected = Query(
+        {},
+        TableSource("transactions", ColumnSet([])),
+        selected_columns=[
+            Column(None, "finish_ts", None),
+            Column(None, "'transaction'", None),
+            Column(None, "finish_ts", None),
+            Column(None, "user_name", None),
+            Column(None, "user_email", None),
+            Column(None, "transaction_name", None),
+            Column(None, "transaction_name", None),
+            Column(None, "transaction_name", None),
+            Column(None, "0", None),
+            Column(None, "contexts[geo.country_code]", None),
+            Column(None, "contexts[geo.region]", None),
+            Column(None, "contexts[geo.city]", None),
+            Column(None, "NULL", None),
+        ],
+    )
+
+    def mock_detect_table(*args, **kwargs):
+        return "transactions"
+
+    dataset = DiscoverDataset()
+    DiscoverColumnProcessor(
+        dataset._DiscoverDataset__events_columns,
+        dataset._DiscoverDataset__transactions_columns,
+        mock_detect_table,
+    ).process_query(unprocessed, HTTPRequestSettings())
+    assert (
+        expected.get_selected_columns_from_ast()
+        == unprocessed.get_selected_columns_from_ast()
+    )


### PR DESCRIPTION
Add an AST processor to mimic what happens in discover column_expr. This however
doesn't call the sub table processors, since I'm assuming those are called
automatically (for the time and tags/contexts conversions).