### PR TITLE
feat: Update consumer to take storage instead of dataset

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -34,7 +34,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "consumer",
                 "--auto-offset-reset=latest",
                 "--log-level=debug",
-                "--dataset=transactions",
+                "--storage=transactions",
                 "--consumer-group=transactions_group",
             ],
         ),

--- a/snuba/consumers/snapshot_worker.py
+++ b/snuba/consumers/snapshot_worker.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping, Optional, Set
 from confluent_kafka import Producer
 
 from snuba.consumer import ConsumerWorker, KafkaMessageMetadata
-from snuba.datasets.dataset import Dataset
+from snuba.datasets.storage import WritableTableStorage
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -34,7 +34,7 @@ class SnapshotAwareWorker(ConsumerWorker):
 
     def __init__(
         self,
-        dataset: Dataset,
+        storage: WritableTableStorage,
         producer: Producer,
         snapshot_id: SnapshotId,
         transaction_data: TransactionData,
@@ -42,7 +42,7 @@ class SnapshotAwareWorker(ConsumerWorker):
         replacements_topic: Optional[Topic] = None,
     ) -> None:
         super().__init__(
-            dataset=dataset,
+            storage=storage,
             producer=producer,
             replacements_topic=replacements_topic,
             metrics=metrics,

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -48,7 +48,9 @@ def run(events_file, dataset, repeat=1, profile_process=False, profile_write=Fal
         for statement in storage.get_schemas().get_create_statements():
             clickhouse_rw.execute(statement.statement)
 
-    consumer = ConsumerWorker(dataset, metrics=DummyMetricsBackend())
+    writable_storage = dataset.get_writable_storage()
+
+    consumer = ConsumerWorker(writable_storage, metrics=DummyMetricsBackend())
 
     messages = get_messages(events_file)
     messages = chain(*([messages] * repeat))

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -58,6 +58,7 @@ BULK_CLICKHOUSE_BUFFER = 10000
 # Processor/Writer Options
 DEFAULT_BROKERS = ["localhost:9092"]
 DEFAULT_DATASET_BROKERS: Mapping[str, Sequence[str]] = {}
+DEFAULT_STORAGE_BROKERS: Mapping[str, Sequence[str]] = {}
 
 DEFAULT_MAX_BATCH_SIZE = 50000
 DEFAULT_MAX_BATCH_TIME_MS = 2 * 1000

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -415,7 +415,9 @@ if application.debug or application.testing:
         if type_ == "insert":
             from snuba.consumer import ConsumerWorker
 
-            worker = ConsumerWorker(dataset, metrics=metrics)
+            storage = dataset.get_writable_storage()
+
+            worker = ConsumerWorker(storage, metrics=metrics)
         else:
             from snuba.replacer import ReplacerWorker
 

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -6,7 +6,7 @@ from typing import Optional
 from uuid import uuid1
 
 from snuba.consumers.snapshot_worker import SnapshotAwareWorker
-from snuba.datasets.factory import get_dataset
+from snuba.datasets.storages.factory import get_storage
 from snuba.processor import ProcessorAction, ProcessedMessage
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
@@ -66,12 +66,12 @@ class TestSnapshotWorker:
     def test_send_message(
         self, value: str, expected: Optional[ProcessedMessage],
     ) -> None:
-        dataset = get_dataset("groupedmessage")
+        storage = get_storage("groupedmessages")
         snapshot_id = uuid1()
         transact_data = TransactionData(xmin=100, xmax=200, xip_list=[120, 130])
 
         worker = SnapshotAwareWorker(
-            dataset=dataset,
+            storage=storage,
             producer=FakeConfluentKafkaProducer(),
             snapshot_id=str(snapshot_id),
             transaction_data=transact_data,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -29,7 +29,7 @@ class TestConsumer(BaseEventsTest):
         )
 
         test_worker = ConsumerWorker(
-            self.dataset,
+            self.dataset.get_writable_storage(),
             producer=FakeConfluentKafkaProducer(),
             replacements_topic=Topic(
                 enforce_table_writer(self.dataset)
@@ -48,7 +48,7 @@ class TestConsumer(BaseEventsTest):
 
     def test_skip_too_old(self):
         test_worker = ConsumerWorker(
-            self.dataset,
+            self.dataset.get_writable_storage(),
             producer=FakeConfluentKafkaProducer(),
             replacements_topic=Topic(
                 enforce_table_writer(self.dataset)
@@ -78,7 +78,7 @@ class TestConsumer(BaseEventsTest):
     def test_produce_replacement_messages(self):
         producer = FakeConfluentKafkaProducer()
         test_worker = ConsumerWorker(
-            self.dataset,
+            self.dataset.get_writable_storage(),
             producer=producer,
             replacements_topic=Topic(
                 enforce_table_writer(self.dataset)


### PR DESCRIPTION
Consumers are now associated with a storage instead of
a datset. In future when entities are introduced, consumers and replacers
may become entity rather than storage specific.

We will likely want to register DEFAULT_STORAGE_BROKERS everywhere before
merging this change, however it will only actually make a difference if
the user is not explicitly specifying the consumer dataset (i.e using default
events) and there is a different default registered for events in
DEFAULT_DATASET_BROKERS. We do not do this anywhere.

See also https://github.com/getsentry/snuba/pull/861