### PR TITLE
ref: Deprecate dataset.get_table_writer()

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -66,8 +66,10 @@ def bootstrap(
         topics = {}
         for name in ACTIVE_DATASET_NAMES:
             dataset = get_dataset(name)
-            table_writer = dataset.get_table_writer()
-            if table_writer:
+            writable_storage = dataset.get_writable_storage()
+
+            if writable_storage:
+                table_writer = writable_storage.get_table_writer()
                 stream_loader = table_writer.get_stream_loader()
                 for topic_spec in stream_loader.get_all_topic_specs():
                     if topic_spec.topic_name in topics:

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -4,7 +4,6 @@ from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.escaping import escape_identifier
 from snuba.datasets.plans.query_plan import StorageQueryPlanBuilder
 from snuba.datasets.storage import Storage, WritableStorage, WritableTableStorage
-from snuba.datasets.table_storage import TableWriter
 from snuba.query.extensions import QueryExtension
 from snuba.query.parsing import ParsingContext
 from snuba.query.query import Query
@@ -125,19 +124,6 @@ class Dataset(object):
         and datasets can have more than one writable storage.
         """
         return self.__writable_storage
-
-    def get_table_writer(self) -> Optional[TableWriter]:
-        """
-        We allow only one table storage we can write onto per dataset as of now.
-        This will move to the entity as soon as we have entities, and
-        the constraint of one writable storage will drop as soon as the consumers
-        start referencing entities and storages instead of datasets.
-        """
-        return (
-            self.__writable_storage.get_table_writer()
-            if self.__writable_storage
-            else None
-        )
 
     # Old methods that we are migrating away from
     def column_expr(

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -89,11 +89,12 @@ def get_enabled_dataset_names() -> Sequence[str]:
 
 
 def enforce_table_writer(dataset: Dataset) -> TableWriter:
-    table_writer = dataset.get_table_writer()
+    writable_storage = dataset.get_writable_storage()
+
     assert (
-        table_writer is not None
+        writable_storage is not None
     ), f"Dataset{dataset} does not have a writable storage."
-    return table_writer
+    return writable_storage.get_table_writer()
 
 
 def ensure_not_internal(dataset: Dataset) -> None:

--- a/snuba/migrations/migrate.py
+++ b/snuba/migrations/migrate.py
@@ -36,8 +36,10 @@ def _run_schema(conn: Client, schema: Schema) -> None:
 
 def run(conn: Client, dataset: Dataset) -> None:
     schemas: MutableSequence[Schema] = []
-    writer = dataset.get_table_writer()
-    if writer:
+
+    writable_storage = dataset.get_writable_storage()
+    if writable_storage:
+        writer = writable_storage.get_table_writer()
         schemas.append(writer.get_schema())
     for storage in dataset.get_all_storages():
         schemas.append(storage.get_schemas().get_read_schema())

--- a/tests/migrations/test_migrate.py
+++ b/tests/migrations/test_migrate.py
@@ -27,10 +27,11 @@ class TestMigrate(BaseDatasetTest):
         from snuba.migrations.parse_schema import get_local_schema
 
         for dataset_name in DATASET_NAMES:
-            table_writer = get_dataset(dataset_name).get_table_writer()
-            if not table_writer:
+            writable_storage = get_dataset(dataset_name).get_writable_storage()
+            if not writable_storage:
                 continue
 
+            table_writer = writable_storage.get_table_writer()
             dataset_schema = table_writer.get_schema()
             local_table_name = dataset_schema.get_local_table_name()
             local_schema = get_local_schema(self.clickhouse, local_table_name)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1284,7 +1284,9 @@ class TestApi(BaseApiTest):
 
         assert self.app.post("/tests/events/drop").status_code == 200
         dataset = get_dataset("events")
-        writer = dataset.get_writable_storage().get_table_writer()
+        storage = dataset.get_writable_storage()
+        assert storage is not None
+        writer = storage.get_table_writer()
         table = writer.get_schema().get_table_name()
         assert table not in self.clickhouse.execute("SHOW TABLES")
         assert self.redis_db_size() == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1284,7 +1284,7 @@ class TestApi(BaseApiTest):
 
         assert self.app.post("/tests/events/drop").status_code == 200
         dataset = get_dataset("events")
-        writer = dataset.get_table_writer()
+        writer = dataset.get_writable_storage().get_table_writer()
         table = writer.get_schema().get_table_name()
         assert table not in self.clickhouse.execute("SHOW TABLES")
         assert self.redis_db_size() == 0

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -7,7 +7,9 @@ from snuba import perf
 class TestPerf(BaseEventsTest):
     def test(self):
         dataset = get_dataset("events")
-        table = dataset.get_writable_storage().get_table_writer().get_schema().get_local_table_name()
+        storage = dataset.get_writable_storage()
+        assert storage is not None
+        table = storage.get_table_writer().get_schema().get_local_table_name()
 
         assert self.clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 0
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -7,7 +7,7 @@ from snuba import perf
 class TestPerf(BaseEventsTest):
     def test(self):
         dataset = get_dataset("events")
-        table = dataset.get_table_writer().get_schema().get_local_table_name()
+        table = dataset.get_writable_storage().get_table_writer().get_schema().get_local_table_name()
 
         assert self.clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 0
 


### PR DESCRIPTION
We don't need this anymore. Instead we should get any properties
of a writable storage via dataset.get_writable_storage() instead.