### PR TITLE
ref(devserver): Update the devserver command to use new syntax

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -45,17 +45,29 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "consumer",
                 "--auto-offset-reset=latest",
                 "--log-level=debug",
-                "--dataset=sessions",
+                "--storage=sessions_raw",
                 "--consumer-group=sessions_group",
             ],
         ),
         (
             "consumer",
-            ["snuba", "consumer", "--auto-offset-reset=latest", "--log-level=debug"],
+            [
+                "snuba",
+                "consumer",
+                "--auto-offset-reset=latest",
+                "--log-level=debug",
+                "--storage=events",
+            ],
         ),
         (
             "replacer",
-            ["snuba", "replacer", "--auto-offset-reset=latest", "--log-level=debug"],
+            [
+                "snuba",
+                "replacer",
+                "--auto-offset-reset=latest",
+                "--log-level=debug",
+                "--storage=events",
+            ],
         ),
     ]
 


### PR DESCRIPTION
Use the new syntax for the consumer and replacer in devserver.
--dataset will be deprecated soon.
Ensure that a storage name is always passed, as this will become
a mandatory field and the events default will be eventually removed.