### PR TITLE
feat(split) Move the split logic from web to plans

### DIFF
--- a/snuba/datasets/plans/split.py
+++ b/snuba/datasets/plans/split.py
@@ -10,6 +10,11 @@ from snuba.datasets.plans.split_strategy import StorageQuerySplitStrategy
 from snuba.query.query import Query
 from snuba.request import Request
 from snuba.util import is_condition
+
+# TODO: Importing snuba.web here is just wrong. What's need to be done to avoid this
+# dependency is a refactoring of the methods that return RawQueryResult to make them
+# depend on Result + some debug data structure instead. Also It requires removing
+# extra data from the result of the query.
 from snuba.web import RawQueryResult
 
 # Every time we find zero results for a given step, expand the search window by

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -12,10 +12,10 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
-from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.errors_replacer import ErrorsReplacer, ReplacerState
+from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.events_processor import EventsProcessor
-from snuba.web.split import (
+from snuba.datasets.plans.split import (
     ColumnSplitQueryStrategy,
     TimeSplitQueryStrategy,
 )

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -17,13 +17,13 @@ from snuba.clickhouse.columns import (
     UUID,
     WithDefault,
 )
-from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.tagsmap import NestedFieldConditionOptimizer
 from snuba.query.processors.transaction_column_processor import (
     TransactionColumnProcessor,
 )
-from snuba.web.split import (
+from snuba.datasets.dataset_schemas import StorageSchemas
+from snuba.datasets.plans.split import (
     ColumnSplitQueryStrategy,
     TimeSplitQueryStrategy,
 )

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -7,7 +7,7 @@ from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SimpleQueryPlanExecutionStrategy
-from snuba.web.split import (
+from snuba.datasets.plans.split import (
     ColumnSplitQueryStrategy,
     TimeSplitQueryStrategy,
 )


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/865 did not move the file split.py out of the web nodule to simplify the review process so that the changes were visible.
This PR just moves the file outside and calls out the import that requires a refactoring to remove. Like for everyone depending on RawQueryResult