### PR TITLE
ref(settings): Enable query cache by default

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -36,7 +36,7 @@ REDIS_PORT = 6379
 REDIS_PASSWORD = None
 REDIS_DB = 1
 
-USE_RESULT_CACHE = False
+USE_RESULT_CACHE = True
 
 # Query Recording Options
 RECORD_QUERIES = False
@@ -117,7 +117,9 @@ def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
             assert isinstance(settings_spec.loader, importlib.abc.Loader)
             settings_spec.loader.exec_module(settings_module)
         else:
-            module_format = ".%s" if settings.startswith("settings_") else ".settings_%s"
+            module_format = (
+                ".%s" if settings.startswith("settings_") else ".settings_%s"
+            )
             settings_module = importlib.import_module(module_format % settings, "snuba")
 
         for attr in dir(settings_module):


### PR DESCRIPTION
Redis is already required by virtue of replacement state, so I'm not sure what other benefits we would get from this being disabled in the default configuration. There is possibly an argument to be made against its use in development, but that seems like the special case, not the common one.

We might also want to reconsider the default value for the `cache_expiry_sec` dynamic configuration — it's also set at 1 second which seems extremely low for any practical use case.

If we don't want to do this for some reason, we should change so that deduplication is off by default — right now the default is on, which is the worst of both worlds.