### PR TITLE
ref(query): Simplify error control flow for query

### DIFF
--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -4,12 +4,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Callable, Sequence
 
-from snuba.web import RawQueryResult
+from snuba.web import QueryResult
 from snuba.query.query_processor import QueryProcessor
 from snuba.request import Request
 
 
-QueryRunner = Callable[[Request], RawQueryResult]
+QueryRunner = Callable[[Request], QueryResult]
 
 
 @dataclass(frozen=True)
@@ -50,7 +50,7 @@ class QueryPlanExecutionStrategy(ABC):
     """
 
     @abstractmethod
-    def execute(self, request: Request, runner: QueryRunner) -> RawQueryResult:
+    def execute(self, request: Request, runner: QueryRunner) -> QueryResult:
         """
         Executes the query plan. The request parameter provides query and query settings.
         The runner parameters is a function to actually run one individual query on the

--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -8,17 +8,17 @@ from snuba.datasets.plans.query_plan import (
 )
 from snuba.datasets.storage import QueryStorageSelector, ReadableStorage
 
-# TODO: Importing snuba.web here is just wrong. What's need to be done to avoid this
-# dependency is a refactoring of the methods that return RawQueryResult to make them
-# depend on Result + some debug data structure instead. Also It requires removing
-# extra data from the result of the query.
-from snuba.web import RawQueryResult
+# TODO: Importing snuba.web here is just wrong. What's need to be done to avoid
+# this dependency is a refactoring of the methods that return QueryResult to
+# make them depend on Result + some debug data structure instead. Also It
+# requires removing extra data from the result of the query.
+from snuba.web import QueryResult
 from snuba.query.query_processor import QueryProcessor
 from snuba.request import Request
 
 
 class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy):
-    def execute(self, request: Request, runner: QueryRunner) -> RawQueryResult:
+    def execute(self, request: Request, runner: QueryRunner) -> QueryResult:
         return runner(request)
 
 

--- a/snuba/subscriptions/executor.py
+++ b/snuba/subscriptions/executor.py
@@ -50,9 +50,9 @@ class SubscriptionExecutor:
         )
 
         with self.__concurrent_gauge:
-            # XXX: The ``extra`` is discarded from ``RawQueryResult`` since it
-            # is not particularly useful in this context and duplicates data
-            # that is already being published to the query log.
+            # XXX: The ``extra`` is discarded from ``QueryResult`` since it is
+            # not particularly useful in this context and duplicates data that
+            # is already being published to the query log.
             return parse_and_run_query(self.__dataset, request, timer).result
 
     def execute(self, task: ScheduledTask[Subscription], tick: Tick) -> Future[Result]:

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -1,21 +1,28 @@
 from typing import Any, Mapping, NamedTuple
 
+from mypy_extensions import TypedDict
+
 from snuba.reader import Result
+
+
+class RawQueryExtraData(TypedDict):
+    stats: Mapping[str, Any]
+    sql: str
 
 
 class RawQueryException(Exception):
     """
-    Exception raiesd during query execution that is used to carry context
-    back up the stack to the HTTP response. This exception should always be
-    chained with another exception that contains additional detail about the
-    cause of the exception.
+    Exception raised during query execution that is used to carry extra data
+    back up the stack to the HTTP response -- basically a ``RawQueryResult``,
+    but without an actual ``Result`` instance. This exception should always
+    be chained with another exception that contains additional detail about
+    the cause of the exception.
     """
 
-    def __init__(self, stats: Mapping[str, Any], sql: str):
-        self.stats = stats
-        self.sql = sql
+    def __init__(self, extra: RawQueryExtraData):
+        self.extra = extra
 
 
 class RawQueryResult(NamedTuple):
     result: Result
-    extra: Any
+    extra: RawQueryExtraData

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -5,24 +5,24 @@ from mypy_extensions import TypedDict
 from snuba.reader import Result
 
 
-class RawQueryExtraData(TypedDict):
+class QueryExtraData(TypedDict):
     stats: Mapping[str, Any]
     sql: str
 
 
-class RawQueryException(Exception):
+class QueryException(Exception):
     """
     Exception raised during query execution that is used to carry extra data
-    back up the stack to the HTTP response -- basically a ``RawQueryResult``,
+    back up the stack to the HTTP response -- basically a ``QueryResult``,
     but without an actual ``Result`` instance. This exception should always
     be chained with another exception that contains additional detail about
     the cause of the exception.
     """
 
-    def __init__(self, extra: RawQueryExtraData):
+    def __init__(self, extra: QueryExtraData):
         self.extra = extra
 
 
-class RawQueryResult(NamedTuple):
+class QueryResult(NamedTuple):
     result: Result
-    extra: RawQueryExtraData
+    extra: QueryExtraData

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -4,14 +4,16 @@ from snuba.reader import Result
 
 
 class RawQueryException(Exception):
-    def __init__(
-        self, err_type: str, message: str, stats: Mapping[str, Any], sql: str, **meta
-    ):
-        self.err_type = err_type
-        self.message = message
+    """
+    Exception raiesd during query execution that is used to carry context
+    back up the stack to the HTTP response. This exception should always be
+    chained with another exception that contains additional detail about the
+    cause of the exception.
+    """
+
+    def __init__(self, stats: Mapping[str, Any], sql: str):
         self.stats = stats
         self.sql = sql
-        self.meta = meta
 
 
 class RawQueryResult(NamedTuple):

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -182,7 +182,7 @@ def raw_query(
                 else:
                     logger.exception("Error running query: %s\n%s", sql, cause)
                     stats = update_with_status("error")
-                raise RawQueryException(stats=stats, sql=sql) from cause
+                raise RawQueryException({"stats": stats, "sql": sql}) from cause
 
     stats = update_with_status("success")
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -23,7 +23,7 @@ from snuba.state.rate_limit import (
 from snuba.util import force_bytes
 from snuba.utils.codecs import JSONCodec
 from snuba.utils.metrics.timer import Timer
-from snuba.web import RawQueryException, RawQueryResult
+from snuba.web import QueryException, QueryResult
 from snuba.web.query_metadata import ClickhouseQueryMetadata, SnubaQueryMetadata
 
 cache: Cache[Any] = RedisCache(redis_client, "snuba-query-cache:", JSONCodec())
@@ -62,7 +62,7 @@ def raw_query(
     query_metadata: SnubaQueryMetadata,
     stats: MutableMapping[str, Any],
     trace_id: Optional[str] = None,
-) -> RawQueryResult:
+) -> QueryResult:
     """
     Submits a raw SQL query to the DB and does some post-processing on it to
     fix some of the formatting issues in the result JSON.
@@ -182,8 +182,8 @@ def raw_query(
                 else:
                     logger.exception("Error running query: %s\n%s", sql, cause)
                     stats = update_with_status("error")
-                raise RawQueryException({"stats": stats, "sql": sql}) from cause
+                raise QueryException({"stats": stats, "sql": sql}) from cause
 
     stats = update_with_status("success")
 
-    return RawQueryResult(result, {"stats": stats, "sql": sql})
+    return QueryResult(result, {"stats": stats, "sql": sql})

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -16,7 +16,7 @@ from snuba.query.timeseries import TimeSeriesExtensionProcessor
 from snuba.request import Request
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.metrics.timer import Timer
-from snuba.web import RawQueryException, RawQueryResult
+from snuba.web import QueryException, QueryResult
 from snuba.web.db_query import raw_query
 from snuba.web.query_metadata import SnubaQueryMetadata
 from snuba.web.split import split_query
@@ -28,7 +28,7 @@ metrics = MetricsWrapper(environment.metrics, "api")
 
 def parse_and_run_query(
     dataset: Dataset, request: Request, timer: Timer
-) -> RawQueryResult:
+) -> QueryResult:
     """
     Runs a Snuba Query, then records the metadata about each split query that was run.
     """
@@ -50,7 +50,7 @@ def parse_and_run_query(
             dataset=dataset, request=request, timer=timer, query_metadata=query_metadata
         )
         record_query(request_copy, timer, query_metadata)
-    except RawQueryException as error:
+    except QueryException as error:
         record_query(request_copy, timer, query_metadata)
         raise error
 
@@ -63,7 +63,7 @@ def _run_query_pipeline(
     request: Request,
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
-) -> RawQueryResult:
+) -> QueryResult:
     """
     Runs the query processing and execution pipeline for a Snuba Query. This means it takes a Dataset
     and a Request and returns the results of the query.
@@ -133,7 +133,7 @@ def _format_storage_query_and_run(
     from_date: datetime,
     to_date: datetime,
     request: Request,
-) -> RawQueryResult:
+) -> QueryResult:
     """
     Formats the Storage Query and pass it to the DB specific code for execution.
     TODO: When we will have the AST in production and we will have the StorageQuery

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -40,7 +40,7 @@ from snuba.utils.metrics.timer import Timer
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.web.converters import DatasetConverter
-from snuba.web import RawQueryException
+from snuba.web import QueryException
 from snuba.web.query import parse_and_run_query
 
 
@@ -277,7 +277,7 @@ def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
 
     try:
         result = parse_and_run_query(dataset, request, timer)
-    except RawQueryException as exception:
+    except QueryException as exception:
         status = 500
         details: Mapping[str, Any]
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -304,12 +304,7 @@ def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
 
         return Response(
             json.dumps(
-                {
-                    "error": details,
-                    "sql": exception.sql,
-                    "stats": exception.stats,
-                    "timing": timer.for_json(),
-                }
+                {"error": details, "timing": timer.for_json(), **exception.extra}
             ),
             status,
             {"Content-Type": "application/json"},

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -7,7 +7,7 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.data import InvalidSubscriptionError, SubscriptionData
 from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDeleter
 from snuba.utils.metrics.timer import Timer
-from snuba.web import RawQueryException
+from snuba.web import QueryException
 from tests.subscriptions import BaseSubscriptionTest
 
 
@@ -31,7 +31,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
     def test_invalid_condition_column(self):
         creator = SubscriptionCreator(self.dataset)
-        with raises(RawQueryException):
+        with raises(QueryException):
             creator.create(
                 SubscriptionData(
                     123,
@@ -45,7 +45,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
     def test_invalid_aggregation(self):
         creator = SubscriptionCreator(self.dataset)
-        with raises(RawQueryException):
+        with raises(QueryException):
             creator.create(
                 SubscriptionData(
                     123,

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -10,7 +10,7 @@ from snuba.query.query import Query
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.metrics.timer import Timer
-from snuba.web import RawQueryResult
+from snuba.web import QueryResult
 from snuba.web.split import split_query
 
 
@@ -37,10 +37,7 @@ def test_no_split(dataset_name: str):
             "limit": 100,
             "offset": 50,
         },
-        events.get_all_storages()[0]
-        .get_schemas()
-        .get_read_schema()
-        .get_data_source(),
+        events.get_all_storages()[0].get_schemas().get_read_schema().get_data_source(),
     )
 
     @split_query
@@ -98,9 +95,9 @@ def test_col_split(
     def do_query(dataset: Dataset, request: Request, timer: Timer):
         selected_cols = request.query.get_selected_columns()
         if selected_cols == list(first_query_data[0].keys()):
-            return RawQueryResult({"data": first_query_data}, {})
+            return QueryResult({"data": first_query_data}, {})
         elif selected_cols == list(second_query_data[0].keys()):
-            return RawQueryResult({"data": second_query_data}, {})
+            return QueryResult({"data": second_query_data}, {})
         else:
             raise ValueError(f"Unexpected selected columns: {selected_cols}")
 
@@ -114,10 +111,7 @@ def test_col_split(
             "limit": 100,
             "offset": 50,
         },
-        events.get_all_storages()[0]
-        .get_schemas()
-        .get_read_schema()
-        .get_data_source(),
+        events.get_all_storages()[0].get_schemas().get_read_schema().get_data_source(),
     )
 
     request = Request(


### PR DESCRIPTION
This change includes some refactoring to simplify the eventual integration of #882 and also just clean up some of my own favorite functions.

This change:

1. reduces the nesting level of `raw_query` by consolidating inner exception handling into a single location,
2. simplifies `RawQueryException` to only contain data that is fit for its purpose (as documented) so that it instead carries additional specialized exception data via exception chaining which reduces redundancy,
3. moves exception detail formatting to `snuba.web.views` and out of the query execution code,
4. removes the `WebQueryResult` by consolidating `run_query` and `format_query` into `dataset_query` and directly returning a `Response` object.