### PR TITLE
Clickhouse authentication based on user/pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ Data is written into the table `sentry_local`: `select count() from sentry_local
 
 Snuba assumes:
 
-1. A Clickhouse server endpoint at `CLICKHOUSE_HOST` (default `localhost`).
-2. A redis instance running at `REDIS_HOST` (default `localhost`). On port
+* A Clickhouse server endpoint at `CLICKHOUSE_HOST` (default `localhost`) with:
+  * A user configured with username `CLICKHOUSE_USER` (default `default`) and
+    password `CLICKHOUSE_PASS` (default empty string).
+* A redis instance running at `REDIS_HOST` (default `localhost`). On port
    `6379`
 
 A quick way to get these services running is to set up sentry, then use:

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -20,6 +20,18 @@ from snuba.environment import setup_logging
     help="Clickhouse native port to write to.",
 )
 @click.option(
+    "--clickhouse-user",
+    default=settings.CLICKHOUSE_USER,
+    type=str,
+    help="Clickhouse username.",
+)
+@click.option(
+    "--clickhouse-pass",
+    default=settings.CLICKHOUSE_PASS,
+    type=str,
+    help="Clickhouse password.",
+)
+@click.option(
     "--dry-run",
     type=bool,
     default=True,
@@ -38,6 +50,8 @@ def cleanup(
     *,
     clickhouse_host: str,
     clickhouse_port: int,
+    clickhouse_user: str,
+    clickhouse_pass: str,
     dry_run: bool,
     database: str,
     dataset_name: str,
@@ -55,6 +69,8 @@ def cleanup(
     dataset = get_dataset(dataset_name)
     table = enforce_table_writer(dataset).get_schema().get_local_table_name()
 
-    clickhouse = ClickhousePool(clickhouse_host, clickhouse_port)
+    clickhouse = ClickhousePool(
+        clickhouse_host, clickhouse_port, clickhouse_user, clickhouse_pass
+    )
     num_dropped = run_cleanup(clickhouse, database, table, dry_run=dry_run)
     logger.info("Dropped %s partitions on %s" % (num_dropped, clickhouse_host))

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -19,6 +19,18 @@ from snuba.environment import setup_logging
     type=int,
     help="Clickhouse native port to write to.",
 )
+@click.option(
+    "--clickhouse-user",
+    default=settings.CLICKHOUSE_USER,
+    type=str,
+    help="Clickhouse username.",
+)
+@click.option(
+    "--clickhouse-pass",
+    default=settings.CLICKHOUSE_PASS,
+    type=str,
+    help="Clickhouse password.",
+)
 @click.option("--database", default="default", help="Name of the database to target.")
 @click.option(
     "--dataset",
@@ -38,6 +50,8 @@ def optimize(
     *,
     clickhouse_host: str,
     clickhouse_port: int,
+    clickhouse_user: str,
+    clickhouse_pass: str,
     database: str,
     dataset_name: str,
     timeout: int,

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -117,11 +117,7 @@ def replacer(
     ), f"Storage {type(storage)} does not have a replacement topic."
     replacements_topic = replacements_topic or default_replacement_topic_spec.topic_name
 
-    metrics = MetricsWrapper(
-        environment.metrics,
-        "replacer",
-        tags=metrics_tags,
-    )
+    metrics = MetricsWrapper(environment.metrics, "replacer", tags=metrics_tags,)
 
     client_settings = {
         # Replacing existing rows requires reconstructing the entire tuple for each
@@ -138,6 +134,8 @@ def replacer(
     clickhouse = ClickhousePool(
         settings.CLICKHOUSE_HOST,
         settings.CLICKHOUSE_PORT,
+        settings.CLICKHOUSE_USER,
+        settings.CLICKHOUSE_PASS,
         client_settings=client_settings,
     )
 

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -25,6 +25,8 @@ class ClickhousePool(object):
         self,
         host: str,
         port: int,
+        user="default",
+        password="",
         connect_timeout=1,
         send_receive_timeout=300,
         max_pool_size=settings.CLICKHOUSE_MAX_POOL_SIZE,
@@ -32,6 +34,8 @@ class ClickhousePool(object):
     ):
         self.host = host
         self.port = port
+        self.user = user
+        self.password = password
         self.connect_timeout = connect_timeout
         self.send_receive_timeout = send_receive_timeout
         self.client_settings = client_settings
@@ -126,6 +130,8 @@ class ClickhousePool(object):
         return Client(
             host=self.host,
             port=self.port,
+            user=self.user,
+            password=self.password,
             connect_timeout=self.connect_timeout,
             send_receive_timeout=self.send_receive_timeout,
             settings=self.client_settings,

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -32,10 +32,17 @@ def setup_sentry() -> None:
     )
 
 
-clickhouse_rw = ClickhousePool(settings.CLICKHOUSE_HOST, settings.CLICKHOUSE_PORT)
+clickhouse_rw = ClickhousePool(
+    settings.CLICKHOUSE_HOST,
+    settings.CLICKHOUSE_PORT,
+    settings.CLICKHOUSE_USER,
+    settings.CLICKHOUSE_PASS,
+)
 clickhouse_ro = ClickhousePool(
     settings.CLICKHOUSE_HOST,
     settings.CLICKHOUSE_PORT,
+    settings.CLICKHOUSE_USER,
+    settings.CLICKHOUSE_PASS,
     client_settings={"readonly": True},
 )
 

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -21,6 +21,8 @@ DATASET_MODE = "local"
 ).split(":", 1)
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", default_clickhouse_host)
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", default_clickhouse_port))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASS = os.environ.get("CLICKHOUSE_PASS", "")
 CLICKHOUSE_HTTP_PORT = int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123))
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
@@ -117,7 +119,9 @@ def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
             assert isinstance(settings_spec.loader, importlib.abc.Loader)
             settings_spec.loader.exec_module(settings_module)
         else:
-            module_format = ".%s" if settings.startswith("settings_") else ".settings_%s"
+            module_format = (
+                ".%s" if settings.startswith("settings_") else ".settings_%s"
+            )
             settings_module = importlib.import_module(module_format % settings, "snuba")
 
         for attr in dir(settings_module):

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -36,7 +36,12 @@ class TestClickhouse(BaseEventsTest):
             errors.NetworkError,
             '{"data": "to my face"}',
         ]
-        cp = ClickhousePool(settings.CLICKHOUSE_HOST, settings.CLICKHOUSE_PORT)
+        cp = ClickhousePool(
+            settings.CLICKHOUSE_HOST,
+            settings.CLICKHOUSE_PORT,
+            settings.CLICKHOUSE_USER,
+            settings.CLICKHOUSE_PASS,
+        )
         cp.execute("SHOW TABLES")
         assert FakeClient.return_value.execute.mock_calls == [
             call("SHOW TABLES"),


### PR DESCRIPTION
Currently the connection from Snuba to Clickhouse is unauthenticated. By adding authentication based on username/password, security of the product is increased.

1. To reproduce, start clickhouse with authentication by:
* Create a file `testuser.xml` with contents:
```
<yandex>
    <users>
      <default remove="remove"></default>
      <testuser>
          <profile>default</profile>
          <password>qwerty</password>
      </testuser>
    </users>
</yandex>
```
* Start clickhouse with the following command:
```
docker run --rm -it --name some-clickhouse-server --ulimit nofile=262144:262144 -v /path/to/testuser.xml:/etc/clickhouse-server/users.d/testuser.xml -p 9000:9000 yandex/clickhouse-server
```

2. To test if clickhouse authentication works as expected:
```
from clickhouse_driver import Client

client = Client('localhost')
client.execute('SHOW DATABASES')
# should give auth error

client = Client('localhost', user='testuser', password='qwerty')
client.execute('SHOW DATABASES')
# [('default',), ('system',)]
```

3. Run normal tests with:
```
export CLICKHOUSE_USER=testuser
export CLICKHOUSE_PASS=qwerty
```