### PR TITLE
ref(query): Split up stages of physical query execution

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -174,9 +174,9 @@ def raw_query(
                         }
                     )
 
-                    if use_cache:
-                        cache.set(query_id, result)
-                        timer.mark("cache_set")
+                if use_cache:
+                    cache.set(query_id, result)
+                    timer.mark("cache_set")
     except Exception as cause:
         if isinstance(cause, RateLimitExceeded):
             stats = update_with_status("rate-limited")


### PR DESCRIPTION
This splits up the stages of raw query execution into independent stages:

1. `execute_query_with_deduplication` applies deduplication logic
2. `execute_query_with_caching` implements simple read through caching to the query
3. `execute_query_with_rate_limits` enforces rate limits to the query, and adjusts query settings based on current rate limit activity
4. `execute_query` runs the query on ClickHouse and and adjusts query settings for consistency and performance

The intended effect here is that these processing stages are completely encapsulated within a single function, which may be removed from the stack (or even reordered) without impacting the ability of other stages to execute. (This can result in the timings and stats being different in order and content, however.)

The independent commits in this set of changes should be independently reviewable, which may help to understand the evolution of this process and how things were factored out, rather than trying to digest the whole set at once.