### PR TITLE
fix(query processing) Make column_expr work properly in ORDER BY clauses

### DIFF
--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -57,8 +57,7 @@ def column_expr(
     elif isinstance(column_name, str) and QUOTED_LITERAL_RE.match(column_name):
         return escape_literal(column_name[1:-1])
     else:
-        fix_orderby_col_processing = state.get_config("fix_orderby_col_processing", 1)
-        if fix_orderby_col_processing:
+        if state.get_config("fix_orderby_col_processing", 1):
             # column_name may be prefixed by `-` if this is in an ORDER BY clause that
             # is not present elsewhere in the query (thus was not given an alias).
             # This means we need to strip it from the column_name we pass to the column_expr
@@ -73,6 +72,7 @@ def column_expr(
             negate = ""
             col = column_name
         expr = f"{negate}{dataset.column_expr(col, query, parsing_context)}"
+
     if aggregate:
         expr = function_expr(aggregate, expr)
 

--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -60,11 +60,14 @@ def column_expr(
         fix_orderby_col_processing = state.get_config("fix_orderby_col_processing", 1)
         if fix_orderby_col_processing:
             # column_name may be prefixed by `-` if this is in an ORDER BY clause that
-            # is not present elsewhere in the query (thus it was not given an alias).
+            # is not present elsewhere in the query (thus was not given an alias).
             # This means we need to strip it from the column_name we pass to the column_expr
-            # method and add it back to the result.
+            # method and add it back to the result since the column_expr functions should
+            # not deal with the order by syntax.
             match = NEGATE_RE.match(column_name)
-            assert match, f"Invalid column format: {column_name}"
+            assert (
+                match
+            ), f"Invalid column format: {column_name}. Cannot strip the order by prefix"
             negate, col = match.groups()
         else:
             negate = ""

--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -62,7 +62,7 @@ def column_expr(
             # is not present elsewhere in the query (thus was not given an alias).
             # This means we need to strip it from the column_name we pass to the column_expr
             # method and add it back to the result since the column_expr functions should
-            # not deal with the order by syntax.
+            # not deal with the ORDER BY syntax.
             match = NEGATE_RE.match(column_name)
             assert (
                 match

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -251,3 +251,20 @@ class TestEventsDataset(BaseEventsTest):
             )
             == "-`exception_stacks.type`"
         )
+
+        assert (
+            column_expr(self.dataset, "-tags[myTag]", deepcopy(query), ParsingContext())
+            == "-(tags.value[indexOf(tags.key, 'myTag')] AS `tags[myTag]`)"
+        )
+
+        context = ParsingContext()
+        context.add_alias("`tags[myTag]`")
+        assert (
+            column_expr(self.dataset, "-tags[myTag]", deepcopy(query), context)
+            == "-`tags[myTag]`"
+        )
+
+        assert (
+            column_expr(self.dataset, "-group_id", deepcopy(query), ParsingContext())
+            == "-(nullIf(group_id, 0) AS group_id)"
+        )


### PR DESCRIPTION
@mitsuhiko noticed that, when adding `-sessions` column in a query for the Sessions dataset, the query would fail because the column_expr method would not understand the name of the column because of the hyphen in front and thus fail to resolve it to an aggregation.

A simpler use case is:
```
{
    "selected_columns": ["event_id"],
    "orderby": ["-tags[asd]"],
    "project": [1],
    "from_date": "2020-04-17T23:33:39",
    "to_date": "2020-04-22T23:33:39",
    "granularity": 3600
}
```

The result is:
```
DB::Exception: Missing columns: 'tags[asd]' while processing query: 'SELECT event_id FROM sentry_local PREWHERE project_id IN (1) WHERE (timestamp >= toDateTime('2020-04-17T23:33
:39')) AND (timestamp < toDateTime('2020-04-22T23:33:39')) AND (deleted = 0) ORDER BY `tags[asd]` DESC LIMIT 0, 1000'
```

column_expr receives the column `-tags[asd]` instead of `tags[asd]` thus it does not know it has to resolve it.

This PR pre processes the column name before passing it to the dataset specific column_expr method by stripping the hyphen and adding it back to the result if needed.