### PR TITLE
fix: Quiet down mypy errors from sentry_sdk

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -52,6 +52,9 @@ ignore_missing_imports = True
 [mypy-sentry_relay.consts]
 ignore_missing_imports = True
 
+[mypy-sentry_sdk]
+no_implicit_reexport = False
+
 [mypy-setuptools]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-python/issues/375