### PR TITLE
fix(discover) Fix for duration queries on events tables

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -299,6 +299,8 @@ class DiscoverDataset(TimeSeriesDataset):
                 column_name = "tags[sentry:dist]"
             if column_name == "user":
                 column_name = "tags[sentry:user]"
+            if column_name == "duration":
+                return "0"
             if self.__transactions_columns.get(column_name):
                 return "NULL"
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -527,3 +527,24 @@ class TestDiscoverApi(BaseApiTest):
             ).data
         )
         assert result["data"] == [{"contexts[device.online]": "True"}]
+
+    def test_duration_in_event_query(self):
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [["quantile(0.95)", "duration", "p95"]],
+                    "conditions": [["type", "=", "error"]],
+                    "groupby": ["time"],
+                    "orderby": "time",
+                    "granularity": 300,
+                    "limit": 1000,
+                }
+            ),
+        )
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert len(data["data"]) == 1
+        assert data["data"][0]["p95"] == 0.0


### PR DESCRIPTION
This is a bit of a hack, but there are a lot of errors caused when users ask for
duration or duration aggregates on error events instead of transaction events.
Attempt to handle most of them by returning 0 if errors are used.