### PR TITLE
feat(dataset) Make dataset related interfaces generic

### DIFF
--- a/snuba/clickhouse/dictquery.py
+++ b/snuba/clickhouse/dictquery.py
@@ -3,6 +3,7 @@ from snuba import util
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.sql import SqlQuery
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.query.columns import column_expr, conditions_expr
 from snuba.query.parsing import ParsingContext
 from snuba.request.request_settings import RequestSettings
@@ -19,7 +20,10 @@ class DictSqlQuery(SqlQuery):
     """
 
     def __init__(
-        self, dataset: Dataset, query: Query, settings: RequestSettings,
+        self,
+        dataset: Dataset[ClickhouseQueryPlan, Query],
+        query: Query,
+        settings: RequestSettings,
     ) -> None:
         parsing_context = ParsingContext()
 

--- a/snuba/datasets/errors.py
+++ b/snuba/datasets/errors.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
 from typing import FrozenSet, Mapping, Sequence, Union
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.errors_replacer import ReplacerState
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.errors import promoted_tag_columns
 from snuba.datasets.storages.factory import get_writable_storage
@@ -17,7 +19,7 @@ from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsPro
 from snuba.query.timeseries import TimeSeriesExtension
 
 
-class ErrorsDataset(TimeSeriesDataset):
+class ErrorsDataset(TimeSeriesDataset[ClickhouseQuery, ClickhouseQueryPlan]):
     """
     Represents the collections of all event types that are not transactions.
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from typing import Mapping, Sequence, Union
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.events import (
     get_column_tag_map,
@@ -20,7 +22,7 @@ from snuba.query.timeseries import TimeSeriesExtension
 from snuba.util import qualified_column
 
 
-class EventsDataset(TimeSeriesDataset):
+class EventsDataset(TimeSeriesDataset[ClickhouseQuery, ClickhouseQueryPlan]):
     """
     Represents the collection of classic sentry "error" type events
     and the particular quirks of storing and querying them.

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Mapping, Optional, Sequence, Union
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
 from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.factory import get_dataset
@@ -15,13 +16,13 @@ from snuba.datasets.schemas.join import (
 )
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storage import ReadableStorage
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.datasets.table_storage import TableWriter
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.columns import QUALIFIED_COLUMN_REGEX
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
 from snuba.query.parsing import ParsingContext
-from snuba.query.processors import QueryProcessor
 from snuba.query.processors.join_optimizers import SimpleJoinOptimizer
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
@@ -29,7 +30,7 @@ from snuba.query.timeseries import TimeSeriesExtension
 from snuba.util import qualified_column
 
 
-class JoinedStorage(ReadableStorage):
+class JoinedStorage(ReadableStorage[ClickhouseQuery]):
     def __init__(self, join_structure: JoinClause) -> None:
         self.__structure = join_structure
 
@@ -41,7 +42,7 @@ class JoinedStorage(ReadableStorage):
     def get_table_writer(self) -> Optional[TableWriter]:
         return None
 
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
+    def get_query_processors(self) -> Sequence[QueryProcessor[ClickhouseQuery]]:
         return [SimpleJoinOptimizer(), PrewhereProcessor()]
 
 

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import TimeSeriesDataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.query.extensions import QueryExtension
@@ -12,7 +14,7 @@ from snuba.query.processors import QueryProcessor
 from snuba.query.timeseries import TimeSeriesExtension
 
 
-class OutcomesDataset(TimeSeriesDataset):
+class OutcomesDataset(TimeSeriesDataset[ClickhouseQuery, ClickhouseQueryPlan]):
     """
     Tracks event ingestion outcomes in Sentry.
     """

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import TimeSeriesDataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.query.extensions import QueryExtension
@@ -12,7 +14,7 @@ from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnP
 from snuba.query.timeseries import TimeSeriesExtension
 
 
-class OutcomesRawDataset(TimeSeriesDataset):
+class OutcomesRawDataset(TimeSeriesDataset[ClickhouseQuery, ClickhouseQueryPlan]):
     def __init__(self) -> None:
         storage = get_storage("outcomes_raw")
         read_schema = storage.get_schemas().get_read_schema()

--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Sequence
+from typing import Callable, Generic, Sequence, TypeVar
 
-from snuba.clickhouse.processors import QueryProcessor
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.request import Request
 from snuba.request.request_settings import RequestSettings
@@ -56,14 +56,17 @@ class QueryPlanExecutionStrategy(ABC):
         raise NotImplementedError
 
 
-class ClickhouseQueryPlanBuilder(ABC):
+TQueryPlan = TypeVar("TQueryPlan")
+
+
+class QueryPlanBuilder(ABC, Generic[TQueryPlan]):
     """
     Embeds the dataset specific logic that selects which storage to use
     to execute the query and produces the storage query.
     This is provided by a dataset and, when executed, it returns a
-    ClickhouseQueryPlan that embeds what is needed to run the storage query.
+    query plan that embeds what is needed to run the storage query.
     """
 
     @abstractmethod
-    def build_plan(self, request: Request) -> ClickhouseQueryPlan:
+    def build_plan(self, request: Request) -> TQueryPlan:
         raise NotImplementedError

--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -29,7 +29,7 @@ class ClickhouseQueryPlan:
     """
 
     query: Query
-    query_processors: Sequence[QueryProcessor]
+    query_processors: Sequence[QueryProcessor[Query]]
     execution_strategy: QueryPlanExecutionStrategy
 
 

--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -1,10 +1,10 @@
 from typing import Optional, Sequence
 
-from snuba.clickhouse.processors import QueryProcessor
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.datasets.plans.query_plan import (
     ClickhouseQueryPlan,
-    ClickhouseQueryPlanBuilder,
+    QueryPlanBuilder,
     QueryPlanExecutionStrategy,
     QueryRunner,
 )
@@ -27,7 +27,7 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy):
         return runner(query, request_settings)
 
 
-class SingleStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
+class SingleStorageQueryPlanBuilder(QueryPlanBuilder[ClickhouseQueryPlan]):
     """
     Builds the Clickhouse Query Execution Plan for a dataset that is based on
     a single storage.
@@ -35,8 +35,8 @@ class SingleStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
 
     def __init__(
         self,
-        storage: ReadableStorage,
-        post_processors: Optional[Sequence[QueryProcessor]] = None,
+        storage: ReadableStorage[Query],
+        post_processors: Optional[Sequence[QueryProcessor[Query]]] = None,
     ) -> None:
         # The storage the query is based on
         self.__storage = storage
@@ -69,15 +69,15 @@ class SingleStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
         )
 
 
-class SelectedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
+class SelectedStorageQueryPlanBuilder(QueryPlanBuilder[ClickhouseQueryPlan]):
     """
     A query plan builder that selects one of multiple storages in the dataset.
     """
 
     def __init__(
         self,
-        selector: QueryStorageSelector,
-        post_processors: Optional[Sequence[QueryProcessor]] = None,
+        selector: QueryStorageSelector[Query],
+        post_processors: Optional[Sequence[QueryProcessor[Query]]] = None,
     ) -> None:
         self.__selector = selector
         self.__post_processors = post_processors or []

--- a/snuba/datasets/querylog.py
+++ b/snuba/datasets/querylog.py
@@ -1,12 +1,14 @@
 from typing import Mapping
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.query.extensions import QueryExtension
 
 
-class QuerylogDataset(Dataset):
+class QuerylogDataset(Dataset[ClickhouseQuery, ClickhouseQueryPlan]):
     def __init__(self) -> None:
 
         storage = get_writable_storage("querylog")

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import TimeSeriesDataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.query.extensions import QueryExtension
@@ -15,7 +17,7 @@ from snuba.query.project_extension import ProjectExtension, ProjectExtensionProc
 from snuba.query.timeseries import TimeSeriesExtension
 
 
-class SessionsDataset(TimeSeriesDataset):
+class SessionsDataset(TimeSeriesDataset[ClickhouseQuery, ClickhouseQueryPlan]):
     def __init__(self) -> None:
         writable_storage = get_writable_storage("sessions_raw")
         materialized_storage = get_storage("sessions_hourly")

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -32,8 +32,7 @@ all_columns = ColumnSet(
         (
             "event_hash",
             WithCodecs(
-                Materialized(UInt(64), "cityHash64(toString(event_id))",),
-                ["NONE"],
+                Materialized(UInt(64), "cityHash64(toString(event_id))",), ["NONE"],
             ),
         ),
         ("platform", LowCardinality(String())),
@@ -54,10 +53,7 @@ all_columns = ColumnSet(
         ("contexts", Nested([("key", String()), ("value", String())])),
         ("_contexts_flattened", String()),
         ("transaction_name", WithDefault(LowCardinality(String()), "''")),
-        (
-            "transaction_hash",
-            Materialized(UInt(64), "cityHash64(transaction_name)"),
-        ),
+        ("transaction_hash", Materialized(UInt(64), "cityHash64(transaction_name)"),),
         ("span_id", Nullable(UInt(64))),
         ("trace_id", Nullable(UUID())),
         ("partition", UInt(16)),
@@ -161,14 +157,8 @@ storage = WritableTableStorage(
             write_schema=schema,
             read_schema=schema,
             required_columns=required_columns,
-            tag_column_map={
-                "tags": promoted_tag_columns,
-                "contexts": {},
-            },
-            promoted_tags={
-                "tags": promoted_tag_columns.keys(),
-                "contexts": {},
-            },
+            tag_column_map={"tags": promoted_tag_columns, "contexts": {},},
+            promoted_tags={"tags": promoted_tag_columns.keys(), "contexts": {},},
             state_name=ReplacerState.ERRORS,
         ),
     ),

--- a/snuba/datasets/storages/processors.py
+++ b/snuba/datasets/storages/processors.py
@@ -1,17 +1,19 @@
 from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
 
-from snuba.clickhouse.query import Query
 from snuba.request.request_settings import RequestSettings
 
+TStorageQuery = TypeVar("TStorageQuery")
 
-class QueryProcessor(ABC):
+
+class QueryProcessor(ABC, Generic[TStorageQuery]):
     """
-    A transformation applied to a Clickhouse Query. This transformation mutates the
+    A transformation applied to a storage query. This transformation mutates the
     Query object in place.
 
-    Processors that extend this class are executed during the Clickhouse specific part
+    Processors that extend this class are executed during the storage specific part
     of the query execution pipeline.
-    As their logical counterparts, Clickhouse query processors are stateless and are
+    As their logical counterparts, Storage query processors are stateless and are
     independent from each other. Each processor must leave the query in a valid state
     and must not depend on the execution of another processor before or after.
 
@@ -20,6 +22,8 @@ class QueryProcessor(ABC):
     """
 
     @abstractmethod
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(
+        self, query: TStorageQuery, request_settings: RequestSettings
+    ) -> None:
         # TODO: Make the Query class immutable.
         raise NotImplementedError

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from typing import Mapping, Sequence, Union
 
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import ColumnSplitSpec, TimeSeriesDataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.tags_column_processor import TagColumnProcessor
@@ -17,7 +19,7 @@ from snuba.query.project_extension import ProjectExtension, ProjectExtensionProc
 from snuba.query.timeseries import TimeSeriesExtension
 
 
-class TransactionsDataset(TimeSeriesDataset):
+class TransactionsDataset(TimeSeriesDataset[ClickhouseQuery, ClickhouseQueryPlan]):
     def __init__(self) -> None:
         storage = get_writable_storage("transactions")
         schema = storage.get_table_writer().get_schema()

--- a/snuba/migrations/migrate.py
+++ b/snuba/migrations/migrate.py
@@ -3,7 +3,9 @@ import logging
 from clickhouse_driver import Client
 from typing import MutableSequence
 
+from snuba.clickhouse.query import Query
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.schemas import Schema
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.migrations.parse_schema import get_local_schema
@@ -34,7 +36,7 @@ def _run_schema(conn: Client, schema: Schema) -> None:
         logger.warn(difference)
 
 
-def run(conn: Client, dataset: Dataset) -> None:
+def run(conn: Client, dataset: Dataset[ClickhouseQueryPlan, Query]) -> None:
     schemas: MutableSequence[Schema] = []
 
     writable_storage = dataset.get_writable_storage()

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -4,7 +4,9 @@ from typing import Any, MutableMapping, Optional
 
 from snuba import state
 from snuba.clickhouse.escaping import NEGATE_RE
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.query.expressions import Expression
 from snuba.query.parser.conditions import parse_conditions_to_expr
 from snuba.query.parser.expressions import parse_aggregation, parse_expression
@@ -14,7 +16,10 @@ from snuba.util import is_function, to_list, tuplify
 logger = logging.getLogger(__name__)
 
 
-def parse_query(body: MutableMapping[str, Any], dataset: Dataset) -> Query:
+def parse_query(
+    body: MutableMapping[str, Any],
+    dataset: Dataset[ClickhouseQueryPlan, ClickhouseQuery],
+) -> Query:
     """
     Parses the query body generating the AST. This only takes into
     account the initial query body. Extensions are parsed by extension
@@ -36,7 +41,10 @@ def parse_query(body: MutableMapping[str, Any], dataset: Dataset) -> Query:
             return Query(body, None)
 
 
-def _parse_query_impl(body: MutableMapping[str, Any], dataset: Dataset) -> Query:
+def _parse_query_impl(
+    body: MutableMapping[str, Any],
+    dataset: Dataset[ClickhouseQueryPlan, ClickhouseQuery],
+) -> Query:
     aggregate_exprs = []
     for aggregation in body.get("aggregations", []):
         assert isinstance(aggregation, (list, tuple))

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -1,7 +1,9 @@
 from collections import OrderedDict
 from typing import Any, Callable, Optional, Sequence, TypeVar
 
+from snuba.clickhouse.query import Query
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.query.expressions import (
     Argument,
     Expression,
@@ -32,7 +34,7 @@ def parse_conditions(
     or_builder: Callable[[Sequence[TExpression]], Optional[TExpression]],
     unpack_array_condition_builder: Callable[[TExpression, str, Any], TExpression],
     simple_condition_builder: Callable[[TExpression, str, Any], TExpression],
-    dataset: Dataset,
+    dataset: Dataset[ClickhouseQueryPlan, Query],
     conditions: Any,
     array_join: Optional[str],
     depth: int = 0,
@@ -125,7 +127,9 @@ def parse_conditions(
 
 
 def parse_conditions_to_expr(
-    expr: Sequence[Any], dataset: Dataset, arrayjoin: Optional[str]
+    expr: Sequence[Any],
+    dataset: Dataset[ClickhouseQueryPlan, Query],
+    arrayjoin: Optional[str],
 ) -> Optional[Expression]:
     """
     Relies on parse_conditions to parse a list of conditions into an Expression.

--- a/snuba/query/processors/events_column_processor.py
+++ b/snuba/query/processors/events_column_processor.py
@@ -1,10 +1,10 @@
-from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.request.request_settings import RequestSettings
 
 
-class EventsColumnProcessor(QueryProcessor):
+class EventsColumnProcessor(QueryProcessor[Query]):
     """
     Strip any dashes out of the event ID to match what is stored internally.
     """

--- a/snuba/query/processors/join_optimizers.py
+++ b/snuba/query/processors/join_optimizers.py
@@ -1,11 +1,11 @@
-from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.datasets.schemas.join import JoinClause
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.query.columns import QUALIFIED_COLUMN_REGEX
 from snuba.request.request_settings import RequestSettings
 
 
-class SimpleJoinOptimizer(QueryProcessor):
+class SimpleJoinOptimizer(QueryProcessor[Query]):
     """
     Simplest possible join optimizer. It turns a join expression into a single
     table expression if only one table is referenced in the query.

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -1,13 +1,13 @@
 from typing import Optional, Sequence
 
 from snuba import settings, util
-from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
 
 
-class PrewhereProcessor(QueryProcessor):
+class PrewhereProcessor(QueryProcessor[Query]):
     """
     Moves top level conditions into the pre-where clause
     according to the list of candidates provided by the query data source.

--- a/snuba/query/processors/readonly_events.py
+++ b/snuba/query/processors/readonly_events.py
@@ -1,11 +1,11 @@
 from snuba import state
-from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.datasets.schemas.tables import TableSource
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.request.request_settings import RequestSettings
 
 
-class ReadOnlyTableSelector(QueryProcessor):
+class ReadOnlyTableSelector(QueryProcessor[Query]):
     """
     Replaces the data source in the query with a TableSource if the table
     name of the original datasource is the one provided to the constructor,

--- a/snuba/query/processors/tagsmap.py
+++ b/snuba/query/processors/tagsmap.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional, List, NamedTuple, Set
 
-from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.datasets.events_format import escape_field
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.datasets.tags_column_processor import NESTED_COL_EXPR_RE
 from snuba.query.expressions import Column, Expression
 from snuba.query.types import Condition
@@ -29,7 +29,7 @@ class OptimizableCondition(NamedTuple):
 logger = logging.getLogger(__name__)
 
 
-class NestedFieldConditionOptimizer(QueryProcessor):
+class NestedFieldConditionOptimizer(QueryProcessor[Query]):
     """
     This processor scans the the conditions in the query and converts
     top level eq/neq conditions on specific nested fields, into LIKE/NOT LIKE

--- a/snuba/query/processors/transaction_column_processor.py
+++ b/snuba/query/processors/transaction_column_processor.py
@@ -1,10 +1,10 @@
 from snuba.clickhouse.query import Query
-from snuba.clickhouse.processors import QueryProcessor
+from snuba.datasets.storages.processors import QueryProcessor
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.request.request_settings import RequestSettings
 
 
-class TransactionColumnProcessor(QueryProcessor):
+class TransactionColumnProcessor(QueryProcessor[Query]):
     """
     Strip any dashes out of the event ID to match what is stored internally.
     """

--- a/snuba/request/schema.py
+++ b/snuba/request/schema.py
@@ -5,7 +5,9 @@ import uuid
 
 from typing import Any, Mapping, Type
 
+from snuba.clickhouse.query import Query
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.query.extensions import QueryExtension
 from snuba.query.parser import parse_query
 from snuba.query.schema import GENERIC_QUERY_SCHEMA
@@ -81,7 +83,9 @@ class RequestSchema:
         }
         return cls(generic_schema, settings_schema, extensions_schemas, settings_class)
 
-    def validate(self, value, dataset: Dataset, referrer: str) -> Request:
+    def validate(
+        self, value, dataset: Dataset[ClickhouseQueryPlan, Query], referrer: str
+    ) -> Request:
         value = validate_jsonschema(value, self.__composite_schema)
 
         query_body = {
@@ -105,7 +109,9 @@ class RequestSchema:
 
         query = parse_query(query_body, dataset)
         request_id = uuid.uuid4().hex
-        return Request(request_id, query, self.__setting_class(**settings), extensions, referrer)
+        return Request(
+            request_id, query, self.__setting_class(**settings), extensions, referrer
+        )
 
     def __generate_template_impl(self, schema) -> Any:
         """


### PR DESCRIPTION
While we decided to make the storage layer Clickhouse specific, I think it can still be useful to make the abstract classes (dataset, storage, QueryPlanBuilder, QueryProcessor, etc) Generic with the storage query and query plan as parameter. 
This means only the implementations are Clickhouse specific, which makes it better defined which components have to be clickhouse specific.