### PR TITLE
fix(errors): Fix the timestamps used in the ErrorsProcessor

### DIFF
--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -1,12 +1,12 @@
+import pytz
+
 from datetime import datetime, timedelta
 from uuid import UUID
 
-import pytz
-
-from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.datasets.errors_processor import ErrorsProcessor
 from snuba.consumer import KafkaMessageMetadata
 from snuba.processor import ProcessorAction
+from snuba.settings import PAYLOAD_DATETIME_FORMAT
 
 
 def test_error_processor() -> None:

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -1,5 +1,7 @@
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from uuid import UUID
+
+import pytz
 
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.datasets.errors_processor import ErrorsProcessor
@@ -8,7 +10,7 @@ from snuba.processor import ProcessorAction
 
 
 def test_error_processor() -> None:
-    received_timestamp = datetime.now(timezone.utc) - timedelta(minutes=1)
+    received_timestamp = datetime.now() - timedelta(minutes=1)
     error_timestamp = received_timestamp - timedelta(minutes=1)
 
     error = (
@@ -286,7 +288,9 @@ def test_error_processor() -> None:
         "group_id": 100,
         "primary_hash": "04233d08ac90cf6fc015b1be5932e7e2",
         "event_string": "dcb9d002cac548c795d1c9adbfc68040",
-        "received": received_timestamp.replace(tzinfo=None, microsecond=0),
+        "received": received_timestamp.astimezone(pytz.utc).replace(
+            tzinfo=None, microsecond=0
+        ),
         "message": "",
         "title": "ClickHouseError: [171] DB::Exception: Block structure mismatch",
         "culprit": "snuba.clickhouse.http in write",

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -1,14 +1,16 @@
-import pytest
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.datasets.errors_processor import ErrorsProcessor
 from snuba.consumer import KafkaMessageMetadata
 from snuba.processor import ProcessorAction
 
 
-@pytest.mark.xfail
 def test_error_processor() -> None:
+    received_timestamp = datetime.now(timezone.utc) - timedelta(minutes=1)
+    error_timestamp = received_timestamp - timedelta(minutes=1)
+
     error = (
         2,
         "insert",
@@ -21,7 +23,7 @@ def test_error_processor() -> None:
             "dist": None,
             "platform": "python",
             "message": "",
-            "datetime": "2020-01-30T22:48:49.894703Z",
+            "datetime": error_timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
             "primary_hash": "04233d08ac90cf6fc015b1be5932e7e2",
             "data": {
                 "event_id": "dcb9d002cac548c795d1c9adbfc68040",
@@ -30,7 +32,7 @@ def test_error_processor() -> None:
                 "dist": None,
                 "platform": "python",
                 "message": "",
-                "datetime": "2020-01-30T22:48:49.894703Z",
+                "datetime": error_timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
                 "tags": [
                     ["handled", "no"],
                     ["level", "error"],
@@ -72,22 +74,30 @@ def test_error_processor() -> None:
                         {
                             "category": "snuba.utils.streams.batching",
                             "level": "info",
-                            "timestamp": 1580424519.772524,
-                            "data": {"asctime": "2020-01-30 22:48:39,772"},
+                            "timestamp": error_timestamp.timestamp(),
+                            "data": {
+                                "asctime": error_timestamp.strftime(
+                                    PAYLOAD_DATETIME_FORMAT
+                                )
+                            },
                             "message": "New partitions assigned: {}",
                             "type": "default",
                         },
                         {
                             "category": "snuba.utils.streams.batching",
                             "level": "info",
-                            "timestamp": 1580424529.867766,
-                            "data": {"asctime": "2020-01-30 22:48:49,867"},
+                            "timestamp": error_timestamp.timestamp(),
+                            "data": {
+                                "asctime": error_timestamp.strftime(
+                                    PAYLOAD_DATETIME_FORMAT
+                                )
+                            },
                             "message": "Flushing ",
                             "type": "default",
                         },
                         {
                             "category": "httplib",
-                            "timestamp": 1580424529.891891,
+                            "timestamp": error_timestamp.timestamp(),
                             "type": "http",
                             "data": {
                                 "url": "http://127.0.0.1:8123/",
@@ -177,7 +187,7 @@ def test_error_processor() -> None:
                     "ipython-genutils": "0.2.0",
                     "isodate": "0.6.0",
                 },
-                "received": 1580424529.947908,
+                "received": received_timestamp.timestamp(),
                 "sdk": {
                     "version": "0.0.0.0.1",
                     "name": "sentry.python",
@@ -193,7 +203,7 @@ def test_error_processor() -> None:
                         "threading",
                     ],
                 },
-                "timestamp": 1580424529.894703,
+                "timestamp": error_timestamp.timestamp(),
                 "title": "ClickHouseError: [171] DB::Exception: Block structure mismatch",
                 "type": "error",
                 "version": "7",
@@ -204,7 +214,7 @@ def test_error_processor() -> None:
     expected_result = {
         "org_id": 3,
         "project_id": 300688,
-        "timestamp": datetime(2020, 1, 30, 22, 48, 49, 894703),
+        "timestamp": error_timestamp.replace(tzinfo=None),
         "event_id": str(UUID("dcb9d002cac548c795d1c9adbfc68040")),
         "platform": "python",
         "dist": None,
@@ -276,7 +286,7 @@ def test_error_processor() -> None:
         "group_id": 100,
         "primary_hash": "04233d08ac90cf6fc015b1be5932e7e2",
         "event_string": "dcb9d002cac548c795d1c9adbfc68040",
-        "received": datetime.utcfromtimestamp(1580424529),
+        "received": received_timestamp.replace(tzinfo=None, microsecond=0),
         "message": "",
         "title": "ClickHouseError: [171] DB::Exception: Block structure mismatch",
         "culprit": "snuba.clickhouse.http in write",
@@ -325,5 +335,6 @@ def test_error_processor() -> None:
     )
     ret = processor.process_message(error, meta)
 
+    assert ret is not None
     assert ret.action == ProcessorAction.INSERT
     assert ret.data == [expected_result]


### PR DESCRIPTION
When building the errors processor test I forgot to account for the events retention. Thus, three months later, the test started failing.
This should fix the test.