### PR TITLE
fix(errors processor) Remove a timezone replacement that does nothing

### DIFF
--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -216,7 +216,7 @@ def test_error_processor() -> None:
     expected_result = {
         "org_id": 3,
         "project_id": 300688,
-        "timestamp": error_timestamp.replace(tzinfo=None),
+        "timestamp": error_timestamp,
         "event_id": str(UUID("dcb9d002cac548c795d1c9adbfc68040")),
         "platform": "python",
         "dist": None,


### PR DESCRIPTION
This was left behind in the previous version of PR #910