### PR TITLE
ref(timeseries): Record how frequently `from_date`/`to_date` are defaulted

### DIFF
--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -1,8 +1,15 @@
 import copy
 from datetime import datetime, timedelta
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
 import jsonschema
+
+from snuba import environment
+from snuba.utils.metrics.backends.wrapper import MetricsWrapper
+from snuba.utils.metrics.decorators import track_calls
+
+
+timeseries_metrics = MetricsWrapper(environment.metrics, "extensions.timeseries")
 
 
 def get_time_series_extension_properties(
@@ -14,14 +21,22 @@ def get_time_series_extension_properties(
             "from_date": {
                 "type": "string",
                 "format": "date-time",
-                "default": lambda: (
-                    datetime.utcnow().replace(microsecond=0) - default_window
-                ).isoformat(),
+                "default": track_calls(
+                    timeseries_metrics,
+                    "from_date.default",
+                    lambda: (
+                        datetime.utcnow().replace(microsecond=0) - default_window
+                    ).isoformat(),
+                ),
             },
             "to_date": {
                 "type": "string",
                 "format": "date-time",
-                "default": lambda: datetime.utcnow().replace(microsecond=0).isoformat(),
+                "default": track_calls(
+                    timeseries_metrics,
+                    "to_date.default",
+                    lambda: datetime.utcnow().replace(microsecond=0).isoformat(),
+                ),
             },
             "granularity": {
                 "type": "number",
@@ -44,13 +59,19 @@ def validate_jsonschema(value, schema, set_defaults=True):
     """
     orig = jsonschema.Draft6Validator.VALIDATORS["properties"]
 
-    def validate_and_default(validator, properties, instance, schema):
+    def validate_and_default(
+        validator,
+        properties: Mapping[str, Any],
+        instance: MutableMapping[str, Any],
+        schema,
+    ):
         for property, subschema in properties.items():
-            if "default" in subschema:
+            if property not in instance and "default" in subschema:
                 if callable(subschema["default"]):
-                    instance.setdefault(property, subschema["default"]())
+                    default_value = subschema["default"]()
                 else:
-                    instance.setdefault(property, copy.deepcopy(subschema["default"]))
+                    default_value = copy.deepcopy(subschema["default"])
+                instance[property] = default_value
 
         for error in orig(validator, properties, instance, schema):
             yield error

--- a/snuba/utils/metrics/decorators.py
+++ b/snuba/utils/metrics/decorators.py
@@ -1,0 +1,20 @@
+from functools import wraps
+from typing import Callable, TypeVar
+
+from snuba.utils.metrics.backends.abstract import MetricsBackend
+
+
+T = TypeVar("T")
+
+
+def track_calls(
+    metrics: MetricsBackend, key: str, function: Callable[[], T]
+) -> Callable[[], T]:
+    """Tracks how frequently a function is called."""
+
+    @wraps(function)
+    def tracker() -> T:
+        metrics.increment(key)
+        return function()
+
+    return tracker

--- a/tests/utils/metrics/test_decorators.py
+++ b/tests/utils/metrics/test_decorators.py
@@ -1,0 +1,14 @@
+from unittest.mock import sentinel
+
+from snuba.utils.metrics.decorators import track_calls
+from tests.backends.metrics import Increment, TestingMetricsBackend
+
+
+def test_track_calls() -> None:
+    backend = TestingMetricsBackend()
+    key = "key"
+    assert (
+        track_calls(backend, key, lambda: sentinel.RETURN_VALUE)()
+        is sentinel.RETURN_VALUE
+    )
+    assert backend.calls == [Increment(key, 1, None)]


### PR DESCRIPTION
We'd like to deprecate these defaults, so adding this to figure out if it's safe to remove them outright.

This also adds a `track_calls` decorator to `snuba.utils.metrics.decorators` that might be generically useful. 