### PR TITLE
ref: Remove DEFAULT_DATASET_BROKERS from settings

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -57,7 +57,6 @@ BULK_CLICKHOUSE_BUFFER = 10000
 
 # Processor/Writer Options
 DEFAULT_BROKERS = ["localhost:9092"]
-DEFAULT_DATASET_BROKERS: Mapping[str, Sequence[str]] = {}
 DEFAULT_STORAGE_BROKERS: Mapping[str, Sequence[str]] = {}
 
 DEFAULT_MAX_BATCH_SIZE = 50000


### PR DESCRIPTION
This is no longer being used anywhere.