### PR TITLE
fix(logger) Lower the minimum log level to send a Sentry event to warning

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -7,6 +7,7 @@ from typing import Optional
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from snuba import settings
 from snuba.util import create_metrics
@@ -24,7 +25,11 @@ def setup_logging(level: Optional[str] = None) -> None:
 def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
-        integrations=[FlaskIntegration(), GnuBacktraceIntegration()],
+        integrations=[
+            FlaskIntegration(),
+            GnuBacktraceIntegration(),
+            LoggingIntegration(event_level=logging.WARNING),
+        ],
         release=os.getenv("SNUBA_RELEASE"),
     )
 


### PR DESCRIPTION
We have a few cases around the code base of warnings that would be very useful if they showed up in sentry, but the minimum error level is error now and they show only as breadcrumbs.

This lowers it to Warning. I checked all the cases we have in the code base and it should not pollute our dashboards nor impact our ingestion, none is supposed to happen extremely frequently (unless there is an issue).

Adding debug to breadcrumbs could be useful as well, though there are a few cases we may want to downgrade first (like we log all messages consumed in some consumers).

<img width="912" alt="Screen Shot 2020-05-01 at 11 44 08 AM" src="https://user-images.githubusercontent.com/1626430/80832236-1c5bdf80-8ba1-11ea-9111-7275d66286c8.png">
