### PR TITLE
feat: Update bulk load and confirm load scripts to take storage name

### DIFF
--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -20,7 +20,7 @@ from snuba.writer import BufferedWriterWrapper
 )
 @click.option(
     "--source",
-    help="Source of the dump. Depending on the dataset it may have different meaning.",
+    help="Source of the dump. Depending on the storage it may have different meaning.",
 )
 @click.option("--dest-table", help="Clickhouse destination table.")
 @click.option("--log-level", help="Logging level to use.")

--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -4,7 +4,8 @@ from typing import Optional
 import click
 
 from snuba import settings
-from snuba.datasets.factory import DATASET_NAMES, enforce_table_writer, get_dataset
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_cdc_storage, CDC_STORAGES
 from snuba.environment import setup_logging, setup_sentry
 from snuba.snapshots.postgres_snapshot import PostgresSnapshot
 from snuba.writer import BufferedWriterWrapper
@@ -12,10 +13,10 @@ from snuba.writer import BufferedWriterWrapper
 
 @click.command()
 @click.option(
-    "--dataset",
-    "dataset_name",
-    type=click.Choice(DATASET_NAMES),
-    help="The dataset to bulk load",
+    "--storage",
+    "storage_name",
+    type=click.Choice([storage_key.value for storage_key in CDC_STORAGES.keys()]),
+    help="The CDC storage to bulk load",
 )
 @click.option(
     "--source",
@@ -25,9 +26,9 @@ from snuba.writer import BufferedWriterWrapper
 @click.option("--log-level", help="Logging level to use.")
 def bulk_load(
     *,
-    dataset_name: str,
+    storage_name: str,
     dest_table: Optional[str],
-    source: Optional[str],
+    source: str,
     log_level: Optional[str] = None,
 ) -> None:
     setup_logging(log_level)
@@ -35,22 +36,24 @@ def bulk_load(
 
     logger = logging.getLogger("snuba.load-snapshot")
     logger.info(
-        "Start bulk load process for dataset %s, from source %s", dataset_name, source
+        "Start bulk load process for storage %s, from source %s", storage_name, source
     )
-    dataset = get_dataset(dataset_name)
+
+    storage = get_cdc_storage(StorageKey(storage_name))
+    table_writer = storage.get_table_writer()
 
     # TODO: Have a more abstract way to load sources if/when we support more than one.
     snapshot_source = PostgresSnapshot.load(
         product=settings.SNAPSHOT_LOAD_PRODUCT, path=source,
     )
 
-    loader = enforce_table_writer(dataset).get_bulk_loader(snapshot_source, dest_table)
+    loader = table_writer.get_bulk_loader(snapshot_source, dest_table)
     # TODO: see whether we need to pass options to the writer
     writer = BufferedWriterWrapper(
-        enforce_table_writer(dataset).get_bulk_writer(table_name=dest_table),
+        table_writer.get_bulk_writer(table_name=dest_table),
         settings.BULK_CLICKHOUSE_BUFFER,
     )
 
-    clickhouse_ro = dataset.get_writable_storage().get_cluster().get_clickhouse_ro()
+    clickhouse_ro = storage.get_cluster().get_clickhouse_ro()
 
     loader.load(writer, clickhouse_ro)

--- a/snuba/cli/confirm_load.py
+++ b/snuba/cli/confirm_load.py
@@ -3,11 +3,11 @@ import logging
 from typing import Optional, Sequence
 
 import click
-from confluent_kafka import Producer
+from confluent_kafka import KafkaError, Message, Producer
 
 from snuba import settings
-from snuba.datasets.factory import DATASET_NAMES, get_dataset
-from snuba.datasets.cdc import CdcStorage
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_cdc_storage, CDC_STORAGES
 from snuba.environment import setup_logging, setup_sentry
 from snuba.snapshots.postgres_snapshot import PostgresSnapshot
 from snuba.stateful_consumer.control_protocol import SnapshotLoaded, TransactionData
@@ -19,10 +19,10 @@ from snuba.stateful_consumer.control_protocol import SnapshotLoaded, Transaction
     "--bootstrap-server", multiple=True, help="Kafka bootstrap server to use.",
 )
 @click.option(
-    "--dataset",
-    "dataset_name",
-    type=click.Choice(DATASET_NAMES),
-    help="The dataset to bulk load",
+    "--storage",
+    "storage_name",
+    type=click.Choice([storage_key.value for storage_key in CDC_STORAGES.keys()]),
+    help="The CDC storage to confirm load",
 )
 @click.option(
     "--source",
@@ -33,7 +33,7 @@ def confirm_load(
     *,
     control_topic: Optional[str],
     bootstrap_server: Sequence[str],
-    dataset_name: str,
+    storage_name: str,
     source: str,
     log_level: Optional[str] = None,
 ) -> None:
@@ -47,18 +47,12 @@ def confirm_load(
 
     logger = logging.getLogger("snuba.loaded-snapshot")
     logger.info(
-        "Sending load completion message for dataset %s, from source %s",
-        dataset_name,
+        "Sending load completion message for storage %s, from source %s",
+        storage_name,
         source,
     )
 
-    dataset = get_dataset(dataset_name)
-
-    storage = dataset.get_writable_storage()
-
-    assert isinstance(
-        storage, CdcStorage
-    ), "Only CDC storages have a control topic thus are supported."
+    storage = get_cdc_storage(StorageKey(storage_name))
 
     control_topic = control_topic or storage.get_default_control_topic()
 
@@ -90,7 +84,7 @@ def confirm_load(
     )
     json_string = json.dumps(msg.to_dict())
 
-    def delivery_callback(error, message) -> None:
+    def delivery_callback(error: KafkaError, message: Message) -> None:
         if error is not None:
             raise error
         else:

--- a/snuba/cli/confirm_load.py
+++ b/snuba/cli/confirm_load.py
@@ -26,7 +26,7 @@ from snuba.stateful_consumer.control_protocol import SnapshotLoaded, Transaction
 )
 @click.option(
     "--source",
-    help="Source of the dump. Depending on the dataset it may have different meaning.",
+    help="Source of the dump. Depending on the storage it may have different meaning.",
 )
 @click.option("--log-level", help="Logging level to use.")
 def confirm_load(

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -21,7 +21,7 @@ from snuba.datasets.storages.transactions import storage as transactions_storage
 
 CDC_STORAGES: Mapping[StorageKey, CdcStorage] = {
     storage.get_storage_key(): storage
-    for storage in [groupedmessages_storage, groupassignees_storage,]
+    for storage in [groupedmessages_storage, groupassignees_storage]
 }
 
 WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
@@ -41,7 +41,7 @@ WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
 
 NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
     storage.get_storage_key(): storage
-    for storage in [outcomes_hourly_storage, sessions_hourly_storage,]
+    for storage in [outcomes_hourly_storage, sessions_hourly_storage]
 }
 
 STORAGES: Mapping[StorageKey, ReadableTableStorage] = {


### PR DESCRIPTION
Bulk loading now takes a storage name instead of a dataset name. This
is in line with consumers and replacers which also operate directly
on a storage. Datasets are no longer referenced anywhere on the write
path, all writers now target a single storage.