### PR TITLE
fix(splitter) Temporarily disable col splitter for transactions

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -225,12 +225,5 @@ storage = WritableTableStorage(
         TransactionColumnProcessor(),
         PrewhereProcessor(),
     ],
-    query_splitters=[
-        ColumnSplitQueryStrategy(
-            id_column="event_id",
-            project_column="project_id",
-            timestamp_column="finish_ts",
-        ),
-        TimeSplitQueryStrategy(timestamp_col="finish_ts"),
-    ],
+    query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
 )


### PR DESCRIPTION
Before the splitter change #865, split on transactions was basically not happening since some column names were hardcoded.

Now this happens in discover (both time and column), the problem is that the translation of the column name "timestamp" into "finish_ts" happens only when doing the clickhouse formatting of the query and it reruns the table selection to do such formatting. This means, when doing column splitting on some specific queries on transactions, the first chunk can be transformed by the formatter in the wrong way since it can be detected as errors not transactions (the query is simpler) thus timestamp is not translated into finish_ts.

This is the step 1 of the fix. Disable the broken code, anyway this kind of splitting on transactions was almost never happening.
Step 2 will make it work independently on the formatting.
Step 3, will remove the issue by moving the query translation earlier on with the AST.