### PR TITLE
perf(prewhere) Exclude NOT IN conditions

### DIFF
--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -40,6 +40,7 @@ class PrewhereProcessor(QueryProcessor):
             (util.columns_in_expr(cond[0]), cond)
             for cond in conditions
             if util.is_condition(cond)
+            and cond[1] != "NOT IN"
             and any(col in prewhere_keys for col in util.columns_in_expr(cond[0]))
         ]
         # Use the condition that has the highest priority (based on the

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -6,6 +6,19 @@ from snuba.clickhouse.query import Query
 from snuba.query.types import Condition
 from snuba.request.request_settings import RequestSettings
 
+ALLOWED_OPERATORS = [
+    ">",
+    "<",
+    ">=",
+    "<=",
+    "=",
+    "!=",
+    "IN",
+    "IS NULL",
+    "IS NOT NULL",
+    "LIKE",
+]
+
 
 class PrewhereProcessor(QueryProcessor):
     """
@@ -40,7 +53,7 @@ class PrewhereProcessor(QueryProcessor):
             (util.columns_in_expr(cond[0]), cond)
             for cond in conditions
             if util.is_condition(cond)
-            and cond[1] != "NOT IN"
+            and cond[1] in ALLOWED_OPERATORS
             and any(col in prewhere_keys for col in util.columns_in_expr(cond[0]))
         ]
         # Use the condition that has the highest priority (based on the

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -43,6 +43,14 @@ test_data = [
         [[["a", "=", "1"], ["b", "=", "2"]]],
         [["c", "=", "3"]],
     ),
+    (
+        # Exclude NOT IN condition from the prewhere as they are generally not excluding
+        # most of the dataset.
+        {"conditions": [["a", "NOT IN", [1, 2, 3]], ["b", "=", "2"], ["c", "=", "3"]]},
+        ["a", "b"],
+        [["a", "NOT IN", [1, 2, 3]], ["c", "=", "3"]],
+        [["b", "=", "2"]],
+    ),
 ]
 
 


### PR DESCRIPTION
Prewhere works well when it selects few values out of a high selectivity column.
The prewhere candidates for a storage are generally picked with this idea in mind.
If we promote a `NOT IN` condition over a high selectivity column we are generally having the opposite effect by excluding a small subset of the dataset.