### PR TITLE
fix: Fix bulk writer chunk size

### DIFF
--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -171,7 +171,7 @@ class TableWriter:
             table_name,
             lambda row: rapidjson.dumps(row).encode("utf-8"),
             options,
-            chunk_size=settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
+            chunk_size=settings.BULK_CLICKHOUSE_BUFFER,
         )
 
     def get_bulk_loader(


### PR DESCRIPTION
This fixes an error introduced in #907 that incorrectly changed the
chunk size for the bulk writer to reference the wrong setting.