### PR TITLE
ref(events): Move discover column aliasing into events dataset

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -338,12 +338,6 @@ class DiscoverDataset(TimeSeriesDataset):
         else:
             if column_name == "time":
                 return self.time_expr("timestamp", query.get_granularity(), table_alias)
-            if column_name == "release":
-                column_name = "tags[sentry:release]"
-            if column_name == "dist":
-                column_name = "tags[sentry:dist]"
-            if column_name == "user":
-                column_name = "tags[sentry:user]"
             if self.__transactions_columns.get(column_name):
                 return "NULL"
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -54,6 +54,17 @@ class EventsDataset(TimeSeriesDataset):
         parsing_context: ParsingContext,
         table_alias: str = "",
     ):
+        # These column aliases originally existed in the ``discover`` dataset,
+        # but now live here to maintain compatibility between the discover data
+        # model and the events data model that is used for subscriptions. In
+        # the future, these should be resolved at the entity level.
+        if column_name == "release":
+            column_name = "tags[sentry:release]"
+        elif column_name == "dist":
+            column_name = "tags[sentry:dist]"
+        elif column_name == "user":
+            column_name = "tags[sentry:user]"
+
         processed_column = self.__tags_processor.process_column_expression(
             column_name, query, parsing_context, table_alias
         )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -451,18 +451,14 @@ class TestUtil(BaseTest):
                 tuplify(
                     [
                         "if",
-                        [
-                            ["in", ["release", "tuple", ["'foo'"]]],
-                            "release",
-                            "'other'",
-                        ],
-                        "release",
+                        [["in", ["val", "tuple", ["'foo'"]]], "val", "'other'"],
+                        "val",
                     ]
                 ),
                 deepcopy(query),
                 ParsingContext(),
             )
-            == "(if(in(release, tuple('foo')), release, 'other') AS release)"
+            == "(if(in(val, tuple('foo')), val, 'other') AS val)"
         )
         assert (
             complex_column_expr(
@@ -470,14 +466,14 @@ class TestUtil(BaseTest):
                 tuplify(
                     [
                         "if",
-                        ["in", ["release", "tuple", ["'foo'"]], "release", "'other'"],
-                        "release",
+                        ["in", ["val", "tuple", ["'foo'"]], "val", "'other'"],
+                        "val",
                     ]
                 ),
                 deepcopy(query),
                 ParsingContext(),
             )
-            == "(if(in(release, tuple('foo')), release, 'other') AS release)"
+            == "(if(in(val, tuple('foo')), val, 'other') AS val)"
         )
 
         # TODO once search_message is filled in everywhere, this can be just 'message' again.


### PR DESCRIPTION
This "backports" (so to speak) the column aliasing logic from the discover dataset (our closest thing to a customer-facing logical data model) to the events dataset.

This is intended to ensure that aggregation and filtering behavior is consistent between the two different dataset representations, at least until there is a single consistent logical representation (which will happen with the entity work.) Since this consistency is not structurally enforced, we will have to be careful to ensure to not invalidate this property until the implementation of entities enforces it inherently. (There are actually three different representations if the errors dataset is included, though no changes are required here — the errors dataset already exposes these columns by virtue of tag promotion, though it's unclear if that was ever intended to be a public interface.)

This also mirrors the type of changes that are going to be applied to transactions to support metric alerts on performance data.