### PR TITLE
fix(replacements) Add even more metrics to troubleshoot the PostReplacementConsistencyEnforcer

### DIFF
--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -94,9 +94,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
             if set_final != query.get_final():
                 metrics.increment("mismatch.final")
                 logger.warning(
-                    "Discrepancy between project_extension and processor. Ext final: %r. Processor final: %r.",
-                    query.get_final(),
-                    set_final,
+                    "Final discrepancy between project_extension and processor.",
+                    extra={"extension": query.get_final(), "processor": set_final},
                     exc_info=True,
                 )
 
@@ -127,8 +126,10 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     },
                 )
                 logger.warning(
-                    "Discrepancy between project_extension and processor. Ext condition: %r. Processor condition: %r.",
-                    existing_groups_conditions,
-                    condition_to_add,
+                    "Groups discrepancy between project_extension and processor.",
+                    extra={
+                        "extension": existing_groups_conditions,
+                        "processor": condition_to_add,
+                    },
                     exc_info=True,
                 )

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -91,11 +91,14 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         else:
             # This is disabled. We assume the query was modified accordingly by the extension
             # and compare the results.
-            # TODO: Swap all this with logger warnings after verifying this does not flood the logs
-            log_issue = False
             if set_final != query.get_final():
-                log_issue = True
                 metrics.increment("mismatch.final")
+                logger.warning(
+                    "Discrepancy between project_extension and processor. Ext final: %r. Processor final: %r.",
+                    query.get_final(),
+                    set_final,
+                    exc_info=True,
+                )
 
             existing_groups_conditions = [
                 c[2]
@@ -111,7 +114,6 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     "Multiple group exclusion conditions in the Query", exc_info=True
                 )
                 return
-
             if (condition_to_add[2] if condition_to_add else None) != (
                 existing_groups_conditions[0]
                 if len(existing_groups_conditions) > 0
@@ -124,12 +126,9 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                         "processor": str(condition_to_add is not None),
                     },
                 )
-                log_issue = True
-
-            if log_issue:
                 logger.warning(
-                    "Discrepancy between project_extension and replacement consistency processor",
+                    "Discrepancy between project_extension and processor. Ext condition: %r. Processor condition: %r.",
+                    existing_groups_conditions,
+                    condition_to_add,
                     exc_info=True,
                 )
-            else:
-                metrics.increment("match")


### PR DESCRIPTION
PR #932 (https://github.com/getsentry/snuba/pull/932/files#diff-249a3fa811e95624b5a47320cc575abaR130) showed some discrepancies.
The problem is that, it seems the local variable picked up when creating the sentry event are capped and not all the local variables are visible in the stack trace. Critically missing the ones I need: the original condition from the query.

This tweaks the warning to ensure the groups that are not matching are highlighted properly.