### PR TITLE
fix(parser) Parse tags_key/tags_value as FunctionCall and not Column

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -27,6 +27,7 @@ from snuba.query.processors import QueryProcessor
 from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.impact_processor import ImpactProcessor
+from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
@@ -269,6 +270,7 @@ class DiscoverDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
+            TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
             # Apdex and Impact seem very good candidates for
             # being defined by the Transaction entity when it will

--- a/snuba/datasets/errors.py
+++ b/snuba/datasets/errors.py
@@ -13,6 +13,7 @@ from snuba.query.logical import Query
 from snuba.query.parsing import ParsingContext
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
@@ -89,6 +90,7 @@ class ErrorsDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
+            TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
             TimeSeriesColumnProcessor(self.__time_group_columns),
         ]

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -4,10 +4,7 @@ from typing import Mapping, Sequence
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.events import (
-    get_column_tag_map,
-    get_promoted_columns,
-)
+from snuba.datasets.storages.events import get_column_tag_map, get_promoted_columns
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.tags_column_processor import TagColumnProcessor
 from snuba.query.extensions import QueryExtension
@@ -15,6 +12,7 @@ from snuba.query.logical import Query
 from snuba.query.parsing import ParsingContext
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
@@ -111,6 +109,7 @@ class EventsDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
+            TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
             TimeSeriesColumnProcessor(self.__time_group_columns),
         ]

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -7,7 +7,6 @@ from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
-from snuba.datasets.plans.split_strategy import QuerySplitStrategy
 from snuba.datasets.schemas.join import (
     JoinClause,
     JoinCondition,
@@ -27,6 +26,7 @@ from snuba.query.parsing import ParsingContext
 from snuba.query.processors import QueryProcessor as LogicalProcessor
 from snuba.query.processors.join_optimizers import SimpleJoinOptimizer
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectWithGroupsProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
@@ -200,4 +200,7 @@ class Groups(TimeSeriesDataset):
         }
 
     def get_query_processors(self) -> Sequence[LogicalProcessor]:
-        return [TimeSeriesColumnProcessor(self.__time_group_columns)]
+        return [
+            TagsExpanderProcessor(),
+            TimeSeriesColumnProcessor(self.__time_group_columns),
+        ]

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -12,7 +12,7 @@ from snuba.query.conditions import (
     is_binary_condition,
     is_in_condition,
 )
-from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.expressions import Expression, FunctionCall, Literal
 from snuba.query.parser.strings import NESTED_COL_EXPR_RE
 
 from snuba.query.logical import Query
@@ -173,8 +173,8 @@ class TagColumnProcessor:
             # This is to make mypy happy.
             assert isinstance(condition, FunctionCall)
             if (
-                isinstance(condition.parameters[0], Column)
-                and condition.parameters[0].column_name == "tags_key"
+                isinstance(condition.parameters[0], FunctionCall)
+                and condition.parameters[0].function_name == "tags_key"
                 and isinstance(condition.parameters[1], Literal)
             ):
                 # Tags are strings, but mypy does not know that
@@ -183,8 +183,8 @@ class TagColumnProcessor:
         if is_in_condition(condition):
             assert isinstance(condition, FunctionCall)
             if (
-                isinstance(condition.parameters[0], Column)
-                and condition.parameters[0].column_name == "tags_key"
+                isinstance(condition.parameters[0], FunctionCall)
+                and condition.parameters[0].function_name == "tags_key"
             ):
                 # The parameters of the inner function `a IN tuple(b,c,d)`
                 assert isinstance(condition.parameters[1], FunctionCall)
@@ -215,10 +215,10 @@ class TagColumnProcessor:
         select_clause = query.get_selected_columns_from_ast() or []
 
         tags_key_found = any(
-            col.column_name == "tags_key"
+            f.function_name == "tags_key"
             for expression in select_clause
-            for col in expression
-            if isinstance(col, Column)
+            for f in expression
+            if isinstance(f, FunctionCall)
         )
 
         if not tags_key_found:

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -13,6 +13,7 @@ from snuba.query.processors import QueryProcessor
 from snuba.query.processors.apdex_processor import ApdexProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.impact_processor import ImpactProcessor
+from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
@@ -123,6 +124,7 @@ class TransactionsDataset(TimeSeriesDataset):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
+            TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
             ApdexProcessor(),
             ImpactProcessor(),

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -1,6 +1,12 @@
 import re
 
-from snuba.query.expressions import Column, Expression, Literal, SubscriptableReference
+from snuba.query.expressions import (
+    Column,
+    Expression,
+    FunctionCall,
+    Literal,
+    SubscriptableReference,
+)
 from snuba.util import QUOTED_LITERAL_RE
 
 # A column name like "tags[url]"
@@ -28,6 +34,9 @@ def parse_string_to_expr(val: str) -> Expression:
             column=Column(None, col_name, None),
             key=Literal(None, key_name),
         )
+
+    if val in ("tags_key", "tags_value"):
+        return FunctionCall(None, val, tuple())
 
     # TODO: This will use the schema of the dataset/entity to decide if the expression is
     # a column or a literal.

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -35,18 +35,6 @@ def parse_string_to_expr(val: str) -> Expression:
             key=Literal(None, key_name),
         )
 
-    if val in ("tags_key", "tags_value"):
-        # Nested columns are usually accessed through array operations like elementAt
-        # and these operations are exposed in the Snuba syntax as functions.
-        # tags_key and tags_value also have this special syntax but the content of the SQL
-        # query is in the end another array operation (arrayJoin).
-        #
-        # The question remains whether we should expose arrayJoin at all but that would
-        # not be a backward compatible change.
-        return FunctionCall(
-            val, "arrayJoin", (Column(None, val.replace("_", "."), None),)
-        )
-
     # TODO: This will use the schema of the dataset/entity to decide if the expression is
     # a column or a literal.
     if val.isdigit():

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -3,7 +3,6 @@ import re
 from snuba.query.expressions import (
     Column,
     Expression,
-    FunctionCall,
     Literal,
     SubscriptableReference,
 )

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -36,7 +36,16 @@ def parse_string_to_expr(val: str) -> Expression:
         )
 
     if val in ("tags_key", "tags_value"):
-        return FunctionCall(None, val, tuple())
+        # Nested columns are usually accessed through array operations like elementAt
+        # and these operations are exposed in the Snuba syntax as functions.
+        # tags_key and tags_value also have this special syntax but the content of the SQL
+        # query is in the end another array operation (arrayJoin).
+        #
+        # The question remains whether we should expose arrayJoin at all but that would
+        # not be a backward compatible change.
+        return FunctionCall(
+            val, "arrayJoin", (Column(None, val.replace("_", "."), None),)
+        )
 
     # TODO: This will use the schema of the dataset/entity to decide if the expression is
     # a column or a literal.

--- a/snuba/query/processors/tags_expander.py
+++ b/snuba/query/processors/tags_expander.py
@@ -1,0 +1,38 @@
+from dataclasses import replace
+
+from snuba.query.processors import QueryProcessor
+from snuba.query.expressions import Column, Expression, FunctionCall
+from snuba.query.logical import Query
+from snuba.request.request_settings import RequestSettings
+
+
+class TagsExpanderProcessor(QueryProcessor):
+    """
+    Transforms the special syntax we provide to expand the tags column into a call
+    to arrayJoin so that, after this query processor, tags_key and tags_value special
+    columns are not treated as a special case but they are valid expressions on a
+    valid column name.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def transform_expression(exp: Expression) -> Expression:
+            # This is intentionally not configurable in order to discourage creating
+            # a special syntax for expressions that should be function calls.
+            if isinstance(exp, Column) and exp.column_name in (
+                "tags_key",
+                "tags_value",
+            ):
+                return FunctionCall(
+                    exp.alias or exp.column_name,
+                    "arrayJoin",
+                    (
+                        replace(
+                            exp,
+                            alias=None,
+                            column_name=exp.column_name.replace("_", "."),
+                        ),
+                    ),
+                )
+            return exp
+
+        query.transform_expressions(transform_expression)

--- a/snuba/query/processors/tags_expander.py
+++ b/snuba/query/processors/tags_expander.py
@@ -1,8 +1,8 @@
 from dataclasses import replace
 
-from snuba.query.processors import QueryProcessor
 from snuba.query.expressions import Column, Expression, FunctionCall
 from snuba.query.logical import Query
+from snuba.query.processors import QueryProcessor
 from snuba.request.request_settings import RequestSettings
 
 

--- a/tests/query/processors/test_tags_expander.py
+++ b/tests/query/processors/test_tags_expander.py
@@ -1,0 +1,66 @@
+from snuba.datasets.factory import get_dataset
+from snuba.query.conditions import OPERATOR_TO_FUNCTION, binary_condition, in_condition
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.parser import parse_query
+from snuba.query.processors.tags_expander import TagsExpanderProcessor
+from snuba.request.request_settings import HTTPRequestSettings
+
+
+def test_tags_expander() -> None:
+    query_body = {
+        "selected_columns": [
+            ["f1", ["tags_key", "column2"], "f1_alias"],
+            ["f2", [], "f2_alias"],
+        ],
+        "aggregations": [
+            ["count", "platform", "platforms"],
+            ["testF", ["platform", "tags_value"], "top_platforms"],
+        ],
+        "conditions": [["tags_key", "=", "tags_key"]],
+        "having": [["tags_value", "IN", ["tag"]]],
+    }
+
+    events = get_dataset("events")
+    query = parse_query(query_body, events)
+
+    processor = TagsExpanderProcessor()
+    request_settings = HTTPRequestSettings()
+    processor.process_query(query, request_settings)
+
+    assert query.get_selected_columns_from_ast() == [
+        FunctionCall("platforms", "count", (Column(None, "platform", None),)),
+        FunctionCall(
+            "top_platforms",
+            "testF",
+            (
+                Column(None, "platform", None),
+                FunctionCall(
+                    "tags_value", "arrayJoin", (Column(None, "tags.value", None),)
+                ),
+            ),
+        ),
+        FunctionCall(
+            "f1_alias",
+            "f1",
+            (
+                FunctionCall(
+                    "tags_key", "arrayJoin", (Column(None, "tags.key", None),)
+                ),
+                Column(None, "column2", None),
+            ),
+        ),
+        FunctionCall("f2_alias", "f2", tuple()),
+    ]
+
+    assert query.get_condition_from_ast() == binary_condition(
+        None,
+        OPERATOR_TO_FUNCTION["="],
+        FunctionCall("tags_key", "arrayJoin", (Column(None, "tags.key", None),)),
+        Literal(None, "tags_key"),
+    )
+
+    assert query.get_having_from_ast() == in_condition(
+        None,
+        FunctionCall("tags_value", "arrayJoin", (Column(None, "tags.value", None),)),
+        [Literal(None, "tag")],
+    )

--- a/tests/query/processors/test_tags_processor.py
+++ b/tests/query/processors/test_tags_processor.py
@@ -168,6 +168,8 @@ def test_tags_processor(query_body, expected_query) -> None:
     query = parse_query(query_body, dataset)
     request_settings = HTTPRequestSettings()
     request = Request("a", query, request_settings, {}, "r")
+    for p in dataset.get_query_processors():
+        p.process_query(query, request_settings)
     plan = dataset.get_query_plan_builder().build_plan(request)
 
     assert (


### PR DESCRIPTION
It seems to me that, as long as there won't be any much deeper refactoring of tags_key/value fields that would change the query language as well, it would be more appropriate to parse `tag_keys` and `tag_values` as FunctionCall and not Columns since they are not Columns, they do not produce one result per record but basically a join expression that is then transformed into a different function call.