### PR TITLE
fix(project extension) Collect metrics about the prevalence of group mismatch

### DIFF
--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -1,5 +1,6 @@
 import logging
 
+from copy import deepcopy
 from typing import Optional
 
 from snuba import environment, settings
@@ -130,8 +131,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                 logger.warning(
                     "Groups discrepancy between project_extension and processor.",
                     extra={
-                        "extension": existing_groups_conditions,
-                        "processor": condition_to_add,
+                        "extension": deepcopy(existing_groups_conditions),
+                        "processor": deepcopy(condition_to_add),
                     },
                     exc_info=True,
                 )

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -98,6 +98,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     extra={"extension": query.get_final(), "processor": set_final},
                     exc_info=True,
                 )
+            else:
+                metrics.increment("match.final", tags={"value": str(set_final)})
 
             existing_groups_conditions = [
                 c[2]
@@ -132,4 +134,9 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                         "processor": condition_to_add,
                     },
                     exc_info=True,
+                )
+            else:
+                metrics.increment(
+                    "match.group_id",
+                    tags={"condition_present": str(condition_to_add is not None)},
                 )


### PR DESCRIPTION
I observed a bunch of mismatches in the list of groups created by the project extension and the one created by the query processor (https://github.com/getsentry/snuba/pull/935). It seems they are asking redis the same data so this is tricky.
This collects an additional metric to see how common these issues are.