### PR TITLE
feat(datasets) Make QueryPlanBuilder generic

### DIFF
--- a/snuba/clickhouse/planner/query_plan.py
+++ b/snuba/clickhouse/planner/query_plan.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.clickhouse.sql import SqlQuery
+from snuba.datasets.plans.query_plan import QueryPlanBuilder as LogicalQueryPlanBuilder
+from snuba.datasets.plans.query_plan import QueryPlanExecutionStrategy
+from snuba.reader import Reader
+from snuba.request import Request
+from snuba.request.request_settings import RequestSettings
+from snuba.web import QueryResult
+
+QueryRunner = Callable[[Query, RequestSettings, Reader[SqlQuery]], QueryResult]
+
+
+@dataclass(frozen=True)
+class QueryPlan:
+    """
+    Provides the directions to execute a Clickhouse Query against one storage
+    or multiple joined ones.
+    This is produced by QueryPlanBuilder (provided by the dataset) after the dataset
+    query processing has been performed and the storage/s has/have been selected.
+    It embeds the Clickhouse Query (the query to run on the storage after translation),
+    and the sequence of storage specific QueryProcessors to apply to the query after
+    the the storage has been selected. These have to be executed only once per plan
+    contrarily to the DB Query Processors, still provided by the storage, which
+    are executed by the execution strategy at every DB Query.
+    It also provides a plan execution strategy that takes care of coordinating the
+    execution of the query against the database. The execution strategy can also decide
+    to split the query into multiple chunks.
+    """
+
+    query: Query
+    plan_processors: Sequence[QueryProcessor]
+    execution_strategy: QueryPlanExecutionStrategy[Query, QueryRunner]
+
+
+class QueryPlanBuilder(LogicalQueryPlanBuilder[QueryPlan], ABC):
+    """
+    Produces a Query Plan to run a query on Clickhouse.
+    """
+
+    @abstractmethod
+    def build_plan(self, request: Request) -> QueryPlan:
+        raise NotImplementedError

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -2,7 +2,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.escaping import escape_identifier
-from snuba.datasets.plans.query_plan import ClickhouseQueryPlanBuilder
+from snuba.clickhouse.planner.query_plan import QueryPlanBuilder
 from snuba.datasets.storage import Storage, WritableStorage, WritableTableStorage
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
@@ -31,7 +31,7 @@ class Dataset(object):
       query before deciding which Storage to use. These processors are defined
       by the dataset
     - the Storage to run the query onto is selected and the query is transformed
-      into a Clickhouse Query. This is done by a ClickhouseQueryPlanBuilder. This object
+      into a Clickhouse Query. This is done by a QueryPlanBuilder. This object
       produces a plan that includes the Query contextualized on the storage/s, the
       list of processors to apply and the strategy to run the query (in case of
       any strategy more complex than a single DB query like a split).
@@ -49,7 +49,7 @@ class Dataset(object):
         self,
         *,
         storages: Sequence[Storage],
-        query_plan_builder: ClickhouseQueryPlanBuilder,
+        query_plan_builder: QueryPlanBuilder,
         abstract_column_set: ColumnSet,
         writable_storage: Optional[WritableStorage],
     ) -> None:
@@ -88,7 +88,7 @@ class Dataset(object):
         # TODO: Make this available to the dataset query processors.
         return self.__abstract_column_set
 
-    def get_query_plan_builder(self) -> ClickhouseQueryPlanBuilder:
+    def get_query_plan_builder(self) -> QueryPlanBuilder:
         """
         Returns the component that transforms a Snuba query in a Storage query by selecting
         the storage and provides the directions on how to run the query.
@@ -139,7 +139,7 @@ class TimeSeriesDataset(Dataset):
         self,
         *,
         storages: Sequence[Storage],
-        query_plan_builder: ClickhouseQueryPlanBuilder,
+        query_plan_builder: QueryPlanBuilder,
         abstract_column_set: ColumnSet,
         writable_storage: Optional[WritableStorage],
         time_group_columns: Mapping[str, str],

--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -1,46 +1,19 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Callable, Sequence
+from typing import Generic, TypeVar
 
-from snuba.clickhouse.processors import QueryProcessor
-from snuba.clickhouse.query import Query
-from snuba.clickhouse.sql import SqlQuery
-from snuba.reader import Reader
 from snuba.request import Request
 from snuba.request.request_settings import RequestSettings
 from snuba.web import QueryResult
 
-QueryRunner = Callable[[Query, RequestSettings, Reader[SqlQuery]], QueryResult]
+TStorageQuery = TypeVar("TStorageQuery")
+TQueryRunner = TypeVar("TQueryRunner")
 
 
-@dataclass(frozen=True)
-class ClickhouseQueryPlan:
+class QueryPlanExecutionStrategy(ABC, Generic[TStorageQuery, TQueryRunner]):
     """
-    Provides the directions to execute a Clickhouse Query against one storage
-    or multiple joined ones.
-    This is produced by ClickhouseQueryPlanBuilder (provided by the dataset)
-    after the dataset query processing has been performed and the storage/s
-    has/have been selected.
-    It embeds the Clickhouse Query (the query to run on the storage after translation),
-    and the sequence of storage specific QueryProcessors to apply to the query after
-    the the storage has been selected. These have to be executed only once per plan
-    contrarily to the DB Query Processors, still provided by the storage, which
-    are executed by the execution strategy at every DB Query.
-    It also provides a plan execution strategy that takes care of coordinating the
-    execution of the query against the database. The execution strategy can also decide
-    to split the query into multiple chunks.
-    """
-
-    query: Query
-    plan_processors: Sequence[QueryProcessor]
-    execution_strategy: QueryPlanExecutionStrategy
-
-
-class QueryPlanExecutionStrategy(ABC):
-    """
-    Orchestrates the executions of a query. An example use case is split
+    Orchestrates the executions of a storage query. An example use case is split
     queries, when the split is done at storage level.
     It does not know how to run a query against a DB, but it knows how
     and whether to break down a query and how to assemble the results back.
@@ -57,7 +30,10 @@ class QueryPlanExecutionStrategy(ABC):
 
     @abstractmethod
     def execute(
-        self, query: Query, request_settings: RequestSettings, runner: QueryRunner,
+        self,
+        query: TStorageQuery,
+        request_settings: RequestSettings,
+        runner: TQueryRunner,
     ) -> QueryResult:
         """
         Executes the Query passed in as parameter.
@@ -67,14 +43,18 @@ class QueryPlanExecutionStrategy(ABC):
         raise NotImplementedError
 
 
-class ClickhouseQueryPlanBuilder(ABC):
+TQueryPlan = TypeVar("TQueryPlan")
+
+
+class QueryPlanBuilder(ABC, Generic[TQueryPlan]):
     """
     Embeds the dataset specific logic that selects which storage to use
     to execute the query and produces the storage query.
     This is provided by a dataset and, when executed, it returns a
-    ClickhouseQueryPlan that embeds what is needed to run the storage query.
+    query plan that embeds what is needed to run the storage query. The query
+    plan class depends on the storage implementation.
     """
 
     @abstractmethod
-    def build_plan(self, request: Request) -> ClickhouseQueryPlan:
+    def build_plan(self, request: Request) -> TQueryPlan:
         raise NotImplementedError

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -73,7 +73,7 @@ def _run_query_pipeline(
     This process includes:
     - Applying dataset specific syntax extensions (QueryExtension)
     - Applying dataset query processors on the abstract Snuba query.
-    - Using the dataset provided ClickhouseQueryPlanBuilder to build a ClickhouseQueryPlan. This step
+    - Using the dataset provided QueryPlanBuilder to build a Clickhouse QueryPlan. This step
       transforms the Snuba Query into the Storage Query (that is contextual to the storage/s).
       From this point on none should depend on the dataset.
     - Executing the plan specific query processors.


### PR DESCRIPTION
#904 is becoming an unmanageable monster. Better addressing it step by step.

This is taking care of QueryPlanBuilder and QueryExecutionStrategy only by adding the generic version and providing the clickhouse implementation in a separate module in the clickhouse/plans directory. I think the QueryPlan class itself won't have a generic version (that's a dataclass with no methods)

Next steps:
- try to move the logic of the query execution strategy implementation in the generic version. I think we can make it work entirely on the generic (but I still have to verify the details).
- try to make the StorageSelectors generic.
- make storage query processors generic
- make storages generic and add the clickhouse implementation
- make the abstract dataset class generic with respect to the physical layer.