### PR TITLE
feat(AST) Declarative, regex inspired, AST expression matcher.

### DIFF
--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -106,13 +106,16 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
         raise NotImplementedError
 
 
+OptionalScalarType = Union[None, bool, str, float, int, date, datetime]
+
+
 @dataclass(frozen=True)
 class Literal(Expression):
     """
     A literal in the SQL expression
     """
 
-    value: Union[None, bool, str, float, int, date, datetime]
+    value: OptionalScalarType
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         return func(self)
@@ -163,9 +166,7 @@ class SubscriptableReference(Expression):
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         transformed = replace(
-            self,
-            column=self.column.transform(func),
-            key=self.key.transform(func),
+            self, column=self.column.transform(func), key=self.key.transform(func),
         )
         return func(transformed)
 

--- a/snuba/query/matcher.py
+++ b/snuba/query/matcher.py
@@ -1,0 +1,117 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Mapping, Optional, Tuple, Union
+
+from snuba.query.expressions import Column as ColumnExpr
+from snuba.query.expressions import Expression, FunctionCall
+
+Node = Union[Expression, Optional[str]]
+
+
+class Matcher(ABC):
+    @abstractmethod
+    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class Param(Matcher):
+    name: str
+    matcher: Matcher
+
+    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+        positive_match, parameters = self.matcher.match(node)
+        if not positive_match:
+            return (False, {})
+
+        return (True, {**parameters, **{self.name: node}})
+
+
+@dataclass(frozen=True)
+class Any(Matcher):
+    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+        return (True, {})
+
+
+@dataclass(frozen=True)
+class String(Matcher):
+    value: str
+
+    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+        return (
+            isinstance(node, str) and node == self.value,
+            {},
+        )
+
+
+@dataclass(frozen=True)
+class Column(Matcher):
+    alias: Optional[Matcher] = None
+    column_name: Optional[Matcher] = None
+    table_name: Optional[Matcher] = None
+
+    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+        if not isinstance(node, ColumnExpr):
+            return (False, {})
+
+        params: Mapping[str, Node] = {}
+        if self.alias:
+            alias_match, alias_params = self.alias.match(node.alias)
+            if not alias_match:
+                return (False, {})
+            else:
+                params = {**params, **alias_params}
+
+        if self.column_name:
+            column_match, column_params = self.column_name.match(node.column_name)
+            if not column_match:
+                return (False, {})
+            else:
+                params = {**params, **column_params}
+
+        if self.table_name:
+            table_match, table_params = self.table_name.match(node.table_name)
+            if not table_match:
+                return (False, {})
+            else:
+                params = {**params, **table_params}
+
+        return (True, params)
+
+
+@dataclass(frozen=True)
+class Function(Matcher):
+    alias: Optional[Matcher] = None
+    function_name: Optional[Matcher] = None
+    function_parameters: Optional[Tuple[Matcher, ...]] = None
+
+    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+        if not isinstance(node, FunctionCall):
+            return (False, {})
+
+        params: Mapping[str, Node] = {}
+        if self.alias:
+            alias_match, alias_params = self.alias.match(node.alias)
+            if not alias_match:
+                return (False, {})
+            else:
+                params = {**params, **alias_params}
+
+        if self.function_name:
+            function_match, function_params = self.function_name.match(
+                node.function_name
+            )
+            if not function_match:
+                return (False, {})
+            else:
+                params = {**params, **function_params}
+
+        if self.function_parameters:
+            for p in enumerate(self.function_parameters):
+                parameter_match, parameter_params = p[1].match(node.parameters[p[0]])
+                if not parameter_match:
+                    return (False, {})
+                else:
+                    params = {**params, **parameter_params}
+
+        return (True, params)

--- a/snuba/query/matcher.py
+++ b/snuba/query/matcher.py
@@ -128,6 +128,11 @@ class String(Pattern[Optional[str]]):
 
 @dataclass(frozen=True)
 class Or(Pattern[TNode], Generic[TNode]):
+    """
+    Union of multiple patterns. Matches if at least one is a valid match
+    and returns the first valid one.
+    """
+
     patterns: Sequence[Pattern[TNode]]
 
     def match(self, node: TNode) -> Optional[MatchResult]:

--- a/snuba/query/matcher.py
+++ b/snuba/query/matcher.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import date, datetime
-from typing import Generic, Mapping, Optional, Tuple, TypeVar
+from typing import Generic, Mapping, Optional, Sequence, Tuple, TypeVar
 
 from snuba.query.expressions import Column as ColumnExpr
 from snuba.query.expressions import Expression, FunctionCall
@@ -124,6 +124,18 @@ class String(Pattern[Optional[str]]):
 
     def match(self, node: Optional[str]) -> Optional[MatchResult]:
         return MatchResult() if node == self.value else None
+
+
+@dataclass(frozen=True)
+class Or(Pattern[TNode], Generic[TNode]):
+    patterns: Sequence[Pattern[TNode]]
+
+    def match(self, node: TNode) -> Optional[MatchResult]:
+        for p in self.patterns:
+            ret = p.match(node)
+            if ret:
+                return ret
+        return None
 
 
 @dataclass(frozen=True)

--- a/snuba/query/matcher.py
+++ b/snuba/query/matcher.py
@@ -1,117 +1,201 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Mapping, Optional, Tuple, Union
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Generic, Mapping, Optional, Tuple, TypeVar
 
 from snuba.query.expressions import Column as ColumnExpr
 from snuba.query.expressions import Expression, FunctionCall
 
-Node = Union[Expression, Optional[str]]
+TNode = TypeVar("TNode")
 
 
-class Matcher(ABC):
+@dataclass(frozen=True)
+class MatchResult:
+    """
+    Contains the parameters found in an expression by a Pattern.
+    Parameters are the equivalent to groups in regular expressions, they
+    are named parts of the expression we are matching that are identified
+    when a valid match is found.
+    """
+
+    expressions: Mapping[str, Expression] = field(default_factory=dict)
+    strings: Mapping[str, Optional[str]] = field(default_factory=dict)
+    ints: Mapping[str, Optional[int]] = field(default_factory=dict)
+    floats: Mapping[str, Optional[float]] = field(default_factory=dict)
+    dates: Mapping[str, Optional[date]] = field(default_factory=dict)
+    datetimes: Mapping[str, Optional[datetime]] = field(default_factory=dict)
+
+    def merge(self, values: MatchResult) -> MatchResult:
+        return MatchResult(
+            expressions={**self.expressions, **values.expressions},
+            strings={**self.strings, **values.strings},
+            ints={**self.ints, **values.ints},
+            floats={**self.floats, **values.floats},
+            dates={**self.dates, **values.dates},
+            datetimes={**self.datetimes, **values.datetimes},
+        )
+
+
+class Pattern(ABC, Generic[TNode]):
+    """
+    Tries to match a given node (like an AST Expression) with the rules provided
+    when instantiating this class. This is meant to work like a regular expression
+    but for AST expressions.
+
+    When a node is provided to this method, if this method return an instance of
+    MatchResult it means the node fully matches the pattern.
+    If the pattern defines named parameters, their value is returned as part of
+    the MatchResult object returned.
+    More on how to define parameters in the Param class.
+
+    This is not supposed to ever throw as long as the node is properly is a valid
+    data structure, even if it does not match the pattern.
+    """
+
     @abstractmethod
-    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+    def match(self, node: TNode) -> Optional[MatchResult]:
+        """
+        Returns a MatchResult if the node provided matches this pattern
+        otherwise it returns None.
+        """
         raise NotImplementedError
 
 
 @dataclass(frozen=True)
-class Param(Matcher):
+class Param(Pattern[TNode], Generic[TNode]):
+    """
+    Defines a named parameter in a Pattern. When matching the overall Pattern,
+    if the Pattern nested in this object matches, the corresponding input node
+    will be given a name and returned as part of the MatchResult return value.
+    This is meant to represent what a group is in a regex.
+
+    Params can be nested, and they can wrap any valid Pattern.
+    """
+
     name: str
-    matcher: Matcher
+    pattern: Pattern[TNode]
 
-    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
-        positive_match, parameters = self.matcher.match(node)
-        if not positive_match:
-            return (False, {})
+    def match(self, node: TNode) -> Optional[MatchResult]:
+        result = self.pattern.match(node)
+        if not result:
+            return None
 
-        return (True, {**parameters, **{self.name: node}})
-
-
-@dataclass(frozen=True)
-class Any(Matcher):
-    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
-        return (True, {})
-
-
-@dataclass(frozen=True)
-class String(Matcher):
-    value: str
-
-    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
-        return (
-            isinstance(node, str) and node == self.value,
-            {},
+        return result.merge(
+            MatchResult(
+                expressions={self.name: node} if isinstance(node, Expression) else {},
+                strings={self.name: node} if isinstance(node, str) else {},
+                ints={self.name: node} if isinstance(node, int) else {},
+                floats={self.name: node} if isinstance(node, float) else {},
+                dates={self.name: node} if isinstance(node, date) else {},
+                datetimes={self.name: node} if isinstance(node, datetime) else {},
+            )
         )
 
 
 @dataclass(frozen=True)
-class Column(Matcher):
-    alias: Optional[Matcher] = None
-    column_name: Optional[Matcher] = None
-    table_name: Optional[Matcher] = None
+class AnyExpression(Pattern[Expression]):
+    """
+    Successfully matches any expression
+    """
 
-    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
-        if not isinstance(node, ColumnExpr):
-            return (False, {})
-
-        params: Mapping[str, Node] = {}
-        if self.alias:
-            alias_match, alias_params = self.alias.match(node.alias)
-            if not alias_match:
-                return (False, {})
-            else:
-                params = {**params, **alias_params}
-
-        if self.column_name:
-            column_match, column_params = self.column_name.match(node.column_name)
-            if not column_match:
-                return (False, {})
-            else:
-                params = {**params, **column_params}
-
-        if self.table_name:
-            table_match, table_params = self.table_name.match(node.table_name)
-            if not table_match:
-                return (False, {})
-            else:
-                params = {**params, **table_params}
-
-        return (True, params)
+    def match(self, node: Expression) -> Optional[MatchResult]:
+        return MatchResult()
 
 
 @dataclass(frozen=True)
-class Function(Matcher):
-    alias: Optional[Matcher] = None
-    function_name: Optional[Matcher] = None
-    function_parameters: Optional[Tuple[Matcher, ...]] = None
+class AnyString(Pattern[Optional[str]]):
+    """
+    Successfully matches any string
+    """
 
-    def match(self, node: Node) -> Tuple[bool, Mapping[str, Node]]:
+    def match(self, node: Optional[str]) -> Optional[MatchResult]:
+        return MatchResult()
+
+
+@dataclass(frozen=True)
+class String(Pattern[Optional[str]]):
+    """
+    Matches one specific string (or None).
+    """
+
+    value: Optional[str]
+
+    def match(self, node: Optional[str]) -> Optional[MatchResult]:
+        return MatchResult() if node == self.value else None
+
+
+@dataclass(frozen=True)
+class Column(Pattern[Expression]):
+    """
+    Matches a Column in an AST expression.
+    The column is defined by alias, name and table. For each a Pattern can be
+    provided. If one of these Patters is left None, that field will be ignored
+    when matching (equivalent to Any, but less verbose).
+    """
+
+    alias: Optional[Pattern[Optional[str]]] = None
+    column_name: Optional[Pattern[Optional[str]]] = None
+    table_name: Optional[Pattern[Optional[str]]] = None
+
+    def match(self, node: Expression) -> Optional[MatchResult]:
+        if not isinstance(node, ColumnExpr):
+            return None
+
+        result = MatchResult()
+        for pattern, value in (
+            (self.alias, node.alias),
+            (self.column_name, node.column_name),
+            (self.table_name, node.table_name),
+        ):
+            if pattern:
+                partial_result = pattern.match(value)
+                if not partial_result:
+                    return None
+                result = result.merge(partial_result)
+
+        return result
+
+
+@dataclass(frozen=True)
+class Function(Pattern[Expression]):
+    """
+    Matches a Function in the AST expression.
+    It works like the Column Pattern. if alias, function_name and function_parameters
+    are provided, they have to match, otherwise they are ignored.
+    """
+
+    alias: Optional[Pattern[Optional[str]]] = None
+    function_name: Optional[Pattern[Optional[str]]] = None
+    function_parameters: Optional[Tuple[Pattern[Expression], ...]] = None
+
+    def match(self, node: Expression) -> Optional[MatchResult]:
         if not isinstance(node, FunctionCall):
-            return (False, {})
+            return None
 
-        params: Mapping[str, Node] = {}
-        if self.alias:
-            alias_match, alias_params = self.alias.match(node.alias)
-            if not alias_match:
-                return (False, {})
-            else:
-                params = {**params, **alias_params}
-
-        if self.function_name:
-            function_match, function_params = self.function_name.match(
-                node.function_name
-            )
-            if not function_match:
-                return (False, {})
-            else:
-                params = {**params, **function_params}
+        result = MatchResult()
+        for pattern, value in (
+            (self.alias, node.alias),
+            (self.function_name, node.function_name),
+        ):
+            if pattern:
+                partial_result = pattern.match(value)
+                if not partial_result:
+                    return None
+                result = result.merge(partial_result)
 
         if self.function_parameters:
-            for p in enumerate(self.function_parameters):
-                parameter_match, parameter_params = p[1].match(node.parameters[p[0]])
-                if not parameter_match:
-                    return (False, {})
+            if len(self.function_parameters) != len(node.parameters):
+                return None
+            for index, param_pattern in enumerate(self.function_parameters):
+                p_result = param_pattern.match(node.parameters[index])
+                if not p_result:
+                    return None
                 else:
-                    params = {**params, **parameter_params}
+                    result = result.merge(p_result)
 
-        return (True, params)
+        return result
+
+
+# TODO: Add more Patterns when needed.

--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -21,17 +21,19 @@ TMatchedType = TypeVar("TMatchedType", covariant=True)
 class MatchResult:
     """
     Contains the parameters found in an expression by a Pattern.
-    Parameters are the equivalent to groups in regular expressions, they are named parts
-    of the expression we are matching that are identified when a valid match is found.
+    Parameters are the equivalent to groups in regular expressions,
+    they are named parts of the expression we are matching that are
+    identified when a valid match is found.
     """
 
     results: Mapping[str, MatchType] = field(default_factory=dict)
 
     def expression(self, name: str) -> Expression:
         """
-        Return an expression from the results given the name of the parameter it matched.
-        Since we cannot match None Expressions (because they do not exist in the AST)
-        this does not need to return Optional.
+        Return an expression from the results given the name of the
+        parameter it matched.
+        Since we cannot match None Expressions (because they do not
+        exist in the AST) this does not need to return Optional.
         """
         ret = self.results[name]
         assert isinstance(ret, Expression)
@@ -39,11 +41,13 @@ class MatchResult:
 
     def scalar(self, name: str) -> OptionalScalarType:
         """
-        Return a scalar from the results given the name of the parameter it matched.
-        Scalars are all individual types in the AST that are not structured expressions.
-        There are several places in the AST where a scalar can be None (like aliases)
-        thus it is possible that the matched node is None, thus we need to be able to
-        return None.
+        Return a scalar from the results given the name of the parameter
+        it matched.
+        Scalars are all individual types in the AST that are not
+        structured expressions.
+        There are several places in the AST where a scalar can be None
+        (like aliases) thus it is possible that the matched node is None,
+        thus we need to be able to return None.
         """
         ret = self.results[name]
         assert ret is None or isinstance(ret, (str, int, float, date, datetime))
@@ -51,7 +55,8 @@ class MatchResult:
 
     def string(self, name: str) -> str:
         """
-        Returns a string present in the result, guaranteeing the string is there or throws.
+        Returns a string present in the result, guaranteeing the string
+        is there or throws.
         """
         ret = self.results[name]
         assert isinstance(ret, str)
@@ -66,24 +71,25 @@ class MatchResult:
 
 class Pattern(ABC, Generic[TMatchedType]):
     """
-    Tries to match a given node (like an AST Expression) with the rules provided
-    when instantiating this class. This is meant to work like a regular expression
-    but for AST expressions.
+    Tries to match a given node (like an AST Expression) with the rules
+    provided when instantiating this class. This is meant to work like
+    a regular expression but for AST expressions.
 
-    When a node is provided to this method, if this method returns an instance of
-    MatchResult, it means the node fully matches the pattern.
-    If the pattern defines named parameters, their value is returned as part of
-    the MatchResult object returned.
+    When a node is provided to this method, if this method returns an
+    instance of MatchResult, it means the node fully matches the pattern.
+    If the pattern defines named parameters, their value is returned
+    as part of the MatchResult object returned.
     More on how to define parameters in the Param class.
 
-    This is not supposed to ever throw as long as the node is properly is a valid
-    data structure, even if it does not match the pattern.
+    This is not supposed to ever throw as long as the node is properly
+    is a valid data structure, even if it does not match the pattern.
 
-    This is parametric but the parameter is not used in the class. This is because
-    the parameter is meant only to statically type check that patterns are composed
-    in a way that makes sense (like not try to match a table name as a Column since
-    it is impossible). It represent the type effectively matched by the expression
-    thus covariant, not the type of the object the Pattern can try to match so that
+    This is parametric but the parameter is not used in the class.
+    This is because the parameter is meant only to statically type check
+    that patterns are composed in a way that makes sense (like not try
+    to match a table name as a Column since it is impossible). It
+    represent the type effectively matched by the expression thus covariant,
+    not the type of the object the Pattern can try to match so that
     Pattern[Column] is a subtype of Pattern[Expression].
     """
 
@@ -93,10 +99,11 @@ class Pattern(ABC, Generic[TMatchedType]):
         Returns a MatchResult if the node provided matches this pattern
         otherwise it returns None.
 
-        The parameter is not TMatchedType in that TMatchedType is the type of the
-        Node effectively matched. That would be a subtype of the type we try to match.
-        For example a Column Pattern should be able to get an Expression and match
-        a Column. TMatchedType is Column.
+        The parameter is not TMatchedType in that TMatchedType is the
+        type of the Node effectively matched. That would be a subtype
+        of the type we try to match.
+        For example a Column Pattern should be able to get an Expression
+        and match a Column. TMatchedType is Column.
         """
         raise NotImplementedError
 
@@ -104,10 +111,11 @@ class Pattern(ABC, Generic[TMatchedType]):
 @dataclass(frozen=True)
 class Param(Pattern[TMatchedType]):
     """
-    Defines a named parameter in a Pattern. When matching the overall Pattern,
-    if the Pattern nested in this object matches, the corresponding input node
-    will be given a name and returned as part of the MatchResult return value.
-    This is meant to represent what a group is in a regex.
+    Defines a named parameter in a Pattern. When matching the overall
+    Pattern, if the Pattern nested in this object matches, the
+    corresponding input node will be given a name and returned as part
+    of the MatchResult return value. This is meant to represent what
+    a group is in a regex.
 
     Params can be nested, and they can wrap any valid Pattern.
 
@@ -205,9 +213,10 @@ class Or(Pattern[TMatchedType]):
 class Column(Pattern[ColumnExpr]):
     """
     Matches a Column in an AST expression.
-    The column is defined by alias, name and table. For each, a Pattern can be
-    provided. If one of these Patterns is left None, that field will be ignored
-    when matching (equivalent to Any, but less verbose).
+    The column is defined by alias, name and table. For each,
+    a Pattern can be provided. If one of these Patterns is
+    left None, that field will be ignored when matching
+    (equivalent to Any, but less verbose).
     """
 
     alias: Optional[Pattern[Optional[str]]] = None

--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -9,6 +9,7 @@ from typing import Generic, Mapping, Optional, Sequence, Tuple, Type, TypeVar, U
 from snuba.query.expressions import Column as ColumnExpr
 from snuba.query.expressions import Expression
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
+from snuba.query.expressions import Literal as LiteralExpr
 
 ScalarType = Union[str, int, float, date, datetime]
 OptionalScalarType = Optional[ScalarType]
@@ -114,16 +115,6 @@ class AnyExpression(Pattern[Expression]):
 
 
 @dataclass(frozen=True)
-class AnyOptionalString(Pattern[OptionalScalarType]):
-    """
-    Match any string including the None value
-    """
-
-    def match(self, node: OptionalScalarType) -> Optional[MatchResult]:
-        return MatchResult() if node is None or isinstance(node, str) else None
-
-
-@dataclass(frozen=True)
 class Any(Pattern[TNode]):
     """
     Match any concrete expression/scalar of the type provided
@@ -133,6 +124,16 @@ class Any(Pattern[TNode]):
 
     def match(self, node: TNode) -> Optional[MatchResult]:
         return MatchResult() if isinstance(node, self.type) else None
+
+
+@dataclass(frozen=True)
+class AnyOptionalString(Pattern[OptionalScalarType]):
+    """
+    Match any string including the None value
+    """
+
+    def match(self, node: OptionalScalarType) -> Optional[MatchResult]:
+        return MatchResult() if node is None or isinstance(node, str) else None
 
 
 @dataclass(frozen=True)
@@ -216,10 +217,10 @@ class Column(Pattern[Expression]):
 @dataclass(frozen=True)
 class Literal(Pattern[Expression]):
     alias: Optional[Pattern[OptionalScalarType]] = None
-    value: Optional[Pattern[ScalarType]] = None
+    value: Optional[Pattern[OptionalScalarType]] = None
 
     def match(self, node: Expression) -> Optional[MatchResult]:
-        if not isinstance(node, Literal):
+        if not isinstance(node, LiteralExpr):
             return None
 
         result = MatchResult()

--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -242,7 +242,7 @@ class Column(Pattern[ColumnExpr]):
 @dataclass(frozen=True)
 class Literal(Pattern[LiteralExpr]):
     alias: Optional[Pattern[Optional[str]]] = None
-    value: Optional[Pattern[Optional[str]]] = None
+    value: Optional[Pattern[OptionalScalarType]] = None
 
     def match(self, node: AnyType) -> Optional[MatchResult]:
         if not isinstance(node, LiteralExpr):

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -24,31 +24,31 @@ from snuba.query.matchers import (
 test_cases = [
     (
         "Single node match",
-        Column(None, String("test_col"), OptionalString("table")),
+        Column(None, OptionalString("table"), String("test_col")),
         ColumnExpr("alias_we_don't_care_of", "test_col", "table"),
         MatchResult(),
     ),
     (
         "Single node no match",
-        Column(None, String("test_col"), None),
+        Column(None, None, String("test_col")),
         ColumnExpr(None, "not_a_test_col", None),
         None,
     ),
     (
         "Matches a None table name",
-        Column(None, None, Param("table_name", AnyOptionalString())),
+        Column(None, Param("table_name", AnyOptionalString()), None),
         ColumnExpr(None, "not_a_test_col", None),
         MatchResult({"table_name": None}),
     ),
     (
         "Matches None as table name",
-        Column(None, None, Param("table_name", OptionalString(None))),
+        Column(None, Param("table_name", OptionalString(None)), None),
         ColumnExpr(None, "not_a_test_col", None),
         MatchResult({"table_name": None}),
     ),
     (
         "Not matching a non None table",
-        Column(None, None, Param("table_name", OptionalString(None))),
+        Column(None, Param("table_name", OptionalString(None)), None),
         ColumnExpr(None, "not_a_test_col", "not None"),
         None,
     ),
@@ -56,8 +56,8 @@ test_cases = [
         "Matches a column with all fields",
         Column(
             Param("alias", AnyOptionalString()),
-            Param("column_name", Any(str)),
             Param("table_name", AnyOptionalString()),
+            Param("column_name", Any(str)),
         ),
         ColumnExpr("alias", "test_col", "table_name"),
         MatchResult(
@@ -96,7 +96,7 @@ test_cases = [
     ),
     (
         "Match any expression of Column type within function",
-        FunctionCall(None, None, (Param("p1", Any(ColumnExpr)),),),
+        FunctionCall(None, None, (Param("p1", Any(ColumnExpr)),)),
         FunctionCallExpr(
             "irrelevant",
             "irrelevant",
@@ -106,7 +106,7 @@ test_cases = [
     ),
     (
         "Does not match any Column",
-        FunctionCall(None, None, (Param("p1", Any(ColumnExpr)),),),
+        FunctionCall(None, None, (Param("p1", Any(ColumnExpr)),)),
         FunctionCallExpr("irrelevant", "irrelevant", (LiteralExpr(None, "str"),),),
         None,
     ),
@@ -114,8 +114,8 @@ test_cases = [
         "Union of two patterns - match",
         Or(
             [
-                Param("option1", Column(None, String("col_name"), None)),
-                Param("option2", Column(None, String("other_col_name"), None)),
+                Param("option1", Column(None, None, String("col_name"))),
+                Param("option2", Column(None, None, String("other_col_name"))),
             ]
         ),
         ColumnExpr(None, "other_col_name", None),
@@ -125,8 +125,8 @@ test_cases = [
         "Union of two patterns - no match",
         Or(
             [
-                Param("option1", Column(None, String("col_name"), None)),
-                Param("option2", Column(None, String("other_col_name"), None)),
+                Param("option1", Column(None, None, String("col_name"))),
+                Param("option2", Column(None, None, String("other_col_name"))),
             ]
         ),
         ColumnExpr(None, "none_of_the_two", None),
@@ -138,8 +138,8 @@ test_cases = [
             "one_of_the_two",
             Or(
                 [
-                    Column(None, String("col_name1"), None),
-                    Column(None, String("col_name2"), None),
+                    Column(None, None, String("col_name1")),
+                    Column(None, None, String("col_name2")),
                 ]
             ),
         ),
@@ -170,8 +170,8 @@ test_cases = [
             Param("alias", OptionalString(None)),
             String("f_name"),
             (
-                Param("p_1", Column(None, Any(str), None)),
-                Param("p_2", Column(None, Any(str), None)),
+                Param("p_1", Column(None, None, Any(str))),
+                Param("p_2", Column(None, None, Any(str))),
             ),
         ),
         FunctionCallExpr(
@@ -196,8 +196,8 @@ test_cases = [
             None,
             None,
             (
-                Param("p_1", Column(None, Any(str), None)),
-                Param("p_2", Column(None, Any(str), None)),
+                Param("p_1", Column(None, None, Any(str))),
+                Param("p_2", Column(None, None, Any(str))),
             ),
             with_optionals=True,
         ),
@@ -224,8 +224,8 @@ test_cases = [
             None,
             None,
             (
-                Param("p_1", Column(None, Any(str), None)),
-                Param("p_2", Column(None, Any(str), None)),
+                Param("p_1", Column(None, None, Any(str))),
+                Param("p_2", Column(None, None, Any(str))),
             ),
             with_optionals=True,
         ),
@@ -241,7 +241,7 @@ test_cases = [
             String("f_name"),
             (
                 FunctionCall(
-                    None, String("f"), (Column(None, String("my_col"), None),)
+                    None, String("f"), (Column(None, None, String("my_col")),)
                 ),
                 Param(
                     "second_function",
@@ -266,7 +266,7 @@ test_cases = [
             String("f_name"),
             (
                 FunctionCall(
-                    None, String("f"), (Column(None, String("my_col"), None),)
+                    None, String("f"), (Column(None, None, String("my_col")),)
                 ),
                 Param(
                     "second_function",
@@ -308,7 +308,7 @@ def test_accessors() -> None:
         None,
         String("f_name"),
         (
-            FunctionCall(None, String("f"), (Column(None, String("my_col"), None),)),
+            FunctionCall(None, String("f"), (Column(None, None, String("my_col")),)),
             Param(
                 "second_function",
                 FunctionCall(None, Param("second_function_name", Any(str)), None),

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -3,13 +3,16 @@ from typing import Optional
 import pytest
 
 from snuba.query.expressions import Column as ColumnExpr
-from snuba.query.expressions import Expression, FunctionCall
-from snuba.query.matcher import (
+from snuba.query.expressions import Expression
+from snuba.query.expressions import FunctionCall as FunctionCallExpr
+from snuba.query.matchers import (
+    Any,
     AnyExpression,
     AnyString,
     Column,
-    Function,
+    FunctionCall,
     MatchResult,
+    OptionalString,
     Or,
     Param,
     Pattern,
@@ -18,21 +21,43 @@ from snuba.query.matcher import (
 
 test_cases = [
     (
-        Column(None, String("test_col"), String("table")),
+        "Single node match",
+        Column(None, String("test_col"), OptionalString("table")),
         ColumnExpr("alias_we_don't_care_of", "test_col", "table"),
         MatchResult(),
     ),  # Simple single node column that matches
     (
+        "Single node no match",
         Column(None, String("test_col"), None),
         ColumnExpr(None, "not_a_test_col", None),
         None,
     ),  # Simple single node column that does not match
     (
+        "Matches a None table name",
+        Column(None, None, Param("table_name", AnyString())),
+        ColumnExpr(None, "not_a_test_col", None),
+        MatchResult({"table_name": None}),
+    ),  # Matches a None table name
+    (
+        "Matches a column with all fields",
+        Column(
+            Param("alias", AnyString()),
+            Param("column_name", Any(str)),
+            Param("table_name", AnyString()),
+        ),
+        ColumnExpr("alias", "test_col", "table_name"),
+        MatchResult(
+            {"alias": "alias", "column_name": "test_col", "table_name": "table_name"}
+        ),
+    ),  # Matches a column with all fields
+    (
+        "Match anything",
         AnyExpression(),
         ColumnExpr(None, "something_irrelevant", None),
         MatchResult(),
     ),  # Pattern that matches anything
     (
+        "Union of two patterns - match",
         Or(
             [
                 Param("option1", Column(None, String("col_name"), None)),
@@ -40,9 +65,10 @@ test_cases = [
             ]
         ),
         ColumnExpr(None, "other_col_name", None),
-        MatchResult(expressions={"option2": ColumnExpr(None, "other_col_name", None)}),
+        MatchResult({"option2": ColumnExpr(None, "other_col_name", None)}),
     ),  # Two patterns in OR. One matches.
     (
+        "Union of two patterns - no match",
         Or(
             [
                 Param("option1", Column(None, String("col_name"), None)),
@@ -53,21 +79,23 @@ test_cases = [
         None,
     ),  # Two patterns in OR. None matches.
     (
-        Column(None, Param("col_name", AnyString()), None),
+        "Any string match",
+        Column(None, Param("col_name", Any(str)), None),
         ColumnExpr(None, "something_relevant", "not_that_we_care_about_the_table"),
-        MatchResult(strings={"col_name": "something_relevant"}),
+        MatchResult({"col_name": "something_relevant"}),
     ),  # Pattern that matches any string and returns it
     (
-        Function(
-            None,
+        "returns the columns in any function",
+        FunctionCall(
+            Param("alias", OptionalString(None)),
             String("f_name"),
             (
-                Param("p_1", Column(None, AnyString(), None)),
-                Param("p_2", Column(None, AnyString(), None)),
+                Param("p_1", Column(None, Any(str), None)),
+                Param("p_2", Column(None, Any(str), None)),
             ),
         ),
-        FunctionCall(
-            "irrelevant_alias",
+        FunctionCallExpr(
+            None,
             "f_name",
             (
                 ColumnExpr(None, "c_name1", None),
@@ -75,66 +103,74 @@ test_cases = [
             ),
         ),
         MatchResult(
-            expressions={
+            {
+                "alias": None,
                 "p_1": ColumnExpr(None, "c_name1", None),
                 "p_2": ColumnExpr("another_irrelevant_alias", "c_name2", None),
             }
         ),
     ),  # Match any a function given a function name and returns the columns
     (
-        Function(
+        "nested parameters no match",
+        FunctionCall(
             None,
             String("f_name"),
             (
-                Function(None, String("f"), (Column(None, String("my_col"), None),)),
+                FunctionCall(
+                    None, String("f"), (Column(None, String("my_col"), None),)
+                ),
                 Param(
                     "second_function",
-                    Function(None, Param("second_function_name", AnyString()), None),
+                    FunctionCall(None, Param("second_function_name", Any(str)), None),
                 ),
             ),
         ),
-        FunctionCall(
+        FunctionCallExpr(
             "irrelevant",
             "relevant_and_wrong",
             (
-                FunctionCall(None, "f", (ColumnExpr(None, "my_col", None),)),
-                FunctionCall(None, "bla", tuple()),
+                FunctionCallExpr(None, "f", (ColumnExpr(None, "my_col", None),)),
+                FunctionCallExpr(None, "bla", tuple()),
             ),
         ),
         None,
     ),  # Complex structure with nested parameters. No match
     (
-        Function(
+        "complex structure matches",
+        FunctionCall(
             None,
             String("f_name"),
             (
-                Function(None, String("f"), (Column(None, String("my_col"), None),)),
+                FunctionCall(
+                    None, String("f"), (Column(None, String("my_col"), None),)
+                ),
                 Param(
                     "second_function",
-                    Function(None, Param("second_function_name", AnyString()), None),
+                    FunctionCall(None, Param("second_function_name", Any(str)), None),
                 ),
             ),
         ),
-        FunctionCall(
+        FunctionCallExpr(
             "irrelevant",
             "f_name",
             (
-                FunctionCall(None, "f", (ColumnExpr(None, "my_col", None),)),
-                FunctionCall(None, "second_name", tuple()),
+                FunctionCallExpr(None, "f", (ColumnExpr(None, "my_col", None),)),
+                FunctionCallExpr(None, "second_name", tuple()),
             ),
         ),
         MatchResult(
-            strings={"second_function_name": "second_name"},
-            expressions={
-                "second_function": FunctionCall(None, "second_name", tuple()),
+            {
+                "second_function_name": "second_name",
+                "second_function": FunctionCallExpr(None, "second_name", tuple()),
             },
         ),
     ),  # Complex structure with nested parameters. This matches
 ]
 
 
-@pytest.mark.parametrize("pattern, expression, expected_result", test_cases)
+@pytest.mark.parametrize("name, pattern, expression, expected_result", test_cases)
 def test_base_expression(
+    name: str,
     pattern: Pattern[Expression],
     expression: Expression,
     expected_result: Optional[MatchResult],

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -40,8 +40,18 @@ test_cases = [
             ]
         ),
         ColumnExpr(None, "other_col_name", None),
-        MatchResult(expressions={"option2": ColumnExpr(None, "other_col_name", None)},),
-    ),
+        MatchResult(expressions={"option2": ColumnExpr(None, "other_col_name", None)}),
+    ),  # Two patterns in OR. One matches.
+    (
+        Or(
+            [
+                Param("option1", Column(None, String("col_name"), None)),
+                Param("option2", Column(None, String("other_col_name"), None)),
+            ]
+        ),
+        ColumnExpr(None, "none_of_the_two", None),
+        None,
+    ),  # Two patterns in OR. None matches.
     (
         Column(None, Param("col_name", AnyString()), None),
         ColumnExpr(None, "something_relevant", "not_that_we_care_about_the_table"),

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -148,7 +148,7 @@ test_cases = [
     ),
     (
         "Match String Literal",
-        Literal(None, OptionalString("value")),
+        Literal(None, String("value")),
         LiteralExpr("irrelevant", "value"),
         MatchResult(),
     ),
@@ -189,6 +189,50 @@ test_cases = [
                 "p_2": ColumnExpr("another_irrelevant_alias", "c_name2", None),
             }
         ),
+    ),
+    (
+        "matches a function with optional params",
+        FunctionCall(
+            None,
+            None,
+            (
+                Param("p_1", Column(None, Any(str), None)),
+                Param("p_2", Column(None, Any(str), None)),
+            ),
+            with_optionals=True,
+        ),
+        FunctionCallExpr(
+            "irrelevant",
+            "irrelevant",
+            (
+                ColumnExpr(None, "c_name1", None),
+                ColumnExpr("another_irrelevant_alias", "c_name2", None),
+                ColumnExpr("optional_1", "optional_1", None),
+                ColumnExpr("optional_2", "optional_2", None),
+            ),
+        ),
+        MatchResult(
+            {
+                "p_1": ColumnExpr(None, "c_name1", None),
+                "p_2": ColumnExpr("another_irrelevant_alias", "c_name2", None),
+            }
+        ),
+    ),
+    (
+        "dows not match even with optionals",
+        FunctionCall(
+            None,
+            None,
+            (
+                Param("p_1", Column(None, Any(str), None)),
+                Param("p_2", Column(None, Any(str), None)),
+            ),
+            with_optionals=True,
+        ),
+        FunctionCallExpr(
+            "irrelevant", "irrelevant", (ColumnExpr(None, "c_name1", None),),
+        ),
+        None,
     ),
     (
         "nested parameters no match",

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -148,7 +148,7 @@ test_cases = [
     ),
     (
         "Match String Literal",
-        Literal(None, String("value")),
+        Literal(None, OptionalString("value")),
         LiteralExpr("irrelevant", "value"),
         MatchResult(),
     ),

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -1,0 +1,29 @@
+
+from snuba.query.expressions import FunctionCall
+from snuba.query.expressions import Column as ColumnExpr
+from snuba.query.matcher import Any, Param, Function, String
+
+def test_base_expression() -> None:
+    expression = FunctionCall(
+        None,
+        "f",
+        (
+            FunctionCall(None, "f2", (ColumnExpr(None, "c", None), ColumnExpr(None, "c2", None))),
+            ColumnExpr(None, "c3", None),
+        )
+    )
+
+    matcher = Function(
+        None,
+        Param("f_name", Any()),
+        (Param("inner", Function(None, Param("inner_name", String("f2")), None)), Any())
+    )
+
+    result, params = matcher.match(expression)
+
+    assert result == True
+    assert params == {
+        "f_name": "f",
+        "inner": FunctionCall(None, "f2", (ColumnExpr(None, "c", None), ColumnExpr(None, "c2", None))),
+        "inner_name": "f2",
+    }

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -171,7 +171,7 @@ test_cases = [
 @pytest.mark.parametrize("name, pattern, expression, expected_result", test_cases)
 def test_base_expression(
     name: str,
-    pattern: Pattern[Expression, Expression],
+    pattern: Pattern[Expression],
     expression: Expression,
     expected_result: Optional[MatchResult],
 ) -> None:

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -1,29 +1,122 @@
+from typing import Optional
 
-from snuba.query.expressions import FunctionCall
+import pytest
+
 from snuba.query.expressions import Column as ColumnExpr
-from snuba.query.matcher import Any, Param, Function, String
+from snuba.query.expressions import Expression, FunctionCall
+from snuba.query.matcher import (
+    AnyExpression,
+    AnyString,
+    Column,
+    Function,
+    MatchResult,
+    Param,
+    Pattern,
+    String,
+)
 
-def test_base_expression() -> None:
-    expression = FunctionCall(
+test_cases = [
+    (
+        Column(None, String("test_col"), String("table")),
+        ColumnExpr("alias_we_don't_care_of", "test_col", "table"),
+        MatchResult(),
+    ),  # Simple single node column that matches
+    (
+        Column(None, String("test_col"), None),
+        ColumnExpr(None, "not_a_test_col", None),
         None,
-        "f",
-        (
-            FunctionCall(None, "f2", (ColumnExpr(None, "c", None), ColumnExpr(None, "c2", None))),
-            ColumnExpr(None, "c3", None),
-        )
-    )
-
-    matcher = Function(
+    ),  # Simple single node column that does not match
+    (
+        AnyExpression(),
+        ColumnExpr(None, "something_irrelevant", None),
+        MatchResult(),
+    ),  # Pattern that matches anything
+    (
+        Column(None, Param("col_name", AnyString()), None),
+        ColumnExpr(None, "something_relevant", "not_that_we_care_about_the_table"),
+        MatchResult(strings={"col_name": "something_relevant"}),
+    ),  # Pattern that matches any string and returns it
+    (
+        Function(
+            None,
+            String("f_name"),
+            (
+                Param("p_1", Column(None, AnyString(), None)),
+                Param("p_2", Column(None, AnyString(), None)),
+            ),
+        ),
+        FunctionCall(
+            "irrelevant_alias",
+            "f_name",
+            (
+                ColumnExpr(None, "c_name1", None),
+                ColumnExpr("another_irrelevant_alias", "c_name2", None),
+            ),
+        ),
+        MatchResult(
+            expressions={
+                "p_1": ColumnExpr(None, "c_name1", None),
+                "p_2": ColumnExpr("another_irrelevant_alias", "c_name2", None),
+            }
+        ),
+    ),  # Match any a function given a function name and returns the columns
+    (
+        Function(
+            None,
+            String("f_name"),
+            (
+                Function(None, String("f"), (Column(None, String("my_col"), None),)),
+                Param(
+                    "second_function",
+                    Function(None, Param("second_function_name", AnyString()), None),
+                ),
+            ),
+        ),
+        FunctionCall(
+            "irrelevant",
+            "relevant_and_wrong",
+            (
+                FunctionCall(None, "f", (ColumnExpr(None, "my_col", None),)),
+                FunctionCall(None, "bla", tuple()),
+            ),
+        ),
         None,
-        Param("f_name", Any()),
-        (Param("inner", Function(None, Param("inner_name", String("f2")), None)), Any())
-    )
+    ),  # Complex structure with nested parameters. No match
+    (
+        Function(
+            None,
+            String("f_name"),
+            (
+                Function(None, String("f"), (Column(None, String("my_col"), None),)),
+                Param(
+                    "second_function",
+                    Function(None, Param("second_function_name", AnyString()), None),
+                ),
+            ),
+        ),
+        FunctionCall(
+            "irrelevant",
+            "f_name",
+            (
+                FunctionCall(None, "f", (ColumnExpr(None, "my_col", None),)),
+                FunctionCall(None, "second_name", tuple()),
+            ),
+        ),
+        MatchResult(
+            strings={"second_function_name": "second_name"},
+            expressions={
+                "second_function": FunctionCall(None, "second_name", tuple()),
+            },
+        ),
+    ),  # Complex structure with nested parameters. This matches
+]
 
-    result, params = matcher.match(expression)
 
-    assert result == True
-    assert params == {
-        "f_name": "f",
-        "inner": FunctionCall(None, "f2", (ColumnExpr(None, "c", None), ColumnExpr(None, "c2", None))),
-        "inner_name": "f2",
-    }
+@pytest.mark.parametrize("pattern, expression, expected_result", test_cases)
+def test_base_expression(
+    pattern: Pattern[Expression],
+    expression: Expression,
+    expected_result: Optional[MatchResult],
+) -> None:
+    res = pattern.match(expression)
+    assert res == expected_result

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -171,7 +171,7 @@ test_cases = [
 @pytest.mark.parametrize("name, pattern, expression, expected_result", test_cases)
 def test_base_expression(
     name: str,
-    pattern: Pattern[Expression],
+    pattern: Pattern[Expression, Expression],
     expression: Expression,
     expected_result: Optional[MatchResult],
 ) -> None:

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.matchers import (
     Any,
     AnyExpression,
-    AnyString,
+    AnyOptionalString,
     Column,
     FunctionCall,
     MatchResult,
@@ -34,16 +34,16 @@ test_cases = [
     ),  # Simple single node column that does not match
     (
         "Matches a None table name",
-        Column(None, None, Param("table_name", AnyString())),
+        Column(None, None, Param("table_name", AnyOptionalString())),
         ColumnExpr(None, "not_a_test_col", None),
         MatchResult({"table_name": None}),
     ),  # Matches a None table name
     (
         "Matches a column with all fields",
         Column(
-            Param("alias", AnyString()),
+            Param("alias", AnyOptionalString()),
             Param("column_name", Any(str)),
-            Param("table_name", AnyString()),
+            Param("table_name", AnyOptionalString()),
         ),
         ColumnExpr("alias", "test_col", "table_name"),
         MatchResult(

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -10,6 +10,7 @@ from snuba.query.matcher import (
     Column,
     Function,
     MatchResult,
+    Or,
     Param,
     Pattern,
     String,
@@ -31,6 +32,16 @@ test_cases = [
         ColumnExpr(None, "something_irrelevant", None),
         MatchResult(),
     ),  # Pattern that matches anything
+    (
+        Or(
+            [
+                Param("option1", Column(None, String("col_name"), None)),
+                Param("option2", Column(None, String("other_col_name"), None)),
+            ]
+        ),
+        ColumnExpr(None, "other_col_name", None),
+        MatchResult(expressions={"option2": ColumnExpr(None, "other_col_name", None)},),
+    ),
     (
         Column(None, Param("col_name", AnyString()), None),
         ColumnExpr(None, "something_relevant", "not_that_we_care_about_the_table"),


### PR DESCRIPTION
I find myself writing ugly code like this way too often when working with the AST to find whether an expression matches a structure:
https://github.com/getsentry/snuba/pull/941/files#diff-ca753e14c67da74d0c4fa9de69f59fc2R75-R81
https://github.com/getsentry/snuba/blob/master/snuba/query/processors/tagsmap.py#L131-L135
(there are more)

The issue there is that, every time, we need to manually navigate the subtree we are interested into, validate if the node is of the type we want and keep doing it. This is very verbose. Moreover if we want parameters to be extracted (like in the datetime case above), first we need to check whether the expression has the right structure and then traverse it again to extract what we need.

This PR introduces a simple api to provide a declarative way to define a pattern (with named parameters) we want to match an expression against. It is meant to be used like we do for regular expressions, but with types and on a tree like structure.

Example 1:
https://github.com/getsentry/snuba/pull/941/files#diff-ca753e14c67da74d0c4fa9de69f59fc2R75-R81 Could become something like:
```
pattern = Function(
    None,
    String(">="),
    (Column(None, String("timestamp"), None),
      Param("timestamp": Literal(None, AnyDateTime())). #Still have to build the literal but it is trivial

res = pattern.match(expression)
my_datetime = res.datetimes["timestamp"]
# No more isinstance
```

Furthermore this could be used to simplify matchers in the rule based query translator. Like here: https://github.com/getsentry/snuba/pull/936/files#diff-7611169cbefa4facc1d2f11679d80dd2R64-R66
We would be easily able to define a translation rule as a Pattern + an Executor, where the pattern does not need subclassing to be implemented (it would be enough to instantiate a Pattern from this PR) and the executor would be fed the MatchResult to build the translated expression.

In a followup I will implement a visitor that allows to find a pattern in an expression instead of just matching the whole expression.