### PR TITLE
ref(migration): Consolidate migration tasks

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -7,7 +7,7 @@ from snuba import settings
 from snuba.clusters.cluster import CLUSTERS
 from snuba.datasets.factory import ACTIVE_DATASET_NAMES, get_dataset
 from snuba.environment import setup_logging
-from snuba.migrations.migrate import run
+from snuba.migrations import migrate
 
 
 @click.command()
@@ -121,39 +121,4 @@ def bootstrap(
                     raise
                 time.sleep(1)
 
-    # Need to better figure out if we are configured to use replicated
-    # tables or distributed tables, etc.
-
-    # Create the tables for every dataset.
-    for name in ACTIVE_DATASET_NAMES:
-        dataset = get_dataset(name)
-
-        logger.debug("Creating tables for dataset %s", name)
-        run_migrations = False
-        for storage in dataset.get_all_storages():
-            clickhouse_rw = storage.get_cluster().get_clickhouse_rw()
-            existing_tables = {row[0] for row in clickhouse_rw.execute("show tables")}
-            for statement in storage.get_schemas().get_create_statements():
-                if statement.table_name not in existing_tables:
-                    # This is a hack to deal with updates to Materialized views.
-                    # It seems that ClickHouse would parse the SELECT statement that defines a
-                    # materialized view even if the view already exists and the CREATE statement
-                    # includes the IF NOT EXISTS clause.
-                    # When we add a column to a matview, though, we will be in a state where, by
-                    # running bootstrap, ClickHouse will parse the SQL statement to try to create
-                    # the view and fail because the column does not exist yet on the underlying table,
-                    # since the migration on the underlying table has not ran yet.
-                    # Migrations are per dataset so they can only run after the bootstrap of an
-                    # entire dataset has run. So we would have bootstrap depending on migration
-                    # and migration depending on bootstrap.
-                    # In order to break this dependency we skip bootstrap DDL calls here if the
-                    # table/view already exists, so it is always safe to run bootstrap first.
-                    logger.debug("Executing:\n%s", statement.statement)
-                    clickhouse_rw.execute(statement.statement)
-                else:
-                    logger.debug("Skipping existing table %s", statement.table_name)
-                    run_migrations = True
-        if run_migrations:
-            logger.debug("Running missing migrations for dataset %s", name)
-            run(dataset)
-        logger.info("Tables for dataset %s created.", name)
+    migrate.run()

--- a/snuba/cli/migrate.py
+++ b/snuba/cli/migrate.py
@@ -3,33 +3,18 @@ from typing import Optional
 
 import click
 
-from snuba.datasets.factory import ACTIVE_DATASET_NAMES, get_dataset
 from snuba.environment import setup_logging
+from snuba.migrations.migrate import logger, run
 from snuba.util import local_dataset_mode
 
 
 @click.command()
 @click.option("--log-level", help="Logging level to use.")
-@click.option(
-    "--dataset",
-    "dataset_name",
-    type=click.Choice(ACTIVE_DATASET_NAMES),
-    help="The dataset to target",
-)
-def migrate(
-    *, log_level: Optional[str] = None, dataset_name: Optional[str] = None
-) -> None:
-    from snuba.migrations.migrate import logger, run
-
+def migrate(*, log_level: Optional[str] = None) -> None:
     setup_logging(log_level)
 
     if not local_dataset_mode():
         logger.error("The migration tool can only work on local dataset mode.")
         sys.exit(1)
 
-    dataset_names = [dataset_name] if dataset_name else ACTIVE_DATASET_NAMES
-    for name in dataset_names:
-        dataset = get_dataset(name)
-        logger.info("Migrating dataset %s", name)
-
-        run(dataset)
+    run()

--- a/snuba/migrations/migrate.py
+++ b/snuba/migrations/migrate.py
@@ -3,13 +3,26 @@ import logging
 from clickhouse_driver import Client
 from typing import MutableSequence
 
-from snuba.datasets.dataset import Dataset
 from snuba.datasets.schemas import Schema
 from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_storage
 from snuba.migrations.parse_schema import get_local_schema
 
 
 logger = logging.getLogger("snuba.migrate")
+
+STORAGES_TO_MIGRATE = [
+    StorageKey.EVENTS,
+    StorageKey.ERRORS,
+    StorageKey.GROUPEDMESSAGES,
+    StorageKey.GROUPASSIGNEES,
+    StorageKey.OUTCOMES_RAW,
+    StorageKey.OUTCOMES_HOURLY,
+    StorageKey.SESSIONS_RAW,
+    StorageKey.SESSIONS_HOURLY,
+    StorageKey.TRANSACTIONS,
+]
 
 
 def _run_schema(conn: Client, schema: Schema) -> None:
@@ -34,17 +47,30 @@ def _run_schema(conn: Client, schema: Schema) -> None:
         logger.warn(difference)
 
 
-def run(dataset: Dataset) -> None:
-    schemas: MutableSequence[Schema] = []
-    writable_storage = dataset.get_writable_storage()
-    if writable_storage:
-        # This ensures that the writable storage table is always migrated before
-        # other storages required for that dataset
-        schemas.append(writable_storage.get_table_writer().get_schema())
+def run() -> None:
+    # Create the tables for all of the storages to be migrated.
+    for storage_key in STORAGES_TO_MIGRATE:
+        storage_name = storage_key.value
+        logger.info("Creating tables for storage %s", storage_name)
+        storage = get_storage(storage_key)
+        clickhouse_rw = storage.get_cluster().get_clickhouse_rw()
 
-    for storage in dataset.get_all_storages():
-        schemas.append(storage.get_schemas().get_read_schema())
+        for statement in storage.get_schemas().get_create_statements():
+            logger.debug("Executing:\n%s", statement.statement)
+            clickhouse_rw.execute(statement.statement)
 
-    for schema in schemas:
-        conn = storage.get_cluster().get_clickhouse_rw()
-        _run_schema(conn, schema)
+        # Run migrations
+        logger.info("Migrating storage %s", storage_name)
+        schemas: MutableSequence[Schema] = []
+
+        read_schema = storage.get_schemas().get_read_schema()
+        write_schema = storage.get_schemas().get_write_schema()
+
+        if write_schema:
+            schemas.append(write_schema)
+
+        schemas.append(read_schema)
+
+        for schema in schemas:
+            conn = storage.get_cluster().get_clickhouse_rw()
+            _run_schema(conn, schema)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -263,7 +263,7 @@ def dataset_query_view(*, dataset: Dataset, timer: Timer):
 def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
     assert http_request.method == "POST"
     ensure_not_internal(dataset)
-    ensure_table_exists(dataset)
+    ensure_tables_migrated()
 
     request = validate_request_content(
         body,
@@ -356,32 +356,26 @@ if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
 
-    _ensured: MutableMapping[Dataset, bool] = {}
+    _ensured = False
 
-    def ensure_table_exists(dataset: Dataset, force: bool = False) -> None:
-        if not force and _ensured.get(dataset, False):
+    def ensure_tables_migrated(force: bool = False) -> None:
+        global _ensured
+        if not force and _ensured:
             return
 
         assert local_dataset_mode(), "Cannot create table in distributed mode"
 
         from snuba.migrations import migrate
 
-        # We cannot build distributed tables this way. So this only works in local
-        # mode.
-        for storage in dataset.get_all_storages():
-            clickhouse_rw = storage.get_cluster().get_clickhouse_rw()
-            for statement in storage.get_schemas().get_create_statements():
-                clickhouse_rw.execute(statement.statement)
+        migrate.run()
 
-        migrate.run(dataset)
-
-        _ensured[dataset] = True
+        _ensured = True
 
     @application.route("/tests/<dataset:dataset>/insert", methods=["POST"])
     def write(*, dataset: Dataset):
         from snuba.processor import ProcessorAction
 
-        ensure_table_exists(dataset)
+        ensure_tables_migrated()
 
         rows = []
         offset_base = int(round(time.time() * 1000))
@@ -405,7 +399,7 @@ if application.debug or application.testing:
 
     @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])
     def eventstream(*, dataset: Dataset):
-        ensure_table_exists(dataset)
+        ensure_tables_migrated()
         record = json.loads(http_request.data)
 
         version = record[0]
@@ -426,9 +420,11 @@ if application.debug or application.testing:
 
         if type_ == "insert":
             from snuba.consumer import ConsumerWorker
+
             worker = ConsumerWorker(storage, metrics=metrics)
         else:
             from snuba.replacer import ReplacerWorker
+
             clickhouse_rw = storage.get_cluster().get_clickhouse_rw()
             worker = ReplacerWorker(clickhouse_rw, storage, metrics=metrics)
 
@@ -446,7 +442,7 @@ if application.debug or application.testing:
             for statement in storage.get_schemas().get_drop_statements():
                 clickhouse_rw.execute(statement.statement)
 
-        ensure_table_exists(dataset, force=True)
+        ensure_tables_migrated(force=True)
         redis_client.flushdb()
         return ("ok", 200, {"Content-Type": "text/plain"})
 
@@ -457,5 +453,5 @@ if application.debug or application.testing:
 
 else:
 
-    def ensure_table_exists(dataset: Dataset, force: bool = False) -> None:
+    def ensure_tables_migrated(force: bool = False) -> None:
         pass

--- a/tests/migrations/test_migrate.py
+++ b/tests/migrations/test_migrate.py
@@ -4,7 +4,9 @@ from snuba.datasets.factory import DATASET_NAMES, get_dataset
 
 # TODO: Remove this once querylog is in prod and no longer disabled
 from snuba import settings
+
 settings.DISABLED_DATASETS = set()
+
 
 class TestMigrate(BaseDatasetTest):
     def setup_method(self, test_method):
@@ -19,9 +21,7 @@ class TestMigrate(BaseDatasetTest):
     def test_runs_migrations_without_errors(self):
         from snuba.migrations.migrate import run
 
-        for dataset_name in DATASET_NAMES:
-            dataset = get_dataset(dataset_name)
-            run(dataset)
+        run()
 
     def test_no_schema_diffs(self):
         from snuba.migrations.parse_schema import get_local_schema


### PR DESCRIPTION
Migration tasks are currently split between the bootrap and migrate
commnands, which is rather confusing. It requires the user to run both
the bootstrap and migrate commands sequentially in order to ensure all
migrations actually run. Now only migrate needs to be run to perform all
the migrations.

This simplifies the implementation quite a bit, since we no longer need
the hack to ensure that materialized views are created after the
underlying raw tables. Instead we define the order in which storages
must be migrated. This implementation is intended to be temporary and
should be replaced by a proper migration system soon.