### PR TITLE
ref(transactions): Move discover column aliasing into transactions dataset

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -306,20 +306,6 @@ class DiscoverDataset(TimeSeriesDataset):
         if detected_dataset == TRANSACTIONS:
             if column_name == "time":
                 return self.time_expr("finish_ts", query.get_granularity(), table_alias)
-            if column_name == "type":
-                return "'transaction'"
-            if column_name == "timestamp":
-                return "finish_ts"
-            if column_name == "username":
-                return "user_name"
-            if column_name == "email":
-                return "user_email"
-            if column_name == "transaction":
-                return "transaction_name"
-            if column_name == "message":
-                return "transaction_name"
-            if column_name == "title":
-                return "transaction_name"
             if column_name == "group_id":
                 # TODO: We return 0 here instead of NULL so conditions like group_id
                 # in (1, 2, 3) will work, since Clickhouse won't run a query like:
@@ -327,12 +313,6 @@ class DiscoverDataset(TimeSeriesDataset):
                 # When we have the query AST, we should solve this by transforming the
                 # nonsensical conditions instead.
                 return "0"
-            if column_name == "geo_country_code":
-                column_name = "contexts[geo.country_code]"
-            if column_name == "geo_region":
-                column_name = "contexts[geo.region]"
-            if column_name == "geo_city":
-                column_name = "contexts[geo.city]"
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -304,8 +304,6 @@ class DiscoverDataset(TimeSeriesDataset):
         )
 
         if detected_dataset == TRANSACTIONS:
-            if column_name == "time":
-                return self.time_expr("finish_ts", query.get_granularity(), table_alias)
             if column_name == "group_id":
                 # TODO: We return 0 here instead of NULL so conditions like group_id
                 # in (1, 2, 3) will work, since Clickhouse won't run a query like:
@@ -316,8 +314,6 @@ class DiscoverDataset(TimeSeriesDataset):
             if self.__events_columns.get(column_name):
                 return "NULL"
         else:
-            if column_name == "time":
-                return self.time_expr("timestamp", query.get_granularity(), table_alias)
             if column_name == "release":
                 column_name = "tags[sentry:release]"
             if column_name == "dist":

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -32,6 +32,7 @@ class TransactionsDataset(TimeSeriesDataset):
         self.__time_group_columns = {
             "bucketed_start": "start_ts",
             "bucketed_end": "finish_ts",
+            "time": "finish_ts",
         }
         super().__init__(
             storages=[storage],

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -84,6 +84,34 @@ class TransactionsDataset(TimeSeriesDataset):
             return f"coalesce(IPv4NumToString(ip_address_v4), IPv6NumToString(ip_address_v6))"
         if column_name == "event_id":
             return "replaceAll(toString(event_id), '-', '')"
+
+        # These column aliases originally existed in the ``discover`` dataset,
+        # but now live here to maintain compatibility between the composite
+        # ``discover`` dataset and the standalone ``transaction`` dataset. In
+        # the future, these aliases hould be defined on the Transaction entity
+        # instead of the dataset.
+        if column_name == "type":
+            return "'transaction'"
+        if column_name == "timestamp":
+            return "finish_ts"
+        if column_name == "username":
+            return "user_name"
+        if column_name == "email":
+            return "user_email"
+        if column_name == "transaction":
+            return "transaction_name"
+        if column_name == "message":
+            return "transaction_name"
+        if column_name == "title":
+            return "transaction_name"
+
+        if column_name == "geo_country_code":
+            column_name = "contexts[geo.country_code]"
+        if column_name == "geo_region":
+            column_name = "contexts[geo.region]"
+        if column_name == "geo_city":
+            column_name = "contexts[geo.city]"
+
         processed_column = self.__tags_processor.process_column_expression(
             column_name, query, parsing_context, table_alias
         )


### PR DESCRIPTION
Like #934, but with hopefully less collateral damage since the `transactions` dataset isn't used directly.

This is intended to ensure that aggregation and filtering behavior is consistent between the two different dataset representations of a ``Transaction`` (until there is a single logical representation which will come along with the entity work) since the ``transactions`` dataset will be the entrypoint for subscriptions on transaction data (until that also is changed as a side effect of the entity work.)

Since this consistency is not structurally enforced, we will have to be careful to ensure to not invalidate this property until the implementation of entities enforces it inherently.