### PR TITLE
fix(sessions): Count abnormal sessions also as errored

### DIFF
--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -54,3 +54,99 @@ class TestSessionProcessor(BaseTest):
                 "received": timestamp.replace(tzinfo=None),
             }
         ]
+
+    def test_ingest_session_event_abnormal(self):
+        timestamp = datetime.now(timezone.utc)
+        started = timestamp - timedelta(hours=1)
+
+        payload = {
+            "device_family": "iPhone12,3",
+            "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+            "duration": 1947.49,
+            "environment": "production",
+            "org_id": 1,
+            "os": "iOS",
+            "os_version": "13.3.1",
+            "project_id": 42,
+            "release": "sentry-test@1.0.0",
+            "retention_days": 90,
+            "seq": 42,
+            "errors": 0,
+            "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "started": started.timestamp(),
+            "status": "abnormal",
+            "received": timestamp.timestamp(),
+        }
+
+        meta = KafkaMessageMetadata(offset=1, partition=2)
+        processor = SessionsProcessor()
+        ret = processor.process_message(payload, meta)
+        assert ret is not None
+
+        assert ret.action == ProcessorAction.INSERT
+        assert ret.data == [
+            {
+                "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                "duration": 1947490,
+                "environment": "production",
+                "org_id": 1,
+                "project_id": 42,
+                "release": "sentry-test@1.0.0",
+                "retention_days": 90,
+                "seq": 42,
+                # abnormal counts as at least one error
+                "errors": 1,
+                "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+                "started": started.replace(tzinfo=None),
+                "status": 3,
+                "received": timestamp.replace(tzinfo=None),
+            }
+        ]
+
+    def test_ingest_session_event_crashed(self):
+        timestamp = datetime.now(timezone.utc)
+        started = timestamp - timedelta(hours=1)
+
+        payload = {
+            "device_family": "iPhone12,3",
+            "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+            "duration": 1947.49,
+            "environment": "production",
+            "org_id": 1,
+            "os": "iOS",
+            "os_version": "13.3.1",
+            "project_id": 42,
+            "release": "sentry-test@1.0.0",
+            "retention_days": 90,
+            "seq": 42,
+            "errors": 0,
+            "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "started": started.timestamp(),
+            "status": "crashed",
+            "received": timestamp.timestamp(),
+        }
+
+        meta = KafkaMessageMetadata(offset=1, partition=2)
+        processor = SessionsProcessor()
+        ret = processor.process_message(payload, meta)
+        assert ret is not None
+
+        assert ret.action == ProcessorAction.INSERT
+        assert ret.data == [
+            {
+                "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                "duration": 1947490,
+                "environment": "production",
+                "org_id": 1,
+                "project_id": 42,
+                "release": "sentry-test@1.0.0",
+                "retention_days": 90,
+                "seq": 42,
+                # abnormal counts as at least one error
+                "errors": 1,
+                "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+                "started": started.replace(tzinfo=None),
+                "status": 2,
+                "received": timestamp.replace(tzinfo=None),
+            }
+        ]


### PR DESCRIPTION
Health sessions are supposed to be `sessions - errored` and errored
but not crashed/abnormal sessions are supposed to be
`errored - crashed - abnormal`.  We're currently not forcing abnormal sessions
to have an error count so the total count can be wrong.

Before we did this modification for crashed in relay but it makes more
sense to do this in snuba instead.