### PR TITLE
fix(sessions): Correctly check for the NIL_UUID on crashes

### DIFF
--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -111,9 +111,9 @@ materialized_view_schema = MaterializedViewSchema(
             countIfState(session_id, status == 2) as sessions_crashed,
             countIfState(session_id, status == 3) as sessions_abnormal,
             uniqIfState(session_id, errors > 0) as sessions_errored,
-            uniqIfState(distinct_id, status == 2) as users_crashed,
-            uniqIfState(distinct_id, status == 3) as users_abnormal,
-            uniqIfState(distinct_id, errors > 0) as users_errored
+            uniqIfState(distinct_id, distinct_id != '{NIL_UUID}' and status == 2) as users_crashed,
+            uniqIfState(distinct_id, distinct_id != '{NIL_UUID}' and status == 3) as users_abnormal,
+            uniqIfState(distinct_id, distinct_id != '{NIL_UUID}' and errors > 0) as users_errored
         FROM
             %(source_table_name)s
         GROUP BY


### PR DESCRIPTION
Currently the nil user is counted as well which is not intended.  This unfortunately
changes the materialized view so this won't affect the already existing MV.