### PR TITLE
fix(final): Convert the groups list into tuples when checking equality

### DIFF
--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -116,8 +116,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     "Multiple group exclusion conditions in the Query", exc_info=True
                 )
                 return
-            if (condition_to_add[2] if condition_to_add else None) != (
-                existing_groups_conditions[0]
+            if (tuple(condition_to_add[2]) if condition_to_add else None) != (
+                tuple(existing_groups_conditions[0])
                 if len(existing_groups_conditions) > 0
                 else None
             ):
@@ -133,6 +133,7 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     extra={
                         "extension": deepcopy(existing_groups_conditions),
                         "processor": deepcopy(condition_to_add),
+                        "processor_projects": project_ids,
                     },
                     exc_info=True,
                 )


### PR DESCRIPTION
After adding the deepcopy and the last metrics it seems the number of warnings where the two lists of projects (generated by the extension and by the processor) are actually identicaly has reduced to very few (probably the deepcopy helped). 
There still are some which means that is not enough. Trying to convert them to tuples when checking for equality to ensure we are always comparing apples with apples.

The other discrepancies are very likely to be due to the redis project flag changing between extension processing and the processor, since all the evidence points into the redis api returning different results for the same input (the project list is always the same applied in both cases).

In any case, from the production metrics show the discrepancies per day being in the order of magnitude of 1 over 10k matches. 