### PR TITLE
Add query span data

### DIFF
--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 
 from snuba import settings
 from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
@@ -118,6 +118,20 @@ class AstSqlQuery(SqlQuery):
         if self.__limit is not None:
             limit_clause = f"LIMIT {self.__limit} OFFSET {self.__offset}"
 
+        self.__sql_data = {
+            "query_type": "ast_query",
+            "select": select_clause,
+            "from": from_clause,
+            "join": array_join_clause,
+            "prewhere": prewhere_clause,
+            "where": where_clause,
+            "group": group_clause,
+            "having": having_clause,
+            "order": order_clause,
+            "limitby": limitby_clause,
+            "limit": limit_clause,
+        }
+
         self.__formatted_query = " ".join(
             [
                 c
@@ -138,3 +152,6 @@ class AstSqlQuery(SqlQuery):
         )
 
         return self.__formatted_query
+
+    def _sql_data_impl(self) -> Dict[str, str]:
+        return self.__sql_data

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -49,8 +49,8 @@ class AstSqlQuery(SqlQuery):
         self.__sql_data: Optional[Dict[str, str]] = None
 
     def _sql_data_list(self) -> List[Tuple[str, str]]:
-        if self.__sql_data:
-            return self.__sql_data
+        if self.__sql_data_list:
+            return self.__sql_data_list
 
         parsing_context = ParsingContext()
         formatter = ClickhouseExpressionFormatter(parsing_context)

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Mapping, Optional, Sequence, Tuple
 
 from snuba import settings
 from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
@@ -44,11 +44,11 @@ class AstSqlQuery(SqlQuery):
         self.__prewhere = query.get_prewhere_ast()
 
         self.__settings = settings
-        self.__sql_data_list: Optional[List[Tuple[str, str]]] = None
+        self.__sql_data_list: Optional[Sequence[Tuple[str, str]]] = None
         self.__formatted_query: Optional[str] = None
-        self.__sql_data: Optional[Dict[str, str]] = None
+        self.__sql_data: Optional[Sequence[str, str]] = None
 
-    def _sql_data_list(self) -> List[Tuple[str, str]]:
+    def _sql_data_list(self) -> Sequence[Tuple[str, str]]:
         if self.__sql_data_list:
             return self.__sql_data_list
 
@@ -125,7 +125,7 @@ class AstSqlQuery(SqlQuery):
             for k, v in [
                 ("select", select_clause),
                 ("from", from_clause),
-                ("join", array_join_clause),
+                ("array_join", array_join_clause),
                 ("prewhere", prewhere_clause),
                 ("where", where_clause),
                 ("group", group_clause),
@@ -147,7 +147,7 @@ class AstSqlQuery(SqlQuery):
 
         return self.__formatted_query
 
-    def sql_data(self) -> Dict[str, str]:
+    def sql_data(self) -> Mapping[str, str]:
         if self.__sql_data:
             return self.__sql_data
 

--- a/snuba/clickhouse/astquery.py
+++ b/snuba/clickhouse/astquery.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple, Dict
+from typing import Dict, List, Optional, Tuple
 
 from snuba import settings
 from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
@@ -143,7 +143,7 @@ class AstSqlQuery(SqlQuery):
         if self.__formatted_query:
             return self.__formatted_query
 
-        self.__formatted_query = " ".join([c for n, c in self._sql_data_list()])
+        self.__formatted_query = " ".join([c for _, c in self._sql_data_list()])
 
         return self.__formatted_query
 

--- a/snuba/clickhouse/dictquery.py
+++ b/snuba/clickhouse/dictquery.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from snuba import settings as snuba_settings
 from snuba import util
 from snuba.clickhouse.query import Query
@@ -112,6 +114,20 @@ class DictSqlQuery(SqlQuery):
         if query.get_limit() is not None:
             limit_clause = "LIMIT {}, {}".format(query.get_offset(), query.get_limit())
 
+        self.__sql_data = {
+            "query_type": "dict_query",
+            "select": select_clause,
+            "from": from_clause,
+            "join": join_clause,
+            "prewhere": prewhere_clause,
+            "where": where_clause,
+            "group": group_clause,
+            "having": having_clause,
+            "order": order_clause,
+            "limitby": limitby_clause,
+            "limit": limit_clause,
+        }
+
         self.__formatted_query = " ".join(
             [
                 c
@@ -133,3 +149,6 @@ class DictSqlQuery(SqlQuery):
 
     def _format_query_impl(self) -> str:
         return self.__formatted_query
+
+    def _sql_data_impl(self) -> Dict[str, str]:
+        return self.__sql_data

--- a/snuba/clickhouse/dictquery.py
+++ b/snuba/clickhouse/dictquery.py
@@ -114,24 +114,22 @@ class DictSqlQuery(SqlQuery):
         if query.get_limit() is not None:
             limit_clause = "LIMIT {}, {}".format(query.get_offset(), query.get_limit())
 
-        self.__sql_data = dict(
-            [
-                (k, v)
-                for k, v in [
-                    ("select", select_clause),
-                    ("from", from_clause),
-                    ("join", join_clause),
-                    ("prewhere", prewhere_clause),
-                    ("where", where_clause),
-                    ("group", group_clause),
-                    ("having", having_clause),
-                    ("order", order_clause),
-                    ("limitby", limitby_clause),
-                    ("limit", limit_clause),
-                ]
-                if v
+        self.__sql_data = {
+            k: v
+            for k, v in [
+                ("select", select_clause),
+                ("from", from_clause),
+                ("join", join_clause),
+                ("prewhere", prewhere_clause),
+                ("where", where_clause),
+                ("group", group_clause),
+                ("having", having_clause),
+                ("order", order_clause),
+                ("limitby", limitby_clause),
+                ("limit", limit_clause),
             ]
-        )
+            if v
+        }
 
         self.__formatted_query = " ".join(
             [

--- a/snuba/clickhouse/dictquery.py
+++ b/snuba/clickhouse/dictquery.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import List, Tuple
 
 from snuba import settings as snuba_settings
 from snuba import util
@@ -114,19 +114,18 @@ class DictSqlQuery(SqlQuery):
         if query.get_limit() is not None:
             limit_clause = "LIMIT {}, {}".format(query.get_offset(), query.get_limit())
 
-        self.__sql_data = {
-            "query_type": "dict_query",
-            "select": select_clause,
-            "from": from_clause,
-            "join": join_clause,
-            "prewhere": prewhere_clause,
-            "where": where_clause,
-            "group": group_clause,
-            "having": having_clause,
-            "order": order_clause,
-            "limitby": limitby_clause,
-            "limit": limit_clause,
-        }
+        self.__sql_data = [
+            ("select", select_clause),
+            ("from", from_clause),
+            ("join", join_clause),
+            ("prewhere", prewhere_clause),
+            ("where", where_clause),
+            ("group", group_clause),
+            ("having", having_clause),
+            ("order", order_clause),
+            ("limitby", limitby_clause),
+            ("limit", limit_clause),
+        ]
 
         self.__formatted_query = " ".join(
             [
@@ -150,5 +149,5 @@ class DictSqlQuery(SqlQuery):
     def _format_query_impl(self) -> str:
         return self.__formatted_query
 
-    def _sql_data_impl(self) -> Dict[str, str]:
+    def _sql_data_impl(self) -> List[Tuple[str, str]]:
         return self.__sql_data

--- a/snuba/clickhouse/dictquery.py
+++ b/snuba/clickhouse/dictquery.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Dict
 
 from snuba import settings as snuba_settings
 from snuba import util
@@ -114,18 +114,24 @@ class DictSqlQuery(SqlQuery):
         if query.get_limit() is not None:
             limit_clause = "LIMIT {}, {}".format(query.get_offset(), query.get_limit())
 
-        self.__sql_data = [
-            ("select", select_clause),
-            ("from", from_clause),
-            ("join", join_clause),
-            ("prewhere", prewhere_clause),
-            ("where", where_clause),
-            ("group", group_clause),
-            ("having", having_clause),
-            ("order", order_clause),
-            ("limitby", limitby_clause),
-            ("limit", limit_clause),
-        ]
+        self.__sql_data = dict(
+            [
+                (k, v)
+                for k, v in [
+                    ("select", select_clause),
+                    ("from", from_clause),
+                    ("join", join_clause),
+                    ("prewhere", prewhere_clause),
+                    ("where", where_clause),
+                    ("group", group_clause),
+                    ("having", having_clause),
+                    ("order", order_clause),
+                    ("limitby", limitby_clause),
+                    ("limit", limit_clause),
+                ]
+                if v
+            ]
+        )
 
         self.__formatted_query = " ".join(
             [
@@ -149,5 +155,5 @@ class DictSqlQuery(SqlQuery):
     def _format_query_impl(self) -> str:
         return self.__formatted_query
 
-    def _sql_data_impl(self) -> List[Tuple[str, str]]:
+    def sql_data(self) -> Dict[str, str]:
         return self.__sql_data

--- a/snuba/clickhouse/dictquery.py
+++ b/snuba/clickhouse/dictquery.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Mapping
 
 from snuba import settings as snuba_settings
 from snuba import util
@@ -153,5 +153,5 @@ class DictSqlQuery(SqlQuery):
     def _format_query_impl(self) -> str:
         return self.__formatted_query
 
-    def sql_data(self) -> Dict[str, str]:
+    def sql_data(self) -> Mapping[str, str]:
         return self.__sql_data

--- a/snuba/clickhouse/sql.py
+++ b/snuba/clickhouse/sql.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Mapping, Optional
 
 
 class SqlQuery(ABC):
@@ -35,6 +35,6 @@ class SqlQuery(ABC):
         return query
 
     @abstractmethod
-    def sql_data(self) -> Dict[str, str]:
+    def sql_data(self) -> Mapping[str, str]:
         """Returns a lust of parsed SQL elements from this query"""
         raise NotImplementedError

--- a/snuba/clickhouse/sql.py
+++ b/snuba/clickhouse/sql.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Dict
+from typing import Optional, List, Tuple
 
 
 class SqlQuery(ABC):
@@ -34,8 +34,14 @@ class SqlQuery(ABC):
             query = f"{query} FORMAT {format}"
         return query
 
-    def _sql_data_impl(self) -> Dict[str, str]:
+    def _sql_data_impl(self) -> List[Tuple[str, str]]:
+        """
+        Returns a list of parsed SQL elements for logging, must be
+        implemented by the subclass to provide functionality to the ``sql_data``
+        function.
+        """
         raise NotImplementedError
 
-    def sql_data(self) -> Dict[str, str]:
+    def sql_data(self) -> List[Tuple[str, str]]:
+        """Returns a lust of parsed SQL elements from this query"""
         return self._sql_data_impl()

--- a/snuba/clickhouse/sql.py
+++ b/snuba/clickhouse/sql.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, List, Tuple
+from typing import Optional, Dict
 
 
 class SqlQuery(ABC):
@@ -34,14 +34,7 @@ class SqlQuery(ABC):
             query = f"{query} FORMAT {format}"
         return query
 
-    def _sql_data_impl(self) -> List[Tuple[str, str]]:
-        """
-        Returns a list of parsed SQL elements for logging, must be
-        implemented by the subclass to provide functionality to the ``sql_data``
-        function.
-        """
-        raise NotImplementedError
-
-    def sql_data(self) -> List[Tuple[str, str]]:
+    @abstractmethod
+    def sql_data(self) -> Dict[str, str]:
         """Returns a lust of parsed SQL elements from this query"""
-        return self._sql_data_impl()
+        raise NotImplementedError

--- a/snuba/clickhouse/sql.py
+++ b/snuba/clickhouse/sql.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 
 class SqlQuery(ABC):

--- a/snuba/clickhouse/sql.py
+++ b/snuba/clickhouse/sql.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Dict
 
 
 class SqlQuery(ABC):
@@ -33,3 +33,9 @@ class SqlQuery(ABC):
         if format is not None:
             query = f"{query} FORMAT {format}"
         return query
+
+    def _sql_data_impl(self) -> Dict[str, str]:
+        raise NotImplementedError
+
+    def sql_data(self) -> Dict[str, str]:
+        return self._sql_data_impl()

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -176,7 +176,7 @@ def _format_storage_query_and_run(
             span.set_tag("query_type", "ast")
         except Exception:
             sql_data = formatted_query.sql_data()
-            span.set_data("query_type", "dict")
+            span.set_tag("query_type", "dict")
 
         for k, v in sql_data:
             span.set_data(k, v)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -174,12 +174,11 @@ def _format_storage_query_and_run(
         try:
             sql_data = AstSqlQuery(clickhouse_query, request_settings).sql_data()
             span.set_tag("query_type", "ast")
+            span.set_data("ast_query", sql_data)
         except Exception:
-            sql_data = formatted_query.sql_data()
             span.set_tag("query_type", "dict")
 
-        for k, v in sql_data:
-            span.set_data(k, v)
+        span.set_data("dict_query", formatted_query.sql_data())
 
         return raw_query(
             clickhouse_query,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -172,9 +172,10 @@ def _format_storage_query_and_run(
     ) as span:
         span.set_tag("table", source)
         try:
-            sql_data = AstSqlQuery(clickhouse_query, request_settings).sql_data()
+            span.set_data(
+                "ast_query", AstSqlQuery(clickhouse_query, request_settings).sql_data()
+            )
             span.set_tag("query_type", "ast")
-            span.set_data("ast_query", sql_data)
         except Exception:
             span.set_tag("query_type", "dict")
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -177,6 +177,7 @@ def _format_storage_query_and_run(
             )
             span.set_tag("query_type", "ast")
         except Exception:
+            logger.warning("Failed to format ast query", exc_info=True)
             span.set_tag("query_type", "dict")
 
         span.set_data("dict_query", formatted_query.sql_data())

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -173,10 +173,12 @@ def _format_storage_query_and_run(
         span.set_tag("table", source)
         try:
             sql_data = AstSqlQuery(clickhouse_query, request_settings).sql_data()
+            span.set_tag("query_type", "ast")
         except Exception:
             sql_data = formatted_query.sql_data()
+            span.set_data("query_type", "dict")
 
-        for k, v in sql_data.items():
+        for k, v in sql_data:
             span.set_data(k, v)
 
         return raw_query(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -172,12 +172,12 @@ def _format_storage_query_and_run(
     ) as span:
         span.set_tag("table", source)
         try:
-            span.set_tag(
-                "ast_query",
-                AstSqlQuery(clickhouse_query, request_settings).format_sql(),
-            )
+            sql_data = AstSqlQuery(clickhouse_query, request_settings).sql_data()
         except Exception:
-            logger.warning("Failed to format ast query", exc_info=True)
+            sql_data = formatted_query.sql_data()
+
+        for k, v in sql_data.items():
+            span.set_data(k, v)
 
         return raw_query(
             clickhouse_query,

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -46,18 +46,14 @@ test_cases = [
                 OrderBy(OrderByDirection.DESC, Column(None, "column2", "table1")),
             ],
         ),
-        [
-            ("select", "SELECT column1, table1.column2, (column3 AS al)"),
-            ("from", "FROM my_table"),
-            ("join", ""),
-            ("prewhere", ""),
-            ("where", "WHERE eq(al, 'blabla')"),
-            ("group", "GROUP BY (column1, table1.column2, al, column4)"),
-            ("having", "HAVING eq(column1, 123)"),
-            ("order", "ORDER BY column1 ASC, table1.column2 DESC"),
-            ("limitby", ""),
-            ("limit", ""),
-        ],
+        {
+            "from": "FROM my_table",
+            "group": "GROUP BY (column1, table1.column2, al, column4)",
+            "having": "HAVING eq(column1, 123)",
+            "order": "ORDER BY column1 ASC, table1.column2 DESC",
+            "select": "SELECT column1, table1.column2, (column3 AS al)",
+            "where": "WHERE eq(al, 'blabla')",
+        },
     ),
     (
         # Query with complex functions
@@ -117,22 +113,14 @@ test_cases = [
                 )
             ],
         ),
-        [
-            (
-                "select",
-                "SELECT (doSomething(column1, table1.column2, (column3 AS al))(column1) AS "
-                "my_complex_math)",
-            ),
-            ("from", "FROM my_table"),
-            ("join", ""),
-            ("prewhere", ""),
-            ("where", "WHERE and(eq(al, 'blabla'), neq(al, 'blabla'))"),
-            ("group", "GROUP BY (my_complex_math)"),
-            ("having", ""),
-            ("order", "ORDER BY f(column1) ASC"),
-            ("limitby", ""),
-            ("limit", ""),
-        ],
+        {
+            "from": "FROM my_table",
+            "group": "GROUP BY (my_complex_math)",
+            "order": "ORDER BY f(column1) ASC",
+            "select": "SELECT (doSomething(column1, table1.column2, (column3 AS "
+            "al))(column1) AS my_complex_math)",
+            "where": "WHERE and(eq(al, 'blabla'), neq(al, 'blabla'))",
+        },
     ),
     (
         # Query with escaping
@@ -149,18 +137,12 @@ test_cases = [
             ],
             order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
         ),
-        [
-            ("select", "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2)"),
-            ("from", "FROM my_table"),
-            ("join", ""),
-            ("prewhere", ""),
-            ("where", ""),
-            ("group", "GROUP BY (al1, al2)"),
-            ("having", ""),
-            ("order", "ORDER BY column1 ASC"),
-            ("limitby", ""),
-            ("limit", ""),
-        ],
+        {
+            "from": "FROM my_table",
+            "group": "GROUP BY (al1, al2)",
+            "order": "ORDER BY column1 ASC",
+            "select": "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2)",
+        },
     ),
 ]
 
@@ -202,17 +184,16 @@ def test_format_clickhouse_specific_query() -> None:
     request_settings = HTTPRequestSettings()
     clickhouse_query = AstSqlQuery(query, request_settings)
 
-    expected = [
-        ("select", "SELECT column1, table1.column2"),
-        ("from", "FROM my_table FINAL SAMPLE 0.1"),
-        ("join", "ARRAY JOIN column1"),
-        ("prewhere", ""),
-        ("where", "WHERE eq(column1, 'blabla')"),
-        ("group", "GROUP BY (column1, table1.column2) WITH TOTALS"),
-        ("having", "HAVING eq(column1, 123)"),
-        ("order", "ORDER BY column1 ASC"),
-        ("limitby", "LIMIT 10 BY environment"),
-        ("limit", "LIMIT 100 OFFSET 50"),
-    ]
+    expected = {
+        "from": "FROM my_table FINAL SAMPLE 0.1",
+        "group": "GROUP BY (column1, table1.column2) WITH TOTALS",
+        "having": "HAVING eq(column1, 123)",
+        "join": "ARRAY JOIN column1",
+        "limit": "LIMIT 100 OFFSET 50",
+        "limitby": "LIMIT 10 BY environment",
+        "order": "ORDER BY column1 ASC",
+        "select": "SELECT column1, table1.column2",
+        "where": "WHERE eq(column1, 'blabla')",
+    }
 
     assert clickhouse_query.sql_data() == expected

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -188,7 +188,7 @@ def test_format_clickhouse_specific_query() -> None:
         "from": "FROM my_table FINAL SAMPLE 0.1",
         "group": "GROUP BY (column1, table1.column2) WITH TOTALS",
         "having": "HAVING eq(column1, 123)",
-        "join": "ARRAY JOIN column1",
+        "array_join": "ARRAY JOIN column1",
         "limit": "LIMIT 100 OFFSET 50",
         "limitby": "LIMIT 10 BY environment",
         "order": "ORDER BY column1 ASC",

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -1,0 +1,218 @@
+import pytest
+
+from typing import List, Tuple
+
+from snuba.clickhouse.astquery import AstSqlQuery
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.schemas.tables import TableSource
+from snuba.query.conditions import binary_condition
+from snuba.query.expressions import (
+    Column,
+    CurriedFunctionCall,
+    FunctionCall,
+    Literal,
+)
+from snuba.query.logical import OrderBy, OrderByDirection, Query
+from snuba.request.request_settings import HTTPRequestSettings
+
+test_cases = [
+    (
+        # Simple query with aliases and multiple tables
+        Query(
+            {},
+            TableSource("my_table", ColumnSet([])),
+            selected_columns=[
+                Column(None, "column1", None),
+                Column(None, "column2", "table1"),
+                Column("al", "column3", None),
+            ],
+            condition=binary_condition(
+                None,
+                "eq",
+                lhs=Column("al", "column3", None),
+                rhs=Literal(None, "blabla"),
+            ),
+            groupby=[
+                Column(None, "column1", None),
+                Column(None, "column2", "table1"),
+                Column("al", "column3", None),
+                Column(None, "column4", None),
+            ],
+            having=binary_condition(
+                None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+            ),
+            order_by=[
+                OrderBy(OrderByDirection.ASC, Column(None, "column1", None)),
+                OrderBy(OrderByDirection.DESC, Column(None, "column2", "table1")),
+            ],
+        ),
+        [
+            ("select", "SELECT column1, table1.column2, (column3 AS al)"),
+            ("from", "FROM my_table"),
+            ("join", ""),
+            ("prewhere", ""),
+            ("where", "WHERE eq(al, 'blabla')"),
+            ("group", "GROUP BY (column1, table1.column2, al, column4)"),
+            ("having", "HAVING eq(column1, 123)"),
+            ("order", "ORDER BY column1 ASC, table1.column2 DESC"),
+            ("limitby", ""),
+            ("limit", ""),
+        ],
+    ),
+    (
+        # Query with complex functions
+        Query(
+            {},
+            TableSource("my_table", ColumnSet([])),
+            selected_columns=[
+                CurriedFunctionCall(
+                    "my_complex_math",
+                    FunctionCall(
+                        None,
+                        "doSomething",
+                        [
+                            Column(None, "column1", None),
+                            Column(None, "column2", "table1"),
+                            Column("al", "column3", None),
+                        ],
+                    ),
+                    [Column(None, "column1", None)],
+                )
+            ],
+            condition=binary_condition(
+                None,
+                "and",
+                lhs=binary_condition(
+                    None,
+                    "eq",
+                    lhs=Column("al", "column3", None),
+                    rhs=Literal(None, "blabla"),
+                ),
+                rhs=binary_condition(
+                    None,
+                    "neq",  # yes, not very smart
+                    lhs=Column("al", "column3", None),
+                    rhs=Literal(None, "blabla"),
+                ),
+            ),
+            groupby=[
+                CurriedFunctionCall(
+                    "my_complex_math",
+                    FunctionCall(
+                        None,
+                        "doSomething",
+                        [
+                            Column(None, "column1", None),
+                            Column(None, "column2", "table1"),
+                            Column("al", "column3", None),
+                        ],
+                    ),
+                    [Column(None, "column1", None)],
+                )
+            ],
+            order_by=[
+                OrderBy(
+                    OrderByDirection.ASC,
+                    FunctionCall(None, "f", [Column(None, "column1", None)]),
+                )
+            ],
+        ),
+        [
+            (
+                "select",
+                "SELECT (doSomething(column1, table1.column2, (column3 AS al))(column1) AS "
+                "my_complex_math)",
+            ),
+            ("from", "FROM my_table"),
+            ("join", ""),
+            ("prewhere", ""),
+            ("where", "WHERE and(eq(al, 'blabla'), neq(al, 'blabla'))"),
+            ("group", "GROUP BY (my_complex_math)"),
+            ("having", ""),
+            ("order", "ORDER BY f(column1) ASC"),
+            ("limitby", ""),
+            ("limit", ""),
+        ],
+    ),
+    (
+        # Query with escaping
+        Query(
+            {},
+            TableSource("my_table", ColumnSet([])),
+            selected_columns=[
+                Column("al1", "field_##$$%", None),
+                Column("al2", "f@!@", "t&^%$"),
+            ],
+            groupby=[
+                Column("al1", "field_##$$%", None),
+                Column("al2", "f@!@", "t&^%$"),
+            ],
+            order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
+        ),
+        [
+            ("select", "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2)"),
+            ("from", "FROM my_table"),
+            ("join", ""),
+            ("prewhere", ""),
+            ("where", ""),
+            ("group", "GROUP BY (al1, al2)"),
+            ("having", ""),
+            ("order", "ORDER BY column1 ASC"),
+            ("limitby", ""),
+            ("limit", ""),
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("query, data", test_cases)
+def test_format_expressions(query: Query, data: List[Tuple[str, str]]) -> None:
+    request_settings = HTTPRequestSettings()
+    clickhouse_query = AstSqlQuery(query, request_settings)
+    assert clickhouse_query.sql_data() == data
+
+
+def test_format_clickhouse_specific_query() -> None:
+    """
+    Adds a few of the Clickhosue specific fields to the query.
+    """
+
+    query = Query(
+        {"sample": 0.1, "totals": True, "limitby": (10, "environment")},
+        TableSource("my_table", ColumnSet([])),
+        selected_columns=[
+            Column(None, "column1", None),
+            Column(None, "column2", "table1"),
+        ],
+        condition=binary_condition(
+            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, "blabla"),
+        ),
+        groupby=[Column(None, "column1", None), Column(None, "column2", "table1")],
+        having=binary_condition(
+            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+        ),
+        order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
+        array_join=Column(None, "column1", None),
+    )
+
+    query.set_final(True)
+    query.set_offset(50)
+    query.set_limit(100)
+
+    request_settings = HTTPRequestSettings()
+    clickhouse_query = AstSqlQuery(query, request_settings)
+
+    expected = [
+        ("select", "SELECT column1, table1.column2"),
+        ("from", "FROM my_table FINAL SAMPLE 0.1"),
+        ("join", "ARRAY JOIN column1"),
+        ("prewhere", ""),
+        ("where", "WHERE eq(column1, 'blabla')"),
+        ("group", "GROUP BY (column1, table1.column2) WITH TOTALS"),
+        ("having", "HAVING eq(column1, 123)"),
+        ("order", "ORDER BY column1 ASC"),
+        ("limitby", "LIMIT 10 BY environment"),
+        ("limit", "LIMIT 100 OFFSET 50"),
+    ]
+
+    assert clickhouse_query.sql_data() == expected


### PR DESCRIPTION
This PR removes the ast_query tag and adds query data elements instead. The type of query being used is also added as a tag.

