### PR TITLE
test: Stop using global ClickHouse settings in tests

### DIFF
--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -2,7 +2,6 @@ from unittest.mock import call, patch
 
 from clickhouse_driver import errors
 
-from snuba import settings
 from snuba.clickhouse.columns import Array, ColumnSet, Nested, Nullable, String, UInt
 from snuba.clickhouse.native import ClickhousePool
 from snuba.datasets.factory import enforce_table_writer
@@ -36,7 +35,7 @@ class TestClickhouse(BaseEventsTest):
             errors.NetworkError,
             '{"data": "to my face"}',
         ]
-        cp = ClickhousePool(settings.CLICKHOUSE_HOST, settings.CLICKHOUSE_PORT)
+        cp = ClickhousePool("localhost", 9000)
         cp.execute("SHOW TABLES")
         assert FakeClient.return_value.execute.mock_calls == [
             call("SHOW TABLES"),

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -35,7 +35,7 @@ class TestClickhouse(BaseEventsTest):
             errors.NetworkError,
             '{"data": "to my face"}',
         ]
-        cp = ClickhousePool("localhost", 9000)
+        cp = ClickhousePool("0:0:0:0", 9000)
         cp.execute("SHOW TABLES")
         assert FakeClient.return_value.execute.mock_calls == [
             call("SHOW TABLES"),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -47,7 +47,7 @@ class TestHTTPBatchWriter(BaseEventsTest):
     def test_chunks(self, chunk_size, input, expected_chunks):
         writer = FakeHTTPWriter(
             "mysterious_inexistent_table",
-            "localhost",
+            "0:0:0:0",
             9000,
             lambda a: a,
             None,

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -6,7 +6,6 @@ from tests.base import BaseEventsTest
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.http import HTTPBatchWriter
 from snuba.datasets.factory import enforce_table_writer
-from snuba import settings
 from snuba.writer import WriterTableRow
 
 
@@ -48,8 +47,8 @@ class TestHTTPBatchWriter(BaseEventsTest):
     def test_chunks(self, chunk_size, input, expected_chunks):
         writer = FakeHTTPWriter(
             "mysterious_inexistent_table",
-            settings.CLICKHOUSE_HOST,
-            settings.CLICKHOUSE_HTTP_PORT,
+            "localhost",
+            9000,
             lambda a: a,
             None,
             chunk_size,


### PR DESCRIPTION
We need to stop referencing these in tests since these global settings
are being deprecated, and will become cluster specific values.