### PR TITLE
ref(tests): Add `dataset_manager` for parameterizing dataset fixtures

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,12 +1,14 @@
 import calendar
-
+import uuid
+from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime, timedelta
 from hashlib import md5
-import uuid
+from typing import Iterator, Optional
 
 from snuba import settings
 from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.redis import redis_client
 
@@ -43,8 +45,33 @@ def get_event():
     return wrap_raw_event(deepcopy(raw_event))
 
 
+@contextmanager
+def dataset_manager(name: str) -> Iterator[Dataset]:
+    dataset = get_dataset(name)
+
+    for storage in dataset.get_all_storages():
+        clickhouse = storage.get_cluster().get_connection(
+            ClickhouseClientSettings.MIGRATE
+        )
+        for statement in storage.get_schemas().get_drop_statements():
+            clickhouse.execute(statement.statement)
+
+        for statement in storage.get_schemas().get_create_statements():
+            clickhouse.execute(statement.statement)
+
+    try:
+        yield dataset
+    finally:
+        for storage in dataset.get_all_storages():
+            clickhouse = storage.get_cluster().get_connection(
+                ClickhouseClientSettings.MIGRATE
+            )
+            for statement in storage.get_schemas().get_drop_statements():
+                clickhouse.execute(statement.statement)
+
+
 class BaseTest(object):
-    def setup_method(self, test_method, dataset_name=None):
+    def setup_method(self, test_method, dataset_name: Optional[str] = None):
         assert (
             settings.TESTING
         ), "settings.TESTING is False, try `SNUBA_SETTINGS=test` or `make test`"
@@ -52,29 +79,18 @@ class BaseTest(object):
         self.database = "default"
         self.dataset_name = dataset_name
 
-        if self.dataset_name:
-            self.dataset = get_dataset(self.dataset_name)
-
-            for storage in self.dataset.get_all_storages():
-                clickhouse = storage.get_cluster().get_connection(
-                    ClickhouseClientSettings.MIGRATE
-                )
-                for statement in storage.get_schemas().get_drop_statements():
-                    clickhouse.execute(statement.statement)
-
-                for statement in storage.get_schemas().get_create_statements():
-                    clickhouse.execute(statement.statement)
+        if dataset_name is not None:
+            self.__dataset_manager = dataset_manager(dataset_name)
+            self.dataset = self.__dataset_manager.__enter__()
+        else:
+            self.__dataset_manager = None
+            self.dataset = None
 
         redis_client.flushdb()
 
     def teardown_method(self, test_method):
-        if self.dataset_name:
-            for storage in self.dataset.get_all_storages():
-                clickhouse = storage.get_cluster().get_connection(
-                    ClickhouseClientSettings.MIGRATE
-                )
-                for statement in storage.get_schemas().get_drop_statements():
-                    clickhouse.execute(statement.statement)
+        if self.__dataset_manager:
+            self.__dataset_manager.__exit__(None, None, None)
 
         redis_client.flushdb()
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -15,6 +15,8 @@ class TestDiscoverApi(BaseApiTest):
     def setup_method(self, test_method):
         super().setup_method(test_method)
 
+        # XXX: This should use the ``discover`` dataset directly, but that will
+        # require some updates to the test base classes to work correctly.
         self.__dataset_manager = ExitStack()
         for dataset_name in ["events", "transactions"]:
             self.__dataset_manager.enter_context(dataset_manager(dataset_name))

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1,20 +1,23 @@
 import calendar
+import uuid
+from contextlib import ExitStack
 from datetime import datetime
 from functools import partial
+
 import simplejson as json
-import uuid
 
 from snuba import settings
 from snuba.datasets.factory import enforce_table_writer, get_dataset
-
-from tests.base import BaseApiTest, get_event
+from tests.base import BaseApiTest, dataset_manager, get_event
 
 
 class TestDiscoverApi(BaseApiTest):
     def setup_method(self, test_method):
-        # Setup both tables
-        super().setup_method(test_method, "events")
-        super().setup_method(test_method, "transactions")
+        super().setup_method(test_method)
+
+        self.__dataset_manager = ExitStack()
+        for dataset_name in ["events", "transactions"]:
+            self.__dataset_manager.enter_context(dataset_manager(dataset_name))
 
         self.app.post = partial(self.app.post, headers={"referer": "test"})
         self.project_id = 1
@@ -22,6 +25,9 @@ class TestDiscoverApi(BaseApiTest):
         self.base_time = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
         self.generate_event()
         self.generate_transaction()
+
+    def teardown_method(self, test_method):
+        self.__dataset_manager.__exit__(None, None, None)
 
     def generate_event(self):
         self.dataset = get_dataset("events")


### PR DESCRIPTION
This decouples the dataset-specific setup/teardown logic so that it can be reused out of the `BaseTest` class hierarchy and reused as a pytest fixture.

The rationale for this change: I'm planning on parametrizing some stateful tests on various datasets for subscriptions. I know there are some other test parametrized on dataset (mostly in query processing) but all of the ones that I know of are stateless and don't require table setup/teardown. I don't have a comprehensive view of the test suite, but as far as I know/remember, all of our stateful tests target a single dataset (usually events.)

By decoupling this from the test class hierarchy, `dataset` can be (relatively) easily parametrized:


```python
@pytest.fixture(params=DATASET_NAMES)
def dataset(request) -> Iterator[Dataset]:
    with dataset_manager(request.param) as instance:
        yield instance

def test(dataset: Dataset) -> None:
    pass  # will be called with both `EventsDataset` and `TransactionsDataset`
```