### PR TITLE
feat(query): add spans to query call stack

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -6,9 +6,10 @@ from datetime import date, datetime
 from typing import Iterable, Mapping, Optional
 from uuid import UUID
 
+import sentry_sdk
+
 from clickhouse_driver import Client, errors
 from dateutil.tz import tz
-from sentry_sdk.tracing import Span
 
 from snuba import settings
 from snuba.clickhouse.columns import Array
@@ -44,8 +45,8 @@ class ClickhousePool(object):
         for _ in range(max_pool_size):
             self.pool.put(None)
 
-    @with_span(op="db", var="span")
-    def execute(self, *args, span: Span = None, **kwargs):
+    @with_span(op="db")
+    def execute(self, *args, **kwargs):
         """
         Execute a clickhouse query with a single quick retry in case of
         connection failure.
@@ -54,8 +55,9 @@ class ClickhousePool(object):
         return relatively quickly with an error in case of more persistent
         failures.
         """
-        if span and len(args):
-            span.set_data("query", args[0])
+        with sentry_sdk.configure_scope() as scope:
+            if scope.span and len(args):
+                scope.span.set_data("query", args[0])
 
         try:
             conn = self.pool.get(block=True)
@@ -87,8 +89,8 @@ class ClickhousePool(object):
         finally:
             self.pool.put(conn, block=False)
 
-    @with_span(var="span", op="db")
-    def execute_robust(self, *args, span: Span = None, **kwargs):
+    @with_span(op="db")
+    def execute_robust(self, *args, **kwargs):
         """
         Execute a clickhouse query with a bit more tenacity. Make more retry
         attempts, (infinite in the case of too many simultaneous queries
@@ -100,12 +102,16 @@ class ClickhousePool(object):
         """
         attempts_remaining = 3
 
+        with sentry_sdk.configure_scope() as scope:
+            span = scope.span
+
         if span and len(args):
             span.set_data("query", args[0])
 
         while True:
             try:
-                span.set_data("attempt", 4 - attempts_remaining)
+                if span:
+                    span.set_data("attempt", 4 - attempts_remaining)
                 return self.execute(*args, **kwargs)
             except (errors.NetworkError, errors.SocketTimeoutError, EOFError) as e:
                 # Try 3 times on connection issues.

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -87,7 +87,7 @@ class ClickhousePool(object):
         finally:
             self.pool.put(conn, block=False)
 
-    @with_span(op="db")
+    @with_span(var="span", op="db")
     def execute_robust(self, *args, span: Span = None, **kwargs):
         """
         Execute a clickhouse query with a bit more tenacity. Make more retry

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -3,7 +3,7 @@ from typing import Callable, MutableMapping, Set, Sequence
 from snuba import settings
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.table_storage import TableWriter
-
+from snuba.util import with_span
 
 DATASETS_IMPL: MutableMapping[str, Dataset] = {}
 DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
@@ -33,6 +33,7 @@ class InvalidDatasetError(Exception):
     """Exception raised on invalid dataset access."""
 
 
+@with_span()
 def get_dataset(name: str) -> Dataset:
     if name in DATASETS_IMPL:
         return DATASETS_IMPL[name]

--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -1,5 +1,7 @@
 from typing import Optional, Sequence
 
+import sentry_sdk
+
 from snuba import state
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
@@ -20,6 +22,7 @@ from snuba.request.request_settings import RequestSettings
 # dependency is a refactoring of the methods that return RawQueryResult to make them
 # depend on Result + some debug data structure instead. Also It requires removing
 # extra data from the result of the query.
+from snuba.util import with_span
 from snuba.web import QueryResult
 
 
@@ -34,6 +37,7 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy):
         self.__query_processors = db_query_processors
         self.__splitters = splitters or []
 
+    @with_span()
     def execute(
         self, query: Query, request_settings: RequestSettings, runner: QueryRunner
     ) -> QueryResult:
@@ -41,17 +45,23 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy):
             query: Query, request_settings: RequestSettings
         ) -> QueryResult:
             for processor in self.__query_processors:
-                processor.process_query(query, request_settings)
+                with sentry_sdk.start_span(
+                    description=type(processor).__name__, op="processor"
+                ):
+                    processor.process_query(query, request_settings)
             return runner(query, request_settings, self.__cluster.get_reader())
 
         use_split = state.get_config("use_split", 0)
         if use_split:
             for splitter in self.__splitters:
-                result = splitter.execute(
-                    query, request_settings, process_and_run_query
-                )
-                if result is not None:
-                    return result
+                with sentry_sdk.start_span(
+                    description=type(splitter).__name__, op="splitter"
+                ):
+                    result = splitter.execute(
+                        query, request_settings, process_and_run_query
+                    )
+                    if result is not None:
+                        return result
 
         return process_and_run_query(query, request_settings)
 
@@ -79,6 +89,7 @@ class SingleStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
         # candidate to be added here as post process.
         self.__post_processors = post_processors or []
 
+    @with_span()
     def build_plan(self, request: Request) -> ClickhouseQueryPlan:
         # TODO: The translator is going to be configured with a mapping between logical
         # and physical schema that is a property of the relation between dataset (later
@@ -117,6 +128,7 @@ class SelectedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
         self.__selector = selector
         self.__post_processors = post_processors or []
 
+    @with_span()
     def build_plan(self, request: Request) -> ClickhouseQueryPlan:
         storage = self.__selector.select_storage(request.query, request.settings)
         clickhouse_query = QueryTranslator().translate(request.query)

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -4,6 +4,8 @@ from dateutil.parser import parse as dateutil_parse
 from functools import wraps
 from typing import (
     Any,
+    Callable,
+    cast,
     Iterator,
     List,
     Mapping,
@@ -13,7 +15,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    Callable,
 )
 
 import inspect
@@ -332,11 +333,14 @@ def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
     )
 
 
-def with_span(op="function"):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def with_span(op: str = "function") -> Callable[[F], F]:
     """ Wraps a function call in a Sentry AM span
     """
 
-    def decorator(func: Callable):
+    def decorator(func: F) -> F:
         frame_info = inspect.stack()[1]
         filename = frame_info.filename
 
@@ -346,6 +350,6 @@ def with_span(op="function"):
                 span.set_data("filename", filename)
                 return func(*args, **kwargs)
 
-        return wrapper
+        return cast(F, wrapper)
 
     return decorator

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -332,11 +332,8 @@ def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
     )
 
 
-def with_span(op="function", var=None):
+def with_span(op="function"):
     """ Wraps a function call in a Sentry AM span
-
-    If a name is provided to `var` the called function will receive the span
-    object as a kwarg with the provided name.
     """
 
     def decorator(func: Callable):
@@ -347,8 +344,6 @@ def with_span(op="function", var=None):
         def wrapper(*args, **kwargs) -> Any:
             with sentry_sdk.start_span(description=func.__name__, op=op) as span:
                 span.set_data("filename", filename)
-                if var:
-                    kwargs[var] = span
                 return func(*args, **kwargs)
 
         return wrapper

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -13,6 +13,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    Callable,
 )
 
 import inspect
@@ -332,12 +333,18 @@ def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
 
 
 def with_span(op="function", var=None):
-    def decorator(func):
+    """ Wraps a function call in a Sentry AM span
+
+    If a name is provided to `var` the called function will receive the span
+    object as a kwarg with the provided name.
+    """
+
+    def decorator(func: Callable):
         frame_info = inspect.stack()[1]
         filename = frame_info.filename
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args, **kwargs) -> Any:
             with sentry_sdk.start_span(description=func.__name__, op=op) as span:
                 span.set_data("filename", filename)
                 if var:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -34,7 +34,7 @@ from snuba.state.rate_limit import RateLimitExceeded
 from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import InvalidSubscriptionError, PartitionId
 from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDeleter
-from snuba.util import local_dataset_mode
+from snuba.util import local_dataset_mode, with_span
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.streams.kafka import KafkaPayload
@@ -263,19 +263,21 @@ def dataset_query_view(*, dataset: Dataset, timer: Timer):
         assert False, "unexpected fallthrough"
 
 
+@with_span()
 def dataset_query(dataset: Dataset, body, timer: Timer) -> Response:
     assert http_request.method == "POST"
-    ensure_not_internal(dataset)
-    ensure_tables_migrated()
+
+    with sentry_sdk.start_span(description="ensure_dataset", op="validate"):
+        ensure_not_internal(dataset)
+        ensure_tables_migrated()
+
+    with sentry_sdk.start_span(description="build_schema", op="validate"):
+        schema = RequestSchema.build_with_extensions(
+            dataset.get_extensions(), HTTPRequestSettings
+        )
 
     request = validate_request_content(
-        body,
-        RequestSchema.build_with_extensions(
-            dataset.get_extensions(), HTTPRequestSettings
-        ),
-        timer,
-        dataset,
-        http_request.referrer,
+        body, schema, timer, dataset, http_request.referrer,
     )
 
     try:


### PR DESCRIPTION
This PR adds many spans to the query execution code path. I'm assuming the function decorator will be contentious, though.

![image](https://user-images.githubusercontent.com/64794809/82579012-2d25c280-9b5b-11ea-8941-3a2122d15ee5.png)

