### PR TITLE
fix(transactions): Group on finish instead of start time

### DIFF
--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -64,7 +64,7 @@ class TransactionsDataset(TimeSeriesDataset):
             "timeseries": TimeSeriesExtension(
                 default_granularity=3600,
                 default_window=timedelta(days=5),
-                timestamp_column="start_ts",
+                timestamp_column="finish_ts",
             ),
         }
 


### PR DESCRIPTION
This makes the time grouping behavior of the ``transactions`` dataset
consistent with that of the ``discover`` dataset.