### PR TITLE
feat(ast) Introduce path field in column and minimal column resolution system

### DIFF
--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -77,6 +77,9 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             ret.append(escape_identifier(exp.table_name) or "")
             ret.append(".")
         ret.append(escape_identifier(exp.column_name) or "")
+        for p in exp.path:
+            ret.append(".")
+            ret.append(escape_identifier(p) or "")
 
         return self.__alias("".join(ret), exp.alias)
 

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -77,7 +77,6 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             ret.append(escape_identifier(exp.table_name) or "")
             ret.append(".")
         ret.append(escape_identifier(exp.column_name) or "")
-
         return self.__alias("".join(ret), exp.alias)
 
     def __visit_params(self, parameters: Sequence[Expression]) -> str:

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -77,9 +77,6 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             ret.append(escape_identifier(exp.table_name) or "")
             ret.append(".")
         ret.append(escape_identifier(exp.column_name) or "")
-        for p in exp.path:
-            ret.append(".")
-            ret.append(escape_identifier(p) or "")
 
         return self.__alias("".join(ret), exp.alias)
 

--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -77,6 +77,10 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             ret.append(escape_identifier(exp.table_name) or "")
             ret.append(".")
         ret.append(escape_identifier(exp.column_name) or "")
+        for p in exp.path:
+            ret.append(".")
+            ret.append(escape_identifier(p) or "")
+
         return self.__alias("".join(ret), exp.alias)
 
     def __visit_params(self, parameters: Sequence[Expression]) -> str:

--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -21,7 +21,7 @@ def get_project_ids_in_query(query: Query, project_column: str) -> Optional[Set[
     - If a project_id is a parameter of a function that returns the project_id itself
       it is not supported. It would be very hard to support every function without a
       whitelist/blacklist of allowed functions in Snuba queries.
-    - boolean functions are not supported. So we do\ not unpack and/or/not conditions
+    - boolean functions are not supported. So we do not unpack and/or/not conditions
       expressed as functions. We will be able to do that with the AST.
     - does not exclude projects referenced in NOT conditions.
 

--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -21,7 +21,7 @@ def get_project_ids_in_query(query: Query, project_column: str) -> Optional[Set[
     - If a project_id is a parameter of a function that returns the project_id itself
       it is not supported. It would be very hard to support every function without a
       whitelist/blacklist of allowed functions in Snuba queries.
-    - boolean functions are not supported. So we do not unpack and/or/not conditions
+    - boolean functions are not supported. So we do\ not unpack and/or/not conditions
       expressed as functions. We will be able to do that with the AST.
     - does not exclude projects referenced in NOT conditions.
 

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,8 +1,8 @@
 from typing import Sequence
 
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_cdc_storage
 from snuba.query.processors import QueryProcessor

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_cdc_storage
@@ -26,6 +27,7 @@ class GroupAssigneeDataset(Dataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=schema.get_columns(),
             writable_storage=storage,
+            column_resolver=SingleTableResolver(schema.get_columns()),
         )
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -2,6 +2,7 @@ from typing import Sequence
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_cdc_storage
 from snuba.query.processors import QueryProcessor
@@ -23,6 +24,7 @@ class GroupedMessageDataset(Dataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=schema.get_columns(),
             writable_storage=storage,
+            column_resolver=SingleTableResolver(schema.get_columns()),
         )
 
     def get_prewhere_keys(self) -> Sequence[str]:

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -175,12 +175,12 @@ class TimeSeriesDataset(Dataset):
         )
         # Convenience columns that evaluate to a bucketed time. The bucketing
         # depends on the granularity parameter.
-        # The bucketed time column names cannot be overlapping with existing
-        # schema columns
+        # The bucketed time column names must reference columns defined in the logical
+        # schema
         for bucketed_column in time_group_columns.keys():
             assert (
-                bucketed_column not in abstract_column_set
-            ), f"Bucketed column {bucketed_column} is already defined in the schema"
+                bucketed_column in abstract_column_set
+            ), f"Bucketed column {bucketed_column} is not defined in the schema"
         self.__time_group_columns = time_group_columns
         self.__time_parse_columns = time_parse_columns
 

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -3,8 +3,8 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.escaping import escape_identifier
 from snuba.datasets.plans.query_plan import ClickhouseQueryPlanBuilder
-from snuba.datasets.storage import Storage, WritableStorage, WritableTableStorage
 from snuba.datasets.schemas.resolver import ColumnResolver
+from snuba.datasets.storage import Storage, WritableStorage, WritableTableStorage
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
 from snuba.query.parsing import ParsingContext

--- a/snuba/datasets/errors.py
+++ b/snuba/datasets/errors.py
@@ -4,6 +4,7 @@ from typing import FrozenSet, Mapping, Sequence
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.errors_replacer import ReplacerState
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors import promoted_tag_columns
 from snuba.datasets.storages.factory import get_writable_storage
@@ -37,6 +38,7 @@ class ErrorsDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=columns,
             writable_storage=storage,
+            column_resolver=SingleTableResolver(columns, ["tags_key", "tags_value"]),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp", "received"),
         )

--- a/snuba/datasets/errors.py
+++ b/snuba/datasets/errors.py
@@ -38,7 +38,9 @@ class ErrorsDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=columns,
             writable_storage=storage,
-            column_resolver=SingleTableResolver(columns, ["tags_key", "tags_value"]),
+            column_resolver=SingleTableResolver(
+                columns, ["tags_key", "tags_value", "time", "rtime"]
+            ),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp", "received"),
         )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -3,6 +3,7 @@ from typing import Mapping, Sequence
 
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.events import get_column_tag_map, get_promoted_columns
 from snuba.datasets.storages.factory import get_writable_storage
@@ -35,6 +36,7 @@ class EventsDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=columns,
             writable_storage=storage,
+            column_resolver=SingleTableResolver(columns, ["tags_key", "tags_value"]),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp", "received"),
         )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -36,7 +36,9 @@ class EventsDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=columns,
             writable_storage=storage,
-            column_resolver=SingleTableResolver(columns, ["tags_key", "tags_value"]),
+            column_resolver=SingleTableResolver(
+                columns, ["tags_key", "tags_value", "time", "rtime"]
+            ),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp", "received"),
         )

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -4,6 +4,7 @@ from typing import Mapping, Optional, Sequence
 from snuba.clickhouse.processors import QueryProcessor as ClickhouseProcessor
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.dataset import TimeSeriesDataset
+from snuba.datasets.schemas.resolver import JoinedTablesResolver
 from snuba.datasets.dataset_schemas import StorageSchemas
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
@@ -138,6 +139,9 @@ class Groups(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=schema.get_columns(),
             writable_storage=None,
+            column_resolver=JoinedTablesResolver(
+                join_structure, {self.EVENTS_ALIAS: ["tags_key", "tags_value"],}
+            ),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=[
                 "events.timestamp",

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
+from snuba.clickhouse.columns import ColumnSet, DateTime
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
@@ -29,6 +30,7 @@ class OutcomesDataset(TimeSeriesDataset):
         materialized_storage = get_storage(StorageKey.OUTCOMES_HOURLY)
         read_schema = materialized_storage.get_schemas().get_read_schema()
         self.__time_group_columns = {"time": "timestamp"}
+        columns = read_schema.get_columns() + ColumnSet([("time", DateTime())])
         super().__init__(
             storages=[writable_storage, materialized_storage],
             query_plan_builder=SingleStorageQueryPlanBuilder(
@@ -37,9 +39,9 @@ class OutcomesDataset(TimeSeriesDataset):
                 # selector that decides when to use the materialized data.
                 storage=materialized_storage,
             ),
-            abstract_column_set=read_schema.get_columns(),
+            abstract_column_set=columns,
             writable_storage=writable_storage,
-            column_resolver=SingleTableResolver(read_schema.get_columns(), ["time"]),
+            column_resolver=SingleTableResolver(columns),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp",),
         )

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -4,6 +4,7 @@ from typing import Mapping, Sequence
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
@@ -38,6 +39,7 @@ class OutcomesDataset(TimeSeriesDataset):
             ),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=writable_storage,
+            column_resolver=SingleTableResolver(read_schema.get_columns()),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp",),
         )

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -39,7 +39,7 @@ class OutcomesDataset(TimeSeriesDataset):
             ),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=writable_storage,
-            column_resolver=SingleTableResolver(read_schema.get_columns()),
+            column_resolver=SingleTableResolver(read_schema.get_columns(), ["time"]),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp",),
         )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
+from snuba.clickhouse.columns import ColumnSet, DateTime
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.schemas.resolver import SingleTableResolver
@@ -20,12 +21,13 @@ class OutcomesRawDataset(TimeSeriesDataset):
         read_schema = storage.get_schemas().get_read_schema()
 
         self.__time_group_columns = {"time": "timestamp"}
+        columns = read_schema.get_columns() + ColumnSet([("time", DateTime())])
         super().__init__(
             storages=[storage],
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
-            abstract_column_set=read_schema.get_columns(),
+            abstract_column_set=columns,
             writable_storage=None,
-            column_resolver=SingleTableResolver(read_schema.get_columns(), ["time"]),
+            column_resolver=SingleTableResolver(columns),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp",),
         )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -25,7 +25,7 @@ class OutcomesRawDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=None,
-            column_resolver=SingleTableResolver(read_schema.get_columns()),
+            column_resolver=SingleTableResolver(read_schema.get_columns(), ["time"]),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp",),
         )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -2,9 +2,10 @@ from datetime import timedelta
 from typing import Mapping, Sequence
 
 from snuba.datasets.dataset import TimeSeriesDataset
+from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
-from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
 from snuba.query.processors import QueryProcessor
@@ -24,6 +25,7 @@ class OutcomesRawDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=None,
+            column_resolver=SingleTableResolver(read_schema.get_columns()),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("timestamp",),
         )

--- a/snuba/datasets/querylog.py
+++ b/snuba/datasets/querylog.py
@@ -2,6 +2,7 @@ from typing import Mapping
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.query.extensions import QueryExtension
@@ -18,6 +19,7 @@ class QuerylogDataset(Dataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=columns,
             writable_storage=storage,
+            column_resolver=SingleTableResolver(columns),
         )
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/schemas/resolver.py
+++ b/snuba/datasets/schemas/resolver.py
@@ -1,9 +1,17 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Sequence
+from typing import NamedTuple, Optional, Sequence
 
+from snuba.clickhouse.columns import ColumnSet
 from snuba.query.expressions import Column
 
+
 ColumnParts = Sequence[str]
+
+
+class ResolvedCol(NamedTuple):
+    table_name: Optional[str]
+    column_name: str
+    path: Sequence[str]
 
 
 class ColumnResolver(ABC):
@@ -15,17 +23,43 @@ class ColumnResolver(ABC):
     decompose a column expression found in a query into entity (table), base column name and
     path for nested columns.
 
-    In order to keep the coupling with the query language minimum, this expects the parser to
-    provide a structured representation of a column as a sequence of strings instead of the bare
-    representation (string) found in the query.
-    Still this cannot be totally decoupled from the query language.
+    TODO: Revisit this interface when we introduce entities. We may have to increase its
+    responsibilities depending on how we decide to infer, given a column, which entity defines it.
+    If we require the query to fully qualify all columns (errors.message for example), this can
+    stay as it is. If instead we will infer the requested entity from the context of the query
+    like we do today, this will need to know a lot more about the query, be coupled to that
+    structure and being potentially able to make wider changes to the query itself.
+    Moving such responsibility here would be easy enough that we can keep this simpler till
+    entities are introduced.
     """
 
     @abstractmethod
-    def resolve_column(self, query_column: ColumnParts) -> Optional[Column]:
+    def resolve_column(self, query_column: str) -> Optional[ResolvedCol]:
         """
         Transforms the column parts found in the query (like ["events", "tags", "value"]) into
         a valid Column object for the logical AST. If the column cannot be resolved, this
         returns None.
         """
         raise NotImplementedError
+
+
+class SingleTableResolver(ColumnResolver):
+    def __init__(
+        self,
+        columns: ColumnSet,
+        virtual_column_names: Sequence[str],
+        table_name: Optional[str] = None,
+    ) -> None:
+        self.__columns = columns
+        self.__virtual_column_names = virtual_column_names
+        self.__table_name = table_name
+
+    def resolve_column(self, query_column: str) -> Optional[Column]:
+        schema_column = self.__columns.columns.get(query_column)
+        if schema_column:
+            return ResolvedCol(table_name=self.__table_name,)
+
+        elif query_column[0] in self.__virtual_column_names:
+            pass
+        else:
+            return None

--- a/snuba/datasets/schemas/resolver.py
+++ b/snuba/datasets/schemas/resolver.py
@@ -13,33 +13,39 @@ class ResolvedCol(NamedTuple):
 
 class ColumnResolver(ABC):
     """
-    A ColumnResolver is a component that knows the logical schema of a data set and is capable
-    of resolving tables and nested columns from the representation we receive in the query.
+    A ColumnResolver is a component that knows the logical schema of a
+    data set and is capable of resolving tables and nested columns from
+    the representation we receive in the query.
 
-    This assumes the parser does not have enough information from the query language alone to
-    decompose a column expression found in a query into entity (table), base column name and
-    path for nested columns. Should we change the query language in such a way that a reference
-    to a column had non ambiguous information about entity name and nested columns this would
-    become a simple validator.
+    This assumes the parser does not have enough information from the
+    query language alone to decompose a column expression found in a query
+    into entity (table), base column name and path for nested columns.
+    Should we change the query language in such a way that a reference to
+    a column had non ambiguous information about entity name and nested
+    columns this would become a simple validator.
 
-    TODO: Revisit this interface when we introduce entities. We may have to increase its
-    responsibilities depending on how we decide to infer, given a column, which entity defines it.
-    If we require the query to fully qualify all columns (errors.message for example), this can
-    stay as it is. If instead we will infer the requested entity from the context of the query
-    like we do today this will need to know a lot more about the query, be coupled to that
-    structure and being potentially able to make wider changes to the query itself.
-    Moving such responsibility here would be easy enough that we can keep this simpler till
-    entities are introduced.
+    TODO: Revisit this interface when we introduce entities. We may have
+    to increase its responsibilities depending on how we decide to infer,
+    given a column, which entity defines it. If we require the query to
+    fully qualify all columns (errors.message for example), this can stay
+    as it is. If instead we will infer the requested entity from the
+    context of the query like we do today this will need to know a lot
+    more about the query, be coupled to that structure and being potentially
+    able to make wider changes to the query itself.
+    Moving such responsibility here would be easy enough that we can keep
+    this simpler till entities are introduced.
     """
 
     @abstractmethod
     def resolve_column(self, query_column: str) -> Optional[ResolvedCol]:
         """
-        Transforms the column string found in the query into a ResolvedCol if such expression is
-        valid with respect to the logical schema of the dataset. If not it returns None.
+        Transforms the column string found in the query into a ResolvedCol
+        if such expression is valid with respect to the logical schema of
+        the dataset. If not it returns None.
 
-        This does not return a Column object to avoid having to deal with the alias, that this
-        class should not have the right to know or change.
+        This does not return a Column object to avoid having to deal with
+        the alias, that this class should not have the right to know or
+        change.
         """
         raise NotImplementedError
 
@@ -51,26 +57,31 @@ def _resolve_column_in_set(
     column_name: str,
 ) -> Optional[ResolvedCol]:
     """
-    Resolves a column expressed as `<base>.<path>` which is what our schema, the ColumnSet
-    class and Clickhouse itself currently support. The query language is fairly agnostic
-    to this limitation.
-    ColumnSet would not support multi-level nesting (col.nested.more_nested), nor flat column
-    names with `.` inside (my.column.name). So if Clickhouse first and our schema abstraction
-    started supporting more flexible nesting, this implementation would have to be expanded.
+    Resolves a column expressed as `<base>.<path>` which is what our
+    schema, the ColumnSet class and Clickhouse itself currently support.
+    The query language is fairly agnostic to this limitation.
+    ColumnSet would not support multi-level nesting (col.nested.more_nested).
+    So if Clickhouse first and our schema abstraction started supporting
+    more flexible nesting, this implementation would have to be expanded.
+
+    Also ColumnSet technically does not support column names that include
+    a `.` (my.tags.key). Still this implementation is agnostic to that as
+    long as ColumnSet keeps exposing the same interface.
     """
     flattened_col = column_set.get(column_name)
     if flattened_col:
         return ResolvedCol(
             table_name=table_name,
-            # FlattenedColumn.name is the name of the column for non nested columns while
-            # it is the first and only level of nesting if the column is nested.
+            # FlattenedColumn.name is the name of the column for non nested
+            # columns while it is the first and only level of nesting if the
+            # column is nested.
             column_name=flattened_col.base_name or flattened_col.name,
             path=[flattened_col.name] if flattened_col.base_name else [],
         )
     elif (
-        # This `any` call is to identify nested column referenced with the base name without
-        # a path (like `tags`). That is not present at all as a flattened column in
-        # the ColumnSet object.
+        # This `any` call is to identify nested column referenced with
+        # the base name without a path (like `tags`). That is not present
+        # at all as a flattened column in the ColumnSet object.
         any(c for c in column_set.columns if c.name == column_name)
         or column_name in virtual_column_names
     ):
@@ -87,11 +98,12 @@ class SingleTableResolver(ColumnResolver):
         table_name: Optional[str] = None,
     ) -> None:
         self.__columns = columns
-        # virtual_column_names includes those columns we accept in a query for a dataset that
-        # are not part of the schema officially. Examples tags_key and tags_value and that's
-        # it.
-        # TODO: Consider moving the resolution of tags_key/tags_value to arrayJoin before
-        # column resolution.
+        # virtual_column_names includes those columns we accept in a query
+        # for a dataset that are not part of the schema officially. Examples
+        # tags_key and tags_value and that's it.
+        #
+        # TODO: Consider moving the resolution of tags_key/tags_value to
+        # arrayJoin before column resolution.
         self.__virtual_column_names = virtual_column_names or []
         self.__table_name = table_name
 
@@ -103,8 +115,8 @@ class SingleTableResolver(ColumnResolver):
 
 class JoinedTablesResolver(ColumnResolver):
     """
-    Resolves columns in a join query where all columns are supposed to be fully qualified
-    with the table alias prepended.
+    Resolves columns in a join query where all columns are supposed to
+    be fully qualified with the table alias prepended.
     """
 
     def __init__(

--- a/snuba/datasets/schemas/resolver.py
+++ b/snuba/datasets/schemas/resolver.py
@@ -1,0 +1,31 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Sequence
+
+from snuba.query.expressions import Column
+
+ColumnParts = Sequence[str]
+
+
+class ColumnResolver(ABC):
+    """
+    A ColumnResolver is a component that knows the logical schema of a data set and is capable
+    of resolving entities and nested column from the representation that we receive in the query.
+
+    This assumes the parser does not have enough information from the query language alone to
+    decompose a column expression found in a query into entity (table), base column name and
+    path for nested columns.
+
+    In order to keep the coupling with the query language minimum, this expects the parser to
+    provide a structured representation of a column as a sequence of strings instead of the bare
+    representation (string) found in the query.
+    Still this cannot be totally decoupled from the query language.
+    """
+
+    @abstractmethod
+    def resolve_column(self, query_column: ColumnParts) -> Optional[Column]:
+        """
+        Transforms the column parts found in the query (like ["events", "tags", "value"]) into
+        a valid Column object for the logical AST. If the column cannot be resolved, this
+        returns None.
+        """
+        raise NotImplementedError

--- a/snuba/datasets/schemas/resolver.py
+++ b/snuba/datasets/schemas/resolver.py
@@ -19,7 +19,7 @@ class ColumnResolver(ABC):
     This assumes the parser does not have enough information from the query language alone to
     decompose a column expression found in a query into entity (table), base column name and
     path for nested columns. Should we change the query language in such a way that a reference
-    to a column had non ambiguous information about entity name and nested columns this will
+    to a column had non ambiguous information about entity name and nested columns this would
     become a simple validator.
 
     TODO: Revisit this interface when we introduce entities. We may have to increase its
@@ -39,7 +39,7 @@ class ColumnResolver(ABC):
         valid with respect to the logical schema of the dataset. If not it returns None.
 
         This does not return a Column object to avoid having to deal with the alias, that this
-        class should not have the right of changing.
+        class should not have the right to know or change.
         """
         raise NotImplementedError
 

--- a/snuba/datasets/schemas/resolver.py
+++ b/snuba/datasets/schemas/resolver.py
@@ -73,11 +73,11 @@ class SingleTableResolver(ColumnResolver):
     def __init__(
         self,
         columns: ColumnSet,
-        virtual_column_names: Sequence[str],
+        virtual_column_names: Optional[Sequence[str]] = None,
         table_name: Optional[str] = None,
     ) -> None:
         self.__columns = columns
-        self.__virtual_column_names = virtual_column_names
+        self.__virtual_column_names = virtual_column_names or []
         self.__table_name = table_name
 
     def resolve_column(self, query_column: str) -> Optional[ResolvedCol]:

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -34,7 +34,9 @@ class SessionsDataset(TimeSeriesDataset):
             ),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=writable_storage,
-            column_resolver=SingleTableResolver(read_schema.get_columns()),
+            column_resolver=SingleTableResolver(
+                read_schema.get_columns(), ["bucketed_started"]
+            ),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("started", "received"),
         )

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -3,6 +3,7 @@ from typing import Mapping, Sequence
 
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.query.extensions import QueryExtension
@@ -33,6 +34,7 @@ class SessionsDataset(TimeSeriesDataset):
             ),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=writable_storage,
+            column_resolver=SingleTableResolver(read_schema.get_columns()),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("started", "received"),
         )

--- a/snuba/datasets/storages/events_column_processor.py
+++ b/snuba/datasets/storages/events_column_processor.py
@@ -17,7 +17,7 @@ class EventsColumnProcessor(QueryProcessor):
                         exp.alias,
                         "nullIf",
                         (
-                            Column(None, exp.column_name, exp.table_name),
+                            Column(None, exp.table_name, exp.column_name),
                             Literal(None, 0),
                         ),
                     )
@@ -29,8 +29,8 @@ class EventsColumnProcessor(QueryProcessor):
                         exp.alias,
                         "coalesce",
                         (
-                            Column(None, exp.column_name, exp.table_name),
-                            Column(None, "search_message", exp.table_name),
+                            Column(None, exp.table_name, exp.column_name),
+                            Column(None, exp.table_name, "search_message"),
                         ),
                     )
 

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -77,7 +77,7 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                         not_in_condition(
                             None,
                             FunctionCall(
-                                None, "assumeNotNull", (Column(None, "group_id", None),)
+                                None, "assumeNotNull", (Column(None, None, "group_id"),)
                             ),
                             [Literal(None, p) for p in exclude_group_ids],
                         )

--- a/snuba/datasets/storages/transaction_column_processor.py
+++ b/snuba/datasets/storages/transaction_column_processor.py
@@ -18,7 +18,7 @@ class TransactionColumnProcessor(QueryProcessor):
                         "replaceAll",
                         (
                             FunctionCall(
-                                None, "toString", (Column(None, "event_id", None),),
+                                None, "toString", (Column(None, None, "event_id"),),
                             ),
                             Literal(None, "-"),
                             Literal(None, ""),

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -176,7 +176,7 @@ class TagColumnProcessor:
                 isinstance(condition.parameters[0], FunctionCall)
                 and condition.parameters[0].function_name == "arrayJoin"
                 and condition.parameters[0].parameters
-                == (Column(None, None, "tags.key"),)
+                == (Column(None, None, "tags", ("key",)),)
                 and isinstance(condition.parameters[1], Literal)
             ):
                 # Tags are strings, but mypy does not know that
@@ -188,7 +188,7 @@ class TagColumnProcessor:
                 isinstance(condition.parameters[0], FunctionCall)
                 and condition.parameters[0].function_name == "arrayJoin"
                 and condition.parameters[0].parameters
-                == (Column(None, None, "tags.key"),)
+                == (Column(None, None, "tags", ("key",)),)
             ):
                 # The parameters of the inner function `a IN tuple(b,c,d)`
                 assert isinstance(condition.parameters[1], FunctionCall)
@@ -220,7 +220,7 @@ class TagColumnProcessor:
 
         tags_key_found = any(
             f.function_name == "arrayJoin"
-            and f.parameters == (Column(None, None, "tags.key"),)
+            and f.parameters == (Column(None, None, "tags", ("key",)),)
             for expression in select_clause
             for f in expression
             if isinstance(f, FunctionCall)

--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -176,7 +176,7 @@ class TagColumnProcessor:
                 isinstance(condition.parameters[0], FunctionCall)
                 and condition.parameters[0].function_name == "arrayJoin"
                 and condition.parameters[0].parameters
-                == (Column(None, "tags.key", None),)
+                == (Column(None, None, "tags.key"),)
                 and isinstance(condition.parameters[1], Literal)
             ):
                 # Tags are strings, but mypy does not know that
@@ -188,7 +188,7 @@ class TagColumnProcessor:
                 isinstance(condition.parameters[0], FunctionCall)
                 and condition.parameters[0].function_name == "arrayJoin"
                 and condition.parameters[0].parameters
-                == (Column(None, "tags.key", None),)
+                == (Column(None, None, "tags.key"),)
             ):
                 # The parameters of the inner function `a IN tuple(b,c,d)`
                 assert isinstance(condition.parameters[1], FunctionCall)
@@ -220,7 +220,7 @@ class TagColumnProcessor:
 
         tags_key_found = any(
             f.function_name == "arrayJoin"
-            and f.parameters == (Column(None, "tags.key", None),)
+            and f.parameters == (Column(None, None, "tags.key"),)
             for expression in select_clause
             for f in expression
             if isinstance(f, FunctionCall)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -3,6 +3,7 @@ from typing import Mapping, Sequence
 
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.schemas.resolver import SingleTableResolver
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.tags_column_processor import TagColumnProcessor
@@ -38,6 +39,7 @@ class TransactionsDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=schema.get_columns(),
             writable_storage=storage,
+            column_resolver=SingleTableResolver(columns, ["tags_key", "tags_value"]),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("start_ts", "finish_ts"),
         )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -39,7 +39,9 @@ class TransactionsDataset(TimeSeriesDataset):
             query_plan_builder=SingleStorageQueryPlanBuilder(storage=storage),
             abstract_column_set=schema.get_columns(),
             writable_storage=storage,
-            column_resolver=SingleTableResolver(columns, ["tags_key", "tags_value"]),
+            column_resolver=SingleTableResolver(
+                columns, ["tags_key", "tags_value", "time"]
+            ),
             time_group_columns=self.__time_group_columns,
             time_parse_columns=("start_ts", "finish_ts"),
         )

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -132,10 +132,6 @@ class Column(Expression):
 
     table_name: Optional[str]
     column_name: str
-    # For nested column, this is the path following the main column name.
-    # For tags.key as an example, tags is the column_name and (value,) would
-    # be the path
-    path: Tuple[str, ...] = tuple()
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         return func(self)

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -132,6 +132,10 @@ class Column(Expression):
 
     table_name: Optional[str]
     column_name: str
+    # For nested column, this is the path following the main column name.
+    # For tags.key as an example, tags is the column_name and (value,) would
+    # be the path
+    path: Tuple[str, ...] = tuple()
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         return func(self)

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -130,8 +130,12 @@ class Column(Expression):
     Represent a column in the schema of the dataset.
     """
 
-    column_name: str
     table_name: Optional[str]
+    column_name: str
+    # For nested column, this is the path following the main column name.
+    # For tags.key as an example, tags is the column_name and (value,) would
+    # be the path
+    path: Tuple[str, ...] = tuple()
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         return func(self)
@@ -163,9 +167,7 @@ class SubscriptableReference(Expression):
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         transformed = replace(
-            self,
-            column=self.column.transform(func),
-            key=self.key.transform(func),
+            self, column=self.column.transform(func), key=self.key.transform(func),
         )
         return func(transformed)
 

--- a/snuba/query/organization_extension.py
+++ b/snuba/query/organization_extension.py
@@ -31,7 +31,7 @@ class OrganizationExtensionProcessor(ExtensionQueryProcessor):
             binary_condition(
                 None,
                 ConditionFunctions.EQ,
-                Column(None, "org_id", None),
+                Column(None, None, "org_id"),
                 Literal(None, organization_id),
             )
         )

--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -50,7 +50,7 @@ class ClickhouseVisitor(NodeVisitor):
         return str(node.text)
 
     def visit_column_name(self, node: Node, visited_children: Iterable[Any]) -> Column:
-        return Column(None, node.text, None)
+        return Column(None, None, node.text)
 
     def visit_numeric_literal(
         self, node: Node, visited_children: Iterable[Any]

--- a/snuba/query/parser/strings.py
+++ b/snuba/query/parser/strings.py
@@ -30,7 +30,7 @@ def parse_string_to_expr(val: str) -> Expression:
             #
             # TODO: adopt this approach to all expression generated during parsing.
             alias=val,
-            column=Column(None, col_name, None),
+            column=Column(None, None, col_name),
             key=Literal(None, key_name),
         )
 
@@ -45,4 +45,4 @@ def parse_string_to_expr(val: str) -> Expression:
             if QUOTED_LITERAL_RE.match(val):
                 return Literal(None, val[1:-1])
             else:
-                return Column(None, val, None)
+                return Column(None, None, val)

--- a/snuba/query/processors/tags_expander.py
+++ b/snuba/query/processors/tags_expander.py
@@ -22,6 +22,7 @@ class TagsExpanderProcessor(QueryProcessor):
                 "tags_key",
                 "tags_value",
             ):
+                name_split = exp.column_name.split("_")
                 return FunctionCall(
                     exp.alias or exp.column_name,
                     "arrayJoin",
@@ -29,7 +30,8 @@ class TagsExpanderProcessor(QueryProcessor):
                         replace(
                             exp,
                             alias=None,
-                            column_name=exp.column_name.replace("_", "."),
+                            column_name=name_split[0],
+                            path=(name_split[1],),
                         ),
                     ),
                 )

--- a/snuba/query/processors/timeseries_column_processor.py
+++ b/snuba/query/processors/timeseries_column_processor.py
@@ -22,17 +22,17 @@ class TimeSeriesColumnProcessor(QueryProcessor):
             3600: FunctionCall(
                 alias,
                 "toStartOfHour",
-                (Column(None, column_name, None), Literal(None, "Universal")),
+                (Column(None, None, column_name), Literal(None, "Universal")),
             ),
             60: FunctionCall(
                 alias,
                 "toStartOfMinute",
-                (Column(None, column_name, None), Literal(None, "Universal")),
+                (Column(None, None, column_name), Literal(None, "Universal")),
             ),
             86400: FunctionCall(
                 alias,
                 "toDate",
-                (Column(None, column_name, None), Literal(None, "Universal")),
+                (Column(None, None, column_name), Literal(None, "Universal")),
             ),
         }.get(granularity)
         if not function_call:
@@ -48,7 +48,7 @@ class TimeSeriesColumnProcessor(QueryProcessor):
                                 FunctionCall(
                                     None,
                                     "toUInt32",
-                                    (Column(None, column_name, None),),
+                                    (Column(None, None, column_name),),
                                 ),
                                 Literal(None, granularity),
                             ),

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -89,7 +89,7 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
             query.add_condition_to_ast(
                 in_condition(
                     None,
-                    Column(None, self.__project_column, None),
+                    Column(None, None, self.__project_column),
                     [Literal(None, p) for p in project_ids],
                 )
             )
@@ -143,7 +143,7 @@ class ProjectWithGroupsProcessor(ProjectExtensionProcessor):
                         not_in_condition(
                             None,
                             FunctionCall(
-                                None, "assumeNotNull", (Column(None, "group_id", None),)
+                                None, "assumeNotNull", (Column(None, None, "group_id"),)
                             ),
                             [Literal(None, p) for p in exclude_group_ids],
                         )

--- a/snuba/query/timeseries_extension.py
+++ b/snuba/query/timeseries_extension.py
@@ -98,13 +98,13 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
                 binary_condition(
                     None,
                     ConditionFunctions.GTE,
-                    Column(None, self.__timestamp_column, None),
+                    Column(None, None, self.__timestamp_column),
                     Literal(None, from_date),
                 ),
                 binary_condition(
                     None,
                     ConditionFunctions.LT,
-                    Column(None, self.__timestamp_column, None),
+                    Column(None, None, self.__timestamp_column),
                     Literal(None, to_date),
                 ),
             )

--- a/snuba/request/schema.py
+++ b/snuba/request/schema.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Type
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.extensions import QueryExtension
-from snuba.query.parser import parse_query
+from snuba.query.parser import build_query
 from snuba.query.schema import GENERIC_QUERY_SCHEMA
 from snuba.request import Request
 from snuba.request.request_settings import (
@@ -103,7 +103,7 @@ class RequestSchema:
                 if key in value
             }
 
-        query = parse_query(query_body, dataset)
+        query = build_query(query_body, dataset)
         request_id = uuid.uuid4().hex
         return Request(request_id, query, self.__setting_class(**settings), extensions, referrer)
 

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -26,17 +26,21 @@ test_expressions = [
         "(table1.column1 AS alias)",
     ),  # Column with table and alias
     (
+        Column("alias", "table1", "column1", ("sub_col1", "sub_col2")),
+        "(table1.column1.sub_col1.sub_col2 AS alias)",
+    ),  # Column with table, alias and path
+    (
         FunctionCall(
             None,
             "f1",
             (
-                Column(None, "table1", "param1"),
+                Column(None, "table1", "tags", ("value",)),
                 Column(None, "table1", "param2"),
                 Literal(None, None),
                 Literal(None, "test_string"),
             ),
         ),
-        "f1(table1.param1, table1.param2, NULL, 'test_string')",
+        "f1(table1.tags.value, table1.param2, NULL, 'test_string')",
     ),  # Simple function call with columns and literals
     (
         FunctionCall(
@@ -51,8 +55,8 @@ test_expressions = [
             None,
             "f1",
             (
-                FunctionCall(None, "f2", (Column(None, "table1", "param1"))),
-                FunctionCall(None, "f3", (Column(None, "table1", "param2"))),
+                FunctionCall(None, "f2", (Column(None, "table1", "param1"),)),
+                FunctionCall(None, "f3", (Column(None, "table1", "param2"),)),
             ),
         ),
         "f1(f2(table1.param1), f3(table1.param2))",
@@ -62,8 +66,8 @@ test_expressions = [
             None,
             "f1",
             (
-                FunctionCall("al1", "f2", (Column(None, "table1", "param1"))),
-                FunctionCall("al2", "f3", (Column(None, "table1", "param2"))),
+                FunctionCall("al1", "f2", (Column(None, "table1", "param1"),)),
+                FunctionCall("al2", "f3", (Column(None, "table1", "param2"),)),
             ),
         ),
         "f1((f2(table1.param1) AS al1), (f3(table1.param2) AS al2))",
@@ -123,9 +127,9 @@ def test_aliases() -> None:
         None,
         "f1",
         (
-            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"))),
-            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"))),
-            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"))),
+            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"),)),
+            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"),)),
+            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"),)),
         ),
     )
 

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -26,21 +26,21 @@ test_expressions = [
         "(table1.column1 AS alias)",
     ),  # Column with table and alias
     (
-        Column("alias", "table1", "column1", ("sub_col1", "sub_col2")),
-        "(table1.column1.sub_col1.sub_col2 AS alias)",
+        Column("alias", "table1", "column1"),
+        "(table1.column1 AS alias)",
     ),  # Column with table, alias and path
     (
         FunctionCall(
             None,
             "f1",
             (
-                Column(None, "table1", "tags", ("value",)),
+                Column(None, "table1", "tags"),
                 Column(None, "table1", "param2"),
                 Literal(None, None),
                 Literal(None, "test_string"),
             ),
         ),
-        "f1(table1.tags.value, table1.param2, NULL, 'test_string')",
+        "f1(table1.tags, table1.param2, NULL, 'test_string')",
     ),  # Simple function call with columns and literals
     (
         FunctionCall(

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -26,6 +26,10 @@ test_expressions = [
         "(table1.column1 AS alias)",
     ),  # Column with table and alias
     (
+        Column("alias", "table1", "column1", ("sub_col1", "sub_col2")),
+        "(table1.column1.sub_col1.sub_col2 AS alias)",
+    ),  # Column with table, alias and path
+    (
         Column("alias", "table1", "column1"),
         "(table1.column1 AS alias)",
     ),  # Column with table, alias and path
@@ -34,13 +38,13 @@ test_expressions = [
             None,
             "f1",
             (
-                Column(None, "table1", "tags"),
+                Column(None, "table1", "tags", ("value",)),
                 Column(None, "table1", "param2"),
                 Literal(None, None),
                 Literal(None, "test_string"),
             ),
         ),
-        "f1(table1.tags, table1.param2, NULL, 'test_string')",
+        "f1(table1.tags.value, table1.param2, NULL, 'test_string')",
     ),  # Simple function call with columns and literals
     (
         FunctionCall(

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -19,10 +19,10 @@ test_expressions = [
     (Literal(None, None), "NULL",),  # NULL
     (Literal(None, True), "true",),  # True
     (Literal(None, False), "false",),  # False
-    (Column(None, "column1", "table1"), "table1.column1"),  # Basic Column no alias
-    (Column(None, "column1", None), "column1"),  # Basic Column with no table
+    (Column(None, "table1", "column1"), "table1.column1"),  # Basic Column no alias
+    (Column(None, None, "column1"), "column1"),  # Basic Column with no table
     (
-        Column("alias", "column1", "table1"),
+        Column("alias", "table1", "column1"),
         "(table1.column1 AS alias)",
     ),  # Column with table and alias
     (
@@ -30,8 +30,8 @@ test_expressions = [
             None,
             "f1",
             (
-                Column(None, "param1", "table1"),
-                Column(None, "param2", "table1"),
+                Column(None, "table1", "param1"),
+                Column(None, "table1", "param2"),
                 Literal(None, None),
                 Literal(None, "test_string"),
             ),
@@ -42,7 +42,7 @@ test_expressions = [
         FunctionCall(
             "alias",
             "f1",
-            (Column(None, "param1", "table1"), Column("alias1", "param2", "table1")),
+            (Column(None, "table1", "param1"), Column("alias1", "table1", "param2")),
         ),
         "(f1(table1.param1, (table1.param2 AS alias1)) AS alias)",
     ),  # Function with alias
@@ -51,8 +51,8 @@ test_expressions = [
             None,
             "f1",
             (
-                FunctionCall(None, "f2", (Column(None, "param1", "table1"))),
-                FunctionCall(None, "f3", (Column(None, "param2", "table1"))),
+                FunctionCall(None, "f2", (Column(None, "table1", "param1"))),
+                FunctionCall(None, "f3", (Column(None, "table1", "param2"))),
             ),
         ),
         "f1(f2(table1.param1), f3(table1.param2))",
@@ -62,8 +62,8 @@ test_expressions = [
             None,
             "f1",
             (
-                FunctionCall("al1", "f2", (Column(None, "param1", "table1"))),
-                FunctionCall("al2", "f3", (Column(None, "param2", "table1"))),
+                FunctionCall("al1", "f2", (Column(None, "table1", "param1"))),
+                FunctionCall("al2", "f3", (Column(None, "table1", "param2"))),
             ),
         ),
         "f1((f2(table1.param1) AS al1), (f3(table1.param2) AS al2))",
@@ -71,10 +71,10 @@ test_expressions = [
     (
         CurriedFunctionCall(
             None,
-            FunctionCall(None, "f0", (Column(None, "param1", "table1"),)),
+            FunctionCall(None, "f0", (Column(None, "table1", "param1"),)),
             (
-                FunctionCall(None, "f1", (Column(None, "param2", "table1"),)),
-                Column(None, "param3", "table1"),
+                FunctionCall(None, "f1", (Column(None, "table1", "param2"),)),
+                Column(None, "table1", "param3"),
             ),
         ),
         "f0(table1.param1)(f1(table1.param2), table1.param3)",
@@ -91,7 +91,7 @@ test_expressions = [
                         None, "testFunc", (Argument(None, "x"), Argument(None, "y"))
                     ),
                 ),
-                Column(None, "test", None),
+                Column(None, None, "test"),
             ),
         ),
         "arrayExists((x, y -> testFunc(x, y)), test)",
@@ -107,8 +107,8 @@ def test_format_expressions(expression: Expression, expected: str) -> None:
 
 def test_aliases() -> None:
     # No context
-    col1 = Column("al1", "column1", "table1")
-    col2 = Column("al1", "column1", "table1")
+    col1 = Column("al1", "table1", "column1")
+    col2 = Column("al1", "table1", "column1")
 
     assert col1.accept(ClickhouseExpressionFormatter()) == "(table1.column1 AS al1)"
     assert col2.accept(ClickhouseExpressionFormatter()) == "(table1.column1 AS al1)"
@@ -123,9 +123,9 @@ def test_aliases() -> None:
         None,
         "f1",
         (
-            FunctionCall("tag[something]", "tag", (Column(None, "column1", "table1"))),
-            FunctionCall("tag[something]", "tag", (Column(None, "column1", "table1"))),
-            FunctionCall("tag[something]", "tag", (Column(None, "column1", "table1"))),
+            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"))),
+            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"))),
+            FunctionCall("tag[something]", "tag", (Column(None, "table1", "column1"))),
         ),
     )
 
@@ -135,19 +135,19 @@ def test_aliases() -> None:
 
 test_escaped = [
     (
-        Column(None, "tags.values", "table.something"),
+        Column(None, "table.something", "tags.values"),
         "table.something.tags.values",
     ),  # Columns with dot are not escaped
     (
-        Column(None, "tags[something]", "weird_!@#$%^^&*_table"),
+        Column(None, "weird_!@#$%^^&*_table", "tags[something]"),
         "`weird_!@#$%^^&*_table`.`tags[something]`",
     ),  # Somebody thought that table name was a good idea.
     (
-        Column("alias.cannot.have.dot", "columns.can", "table"),
+        Column("alias.cannot.have.dot", "table", "columns.can"),
         "(table.columns.can AS `alias.cannot.have.dot`)",
     ),  # Escaping is different between columns and aliases
     (
-        FunctionCall(None, "f*&^%$#unction", (Column(None, "column", "table"))),
+        FunctionCall(None, "f*&^%$#unction", (Column(None, "table", "column"),)),
         "`f*&^%$#unction`(table.column)",
     ),  # Function names can be escaped. Hopefully it will never happen
 ]

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -22,28 +22,28 @@ test_cases = [
             {},
             TableSource("my_table", ColumnSet([])),
             selected_columns=[
-                Column(None, "column1", None),
-                Column(None, "column2", "table1"),
-                Column("al", "column3", None),
+                Column(None, None, "column1"),
+                Column(None, "table1", "column2"),
+                Column("al", None, "column3"),
             ],
             condition=binary_condition(
                 None,
                 "eq",
-                lhs=Column("al", "column3", None),
+                lhs=Column("al", None, "column3"),
                 rhs=Literal(None, "blabla"),
             ),
             groupby=[
-                Column(None, "column1", None),
-                Column(None, "column2", "table1"),
-                Column("al", "column3", None),
-                Column(None, "column4", None),
+                Column(None, None, "column1"),
+                Column(None, "table1", "column2"),
+                Column("al", None, "column3"),
+                Column(None, None, "column4"),
             ],
             having=binary_condition(
-                None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+                None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
             ),
             order_by=[
-                OrderBy(OrderByDirection.ASC, Column(None, "column1", None)),
-                OrderBy(OrderByDirection.DESC, Column(None, "column2", "table1")),
+                OrderBy(OrderByDirection.ASC, Column(None, None, "column1")),
+                OrderBy(OrderByDirection.DESC, Column(None, "table1", "column2")),
             ],
         ),
         {
@@ -66,13 +66,13 @@ test_cases = [
                     FunctionCall(
                         None,
                         "doSomething",
-                        [
-                            Column(None, "column1", None),
-                            Column(None, "column2", "table1"),
-                            Column("al", "column3", None),
-                        ],
+                        (
+                            Column(None, None, "column1"),
+                            Column(None, "table1", "column2"),
+                            Column("al", None, "column3"),
+                        ),
                     ),
-                    [Column(None, "column1", None)],
+                    (Column(None, None, "column1"),),
                 )
             ],
             condition=binary_condition(
@@ -81,13 +81,13 @@ test_cases = [
                 lhs=binary_condition(
                     None,
                     "eq",
-                    lhs=Column("al", "column3", None),
+                    lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
                 ),
                 rhs=binary_condition(
                     None,
                     "neq",  # yes, not very smart
-                    lhs=Column("al", "column3", None),
+                    lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
                 ),
             ),
@@ -97,19 +97,19 @@ test_cases = [
                     FunctionCall(
                         None,
                         "doSomething",
-                        [
-                            Column(None, "column1", None),
-                            Column(None, "column2", "table1"),
-                            Column("al", "column3", None),
-                        ],
+                        (
+                            Column(None, None, "column1"),
+                            Column(None, "table1", "column2"),
+                            Column("al", None, "column3"),
+                        ),
                     ),
-                    [Column(None, "column1", None)],
+                    (Column(None, None, "column1"),),
                 )
             ],
             order_by=[
                 OrderBy(
                     OrderByDirection.ASC,
-                    FunctionCall(None, "f", [Column(None, "column1", None)]),
+                    FunctionCall(None, "f", (Column(None, None, "column1"),)),
                 )
             ],
         ),
@@ -128,14 +128,14 @@ test_cases = [
             {},
             TableSource("my_table", ColumnSet([])),
             selected_columns=[
-                Column("al1", "field_##$$%", None),
-                Column("al2", "f@!@", "t&^%$"),
+                Column("al1", None, "field_##$$%"),
+                Column("al2", "t&^%$", "f@!@"),
             ],
             groupby=[
-                Column("al1", "field_##$$%", None),
-                Column("al2", "f@!@", "t&^%$"),
+                Column("al1", None, "field_##$$%"),
+                Column("al2", "t&^%$", "f@!@"),
             ],
-            order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
+            order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         ),
         {
             "from": "FROM my_table",
@@ -163,18 +163,18 @@ def test_format_clickhouse_specific_query() -> None:
         {"sample": 0.1, "totals": True, "limitby": (10, "environment")},
         TableSource("my_table", ColumnSet([])),
         selected_columns=[
-            Column(None, "column1", None),
-            Column(None, "column2", "table1"),
+            Column(None, None, "column1"),
+            Column(None, "table1", "column2"),
         ],
         condition=binary_condition(
-            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, "blabla"),
+            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
         ),
-        groupby=[Column(None, "column1", None), Column(None, "column2", "table1")],
+        groupby=[Column(None, None, "column1"), Column(None, "table1", "column2")],
         having=binary_condition(
-            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
         ),
-        order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
-        array_join=Column(None, "column1", None),
+        order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
+        array_join=Column(None, None, "column1"),
     )
 
     query.set_final(True)

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -20,28 +20,28 @@ test_cases = [
             {},
             TableSource("my_table", ColumnSet([])),
             selected_columns=[
-                Column(None, "column1", None),
-                Column(None, "column2", "table1"),
-                Column("al", "column3", None),
+                Column(None, None, "column1"),
+                Column(None, "table1", "column2"),
+                Column("al", None, "column3"),
             ],
             condition=binary_condition(
                 None,
                 "eq",
-                lhs=Column("al", "column3", None),
+                lhs=Column("al", None, "column3"),
                 rhs=Literal(None, "blabla"),
             ),
             groupby=[
-                Column(None, "column1", None),
-                Column(None, "column2", "table1"),
-                Column("al", "column3", None),
-                Column(None, "column4", None),
+                Column(None, None, "column1"),
+                Column(None, "table1", "column2"),
+                Column("al", None, "column3"),
+                Column(None, None, "column4"),
             ],
             having=binary_condition(
-                None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+                None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
             ),
             order_by=[
-                OrderBy(OrderByDirection.ASC, Column(None, "column1", None)),
-                OrderBy(OrderByDirection.DESC, Column(None, "column2", "table1")),
+                OrderBy(OrderByDirection.ASC, Column(None, None, "column1")),
+                OrderBy(OrderByDirection.DESC, Column(None, "table1", "column2")),
             ],
         ),
         (
@@ -65,12 +65,12 @@ test_cases = [
                         None,
                         "doSomething",
                         [
-                            Column(None, "column1", None),
-                            Column(None, "column2", "table1"),
-                            Column("al", "column3", None),
+                            Column(None, None, "column1"),
+                            Column(None, "table1", "column2"),
+                            Column("al", None, "column3"),
                         ],
                     ),
-                    [Column(None, "column1", None)],
+                    [Column(None, None, "column1")],
                 )
             ],
             condition=binary_condition(
@@ -79,13 +79,13 @@ test_cases = [
                 lhs=binary_condition(
                     None,
                     "eq",
-                    lhs=Column("al", "column3", None),
+                    lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
                 ),
                 rhs=binary_condition(
                     None,
                     "neq",  # yes, not very smart
-                    lhs=Column("al", "column3", None),
+                    lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
                 ),
             ),
@@ -96,18 +96,18 @@ test_cases = [
                         None,
                         "doSomething",
                         [
-                            Column(None, "column1", None),
-                            Column(None, "column2", "table1"),
-                            Column("al", "column3", None),
+                            Column(None, None, "column1"),
+                            Column(None, "table1", "column2"),
+                            Column("al", None, "column3"),
                         ],
                     ),
-                    [Column(None, "column1", None)],
+                    [Column(None, None, "column1")],
                 )
             ],
             order_by=[
                 OrderBy(
                     OrderByDirection.ASC,
-                    FunctionCall(None, "f", [Column(None, "column1", None)]),
+                    FunctionCall(None, "f", [Column(None, None, "column1")]),
                 )
             ],
         ),
@@ -125,14 +125,14 @@ test_cases = [
             {},
             TableSource("my_table", ColumnSet([])),
             selected_columns=[
-                Column("al1", "field_##$$%", None),
-                Column("al2", "f@!@", "t&^%$"),
+                Column("al1", None, "field_##$$%"),
+                Column("al2", "t&^%$", "f@!@"),
             ],
             groupby=[
-                Column("al1", "field_##$$%", None),
-                Column("al2", "f@!@", "t&^%$"),
+                Column("al1", None, "field_##$$%"),
+                Column("al2", "t&^%$", "f@!@"),
             ],
-            order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
+            order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         ),
         (
             "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2) "
@@ -160,18 +160,18 @@ def test_format_clickhouse_specific_query() -> None:
         {"sample": 0.1, "totals": True, "limitby": (10, "environment")},
         TableSource("my_table", ColumnSet([])),
         selected_columns=[
-            Column(None, "column1", None),
-            Column(None, "column2", "table1"),
+            Column(None, None, "column1"),
+            Column(None, "table1", "column2"),
         ],
         condition=binary_condition(
-            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, "blabla"),
+            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
         ),
-        groupby=[Column(None, "column1", None), Column(None, "column2", "table1")],
+        groupby=[Column(None, None, "column1"), Column(None, "table1", "column2")],
         having=binary_condition(
-            None, "eq", lhs=Column(None, "column1", None), rhs=Literal(None, 123),
+            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
         ),
-        order_by=[OrderBy(OrderByDirection.ASC, Column(None, "column1", None))],
-        array_join=Column(None, "column1", None),
+        order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
+        array_join=Column(None, None, "column1"),
     )
 
     query.set_final(True)

--- a/tests/datasets/schemas/test_resolvers.py
+++ b/tests/datasets/schemas/test_resolvers.py
@@ -1,0 +1,95 @@
+from snuba.clickhouse.columns import ColumnSet, Nested, String, UInt
+from snuba.datasets.schemas.join import JoinClause, JoinType, TableJoinNode
+from snuba.datasets.schemas.resolver import (
+    JoinedTablesResolver,
+    ResolvedCol,
+    SingleTableResolver,
+)
+
+
+def test_single_column_set_resolver() -> None:
+    col_set = ColumnSet(
+        [
+            ("col1", String()),
+            ("col_2", UInt(8)),
+            ("tags", Nested([("key", String()), ("value", String())])),
+        ]
+    )
+
+    resolver = SingleTableResolver(col_set, ["tags_key", "tags_value"], "table")
+    assert resolver.resolve_column("col1") == ResolvedCol(
+        table_name="table", column_name="col1", path=[]
+    )
+    assert resolver.resolve_column("col_2") == ResolvedCol(
+        table_name="table", column_name="col_2", path=[]
+    )
+    assert resolver.resolve_column("tags") == ResolvedCol(
+        table_name="table", column_name="tags", path=[]
+    )
+    assert resolver.resolve_column("tags.value") == ResolvedCol(
+        table_name="table", column_name="tags", path=["value"]
+    )
+    assert resolver.resolve_column("tags_value") == ResolvedCol(
+        table_name="table", column_name="tags_value", path=[]
+    )
+    assert resolver.resolve_column("something_else") is None
+
+
+def test_joined_column_set_resolver() -> None:
+    join_root = JoinClause(
+        left_node=TableJoinNode(
+            table_name="table1",
+            columns=ColumnSet(
+                [
+                    ("col1", String()),
+                    ("col_2", UInt(8)),
+                    ("tags", Nested([("key", String()), ("value", String())])),
+                ]
+            ),
+            mandatory_conditions=[],
+            prewhere_candidates=[],
+            alias="table1",
+        ),
+        right_node=TableJoinNode(
+            table_name="table2",
+            columns=ColumnSet(
+                [
+                    ("col1", String()),
+                    ("tags", Nested([("key", String()), ("value", String())])),
+                ]
+            ),
+            mandatory_conditions=[],
+            prewhere_candidates=[],
+            alias="table2",
+        ),
+        mapping=[],
+        join_type=JoinType.LEFT,
+    )
+
+    resolver = JoinedTablesResolver(
+        join_root=join_root,
+        virtual_column_names={"table1": ["tags_key", "tags_value"]},
+    )
+
+    assert resolver.resolve_column("col1") is None
+    assert resolver.resolve_column("table1.col1") == ResolvedCol(
+        table_name="table1", column_name="col1", path=[]
+    )
+    assert resolver.resolve_column("table2.col1") == ResolvedCol(
+        table_name="table2", column_name="col1", path=[]
+    )
+    assert resolver.resolve_column("table2.col_2") is None
+    assert resolver.resolve_column("table1.col_2") == ResolvedCol(
+        table_name="table1", column_name="col_2", path=[]
+    )
+    assert resolver.resolve_column("table1.tags") == ResolvedCol(
+        table_name="table1", column_name="tags", path=[]
+    )
+    assert resolver.resolve_column("table1.tags.key") == ResolvedCol(
+        table_name="table1", column_name="tags", path=["key"]
+    )
+    assert resolver.resolve_column("table1.tags_value") == ResolvedCol(
+        table_name="table1", column_name="tags_value", path=[]
+    )
+    assert resolver.resolve_column("table2.tags_value") is None
+    assert resolver.resolve_column("table1.something_else") is None

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -27,7 +27,7 @@ def build_in(project_column: str, projects: Sequence[int]) -> Expression:
         None,
         "in",
         (
-            Column(None, project_column, None),
+            Column(None, None, project_column),
             FunctionCall(None, "tuple", tuple([Literal(None, p) for p in projects])),
         ),
     )
@@ -105,7 +105,7 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
                 "notIn",
                 (
                     FunctionCall(
-                        None, "assumeNotNull", (Column(None, "group_id", None),)
+                        None, "assumeNotNull", (Column(None, None, "group_id"),)
                     ),
                     FunctionCall(
                         None,

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -24,13 +24,13 @@ test_conditions = [
     (
         [["a", "=", 1]],
         FunctionCall(
-            None, ConditionFunctions.EQ, (Column(None, "a", None), Literal(None, 1))
+            None, ConditionFunctions.EQ, (Column(None, None, "a"), Literal(None, 1))
         ),
     ),
     (
         [[["a", "=", 1]]],
         FunctionCall(
-            None, ConditionFunctions.EQ, (Column(None, "a", None), Literal(None, 1))
+            None, ConditionFunctions.EQ, (Column(None, None, "a"), Literal(None, 1))
         ),
     ),
     (
@@ -42,12 +42,12 @@ test_conditions = [
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "a", None), Literal(None, 1)),
+                    (Column(None, None, "a"), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "b", None), Literal(None, 2)),
+                    (Column(None, None, "b"), Literal(None, 2)),
                 ),
             ),
         ),
@@ -61,7 +61,7 @@ test_conditions = [
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "a", None), Literal(None, 1)),
+                    (Column(None, None, "a"), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
@@ -70,12 +70,12 @@ test_conditions = [
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "b", None), Literal(None, 2)),
+                            (Column(None, None, "b"), Literal(None, 2)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "c", None), Literal(None, 3)),
+                            (Column(None, None, "c"), Literal(None, 3)),
                         ),
                     ),
                 ),
@@ -91,12 +91,12 @@ test_conditions = [
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "a", None), Literal(None, 1)),
+                    (Column(None, None, "a"), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "b", None), Literal(None, 2)),
+                    (Column(None, None, "b"), Literal(None, 2)),
                 ),
             ),
         ),
@@ -110,7 +110,7 @@ test_conditions = [
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "a", None), Literal(None, 1)),
+                    (Column(None, None, "a"), Literal(None, 1)),
                 ),
                 FunctionCall(
                     None,
@@ -119,12 +119,12 @@ test_conditions = [
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "b", None), Literal(None, 2)),
+                            (Column(None, None, "b"), Literal(None, 2)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "c", None), Literal(None, 3)),
+                            (Column(None, None, "c"), Literal(None, 3)),
                         ),
                     ),
                 ),
@@ -144,19 +144,19 @@ test_conditions = [
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "a", None), Literal(None, 1)),
+                            (Column(None, None, "a"), Literal(None, 1)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "b", None), Literal(None, 2)),
+                            (Column(None, None, "b"), Literal(None, 2)),
                         ),
                     ),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "c", None), Literal(None, 3)),
+                    (Column(None, None, "c"), Literal(None, 3)),
                 ),
             ),
         ),
@@ -174,12 +174,12 @@ test_conditions = [
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "a", None), Literal(None, 1)),
+                            (Column(None, None, "a"), Literal(None, 1)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "b", None), Literal(None, 2)),
+                            (Column(None, None, "b"), Literal(None, 2)),
                         ),
                     ),
                 ),
@@ -190,12 +190,12 @@ test_conditions = [
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "c", None), Literal(None, 3)),
+                            (Column(None, None, "c"), Literal(None, 3)),
                         ),
                         FunctionCall(
                             None,
                             ConditionFunctions.EQ,
-                            (Column(None, "d", None), Literal(None, 4)),
+                            (Column(None, None, "d"), Literal(None, 4)),
                         ),
                     ),
                 ),
@@ -205,7 +205,7 @@ test_conditions = [
     (
         [[["a", "=", 1], []]],
         FunctionCall(
-            None, ConditionFunctions.EQ, (Column(None, "a", None), Literal(None, 1)),
+            None, ConditionFunctions.EQ, (Column(None, None, "a"), Literal(None, 1)),
         ),
     ),  # Malformed Condition Input
     (
@@ -218,14 +218,14 @@ test_conditions = [
                     None,
                     ConditionFunctions.EQ,
                     (
-                        FunctionCall(None, "tag", (Column(None, "foo", None),)),
+                        FunctionCall(None, "tag", (Column(None, None, "foo"),)),
                         Literal(None, 1),
                     ),
                 ),
                 FunctionCall(
                     None,
                     ConditionFunctions.EQ,
-                    (Column(None, "b", None), Literal(None, 2)),
+                    (Column(None, None, "b"), Literal(None, 2)),
                 ),
             ),
         ),
@@ -235,7 +235,7 @@ test_conditions = [
         FunctionCall(
             None,
             ConditionFunctions.LIKE,
-            (Column(None, "primary_hash", None), Literal(None, "%foo%")),
+            (Column(None, None, "primary_hash"), Literal(None, "%foo%")),
         ),
     ),  # Test output format of LIKE
     (
@@ -252,7 +252,7 @@ test_conditions = [
                             None,
                             "arrayElement",
                             (
-                                Column(None, "exception_stacks.type", None),
+                                Column(None, None, "exception_stacks.type"),
                                 Literal(None, 1),
                             ),
                         ),
@@ -283,7 +283,7 @@ test_conditions = [
                         ),
                     ),
                 ),
-                Column(None, "exception_frames.filename", None),
+                Column(None, None, "exception_frames.filename"),
             ),
         ),
     ),  # Test scalar condition on array column is expanded as an iterator.
@@ -308,7 +308,7 @@ test_conditions = [
                         ),
                     ),
                 ),
-                Column(None, "exception_frames.filename", None),
+                Column(None, None, "exception_frames.filename"),
             ),
         ),
     ),  # Test negative scalar condition on array column is expanded as an all() type iterator.
@@ -320,7 +320,7 @@ test_conditions = [
             None,
             ConditionFunctions.IN,
             (
-                Column(None, "platform", None),
+                Column(None, None, "platform"),
                 FunctionCall(
                     None,
                     "tuple",

--- a/tests/query/parser/test_expressions.py
+++ b/tests/query/parser/test_expressions.py
@@ -11,7 +11,7 @@ from snuba.query.parser.expressions import parse_aggregation
 test_data = [
     (
         ["count", "event_id", None],
-        FunctionCall(None, "count", (Column(None, "event_id", None),)),
+        FunctionCall(None, "count", (Column(None, None, "event_id"),)),
     ),  # Simple aggregation
     (
         ["count()", "", None],
@@ -24,19 +24,19 @@ test_data = [
     (
         ["count()", "event_id", None],
         CurriedFunctionCall(
-            None, FunctionCall(None, "count", ()), (Column(None, "event_id", None),)
+            None, FunctionCall(None, "count", ()), (Column(None, None, "event_id"),)
         ),
     ),  # This is probably wrong, but we cannot disambiguate it at this level
     (
         ["uniq", "platform", "uniq_platforms"],
-        FunctionCall("uniq_platforms", "uniq", (Column(None, "platform", None),)),
+        FunctionCall("uniq_platforms", "uniq", (Column(None, None, "platform"),)),
     ),  # Use the columns provided as parameters
     (
         ["topK(1)", "platform", "top_platforms"],
         CurriedFunctionCall(
             "top_platforms",
             FunctionCall(None, "topK", (Literal(None, 1),)),
-            (Column(None, "platform", None),),
+            (Column(None, None, "platform"),),
         ),
     ),  # Curried function
     (
@@ -44,7 +44,7 @@ test_data = [
         CurriedFunctionCall(
             "p95",
             FunctionCall(None, "quantile", (Literal(None, 0.95),)),
-            (Column(None, "duration", None),),
+            (Column(None, None, "duration"),),
         ),
     ),  # Curried function
     (
@@ -52,7 +52,7 @@ test_data = [
         FunctionCall(
             "apdex_score",
             "apdex",
-            (Column(None, "duration", None), Literal(None, 300),),
+            (Column(None, None, "duration"), Literal(None, 300),),
         ),
     ),  # apdex formula
     (
@@ -78,12 +78,12 @@ test_data = [
                             "multiply",
                             (
                                 FunctionCall(
-                                    None, "log", (Column(None, "times_seen", None),),
+                                    None, "log", (Column(None, None, "times_seen"),),
                                 ),
                                 Literal(None, 600),
                             ),
                         ),
-                        Column(None, "last_seen", None),
+                        Column(None, None, "last_seen"),
                     ),
                 ),
             ),

--- a/tests/query/parser/test_functions.py
+++ b/tests/query/parser/test_functions.py
@@ -9,7 +9,7 @@ def test_complex_conditions_expr() -> None:
         None, "count", ()
     )
     assert parse_function_to_expr(tuplify(["notEmpty", ["foo"]]),) == FunctionCall(
-        None, "notEmpty", (Column(None, "foo", None),)
+        None, "notEmpty", (Column(None, None, "foo"),)
     )
     assert parse_function_to_expr(
         tuplify(["notEmpty", ["arrayElement", ["foo", 1]]]),
@@ -18,7 +18,7 @@ def test_complex_conditions_expr() -> None:
         "notEmpty",
         (
             FunctionCall(
-                None, "arrayElement", (Column(None, "foo", None), Literal(None, 1))
+                None, "arrayElement", (Column(None, None, "foo"), Literal(None, 1))
             ),
         ),
     )
@@ -28,25 +28,25 @@ def test_complex_conditions_expr() -> None:
         None,
         "foo",
         (
-            FunctionCall(None, "bar", (Column(None, "qux", None),)),
-            Column(None, "baz", None),
+            FunctionCall(None, "bar", (Column(None, None, "qux"),)),
+            Column(None, None, "baz"),
         ),
     )
     assert parse_function_to_expr(tuplify(["foo", [], "a"]),) == FunctionCall(
         "a", "foo", ()
     )
     assert parse_function_to_expr(tuplify(["foo", ["b", "c"], "d"]),) == FunctionCall(
-        "d", "foo", (Column(None, "b", None), Column(None, "c", None))
+        "d", "foo", (Column(None, None, "b"), Column(None, None, "c"))
     )
     assert parse_function_to_expr(tuplify(["foo", ["b", "c", ["d"]]]),) == FunctionCall(
         None,
         "foo",
-        (Column(None, "b", None), FunctionCall(None, "c", (Column(None, "d", None),))),
+        (Column(None, None, "b"), FunctionCall(None, "c", (Column(None, None, "d"),))),
     )
 
     assert parse_function_to_expr(
         tuplify(["emptyIfNull", ["project_id"]]),
-    ) == FunctionCall(None, "emptyIfNull", (Column(None, "project_id", None),))
+    ) == FunctionCall(None, "emptyIfNull", (Column(None, None, "project_id"),))
 
     assert parse_function_to_expr(
         tuplify(["or", [["or", ["a", "b"]], "c"]]),
@@ -54,9 +54,9 @@ def test_complex_conditions_expr() -> None:
         None,
         BooleanFunctions.OR,
         binary_condition(
-            None, BooleanFunctions.OR, Column(None, "a", None), Column(None, "b", None)
+            None, BooleanFunctions.OR, Column(None, None, "a"), Column(None, None, "b")
         ),
-        Column(None, "c", None),
+        Column(None, None, "c"),
     )
     assert parse_function_to_expr(
         tuplify(["and", [["and", ["a", "b"]], "c"]]),
@@ -64,9 +64,9 @@ def test_complex_conditions_expr() -> None:
         None,
         BooleanFunctions.AND,
         binary_condition(
-            None, BooleanFunctions.AND, Column(None, "a", None), Column(None, "b", None)
+            None, BooleanFunctions.AND, Column(None, None, "a"), Column(None, None, "b")
         ),
-        Column(None, "c", None),
+        Column(None, None, "c"),
     )
     # (A OR B) AND C
     assert parse_function_to_expr(
@@ -75,9 +75,9 @@ def test_complex_conditions_expr() -> None:
         None,
         BooleanFunctions.AND,
         binary_condition(
-            None, BooleanFunctions.OR, Column(None, "a", None), Column(None, "b", None)
+            None, BooleanFunctions.OR, Column(None, None, "a"), Column(None, None, "b")
         ),
-        Column(None, "c", None),
+        Column(None, None, "c"),
     )
     # A OR B OR C OR D
     assert parse_function_to_expr(
@@ -91,12 +91,12 @@ def test_complex_conditions_expr() -> None:
             binary_condition(
                 None,
                 BooleanFunctions.OR,
-                Column(None, "c", None),
-                Column(None, "d", None),
+                Column(None, None, "c"),
+                Column(None, None, "d"),
             ),
-            Column(None, "b", None),
+            Column(None, None, "b"),
         ),
-        Column(None, "a", None),
+        Column(None, None, "a"),
     )
 
     assert parse_function_to_expr(
@@ -115,11 +115,11 @@ def test_complex_conditions_expr() -> None:
                 None,
                 "in",
                 (
-                    Column(None, "release", None),
+                    Column(None, None, "release"),
                     FunctionCall(None, "tuple", (Literal(None, "foo"),)),
                 ),
             ),
-            Column(None, "release", None),
+            Column(None, None, "release"),
             Literal(None, "other"),
         ),
     )
@@ -130,5 +130,5 @@ def test_complex_conditions_expr() -> None:
     ) == FunctionCall(
         None,
         "positionCaseInsensitive",
-        (Column(None, "message", None), Literal(None, "lol 'single' quotes")),
+        (Column(None, None, "message"), Literal(None, "lol 'single' quotes")),
     )

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -27,14 +27,14 @@ test_cases = [
             {},
             TableSource("events", ColumnSet([])),
             selected_columns=[
-                Column(None, "column2", None),
-                Column(None, "column3", None),
+                Column(None, None, "column2"),
+                Column(None, None, "column3"),
                 FunctionCall(
-                    "test_func_alias", "test_func", (Column(None, "column4", None),)
+                    "test_func_alias", "test_func", (Column(None, None, "column4"),)
                 ),
-                Column(None, "column1", None),
+                Column(None, None, "column1"),
             ],
-            groupby=[Column(None, "column2", None), Column(None, "column3", None)],
+            groupby=[Column(None, None, "column2"), Column(None, None, "column3")],
         ),
     ),  # Basic SELECT composed through the selectedcols and aggregations
     (
@@ -56,20 +56,20 @@ test_cases = [
             {},
             TableSource("events", ColumnSet([])),
             selected_columns=[
-                FunctionCall(None, "format_eventid", (Column(None, "event_id", None),)),
-                FunctionCall("platforms", "count", (Column(None, "platform", None),)),
+                FunctionCall(None, "format_eventid", (Column(None, None, "event_id"),)),
+                FunctionCall("platforms", "count", (Column(None, None, "platform"),)),
                 FunctionCall(
-                    "uniq_platforms", "uniq", (Column(None, "platform", None),)
+                    "uniq_platforms", "uniq", (Column(None, None, "platform"),)
                 ),
                 FunctionCall(
                     "top_platforms",
                     "testF",
-                    (Column(None, "platform", None), Column(None, "field2", None)),
+                    (Column(None, None, "platform"), Column(None, None, "field2")),
                 ),
                 FunctionCall(
                     "f1_alias",
                     "f1",
-                    (Column(None, "column1", None), Column(None, "column2", None)),
+                    (Column(None, None, "column1"), Column(None, None, "column2")),
                 ),
                 FunctionCall("f2_alias", "f2", ()),
             ],
@@ -78,7 +78,7 @@ test_cases = [
                 "in",
                 SubscriptableReference(
                     "tags[sentry:dist]",
-                    Column(None, "tags", None),
+                    Column(None, None, "tags"),
                     Literal(None, "sentry:dist"),
                 ),
                 FunctionCall(
@@ -86,10 +86,10 @@ test_cases = [
                 ),
             ),
             having=binary_condition(
-                None, "greater", Column(None, "times_seen", None), Literal(None, 1)
+                None, "greater", Column(None, None, "times_seen"), Literal(None, 1)
             ),
             groupby=[
-                FunctionCall(None, "format_eventid", (Column(None, "event_id", None),))
+                FunctionCall(None, "format_eventid", (Column(None, None, "event_id"),))
             ],
         ),
     ),  # Format a query with functions in all fields
@@ -102,18 +102,18 @@ test_cases = [
             {},
             TableSource("events", ColumnSet([])),
             selected_columns=[
-                Column(None, "column1", None),
-                Column(None, "column2", None),
+                Column(None, None, "column1"),
+                Column(None, None, "column2"),
             ],
             condition=None,
             groupby=None,
             having=None,
             order_by=[
-                OrderBy(OrderByDirection.ASC, Column(None, "column1", None)),
-                OrderBy(OrderByDirection.DESC, Column(None, "column2", None)),
+                OrderBy(OrderByDirection.ASC, Column(None, None, "column1")),
+                OrderBy(OrderByDirection.DESC, Column(None, None, "column2")),
                 OrderBy(
                     OrderByDirection.DESC,
-                    FunctionCall(None, "func", (Column(None, "column3", None),)),
+                    FunctionCall(None, "func", (Column(None, None, "column3"),)),
                 ),
             ],
         ),
@@ -123,11 +123,11 @@ test_cases = [
         Query(
             {},
             TableSource("events", ColumnSet([])),
-            selected_columns=[Column(None, "column1", None)],
+            selected_columns=[Column(None, None, "column1")],
             condition=None,
-            groupby=[Column(None, "column1", None)],
+            groupby=[Column(None, None, "column1")],
             having=None,
-            order_by=[OrderBy(OrderByDirection.DESC, Column(None, "column1", None))],
+            order_by=[OrderBy(OrderByDirection.DESC, Column(None, None, "column1"))],
         ),
     ),  # Order and group by provided as string
     (
@@ -145,14 +145,14 @@ test_cases = [
                     (
                         SubscriptableReference(
                             "tags[test2]",
-                            Column(None, "tags", None),
+                            Column(None, None, "tags"),
                             Literal(None, "test2"),
                         ),
                     ),
                 ),
-                Column(None, "column1", None),
+                Column(None, None, "column1"),
                 SubscriptableReference(
-                    "tags[test]", Column(None, "tags", None), Literal(None, "test")
+                    "tags[test]", Column(None, None, "tags"), Literal(None, "test")
                 ),
             ],
             groupby=[
@@ -162,7 +162,7 @@ test_cases = [
                     (
                         SubscriptableReference(
                             "tags[test2]",
-                            Column(None, "tags", None),
+                            Column(None, None, "tags"),
                             Literal(None, "test2"),
                         ),
                     ),

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -18,9 +18,9 @@ def test_apdex_format_expressions() -> None:
         {},
         TableSource("events", ColumnSet([])),
         selected_columns=[
-            Column(None, "column2", None),
+            Column(None, None, "column2"),
             FunctionCall(
-                "perf", "apdex", (Column(None, "column1", None), Literal(None, 300))
+                "perf", "apdex", (Column(None, None, "column1"), Literal(None, 300))
             ),
         ],
     )
@@ -28,7 +28,7 @@ def test_apdex_format_expressions() -> None:
         {},
         TableSource("events", ColumnSet([])),
         selected_columns=[
-            Column(None, "column2", None),
+            Column(None, None, "column2"),
             div(
                 plus(
                     FunctionCall(
@@ -38,7 +38,7 @@ def test_apdex_format_expressions() -> None:
                             binary_condition(
                                 None,
                                 ConditionFunctions.LTE,
-                                Column(None, "column1", None),
+                                Column(None, None, "column1"),
                                 Literal(None, 300),
                             ),
                         ),
@@ -54,13 +54,13 @@ def test_apdex_format_expressions() -> None:
                                     binary_condition(
                                         None,
                                         ConditionFunctions.GT,
-                                        Column(None, "column1", None),
+                                        Column(None, None, "column1"),
                                         Literal(None, 300),
                                     ),
                                     binary_condition(
                                         None,
                                         ConditionFunctions.LTE,
-                                        Column(None, "column1", None),
+                                        Column(None, None, "column1"),
                                         multiply(Literal(None, 300), Literal(None, 4)),
                                     ),
                                 ),

--- a/tests/query/processors/test_events_column_processor.py
+++ b/tests/query/processors/test_events_column_processor.py
@@ -12,25 +12,25 @@ def test_events_column_format_expressions() -> None:
         {},
         TableSource("events", ColumnSet([])),
         selected_columns=[
-            Column("dr_claw", "culprit", None),
-            Column("the_group_id", "group_id", None),
-            Column("the_message", "message", None),
+            Column("dr_claw", None, "culprit"),
+            Column("the_group_id", None, "group_id"),
+            Column("the_message", None, "message"),
         ],
     )
     expected = Query(
         {},
         TableSource("events", ColumnSet([])),
         selected_columns=[
-            Column("dr_claw", "culprit", None),
+            Column("dr_claw", None, "culprit"),
             FunctionCall(
                 "the_group_id",
                 "nullIf",
-                (Column(None, "group_id", None), Literal(None, 0),),
+                (Column(None, None, "group_id"), Literal(None, 0),),
             ),
             FunctionCall(
                 "the_message",
                 "coalesce",
-                (Column(None, "message", None), Column(None, "search_message", None),),
+                (Column(None, None, "message"), Column(None, None, "search_message"),),
             ),
         ],
     )

--- a/tests/query/processors/test_functions_processor.py
+++ b/tests/query/processors/test_functions_processor.py
@@ -15,8 +15,8 @@ test_data = [
             {},
             TableSource("events", ColumnSet([])),
             selected_columns=[
-                FunctionCall("alias", "uniq", (Column(None, "column1", None),)),
-                FunctionCall("alias2", "emptyIfNull", (Column(None, "column2", None),)),
+                FunctionCall("alias", "uniq", (Column(None, None, "column1"),)),
+                FunctionCall("alias2", "emptyIfNull", (Column(None, None, "column2"),)),
             ],
         ),
         Query(
@@ -27,7 +27,7 @@ test_data = [
                     "alias",
                     "ifNull",
                     (
-                        FunctionCall(None, "uniq", (Column(None, "column1", None),)),
+                        FunctionCall(None, "uniq", (Column(None, None, "column1"),)),
                         Literal(None, 0),
                     ),
                 ),
@@ -36,7 +36,7 @@ test_data = [
                     "ifNull",
                     (
                         FunctionCall(
-                            None, "emptyIfNull", (Column(None, "column2", None),)
+                            None, "emptyIfNull", (Column(None, None, "column2"),)
                         ),
                         Literal(None, ""),
                     ),
@@ -49,28 +49,28 @@ test_data = [
             {},
             TableSource("events", ColumnSet([])),
             selected_columns=[
-                Column(None, "column1", None),
-                FunctionCall("alias", "uniq", (Column(None, "column1", None),)),
-                FunctionCall("alias2", "emptyIfNull", (Column(None, "column2", None),)),
+                Column(None, None, "column1"),
+                FunctionCall("alias", "uniq", (Column(None, None, "column1"),)),
+                FunctionCall("alias2", "emptyIfNull", (Column(None, None, "column2"),)),
             ],
             condition=FunctionCall(
-                None, "eq", (Column(None, "column1", None), Literal(None, "a"))
+                None, "eq", (Column(None, None, "column1"), Literal(None, "a"))
             ),
             groupby=[
-                FunctionCall("alias3", "uniq", (Column(None, "column5", None),)),
-                FunctionCall("alias4", "emptyIfNull", (Column(None, "column6", None),)),
+                FunctionCall("alias3", "uniq", (Column(None, None, "column5"),)),
+                FunctionCall("alias4", "emptyIfNull", (Column(None, None, "column6"),)),
             ],
         ),
         Query(
             {},
             TableSource("events", ColumnSet([])),
             selected_columns=[
-                Column(None, "column1", None),
+                Column(None, None, "column1"),
                 FunctionCall(
                     "alias",
                     "ifNull",
                     (
-                        FunctionCall(None, "uniq", (Column(None, "column1", None),)),
+                        FunctionCall(None, "uniq", (Column(None, None, "column1"),)),
                         Literal(None, 0),
                     ),
                 ),
@@ -79,21 +79,21 @@ test_data = [
                     "ifNull",
                     (
                         FunctionCall(
-                            None, "emptyIfNull", (Column(None, "column2", None),)
+                            None, "emptyIfNull", (Column(None, None, "column2"),)
                         ),
                         Literal(None, ""),
                     ),
                 ),
             ],
             condition=FunctionCall(
-                None, "eq", (Column(None, "column1", None), Literal(None, "a"))
+                None, "eq", (Column(None, None, "column1"), Literal(None, "a"))
             ),
             groupby=[
                 FunctionCall(
                     "alias3",
                     "ifNull",
                     (
-                        FunctionCall(None, "uniq", (Column(None, "column5", None),)),
+                        FunctionCall(None, "uniq", (Column(None, None, "column5"),)),
                         Literal(None, 0),
                     ),
                 ),
@@ -102,7 +102,7 @@ test_data = [
                     "ifNull",
                     (
                         FunctionCall(
-                            None, "emptyIfNull", (Column(None, "column6", None),)
+                            None, "emptyIfNull", (Column(None, None, "column6"),)
                         ),
                         Literal(None, ""),
                     ),
@@ -118,7 +118,7 @@ test_data = [
                 CurriedFunctionCall(
                     None,
                     FunctionCall(None, "top", (Literal(None, 10),)),
-                    (Column(None, "column1", None),),
+                    (Column(None, None, "column1"),),
                 )
             ],
         ),
@@ -129,7 +129,7 @@ test_data = [
                 CurriedFunctionCall(
                     None,
                     FunctionCall(None, "topK", (Literal(None, 10),)),
-                    (Column(None, "column1", None),),
+                    (Column(None, None, "column1"),),
                 )
             ],
         ),

--- a/tests/query/processors/test_impact.py
+++ b/tests/query/processors/test_impact.py
@@ -18,14 +18,14 @@ def test_impact_format_expressions() -> None:
         {},
         TableSource("events", ColumnSet([])),
         selected_columns=[
-            Column(None, "column2", None),
+            Column(None, None, "column2"),
             FunctionCall(
                 "perf",
                 "impact",
                 (
-                    Column(None, "column1", None),
+                    Column(None, None, "column1"),
                     Literal(None, 300),
-                    Column(None, "user", None),
+                    Column(None, None, "user"),
                 ),
             ),
         ],
@@ -34,7 +34,7 @@ def test_impact_format_expressions() -> None:
         {},
         TableSource("events", ColumnSet([])),
         selected_columns=[
-            Column(None, "column2", None),
+            Column(None, None, "column2"),
             plus(
                 minus(
                     Literal(None, 1),
@@ -44,7 +44,7 @@ def test_impact_format_expressions() -> None:
                                 binary_condition(
                                     None,
                                     ConditionFunctions.LTE,
-                                    Column(None, "column1", None),
+                                    Column(None, None, "column1"),
                                     Literal(None, 300),
                                 ),
                             ),
@@ -56,13 +56,13 @@ def test_impact_format_expressions() -> None:
                                         binary_condition(
                                             None,
                                             ConditionFunctions.GT,
-                                            Column(None, "column1", None),
+                                            Column(None, None, "column1"),
                                             Literal(None, 300),
                                         ),
                                         binary_condition(
                                             None,
                                             ConditionFunctions.LTE,
-                                            Column(None, "column1", None),
+                                            Column(None, None, "column1"),
                                             multiply(
                                                 Literal(None, 300), Literal(None, 4)
                                             ),

--- a/tests/query/processors/test_tags_expander.py
+++ b/tests/query/processors/test_tags_expander.py
@@ -28,14 +28,14 @@ def test_tags_expander() -> None:
     processor.process_query(query, request_settings)
 
     assert query.get_selected_columns_from_ast() == [
-        FunctionCall("platforms", "count", (Column(None, "platform", None),)),
+        FunctionCall("platforms", "count", (Column(None, None, "platform"),)),
         FunctionCall(
             "top_platforms",
             "testF",
             (
-                Column(None, "platform", None),
+                Column(None, None, "platform"),
                 FunctionCall(
-                    "tags_value", "arrayJoin", (Column(None, "tags.value", None),)
+                    "tags_value", "arrayJoin", (Column(None, None, "tags.value"),)
                 ),
             ),
         ),
@@ -44,9 +44,9 @@ def test_tags_expander() -> None:
             "f1",
             (
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, "tags.key", None),)
+                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),)
                 ),
-                Column(None, "column2", None),
+                Column(None, None, "column2"),
             ),
         ),
         FunctionCall("f2_alias", "f2", tuple()),
@@ -55,12 +55,12 @@ def test_tags_expander() -> None:
     assert query.get_condition_from_ast() == binary_condition(
         None,
         OPERATOR_TO_FUNCTION["="],
-        FunctionCall("tags_key", "arrayJoin", (Column(None, "tags.key", None),)),
+        FunctionCall("tags_key", "arrayJoin", (Column(None, None, "tags.key"),)),
         Literal(None, "tags_key"),
     )
 
     assert query.get_having_from_ast() == in_condition(
         None,
-        FunctionCall("tags_value", "arrayJoin", (Column(None, "tags.value", None),)),
+        FunctionCall("tags_value", "arrayJoin", (Column(None, None, "tags.value"),)),
         [Literal(None, "tag")],
     )

--- a/tests/query/processors/test_timeseries_column_processor.py
+++ b/tests/query/processors/test_timeseries_column_processor.py
@@ -17,7 +17,7 @@ tests = [
         FunctionCall(
             "my_time",
             "toStartOfHour",
-            (Column(None, "finish_ts", None), Literal(None, "Universal")),
+            (Column(None, None, "finish_ts"), Literal(None, "Universal")),
         ),
         "(toStartOfHour(finish_ts, 'Universal') AS my_time)",
     ),
@@ -26,7 +26,7 @@ tests = [
         FunctionCall(
             "my_time",
             "toStartOfMinute",
-            (Column(None, "finish_ts", None), Literal(None, "Universal")),
+            (Column(None, None, "finish_ts"), Literal(None, "Universal")),
         ),
         "(toStartOfMinute(finish_ts, 'Universal') AS my_time)",
     ),
@@ -35,7 +35,7 @@ tests = [
         FunctionCall(
             "my_time",
             "toDate",
-            (Column(None, "finish_ts", None), Literal(None, "Universal")),
+            (Column(None, None, "finish_ts"), Literal(None, "Universal")),
         ),
         "(toDate(finish_ts, 'Universal') AS my_time)",
     ),
@@ -51,7 +51,7 @@ tests = [
                         "intDiv",
                         (
                             FunctionCall(
-                                None, "toUInt32", (Column(None, "finish_ts", None),),
+                                None, "toUInt32", (Column(None, None, "finish_ts"),),
                             ),
                             Literal(None, 1440),
                         ),
@@ -75,7 +75,7 @@ def test_timeseries_column_format_expressions(
         TableSource("transactions", ColumnSet([])),
         selected_columns=[
             Column("transaction.duration", "duration", None),
-            Column("my_time", "time", None),
+            Column("my_time", None, "time"),
         ],
     )
     expected = Query(

--- a/tests/query/processors/test_transaction_column_processor.py
+++ b/tests/query/processors/test_transaction_column_processor.py
@@ -15,7 +15,7 @@ def test_transaction_column_format_expressions() -> None:
         TableSource("events", ColumnSet([])),
         selected_columns=[
             Column("transaction.duration", "duration", None),
-            Column("the_event_id", "event_id", None),
+            Column("the_event_id", None, "event_id"),
         ],
     )
     expected = Query(
@@ -27,7 +27,7 @@ def test_transaction_column_format_expressions() -> None:
                 "the_event_id",
                 "replaceAll",
                 (
-                    FunctionCall(None, "toString", (Column(None, "event_id", None),),),
+                    FunctionCall(None, "toString", (Column(None, None, "event_id"),),),
                     Literal(None, "-"),
                     Literal(None, ""),
                 ),

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -15,9 +15,9 @@ def test_expressions_from_basic_condition() -> None:
     f(t1.c1) = t1.c2
     """
 
-    c = Column(None, "c1", "t1")
+    c = Column(None, "t1", "c1")
     f1 = FunctionCall(None, "f", [c])
-    c2 = Column(None, "c2", "t1")
+    c2 = Column(None, "t1", "c2")
 
     condition = binary_condition(None, ConditionFunctions.EQ, f1, c2)
     ret = list(condition)
@@ -34,9 +34,9 @@ def test_aliased_expressions_from_basic_condition() -> None:
     f(t1.c1) as a = t1.c2 as a2
     """
 
-    c = Column(None, "c1", "t1")
+    c = Column(None, "t1", "c1")
     f1 = FunctionCall("a", "f", [c])
-    c2 = Column("a2", "c2", "t1")
+    c2 = Column("a2", "t1", "c2")
 
     condition = binary_condition(None, ConditionFunctions.EQ, f1, c2)
     ret = list(condition)
@@ -49,11 +49,11 @@ def test_map_expressions_in_basic_condition() -> None:
     """
     Change the column name over the expressions in a basic condition
     """
-    c = Column(None, "c1", "t1")
+    c = Column(None, "t1", "c1")
     f1 = FunctionCall(None, "f", [c])
-    c2 = Column(None, "c2", "t1")
+    c2 = Column(None, "t1", "c2")
 
-    c3 = Column(None, "c3", "t1")
+    c3 = Column(None, "t1", "c3")
 
     def replace_col(e: Expression) -> Expression:
         if isinstance(e, Column) and e.column_name == "c1":
@@ -78,21 +78,21 @@ def test_nested_simple_condition() -> None:
     (A=B OR A=B) AND (A=B OR A=B)
     """
 
-    c1 = Column(None, "c1", "t1")
-    c2 = Column(None, "c2", "t1")
+    c1 = Column(None, "t1", "c1")
+    c2 = Column(None, "t1", "c2")
     co1 = binary_condition(None, ConditionFunctions.EQ, c1, c2)
 
-    c3 = Column(None, "c1", "t1")
-    c4 = Column(None, "c2", "t1")
+    c3 = Column(None, "t1", "c1")
+    c4 = Column(None, "t1", "c2")
     co2 = binary_condition(None, ConditionFunctions.EQ, c3, c4)
     or1 = binary_condition(None, BooleanFunctions.OR, co1, co2)
 
-    c5 = Column(None, "c1", "t1")
-    c6 = Column(None, "c2", "t1")
+    c5 = Column(None, "t1", "c1")
+    c6 = Column(None, "t1", "c2")
     co4 = binary_condition(None, ConditionFunctions.EQ, c5, c6)
 
-    c7 = Column(None, "c1", "t1")
-    c8 = Column(None, "c2", "t1")
+    c7 = Column(None, "t1", "c1")
+    c8 = Column(None, "t1", "c2")
     co5 = binary_condition(None, ConditionFunctions.EQ, c7, c8)
     or2 = binary_condition(None, BooleanFunctions.OR, co4, co5)
     and1 = binary_condition(None, BooleanFunctions.AND, or1, or2)
@@ -101,7 +101,7 @@ def test_nested_simple_condition() -> None:
     expected = [c1, c2, co1, c3, c4, co2, or1, c5, c6, co4, c7, c8, co5, or2, and1]
     assert ret == expected
 
-    cX = Column(None, "cX", "t1")
+    cX = Column(None, "t1", "cX")
     co1_b = binary_condition(None, ConditionFunctions.EQ, c1, cX)
     co2_b = binary_condition(None, ConditionFunctions.EQ, c3, cX)
     or1_b = binary_condition(None, BooleanFunctions.OR, co1_b, co2_b)
@@ -141,13 +141,13 @@ def test_processing_functions() -> None:
     in_condition = binary_condition(
         None,
         ConditionFunctions.IN,
-        Column(None, "tag_keys", None),
+        Column(None, None, "tag_keys"),
         literals_tuple(None, [Literal(None, "t1"), Literal(None, "t2")]),
     )
     assert is_in_condition(in_condition)
 
     eq_condition = binary_condition(
-        None, ConditionFunctions.EQ, Column(None, "test", None), Literal(None, "1")
+        None, ConditionFunctions.EQ, Column(None, None, "test"), Literal(None, "1")
     )
     assert is_binary_condition(eq_condition, ConditionFunctions.EQ)
     assert not is_binary_condition(eq_condition, ConditionFunctions.NEQ)

--- a/tests/query/test_expressions.py
+++ b/tests/query/test_expressions.py
@@ -15,12 +15,12 @@ def test_iterate() -> None:
     Test iteration over a subtree. The subtree is a function call in the form
     f2(c3, f1(c1, c2))
     """
-    column1 = Column(None, "c1", "t1")
-    column2 = Column(None, "c2", "t1")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column(None, "t1", "c2")
     function_1 = FunctionCall(None, "f1", (column1, column2))
 
-    column3 = Column(None, "c2", "t1")
-    column4 = Column(None, "c3", "t1")
+    column3 = Column(None, "t1", "c2")
+    column4 = Column(None, "t1", "c3")
     literal = Literal(None, "blablabla")
     function_2i = FunctionCall(None, "f2", (column3, function_1, literal))
     function_2 = CurriedFunctionCall(None, function_2i, (column4,))
@@ -43,10 +43,10 @@ def test_aliased_cols() -> None:
     Test iteration whan columns have aliases. This is the expression
     f2(t1.c2, f1(t1.c1, t1.c2 as a2)) as af1
     """
-    column1 = Column(None, "c1", "t1")
-    column2 = Column("a2", "c2", "t1")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column("a2", "t1", "c2")
     function_1 = FunctionCall(None, "f1", (column1, column2))
-    column3 = Column(None, "c2", "t1")
+    column3 = Column(None, "t1", "c2")
     function_2 = FunctionCall("af1", "f2", (column3, function_1))
 
     expected = [column3, column1, column2, function_1, function_2]
@@ -63,9 +63,9 @@ def test_mapping_column_list() -> None:
             return FunctionCall(None, "f", (e,))
         return e
 
-    column1 = Column(None, "c1", "t1")
-    column2 = Column(None, "c2", "t2")
-    column3 = Column(None, "c3", "t3")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column(None, "t2", "c2")
+    column3 = Column(None, "t3", "c3")
     selected_cols = [column1, column2, column3]
     new_selected_cols = list(map(replace_col, selected_cols))
 
@@ -82,8 +82,8 @@ def test_add_alias() -> None:
     Adds an alias to a column referenced in a function
     f(t1.c1) -> f(t1.c1 as a)
     """
-    column1 = Column(None, "c1", "t1")
-    column2 = Column("a", "c1", "t1")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column("a", "t1", "c1")
 
     def replace_expr(e: Expression) -> Expression:
         if isinstance(e, Column) and e.column_name == "c1":
@@ -112,7 +112,7 @@ def test_mapping_complex_expression() -> None:
             return f4
         return e
 
-    c1 = Column(None, "c1", "t1")
+    c1 = Column(None, "t1", "c1")
     f2 = FunctionCall(None, "fB", (f3,))
     f1 = FunctionCall(None, "f0", (c1, f2))
 
@@ -132,19 +132,19 @@ def test_mapping_complex_expression() -> None:
 
 
 def test_mapping_curried_function() -> None:
-    c1 = Column(None, "c1", "t1")
+    c1 = Column(None, "t1", "c1")
     f1 = FunctionCall(None, "f1", (c1,))
-    c2 = Column(None, "c1", "t1")
+    c2 = Column(None, "t1", "c1")
     f2 = CurriedFunctionCall(None, f1, (c2,))
 
     def replace_col(e: Expression) -> Expression:
         if isinstance(e, Column) and e.column_name == "c1":
-            return Column(None, "c2", "t1")
+            return Column(None, "t1", "c2")
         return e
 
     f3 = f2.transform(replace_col)
 
-    replaced_col = Column(None, "c2", "t1")
+    replaced_col = Column(None, "t1", "c2")
     replaced_function = FunctionCall(None, "f1", (replaced_col,))
     expected = [
         replaced_col,
@@ -156,7 +156,7 @@ def test_mapping_curried_function() -> None:
 
 
 def test_subscriptable() -> None:
-    c1 = Column(None, "tags", "t1")
+    c1 = Column(None, "t1", "tags")
     l1 = Literal(None, "myTag")
     s = SubscriptableReference("alias", c1, l1)
 
@@ -176,8 +176,8 @@ def test_hash() -> None:
     """
     Ensures expressions are hashable
     """
-    column1 = Column(None, "c1", "t1")
-    column2 = Column(None, "c2", "t1")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column(None, "t1", "c2")
     function_1 = FunctionCall(None, "f1", (column1, column2))
     literal = Literal(None, "blablabla")
     function_2 = CurriedFunctionCall(None, function_1, (column1,))

--- a/tests/query/test_organization_extension.py
+++ b/tests/query/test_organization_extension.py
@@ -23,7 +23,7 @@ def test_organization_extension_query_processing_happy_path():
 
     assert query.get_conditions() == [("org_id", "=", 2)]
     assert query.get_condition_from_ast() == binary_condition(
-        None, ConditionFunctions.EQ, Column(None, "org_id", None), Literal(None, 2)
+        None, ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 2)
     )
 
 

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -28,7 +28,7 @@ def build_in(project_column: str, projects: Sequence[int]) -> Expression:
         None,
         "in",
         (
-            Column(None, project_column, None),
+            Column(None, None, project_column),
             FunctionCall(None, "tuple", tuple([Literal(None, p) for p in projects])),
         ),
     )
@@ -178,7 +178,7 @@ class TestProjectExtensionWithGroups(BaseTest):
                     "notIn",
                     (
                         FunctionCall(
-                            None, "assumeNotNull", (Column(None, "group_id", None),)
+                            None, "assumeNotNull", (Column(None, None, "group_id"),)
                         ),
                         FunctionCall(
                             None,

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -14,8 +14,8 @@ def test_iterate_over_query():
     """
     Creates a query with the new AST and iterate over all expressions.
     """
-    column1 = Column(None, "c1", "t1")
-    column2 = Column(None, "c2", "t1")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column(None, "t1", "c2")
     function_1 = FunctionCall("alias", "f1", (column1, column2))
     function_2 = FunctionCall("alias", "f2", (column2,))
 
@@ -62,8 +62,8 @@ def test_replace_expression():
     Create a query with the new AST and replaces a function with a different function
     replaces f1(...) with tag(f1)
     """
-    column1 = Column(None, "c1", "t1")
-    column2 = Column(None, "c2", "t1")
+    column1 = Column(None, "t1", "c1")
+    column2 = Column(None, "t1", "c2")
     function_1 = FunctionCall("alias", "f1", (column1, column2))
     function_2 = FunctionCall("alias", "f2", (column2,))
 

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -27,13 +27,13 @@ def build_time_condition(
         binary_condition(
             None,
             ConditionFunctions.GTE,
-            Column(None, time_columns, None),
+            Column(None, None, time_columns),
             Literal(None, from_date),
         ),
         binary_condition(
             None,
             ConditionFunctions.LT,
-            Column(None, time_columns, None),
+            Column(None, None, time_columns),
             Literal(None, to_date),
         ),
     )

--- a/tests/query/test_visitor.py
+++ b/tests/query/test_visitor.py
@@ -64,14 +64,14 @@ class DummyVisitor(ExpressionVisitor[List[Expression]]):
 
 
 def test_visit_expression():
-    col1 = Column("al", "c1", "t1")
+    col1 = Column("al", "t1", "c1")
     literal1 = Literal("al2", "test")
-    mapping = Column("al2", "tags", "t1")
+    mapping = Column("al2", "t1", "tags")
     key = Literal(None, "myTag")
     tag = SubscriptableReference(None, mapping, key)
     f1 = FunctionCall("al3", "f1", [col1, literal1, tag])
 
-    col2 = Column("al4", "c2", "t1")
+    col2 = Column("al4", "t1", "c2")
     literal2 = Literal("al5", "test2")
     f2 = FunctionCall("al6", "f2", [col2, literal2])
 


### PR DESCRIPTION
Depends on #963 

During query processing, as of now, a nested column like tags.key is represented as
```
Column("alias", "tags.key", "table)
```
This seems brittle to me since anyone who wants to make sense of the nested column has to split a string. This seems needlessly coupled to the query language and error prone.
This PR makes a change to the Column class separating the name from the path. 
The name of the column is `tags` for example, while the path is a tuple of components in the path like `("value",)`.
I kept the base column name in a string instead of having only one tuple since that's what we will be using 96.7% of the times, so only for convenience.

To properly process queries based on the AST on single tables dataset and joined dataset we should resolve the table name and the column structure early in the query pipeline (where we will resolve entities). 
This includes my attempt at building columns resolution based on the current schema data structure (which is not designed for this).
1) It introduces a ColumnResolver interface
2) it plugs to all datasets
3) it executes it right after parsing and with this it is also validating every query only references valid column names
4) updates all the tests that were not using valid column names.

Limitations:
- joined schema and single table schema are not defined through the same data structure. This means we need two different implementations of the resolver. When introducing entities (or before) we should revisit the schema data structure to fit the purpose of the logical schema, which is structured contrarily to the storage schemas which are table schemas.
- tags_key and tags_value resolution happens as part of query processors. I think this is too late. We should move it earlier and before columns resolution so we can get rid of virtual column names.