### PR TITLE
feat(clusters): Add the ability to connect with any node

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -98,7 +98,7 @@ def bootstrap(
 
     # Attempt to connect with every cluster
     for cluster in CLUSTERS:
-        clickhouse = cluster.get_connection(ClickhouseClientSettings.MIGRATE)
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
 
         while True:
             try:

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -58,7 +58,7 @@ def cleanup(
     elif not local_dataset_mode():
         raise click.ClickException("Provide ClickHouse host and port for cleanup")
     else:
-        connection = writable_storage.get_cluster().get_connection(
+        connection = writable_storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.CLEANUP
         )
 

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -63,7 +63,9 @@ def optimize(
         # dataset using the cluster's host/port configuration.
         clickhouse_connections = list(
             set(
-                storage.get_cluster().get_connection(ClickhouseClientSettings.OPTIMIZE)
+                storage.get_cluster().get_query_connection(
+                    ClickhouseClientSettings.OPTIMIZE
+                )
                 for storage in dataset.get_all_storages()
             )
         )

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -194,7 +194,9 @@ class TableWriter:
             source_table=source_table,
             dest_table=dest_table,
             row_processor=row_processor,
-            clickhouse=self.__cluster.get_connection(ClickhouseClientSettings.QUERY),
+            clickhouse=self.__cluster.get_query_connection(
+                ClickhouseClientSettings.QUERY
+            ),
         )
 
     def get_stream_loader(self) -> KafkaStreamLoader:

--- a/snuba/migrations/migrate.py
+++ b/snuba/migrations/migrate.py
@@ -54,7 +54,9 @@ def run() -> None:
         storage_name = storage_key.value
         logger.info("Creating tables for storage %s", storage_name)
         storage = get_storage(storage_key)
-        conn = storage.get_cluster().get_connection(ClickhouseClientSettings.MIGRATE)
+        conn = storage.get_cluster().get_query_connection(
+            ClickhouseClientSettings.MIGRATE
+        )
 
         for statement in storage.get_schemas().get_create_statements():
             logger.debug("Executing:\n%s", statement.statement)

--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -45,7 +45,7 @@ def run(events_file, dataset, repeat=1, profile_process=False, profile_write=Fal
     from snuba.consumer import ConsumerWorker
 
     for storage in dataset.get_all_storages():
-        clickhouse = storage.get_cluster().get_connection(
+        clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.INSERT
         )
         for statement in storage.get_schemas().get_create_statements():

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("snuba.replacer")
 
 class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
     def __init__(self, storage: WritableTableStorage, metrics: MetricsBackend) -> None:
-        self.clickhouse = storage.get_cluster().get_connection(
+        self.clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.REPLACE
         )
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -75,7 +75,7 @@ def check_clickhouse() -> bool:
             dataset = get_dataset(name)
 
             for storage in dataset.get_all_storages():
-                clickhouse = storage.get_cluster().get_connection(
+                clickhouse = storage.get_cluster().get_query_connection(
                     ClickhouseClientSettings.QUERY
                 )
                 clickhouse_tables = clickhouse.execute("show tables")
@@ -440,7 +440,7 @@ if application.debug or application.testing:
     @application.route("/tests/<dataset:dataset>/drop", methods=["POST"])
     def drop(*, dataset: Dataset):
         for storage in dataset.get_all_storages():
-            clickhouse = storage.get_cluster().get_connection(
+            clickhouse = storage.get_cluster().get_query_connection(
                 ClickhouseClientSettings.MIGRATE
             )
             for statement in storage.get_schemas().get_drop_statements():

--- a/tests/base.py
+++ b/tests/base.py
@@ -50,7 +50,7 @@ def dataset_manager(name: str) -> Iterator[Dataset]:
     dataset = get_dataset(name)
 
     for storage in dataset.get_all_storages():
-        clickhouse = storage.get_cluster().get_connection(
+        clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.MIGRATE
         )
         for statement in storage.get_schemas().get_drop_statements():
@@ -63,7 +63,7 @@ def dataset_manager(name: str) -> Iterator[Dataset]:
         yield dataset
     finally:
         for storage in dataset.get_all_storages():
-            clickhouse = storage.get_cluster().get_connection(
+            clickhouse = storage.get_cluster().get_query_connection(
                 ClickhouseClientSettings.MIGRATE
             )
             for statement in storage.get_schemas().get_drop_statements():

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -70,3 +70,11 @@ class TestClusters:
         assert cluster_1.get_connection(
             cluster.ClickhouseClientSettings.QUERY
         ) == cluster_1.get_connection(cluster.ClickhouseClientSettings.QUERY)
+
+        assert cluster_1.get_connection(
+            cluster.ClickhouseClientSettings.OPTIMIZE,
+            cluster.ClickhouseNode("localhost", 8002),
+        ) == cluster_1.get_connection(
+            cluster.ClickhouseClientSettings.OPTIMIZE,
+            cluster.ClickhouseNode("localhost", 8002),
+        )

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -67,14 +67,14 @@ class TestClusters:
     def test_cache_connections(self) -> None:
         cluster_1 = cluster.ClickhouseCluster("localhost", 8000, 8001, {"events"}, True)
 
-        assert cluster_1.get_connection(
+        assert cluster_1.get_query_connection(
             cluster.ClickhouseClientSettings.QUERY
-        ) == cluster_1.get_connection(cluster.ClickhouseClientSettings.QUERY)
+        ) == cluster_1.get_query_connection(cluster.ClickhouseClientSettings.QUERY)
 
-        assert cluster_1.get_connection(
+        assert cluster_1.get_node_connection(
             cluster.ClickhouseClientSettings.OPTIMIZE,
             cluster.ClickhouseNode("localhost", 8002),
-        ) == cluster_1.get_connection(
+        ) == cluster_1.get_node_connection(
             cluster.ClickhouseClientSettings.OPTIMIZE,
             cluster.ClickhouseNode("localhost", 8002),
         )

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -121,7 +121,7 @@ class TestGroupassignee(BaseDatasetTest):
         self.write_processed_records(ret.data)
         ret = (
             get_cluster(StorageSetKey.EVENTS)
-            .get_connection(ClickhouseClientSettings.QUERY)
+            .get_query_connection(ClickhouseClientSettings.QUERY)
             .execute("SELECT * FROM test_groupassignee_local;")
         )
         assert ret[0] == (
@@ -180,7 +180,7 @@ class TestGroupassignee(BaseDatasetTest):
         self.write_processed_records(row.to_clickhouse())
         ret = (
             get_cluster(StorageSetKey.EVENTS)
-            .get_connection(ClickhouseClientSettings.QUERY)
+            .get_query_connection(ClickhouseClientSettings.QUERY)
             .execute("SELECT * FROM test_groupassignee_local;")
         )
         assert ret[0] == (

--- a/tests/migrations/test_migrate.py
+++ b/tests/migrations/test_migrate.py
@@ -27,7 +27,7 @@ def test_no_schema_diffs(dataset: Dataset) -> None:
     if not writable_storage:
         pytest.skip(f"{dataset!r} has no writable storage")
 
-    clickhouse = writable_storage.get_cluster().get_connection(
+    clickhouse = writable_storage.get_cluster().get_query_connection(
         ClickhouseClientSettings.MIGRATE
     )
     table_writer = writable_storage.get_table_writer()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,7 @@ class TestApi(BaseApiTest):
         clickhouse = (
             get_storage(StorageKey.EVENTS)
             .get_cluster()
-            .get_connection(ClickhouseClientSettings.QUERY)
+            .get_query_connection(ClickhouseClientSettings.QUERY)
         )
         res = clickhouse.execute("SELECT count() FROM %s" % self.table)
         assert res[0][0] == 330
@@ -1297,7 +1297,7 @@ class TestApi(BaseApiTest):
         writer = storage.get_table_writer()
         table = writer.get_schema().get_table_name()
         storage = get_storage(StorageKey.EVENTS)
-        clickhouse = storage.get_cluster().get_connection(
+        clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.QUERY
         )
         assert table not in clickhouse.execute("SHOW TABLES")

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -18,7 +18,7 @@ class TestCleanup(BaseEventsTest):
         clickhouse = (
             get_storage(StorageKey.EVENTS)
             .get_cluster()
-            .get_connection(ClickhouseClientSettings.CLEANUP)
+            .get_query_connection(ClickhouseClientSettings.CLEANUP)
         )
 
         parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -48,7 +48,7 @@ class TestConsumer(BaseEventsTest):
         clickhouse = (
             get_storage(StorageKey.EVENTS)
             .get_cluster()
-            .get_connection(ClickhouseClientSettings.QUERY)
+            .get_query_connection(ClickhouseClientSettings.QUERY)
         )
 
         assert clickhouse.execute(

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -132,7 +132,7 @@ class TestGroupedMessage(BaseDatasetTest):
         self.write_processed_records(ret.data)
         ret = (
             get_cluster(StorageSetKey.EVENTS)
-            .get_connection(ClickhouseClientSettings.INSERT)
+            .get_query_connection(ClickhouseClientSettings.INSERT)
             .execute("SELECT * FROM test_groupedmessage_local;")
         )
         assert ret[0] == (
@@ -187,7 +187,7 @@ class TestGroupedMessage(BaseDatasetTest):
         self.write_processed_records(row.to_clickhouse())
         ret = (
             get_cluster(StorageSetKey.EVENTS)
-            .get_connection(ClickhouseClientSettings.QUERY)
+            .get_query_connection(ClickhouseClientSettings.QUERY)
             .execute("SELECT * FROM test_groupedmessage_local;")
         )
         assert ret[0] == (

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -13,7 +13,7 @@ class TestOptimize(BaseEventsTest):
         clickhouse = (
             get_storage(StorageKey.EVENTS)
             .get_cluster()
-            .get_connection(ClickhouseClientSettings.OPTIMIZE)
+            .get_query_connection(ClickhouseClientSettings.OPTIMIZE)
         )
         # no data, 0 partitions to optimize
         parts = optimize.get_partitions_to_optimize(

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -16,7 +16,7 @@ class TestPerf(BaseEventsTest):
         clickhouse = (
             get_storage(StorageKey.EVENTS)
             .get_cluster()
-            .get_connection(ClickhouseClientSettings.QUERY)
+            .get_query_connection(ClickhouseClientSettings.QUERY)
         )
 
         assert clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 0


### PR DESCRIPTION
Extend the get_connection method to add the ability to get a connection
with any node, not just the query node. Migrations will use this
connection in order to run specific commands on a node.