### PR TITLE
fix(split) This should be on by default otherwise no one is testing

### DIFF
--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -44,7 +44,7 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy):
                 processor.process_query(query, request_settings)
             return runner(query, request_settings, self.__cluster.get_reader())
 
-        use_split = state.get_config("use_split", 0)
+        use_split = state.get_config("use_split", 1)
         if use_split:
             for splitter in self.__splitters:
                 result = splitter.execute(


### PR DESCRIPTION
None is testing query with splitter because it is off by default while on in production. 