### PR TITLE
feat(clickhouse): allow configuring clickhouse database

### DIFF
--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -56,9 +56,13 @@ def cleanup(
     ) = writable_storage.get_cluster().get_credentials()
     table = enforce_table_writer(dataset).get_schema().get_local_table_name()
 
-    if clickhouse_host and clickhouse_port:
+    if clickhouse_host and clickhouse_port and database:
         connection = ClickhousePool(
-            clickhouse_host, clickhouse_port, clickhouse_user, clickhouse_password,
+            clickhouse_host,
+            clickhouse_port,
+            clickhouse_user,
+            clickhouse_password,
+            database,
         )
     elif not writable_storage.get_cluster().is_single_node():
         raise click.ClickException("Provide ClickHouse host and port for cleanup")

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -53,12 +53,13 @@ def optimize(
     # passing this information won't be necessary, and running this command once
     # will ensure that optimize is performed on all of the individual nodes for
     # that cluster.
-    if clickhouse_host and clickhouse_port:
+    if clickhouse_host and clickhouse_port and database:
         connection = ClickhousePool(
             clickhouse_host,
             clickhouse_port,
             clickhouse_user,
             clickhouse_password,
+            database,
             send_receive_timeout=ClickhouseClientSettings.OPTIMIZE.value.timeout,
         )
     elif not writable_storage.get_cluster().is_single_node():

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -23,6 +23,7 @@ class HTTPBatchWriter(BatchWriter):
         port: int,
         user: str,
         password: str,
+        database: str,
         encoder: Callable[[WriterTableRow], bytes],
         options: Optional[Mapping[str, Any]] = None,
         chunk_size: Optional[int] = 1,
@@ -40,6 +41,7 @@ class HTTPBatchWriter(BatchWriter):
         self.__encoder = encoder
         self.__user = user
         self.__password = password
+        self.__database = database
 
     def _prepare_chunks(self, rows: Iterable[WriterTableRow]) -> Iterable[bytes]:
         chunk = []
@@ -59,7 +61,7 @@ class HTTPBatchWriter(BatchWriter):
             + urlencode(
                 {
                     **self.__options,
-                    "query": f"INSERT INTO {self.__table_name} FORMAT JSONEachRow",
+                    "query": f"INSERT INTO {self.__database}.{self.__table_name} FORMAT JSONEachRow",
                 }
             ),
             headers={

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -27,6 +27,7 @@ class ClickhousePool(object):
         port: int,
         user: str,
         password: str,
+        database: str,
         connect_timeout=1,
         send_receive_timeout=300,
         max_pool_size=settings.CLICKHOUSE_MAX_POOL_SIZE,
@@ -36,6 +37,7 @@ class ClickhousePool(object):
         self.port = port
         self.user = user
         self.password = password
+        self.database = database
         self.connect_timeout = connect_timeout
         self.send_receive_timeout = send_receive_timeout
         self.client_settings = client_settings
@@ -133,6 +135,7 @@ class ClickhousePool(object):
             port=self.port,
             user=self.user,
             password=self.password,
+            database=self.database,
             connect_timeout=self.connect_timeout,
             send_receive_timeout=self.send_receive_timeout,
             settings=self.client_settings,

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -133,6 +133,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
         port: int,
         user: str,
         password: str,
+        database: str,
         http_port: int,
         storage_sets: Set[str],
         single_node: bool,
@@ -144,6 +145,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
         self.__query_node = ClickhouseNode(host, port)
         self.__user = user
         self.__password = password
+        self.__database = database
         self.__http_port = http_port
         self.__single_node = single_node
         self.__cluster_name = cluster_name
@@ -187,6 +189,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
                 node.port,
                 self.__user,
                 self.__password,
+                self.__database,
                 client_settings=settings,
                 send_receive_timeout=timeout,
             )
@@ -213,6 +216,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
             self.__http_port,
             self.__user,
             self.__password,
+            self.__database,
             encoder,
             options,
             chunk_size,
@@ -255,6 +259,7 @@ CLUSTERS = [
         port=cluster["port"],
         user=cluster.get("user", "default"),
         password=cluster.get("password", ""),
+        database=cluster.get("database", "default"),
         http_port=cluster["http_port"],
         storage_sets=cluster["storage_sets"],
         single_node=cluster["single_node"],

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -22,6 +22,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
         "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
         "storage_sets": {"events", "outcomes", "querylog", "sessions", "transactions"},
         "single_node": True,

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -16,6 +16,7 @@ class TestClusters:
                 "port": 9000,
                 "user": "default",
                 "password": "",
+                "database": "default",
                 "http_port": 8123,
                 "storage_sets": {"events", "outcomes", "querylog", "sessions"},
                 "single_node": True,
@@ -25,6 +26,7 @@ class TestClusters:
                 "port": 9000,
                 "user": "default",
                 "password": "",
+                "database": "default",
                 "http_port": 8123,
                 "storage_sets": {"transactions"},
                 "single_node": False,
@@ -70,7 +72,7 @@ class TestClusters:
 
     def test_cache_connections(self) -> None:
         cluster_1 = cluster.ClickhouseCluster(
-            "localhost", 8000, "default", "", 8001, {"events"}, True
+            "localhost", 8000, "default", "", "default", 8001, {"events"}, True
         )
 
         assert cluster_1.get_query_connection(

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -35,7 +35,7 @@ class TestClickhouse(BaseEventsTest):
             errors.NetworkError,
             '{"data": "to my face"}',
         ]
-        cp = ClickhousePool("0:0:0:0", 9000, "default", "")
+        cp = ClickhousePool("0:0:0:0", 9000, "default", "", "default")
         cp.execute("SHOW TABLES")
         assert FakeClient.return_value.execute.mock_calls == [
             call("SHOW TABLES"),

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -67,7 +67,7 @@ def test_no_split(
         return QueryResult({}, {})
 
     strategy = SimpleQueryPlanExecutionStrategy(
-        ClickhouseCluster("localhost", 1024, "default", "", 80, set(), True),
+        ClickhouseCluster("localhost", 1024, "default", "", "default", 80, set(), True),
         [],
         [
             ColumnSplitQueryStrategy(
@@ -174,7 +174,7 @@ def test_col_split(
     )
 
     strategy = SimpleQueryPlanExecutionStrategy(
-        ClickhouseCluster("localhost", 1024, "default", "", 80, set(), True),
+        ClickhouseCluster("localhost", 1024, "default", "", "default", 80, set(), True),
         [],
         [
             ColumnSplitQueryStrategy(id_column, project_column, timestamp_column),

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -51,6 +51,7 @@ class TestHTTPBatchWriter(BaseEventsTest):
             9000,
             "default",
             "",
+            "default",
             lambda a: a,
             None,
             chunk_size,


### PR DESCRIPTION
Closes https://github.com/getsentry/snuba/issues/874

This PR adds a database variable to the clickhouse connection hence all further read, write clickhouse operations will happen to the tables in this database. I have tested with my development sentry10 setup.