### PR TITLE
fix(ast): Fix matcher check on optional parameters

### DIFF
--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -313,7 +313,7 @@ class FunctionCall(Pattern[FunctionCallExpr]):
                 result = result.merge(partial_result)
 
         if self.parameters:
-            if self.with_optionals is None:
+            if not self.with_optionals:
                 if len(self.parameters) != len(node.parameters):
                     return None
             else:

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -105,6 +105,19 @@ test_cases = [
         MatchResult({"p1": ColumnExpr("relevant", "relevant", "relevant")}),
     ),
     (
+        "Wrong number of parameters, does not match",
+        FunctionCall(None, None, (Param("p1", Any(ColumnExpr)),)),
+        FunctionCallExpr(
+            "irrelevant",
+            "irrelevant",
+            (
+                ColumnExpr("relevant", "relevant", "relevant"),
+                ColumnExpr("relevant", "relevant", "relevant"),
+            ),
+        ),
+        None,
+    ),
+    (
         "Does not match any Column",
         FunctionCall(None, None, (Param("p1", Any(ColumnExpr)),)),
         FunctionCallExpr("irrelevant", "irrelevant", (LiteralExpr(None, "str"),),),


### PR DESCRIPTION
Well, this was dumb.... 
`with_optionals` is boolean so the check should be `if not with_optionals`

Fortunately none is relying on that condition to work yet.