### PR TITLE
feat(ast): Sessions translator

### DIFF
--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -36,7 +36,11 @@ class LiteralMapper(SnubaClickhouseMapper[Literal, Literal]):
     pass
 
 
-class ColumnMapper(SnubaClickhouseMapper[Column, Union[Column, Literal, FunctionCall]]):
+class ColumnMapper(
+    SnubaClickhouseMapper[
+        Column, Union[Column, Literal, FunctionCall, CurriedFunctionCall]
+    ]
+):
     """
     Columns can be translated into other Columns, or Literals (if a Snuba
     column has a hardcoded value on a storage like the event type on

--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -36,11 +36,10 @@ class LiteralMapper(SnubaClickhouseMapper[Literal, Literal]):
     pass
 
 
-class ColumnMapper(
-    SnubaClickhouseMapper[
-        Column, Union[Column, Literal, FunctionCall, CurriedFunctionCall]
-    ]
-):
+ValidColumnMappings = Union[Column, Literal, FunctionCall, CurriedFunctionCall]
+
+
+class ColumnMapper(SnubaClickhouseMapper[Column, ValidColumnMappings]):
     """
     Columns can be translated into other Columns, or Literals (if a Snuba
     column has a hardcoded value on a storage like the event type on

--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -1,5 +1,6 @@
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from snuba.clickhouse.translators.snuba import SnubaClickhouseStrictTranslator
 from snuba.clickhouse.translators.snuba.allowed import (
@@ -9,6 +10,7 @@ from snuba.clickhouse.translators.snuba.allowed import (
 from snuba.query.dsl import arrayElement
 from snuba.query.expressions import Column as ColumnExpr
 from snuba.query.expressions import Expression
+from snuba.query.expressions import CurriedFunctionCall
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.expressions import OptionalScalarType, SubscriptableReference
@@ -25,93 +27,127 @@ from snuba.util import qualified_column
 
 
 @dataclass(frozen=True)
-class ColumnToColumn(ColumnMapper):
+class ColumnToExpression(ColumnMapper, ABC):
+    """
+    Provides some common logic for all the mappers that transform a specific
+    column identified by table and name into one of the allowed expressions
+    a column can be translated into.
+    This exists for convenience just to avoid some code duplication.
+    """
+
+    from_table_name: Optional[str]
+    from_col_name: str
+
+    def attempt_map(
+        self,
+        expression: ColumnExpr,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Optional[
+        Union[ColumnExpr, LiteralExpr, FunctionCallExpr, CurriedFunctionCall]
+    ]:
+        if (
+            expression.column_name == self.from_col_name
+            and expression.table_name == self.from_table_name
+        ):
+            return self._produce_output(expression, children_translator)
+        else:
+            return None
+
+    @abstractmethod
+    def _produce_output(
+        self,
+        expression: ColumnExpr,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Union[ColumnExpr, LiteralExpr, FunctionCallExpr, CurriedFunctionCall]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class ColumnToColumn(ColumnToExpression):
     """
     Maps a column with a name and a table into a column with a different name and table.
 
     The alias is not transformed.
     """
 
-    from_table_name: Optional[str]
-    from_col_name: str
     to_table_name: Optional[str]
     to_col_name: str
 
-    def attempt_map(
+    def _produce_output(
         self,
         expression: ColumnExpr,
         children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[ColumnExpr]:
-        if (
-            expression.column_name == self.from_col_name
-            and expression.table_name == self.from_table_name
-        ):
-            return ColumnExpr(
-                alias=expression.alias
-                or qualified_column(self.from_col_name, self.from_table_name or ""),
-                table_name=self.to_table_name,
-                column_name=self.to_col_name,
-            )
-        else:
-            return None
+    ) -> ColumnExpr:
+        return ColumnExpr(
+            alias=expression.alias
+            or qualified_column(self.from_col_name, self.from_table_name or ""),
+            table_name=self.to_table_name,
+            column_name=self.to_col_name,
+        )
 
 
 @dataclass(frozen=True)
-class ColumnToLiteral(ColumnMapper):
+class ColumnToLiteral(ColumnToExpression):
     """
     Maps a column name into a hardcoded literal preserving the alias.
     """
 
-    from_table_name: Optional[str]
-    from_col_name: str
     to_literal_value: OptionalScalarType
 
-    def attempt_map(
+    def _produce_output(
         self,
         expression: ColumnExpr,
         children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[LiteralExpr]:
-        if (
-            expression.table_name == self.from_table_name
-            and expression.column_name == self.from_col_name
-        ):
-            return LiteralExpr(
-                alias=expression.alias
-                or qualified_column(self.from_col_name, self.from_table_name or ""),
-                value=self.to_literal_value,
-            )
-        else:
-            return None
+    ) -> LiteralExpr:
+        return LiteralExpr(
+            alias=expression.alias
+            or qualified_column(self.from_col_name, self.from_table_name or ""),
+            value=self.to_literal_value,
+        )
 
 
 @dataclass(frozen=True)
-class ColumnToFunction(ColumnMapper):
+class ColumnToFunction(ColumnToExpression):
     """
     Maps a column into a function expression that preserves the alias.
     """
 
-    from_table_name: Optional[str]
-    from_col_name: str
     to_function_name: str
     to_function_params: Tuple[Expression, ...]
 
-    def attempt_map(
+    def _produce_output(
         self,
         expression: ColumnExpr,
         children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[FunctionCallExpr]:
-        if (
-            expression.table_name == self.from_table_name
-            and expression.column_name == self.from_col_name
-        ):
-            return FunctionCallExpr(
-                alias=expression.alias
-                or qualified_column(self.from_col_name, self.from_table_name or ""),
-                function_name=self.to_function_name,
-                parameters=self.to_function_params,
-            )
-        else:
-            return None
+    ) -> FunctionCallExpr:
+        return FunctionCallExpr(
+            alias=expression.alias
+            or qualified_column(self.from_col_name, self.from_table_name or ""),
+            function_name=self.to_function_name,
+            parameters=self.to_function_params,
+        )
+
+
+@dataclass(frozen=True)
+class ColumnToCurriedFunction(ColumnToExpression):
+    """
+    Maps a column into a curried function expression that preserves the alias.
+    """
+
+    to_internal_function: FunctionCallExpr
+    to_function_params: Tuple[Expression, ...]
+
+    def _produce_output(
+        self,
+        expression: ColumnExpr,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> CurriedFunctionCall:
+        return CurriedFunctionCall(
+            alias=expression.alias
+            or qualified_column(self.from_col_name, self.from_table_name or ""),
+            internal_function=self.to_internal_function,
+            parameters=self.to_function_params,
+        )
 
 
 @dataclass(frozen=True)
@@ -146,38 +182,28 @@ class SubscriptableMapper(SubscriptableReferenceMapper):
 
 
 @dataclass(frozen=True)
-class ColumnToMapping(ColumnMapper):
+class ColumnToMapping(ColumnToExpression):
     """
     Maps a column into a mapping expression thus into a Clickhouse
     array access.
     """
 
-    from_column_table: Optional[str]
-    from_column_name: str
-    to_nested_col_table: Optional[str]
+    to_nested_col_table_name: Optional[str]
     to_nested_col_name: str
     to_nested_tag_key: str
 
-    def attempt_map(
+    def _produce_output(
         self,
         expression: ColumnExpr,
         children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[FunctionCallExpr]:
-        if (
-            expression.table_name == self.from_column_table
-            and expression.column_name == self.from_column_name
-        ):
-            return build_mapping_expr(
-                expression.alias
-                or qualified_column(
-                    self.from_column_name, self.from_column_table or ""
-                ),
-                self.to_nested_col_table,
-                self.to_nested_col_name,
-                LiteralExpr(None, self.to_nested_tag_key),
-            )
-        else:
-            return None
+    ) -> FunctionCallExpr:
+        return build_mapping_expr(
+            expression.alias
+            or qualified_column(self.from_col_name, self.from_table_name or ""),
+            self.to_nested_col_table_name,
+            self.to_nested_col_name,
+            LiteralExpr(None, self.to_nested_tag_key),
+        )
 
 
 def build_mapping_expr(

--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -48,15 +48,13 @@ class ColumnToExpression(ColumnMapper, ABC):
             expression.column_name == self.from_col_name
             and expression.table_name == self.from_table_name
         ):
-            return self._produce_output(expression, children_translator)
+            return self._produce_output(expression)
         else:
             return None
 
     @abstractmethod
     def _produce_output(
-        self,
-        expression: ColumnExpr,
-        children_translator: SnubaClickhouseStrictTranslator,
+        self, expression: ColumnExpr,
     ) -> Union[ColumnExpr, LiteralExpr, FunctionCallExpr, CurriedFunctionCall]:
         raise NotImplementedError
 
@@ -72,11 +70,7 @@ class ColumnToColumn(ColumnToExpression):
     to_table_name: Optional[str]
     to_col_name: str
 
-    def _produce_output(
-        self,
-        expression: ColumnExpr,
-        children_translator: SnubaClickhouseStrictTranslator,
-    ) -> ColumnExpr:
+    def _produce_output(self, expression: ColumnExpr) -> ColumnExpr:
         return ColumnExpr(
             alias=expression.alias
             or qualified_column(self.from_col_name, self.from_table_name or ""),
@@ -93,11 +87,7 @@ class ColumnToLiteral(ColumnToExpression):
 
     to_literal_value: OptionalScalarType
 
-    def _produce_output(
-        self,
-        expression: ColumnExpr,
-        children_translator: SnubaClickhouseStrictTranslator,
-    ) -> LiteralExpr:
+    def _produce_output(self, expression: ColumnExpr,) -> LiteralExpr:
         return LiteralExpr(
             alias=expression.alias
             or qualified_column(self.from_col_name, self.from_table_name or ""),
@@ -114,11 +104,7 @@ class ColumnToFunction(ColumnToExpression):
     to_function_name: str
     to_function_params: Tuple[Expression, ...]
 
-    def _produce_output(
-        self,
-        expression: ColumnExpr,
-        children_translator: SnubaClickhouseStrictTranslator,
-    ) -> FunctionCallExpr:
+    def _produce_output(self, expression: ColumnExpr) -> FunctionCallExpr:
         return FunctionCallExpr(
             alias=expression.alias
             or qualified_column(self.from_col_name, self.from_table_name or ""),
@@ -136,11 +122,7 @@ class ColumnToCurriedFunction(ColumnToExpression):
     to_internal_function: FunctionCallExpr
     to_function_params: Tuple[Expression, ...]
 
-    def _produce_output(
-        self,
-        expression: ColumnExpr,
-        children_translator: SnubaClickhouseStrictTranslator,
-    ) -> CurriedFunctionCall:
+    def _produce_output(self, expression: ColumnExpr) -> CurriedFunctionCall:
         return CurriedFunctionCall(
             alias=expression.alias
             or qualified_column(self.from_col_name, self.from_table_name or ""),
@@ -191,11 +173,7 @@ class ColumnToMapping(ColumnToExpression):
     to_nested_col_name: str
     to_nested_tag_key: str
 
-    def _produce_output(
-        self,
-        expression: ColumnExpr,
-        children_translator: SnubaClickhouseStrictTranslator,
-    ) -> FunctionCallExpr:
+    def _produce_output(self, expression: ColumnExpr) -> FunctionCallExpr:
         return build_mapping_expr(
             expression.alias
             or qualified_column(self.from_col_name, self.from_table_name or ""),

--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -9,8 +9,7 @@ from snuba.clickhouse.translators.snuba.allowed import (
 )
 from snuba.query.dsl import arrayElement
 from snuba.query.expressions import Column as ColumnExpr
-from snuba.query.expressions import Expression
-from snuba.query.expressions import CurriedFunctionCall
+from snuba.query.expressions import CurriedFunctionCall, Expression
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.expressions import OptionalScalarType, SubscriptableReference

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,10 +1,16 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
+from snuba.clickhouse.translators.snuba.mappers import (
+    ColumnToCurriedFunction,
+    ColumnToFunction,
+)
+from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.dataset import TimeSeriesDataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
+from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
 from snuba.query.organization_extension import OrganizationExtension
@@ -14,6 +20,12 @@ from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.timeseries_column_processor import TimeSeriesColumnProcessor
 from snuba.query.project_extension import ProjectExtension, ProjectExtensionProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
+
+
+def function_rule(col_name: str, function_name: str) -> ColumnToFunction:
+    return ColumnToFunction(
+        None, col_name, function_name, (Column(None, None, col_name),),
+    )
 
 
 class SessionsDataset(TimeSeriesDataset):
@@ -30,6 +42,28 @@ class SessionsDataset(TimeSeriesDataset):
             # selector that decides when to use the materialized data.
             query_plan_builder=SingleStorageQueryPlanBuilder(
                 storage=materialized_storage,
+                mappers=TranslationMappers(
+                    columns=[
+                        ColumnToCurriedFunction(
+                            None,
+                            "duration_quantiles",
+                            FunctionCall(
+                                None,
+                                "quantilesIfMerge",
+                                (Literal(None, 0.5), Literal(None, 0.9)),
+                            ),
+                            (Column(None, None, "duration_quantiles"),),
+                        ),
+                        function_rule("sessions", "countIfMerge"),
+                        function_rule("sessions_crashed", "countIfMerge"),
+                        function_rule("sessions_abnormal", "countIfMerge"),
+                        function_rule("users", "uniqIfMerge"),
+                        function_rule("sessions_errored", "uniqIfMerge"),
+                        function_rule("users_crashed", "uniqIfMerge"),
+                        function_rule("users_abnormal", "uniqIfMerge"),
+                        function_rule("users_errored", "uniqIfMerge"),
+                    ]
+                ),
             ),
             abstract_column_set=read_schema.get_columns(),
             writable_storage=writable_storage,

--- a/tests/clickhouse/translators/snuba/test_translation.py
+++ b/tests/clickhouse/translators/snuba/test_translation.py
@@ -3,6 +3,7 @@ import pytest
 from snuba.clickhouse.query import Expression as ClickhouseExpression
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToFunction,
+    ColumnToCurriedFunction,
     ColumnToLiteral,
     ColumnToMapping,
     ColumnToColumn,
@@ -49,6 +50,26 @@ def test_column_function_translation() -> None:
         "ip_address",
         "coalesce",
         (Column(None, None, "ip_address_v4"), Column(None, None, "ip_address_v6")),
+    )
+
+
+def test_column_curried_function_translation() -> None:
+    assert ColumnToCurriedFunction(
+        None,
+        "duration_quantiles",
+        FunctionCall(
+            None, "quantilesIfMerge", (Literal(None, 0.5), Literal(None, 0.9),)
+        ),
+        (Column(None, None, "duration_quantiles"),),
+    ).attempt_map(
+        Column(None, None, "duration_quantiles"),
+        SnubaClickhouseMappingTranslator(TranslationMappers()),
+    ) == CurriedFunctionCall(
+        "duration_quantiles",
+        FunctionCall(
+            None, "quantilesIfMerge", (Literal(None, 0.5), Literal(None, 0.9),)
+        ),
+        (Column(None, None, "duration_quantiles"),),
     )
 
 

--- a/tests/clickhouse/translators/snuba/test_translation.py
+++ b/tests/clickhouse/translators/snuba/test_translation.py
@@ -2,11 +2,11 @@ import pytest
 
 from snuba.clickhouse.query import Expression as ClickhouseExpression
 from snuba.clickhouse.translators.snuba.mappers import (
-    ColumnToFunction,
+    ColumnToColumn,
     ColumnToCurriedFunction,
+    ColumnToFunction,
     ColumnToLiteral,
     ColumnToMapping,
-    ColumnToColumn,
     SubscriptableMapper,
 )
 from snuba.clickhouse.translators.snuba.mapping import (

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -9,14 +9,14 @@ from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
 
-def test_events_processing() -> None:
+def test_sessions_processing() -> None:
     query_body = {"selected_columns": ["duration_quantiles", "sessions", "users"]}
 
-    events = get_dataset("sessions")
-    query = parse_query(query_body, events)
+    sessions = get_dataset("sessions")
+    query = parse_query(query_body, sessions)
     request = Request("", query, HTTPRequestSettings(), {}, "")
 
-    query_plan = events.get_query_plan_builder().build_plan(request)
+    query_plan = sessions.get_query_plan_builder().build_plan(request)
     for clickhouse_processor in query_plan.plan_processors:
         clickhouse_processor.process_query(query_plan.query, request.settings)
 

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -1,0 +1,41 @@
+from snuba.clickhouse.query import Query
+from snuba.clickhouse.sql import SqlQuery
+from snuba.datasets.factory import get_dataset
+from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
+from snuba.query.parser import parse_query
+from snuba.reader import Reader
+from snuba.request import Request
+from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
+from snuba.web import QueryResult
+
+
+def test_events_processing() -> None:
+    query_body = {"selected_columns": ["duration_quantiles", "sessions", "users"]}
+
+    events = get_dataset("sessions")
+    query = parse_query(query_body, events)
+    request = Request("", query, HTTPRequestSettings(), {}, "")
+
+    query_plan = events.get_query_plan_builder().build_plan(request)
+    for clickhouse_processor in query_plan.plan_processors:
+        clickhouse_processor.process_query(query_plan.query, request.settings)
+
+    def query_runner(
+        query: Query, settings: RequestSettings, reader: Reader[SqlQuery]
+    ) -> QueryResult:
+        assert query.get_selected_columns_from_ast() == [
+            CurriedFunctionCall(
+                "duration_quantiles",
+                FunctionCall(
+                    None, "quantilesIfMerge", (Literal(None, 0.5), Literal(None, 0.9))
+                ),
+                (Column(None, None, "duration_quantiles"),),
+            ),
+            FunctionCall("sessions", "countIfMerge", (Column(None, None, "sessions"),)),
+            FunctionCall("users", "uniqIfMerge", (Column(None, None, "users"),)),
+        ]
+        return QueryResult({}, {})
+
+    query_plan.execution_strategy.execute(
+        query_plan.query, request.settings, query_runner
+    )


### PR DESCRIPTION
Adds the query translator for the sessions dataset. Like #992, #985 and #978

It also adds a ColumnToCurriedFunction mapper since there is a curried function used in the sessions dataset.