### PR TITLE
fix(ast) Use datetime Literals instead of strings

### DIFF
--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -394,7 +394,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             query,
             self.__timestamp_column,
             ">=",
-            LiteralExpr(None, util.parse_datetime(min(timestamps)).isoformat()),
+            LiteralExpr(None, util.parse_datetime(min(timestamps))),
         )
         # We add 1 second since this gets translated to ('timestamp', '<', to_date)
         # and events are stored with a granularity of 1 second.
@@ -409,10 +409,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             self.__timestamp_column,
             "<",
             LiteralExpr(
-                None,
-                (
-                    util.parse_datetime(max(timestamps)) + timedelta(seconds=1)
-                ).isoformat(),
+                None, (util.parse_datetime(max(timestamps)) + timedelta(seconds=1)),
             ),
         )
 


### PR DESCRIPTION
datetime literals should include a datetime object and not a string. Otherwise the "toDateTime" function is not applied when building the query and the query fails. The other cases are already using datetime.