### PR TITLE
test: Run all tests in a separate ClickHouse database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,4 +36,3 @@ install-librdkafka-src:
 	rm -rf tmp-build-librdkafka
 
 install-librdkafka: $(librdkafka_cmd)
-

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
 import os
 
 os.environ.setdefault("SNUBA_SETTINGS", "test")
+os.environ.setdefault("CLICKHOUSE_DATABASE", "snuba_test")

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,5 @@
 import calendar
+import os
 import uuid
 from contextlib import contextmanager
 from copy import deepcopy
@@ -76,7 +77,7 @@ class BaseTest(object):
             settings.TESTING
         ), "settings.TESTING is False, try `SNUBA_SETTINGS=test` or `make test`"
 
-        self.database = "default"
+        self.database = os.environ.get("CLICKHOUSE_DATABASE", "default")
         self.dataset_name = dataset_name
 
         if dataset_name is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,20 @@
+from snuba import settings
+from snuba.clickhouse.native import ClickhousePool
 from snuba.environment import setup_sentry
 
 
-def pytest_configure():
-    """ Set up the Sentry SDK to avoid errors hidden by configuration """
+def pytest_configure() -> None:
+    """
+    Set up the Sentry SDK to avoid errors hidden by configuration.
+    Ensure the snuba_test database exists
+    """
     setup_sentry()
+
+    # There is only one cluster in test, so fetch the host from there.
+    cluster = settings.CLUSTERS[0]
+
+    connection = ClickhousePool(
+        cluster["host"], cluster["port"], "default", "", "default",
+    )
+
+    connection.execute("CREATE DATABASE IF NOT EXISTS snuba_test;")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,4 +17,5 @@ def pytest_configure() -> None:
         cluster["host"], cluster["port"], "default", "", "default",
     )
 
-    connection.execute("CREATE DATABASE IF NOT EXISTS snuba_test;")
+    database_name = cluster["database"]
+    connection.execute(f"CREATE DATABASE IF NOT EXISTS {database_name};")


### PR DESCRIPTION
We should run our tests in a separate ClickHouse database. This will
allow us to keep tests better separated from dev and simplify the
table name logic and not rely on preprepending the table names with `test_`.