### PR TITLE
test: Make the table names the same in test

### DIFF
--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -56,7 +56,7 @@ class TableSchema(Schema, ABC):
     a simple select and that provides DDL operations.
     """
 
-    TEST_TABLE_PREFIX = "test_"
+    TEST_TABLE_PREFIX = ""
 
     def __init__(
         self,

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Callable, Mapping, NamedTuple, Optional, Sequence
 
-from snuba import settings
 from snuba.clickhouse.columns import ColumnSet, ColumnType
 from snuba.clusters.cluster import get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
@@ -56,8 +55,6 @@ class TableSchema(Schema, ABC):
     a simple select and that provides DDL operations.
     """
 
-    TEST_TABLE_PREFIX = ""
-
     def __init__(
         self,
         columns: ColumnSet,
@@ -91,26 +88,19 @@ class TableSchema(Schema, ABC):
         """
         return self.__table_source
 
-    def _make_test_table(self, table_name: str) -> str:
-        return (
-            table_name
-            if not settings.TESTING
-            else "%s%s" % (self.TEST_TABLE_PREFIX, table_name)
-        )
-
     def get_local_table_name(self) -> str:
         """
         This returns the local table name for a distributed environment.
         It is supposed to be used in DDL commands and for maintenance.
         """
-        return self._make_test_table(self.__local_table_name)
+        return self.__local_table_name
 
     def get_table_name(self) -> str:
         """
         This represents the table we interact with to send queries to Clickhouse.
         In distributed mode this will be a distributed table. In local mode it is a local table.
         """
-        return self._make_test_table(self.__table_name)
+        return self.__table_name
 
     def get_local_drop_table_statement(self) -> DDLStatement:
         return DDLStatement(
@@ -306,10 +296,10 @@ class MaterializedViewSchema(TableSchema):
         self.__dist_destination_table_name = dist_destination_table_name
 
     def __get_local_source_table_name(self) -> str:
-        return self._make_test_table(self.__local_source_table_name)
+        return self.__local_source_table_name
 
     def __get_local_destination_table_name(self) -> str:
-        return self._make_test_table(self.__local_destination_table_name)
+        return self.__local_destination_table_name
 
     def __get_table_definition(
         self, name: str, source_table_name: str, destination_table_name: str

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -19,22 +19,19 @@ def get_dataset_source(dataset_name):
 
 
 test_data = [
-    ({"conditions": [["type", "=", "transaction"]]}, "test_transactions_local",),
-    ({"conditions": [["type", "!=", "transaction"]]}, "test_sentry_local",),
-    ({"conditions": []}, "test_sentry_local",),
-    ({"conditions": [["duration", "=", 0]]}, "test_transactions_local",),
+    ({"conditions": [["type", "=", "transaction"]]}, "transactions_local",),
+    ({"conditions": [["type", "!=", "transaction"]]}, "sentry_local",),
+    ({"conditions": []}, "sentry_local",),
+    ({"conditions": [["duration", "=", 0]]}, "transactions_local",),
     (
         {"conditions": [["event_id", "=", "asdasdasd"], ["duration", "=", 0]]},
-        "test_transactions_local",
+        "transactions_local",
     ),
     # No conditions, other referenced columns
-    ({"selected_columns": ["group_id"]}, "test_sentry_local"),
-    ({"selected_columns": ["trace_id"]}, "test_transactions_local"),
-    ({"selected_columns": ["group_id", "trace_id"]}, "test_sentry_local"),
-    (
-        {"aggregations": [["max", "duration", "max_duration"]]},
-        "test_transactions_local",
-    ),
+    ({"selected_columns": ["group_id"]}, "sentry_local"),
+    ({"selected_columns": ["trace_id"]}, "transactions_local"),
+    ({"selected_columns": ["group_id", "trace_id"]}, "sentry_local"),
+    ({"aggregations": [["max", "duration", "max_duration"]]}, "transactions_local",),
 ]
 
 

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -124,7 +124,7 @@ class TestGroupassignee(BaseDatasetTest):
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute("SELECT * FROM test_groupassignee_local;")
+            .execute("SELECT * FROM groupassignee_local;")
         )
         assert ret[0] == (
             42,  # offset
@@ -183,7 +183,7 @@ class TestGroupassignee(BaseDatasetTest):
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute("SELECT * FROM test_groupassignee_local;")
+            .execute("SELECT * FROM groupassignee_local;")
         )
         assert ret[0] == (
             0,  # offset

--- a/tests/datasets/test_join_source.py
+++ b/tests/datasets/test_join_source.py
@@ -8,12 +8,12 @@ from tests.datasets.schemas.join_examples import (
 test_data = [
     (
         simple_join_structure,
-        "test_table1 t1 INNER JOIN test_table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
+        "table1 t1 INNER JOIN table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
     ),
     (
         complex_join_structure,
-        "test_table1 t1 FULL JOIN test_table2 t2 ON t1.t1c1 = t2.t2c2 "
-        "INNER JOIN test_table3 t3 ON t1.t1c1 = t3.t3c3",
+        "table1 t1 FULL JOIN table2 t2 ON t1.t1c1 = t2.t2c2 "
+        "INNER JOIN table3 t3 ON t1.t1c1 = t3.t3c3",
     ),
 ]
 

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -395,6 +395,6 @@ def test_aliasing() -> None:
     assert sql == (
         "SELECT (arrayElement((arrayJoin(arrayMap((x, y -> array(x, y)), "
         "tags.key, tags.value)) AS snuba_all_tags), 2) AS tags_value) "
-        "FROM test_transactions_local "
+        "FROM transactions_local "
         "WHERE in((arrayElement(snuba_all_tags, 1) AS tags_key), tuple('t1', 't2'))"
     )

--- a/tests/query/processors/test_join_optimizer.py
+++ b/tests/query/processors/test_join_optimizer.py
@@ -13,20 +13,20 @@ test_data = [
         ["t1.t1c1", "t2.t2c2"],
         [["t1.t2c2", "=", "a"]],
         [],
-        "test_table1 t1 INNER JOIN test_table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
+        "table1 t1 INNER JOIN table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
     ),
-    (["t1.t1c1"], [["t1.t1c2", "=", "a"]], [], "test_table1 t1"),
+    (["t1.t1c1"], [["t1.t1c2", "=", "a"]], [], "table1 t1"),
     (
         ["t1.t1c1"],
         [["t2.t1c1", "=", "a"]],
         [],
-        "test_table1 t1 INNER JOIN test_table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
+        "table1 t1 INNER JOIN table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
     ),
     (
         ["t1.t1c1"],
         [],
         ["t2.t2c2"],
-        "test_table1 t1 INNER JOIN test_table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
+        "table1 t1 INNER JOIN table2 t2 ON t1.t1c1 = t2.t2c2 AND t1.t1c3 = t2.t2c4",
     ),
 ]
 

--- a/tests/query/processors/test_tags_processor.py
+++ b/tests/query/processors/test_tags_processor.py
@@ -16,7 +16,7 @@ test_data = [
             "groupby": [],
             "conditions": [["c3", "IN", ["t1", "t2"]]],
         },
-        "SELECT c1, c2, c3 FROM test_transactions_local WHERE c3 IN ('t1', 't2')",
+        "SELECT c1, c2, c3 FROM transactions_local WHERE c3 IN ('t1', 't2')",
     ),
     (
         {
@@ -27,7 +27,7 @@ test_data = [
         },
         (
             "SELECT (tags.value[indexOf(tags.key, 't1')] AS `tags[t1]`) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE (arrayJoin(tags.key) AS tags_key) IN ('t1', 't2')"
         ),
     ),  # Individual tag, no change
@@ -41,7 +41,7 @@ test_data = [
         (
             "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
             "AS all_tags))[2] AS tags_value) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE ((all_tags)[1] AS tags_key) IN ('t1', 't2')"
         ),
     ),  # Tags key in condition but only value in select. This could technically be
@@ -56,7 +56,7 @@ test_data = [
         (
             "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags))[1] "
             "AS tags_key), ((all_tags)[2] AS tags_value) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE col IN ('t1', 't2')"
         ),
     ),  # tags_key and value in select but no condition on it. No change
@@ -69,7 +69,7 @@ test_data = [
         },
         (
             "SELECT (arrayJoin(arrayFilter(tag -> tag IN ('t1','t2'), tags.key)) AS tags_key) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2')"
         ),
     ),  # tags_key in both select and condition. Apply change
@@ -82,7 +82,7 @@ test_data = [
         },
         (
             "SELECT (arrayJoin(arrayFilter(tag -> tag IN ('t1','t2'), tags.key)) AS tags_key), tags_key "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "GROUP BY (tags_key) "
             "HAVING tags_key IN ('t1', 't2')"
         ),
@@ -98,7 +98,7 @@ test_data = [
             "SELECT (((arrayJoin(arrayFilter(pair -> pair[1] IN ('t1','t2'), "
             "arrayMap((x,y) -> [x,y], tags.key, tags.value))) AS all_tags))[1] AS tags_key), "
             "((all_tags)[2] AS tags_value) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2')"
         ),
     ),  # tags_key and value in select and condition. Apply change
@@ -117,7 +117,7 @@ test_data = [
             "SELECT (((arrayJoin(arrayFilter(pair -> pair[1] IN ('t1','t2','t3','t4','t5'), "
             "arrayMap((x,y) -> [x,y], tags.key, tags.value))) AS all_tags))[1] AS tags_key), "
             "((all_tags)[2] AS tags_value) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2') AND "
             "tags_key IN ('t3', 't4') AND "
             "tags_key = 't5'"
@@ -137,7 +137,7 @@ test_data = [
         (
             "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags))[1] "
             "AS tags_key), ((all_tags)[2] AS tags_value) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE (tags_key IN ('t1', 't2') OR tags_key IN ('t3', 't4'))"
         ),
     ),  # Skip OR nested conditions
@@ -154,7 +154,7 @@ test_data = [
         (
             "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags))[1] "
             "AS tags_key), ((all_tags)[2] AS tags_value) "
-            "FROM test_transactions_local "
+            "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2') AND (tags_key IN ('t3', 't4') OR tags_key = 't5')"
         ),
     ),  # Mixed case, some tags_key on top level some are not. Cannot do anything.

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -135,7 +135,7 @@ class TestGroupedMessage(BaseDatasetTest):
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.INSERT)
-            .execute("SELECT * FROM test_groupedmessage_local;")
+            .execute("SELECT * FROM groupedmessage_local;")
         )
         assert ret[0] == (
             42,  # offset
@@ -190,7 +190,7 @@ class TestGroupedMessage(BaseDatasetTest):
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute("SELECT * FROM test_groupedmessage_local;")
+            .execute("SELECT * FROM groupedmessage_local;")
         )
         assert ret[0] == (
             0,  # offset


### PR DESCRIPTION
Drop the `test_` prefix from the ClickHouse tables names and make them
the same as other environments. Since we are using a different database
for tests now, using a different table name is unnecessary.