### PR TITLE
ci: enforce pre-commit and remove useless branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ branches:
   only:
     - master
 
-cache: pip
+cache:
+  pip: true
+  npm: true
 
 stages: [pre_commit, test]
 
@@ -24,7 +26,8 @@ matrix:
         - pre-commit run --files $(git diff --diff-filter=d --name-only master)
     - name: 'Test'
       stage: test
-      language: minimal
+      language: node_js
+      node_js: 10
       services:
         - docker
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,33 @@
-services:
-  - docker
-
 dist: xenial
 
-before_install:
-  - docker pull getsentry/snuba:latest || true
-  - docker build -t getsentry/snuba . --cache-from getsentry/snuba:latest
-  - docker network create --attachable cloudbuild
+stages: [pre_commit, test]
 
-script:
-  - SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test
+matrix:
+  fast_finish: true
+  include:
+    - name: 'pre-commit hooks (includes python formatting + linting)'
+      stage: pre_commit
+      install:
+        - make setup-git
+      script:
+        # Run pre-commit to lint and format check files that were changed (but not deleted) compared to master.
+        # XXX: there is a very small chance that it'll expand to exceed Linux's limits
+        #      `getconf ARG_MAX` - max # bytes of args + environ for exec()
+        - pre-commit run --files $(git diff --diff-filter=d --name-only master)
+    - name: 'Test'
+      stage: test
+      services:
+        - docker
+      before_install:
+        - docker pull getsentry/snuba:latest || true
+        - docker build -t getsentry/snuba . --cache-from getsentry/snuba:latest
+        - docker network create --attachable cloudbuild
+      script:
+        - SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test
+      after_script:
+        - npm install -g @zeus-ci/cli
+        - $(npm bin -g)/zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
+        - $(npm bin -g)/zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml
 
 notifications:
   webhooks:
@@ -20,7 +38,3 @@ notifications:
     on_start: always
     on_cancel: always
     on_error: always
-after_script:
-  - npm install -g @zeus-ci/cli
-  - $(npm bin -g)/zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
-  - $(npm bin -g)/zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 dist: xenial
 
+branches:
+  only:
+    - master
+
 stages: [pre_commit, test]
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
         - pre-commit run --files $(git diff --diff-filter=d --name-only master)
     - name: 'Test'
       stage: test
+      language: minimal
       services:
         - docker
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,29 @@ branches:
   only:
     - master
 
-cache: pip
+cache:
+  pip: true
+  directories:
+    - '$VOLTA_HOME'
+
+env:
+  global:
+    - VOLTA_VERSION=0.8.1
+    - VOLTA_HOME="${HOME}/.volta"
+    - PATH="${HOME}/.volta/bin:${PATH}"
+
+install_volta: &install_volta |-
+  command -v volta && return 0
+  wget --quiet "https://github.com/volta-cli/volta/releases/download/v$VOLTA_VERSION/volta-$VOLTA_VERSION-linux-openssl-1.0.tar.gz"
+  tar -xzf "volta-$VOLTA_VERSION-linux-openssl-1.0.tar.gz" -C "${HOME}/bin"
+  # Running `volta -v` triggers setting up the shims in VOLTA_HOME (otherwise node won't work)
+  volta -v
+
+install_node: &install_node |-
+  command -v node && return 0
+  volta install node@10.16.3
 
 stages: [pre_commit, test]
-
 matrix:
   fast_finish: true
   include:
@@ -34,9 +53,11 @@ matrix:
       script:
         - SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test
       after_script:
-        - npm install -g @zeus-ci/cli
-        - $(npm bin -g)/zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
-        - $(npm bin -g)/zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml
+        - *install_volta
+        - *install_node
+        - volta install @zeus-ci/cli
+        - zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
+        - zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
   include:
     - name: 'pre-commit hooks (includes python formatting + linting)'
       stage: pre_commit
+      language: python
+      python: 2.7
       install:
         - make setup-git
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - name: 'pre-commit hooks (includes python formatting + linting)'
       stage: pre_commit
       language: python
-      python: 2.7
+      python: 3.7
       install:
         - make setup-git
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ branches:
   only:
     - master
 
+cache: pip
+
 stages: [pre_commit, test]
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,10 @@ branches:
   only:
     - master
 
-cache:
-  pip: true
-  directories:
-    - '$VOLTA_HOME'
-
-env:
-  global:
-    - VOLTA_VERSION=0.8.1
-    - VOLTA_HOME="${HOME}/.volta"
-    - PATH="${HOME}/.volta/bin:${PATH}"
-
-install_volta: &install_volta |-
-  command -v volta && return 0
-  wget --quiet "https://github.com/volta-cli/volta/releases/download/v$VOLTA_VERSION/volta-$VOLTA_VERSION-linux-openssl-1.0.tar.gz"
-  tar -xzf "volta-$VOLTA_VERSION-linux-openssl-1.0.tar.gz" -C "${HOME}/bin"
-  # Running `volta -v` triggers setting up the shims in VOLTA_HOME (otherwise node won't work)
-  volta -v
-
-install_node: &install_node |-
-  command -v node && return 0
-  volta install node@10.16.3
+cache: pip
 
 stages: [pre_commit, test]
+
 matrix:
   fast_finish: true
   include:
@@ -53,11 +34,9 @@ matrix:
       script:
         - SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test
       after_script:
-        - *install_volta
-        - *install_node
-        - volta install @zeus-ci/cli
-        - zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
-        - zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml
+        - npm install -g @zeus-ci/cli
+        - $(npm bin -g)/zeus upload -t "application/x-junit+xml" .artifacts/*.junit.xml
+        - $(npm bin -g)/zeus upload -t "application/x-cobertura+xml" .artifacts/coverage.xml
 
 notifications:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 develop: install-python-dependencies setup-git
 
 setup-git:
-	pip install 'pre-commit==2.4.0'
+	pip install 'pre-commit==1.21.0'
 	pre-commit install --install-hooks
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 develop: install-python-dependencies setup-git
 
 setup-git:
-	pip install 'pre-commit==1.21.0'
+	pip install 'pre-commit==2.4.0'
 	pre-commit install --install-hooks
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ endif
 develop: install-python-dependencies setup-git
 
 setup-git:
-	pre-commit install
+	pip install 'pre-commit==2.4.0'
+	pre-commit install --install-hooks
 
 test:
 	SNUBA_SETTINGS=test py.test -vv

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -5,7 +5,6 @@ from snuba.clickhouse.columns import (
     UUID,
     ColumnSet,
     ColumnType,
-    Date,
     DateTime,
     IPv4,
     IPv6,

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -68,7 +68,7 @@ def test_error_processor() -> None:
                     ],
                     "data": "",
                     "method": "POST",
-                    "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba",},
+                    "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
                 },
                 "_relay_processed": True,
                 "breadcrumbs": {

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -403,7 +403,7 @@ class TestDiscoverApi(BaseApiTest):
                     "project": self.project_id,
                     "selected_columns": ["contexts[device.charging]"],
                     "aggregations": [["count()", "", "count"]],
-                    "conditions": [["type", "=", "transaction"],],
+                    "conditions": [["type", "=", "transaction"]],
                     "groupby": ["contexts[device.charging]"],
                     "limit": 1000,
                 }
@@ -422,7 +422,7 @@ class TestDiscoverApi(BaseApiTest):
                     "project": self.project_id,
                     "selected_columns": ["contexts[device.charging]"],
                     "aggregations": [["count()", "", "count"]],
-                    "conditions": [["type", "=", "error"],],
+                    "conditions": [["type", "=", "error"]],
                     "groupby": ["contexts[device.charging]"],
                     "limit": 1000,
                 }


### PR DESCRIPTION
This enforces pre-commit to run in CI, so that files don't start drifting away (then occasional mass-reformatting would be necessary).

Two optimizations here:

- pre-commit is only running on files that are changed (but not deleted) compared to master
- pre-commit is the 1st stage in a multistage build, meaning, if it fails, CI will not move on to the next stage

I've also done a `pre-commit run --all-files` pass here.