### PR TITLE
chore: cull unused dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-branches:
-  only:
-    - master
-
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 services:
   - docker
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,7 +41,6 @@
     "editor.formatOnSave": true
   },
 
-  "python.linting.pylintEnabled": false,
   "python.linting.mypyEnabled": true,
   "python.linting.mypyArgs": ["--strict"],
   "python.linting.flake8Enabled": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,25 +9,15 @@ chardet==3.0.4
 click==6.7
 clickhouse-driver==0.1.1
 confluent-kafka==1.2.0
-
-# backport
-contextlib2==0.5.5
-
 coverage==4.5.1
 datadog==0.21.0
 deprecation==2.0.3
 docopt==0.6.2
 
-# backport
-enum34==1.1.6
-
 # dev
 flake8==3.7.8
 
 Flask==1.0.2
-
-# backports
-funcsigs==1.0.2
 future==0.16.0
 
 # dev
@@ -35,11 +25,6 @@ honcho==1.0.1
 
 idna==2.7
 isodate==0.6.0
-
-# dev
-# probably not used
-isort==4.3.4
-
 itsdangerous==0.24
 Jinja2==2.10.1
 jsonschema==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 atomicwrites==1.1.5
 attrs==18.1.0
+blinker==1.4
 
 # dev
 black==19.10b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ future==0.16.0
 honcho==1.0.1
 
 idna==2.7
-isodate==0.6.0
 itsdangerous==0.24
 Jinja2==2.10.1
 jsonschema==3.0.1
@@ -38,7 +37,6 @@ mypy>=0.761
 packaging==17.1
 parsimonious==0.8.1
 py==1.5.3
-Pygments==2.2.0
 pyparsing==2.2.0
 
 # dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,9 +60,7 @@ Pygments==2.2.0
 pyparsing==2.2.0
 pytest==5.2.4
 pytest-cov==2.5.1
-pytest-forked==1.1.3
 pytest-watch==4.2.0
-pytest-xdist==1.30.0
 python-dateutil==2.7.3
 pytz==2018.4
 python-rapidjson==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,6 @@ prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 py==1.5.3
 Pygments==2.2.0
-pylint==1.9.2
 pycodestyle<2.6.0,>=2.5.0
 pyparsing==2.2.0
 pytest==5.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,7 @@
 atomicwrites==1.1.5
 attrs==18.1.0
 blinker==1.4
-
-# dev
 black==19.10b0
-
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
@@ -14,16 +11,10 @@ coverage==4.5.1
 datadog==0.21.0
 deprecation==2.0.3
 docopt==0.6.2
-
-# dev
 flake8==3.7.8
-
 Flask==1.0.2
 future==0.16.0
-
-# dev
 honcho==1.0.1
-
 idna==2.7
 itsdangerous==0.24
 Jinja2==2.10.1
@@ -38,15 +29,12 @@ packaging==17.1
 parsimonious==0.8.1
 py==1.5.3
 pyparsing==2.2.0
-
-# dev
 pytest==5.2.4
 pytest-cov==2.5.1
 pytest-watch==4.2.0
 colorama==0.3.9
 pathtools==0.1.2
 pluggy==0.13.0
-
 python-dateutil==2.7.3
 pytz==2018.4
 python-rapidjson==0.8.0
@@ -56,11 +44,8 @@ sentry-relay>=0.5.7,<0.6.0
 sentry-sdk==0.13.5
 simplejson==3.15.0
 typing-extensions==3.7.4.1
-
-# dev/backports although these are pulled in by deprecation
 unittest2==1.1.0
 traceback2==1.4.0
-
 urllib3==1.25.3
 uWSGI==2.0.18
 wcwidth==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,6 @@ linecache2==1.0.0
 lz4==2.0.0
 Markdown==2.6.11
 MarkupSafe==1.1.1
-mccabe==0.6.1
 mywsgi==1.0.3
 more-itertools==4.2.0
 mypy>=0.761
@@ -59,7 +58,6 @@ prompt-toolkit==1.0.15
 ptyprocess==0.5.2
 py==1.5.3
 Pygments==2.2.0
-pycodestyle<2.6.0,>=2.5.0
 pyparsing==2.2.0
 pytest==5.2.4
 pytest-cov==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,42 +1,48 @@
-appnope==0.1.0
-argh==0.26.2
-astroid==1.6.5
 atomicwrites==1.1.5
 attrs==18.1.0
-backcall==0.1.0
+
+# dev
 black==19.10b0
-blinker==1.4
+
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
 clickhouse-driver==0.1.1
-colorama==0.3.9
-configparser==3.5.0
 confluent-kafka==1.2.0
+
+# backport
 contextlib2==0.5.5
+
 coverage==4.5.1
 datadog==0.21.0
-decorator==4.3.0
 deprecation==2.0.3
 docopt==0.6.2
+
+# backport
 enum34==1.1.6
+
+# dev
 flake8==3.7.8
+
 Flask==1.0.2
+
+# backports
 funcsigs==1.0.2
 future==0.16.0
+
+# dev
 honcho==1.0.1
+
 idna==2.7
-ipdb==0.11
-ipython==6.4.0
-ipython-genutils==0.2.0
 isodate==0.6.0
+
+# dev
+# probably not used
 isort==4.3.4
+
 itsdangerous==0.24
-jedi==0.12.0
 Jinja2==2.10.1
 jsonschema==3.0.1
-lazy-object-proxy==1.3.1
-linecache2==1.0.0
 lz4==2.0.0
 Markdown==2.6.11
 MarkupSafe==1.1.1
@@ -45,22 +51,18 @@ more-itertools==4.2.0
 mypy>=0.761
 packaging==17.1
 parsimonious==0.8.1
-parso==0.2.1
-pathlib2==2.3.2
-pathtools==0.1.2
-pbr==4.0.4
-petname==2.2
-pexpect==4.6.0
-pickleshare==0.7.4
-pluggy==0.13.0
-prompt-toolkit==1.0.15
-ptyprocess==0.5.2
 py==1.5.3
 Pygments==2.2.0
 pyparsing==2.2.0
+
+# dev
 pytest==5.2.4
 pytest-cov==2.5.1
 pytest-watch==4.2.0
+colorama==0.3.9
+pathtools==0.1.2
+pluggy==0.13.0
+
 python-dateutil==2.7.3
 pytz==2018.4
 python-rapidjson==0.8.0
@@ -68,15 +70,14 @@ redis==2.10.6
 redis-py-cluster==1.3.5
 sentry-relay>=0.5.7,<0.6.0
 sentry-sdk==0.13.5
-simplegeneric==0.8.1
 simplejson==3.15.0
-singledispatch==3.4.0.3
-traceback2==1.4.0
-traitlets==4.3.2
 typing-extensions==3.7.4.1
+
+# dev/backports although these are pulled in by deprecation
 unittest2==1.1.0
+traceback2==1.4.0
+
 urllib3==1.25.3
 uWSGI==2.0.18
 wcwidth==0.1.7
 Werkzeug==0.15.3
-wrapt==1.10.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ argh==0.26.2
 astroid==1.6.5
 atomicwrites==1.1.5
 attrs==18.1.0
-autopep8==1.3.5
 backcall==0.1.0
 black==19.10b0
 blinker==1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ certifi==2018.4.16
 chardet==3.0.4
 click==6.7
 clickhouse-driver==0.1.1
+colorama==0.3.9
 confluent-kafka==1.2.0
 coverage==4.5.1
 datadog==0.21.0
@@ -32,7 +33,6 @@ pyparsing==2.2.0
 pytest==5.2.4
 pytest-cov==2.5.1
 pytest-watch==4.2.0
-colorama==0.3.9
 pathtools==0.1.2
 pluggy==0.13.0
 python-dateutil==2.7.3
@@ -44,8 +44,6 @@ sentry-relay>=0.5.7,<0.6.0
 sentry-sdk==0.13.5
 simplejson==3.15.0
 typing-extensions==3.7.4.1
-unittest2==1.1.0
-traceback2==1.4.0
 urllib3==1.25.3
 uWSGI==2.0.18
 wcwidth==0.1.7


### PR DESCRIPTION
There seems to be quite a few unused dependencies, as well as stuff that wasn't cleaned up from going py2 -> py3.

Also, closes https://github.com/getsentry/snuba/pull/923 since `pylint` is removed.

A lot of this stuff is dev dependencies, currently not sure how production images are built but I'd bet that they have dev deps. It'd be nice to separate out - if there's any interest, I can follow up with that.

(It's quite a bit, see: https://github.com/getsentry/snuba/commit/88f821a1e6c54627eda9c16d13beca5bc61d0b54#diff-f4c265073ea4274a80eca85440875e56)

Another thought: it'd be nice to somehow get the docker build to use travis's pip cache. Currently, everything is being downloaded every time, and some wheels that need to be built are always rebuilt (uwsgi being the big one). Probably can save around a minute or two if this is figured out.