### PR TITLE
feat(state): Add the ability to define CONFIG_STATE instead of runtime config

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -49,6 +49,7 @@ QUERIES_TOPIC = "snuba-queries"
 
 # Runtime Config Options
 CONFIG_MEMOIZE_TIMEOUT = 10
+CONFIG_STATE = {}
 
 # Sentry Options
 SENTRY_DSN = None

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -2,6 +2,8 @@ import random
 import time
 from collections import ChainMap
 from functools import partial
+from unittest.mock import patch
+import pytest
 
 from snuba import state
 from snuba.state import safe_dumps
@@ -52,6 +54,12 @@ class TestState(BaseEventsTest):
         assert state.abtest("1000/2000:5") in (1000, 2000)
         assert state.abtest("1000/2000:0") == 1000
         assert state.abtest("1.5:1/-1.5:1") in (1.5, -1.5)
+
+    @patch("snuba.settings.CONFIG_STATE", {"foo": "bar"})
+    def test_config_local_state(self):
+        assert state.get_config("foo") == "bar"
+        with pytest.raises(TypeError):
+            state.set_config("foo", "other")
 
 
 def test_safe_dumps():


### PR DESCRIPTION
This merges the results gotten back from Redis with the local
CONFIG_STATE taking priority.

This allows administrators to configure settings in their config file
instead of relying on runtime configuration only.