### PR TITLE
fix(schema) Enforce the valid structure of IS NULL conditions in json schema

### DIFF
--- a/snuba/query/schema.py
+++ b/snuba/query/schema.py
@@ -164,7 +164,7 @@ GENERIC_QUERY_SCHEMA = {
                 {
                     # Literal
                     "anyOf": [
-                        {"type": ["string", "number"]},
+                        {"type": ["string", "number", "null"]},
                         {"type": "array", "items": {"type": ["string", "number"]}},
                     ],
                 },


### PR DESCRIPTION
Followup of https://github.com/getsentry/snuba/pull/1005.

This enforce the conditions is valid in the request schema instead of getting to the parser.
So if a condition has a unary operator, only `null` is allowed as right hand side. We cannot just remove the right hand side because that would be a breaking change.
If a condition has a right hand side literal, then the operator must be binary.