### PR TITLE
fix(ast) Adapt the sql string checks in test_api to the ast query.

### DIFF
--- a/snuba/datasets/storages/events_column_processor.py
+++ b/snuba/datasets/storages/events_column_processor.py
@@ -29,8 +29,8 @@ class EventsColumnProcessor(QueryProcessor):
                         exp.alias,
                         "coalesce",
                         (
-                            Column(None, exp.table_name, exp.column_name),
                             Column(None, exp.table_name, "search_message"),
+                            Column(None, exp.table_name, exp.column_name),
                         ),
                     )
 

--- a/tests/query/processors/test_events_column_processor.py
+++ b/tests/query/processors/test_events_column_processor.py
@@ -30,7 +30,7 @@ def test_events_column_format_expressions() -> None:
             FunctionCall(
                 "the_message",
                 "coalesce",
-                (Column(None, None, "message"), Column(None, None, "search_message"),),
+                (Column(None, None, "search_message"), Column(None, None, "message")),
             ),
         ],
     )
@@ -43,7 +43,7 @@ def test_events_column_format_expressions() -> None:
 
     expected = (
         "(nullIf(group_id, 0) AS the_group_id)",
-        "(coalesce(message, search_message) AS the_message)",
+        "(coalesce(search_message, message) AS the_message)",
     )
 
     for idx, column in enumerate(unprocessed.get_selected_columns_from_ast()[1:]):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -706,11 +706,11 @@ class TestApi(BaseApiTest):
             ).data
         )
         assert (
-            # legacy
+            # legacy representation
             "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message"
             in result["sql"]
         ) or (
-            # ast
+            # ast representation
             "PREWHERE notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message"
             in result["sql"]
         )
@@ -734,11 +734,11 @@ class TestApi(BaseApiTest):
             ).data
         )
         assert (
-            # legacy
+            # legacy representation
             "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc') != 0 AND project_id IN (1)"
             in result["sql"]
         ) or (
-            # ast
+            # ast representation
             "PREWHERE and(notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc'), 0), in(project_id, tuple(1)))"
             in result["sql"]
         )
@@ -762,12 +762,14 @@ class TestApi(BaseApiTest):
 
         # make sure the conditions is in PREWHERE and nowhere else
         assert (
-            "PREWHERE project_id IN (1)" in result["sql"]  # legacy
-            or "PREWHERE in(project_id, tuple(1))" in result["sql"]  # ast
+            "PREWHERE project_id IN (1)" in result["sql"]  # legacy representation
+            or "PREWHERE in(project_id, tuple(1))"
+            in result["sql"]  # ast representation
         )
         assert (
-            result["sql"].count("project_id IN (1)") == 1  # legacy
-            or result["sql"].count("in(project_id, tuple(1))") == 1  # ast
+            result["sql"].count("project_id IN (1)") == 1  # legacy representation
+            or result["sql"].count("in(project_id, tuple(1))")
+            == 1  # ast representation
         )
 
     def test_aggregate(self):
@@ -1018,12 +1020,12 @@ class TestApi(BaseApiTest):
         )
         # Issue is expanded once, and alias used subsequently
         assert (
-            "group_id = 0" in response["sql"]
-            or "equals(group_id, 0)" in response["sql"]
+            "group_id = 0" in response["sql"]  # legacy representation
+            or "equals(group_id, 0)" in response["sql"]  # ast representation
         )
         assert (
-            "group_id = 1" in response["sql"]
-            or "equals(group_id, 1)" in response["sql"]
+            "group_id = 1" in response["sql"]  # legacy representation
+            or "equals(group_id, 1)" in response["sql"]  # ast representation
         )
 
     def test_sampling_expansion(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -676,7 +676,12 @@ class TestApi(BaseApiTest):
             ).data
         )
         assert (
+            # legacy representation
             "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc') != 0"
+            in result["sql"]
+        ) or (
+            # ast representation
+            "PREWHERE notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc'), 0)"
             in result["sql"]
         )
 
@@ -701,7 +706,12 @@ class TestApi(BaseApiTest):
             ).data
         )
         assert (
+            # legacy
             "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message"
+            in result["sql"]
+        ) or (
+            # ast
+            "PREWHERE notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message"
             in result["sql"]
         )
 
@@ -724,7 +734,12 @@ class TestApi(BaseApiTest):
             ).data
         )
         assert (
+            # legacy
             "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc') != 0 AND project_id IN (1)"
+            in result["sql"]
+        ) or (
+            # ast
+            "PREWHERE and(notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc'), 0), in(project_id, tuple(1)))"
             in result["sql"]
         )
 
@@ -746,8 +761,14 @@ class TestApi(BaseApiTest):
         )
 
         # make sure the conditions is in PREWHERE and nowhere else
-        assert "PREWHERE project_id IN (1)" in result["sql"]
-        assert result["sql"].count("project_id IN (1)") == 1
+        assert (
+            "PREWHERE project_id IN (1)" in result["sql"]  # legacy
+            or "PREWHERE in(project_id, tuple(1))" in result["sql"]  # ast
+        )
+        assert (
+            result["sql"].count("project_id IN (1)") == 1  # legacy
+            or result["sql"].count("in(project_id, tuple(1))") == 1  # ast
+        )
 
     def test_aggregate(self):
         result = json.loads(
@@ -996,8 +1017,14 @@ class TestApi(BaseApiTest):
             ).data
         )
         # Issue is expanded once, and alias used subsequently
-        assert "group_id = 0" in response["sql"]
-        assert "group_id = 1" in response["sql"]
+        assert (
+            "group_id = 0" in response["sql"]
+            or "equals(group_id, 0)" in response["sql"]
+        )
+        assert (
+            "group_id = 1" in response["sql"]
+            or "equals(group_id, 1)" in response["sql"]
+        )
 
     def test_sampling_expansion(self):
         response = json.loads(
@@ -1701,7 +1728,7 @@ class TestApi(BaseApiTest):
                 ),
             ).data
         )
-        assert "deleted = 0" in result["sql"]
+        assert "deleted = 0" in result["sql"] or "equals(deleted, 0)" in result["sql"]
 
     @patch("snuba.settings.RECORD_QUERIES", True)
     @patch("snuba.state.record_query")


### PR DESCRIPTION
The formatted ast query looks a bit different in some cases with respect to the legacy query. Specifically this impacts the conditions, the ast uses clickhouse functions.
Unfortunately there are some tests in test_api that look for expressions to be present in the sql string. That's not a great way to test to begin with, but, as long as they exist, we still need to make those tests work for the ast query. 
So this PR adds ast specific conditions to those test to maintain the same behavior of the previous test and to make them work on both legacy and ast.