### PR TITLE
fix(ast) Fix alias propagation on apdex and impact

### DIFF
--- a/snuba/query/processors/apdex_processor.py
+++ b/snuba/query/processors/apdex_processor.py
@@ -21,7 +21,7 @@ class ApdexProcessor(QueryProcessor):
                 assert len(exp.parameters) == 2
                 column = exp.parameters[0]
                 satisfied = exp.parameters[1]
-                return apdex(column, satisfied)
+                return apdex(exp.alias, column, satisfied)
 
             return exp
 

--- a/snuba/query/processors/impact_processor.py
+++ b/snuba/query/processors/impact_processor.py
@@ -1,5 +1,6 @@
 from snuba.query.dsl import divide, minus, multiply, plus
 from snuba.query.expressions import (
+    Column,
     Expression,
     FunctionCall,
     Literal,
@@ -25,8 +26,11 @@ class ImpactProcessor(QueryProcessor):
                 satisfied = exp.parameters[1]
                 user_column = exp.parameters[2]
 
+                assert isinstance(column, Column)
+                assert isinstance(satisfied, Literal)
+
                 return plus(
-                    minus(Literal(None, 1), apdex(column, satisfied)),
+                    minus(Literal(None, 1), apdex(None, column, satisfied)),
                     multiply(
                         minus(
                             Literal(None, 1),
@@ -35,12 +39,13 @@ class ImpactProcessor(QueryProcessor):
                                 FunctionCall(
                                     None,
                                     "sqrt",
-                                    (FunctionCall(None, "uniq", user_column)),
+                                    (FunctionCall(None, "uniq", (user_column,)),),
                                 ),
                             ),
                         ),
                         Literal(None, 3),
                     ),
+                    exp.alias,
                 )
 
             return exp

--- a/snuba/query/processors/performance_expressions.py
+++ b/snuba/query/processors/performance_expressions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from snuba.query.conditions import (
     binary_condition,
     BooleanFunctions,
@@ -11,7 +13,7 @@ from snuba.query.expressions import (
 )
 
 
-def apdex(column: Column, satisfied: Literal) -> Expression:
+def apdex(alias: Optional[str], column: Column, satisfied: Literal) -> Expression:
     tolerated = multiply(satisfied, Literal(None, 4))
 
     return divide(
@@ -34,4 +36,5 @@ def apdex(column: Column, satisfied: Literal) -> Expression:
             ),
         ),
         count(),
+        alias,
     )

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -70,6 +70,7 @@ def test_apdex_format_expressions() -> None:
                     ),
                 ),
                 FunctionCall(None, "count", (),),
+                "perf",
             ),
         ],
     )
@@ -84,7 +85,7 @@ def test_apdex_format_expressions() -> None:
         ClickhouseExpressionFormatter()
     )
     assert ret == (
-        "divide(plus(countIf(lessOrEquals(column1, 300)), "
+        "(divide(plus(countIf(lessOrEquals(column1, 300)), "
         "divide(countIf(and(greater(column1, 300), "
-        "lessOrEquals(column1, multiply(300, 4)))), 2)), count())"
+        "lessOrEquals(column1, multiply(300, 4)))), 2)), count()) AS perf)"
     )

--- a/tests/query/processors/test_impact.py
+++ b/tests/query/processors/test_impact.py
@@ -87,18 +87,21 @@ def test_impact_format_expressions() -> None:
                                     FunctionCall(
                                         None,
                                         "uniq",
-                                        Column(
-                                            alias=None,
-                                            column_name="user",
-                                            table_name=None,
+                                        (
+                                            Column(
+                                                alias=None,
+                                                column_name="user",
+                                                table_name=None,
+                                            ),
                                         ),
-                                    )
+                                    ),
                                 ),
                             ),
                         ),
                     ),
                     Literal(None, 3),
                 ),
+                "perf",
             ),
         ],
     )
@@ -113,8 +116,8 @@ def test_impact_format_expressions() -> None:
         ClickhouseExpressionFormatter()
     )
     assert ret == (
-        "plus(minus(1, divide(plus(countIf(lessOrEquals(column1, 300)), "
+        "(plus(minus(1, divide(plus(countIf(lessOrEquals(column1, 300)), "
         "divide(countIf(and(greater(column1, 300), lessOrEquals(column1, "
         "multiply(300, 4)))), 2)), count())), "
-        "multiply(minus(1, divide(1, sqrt(user, uniq(user)))), 3))"
+        "multiply(minus(1, divide(1, sqrt(uniq(user)))), 3)) AS perf)"
     )

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -302,7 +302,6 @@ class TestTransactionsApi(BaseApiTest):
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 1, data
-        print(data)
         assert "apdex_score" in data["data"][0]
         assert data["data"][0] == {
             "transaction_name": "/api/do_things",

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -302,6 +302,7 @@ class TestTransactionsApi(BaseApiTest):
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 1, data
+        print(data)
         assert "apdex_score" in data["data"][0]
         assert data["data"][0] == {
             "transaction_name": "/api/do_things",


### PR DESCRIPTION
Fixes a could of issues with the apdex and impact processors:
1) they were not propagating the alias of the expression (this fixes the test in test_transactions_api)
2) In a few cases the parameters of FunctionCall were not in a tuple as they should be.