### PR TITLE
feat(query): Turn on readthrough cache by default

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -273,7 +273,7 @@ def raw_query(
 
     execute_query_strategy = (
         execute_query_with_readthrough_caching
-        if state.get_config("use_readthrough_query_cache", 0)
+        if state.get_config("use_readthrough_query_cache", 1)
         else execute_query_with_caching
     )
 


### PR DESCRIPTION
This has proven to be useful and Redis is already required so it should be safe to turn this on by default. At some point we should probably document what we use Redis for and any suggested server configuration parameters for our workloads.