### PR TITLE
perf(transactions): Prevent the duplicated storage of promoted trace contexts.

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -71,18 +71,17 @@ class TransactionsMessageProcessor(MessageProcessor):
             return None
 
         transaction_ctx = data["contexts"]["trace"]
-        trace_id = transaction_ctx["trace_id"]
         try:
             processed["event_id"] = str(uuid.UUID(processed["event_id"]))
-            processed["trace_id"] = str(uuid.UUID(trace_id))
-            processed["span_id"] = int(transaction_ctx["span_id"], 16)
-            processed["transaction_op"] = _unicodify(transaction_ctx.get("op") or "")
+            processed["trace_id"] = str(uuid.UUID(transaction_ctx.pop("trace_id")))
+            processed["span_id"] = int(transaction_ctx.pop("span_id"), 16)
+            processed["transaction_op"] = _unicodify(transaction_ctx.pop("op") or "")
             processed["transaction_name"] = _unicodify(data.get("transaction") or "")
             processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
                 data["start_timestamp"],
             )
 
-            status = transaction_ctx.get("status", None)
+            status = transaction_ctx.pop("status", None)
             if status:
                 int_status = SPAN_STATUS_NAME_TO_CODE.get(status, UNKNOWN_SPAN_STATUS)
             else:


### PR DESCRIPTION
Disclaimer: I haven't vetted this change against any Sentry functionality. Should hold off on merging until someone or something gives us the all-good.