### PR TITLE
feat(clusters): Allow invalid storage sets in settings

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -88,7 +88,18 @@ class Cluster(ABC, Generic[TQuery, TWriterOptions]):
         self.__storage_sets = storage_sets
 
     def get_storage_set_keys(self) -> Set[StorageSetKey]:
-        return {StorageSetKey(storage_set) for storage_set in self.__storage_sets}
+        storage_set_keys = set()
+
+        for storage_set in self.__storage_sets:
+            try:
+                storage_set_keys.add(StorageSetKey(storage_set))
+            except ValueError:
+                # We ignore invalid storage set keys since new storage sets will
+                # need to be registered to configuration before they can be used
+                # in Snuba.
+                pass
+
+        return storage_set_keys
 
     @abstractmethod
     def get_reader(self) -> Reader[TQuery]:

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -88,16 +88,16 @@ class Cluster(ABC, Generic[TQuery, TWriterOptions]):
         self.__storage_sets = storage_sets
 
     def get_storage_set_keys(self) -> Set[StorageSetKey]:
+        all_storage_sets = set(key.value for key in StorageSetKey)
+
         storage_set_keys = set()
 
         for storage_set in self.__storage_sets:
-            try:
+            # We ignore invalid storage set keys since new storage sets will
+            # need to be registered to configuration before they can be used
+            # in Snuba.
+            if storage_set in all_storage_sets:
                 storage_set_keys.add(StorageSetKey(storage_set))
-            except ValueError:
-                # We ignore invalid storage set keys since new storage sets will
-                # need to be registered to configuration before they can be used
-                # in Snuba.
-                pass
 
         return storage_set_keys
 

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -24,7 +24,14 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
         "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
         "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
-        "storage_sets": {"events", "outcomes", "querylog", "sessions", "transactions"},
+        "storage_sets": {
+            "events",
+            "migrations",
+            "outcomes",
+            "querylog",
+            "sessions",
+            "transactions",
+        },
         "single_node": True,
     },
 ]

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -18,13 +18,7 @@ class TestClusters:
                 "password": "",
                 "database": "default",
                 "http_port": 8123,
-                "storage_sets": {
-                    "events",
-                    "migrations",
-                    "outcomes",
-                    "querylog",
-                    "sessions",
-                },
+                "storage_sets": {"events", "outcomes", "querylog", "sessions"},
                 "single_node": True,
             },
             {

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -18,7 +18,13 @@ class TestClusters:
                 "password": "",
                 "database": "default",
                 "http_port": 8123,
-                "storage_sets": {"events", "outcomes", "querylog", "sessions"},
+                "storage_sets": {
+                    "events",
+                    "migrations",
+                    "outcomes",
+                    "querylog",
+                    "sessions",
+                },
                 "single_node": True,
             },
             {


### PR DESCRIPTION
Since we have a requirement that all storage sets in Snuba
are present in configuration, we need to allow for invalid
storage sets in cluster configuration so that new storage sets
can be included in settings first before being added to the codebase.