### PR TITLE
fix(tracing) Bring dataset and referrer transaction tags back

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -44,11 +44,6 @@ def parse_and_run_query(
         query_list=[],
     )
 
-    with sentry_sdk.configure_scope() as scope:
-        if scope.span:
-            scope.span.set_tag("dataset", get_dataset_name(dataset))
-            scope.span.set_tag("referrer", request.referrer)
-
     try:
         result = _run_query_pipeline(
             dataset=dataset, request=request, timer=timer, query_metadata=query_metadata

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -232,7 +232,7 @@ def parse_request_body(http_request):
             raise BadRequest(str(error)) from error
 
 
-def _trace_tags(dataset: Dataset) -> None:
+def _trace_transaction_tags(dataset: Dataset) -> None:
     with sentry_sdk.configure_scope() as scope:
         if scope.span:
             scope.span.set_tag("dataset", get_dataset_name(dataset))
@@ -247,7 +247,7 @@ def unqualified_query_view(*, timer: Timer):
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
         dataset = get_dataset(body.pop("dataset", settings.DEFAULT_DATASET_NAME))
-        _trace_tags(dataset)
+        _trace_transaction_tags(dataset)
         return dataset_query(dataset, body, timer)
     else:
         assert False, "unexpected fallthrough"
@@ -266,7 +266,7 @@ def dataset_query_view(*, dataset: Dataset, timer: Timer):
         )
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
-        _trace_tags(dataset)
+        _trace_transaction_tags(dataset)
         return dataset_query(dataset, body, timer)
     else:
         assert False, "unexpected fallthrough"

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -23,6 +23,7 @@ from snuba.datasets.factory import (
     enforce_table_writer,
     ensure_not_internal,
     get_dataset,
+    get_dataset_name,
     get_enabled_dataset_names,
 )
 from snuba.datasets.schemas.tables import TableSchema
@@ -39,10 +40,9 @@ from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic
-from snuba.web.converters import DatasetConverter
 from snuba.web import QueryException
+from snuba.web.converters import DatasetConverter
 from snuba.web.query import parse_and_run_query
-
 
 metrics = MetricsWrapper(environment.metrics, "api")
 
@@ -232,6 +232,13 @@ def parse_request_body(http_request):
             raise BadRequest(str(error)) from error
 
 
+def _trace_tags(dataset: Dataset) -> None:
+    with sentry_sdk.configure_scope() as scope:
+        if scope.span:
+            scope.span.set_tag("dataset", get_dataset_name(dataset))
+            scope.span.set_tag("referrer", http_request.referrer)
+
+
 @application.route("/query", methods=["GET", "POST"])
 @util.time_request("query")
 def unqualified_query_view(*, timer: Timer):
@@ -240,6 +247,7 @@ def unqualified_query_view(*, timer: Timer):
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
         dataset = get_dataset(body.pop("dataset", settings.DEFAULT_DATASET_NAME))
+        _trace_tags(dataset)
         return dataset_query(dataset, body, timer)
     else:
         assert False, "unexpected fallthrough"
@@ -258,6 +266,7 @@ def dataset_query_view(*, dataset: Dataset, timer: Timer):
         )
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
+        _trace_tags(dataset)
         return dataset_query(dataset, body, timer)
     else:
         assert False, "unexpected fallthrough"

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -232,7 +232,7 @@ def parse_request_body(http_request):
             raise BadRequest(str(error)) from error
 
 
-def _trace_transaction_tags(dataset: Dataset) -> None:
+def _trace_transaction(dataset: Dataset) -> None:
     with sentry_sdk.configure_scope() as scope:
         if scope.span:
             scope.span.set_tag("dataset", get_dataset_name(dataset))
@@ -247,7 +247,7 @@ def unqualified_query_view(*, timer: Timer):
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
         dataset = get_dataset(body.pop("dataset", settings.DEFAULT_DATASET_NAME))
-        _trace_transaction_tags(dataset)
+        _trace_transaction(dataset)
         return dataset_query(dataset, body, timer)
     else:
         assert False, "unexpected fallthrough"
@@ -266,7 +266,7 @@ def dataset_query_view(*, dataset: Dataset, timer: Timer):
         )
     elif http_request.method == "POST":
         body = parse_request_body(http_request)
-        _trace_transaction_tags(dataset)
+        _trace_transaction(dataset)
         return dataset_query(dataset, body, timer)
     else:
         assert False, "unexpected fallthrough"


### PR DESCRIPTION
Since we started tracing more spans per snubs transactions, the dataset and referrer tags are being now added to individual spans and not to the transactions, thus not searchable anymore.

These two tags are key to be able to trace specific types of queries so I move them earlier in the request where we still have access to the transaction.