### PR TITLE
build(gha): Add CalVer release automation via Craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,16 @@
+minVersion: "0.10.0"
+github:
+  owner: getsentry
+  repo: snuba
+releaseBranchPrefix: releases
+preReleaseCommand: ''
+changelogPolicy: none
+artifactProvider:
+  name: none
+statusProvider:
+  name: github
+targets:
+  - name: github
+  - name: docker
+    source: us.gcr.io/sentryio/snuba
+    target: getsentry/snuba

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+on:
+  repository_dispatch:
+    types: [release]
+  schedule:
+    # We want the release to be at 9-10am Pacific Time
+    # We also want it to be 1 hour before the on-prem release
+    - cron:  '0 17 15 * *'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: "Release a new version"
+    steps:
+        - id: calver
+          if: ${{ !github.event.client_payload.version }}
+          run: echo "::set-output name=version::$(date +'%y.%-m.0')"
+        - uses: actions/checkout@v2
+        - uses: getsentry/craft@master
+          if: ${{ !github.event.client_payload.skip_prepare }}
+          with:
+            action: prepare
+            version: ${{ github.event.client_payload.version || steps.calver.outputs.version }}
+          env:
+            DRY_RUN: ${{ github.event.client_payload.dry_run }}
+            GIT_COMMITTER_NAME: getsentry-bot
+            GIT_AUTHOR_NAME: getsentry-bot
+            EMAIL: bot@getsentry.com
+        - uses: getsentry/craft@master
+          with:
+            action: publish
+            version: ${{ github.event.client_payload.version || steps.calver.outputs.version }}
+          env:
+            DRY_RUN: ${{ github.event.client_payload.dry_run }}
+            GIT_COMMITTER_NAME: getsentry-bot
+            GIT_AUTHOR_NAME: getsentry-bot
+            EMAIL: bot@getsentry.com
+            DOCKER_USERNAME: 'sentrybuilder'
+            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
See an example run over at [getsentry/relay](https://github.com/getsentry/relay): https://github.com/getsentry/relay/actions/runs/136361479

