### PR TITLE
fix(formatting) Format arrays for clickhouse as [] and not array()

### DIFF
--- a/snuba/query/columns.py
+++ b/snuba/query/columns.py
@@ -12,10 +12,10 @@ from snuba.query.parser.conditions import parse_conditions
 from snuba.query.parser.functions import parse_function
 from snuba.query.parsing import ParsingContext
 from snuba.query.schema import POSITIVE_OPERATORS
+from snuba.query.parser.functions import function_expr
 from snuba.util import (
     alias_expr,
     escape_literal,
-    function_expr,
     is_function,
     QUOTED_LITERAL_RE,
 )

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -1,12 +1,95 @@
 import numbers
+import re
 from datetime import date, datetime
-from typing import Any, Callable, List, Optional, TypeVar, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union
 
-from snuba.query.expressions import Expression, Literal, FunctionCall
+from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
+
+from snuba.clickhouse.escaping import escape_identifier
+from snuba.query.expressions import Expression, FunctionCall, Literal
 from snuba.query.parser.strings import parse_string_to_expr
+from snuba.state import get_config
 from snuba.util import is_function
 
 TExpression = TypeVar("TExpression")
+
+TOPK_FUNCTION_RE = re.compile(r"^top([1-9]\d*)$")
+APDEX_FUNCTION_RE = re.compile(r"^apdex\(\s*([^,]+)+\s*,\s*([\d]+)+\s*\)$")
+IMPACT_FUNCTION_RE = re.compile(
+    r"^impact\(\s*([^,]+)+\s*,\s*([\d]+)+\s*,\s*([^,]+)+\s*\)$"
+)
+FAILURE_RATE_FUNCTION_RE = re.compile(r"^failure_rate\(\)$")
+
+
+def function_expr(fn: str, args_expr: str = "") -> str:
+    """
+    DEPRECATED. Please do not add anything else here. In order to manipulate the
+    query, create a QueryProcessor and register it into your dataset.
+
+    Generate an expression for a given function name and an already-evaluated
+    args expression. This is a place to define convenience functions that evaluate
+    to more complex expressions.
+
+    """
+    if fn.startswith("apdex("):
+        match = APDEX_FUNCTION_RE.match(fn)
+        if match:
+            return "(countIf({col} <= {satisfied}) + (countIf(({col} > {satisfied}) AND ({col} <= {tolerated})) / 2)) / count()".format(
+                col=escape_identifier(match.group(1)),
+                satisfied=match.group(2),
+                tolerated=int(match.group(2)) * 4,
+            )
+        raise ValueError("Invalid format for apdex()")
+    elif fn.startswith("impact("):
+        match = IMPACT_FUNCTION_RE.match(fn)
+        if match:
+            apdex = "(countIf({col} <= {satisfied}) + (countIf(({col} > {satisfied}) AND ({col} <= {tolerated})) / 2)) / count()".format(
+                col=escape_identifier(match.group(1)),
+                satisfied=match.group(2),
+                tolerated=int(match.group(2)) * 4,
+            )
+
+            return "(1 - {apdex}) + ((1 - (1 / sqrt(uniq({user_col})))) * 3)".format(
+                apdex=apdex, user_col=escape_identifier(match.group(3)),
+            )
+        raise ValueError("Invalid format for impact()")
+    elif fn.startswith("failure_rate("):
+        match = FAILURE_RATE_FUNCTION_RE.match(fn)
+        if match:
+            return "countIf((transaction_status != {ok} AND transaction_status != {unknown})) / count()".format(
+                ok=SPAN_STATUS_NAME_TO_CODE["ok"],
+                unknown=SPAN_STATUS_NAME_TO_CODE["unknown_error"],
+            )
+        raise ValueError("Invalid format for failure_rate()")
+    # For functions with no args, (or static args) we allow them to already
+    # include them as part of the function name, eg, "count()" or "sleep(1)"
+    if not args_expr and fn.endswith(")"):
+        return fn
+
+    # Convenience topK function eg "top10", "top3" etc.
+    topk = TOPK_FUNCTION_RE.match(fn)
+    if topk:
+        return "topK({})({})".format(topk.group(1), args_expr)
+
+    # turn uniq() into ifNull(uniq(), 0) so it doesn't return null where
+    # a number was expected.
+    if fn == "uniq":
+        return "ifNull({}({}), 0)".format(fn, args_expr)
+
+    # emptyIfNull(col) is a simple pseudo function supported by Snuba that expands
+    # to the actual clickhouse function ifNull(col, '') Until we figure out the best
+    # way to disambiguate column names from string literals in complex functions.
+    if fn == "emptyIfNull" and args_expr:
+        return "ifNull({}, '')".format(args_expr)
+
+    # Workaround for https://github.com/ClickHouse/ClickHouse/issues/11622
+    # Some distributed queries fail when arrays are passed as array(1,2,3)
+    # and work when they are passed as [1, 2, 3]
+    if get_config("format_clickhouse_arrays", 1) and fn == "array":
+        return f"[{args_expr}]"
+
+    # default: just return fn(args_expr)
+    return "{}({})".format(fn, args_expr)
 
 
 def parse_function(

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -1,12 +1,13 @@
+import inspect
+import logging
+import numbers
+import re
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta
-from dateutil.parser import parse as dateutil_parse
 from functools import wraps
-from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 from typing import (
     Any,
     Callable,
-    cast,
     Iterator,
     List,
     Mapping,
@@ -16,18 +17,15 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
-import inspect
-import logging
-import numbers
-import re
-import _strptime  # NOQA fixes _strptime deferred import issue
-
 import sentry_sdk
+from dateutil.parser import parse as dateutil_parse
 
+import _strptime  # NOQA fixes _strptime deferred import issue
 from snuba import settings
-from snuba.clickhouse.escaping import escape_identifier, escape_string
+from snuba.clickhouse.escaping import escape_string
 from snuba.query.parsing import ParsingContext
 from snuba.query.schema import CONDITION_OPERATORS
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -44,12 +42,6 @@ T = TypeVar("T")
 PART_RE = re.compile(r"\('(\d{4}-\d{2}-\d{2})',\s*(\d+)\)")
 QUOTED_LITERAL_RE = re.compile(r"^'.*'$")
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
-TOPK_FUNCTION_RE = re.compile(r"^top([1-9]\d*)$")
-APDEX_FUNCTION_RE = re.compile(r"^apdex\(\s*([^,]+)+\s*,\s*([\d]+)+\s*\)$")
-IMPACT_FUNCTION_RE = re.compile(
-    r"^impact\(\s*([^,]+)+\s*,\s*([\d]+)+\s*,\s*([^,]+)+\s*\)$"
-)
-FAILURE_RATE_FUNCTION_RE = re.compile(r"^failure_rate\(\)$")
 
 
 def to_list(value: Union[T, List[T]]) -> List[T]:
@@ -67,71 +59,6 @@ def qualified_column(column_name: str, alias: str = "") -> str:
 def parse_datetime(value: str, alignment: int = 1) -> datetime:
     dt = dateutil_parse(value, ignoretz=True).replace(microsecond=0)
     return dt - timedelta(seconds=(dt - dt.min).seconds % alignment)
-
-
-def function_expr(fn: str, args_expr: str = "") -> str:
-    """
-    DEPRECATED. Please do not add anything else here. In order to manipulate the
-    query, create a QueryProcessor and register it into your dataset.
-
-    Generate an expression for a given function name and an already-evaluated
-    args expression. This is a place to define convenience functions that evaluate
-    to more complex expressions.
-
-    """
-    if fn.startswith("apdex("):
-        match = APDEX_FUNCTION_RE.match(fn)
-        if match:
-            return "(countIf({col} <= {satisfied}) + (countIf(({col} > {satisfied}) AND ({col} <= {tolerated})) / 2)) / count()".format(
-                col=escape_identifier(match.group(1)),
-                satisfied=match.group(2),
-                tolerated=int(match.group(2)) * 4,
-            )
-        raise ValueError("Invalid format for apdex()")
-    elif fn.startswith("impact("):
-        match = IMPACT_FUNCTION_RE.match(fn)
-        if match:
-            apdex = "(countIf({col} <= {satisfied}) + (countIf(({col} > {satisfied}) AND ({col} <= {tolerated})) / 2)) / count()".format(
-                col=escape_identifier(match.group(1)),
-                satisfied=match.group(2),
-                tolerated=int(match.group(2)) * 4,
-            )
-
-            return "(1 - {apdex}) + ((1 - (1 / sqrt(uniq({user_col})))) * 3)".format(
-                apdex=apdex, user_col=escape_identifier(match.group(3)),
-            )
-        raise ValueError("Invalid format for impact()")
-    elif fn.startswith("failure_rate("):
-        match = FAILURE_RATE_FUNCTION_RE.match(fn)
-        if match:
-            return "countIf((transaction_status != {ok} AND transaction_status != {unknown})) / count()".format(
-                ok=SPAN_STATUS_NAME_TO_CODE["ok"],
-                unknown=SPAN_STATUS_NAME_TO_CODE["unknown_error"],
-            )
-        raise ValueError("Invalid format for failure_rate()")
-    # For functions with no args, (or static args) we allow them to already
-    # include them as part of the function name, eg, "count()" or "sleep(1)"
-    if not args_expr and fn.endswith(")"):
-        return fn
-
-    # Convenience topK function eg "top10", "top3" etc.
-    topk = TOPK_FUNCTION_RE.match(fn)
-    if topk:
-        return "topK({})({})".format(topk.group(1), args_expr)
-
-    # turn uniq() into ifNull(uniq(), 0) so it doesn't return null where
-    # a number was expected.
-    if fn == "uniq":
-        return "ifNull({}({}), 0)".format(fn, args_expr)
-
-    # emptyIfNull(col) is a simple pseudo function supported by Snuba that expands
-    # to the actual clickhouse function ifNull(col, '') Until we figure out the best
-    # way to disambiguate column names from string literals in complex functions.
-    if fn == "emptyIfNull" and args_expr:
-        return "ifNull({}, '')".format(args_expr)
-
-    # default: just return fn(args_expr)
-    return "{}({})".format(fn, args_expr)
 
 
 # TODO: Fix the type of Tuple concatenation when mypy supports it.

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -100,6 +100,10 @@ test_expressions = [
         ),
         "arrayExists((x, y -> testFunc(x, y)), test)",
     ),  # Lambda expression
+    (
+        FunctionCall("alias", "array", (Literal(None, 1), Literal(None, 2))),
+        "([1, 2] AS alias)",
+    ),  # Formatting an array as [...]
 ]
 
 

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -354,7 +354,7 @@ def test_formatting() -> None:
         ),
         Literal(None, 1),
     ).accept(ClickhouseExpressionFormatter()) == (
-        "(arrayElement((arrayJoin(arrayMap((x, y -> array(x, y)), "
+        "(arrayElement((arrayJoin(arrayMap((x, y -> [x, y]), "
         "tags.key, tags.value)) AS snuba_all_tags), 1) AS tags_key)"
     )
 
@@ -373,7 +373,7 @@ def test_formatting() -> None:
     ).accept(ClickhouseExpressionFormatter()) == (
         "(arrayElement((arrayJoin(arrayFilter((pair -> in("
         "arrayElement(pair, 1), tuple('t1', 't2'))), "
-        "arrayMap((x, y -> array(x, y)), tags.key, tags.value))) AS snuba_all_tags), 1) AS tags_key)"
+        "arrayMap((x, y -> [x, y]), tags.key, tags.value))) AS snuba_all_tags), 1) AS tags_key)"
     )
 
 
@@ -393,7 +393,7 @@ def test_aliasing() -> None:
     sql = AstSqlQuery(processed, HTTPRequestSettings()).format_sql()
 
     assert sql == (
-        "SELECT (arrayElement((arrayJoin(arrayMap((x, y -> array(x, y)), "
+        "SELECT (arrayElement((arrayJoin(arrayMap((x, y -> [x, y]), "
         "tags.key, tags.value)) AS snuba_all_tags), 2) AS tags_value) "
         "FROM transactions_local "
         "WHERE in((arrayElement(snuba_all_tags, 1) AS tags_key), tuple('t1', 't2'))"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -327,6 +327,16 @@ class TestUtil(BaseTest):
             )
             == "(foo() AS a)"
         )
+        state.set_config("format_clickhouse_arrays", 1)
+        assert (
+            complex_column_expr(
+                dataset,
+                tuplify(["array", [1, 2, 3], "a"]),
+                deepcopy(query),
+                ParsingContext(),
+            )
+            == "([1, 2, 3] AS a)"
+        )
         assert (
             complex_column_expr(
                 dataset,


### PR DESCRIPTION
This is a workaround for https://github.com/ClickHouse/ClickHouse/issues/11622.

Using the clickhouse `transform` function, on a distributed table, seems to fail when the two array parameters are passed though the `array` function instead of using the `[]` notation.
So far we did not find a way to fix this and there has not been a lot of activity on the issue I filed on Clickhouse, so we can just format the array as `[]` no matter how the client provides them.

This covers both AST and legacy representation.