### PR TITLE
feat(migrations): Add the not started status to the migrations table

### DIFF
--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -57,6 +57,9 @@ class Runner:
                 "migration_id": migration_id,
                 "timestamp": datetime.now(),
                 "status": Status.COMPLETED.value,
+                # TODO: Version should be incremented each time we update that
+                # migration status
+                "version": 1,
             }
         ]
         connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -14,8 +14,8 @@ class Migration(migration.Migration):
                 statement="""\
                     CREATE TABLE migrations_local (group String, migration_id String,
                     timestamp DateTime, status Enum('completed' = 0, 'in_progress' = 1,
-                    'not_started' = 2)) ENGINE = ReplacingMergeTree(timestamp) ORDER
-                    BY (group, migration_id);
+                    'not_started' = 2), version UInt64 DEFAULT 1)
+                    ENGINE = ReplacingMergeTree(version) ORDER BY (group, migration_id);
                 """,
             ),
         ]

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -13,8 +13,9 @@ class Migration(migration.Migration):
                 storage_set=StorageSetKey.MIGRATIONS,
                 statement="""\
                     CREATE TABLE migrations_local (group String, migration_id String,
-                    timestamp DateTime, status Enum('completed' = 0, 'in_progress' = 1))
-                    ENGINE = ReplacingMergeTree(timestamp) ORDER BY (group, migration_id);
+                    timestamp DateTime, status Enum('completed' = 0, 'in_progress' = 1,
+                    'not_started' = 2)) ENGINE = ReplacingMergeTree(timestamp) ORDER
+                    BY (group, migration_id);
                 """,
             ),
         ]


### PR DESCRIPTION
We should support the not started status in the migrations table in
case we need to rollback a migration for any reason. Since we cannot
actually delete the row from the table we should just update the status
to not started.

This could have been implemented as a second migration, however since no
one is running these yet, I think it would be cleaner to simply edit
the initial migration.