### PR TITLE
fix(migrations): Fix migration IDs

### DIFF
--- a/tests/migrations/test_groups.py
+++ b/tests/migrations/test_groups.py
@@ -1,0 +1,8 @@
+from snuba.migrations.groups import MigrationGroup, get_group_loader
+
+
+def test_load_all_migrations() -> None:
+    for group in MigrationGroup:
+        group_loader = get_group_loader(group)
+        for migration in group_loader.get_migrations():
+            group_loader.load_migration(migration)


### PR DESCRIPTION
This fixes a bug that hardcoded the same migrations list for all groups using
the DirectoryLoader class.

Also add a test to ensure that all listed migrations can be loaded.