### PR TITLE
feat(migrations): Set status to in progress before running migration

### DIFF
--- a/snuba/migrations/context.py
+++ b/snuba/migrations/context.py
@@ -1,0 +1,10 @@
+import logging
+from typing import Callable, NamedTuple
+
+from snuba.migrations.status import Status
+
+
+class Context(NamedTuple):
+    migration_id: str
+    logger: logging.Logger
+    update_status: Callable[[Status], None]

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -1,7 +1,9 @@
 from abc import ABC, abstractmethod, abstractproperty
 from typing import Sequence
 
+from snuba.migrations.context import Context
 from snuba.migrations.operations import Operation
+from snuba.migrations.status import Status
 
 
 class Migration(ABC):
@@ -51,3 +53,13 @@ class Migration(ABC):
     @abstractmethod
     def backwards_local(self) -> Sequence[Operation]:
         raise NotImplementedError
+
+    def forwards(self, context: Context) -> None:
+        migration_id, logger, update_status = context
+        logger.info(f"Running migration: {migration_id}")
+        update_status(Status.IN_PROGRESS)
+        for op in self.forwards_local():
+            context.logger
+            op.execute()
+        logger.info(f"Finished: {migration_id}")
+        update_status(Status.COMPLETED)

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -59,7 +59,6 @@ class Migration(ABC):
         logger.info(f"Running migration: {migration_id}")
         update_status(Status.IN_PROGRESS)
         for op in self.forwards_local():
-            context.logger
             op.execute()
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -47,18 +47,18 @@ class Migration(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def forwards_local(self) -> Sequence[Operation]:
+    def _forwards_local(self) -> Sequence[Operation]:
         raise NotImplementedError
 
     @abstractmethod
-    def backwards_local(self) -> Sequence[Operation]:
+    def _backwards_local(self) -> Sequence[Operation]:
         raise NotImplementedError
 
     def forwards(self, context: Context) -> None:
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
         update_status(Status.IN_PROGRESS)
-        for op in self.forwards_local():
+        for op in self._forwards_local():
             op.execute()
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -1,14 +1,13 @@
 import logging
 
-from clickhouse_driver import errors
 from datetime import datetime
-from enum import Enum
-from typing import NamedTuple
+from functools import partial
 
-from snuba.clickhouse.errors import ClickhouseError
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster, CLUSTERS
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.context import Context
 from snuba.migrations.groups import get_group_loader, MigrationGroup
+from snuba.migrations.status import Status
 
 logger = logging.getLogger("snuba.migrations")
 
@@ -19,76 +18,39 @@ DIST_TABLE_NAME = "migrations_dist"
 TABLE_NAME = LOCAL_TABLE_NAME
 
 
-class Status(Enum):
-    NOT_STARTED = "not_started"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-
-
-class MigrationKey(NamedTuple):
-    group: MigrationGroup
-    migration_id: str
-
-    def __str__(self) -> str:
-        return f"{self.group.value} {self.migration_id}"
-
-
 class Runner:
     def __init__(self) -> None:
         self.__connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
             ClickhouseClientSettings.MIGRATE
         )
 
-    def run_migration(self, migration_key: MigrationKey) -> None:
+    def run_migration(self, group: MigrationGroup, migration_id: str) -> None:
         """
         Run a single migration given its migration key and marks the migration as complete.
         """
-        group = migration_key.group
-        migration_id = migration_key.migration_id
-
         assert all(
             cluster.is_single_node() for cluster in CLUSTERS
         ), "Cannot run migrations for multi node clusters"
 
-        logger.info(f"Running migration: {migration_key}")
-
+        context = Context(
+            migration_id,
+            logger,
+            partial(self._update_migration_status, group, migration_id),
+        )
         migration = get_group_loader(group).load_migration(migration_id)
-
-        self._update_migration_status(migration_key, Status.IN_PROGRESS)
-
-        operations = migration.forwards_local()
-        for op in operations:
-            op.execute()
-
-        logger.info(f"Finished running, updating status: {migration_key}")
-
-        self._update_migration_status(migration_key, Status.COMPLETED)
-
-        logger.info(f"Finished: {migration_key}")
+        migration.forwards(context)
 
     def _update_migration_status(
-        self, migration_key: MigrationKey, status: Status
+        self, group: MigrationGroup, migration_id: str, status: Status
     ) -> None:
         statement = f"INSERT INTO {TABLE_NAME} FORMAT JSONEachRow"
         data = [
             {
-                "group": migration_key.group.value,
-                "migration_id": migration_key.migration_id,
+                "group": group.value,
+                "migration_id": migration_id,
                 "timestamp": datetime.now(),
                 "status": status.value,
             }
         ]
 
-        try:
-            self.__connection.execute(statement, data)
-        except ClickhouseError as e:
-            # HACK: Ignore failures related to non existent table when we're
-            # setting system migrations to non completed statuses. This is required
-            # since the migrations table might not yet exist.
-            allow_fail = (
-                migration_key.group == MigrationGroup.SYSTEM
-                and status != Status.COMPLETED
-            )
-
-            if not allow_fail or e.code != errors.ErrorCodes.UNKNOWN_TABLE:
-                raise e
+        self.__connection.execute(statement, data)

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -1,14 +1,13 @@
 import logging
 
-from clickhouse_driver import errors
 from datetime import datetime
-from enum import Enum
-from typing import NamedTuple
+from functools import partial
 
-from snuba.clickhouse.errors import ClickhouseError
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster, CLUSTERS
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.context import Context
 from snuba.migrations.groups import get_group_loader, MigrationGroup
+from snuba.migrations.status import Status
 
 logger = logging.getLogger("snuba.migrations")
 
@@ -19,61 +18,36 @@ DIST_TABLE_NAME = "migrations_dist"
 TABLE_NAME = LOCAL_TABLE_NAME
 
 
-class Status(Enum):
-    NOT_STARTED = "not_started"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-
-
-class MigrationKey(NamedTuple):
-    group: MigrationGroup
-    migration_id: str
-
-    def __str__(self) -> str:
-        return f"{self.group.value} {self.migration_id}"
-
-
 class Runner:
     def __init__(self) -> None:
         self.__connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
             ClickhouseClientSettings.MIGRATE
         )
 
-    def run_migration(self, migration_key: MigrationKey) -> None:
+    def run_migration(self, group: MigrationGroup, migration_id: str) -> None:
         """
         Run a single migration given its migration key and marks the migration as complete.
         """
-        group = migration_key.group
-        migration_id = migration_key.migration_id
-
         assert all(
             cluster.is_single_node() for cluster in CLUSTERS
         ), "Cannot run migrations for multi node clusters"
 
-        logger.info(f"Running migration: {migration_key}")
-
+        context = Context(
+            migration_id,
+            logger,
+            partial(self._update_migration_status, group, migration_id),
+        )
         migration = get_group_loader(group).load_migration(migration_id)
-
-        self._update_migration_status(migration_key, Status.IN_PROGRESS)
-
-        operations = migration.forwards_local()
-        for op in operations:
-            op.execute()
-
-        logger.info(f"Finished running, updating status: {migration_key}")
-
-        self._update_migration_status(migration_key, Status.COMPLETED)
-
-        logger.info(f"Finished: {migration_key}")
+        migration.forwards(context)
 
     def _update_migration_status(
-        self, migration_key: MigrationKey, status: Status
+        self, group: MigrationGroup, migration_id: str, status: Status
     ) -> None:
         statement = f"INSERT INTO {TABLE_NAME} FORMAT JSONEachRow"
         data = [
             {
-                "group": migration_key.group.value,
-                "migration_id": migration_key.migration_id,
+                "group": group.value,
+                "migration_id": migration_id,
                 "timestamp": datetime.now(),
                 "status": status.value,
                 # TODO: Version should be incremented each time we update that
@@ -82,16 +56,4 @@ class Runner:
             }
         ]
 
-        try:
-            self.__connection.execute(statement, data)
-        except ClickhouseError as e:
-            # HACK: Ignore failures related to non existent table when we're
-            # setting system migrations to non completed statuses. This is required
-            # since the migrations table might not yet exist.
-            allow_fail = (
-                migration_key.group == MigrationGroup.SYSTEM
-                and status != Status.COMPLETED
-            )
-
-            if not allow_fail or e.code != errors.ErrorCodes.UNKNOWN_TABLE:
-                raise e
+        self.__connection.execute(statement, data)

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -1,8 +1,11 @@
 import logging
 
+from clickhouse_driver import errors
 from datetime import datetime
 from enum import Enum
+from typing import NamedTuple
 
+from snuba.clickhouse.errors import ClickhouseError
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster, CLUSTERS
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.groups import get_group_loader, MigrationGroup
@@ -22,47 +25,73 @@ class Status(Enum):
     COMPLETED = "completed"
 
 
+class MigrationKey(NamedTuple):
+    group: MigrationGroup
+    migration_id: str
+
+    def __str__(self) -> str:
+        return f"{self.group.value} {self.migration_id}"
+
+
 class Runner:
-    def run_migration(self, group: MigrationGroup, migration_id: str) -> None:
+    def __init__(self) -> None:
+        self.__connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
+            ClickhouseClientSettings.MIGRATE
+        )
+
+    def run_migration(self, migration_key: MigrationKey) -> None:
         """
-        Run a single migration given its ID and marks the migration as complete.
+        Run a single migration given its migration key and marks the migration as complete.
         """
+        group = migration_key.group
+        migration_id = migration_key.migration_id
+
         assert all(
             cluster.is_single_node() for cluster in CLUSTERS
         ), "Cannot run migrations for multi node clusters"
 
-        logger.info(f"Running migration: {group} {migration_id}")
+        logger.info(f"Running migration: {migration_key}")
 
         migration = get_group_loader(group).load_migration(migration_id)
+
+        self._update_migration_status(migration_key, Status.IN_PROGRESS)
 
         operations = migration.forwards_local()
         for op in operations:
             op.execute()
 
-        logger.info(f"Finished running, updating status: {group} {migration_id}")
+        logger.info(f"Finished running, updating status: {migration_key}")
 
-        # TODO: In addition to marking migrations as completed, we should also mark
-        # migrations as in-progress before we execute the operations. However we
-        # will need to have some mechanism that allows this to be skipped in certain
-        # cases, such as the initial migration that creates the migrations table itself.
-        self._mark_completed(group, migration_id)
+        self._update_migration_status(migration_key, Status.COMPLETED)
 
-        logger.info(f"Finished: {group} {migration_id}")
+        logger.info(f"Finished: {migration_key}")
 
-    def _mark_completed(self, group: MigrationGroup, migration_id: str) -> None:
+    def _update_migration_status(
+        self, migration_key: MigrationKey, status: Status
+    ) -> None:
         statement = f"INSERT INTO {TABLE_NAME} FORMAT JSONEachRow"
         data = [
             {
-                "group": group.value,
-                "migration_id": migration_id,
+                "group": migration_key.group.value,
+                "migration_id": migration_key.migration_id,
                 "timestamp": datetime.now(),
-                "status": Status.COMPLETED.value,
+                "status": status.value,
                 # TODO: Version should be incremented each time we update that
                 # migration status
                 "version": 1,
             }
         ]
-        connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
-            ClickhouseClientSettings.MIGRATE
-        )
-        connection.execute(statement, data)
+
+        try:
+            self.__connection.execute(statement, data)
+        except ClickhouseError as e:
+            # HACK: Ignore failures related to non existent table when we're
+            # setting system migrations to non completed statuses. This is required
+            # since the migrations table might not yet exist.
+            allow_fail = (
+                migration_key.group == MigrationGroup.SYSTEM
+                and status != Status.COMPLETED
+            )
+
+            if not allow_fail or e.code != errors.ErrorCodes.UNKNOWN_TABLE:
+                raise e

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -2,6 +2,8 @@ from typing import Sequence
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration
 from snuba.migrations import operations
+from snuba.migrations.context import Context
+from snuba.migrations.status import Status
 
 
 class Migration(migration.Migration):
@@ -26,3 +28,11 @@ class Migration(migration.Migration):
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
             )
         ]
+
+    def forwards(self, context: Context) -> None:
+        migration_id, logger, update_status = context
+        logger.info(f"Running migration: {migration_id}")
+        for op in self.forwards_local():
+            op.execute()
+        logger.info(f"Finished: {migration_id}")
+        update_status(Status.COMPLETED)

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -7,6 +7,14 @@ from snuba.migrations.status import Status
 
 
 class Migration(migration.Migration):
+    """
+    This migration extends Migration instead of MultiStepMigration since it is
+    responsible for bootstrapping the migration system itself. It skips setting
+    the in progress status in the forwards method and the not started status in
+    the backwards method. Since the migration table doesn't exist yet, we can't
+    write any statuses until this migration is completed.
+    """
+
     blocking = False
 
     def __forwards_local(self) -> Sequence[operations.Operation]:
@@ -30,8 +38,6 @@ class Migration(migration.Migration):
         ]
 
     def forwards(self, context: Context) -> None:
-        # The same as the base forwards methods, only it skips setting the
-        # in progress status since the migrations table won't be created yet.
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
         for op in self.__forwards_local():

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -30,6 +30,8 @@ class Migration(migration.Migration):
         ]
 
     def forwards(self, context: Context) -> None:
+        # The same as the base forwards methods, only it skips setting the
+        # in progress status since the migrations table won't be created yet.
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
         for op in self.forwards_local():

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -9,7 +9,7 @@ from snuba.migrations.status import Status
 class Migration(migration.Migration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def _forwards_local(self) -> Sequence[operations.Operation]:
         return [
             operations.RunSql(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -22,7 +22,7 @@ class Migration(migration.Migration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def _backwards_local(self) -> Sequence[operations.Operation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
@@ -34,7 +34,7 @@ class Migration(migration.Migration):
         # in progress status since the migrations table won't be created yet.
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
-        for op in self.forwards_local():
+        for op in self._forwards_local():
             op.execute()
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -6,10 +6,10 @@ from snuba.migrations.context import Context
 from snuba.migrations.status import Status
 
 
-class Migration(migration.Migration):
+class Migration(migration.CustomMigration):
     blocking = False
 
-    def _forwards_local(self) -> Sequence[operations.Operation]:
+    def __forwards_local(self) -> Sequence[operations.Operation]:
         return [
             operations.RunSql(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -22,7 +22,7 @@ class Migration(migration.Migration):
             ),
         ]
 
-    def _backwards_local(self) -> Sequence[operations.Operation]:
+    def __backwards_local(self) -> Sequence[operations.Operation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
@@ -34,7 +34,7 @@ class Migration(migration.Migration):
         # in progress status since the migrations table won't be created yet.
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
-        for op in self._forwards_local():
+        for op in self.__forwards_local():
             op.execute()
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -6,7 +6,7 @@ from snuba.migrations.context import Context
 from snuba.migrations.status import Status
 
 
-class Migration(migration.CustomMigration):
+class Migration(migration.Migration):
     blocking = False
 
     def __forwards_local(self) -> Sequence[operations.Operation]:

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -2,6 +2,8 @@ from typing import Sequence
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration
 from snuba.migrations import operations
+from snuba.migrations.context import Context
+from snuba.migrations.status import Status
 
 
 class Migration(migration.Migration):
@@ -25,3 +27,11 @@ class Migration(migration.Migration):
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
             )
         ]
+
+    def forwards(self, context: Context) -> None:
+        migration_id, logger, update_status = context
+        logger.info(f"Running migration: {migration_id}")
+        for op in self.forwards_local():
+            op.execute()
+        logger.info(f"Finished: {migration_id}")
+        update_status(Status.COMPLETED)

--- a/snuba/migrations/status.py
+++ b/snuba/migrations/status.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class Status(Enum):
+    NOT_STARTED = "not_started"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -1,10 +1,11 @@
 from snuba.migrations.groups import MigrationGroup
-from snuba.migrations.runner import Runner
+from snuba.migrations.runner import MigrationKey, Runner
 
 
 def test_run_migration() -> None:
     runner = Runner()
-    runner.run_migration(MigrationGroup.SYSTEM, "0001_migrations")
+    migration_key = MigrationKey(MigrationGroup.SYSTEM, "0001_migrations")
+    runner.run_migration(migration_key)
 
     from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
     from snuba.clusters.storage_sets import StorageSetKey

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -1,11 +1,10 @@
 from snuba.migrations.groups import MigrationGroup
-from snuba.migrations.runner import MigrationKey, Runner
+from snuba.migrations.runner import Runner
 
 
 def test_run_migration() -> None:
     runner = Runner()
-    migration_key = MigrationKey(MigrationGroup.SYSTEM, "0001_migrations")
-    runner.run_migration(migration_key)
+    runner.run_migration(MigrationGroup.SYSTEM, "0001_migrations")
 
     from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
     from snuba.clusters.storage_sets import StorageSetKey


### PR DESCRIPTION
Set the migration status to in progress before running the migration
operations.

Note after the version column is introduced we will need to increment
the version on every status update.

We add a hack that allows writing system migrations (except those with
completed status) to fail with unknown table error. This is required
since the table to store the migrations might not exist yet.