### PR TITLE
feat(ast): Wire up the rollout logic in web/query

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Mapping, MutableMapping, Sequence, Set
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
@@ -104,7 +104,7 @@ TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 
 AST_DATASET_ROLLOUT: Mapping[str, int] = {}  # (dataset name: percentage)
 AST_REFERRER_ROLLOUT: Mapping[
-    str, Mapping[str, int]
+    str, Mapping[Optional[str], int]
 ] = {}  # (dataset name: (referrer: percentage))
 
 

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -102,6 +102,11 @@ PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 
+AST_DATASET_ROLLOUT: Mapping[str, int] = {}  # (dataset name: percentage)
+AST_REFERRER_ROLLOUT: Mapping[
+    str, Mapping[str, int]
+] = {}  # (dataset name: (referrer: percentage))
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/web/ast_rollout.py
+++ b/snuba/web/ast_rollout.py
@@ -14,8 +14,9 @@ def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
     on the AST or on the legacy representation.
 
     - if the emergency killswitch is on, then no rollout
-    - if the referrer is rolled out for a specific dataset then use ast
-    - if a dataset is rolled out then use ast
+    - if the referrer percentage is configured for the requested dataset
+      honor that percentage
+    - if a dataset is configured, then honor that percentage
     - if none of the above decide according to the master
         rollout percentage
     """
@@ -27,13 +28,12 @@ def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
     referrer_rollout_config = settings.AST_REFERRER_ROLLOUT.get(dataset_name, None)
     if referrer_rollout_config:
         referrer_percentage = referrer_rollout_config.get(referrer, None)
-        if referrer_percentage is not None and current_percentage < referrer_percentage:
-            return True
+        if referrer_percentage is not None:
+            return current_percentage < referrer_percentage
 
     dataset_rollout_percentage = settings.AST_DATASET_ROLLOUT.get(dataset_name, None)
     if dataset_rollout_percentage is not None:
-        if current_percentage < dataset_rollout_percentage:
-            return True
+        return current_percentage < dataset_rollout_percentage
 
     rollout_rate = get_config(ROLLOUT_RATE_CONFIG, 0)
     if rollout_rate is None:

--- a/snuba/web/ast_rollout.py
+++ b/snuba/web/ast_rollout.py
@@ -1,0 +1,44 @@
+from typing import Optional
+import random
+
+from snuba import settings
+from snuba.state import get_config
+
+
+def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
+    """
+    Applies some rules to decide whether we should run a query based
+    on the AST or on the legacy representation.
+
+    - if the emergency killswitch is on, then no rollout
+    - if a dataset is rolled out then use ast
+    - if the referrer is rolled out for a dataset then use ast
+    - if none of the above decide according to the master
+        rollout percentage
+    """
+
+    if get_config("ast_shutdown", 0):
+        return False
+
+    current_percentage = random.random() * 100
+    dataset_rollout_percentage = settings.AST_DATASET_ROLLOUT.get(dataset_name, None)
+    if dataset_rollout_percentage is not None:
+        if current_percentage < dataset_rollout_percentage:
+            return True
+
+    referrer_rollout_config = settings.AST_REFERRER_ROLLOUT.get(dataset_name, None)
+    if referrer_rollout_config:
+        if referrer is None:
+            # Treat no referrer as empty string. So we can configure
+            # a percentage for queries without referrer.
+            referrer = ""
+        referrer_percentage = referrer_rollout_config.get(referrer, None)
+        if referrer_percentage is not None and current_percentage < referrer_percentage:
+            return True
+
+    rollout_rate = get_config("ast_rollout_rate", 0)
+    if rollout_rate is None:
+        # This is for mypy since it does not believe
+        # (rightfully) that rollout_rate is an int.
+        return False
+    return current_percentage < int(rollout_rate)

--- a/snuba/web/ast_rollout.py
+++ b/snuba/web/ast_rollout.py
@@ -14,8 +14,8 @@ def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
     on the AST or on the legacy representation.
 
     - if the emergency killswitch is on, then no rollout
+    - if the referrer is rolled out for a specific dataset then use ast
     - if a dataset is rolled out then use ast
-    - if the referrer is rolled out for a dataset then use ast
     - if none of the above decide according to the master
         rollout percentage
     """
@@ -24,19 +24,15 @@ def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
         return False
 
     current_percentage = random.random() * 100
+    referrer_rollout_config = settings.AST_REFERRER_ROLLOUT.get(dataset_name, None)
+    if referrer_rollout_config:
+        referrer_percentage = referrer_rollout_config.get(referrer, None)
+        if referrer_percentage is not None and current_percentage < referrer_percentage:
+            return True
+
     dataset_rollout_percentage = settings.AST_DATASET_ROLLOUT.get(dataset_name, None)
     if dataset_rollout_percentage is not None:
         if current_percentage < dataset_rollout_percentage:
-            return True
-
-    referrer_rollout_config = settings.AST_REFERRER_ROLLOUT.get(dataset_name, None)
-    if referrer_rollout_config:
-        if referrer is None:
-            # Treat no referrer as empty string. So we can configure
-            # a percentage for queries without referrer.
-            referrer = ""
-        referrer_percentage = referrer_rollout_config.get(referrer, None)
-        if referrer_percentage is not None and current_percentage < referrer_percentage:
             return True
 
     rollout_rate = get_config(ROLLOUT_RATE_CONFIG, 0)

--- a/snuba/web/ast_rollout.py
+++ b/snuba/web/ast_rollout.py
@@ -4,6 +4,9 @@ import random
 from snuba import settings
 from snuba.state import get_config
 
+ROLLOUT_RATE_CONFIG = "ast_rollout_rate"
+KILLSWITCH_CONFIG = "ast_shutdown"
+
 
 def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
     """
@@ -17,7 +20,7 @@ def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
         rollout percentage
     """
 
-    if get_config("ast_shutdown", 0):
+    if get_config(KILLSWITCH_CONFIG, 0):
         return False
 
     current_percentage = random.random() * 100
@@ -36,7 +39,7 @@ def is_ast_rolled_out(dataset_name: str, referrer: Optional[str]) -> bool:
         if referrer_percentage is not None and current_percentage < referrer_percentage:
             return True
 
-    rollout_rate = get_config("ast_rollout_rate", 0)
+    rollout_rate = get_config(ROLLOUT_RATE_CONFIG, 0)
     if rollout_rate is None:
         # This is for mypy since it does not believe
         # (rightfully) that rollout_rate is an int.

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -187,10 +187,15 @@ def _format_storage_query_and_run(
             and ast_query is not None
         ):
             formatted_query: SqlQuery = ast_query
-            span.set_tag("query_type", "ast")
+            query_type = "ast"
+            metric = "execute.ast"
         else:
             formatted_query = legacy_query
-            span.set_tag("query_type", "legacy")
+            query_type = "legacy"
+            metric = "execute.legacy"
+
+        metrics.increment(metric)
+        span.set_tag("query_type", query_type)
 
     timer.mark("prepare_query")
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -22,9 +22,9 @@ from snuba.util import with_span
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryException, QueryResult
+from snuba.web.ast_rollout import is_ast_rolled_out
 from snuba.web.db_query import raw_query
 from snuba.web.query_metadata import SnubaQueryMetadata
-from snuba.web.ast_rollout import is_ast_rolled_out
 
 logger = logging.getLogger("snuba.query")
 
@@ -188,13 +188,11 @@ def _format_storage_query_and_run(
         ):
             formatted_query: SqlQuery = ast_query
             query_type = "ast"
-            metric = "execute.ast"
         else:
             formatted_query = legacy_query
             query_type = "legacy"
-            metric = "execute.legacy"
 
-        metrics.increment(metric)
+        metrics.increment("execute", tags={"query_type": query_type})
         span.set_tag("query_type", query_type)
 
     timer.mark("prepare_query")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from snuba import settings
 from snuba.clickhouse.native import ClickhousePool
 from snuba.environment import setup_sentry
-from snuba.state import set_config
+from snuba.state import delete_config, set_config
 from snuba.web.ast_rollout import ROLLOUT_RATE_CONFIG
 
 
@@ -29,3 +29,5 @@ def pytest_configure() -> None:
 @pytest.fixture(params=[0, 100], ids=["legacy", "ast"])
 def ast(request) -> None:
     set_config(ROLLOUT_RATE_CONFIG, request.param)
+    yield
+    delete_config(ROLLOUT_RATE_CONFIG)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def pytest_configure() -> None:
 
 
 @pytest.fixture(params=[0, 100], ids=["legacy", "ast"])
-def ast(request) -> None:
+def query_type(request) -> None:
     set_config(ROLLOUT_RATE_CONFIG, request.param)
     yield
     delete_config(ROLLOUT_RATE_CONFIG)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
+import pytest
+
 from snuba import settings
 from snuba.clickhouse.native import ClickhousePool
 from snuba.environment import setup_sentry
+from snuba.state import set_config
+from snuba.web.ast_rollout import ROLLOUT_RATE_CONFIG
 
 
 def pytest_configure() -> None:
@@ -20,3 +24,8 @@ def pytest_configure() -> None:
     database_name = cluster["database"]
     connection.execute(f"DROP DATABASE IF EXISTS {database_name};")
     connection.execute(f"CREATE DATABASE {database_name};")
+
+
+@pytest.fixture(params=[0, 100], ids=["legacy", "ast"])
+def ast(request) -> None:
+    set_config(ROLLOUT_RATE_CONFIG, request.param)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,16 +1,17 @@
 import calendar
+import time
+import uuid
 from datetime import datetime, timedelta
-from dateutil.parser import parse as parse_datetime
 from functools import partial
 from unittest.mock import patch
+
 import pytest
 import pytz
 import simplejson as json
-import time
-import uuid
+from dateutil.parser import parse as parse_datetime
+from sentry_sdk import Client, Hub
 
 from snuba import settings, state
-from sentry_sdk import Hub, Client
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.datasets.storages import StorageKey
@@ -20,6 +21,7 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from tests.base import BaseApiTest
 
 
+@pytest.mark.usefixtures("ast")
 class TestApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="events"):
         super().setup_method(test_method, dataset_name)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,7 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from tests.base import BaseApiTest
 
 
-@pytest.mark.usefixtures("ast")
+@pytest.mark.usefixtures("query_type")
 class TestApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="events"):
         super().setup_method(test_method, dataset_name)

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -1,16 +1,18 @@
 import calendar
+import uuid
 from datetime import datetime, timedelta
 from functools import partial
+
+import pytest
 import pytz
 import simplejson as json
-import uuid
 
 from snuba import settings, state
 from snuba.datasets.factory import enforce_table_writer
-
 from tests.base import BaseApiTest
 
 
+@pytest.mark.usefixtures("ast")
 class TestTransactionsApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="transactions"):
         super().setup_method(test_method, dataset_name)

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -12,7 +12,7 @@ from snuba.datasets.factory import enforce_table_writer
 from tests.base import BaseApiTest
 
 
-@pytest.mark.usefixtures("ast")
+@pytest.mark.usefixtures("query_type")
 class TestTransactionsApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="transactions"):
         super().setup_method(test_method, dataset_name)

--- a/tests/web/test_ast_rollout.py
+++ b/tests/web/test_ast_rollout.py
@@ -1,5 +1,5 @@
 from snuba import settings
-from snuba.state import set_config
+from snuba.state import set_config, delete_config
 from snuba.web.ast_rollout import (
     is_ast_rolled_out,
     KILLSWITCH_CONFIG,
@@ -26,3 +26,6 @@ def test_rollout() -> None:
 
     set_config(ROLLOUT_RATE_CONFIG, 100)
     assert is_ast_rolled_out("outcomes", "something_else") == True
+
+    delete_config(ROLLOUT_RATE_CONFIG)
+    delete_config(KILLSWITCH_CONFIG)

--- a/tests/web/test_ast_rollout.py
+++ b/tests/web/test_ast_rollout.py
@@ -1,0 +1,24 @@
+from snuba import settings
+from snuba.state import set_config
+from snuba.web.ast_rollout import is_ast_rolled_out
+
+
+def test_rollout() -> None:
+    settings.AST_DATASET_ROLLOUT = {"events": 100}
+    settings.AST_REFERRER_ROLLOUT = {"transactions": {"something": 100}}
+    set_config("ast_rollout_rate", 100)
+
+    set_config("ast_shutdown", 1)
+    assert is_ast_rolled_out("events", "something") == False
+
+    set_config("ast_shutdown", 0)
+    assert is_ast_rolled_out("events", "something") == True
+
+    set_config("ast_rollout_rate", 0)
+    assert is_ast_rolled_out("transactions", "something_else") == False
+    assert is_ast_rolled_out("transactions", "something") == True
+
+    assert is_ast_rolled_out("outcomes", "something_else") == False
+
+    set_config("ast_rollout_rate", 100)
+    assert is_ast_rolled_out("outcomes", "something_else") == True

--- a/tests/web/test_ast_rollout.py
+++ b/tests/web/test_ast_rollout.py
@@ -22,6 +22,10 @@ def test_rollout() -> None:
     assert is_ast_rolled_out("transactions", "something_else") == False
     assert is_ast_rolled_out("transactions", "something") == True
 
+    settings.AST_REFERRER_ROLLOUT = {"events": {"something": 0}}
+    settings.AST_DATASET_ROLLOUT = {"events": 100}
+    assert is_ast_rolled_out("events", "something") == False
+
     assert is_ast_rolled_out("outcomes", "something_else") == False
 
     set_config(ROLLOUT_RATE_CONFIG, 100)

--- a/tests/web/test_ast_rollout.py
+++ b/tests/web/test_ast_rollout.py
@@ -1,24 +1,28 @@
 from snuba import settings
 from snuba.state import set_config
-from snuba.web.ast_rollout import is_ast_rolled_out
+from snuba.web.ast_rollout import (
+    is_ast_rolled_out,
+    KILLSWITCH_CONFIG,
+    ROLLOUT_RATE_CONFIG,
+)
 
 
 def test_rollout() -> None:
     settings.AST_DATASET_ROLLOUT = {"events": 100}
     settings.AST_REFERRER_ROLLOUT = {"transactions": {"something": 100}}
-    set_config("ast_rollout_rate", 100)
+    set_config(ROLLOUT_RATE_CONFIG, 100)
 
-    set_config("ast_shutdown", 1)
+    set_config(KILLSWITCH_CONFIG, 1)
     assert is_ast_rolled_out("events", "something") == False
 
-    set_config("ast_shutdown", 0)
+    set_config(KILLSWITCH_CONFIG, 0)
     assert is_ast_rolled_out("events", "something") == True
 
-    set_config("ast_rollout_rate", 0)
+    set_config(ROLLOUT_RATE_CONFIG, 0)
     assert is_ast_rolled_out("transactions", "something_else") == False
     assert is_ast_rolled_out("transactions", "something") == True
 
     assert is_ast_rolled_out("outcomes", "something_else") == False
 
-    set_config("ast_rollout_rate", 100)
+    set_config(ROLLOUT_RATE_CONFIG, 100)
     assert is_ast_rolled_out("outcomes", "something_else") == True


### PR DESCRIPTION
This adds a Rollout Gate for the AST. It is in itw own module so we can easily tweak the rules.
It is based on config and settings. These are the rules:
1) if the emergency killswitch is on, the ast is off
2) if a dataset is in the config and the query fits in the rollout percentage the ast is on
3) if not, and the referrer is in the config for a dataset, and the query fits in the rollout percentage the ast is on
4) if not the default rule applies which is by percentage.

Everything starts at 0.
More rules may be added if we decide to have finer granularity during the rollout.

It also triggers test_api and test_transaction_api both on the legacy representation and on the ast. So now we have regression tests on the ast wired up.