### PR TITLE
perf(tags) Stop writing flattened tags on errors and events

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -98,6 +98,15 @@ class ErrorsProcessor(EventsProcessorBase):
         # an empty string.
         output["transaction_name"] = tags.get("transaction", "") or ""
 
+    def extract_contexts_custom(
+        self,
+        output: MutableMapping[str, Any],
+        event: Mapping[str, Any],
+        contexts: Mapping[str, Any],
+        metadata: Optional[KafkaMessageMetadata] = None,
+    ) -> None:
+        output["_contexts_flattened"] = ""
+
     def extract_promoted_contexts(
         self,
         output: MutableMapping[str, Any],

--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -5,11 +5,7 @@ import _strptime  # NOQA fixes _strptime deferred import issue
 import uuid
 
 from snuba.consumer import KafkaMessageMetadata
-from snuba.datasets.events_format import (
-    extract_extra_contexts,
-    extract_user,
-    flatten_nested_field,
-)
+from snuba.datasets.events_format import extract_user
 from snuba.datasets.events_processor_base import EventsProcessorBase
 from snuba.processor import (
     _as_dict_safe,
@@ -101,16 +97,6 @@ class ErrorsProcessor(EventsProcessorBase):
         # often have transaction_name set to NULL, so we need to replace that with
         # an empty string.
         output["transaction_name"] = tags.get("transaction", "") or ""
-
-    def extract_contexts_custom(
-        self,
-        output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
-        contexts: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
-    ) -> None:
-        key, value = extract_extra_contexts(contexts)
-        output["_contexts_flattened"] = flatten_nested_field(key, value)
 
     def extract_promoted_contexts(
         self,

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -142,15 +142,6 @@ class EventsProcessor(EventsProcessorBase):
         output["device_online"] = _boolify(device_ctx.pop("online", None))
         output["device_charging"] = _boolify(device_ctx.pop("charging", None))
 
-    def extract_contexts_custom(
-        self,
-        output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
-        tags: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
-    ) -> None:
-        pass
-
     def extract_geo(self, output, geo):
         output["geo_country_code"] = _unicodify(geo.get("country_code", None))
         output["geo_region"] = _unicodify(geo.get("region", None))

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -142,6 +142,15 @@ class EventsProcessor(EventsProcessorBase):
         output["device_online"] = _boolify(device_ctx.pop("online", None))
         output["device_charging"] = _boolify(device_ctx.pop("charging", None))
 
+    def extract_contexts_custom(
+        self,
+        output: MutableMapping[str, Any],
+        event: Mapping[str, Any],
+        tags: Mapping[str, Any],
+        metadata: Optional[KafkaMessageMetadata] = None,
+    ) -> None:
+        pass
+
     def extract_geo(self, output, geo):
         output["geo_country_code"] = _unicodify(geo.get("country_code", None))
         output["geo_region"] = _unicodify(geo.get("region", None))

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -251,11 +251,6 @@ def test_error_processor() -> None:
             "this_is_me",
             "snuba",
         ],
-        "_tags_flattened": (
-            "|environment=dev||handled=no||level=error||mechanism=excepthook|"
-            "|runtime=CPython 3.7.6||runtime.name=CPython|"
-            "|sentry:release=4d23338017cdee67daf25f2c||sentry:user=this_is_me||server_name=snuba|"
-        ),
         "contexts.key": [
             "runtime.version",
             "runtime.name",
@@ -276,11 +271,6 @@ def test_error_processor() -> None:
             "POST",
             "tagstore.something",
         ],
-        "_contexts_flattened": (
-            "|geo.city=fake_city||geo.country_code=XY||geo.region=fake_region|"
-            "|request.http_method=POST||request.http_referer=tagstore.something|"
-            "|runtime.build=3.7.6||runtime.name=CPython||runtime.version=3.7.6|"
-        ),
         "partition": 1,
         "offset": 2,
         "message_timestamp": datetime(1970, 1, 1),

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -251,6 +251,7 @@ def test_error_processor() -> None:
             "this_is_me",
             "snuba",
         ],
+        "_tags_flattened": "",
         "contexts.key": [
             "runtime.version",
             "runtime.name",
@@ -271,6 +272,7 @@ def test_error_processor() -> None:
             "POST",
             "tagstore.something",
         ],
+        "_contexts_flattened": "",
         "partition": 1,
         "offset": 2,
         "message_timestamp": datetime(1970, 1, 1),

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -436,19 +436,6 @@ class TestReplacer(BaseEventsTest):
                 ).data
             )["data"]
 
-        assert _fetch_flattened_tags() == [
-            {
-                "tags.key": [
-                    "browser|name",
-                    "browser|to_delete",
-                    "notbrowser",
-                    "notbrowser2",
-                ],
-                "tags.value": ["foo=1", "foo=2", "foo\\3", "foo4"],
-                "_tags_flattened": "|browser\\|name=foo\\=1||browser\\|to_delete=foo\\=2||notbrowser=foo\\\\3||notbrowser2=foo4|",
-            }
-        ]
-
         timestamp = datetime.now(tz=pytz.utc)
 
         message: Message[KafkaPayload] = Message(


### PR DESCRIPTION
We are not reading flattened tags or contexts on errors and events. They consume a lot of space for nothing. This is removing them.