### PR TITLE
feat(migrations): Add a create table operation

### DIFF
--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -52,6 +52,10 @@ class TableSchema(Schema, ABC):
 
     Specifically a TableSchema is something we can read from through
     a simple select and that provides DDL operations.
+
+    Once the new migration system is rolled out, TableSchema will only
+    be used for querying, and any methods that provide DDL operations will
+    be removed.
     """
 
     def __init__(

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -1,5 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import Sequence
 
+
+from snuba.clickhouse.columns import Column
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 
@@ -48,3 +51,34 @@ class DropTable(SqlOperation):
 
     def format_sql(self) -> str:
         return f"DROP TABLE IF EXISTS {self.table_name};"
+
+
+class TableEngine:
+    pass
+
+
+class ReplacingMergeTree(TableEngine):
+    def __init__(self, version_column: str):
+        self.__version_column = version_column
+
+    def __str__(self) -> str:
+        return f"ReplacingMergeTree({self.__version_column})"
+
+
+class CreateTable(SqlOperation):
+    def __init__(
+        self,
+        storage_set: StorageSetKey,
+        table_name: str,
+        columns: Sequence[Column],
+        engine: TableEngine,
+    ):
+        self.__table_name = table_name
+        self.__columns = columns
+        self.__engine = engine
+        super().__init__(storage_set)
+
+    def format_sql(self) -> str:
+        columns = ", ".join([col.for_schema() for col in self.__columns])
+
+        return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns} ENGINE {self.__engine});"

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -72,13 +72,15 @@ class CreateTable(SqlOperation):
         table_name: str,
         columns: Sequence[Column],
         engine: TableEngine,
+        order_by: str,
     ):
         self.__table_name = table_name
         self.__columns = columns
         self.__engine = engine
+        self.__order_by = order_by
         super().__init__(storage_set)
 
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
 
-        return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns} ENGINE {self.__engine});"
+        return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns}) ENGINE {self.__engine} ORDER BY {self.__order_by};"

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1,0 +1,29 @@
+from snuba.clickhouse.columns import Column, Nullable, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.operations import (
+    CreateTable,
+    DropTable,
+    ReplacingMergeTree,
+)
+
+
+def test_create_table() -> None:
+    columns = [
+        Column("id", String()),
+        Column("name", Nullable(String())),
+        Column("version", UInt(64)),
+    ]
+
+    assert (
+        CreateTable(
+            StorageSetKey.EVENTS, "test_table", columns, ReplacingMergeTree("version")
+        ).format_sql()
+        == "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64 ENGINE ReplacingMergeTree(version));"
+    )
+
+
+def test_drop_table() -> None:
+    assert (
+        DropTable(StorageSetKey.EVENTS, "test_table").format_sql()
+        == "DROP TABLE IF EXISTS test_table;"
+    )

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -16,9 +16,13 @@ def test_create_table() -> None:
 
     assert (
         CreateTable(
-            StorageSetKey.EVENTS, "test_table", columns, ReplacingMergeTree("version")
+            StorageSetKey.EVENTS,
+            "test_table",
+            columns,
+            ReplacingMergeTree("version"),
+            "version",
         ).format_sql()
-        == "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64 ENGINE ReplacingMergeTree(version));"
+        == "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64) ENGINE ReplacingMergeTree(version) ORDER BY version;"
     )
 
 


### PR DESCRIPTION
Provide an easier way to define create table operations rather than
requiring raw SQL.