### PR TITLE
feat(migrations): Add a method that runs all migrations at once

### DIFF
--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -1,0 +1,2 @@
+class MigrationInProgress(Exception):
+    pass

--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -1,2 +1,6 @@
 class MigrationInProgress(Exception):
     pass
+
+
+class InvalidMigrationState(Exception):
+    pass

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -121,7 +121,8 @@ class Runner:
             try:
                 data = {}
                 for row in self.__connection.execute(
-                    f"SELECT group, migration_id, status FROM {TABLE_NAME} FINAL;"
+                    f"SELECT group, migration_id, status FROM {TABLE_NAME} FINAL",
+                    settings={"load_balancing": "in_order"},
                 ):
                     group_name, migration_id, status_name = row
                     data[

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -1,10 +1,14 @@
 import logging
 
+from clickhouse_driver import errors
 from datetime import datetime
 from enum import Enum
+from typing import List, MutableMapping, NamedTuple, Optional
 
+from snuba.clickhouse.errors import ClickhouseError
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster, CLUSTERS
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.errors import MigrationInProgress
 from snuba.migrations.groups import get_group_loader, MigrationGroup
 
 logger = logging.getLogger("snuba.migrations")
@@ -22,11 +26,49 @@ class Status(Enum):
     COMPLETED = "completed"
 
 
+class MigrationKey(NamedTuple):
+    group: MigrationGroup
+    migration_id: str
+
+
 class Runner:
-    def run_migration(self, group: MigrationGroup, migration_id: str) -> None:
+    def __init__(self) -> None:
+        self.__connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
+            ClickhouseClientSettings.MIGRATE
+        )
+        self.__migrations_status: Optional[MutableMapping[MigrationKey, Status]] = None
+
+    def run_all(self) -> None:
         """
-        Run a single migration given its ID and marks the migration as complete.
+        Run all pending migrations. Throws an error if any migration is in progress.
         """
+        for migration in self.get_pending_migrations():
+            self.run_migration(migration)
+
+    def get_pending_migrations(self) -> List[MigrationKey]:
+        migrations: List[MigrationKey] = []
+
+        for group in MigrationGroup:
+            group_loader = get_group_loader(group)
+
+            for migration_id in group_loader.get_migrations():
+                migration_key = MigrationKey(group, migration_id)
+                status = self._get_migration_status(migration_key)
+                if status == Status.IN_PROGRESS:
+                    raise MigrationInProgress(migration_key)
+                if status == Status.NOT_STARTED:
+                    migrations.append(migration_key)
+
+        return migrations
+
+    def run_migration(self, migration_key: MigrationKey) -> None:
+        """
+        Run a single migration given its group and ID.
+        Marks the migration as completed.
+        """
+        group = migration_key.group
+        migration_id = migration_key.migration_id
+
         assert all(
             cluster.is_single_node() for cluster in CLUSTERS
         ), "Cannot run migrations for multi node clusters"
@@ -45,18 +87,20 @@ class Runner:
         # migrations as in-progress before we execute the operations. However we
         # will need to have some mechanism that allows this to be skipped in certain
         # cases, such as the initial migration that creates the migrations table itself.
-        self._mark_completed(group, migration_id)
+        self._mark_completed(migration_key)
 
         logger.info(f"Finished: {group} {migration_id}")
 
-    def _mark_completed(self, group: MigrationGroup, migration_id: str) -> None:
+    def _mark_completed(self, migration_key: MigrationKey) -> None:
+        status = Status.COMPLETED
+
         statement = f"INSERT INTO {TABLE_NAME} FORMAT JSONEachRow"
         data = [
             {
-                "group": group.value,
-                "migration_id": migration_id,
+                "group": migration_key.group.value,
+                "migration_id": migration_key.migration_id,
                 "timestamp": datetime.now(),
-                "status": Status.COMPLETED.value,
+                "status": status.value,
                 # TODO: Version should be incremented each time we update that
                 # migration status
                 "version": 1,
@@ -66,3 +110,29 @@ class Runner:
             ClickhouseClientSettings.MIGRATE
         )
         connection.execute(statement, data)
+
+        if self.__migrations_status is not None:
+            self.__migrations_status[migration_key] = status
+
+    def _get_migration_status(self, migration_key: MigrationKey) -> Status:
+        if self.__migrations_status is None:
+            data: MutableMapping[MigrationKey, Status] = {}
+
+            try:
+                data = {}
+                for row in self.__connection.execute(
+                    f"SELECT group, migration_id, status FROM {TABLE_NAME} FINAL;"
+                ):
+                    group_name, migration_id, status_name = row
+                    data[
+                        MigrationKey(MigrationGroup(group_name), migration_id)
+                    ] = Status(status_name)
+                self.__migrations_status = data
+            except ClickhouseError as e:
+                # If the table wasn't created yet, no migrations have started yet.
+                if e.code == errors.ErrorCodes.UNKNOWN_TABLE:
+                    self.__migrations_status = {}
+                else:
+                    raise e
+
+        return self.__migrations_status.get(migration_key, Status.NOT_STARTED)

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -41,10 +41,10 @@ class Runner:
         """
         Run all pending migrations. Throws an error if any migration is in progress.
         """
-        for migration in self.get_pending_migrations():
+        for migration in self._get_pending_migrations():
             self.run_migration(migration)
 
-    def get_pending_migrations(self) -> List[MigrationKey]:
+    def _get_pending_migrations(self) -> List[MigrationKey]:
         migrations: List[MigrationKey] = []
 
         migration_status = self._get_migration_status()

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -103,10 +103,7 @@ class Runner:
                 "version": 1,
             }
         ]
-        connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
-            ClickhouseClientSettings.MIGRATE
-        )
-        connection.execute(statement, data)
+        self.__connection.execute(statement, data)
 
     def _get_migration_status(self) -> Mapping[MigrationKey, Status]:
         data: MutableMapping[MigrationKey, Status] = {}

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -103,7 +103,9 @@ class Runner:
                 "version": 1,
             }
         ]
-        self.__connection.execute(statement, data)
+        self.__connection.execute(
+            statement, data, settings={"load_balancing": "in_order"}
+        )
 
     def _get_migration_status(self) -> Mapping[MigrationKey, Status]:
         data: MutableMapping[MigrationKey, Status] = {}

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -26,17 +26,17 @@ def test_run_migration() -> None:
 def test_get_pending_migrations() -> None:
     runner = Runner()
     total_migrations = get_total_migration_count()
-    assert len(runner.get_pending_migrations()) == total_migrations
+    assert len(runner._get_pending_migrations()) == total_migrations
     runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"))
-    assert len(runner.get_pending_migrations()) == total_migrations - 1
+    assert len(runner._get_pending_migrations()) == total_migrations - 1
 
 
 def test_run_all() -> None:
     runner = Runner()
-    assert len(runner.get_pending_migrations()) == get_total_migration_count()
+    assert len(runner._get_pending_migrations()) == get_total_migration_count()
 
     runner.run_all()
-    assert runner.get_pending_migrations() == []
+    assert runner._get_pending_migrations() == []
 
 
 def get_total_migration_count() -> int:

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -1,13 +1,19 @@
-from snuba.migrations.groups import MigrationGroup
-from snuba.migrations.runner import Runner
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.groups import get_group_loader, MigrationGroup
+from snuba.migrations.runner import MigrationKey, Runner
+
+
+def setup_function() -> None:
+    connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
+        ClickhouseClientSettings.MIGRATE
+    )
+    connection.execute("DROP TABLE IF EXISTS migrations_local;")
 
 
 def test_run_migration() -> None:
     runner = Runner()
-    runner.run_migration(MigrationGroup.SYSTEM, "0001_migrations")
-
-    from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
-    from snuba.clusters.storage_sets import StorageSetKey
+    runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"))
 
     connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
         ClickhouseClientSettings.MIGRATE
@@ -15,3 +21,26 @@ def test_run_migration() -> None:
     assert connection.execute(
         "SELECT group, migration_id, status FROM migrations_local;"
     ) == [("system", "0001_migrations", "completed")]
+
+
+def test_get_pending_migrations() -> None:
+    runner = Runner()
+    total_migrations = get_total_migration_count()
+    assert len(runner.get_pending_migrations()) == total_migrations
+    runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"))
+    assert len(runner.get_pending_migrations()) == total_migrations - 1
+
+
+def test_run_all() -> None:
+    runner = Runner()
+    assert len(runner.get_pending_migrations()) == get_total_migration_count()
+
+    runner.run_all()
+    assert runner.get_pending_migrations() == []
+
+
+def get_total_migration_count() -> int:
+    count = 0
+    for group in MigrationGroup:
+        count += len(get_group_loader(group).get_migrations())
+    return count


### PR DESCRIPTION
Adds the run_all() method to the migration runner. This method runs all migrations
with the not started status. If any in progress migrations exist, nothing will be run
as these will need to be manually resolved first.