### PR TITLE
fix(ast) Avoid duplicates when counting columns in the column splitter

### DIFF
--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -317,7 +317,15 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             return None
 
         total_col_count = len(query.get_all_referenced_columns())
-        total_ast_count = len(query.get_all_ast_referenced_columns())
+        total_ast_count = len(
+            # We need to count the number of table/column name pairs
+            # not the number of distinct Column objects in the query
+            # so to avoid counting aliased columns multiple times.
+            {
+                (col.table_name, col.column_name)
+                for col in query.get_all_ast_referenced_columns()
+            }
+        )
         if total_col_count != total_ast_count:
             metrics.increment("mismatch.total_referenced_columns")
 
@@ -335,7 +343,12 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             ]
         )
 
-        minimal_ast_count = len(minimal_query.get_all_ast_referenced_columns())
+        minimal_ast_count = len(
+            {
+                (col.table_name, col.column_name)
+                for col in minimal_query.get_all_ast_referenced_columns()
+            }
+        )
         minimal_count = len(minimal_query.get_all_referenced_columns())
         if minimal_count != minimal_ast_count:
             metrics.increment("mismatch.minimaL_query_referenced_columns")


### PR DESCRIPTION
The ast can contain aliased expression for columns (and we do that during processing). Technically the old representation could as well, but all processing happened after the splitter in column_expr methods.

The column splitter needs to know how many columns we are loading to apply its optimization. In that case `(col as A)` and `(col as B)` are the same since clickhouse is loading one column not 2.
In the ast these are different nodes because of the alias attribute, so we need to collapse those two when counting.