### PR TITLE
perf(flattened tags) Remove flattened tags/contexts from errors take 2

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -1,21 +1,12 @@
+import logging
+import uuid
 from typing import Any, Mapping, MutableMapping, Optional
 
-import logging
 import _strptime  # NOQA fixes _strptime deferred import issue
-import uuid
-
 from snuba.consumer import KafkaMessageMetadata
-from snuba.datasets.events_format import (
-    extract_extra_contexts,
-    extract_user,
-    flatten_nested_field,
-)
+from snuba.datasets.events_format import extract_user
 from snuba.datasets.events_processor_base import EventsProcessorBase
-from snuba.processor import (
-    _as_dict_safe,
-    _ensure_valid_ip,
-    _unicodify,
-)
+from snuba.processor import _as_dict_safe, _ensure_valid_ip, _unicodify
 
 logger = logging.getLogger(__name__)
 
@@ -109,8 +100,7 @@ class ErrorsProcessor(EventsProcessorBase):
         contexts: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
-        key, value = extract_extra_contexts(contexts)
-        output["_contexts_flattened"] = flatten_nested_field(key, value)
+        pass
 
     def extract_promoted_contexts(
         self,

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -5,7 +5,11 @@ import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.consumer import KafkaMessageMetadata
-from snuba.datasets.events_format import extract_user
+from snuba.datasets.events_format import (
+    extract_user,
+    extract_extra_tags,
+    flatten_nested_field,
+)
 from snuba.datasets.events_processor_base import EventsProcessorBase
 from snuba.processor import (
     _as_dict_safe,
@@ -89,7 +93,8 @@ class EventsProcessor(EventsProcessorBase):
         tags: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
-        pass
+        keys, values = extract_extra_tags(tags)
+        output["_tags_flattened"] = flatten_nested_field(keys, values)
 
     def extract_promoted_contexts(
         self,

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -11,7 +11,6 @@ from snuba.datasets.events_format import (
     extract_extra_contexts,
     extract_extra_tags,
     extract_project_id,
-    flatten_nested_field,
 )
 from snuba.processor import (
     InvalidMessageType,
@@ -232,9 +231,6 @@ class EventsProcessorBase(MessageProcessor, ABC):
             contexts
         )
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
-        processed["_tags_flattened"] = flatten_nested_field(
-            processed["tags.key"], processed["tags.value"]
-        )
 
         exception = (
             data.get("exception", data.get("sentry.interfaces.Exception", None)) or {}

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -251,11 +251,6 @@ def test_error_processor() -> None:
             "this_is_me",
             "snuba",
         ],
-        "_tags_flattened": (
-            "|environment=dev||handled=no||level=error||mechanism=excepthook|"
-            "|runtime=CPython 3.7.6||runtime.name=CPython|"
-            "|sentry:release=4d23338017cdee67daf25f2c||sentry:user=this_is_me||server_name=snuba|"
-        ),
         "contexts.key": [
             "runtime.version",
             "runtime.name",
@@ -276,11 +271,6 @@ def test_error_processor() -> None:
             "POST",
             "tagstore.something",
         ],
-        "_contexts_flattened": (
-            "|geo.city=fake_city||geo.country_code=XY||geo.region=fake_region|"
-            "|request.http_method=POST||request.http_referer=tagstore.something|"
-            "|runtime.build=3.7.6||runtime.name=CPython||runtime.version=3.7.6|"
-        ),
         "partition": 1,
         "offset": 2,
         "message_timestamp": datetime(1970, 1, 1),


### PR DESCRIPTION
This is the same as https://github.com/getsentry/snuba/pull/1033 but it only innvolves the errors table so we can ensure clickhouse would not cause issues with input_format_defaults_for_omitted_fields that is set to `0` inn production.