### PR TITLE
fix(splitter) Do not apply the column splitter if the resulting query is invalid

### DIFF
--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -356,6 +356,10 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
         if total_col_count <= minimal_count:
             return None
 
+        # Ensure the minimal query is actually runnable on its own.
+        if not minimal_query.validate_aliases():
+            return None
+
         result = runner(minimal_query, request_settings)
         del minimal_query
 

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -1,15 +1,16 @@
+from typing import Any, MutableMapping
+
+import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.schemas.tables import TableSource
-from snuba.query.conditions import binary_condition, ConditionFunctions
-from snuba.query.expressions import (
-    Column,
-    Expression,
-    FunctionCall,
-    Literal,
-)
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import OrderBy, OrderByDirection, Query
 from snuba.query.parser import parse_query
+from snuba.request import Request
+from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_iterate_over_query():
@@ -152,3 +153,52 @@ def test_get_all_columns() -> None:
         Column("event_id", None, "event_id"),
         Column("timestamp", None, "timestamp"),
     }
+
+
+VALIDATION_TESTS = [
+    pytest.param(
+        {
+            "selected_columns": ["project_id", "event_id"],
+            "conditions": [["event_id", "IN", ["a", "b"]]],
+        },
+        True,
+        id="No alias references",
+    ),
+    pytest.param(
+        {
+            "selected_columns": ["project_id", ["f", ["event_id"], "not_event"]],
+            "conditions": [["not_event", "IN", ["a", "b"]]],
+        },
+        True,
+        id="Alias declared and referenced",
+    ),
+    pytest.param(
+        {
+            "selected_columns": ["project_id", ["f", ["event_id"], "event_id"]],
+            "conditions": [["event_id", "IN", ["a", "b"]]],
+        },
+        True,
+        id="Alias redefines col and referenced",
+    ),
+    pytest.param(
+        {
+            "selected_columns": ["project_id", ["f", ["event_id"], "event_id"]],
+            "conditions": [["whatsthis", "IN", ["a", "b"]]],
+        },
+        False,
+        id="Alias referenced and not defined",
+    ),
+]
+
+
+@pytest.mark.parametrize("query_body, expected_result", VALIDATION_TESTS)
+def test_alias_validation(
+    query_body: MutableMapping[str, Any], expected_result: bool
+) -> None:
+    events = get_dataset("events")
+    query = parse_query(query_body, events)
+    query_plan = events.get_query_plan_builder().build_plan(
+        Request("", query, HTTPRequestSettings(), {}, "")
+    )
+
+    assert query_plan.query.validate_aliases() == expected_result

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -1,27 +1,27 @@
-import pytest
-
 from datetime import datetime
 from typing import Any, MutableMapping, Sequence
 
+import pytest
+
 from snuba import state
 from snuba.clickhouse.columns import ColumnSet, String
+from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.sql import SqlQuery
 from snuba.clusters.cluster import ClickhouseCluster
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SimpleQueryPlanExecutionStrategy
-from snuba.web.split import (
-    _get_time_range,
-    ColumnSplitQueryStrategy,
-    TimeSplitQueryStrategy,
-)
-from snuba.datasets.schemas.tables import TableSource
-from snuba.query.logical import Query as LogicalQuery
-from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.query.expressions import Column
+from snuba.query.logical import Query as LogicalQuery
 from snuba.query.parser import parse_query
 from snuba.reader import Reader
+from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
+from snuba.web.split import (
+    ColumnSplitQueryStrategy,
+    TimeSplitQueryStrategy,
+    _get_time_range,
+)
 
 
 def setup_function(function) -> None:
@@ -202,98 +202,83 @@ column_split_tests = [
         "event_id",
         "project_id",
         "timestamp",
-        ClickhouseQuery(
-            LogicalQuery(
-                {
-                    "selected_columns": [
-                        "event_id",
-                        "level",
-                        "logger",
-                        "server_name",
-                        "transaction",
-                        "timestamp",
-                        "project_id",
-                    ],
-                    "conditions": [
-                        ("timestamp", ">=", "2019-09-19T10:00:00"),
-                        ("timestamp", "<", "2019-09-19T12:00:00"),
-                        ("project_id", "IN", [1, 2, 3]),
-                    ],
-                    "groupby": ["timestamp"],
-                    "limit": 10,
-                },
-                TableSource("events", column_set),
-            )
-        ),
+        {
+            "selected_columns": [
+                "event_id",
+                "level",
+                "logger",
+                "server_name",
+                "transaction",
+                "timestamp",
+                "project_id",
+            ],
+            "conditions": [
+                ("timestamp", ">=", "2019-09-19T10:00:00"),
+                ("timestamp", "<", "2019-09-19T12:00:00"),
+                ("project_id", "IN", [1, 2, 3]),
+            ],
+            "groupby": ["timestamp"],
+            "limit": 10,
+        },
         False,
     ),  # Query with group by. No split
     (
         "event_id",
         "project_id",
         "timestamp",
-        ClickhouseQuery(
-            LogicalQuery(
-                {
-                    "selected_columns": [
-                        "event_id",
-                        "level",
-                        "logger",
-                        "server_name",
-                        "transaction",
-                        "timestamp",
-                        "project_id",
-                    ],
-                    "conditions": [
-                        ("timestamp", ">=", "2019-09-19T10:00:00"),
-                        ("timestamp", "<", "2019-09-19T12:00:00"),
-                        ("project_id", "IN", [1, 2, 3]),
-                    ],
-                    "limit": 10,
-                },
-                TableSource("events", column_set),
-            )
-        ),
+        {
+            "selected_columns": [
+                "event_id",
+                "level",
+                "logger",
+                "server_name",
+                "transaction",
+                "timestamp",
+                "project_id",
+            ],
+            "conditions": [
+                ("timestamp", ">=", "2019-09-19T10:00:00"),
+                ("timestamp", "<", "2019-09-19T12:00:00"),
+                ("project_id", "IN", [1, 2, 3]),
+            ],
+            "limit": 10,
+        },
         True,
     ),  # Valid query to split
     (
         "event_id",
         "project_id",
         "timestamp",
-        ClickhouseQuery(
-            LogicalQuery(
-                {
-                    "selected_columns": ["event_id"],
-                    "conditions": [
-                        ("timestamp", ">=", "2019-09-19T10:00:00"),
-                        ("timestamp", "<", "2019-09-19T12:00:00"),
-                        ("project_id", "IN", [1, 2, 3]),
-                    ],
-                    "limit": 10,
-                },
-                TableSource("events", column_set),
-            )
-        ),
+        {
+            "selected_columns": ["event_id"],
+            "conditions": [
+                ("timestamp", ">=", "2019-09-19T10:00:00"),
+                ("timestamp", "<", "2019-09-19T12:00:00"),
+                ("project_id", "IN", [1, 2, 3]),
+            ],
+            "limit": 10,
+        },
         False,
     ),  # Valid query but not enough columns to split.
     (
         "event_id",
         "project_id",
         "timestamp",
-        ClickhouseQuery(
-            LogicalQuery(
-                {
-                    "selected_columns": [["f", ["event_id"], "not_event_id"]],
-                    "conditions": [
-                        ("timestamp", ">=", "2019-09-19T10:00:00"),
-                        ("timestamp", "<", "2019-09-19T12:00:00"),
-                        ("project_id", "IN", [1, 2, 3]),
-                    ],
-                    "orderby": ["-not_event_id"],
-                    "limit": 10,
-                },
-                TableSource("events", column_set),
-            )
-        ),
+        {
+            "selected_columns": [
+                ["f", ["event_id"], "not_event_id"],
+                "level",
+                "logger",
+                "server_name",
+            ],
+            "conditions": [
+                ("timestamp", ">=", "2019-09-19T10:00:00"),
+                ("timestamp", "<", "2019-09-19T12:00:00"),
+                ("project_id", "IN", [1, 2, 3]),
+            ],
+            "orderby": ["-not_event_id"],
+            "limit": 10,
+        },
         False,
     ),  # Splitting by column would generate an invalid query
 ]
@@ -306,7 +291,11 @@ column_split_tests = [
 def test_col_split_conditions(
     id_column: str, project_column: str, timestamp_column: str, query, expected_result
 ) -> None:
+    dataset = get_dataset("transactions")
+    query = parse_query(query, dataset)
     splitter = ColumnSplitQueryStrategy(id_column, project_column, timestamp_column)
+    request = Request("a", query, HTTPRequestSettings(), {}, "r")
+    plan = dataset.get_query_plan_builder().build_plan(request)
 
     def do_query(
         query: ClickhouseQuery, request_settings: RequestSettings,
@@ -325,7 +314,7 @@ def test_col_split_conditions(
         )
 
     assert (
-        splitter.execute(query, HTTPRequestSettings(), do_query) is not None
+        splitter.execute(plan.query, HTTPRequestSettings(), do_query) is not None
     ) == expected_result
 
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -291,7 +291,7 @@ column_split_tests = [
 def test_col_split_conditions(
     id_column: str, project_column: str, timestamp_column: str, query, expected_result
 ) -> None:
-    dataset = get_dataset("transactions")
+    dataset = get_dataset("events")
     query = parse_query(query, dataset)
     splitter = ColumnSplitQueryStrategy(id_column, project_column, timestamp_column)
     request = Request("a", query, HTTPRequestSettings(), {}, "r")


### PR DESCRIPTION
This is the followup to https://github.com/getsentry/snuba/pull/1028 
This query is broken:
```
{
    "selected_columns": [
     "user_id",
     "timestamp",
     "project_id",
     "event_id",
     [
       "transform",
       [["toString", ["project_id"]], ["array", ["'1'"]], ["array", ["'sentry'"]], "''"],
       "project"
     ]
    ],
    "conditions": [["project_id", "IN", [1]]],
    "orderby": "-project",
    "project": [1],
    "from_date": "2020-06-2T11:25:28",
    "to_date": "2020-06-3T13:25:28",
    "granularity": 3600
}
```

The column splitter tries to split it, but the minimal query generated is invalid because it still contains a reference to the `project` alias in the orderby, but it looses the declaration of `project`  that was in the select when we build the minimal select.

This adds a method to validate the aliases referenced in a query, and applies it to the column splitter. If the resulting query is invalid, the splitter gives up and go to the next one.