### PR TITLE
feat(ast) Use array accessor function instead of the [] notation in the legacy code.

### DIFF
--- a/snuba/datasets/tags_column_processor.py
+++ b/snuba/datasets/tags_column_processor.py
@@ -145,7 +145,7 @@ class TagColumnProcessor:
                 return qualified_column(self.__string_col(actual_tag), table_alias)
 
         # For the rest, return an expression that looks it up in the nested tags.
-        return "{col}.value[indexOf({col}.key, {tag})]".format(
+        return "arrayElement({col}.value, indexOf({col}.key, {tag}))".format(
             **{
                 "col": qualified_column(col, table_alias),
                 "tag": escape_literal(tag_name),
@@ -256,9 +256,7 @@ class TagColumnProcessor:
             # on (key, value) tag tuples.
             mapping = f"arrayMap((x,y) -> [x,y], {key_list}, {val_list})"
             if filter_tags:
-                filtering = (
-                    f"arrayFilter(pair -> pair[1] IN ({filter_tags}), {mapping})"
-                )
+                filtering = f"arrayFilter(pair -> in(arrayElement(pair, 1), tuple({filter_tags})), {mapping})"
             else:
                 filtering = mapping
 
@@ -268,14 +266,12 @@ class TagColumnProcessor:
             # to refer to it next time (eg. 'all_tags[1] AS tags_key'). instead of
             # expanding the whole tags expression again.
             expr = alias_expr(expr, "all_tags", parsing_context)
-            return "({})[{}]".format(expr, 1 if k_or_v == "key" else 2)
+            return "arrayElement({}, {})".format(expr, 1 if k_or_v == "key" else 2)
         else:
             # If we are only ever going to use one of tags_key or tags_value, don't
             # bother creating the k/v tuples to arrayJoin on, or the all_tags alias
             # to re-use as we won't need it.
             if filter_tags:
-                return (
-                    f"arrayJoin(arrayFilter(tag -> tag IN ({filter_tags}), {key_list}))"
-                )
+                return f"arrayJoin(arrayFilter(tag -> in(tag, tuple({filter_tags})), {key_list}))"
             else:
                 return f"arrayJoin({key_list if k_or_v == 'key' else val_list})"

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -20,7 +20,7 @@ class TestEventsDataset(BaseEventsTest):
         # Single tag expression
         assert (
             column_expr(self.dataset, "tags[foo]", deepcopy(query), ParsingContext())
-            == "(tags.value[indexOf(tags.key, 'foo')] AS `tags[foo]`)"
+            == "(arrayElement(tags.value, indexOf(tags.key, 'foo')) AS `tags[foo]`)"
         )
 
         # Promoted tag expression / no translation
@@ -61,8 +61,8 @@ class TestEventsDataset(BaseEventsTest):
         assert column_expr(
             self.dataset, "tags_key", Query(tag_group_body, source), ParsingContext()
         ) == (
-            "(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
-            "AS all_tags))[1] AS tags_key)"
+            "(arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
+            "AS all_tags), 1) AS tags_key)"
         )
 
         assert (
@@ -175,8 +175,8 @@ class TestEventsDataset(BaseEventsTest):
         query = Query({"groupby": ["tags_key", "tags_value"]}, source,)
         context = ParsingContext()
         assert column_expr(self.dataset, "tags_key", query, context) == (
-            "(((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
-            "AS all_tags))[1] AS tags_key)"
+            "(arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
+            "AS all_tags), 1) AS tags_key)"
         )
 
         # If we want to use `tags_key` again, make sure we use the
@@ -186,7 +186,7 @@ class TestEventsDataset(BaseEventsTest):
         # the `all_tags` alias instead of re-expanding the tags arrayJoin
         assert (
             column_expr(self.dataset, "tags_value", query, context)
-            == "((all_tags)[2] AS tags_value)"
+            == "(arrayElement(all_tags, 2) AS tags_value)"
         )
 
     def test_order_by(self):
@@ -254,7 +254,7 @@ class TestEventsDataset(BaseEventsTest):
 
         assert (
             column_expr(self.dataset, "-tags[myTag]", deepcopy(query), ParsingContext())
-            == "-(tags.value[indexOf(tags.key, 'myTag')] AS `tags[myTag]`)"
+            == "-(arrayElement(tags.value, indexOf(tags.key, 'myTag')) AS `tags[myTag]`)"
         )
 
         context = ParsingContext()

--- a/tests/datasets/test_join_columns.py
+++ b/tests/datasets/test_join_columns.py
@@ -40,7 +40,7 @@ def test_simple_column_expr():
     # Single tag expression
     assert (
         column_expr(dataset, "events.tags[foo]", deepcopy(query), ParsingContext())
-        == "(events.tags.value[indexOf(events.tags.key, 'foo')] AS `events.tags[foo]`)"
+        == "(arrayElement(events.tags.value, indexOf(events.tags.key, 'foo')) AS `events.tags[foo]`)"
     )
 
     # Promoted tag expression / no translation
@@ -63,8 +63,8 @@ def test_simple_column_expr():
     assert column_expr(
         dataset, "events.tags_key", Query(tag_group_body, source), parsing_context
     ) == (
-        "(((arrayJoin(arrayMap((x,y) -> [x,y], events.tags.key, events.tags.value)) "
-        "AS all_tags))[1] AS `events.tags_key`)"
+        "(arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], events.tags.key, events.tags.value)) "
+        "AS all_tags), 1) AS `events.tags_key`)"
     )
 
     assert (
@@ -156,8 +156,8 @@ def test_alias_in_alias():
     query = Query(body, source)
     parsing_context = ParsingContext()
     assert column_expr(dataset, "events.tags_key", query, parsing_context) == (
-        "(((arrayJoin(arrayMap((x,y) -> [x,y], events.tags.key, events.tags.value)) "
-        "AS all_tags))[1] AS `events.tags_key`)"
+        "(arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], events.tags.key, events.tags.value)) "
+        "AS all_tags), 1) AS `events.tags_key`)"
     )
 
     # If we want to use `tags_key` again, make sure we use the
@@ -170,7 +170,7 @@ def test_alias_in_alias():
     # the `all_tags` alias instead of re-expanding the tags arrayJoin
     assert (
         column_expr(dataset, "events.tags_value", query, parsing_context)
-        == "((all_tags)[2] AS `events.tags_value`)"
+        == "(arrayElement(all_tags, 2) AS `events.tags_value`)"
     )
 
 

--- a/tests/query/processors/test_tags_processor.py
+++ b/tests/query/processors/test_tags_processor.py
@@ -29,7 +29,7 @@ test_data = [
             "conditions": [["tags_key", "IN", ["t1", "t2"]]],
         },
         (
-            "SELECT (tags.value[indexOf(tags.key, 't1')] AS `tags[t1]`) "
+            "SELECT (arrayElement(tags.value, indexOf(tags.key, 't1')) AS `tags[t1]`) "
             "FROM transactions_local "
             "WHERE (arrayJoin(tags.key) AS tags_key) IN ('t1', 't2')"
         ),
@@ -42,10 +42,10 @@ test_data = [
             "conditions": [["tags_key", "IN", ["t1", "t2"]]],
         },
         (
-            "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
-            "AS all_tags))[2] AS tags_value) "
+            "SELECT (arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) "
+            "AS all_tags), 2) AS tags_value) "
             "FROM transactions_local "
-            "WHERE ((all_tags)[1] AS tags_key) IN ('t1', 't2')"
+            "WHERE (arrayElement(all_tags, 1) AS tags_key) IN ('t1', 't2')"
         ),
     ),  # Tags key in condition but only value in select. This could technically be
     # optimized but it would add more complexity
@@ -57,8 +57,8 @@ test_data = [
             "conditions": [["col", "IN", ["t1", "t2"]]],
         },
         (
-            "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags))[1] "
-            "AS tags_key), ((all_tags)[2] AS tags_value) "
+            "SELECT (arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags), 1) "
+            "AS tags_key), (arrayElement(all_tags, 2) AS tags_value) "
             "FROM transactions_local "
             "WHERE col IN ('t1', 't2')"
         ),
@@ -71,7 +71,7 @@ test_data = [
             "conditions": [["tags_key", "IN", ["t1", "t2"]]],
         },
         (
-            "SELECT (arrayJoin(arrayFilter(tag -> tag IN ('t1','t2'), tags.key)) AS tags_key) "
+            "SELECT (arrayJoin(arrayFilter(tag -> in(tag, tuple('t1','t2')), tags.key)) AS tags_key) "
             "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2')"
         ),
@@ -84,7 +84,7 @@ test_data = [
             "having": [["tags_key", "IN", ["t1", "t2"]]],
         },
         (
-            "SELECT (arrayJoin(arrayFilter(tag -> tag IN ('t1','t2'), tags.key)) AS tags_key), tags_key "
+            "SELECT (arrayJoin(arrayFilter(tag -> in(tag, tuple('t1','t2')), tags.key)) AS tags_key), tags_key "
             "FROM transactions_local "
             "GROUP BY (tags_key) "
             "HAVING tags_key IN ('t1', 't2')"
@@ -98,9 +98,9 @@ test_data = [
             "conditions": [["tags_key", "IN", ["t1", "t2"]]],
         },
         (
-            "SELECT (((arrayJoin(arrayFilter(pair -> pair[1] IN ('t1','t2'), "
-            "arrayMap((x,y) -> [x,y], tags.key, tags.value))) AS all_tags))[1] AS tags_key), "
-            "((all_tags)[2] AS tags_value) "
+            "SELECT (arrayElement((arrayJoin(arrayFilter(pair -> in(arrayElement(pair, 1), tuple('t1','t2')), "
+            "arrayMap((x,y) -> [x,y], tags.key, tags.value))) AS all_tags), 1) AS tags_key), "
+            "(arrayElement(all_tags, 2) AS tags_value) "
             "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2')"
         ),
@@ -117,9 +117,9 @@ test_data = [
             ],
         },
         (
-            "SELECT (((arrayJoin(arrayFilter(pair -> pair[1] IN ('t1','t2','t3','t4','t5'), "
-            "arrayMap((x,y) -> [x,y], tags.key, tags.value))) AS all_tags))[1] AS tags_key), "
-            "((all_tags)[2] AS tags_value) "
+            "SELECT (arrayElement((arrayJoin(arrayFilter(pair -> in(arrayElement(pair, 1), tuple('t1','t2','t3','t4','t5')), "
+            "arrayMap((x,y) -> [x,y], tags.key, tags.value))) AS all_tags), 1) AS tags_key), "
+            "(arrayElement(all_tags, 2) AS tags_value) "
             "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2') AND "
             "tags_key IN ('t3', 't4') AND "
@@ -138,8 +138,8 @@ test_data = [
             ],
         },
         (
-            "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags))[1] "
-            "AS tags_key), ((all_tags)[2] AS tags_value) "
+            "SELECT (arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags), 1) "
+            "AS tags_key), (arrayElement(all_tags, 2) AS tags_value) "
             "FROM transactions_local "
             "WHERE (tags_key IN ('t1', 't2') OR tags_key IN ('t3', 't4'))"
         ),
@@ -155,8 +155,8 @@ test_data = [
             ],
         },
         (
-            "SELECT (((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags))[1] "
-            "AS tags_key), ((all_tags)[2] AS tags_value) "
+            "SELECT (arrayElement((arrayJoin(arrayMap((x,y) -> [x,y], tags.key, tags.value)) AS all_tags), 1) "
+            "AS tags_key), (arrayElement(all_tags, 2) AS tags_value) "
             "FROM transactions_local "
             "WHERE tags_key IN ('t1', 't2') AND (tags_key IN ('t3', 't4') OR tags_key = 't5')"
         ),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -189,7 +189,7 @@ class TestUtil(BaseTest):
         )
         assert (
             conditions_expr(dataset, conditions, Query({}, source), ParsingContext())
-            == """(notEmpty((tags.value[indexOf(tags.key, 'sentry:environment')] AS `tags[sentry:environment]`)) = 'dev' OR notEmpty(`tags[sentry:environment]`) = 'prod') AND (notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 'joe' OR notEmpty(`tags[sentry:user]`) = 'bob')"""
+            == """(notEmpty((arrayElement(tags.value, indexOf(tags.key, 'sentry:environment')) AS `tags[sentry:environment]`)) = 'dev' OR notEmpty(`tags[sentry:environment]`) = 'prod') AND (notEmpty((`sentry:user` AS `tags[sentry:user]`)) = 'joe' OR notEmpty(`tags[sentry:user]`) = 'bob')"""
         )
 
         # Test scalar condition on array column is expanded as an iterator.


### PR DESCRIPTION
This is basically throw-away code. snuba/datasets/tags_column_processor.py will be removed as soon as the AST is rolled out.
This PR turns some of the expressions from the `[]` notation to the array access function notation since the AST expressions are formatted using array function instead of the subscriptable notation.
This is meant to help validate that the AST generated expression is actually equivalent to the legacy one by making the two easier to compare. they would be the same string now.