### PR TITLE
feat(ast): Outcomes dataset rollout

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -102,7 +102,9 @@ PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 
-AST_DATASET_ROLLOUT: Mapping[str, int] = {}  # (dataset name: percentage)
+AST_DATASET_ROLLOUT: Mapping[str, int] = {
+    "outcomes": 100,
+}  # (dataset name: percentage)
 AST_REFERRER_ROLLOUT: Mapping[
     str, Mapping[Optional[str], int]
 ] = {}  # (dataset name: (referrer: percentage))

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -1,13 +1,15 @@
+import uuid
 from datetime import datetime, timedelta
+
+import pytest
 import pytz
 import simplejson as json
-import uuid
-
-from tests.base import BaseApiTest
 
 from snuba.datasets.factory import enforce_table_writer
+from tests.base import BaseApiTest
 
 
+@pytest.mark.usefixtures("query_type")
 class TestOutcomesApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="outcomes"):
         super().setup_method(test_method, dataset_name)


### PR DESCRIPTION
This will execute the queries for outcomes based on the AST representation by default and in production.

Those queries are very homogeneous, simple and not too high in volume. Their shape is always this
```
SELECT             
    org_id,        
    toStartOfHour(timestamp, 'Universal') AS time, 
    sum(times_seen) AS aggregate
FROM outcomes_hourly_local         
WHERE (org_id = 64411) AND (((timestamp >= toDateTime('2020-06-21T11:00:00', 'Universal')) AND (timestamp < toDateTime('2020-06-22T12:00:00', 'Universal'))) AND (outcome = 1))
GROUP BY (org_id, time)
LIMIT 0, 25
```

So after testing them locally, the risk of rolling this out as a sanity test seems quite low.