### PR TITLE
feat(ast) Make some legacy column_expr prefix instead of infix

### DIFF
--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -170,7 +170,7 @@ class TimeSeriesDataset(Dataset):
             86400: "toDate({column}, 'Universal')",
         }.get(
             granularity,
-            "toDateTime(intDiv(toUInt32({column}), {granularity}) * {granularity}, 'Universal')",
+            "toDateTime(multiply(intDiv(toUInt32({column}), {granularity}), {granularity}), 'Universal')",
         )
         return template.format(column=real_column, granularity=granularity)
 

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -84,8 +84,8 @@ class EventsDataset(TimeSeriesDataset):
                 "contexts[device.charging]",
             }
             boolean_context_template = (
-                "multiIf(%(processed_column)s == '', '', "
-                "%(processed_column)s IN ('1', 'True'), 'True', 'False')"
+                "multiIf(equals(%(processed_column)s, ''), '', "
+                "in(%(processed_column)s, tuple('1', 'True')), 'True', 'False')"
             )
             if column_name in boolean_contexts:
                 return boolean_context_template % (


### PR DESCRIPTION
Like https://github.com/getsentry/snuba/pull/1041

This is throw away code that makes the legacy query representation look more syntactically in line with the ast representation so it is easier to compare them automatically (we already have a function parser that can parse these expressions to compare them).