### PR TITLE
feat(migrations): Add querylog migration

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -9,6 +9,7 @@ from snuba.migrations.migration import Migration
 class MigrationGroup(Enum):
     SYSTEM = "system"
     EVENTS = "events"
+    QUERYLOG = "querylog"
 
 
 class GroupLoader(ABC):
@@ -63,9 +64,18 @@ class EventsLoader(DirectoryLoader):
         return []
 
 
+class QuerylogLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.migrations.snuba_migrations.querylog")
+
+    def get_migrations(self) -> Sequence[str]:
+        return ["0001_querylog"]
+
+
 _REGISTERED_GROUPS = {
     MigrationGroup.SYSTEM: SystemLoader(),
     MigrationGroup.EVENTS: EventsLoader(),
+    MigrationGroup.QUERYLOG: QuerylogLoader(),
 }
 
 

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -69,6 +69,6 @@ class CreateTable(SqlOperation):
 
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
-        engine = self.__engine.get_create_table_statement()
+        engine = self.__engine.get_sql()
 
         return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns}) ENGINE {engine};"

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -55,6 +55,12 @@ class DropTable(SqlOperation):
 
 
 class CreateTable(SqlOperation):
+    """
+    The create table operation takes a table name, column list and table engine.
+    Engine specific clauses like ORDER BY, PARTITION BY, SETTINGS, etc are
+    defined by the table engine.
+    """
+
     def __init__(
         self,
         storage_set: StorageSetKey,

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -57,8 +57,8 @@ class DropTable(SqlOperation):
 class CreateTable(SqlOperation):
     """
     The create table operation takes a table name, column list and table engine.
-    Engine specific clauses like ORDER BY, PARTITION BY, SETTINGS, etc are
-    defined by the table engine.
+    All other clauses (e.g. ORDER BY, PARTITION BY, SETTINGS) are parameters to
+    engine as they are specific to the ClickHouse table engine selected.
     """
 
     def __init__(

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -1,0 +1,77 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    Array,
+    Column,
+    DateTime,
+    Enum,
+    Float,
+    LowCardinality,
+    Nested,
+    Nullable,
+    String,
+    UInt,
+    UUID,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+
+
+class Migration(migration.MultiStepMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.Operation]:
+        status_type = Enum([("success", 0), ("error", 1), ("rate-limited", 2)])
+
+        columns = [
+            Column("request_id", UUID()),
+            Column("request_body", String()),
+            Column("referrer", LowCardinality(String())),
+            Column("dataset", LowCardinality(String())),
+            Column("projects", Array(UInt(64))),
+            Column("organization", Nullable(UInt(64))),
+            Column("timestamp", DateTime()),
+            Column("duration_ms", UInt(32)),
+            Column("status", status_type),
+            Column(
+                "clickhouse_queries",
+                Nested(
+                    [
+                        Column("sql", String()),
+                        Column("status", status_type),
+                        Column("trace_id", Nullable(UUID())),
+                        Column("duration_ms", UInt(32)),
+                        Column("stats", String()),
+                        Column("final", UInt(8)),
+                        Column("cache_hit", UInt(8)),
+                        Column("sample", Float(32)),
+                        Column("max_threads", UInt(8)),
+                        Column("num_days", UInt(32)),
+                        Column("clickhouse_table", LowCardinality(String())),
+                        Column("query_id", String()),
+                        Column("is_duplicate", UInt(8)),
+                        Column("consistent", UInt(8)),
+                    ]
+                ),
+            ),
+        ]
+
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="querylog_local",
+                columns=columns,
+                engine=table_engines.MergeTree(
+                    order_by="(toStartOfDay(timestamp), request_id)",
+                    partition_by="(toMonday(timestamp))",
+                    sample_by="request_id",
+                ),
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.Operation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.QUERYLOG, table_name="querylog_local",
+            )
+        ]

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -1,0 +1,59 @@
+from typing import Mapping, Optional
+
+
+class TableEngine:
+    pass
+
+
+class MergeTree(TableEngine):
+    def __init__(
+        self,
+        order_by: str,
+        partition_by: Optional[str] = None,
+        sample_by: Optional[str] = None,
+        ttl: Optional[str] = None,
+        settings: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self.__order_by = order_by
+        self.__partition_by = partition_by
+        self.__sample_by = sample_by
+        self.__ttl = ttl
+        self.__settings = settings
+
+    def get_create_table_statement(self) -> str:
+        sql = f"{self.get_engine_type()} ORDER BY {self.__order_by}"
+
+        if self.__partition_by:
+            sql += f" PARTITION BY {self.__partition_by}"
+
+        if self.__sample_by:
+            sql += f" SAMPLE BY {self.__sample_by}"
+
+        if self.__ttl:
+            sql += f" TTL {self.__ttl}"
+
+        if self.__settings:
+            settings = ", ".join([f"{k}={v}" for k, v in self.__settings.items()])
+            sql += f" SETTINGS {settings}"
+
+        return sql
+
+    def get_engine_type(self) -> str:
+        return "MergeTree()"
+
+
+class ReplacingMergeTree(MergeTree):
+    def __init__(
+        self,
+        version_column: str,
+        order_by: str,
+        partition_by: Optional[str] = None,
+        sample_by: Optional[str] = None,
+        ttl: Optional[str] = None,
+        settings: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        super().__init__(order_by, partition_by, sample_by, ttl, settings)
+        self.__version_column = version_column
+
+    def get_engine_type(self) -> str:
+        return f"ReplacingMergeTree({self.__version_column})"

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -1,8 +1,19 @@
+from abc import ABC, abstractmethod
+
 from typing import Mapping, Optional
 
 
-class TableEngine:
-    pass
+class TableEngine(ABC):
+    """
+    Represents a ClickHouse table engine, such as any table or view.
+
+    Any changes made to these classes should ensure the result of every migration
+    does not change.
+    """
+
+    @abstractmethod
+    def get_sql(self) -> str:
+        raise NotImplementedError
 
 
 class MergeTree(TableEngine):
@@ -20,8 +31,8 @@ class MergeTree(TableEngine):
         self.__ttl = ttl
         self.__settings = settings
 
-    def get_create_table_statement(self) -> str:
-        sql = f"{self.get_engine_type()} ORDER BY {self.__order_by}"
+    def get_sql(self) -> str:
+        sql = f"{self._get_engine_type()} ORDER BY {self.__order_by}"
 
         if self.__partition_by:
             sql += f" PARTITION BY {self.__partition_by}"
@@ -38,7 +49,7 @@ class MergeTree(TableEngine):
 
         return sql
 
-    def get_engine_type(self) -> str:
+    def _get_engine_type(self) -> str:
         return "MergeTree()"
 
 
@@ -55,5 +66,5 @@ class ReplacingMergeTree(MergeTree):
         super().__init__(order_by, partition_by, sample_by, ttl, settings)
         self.__version_column = version_column
 
-    def get_engine_type(self) -> str:
+    def _get_engine_type(self) -> str:
         return f"ReplacingMergeTree({self.__version_column})"

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3,8 +3,8 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.operations import (
     CreateTable,
     DropTable,
-    ReplacingMergeTree,
 )
+from snuba.migrations.table_engines import ReplacingMergeTree
 
 
 def test_create_table() -> None:
@@ -19,10 +19,13 @@ def test_create_table() -> None:
             StorageSetKey.EVENTS,
             "test_table",
             columns,
-            ReplacingMergeTree("version"),
-            "version",
+            ReplacingMergeTree(
+                version_column="version",
+                order_by="version",
+                settings={"index_granularity": "256"},
+            ),
         ).format_sql()
-        == "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64) ENGINE ReplacingMergeTree(version) ORDER BY version;"
+        == "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64) ENGINE ReplacingMergeTree(version) ORDER BY version SETTINGS index_granularity=256;"
     )
 
 

--- a/tests/migrations/test_table_engines.py
+++ b/tests/migrations/test_table_engines.py
@@ -15,9 +15,9 @@ def test_table_engines() -> None:
         ReplacingMergeTree(
             version_column="timestamp",
             order_by="timestamp",
-            partition_by="(toMonday(timestamp)",
+            partition_by="(toMonday(timestamp))",
             sample_by="id",
             ttl="timestamp + INTERVAL 1 MONTH",
         ).get_sql()
-        == "ReplacingMergeTree(timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH"
+        == "ReplacingMergeTree(timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp)) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH"
     )

--- a/tests/migrations/test_table_engines.py
+++ b/tests/migrations/test_table_engines.py
@@ -1,0 +1,23 @@
+from snuba.migrations.table_engines import MergeTree, ReplacingMergeTree
+
+
+def test_table_engines() -> None:
+    assert (
+        MergeTree(order_by="timestamp",).get_sql() == "MergeTree() ORDER BY timestamp"
+    )
+
+    assert (
+        MergeTree(order_by="date", settings={"index_granularity": "256"}).get_sql()
+        == "MergeTree() ORDER BY date SETTINGS index_granularity=256"
+    )
+
+    assert (
+        ReplacingMergeTree(
+            version_column="timestamp",
+            order_by="timestamp",
+            partition_by="(toMonday(timestamp)",
+            sample_by="id",
+            ttl="timestamp + INTERVAL 1 MONTH",
+        ).get_sql()
+        == "ReplacingMergeTree(timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH"
+    )


### PR DESCRIPTION
Adds a migration group and first migration for creating the querylog table. Also
adds the ability to provide partitioning, sampling, ttl and settings clauses to the
create table operation.