### PR TITLE
fix(migrations): Correctly populate version column

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -33,7 +33,7 @@ class ClickhouseClientSettingsType(NamedTuple):
 class ClickhouseClientSettings(Enum):
     CLEANUP = ClickhouseClientSettingsType({}, None)
     INSERT = ClickhouseClientSettingsType({}, None)
-    MIGRATE = ClickhouseClientSettingsType({}, None)
+    MIGRATE = ClickhouseClientSettingsType({"load_balancing": "in_order"}, None)
     OPTIMIZE = ClickhouseClientSettingsType({}, 10000)
     QUERY = ClickhouseClientSettingsType({"readonly": True}, None)
     REPLACE = ClickhouseClientSettingsType(

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -104,9 +104,7 @@ class Runner:
                 "version": next_version,
             }
         ]
-        self.__connection.execute(
-            statement, data, settings={"load_balancing": "in_order"}
-        )
+        self.__connection.execute(statement, data)
 
     def _get_next_version(self, migration_key: MigrationKey) -> int:
         group = escape_string(migration_key.group.value)
@@ -114,8 +112,7 @@ class Runner:
         conditions = f"group = {group} AND migration_id = {migration_id}"
 
         result = self.__connection.execute(
-            f"SELECT version FROM {TABLE_NAME} FINAL WHERE {conditions};",
-            settings={"load_balancing": "in_order"},
+            f"SELECT version FROM {TABLE_NAME} FINAL WHERE {conditions};"
         )
         if result:
             (version,) = result[0]
@@ -128,8 +125,7 @@ class Runner:
 
         try:
             for row in self.__connection.execute(
-                f"SELECT group, migration_id, status FROM {TABLE_NAME} FINAL",
-                settings={"load_balancing": "in_order"},
+                f"SELECT group, migration_id, status FROM {TABLE_NAME} FINAL"
             ):
                 group_name, migration_id, status_name = row
                 data[MigrationKey(MigrationGroup(group_name), migration_id)] = Status(


### PR DESCRIPTION
Ensure the version column in the migrations table is always
incremented when a row is rewritten. This ensures that the
correct row is replaced when duplicate rows are merged.