### PR TITLE
feat(ast): Rollout some simple queries on the events dataset

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -105,9 +105,13 @@ TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 AST_DATASET_ROLLOUT: Mapping[str, int] = {
     "outcomes": 100,
 }  # (dataset name: percentage)
-AST_REFERRER_ROLLOUT: Mapping[
-    str, Mapping[Optional[str], int]
-] = {}  # (dataset name: (referrer: percentage))
+AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
+    "events": {
+        # Simple queries without splitting or user customizations
+        "Group.filter_by_event_id": 100,
+        "api.group-hashes": 100,
+    }
+}  # (dataset name: (referrer: percentage))
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:


### PR DESCRIPTION
`Group.filter_by_event_id` and `api.group-hashes` are the simplest queries on the events dataset. These are not customizable, they do not contain tags, and are not being split. They are in low volume as well. 
These seem the best candidates to start with to rollout the AST on the events dataset. Which has some meaningful translation and a lot more query processors than outcomes.