### PR TITLE
fix(sessions) Fix potentially empty dates in sessions

### DIFF
--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -43,6 +43,9 @@ class SessionsProcessor(MessageProcessor):
         if message["status"] in ("crashed", "abnormal"):
             errors = max(errors, 1)
 
+        received = _ensure_valid_date(datetime.utcfromtimestamp(message["received"]))
+        started = _ensure_valid_date(datetime.utcfromtimestamp(message["started"]))
+
         processed = {
             "session_id": str(uuid.UUID(message["session_id"])),
             "distinct_id": str(uuid.UUID(message.get("distinct_id") or NIL_UUID)),
@@ -53,12 +56,8 @@ class SessionsProcessor(MessageProcessor):
             "duration": duration,
             "status": STATUS_MAPPING[message["status"]],
             "errors": errors,
-            "received": _ensure_valid_date(
-                datetime.utcfromtimestamp(message["received"])
-            ),
-            "started": _ensure_valid_date(
-                datetime.utcfromtimestamp(message["started"])
-            ),
+            "received": received if received is not None else datetime.now(),
+            "started": started if started is not None else datetime.now(),
             "release": message["release"],
             "environment": message.get("environment") or "",
         }


### PR DESCRIPTION
The sessions consumer may be receiving empty dates for either received or started.
```
[27] Cannot parse input: expected , before: null,"started":"2020-06-24 14:29:26","release":"com.canva.canvaeditor@3.59.0+351801.306064864","environment":""}{"session_id":"2d2290c2-315c-45cb-99f8-981310695: (at row 6333)
```

Defaults to current timestamp if the message is broken and record metrics