### PR TITLE
fix(ast) Use AST in discover detect_table to better detect table

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -72,6 +72,11 @@ def detect_table(
             event_columns.add(col)
         elif transactions_only_columns.get(col):
             transaction_columns.add(col)
+    for col in query.get_all_ast_referenced_columns():
+        if events_only_columns.get(col.column_name):
+            event_columns.add(col.column_name)
+        elif transactions_only_columns.get(col.column_name):
+            transaction_columns.add(col.column_name)
 
     selected_table = None
 

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -3,7 +3,6 @@ from typing import Any, MutableMapping
 from tests.base import BaseDatasetTest
 
 from snuba.datasets.factory import get_dataset
-from snuba.query.logical import Query
 from snuba.query.parser import parse_query
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -4,6 +4,7 @@ from tests.base import BaseDatasetTest
 
 from snuba.datasets.factory import get_dataset
 from snuba.query.logical import Query
+from snuba.query.parser import parse_query
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
 
@@ -31,18 +32,22 @@ test_data = [
     ({"selected_columns": ["group_id"]}, "sentry_local"),
     ({"selected_columns": ["trace_id"]}, "transactions_local"),
     ({"selected_columns": ["group_id", "trace_id"]}, "sentry_local"),
-    ({"aggregations": [["max", "duration", "max_duration"]]}, "transactions_local",),
+    ({"aggregations": [["max", "duration", "max_duration"]]}, "transactions_local"),
+    (
+        {"aggregations": [["apdex(duration, 300)", None, "apdex_duration_300"]]},
+        "transactions_local",
+    ),
 ]
 
 
 class TestDiscover(BaseDatasetTest):
     @pytest.mark.parametrize("query_body, expected_table", test_data)
     def test_data_source(
-        self, query_body: MutableMapping[str, Any], expected_table: str
+        self, query_body: MutableMapping[str, Any], expected_table: str,
     ):
-        query = Query(query_body, None)
         request_settings = HTTPRequestSettings()
         dataset = get_dataset("discover")
+        query = parse_query(query_body, dataset)
         request = Request("a", query, request_settings, {}, "r")
         for processor in get_dataset("discover").get_query_processors():
             processor.process_query(request.query, request.settings)

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -258,7 +258,7 @@ class TestDiscoverApi(BaseApiTest):
                     "dataset": "discover",
                     "project": self.project_id,
                     "aggregations": [["uniq", ["trace_id"], "uniq_trace_id"]],
-                    "conditions": [["type", "!=", "transaction"]],
+                    "conditions": [["type", "=", "error"]],
                     "groupby": "type",
                     "limit": 1000,
                 }

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -537,3 +537,27 @@ class TestDiscoverApi(BaseApiTest):
             ).data
         )
         assert result["data"] == [{"contexts[device.online]": "True"}]
+
+    def test_ast_impossibe_queries(self):
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [
+                        ["apdex(duration, 300)", None, "apdex_duration_300"]
+                    ],
+                    "groupby": ["project_id", "tags[foo]"],
+                    "conditions": [],
+                    "orderby": "apdex_duration_300",
+                    "limit": 1000,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == [
+            {"apdex_duration_300": 1, "tags[foo]": "baz", "project_id": 1}
+        ]


### PR DESCRIPTION
Now that the AST is stable we can use it to find columns that the regular parser
doesn't expose, in particular the columns used in functions such as apdex.