### PR TITLE
feat(ast) Remove alias expander rollout flag

### DIFF
--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -250,8 +250,6 @@ def _expand_aliases(query: Query) -> None:
     take care of not introducing shadowing (easy to enforce at runtime),
     otherwise aliasing is transparent to them.
     """
-    if not state.get_config("query_parsing_expand_aliases", 0):
-        return
     # Pre-inline all nested aliases. This reduces the number of iterations
     # we need to do on the query.
     # Example:

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -299,7 +299,6 @@ def test_format_expressions(
 
 def test_shadowing() -> None:
     state.set_config("query_parsing_enforce_validity", 1)
-    state.set_config("query_parsing_expand_aliases", 1)
     with pytest.raises(ValueError):
         parse_query(
             {
@@ -317,7 +316,6 @@ def test_shadowing() -> None:
 
 def test_circular_aliases() -> None:
     state.set_config("query_parsing_enforce_validity", 1)
-    state.set_config("query_parsing_expand_aliases", 1)
     with pytest.raises(CyclicAliasException):
         parse_query(
             {

--- a/tests/query/parser/test_resolver_visitor.py
+++ b/tests/query/parser/test_resolver_visitor.py
@@ -2,7 +2,6 @@ from typing import Mapping
 
 import pytest
 
-from snuba import state
 from snuba.query.expressions import (
     Column,
     CurriedFunctionCall,
@@ -213,7 +212,6 @@ def test_expand_aliases(
     nested_resolution: bool,
     expected: Expression,
 ) -> None:
-    state.set_config("query_parsing_expand_aliases", 1)
     assert (
         expression.accept(AliasExpanderVisitor(lookup, [], nested_resolution))
         == expected
@@ -221,7 +219,6 @@ def test_expand_aliases(
 
 
 def test_circular_dependency() -> None:
-    state.set_config("query_parsing_expand_aliases", 1)
     with pytest.raises(CyclicAliasException):
         Column(alias=None, table_name=None, column_name="a").accept(
             AliasExpanderVisitor(


### PR DESCRIPTION
This did not break anything. Better be sure it is always enabled because following features will depend on it.