### PR TITLE
feat(ast) Rollout more tag keys/values queries

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -122,6 +122,9 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
         "eventstore.get_unfetched_events": 100,
         "api.organization-events": 100,
         "api.group-events": 100,
+        # Higher volume tag queries
+        "tagstore.__get_tag_key_and_top_values": 100,
+        "tagstore.__get_tag_keys_and_top_values": 100,
     },
     "transactions": {
         # Simple time bucketed queries


### PR DESCRIPTION
These are two queries that use extensively tags_key and tags_value and that are usually optimized by prefiltering tag keys.
These have a higher daily load. One is used 90k times per day. On the other hand they have a quite standard structure with no customizations. Tested both locally and compared the results between old representation and AST.