### PR TITLE
ref(streams): Make stream tests generic on payload type

### DIFF
--- a/snuba/utils/streams/kafka.py
+++ b/snuba/utils/streams/kafka.py
@@ -62,6 +62,11 @@ Headers = Sequence[Tuple[str, bytes]]
 
 
 class KafkaPayload:
+    # XXX: This is not a dataclass since dataclasses do not support classes
+    # with __slots__ *and* default values. Since we create a lot of these
+    # objects, it's probably more important to preserve their performance and
+    # memory impact than it is their developer friendliness (unfortunately.)
+
     __slots__ = ["__key", "__value", "__headers"]
 
     def __init__(
@@ -82,6 +87,16 @@ class KafkaPayload:
     @property
     def headers(self) -> Headers:
         return self.__headers
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, KafkaPayload):
+            return False
+        else:
+            return (
+                self.key == other.key
+                and self.value == other.value
+                and self.headers == other.headers
+            )
 
 
 def as_kafka_configuration_bool(value: Any) -> bool:

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -1,4 +1,5 @@
 import contextlib
+import itertools
 import uuid
 from typing import Iterator, Optional
 from unittest import TestCase
@@ -14,7 +15,7 @@ from snuba.utils.streams.types import Topic
 from tests.utils.streams.mixins import StreamsTestMixin
 
 
-class DummyStreamsTestCase(StreamsTestMixin, TestCase):
+class DummyStreamsTestCase(StreamsTestMixin[int], TestCase):
     def setUp(self) -> None:
         self.broker: DummyBroker[int] = DummyBroker()
 
@@ -35,6 +36,9 @@ class DummyStreamsTestCase(StreamsTestMixin, TestCase):
 
     def get_producer(self) -> DummyProducer[int]:
         return DummyProducer(self.broker)
+
+    def get_payloads(self) -> Iterator[int]:
+        return itertools.count()
 
     @pytest.mark.xfail(
         strict=True, reason="rebalancing not implemented", raises=NotImplementedError

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -24,6 +24,19 @@ from tests.utils.streams.mixins import StreamsTestMixin
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 
 
+def test_payload_equality() -> None:
+    assert KafkaPayload(None, b"") == KafkaPayload(None, b"")
+    assert KafkaPayload(b"key", b"value") == KafkaPayload(b"key", b"value")
+    assert KafkaPayload(None, b"", [("key", b"value")]) == KafkaPayload(
+        None, b"", [("key", b"value")]
+    )
+    assert not KafkaPayload(None, b"a") == KafkaPayload(None, b"b")
+    assert not KafkaPayload(b"this", b"") == KafkaPayload(b"that", b"")
+    assert not KafkaPayload(None, b"", [("key", b"this")]) == KafkaPayload(
+        None, b"", [("key", b"that")]
+    )
+
+
 class TestCodec(Codec[KafkaPayload, int]):
     def encode(self, value: int) -> KafkaPayload:
         return KafkaPayload(None, f"{value}".encode("utf-8"))


### PR DESCRIPTION
This is the first in a series of changes that is intended to make the multiprocessing/parallel consumer work easier to do integrate into our existing stream toolkit. This change itself is largely non-functional but is easy to do (and hopefully review) independently, and should reduce the amount of overall noise in some of the more significant changes to follow.

The next step that I am planning is to remove the `codec` parameter from `KafkaConsumer`/`KafkaProducer` (binding `TPayload` as `KafkaPayload` as part of the class declaration), for several reasons:

1. In practice, we usually just end up using `Message[KafkaPayload]` and not some other payload type.
2. In retrospect, making the codec eagerly decode the payload contents was probably not the right call. There are several places where we want to access the payload _before_ decoding it to make some decision about how (or if) the message should be processed (such as [pre-filtering](https://github.com/getsentry/snuba/blob/120fac00a62981aaf5de973da27c52e720682397/snuba/consumer.py#L56-L57)) which don't really mesh with the current approach. Another forward-looking example is the multiprocessing/parallel consumer, which will take the raw message payload and place it into shared memory, making a child process responsible for the decoding.
3. It's relatively easy to add a wrapper class around `KafkaConsumer[KafkaPayload]` (or producer) that satisfies `Consumer[T]` by transforming `KafkaPayload` -> `T` if necessary — this doesn't need to be coupled to the `KafkaConsumer` implementation itself.