### PR TITLE
feat(migrations): Add distributed table engine

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -244,9 +244,6 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
     def get_cluster_name(self) -> Optional[str]:
         return self.__cluster_name
 
-    def get_distributed_cluster_name(self) -> Optional[str]:
-        return self.__distributed_cluster_name
-
     def get_database(self) -> str:
         return self.__database
 

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -241,7 +241,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
         """
         return self.__single_node
 
-    def get_cluster_name(self) -> Optional[str]:
+    def get_clickhouse_cluster_name(self) -> Optional[str]:
         return self.__cluster_name
 
     def get_database(self) -> str:

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -241,6 +241,15 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
         """
         return self.__single_node
 
+    def get_cluster_name(self) -> Optional[str]:
+        return self.__cluster_name
+
+    def get_distributed_cluster_name(self) -> Optional[str]:
+        return self.__distributed_cluster_name
+
+    def get_database(self) -> str:
+        return self.__database
+
     def get_local_nodes(self) -> Sequence[ClickhouseNode]:
         if self.__single_node:
             return [self.__query_node]

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -76,6 +76,7 @@ class CreateTable(SqlOperation):
 
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
-        engine = self.__engine.get_sql(self.__storage_set_key, self.__table_name)
+        cluster = get_cluster(self.__storage_set_key)
+        engine = self.__engine.get_sql(cluster, self.__table_name)
 
         return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns}) ENGINE {engine};"

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -68,6 +68,7 @@ class CreateTable(SqlOperation):
         columns: Sequence[Column],
         engine: TableEngine,
     ):
+        self.__storage_set_key = storage_set
         self.__table_name = table_name
         self.__columns = columns
         self.__engine = engine
@@ -75,8 +76,6 @@ class CreateTable(SqlOperation):
 
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
-        engine = self.__engine.get_sql(
-            get_cluster(self._storage_set).is_single_node(), self.__table_name
-        )
+        engine = self.__engine.get_sql(self.__storage_set_key, self.__table_name)
 
         return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns}) ENGINE {engine};"

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -2,6 +2,9 @@ from abc import ABC, abstractmethod
 
 from typing import Mapping, Optional
 
+from snuba.clusters.cluster import get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+
 
 class TableEngine(ABC):
     """
@@ -12,7 +15,7 @@ class TableEngine(ABC):
     """
 
     @abstractmethod
-    def get_sql(self, single_node: bool, table_name: str) -> str:
+    def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
         raise NotImplementedError
 
 
@@ -41,8 +44,8 @@ class MergeTree(TableEngine):
         self.__ttl = ttl
         self.__settings = settings
 
-    def get_sql(self, single_node: bool, table_name: str) -> str:
-        sql = f"{self._get_engine_type(single_node, table_name)} ORDER BY {self.__order_by}"
+    def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
+        sql = f"{self._get_engine_type(storage_set_key, table_name)} ORDER BY {self.__order_by}"
 
         if self.__partition_by:
             sql += f" PARTITION BY {self.__partition_by}"
@@ -59,8 +62,8 @@ class MergeTree(TableEngine):
 
         return sql
 
-    def _get_engine_type(self, single_node: bool, table_name: str) -> str:
-        if single_node:
+    def _get_engine_type(self, storage_set_key: StorageSetKey, table_name: str) -> str:
+        if get_cluster(storage_set_key).is_single_node():
             return "MergeTree()"
         else:
             return f"ReplicatedMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}')"
@@ -79,8 +82,27 @@ class ReplacingMergeTree(MergeTree):
         super().__init__(order_by, partition_by, sample_by, ttl, settings)
         self.__version_column = version_column
 
-    def _get_engine_type(self, single_node: bool, table_name: str) -> str:
-        if single_node:
+    def _get_engine_type(self, storage_set_key: StorageSetKey, table_name: str) -> str:
+        if get_cluster(storage_set_key).is_single_node():
             return f"ReplacingMergeTree({self.__version_column})"
         else:
             return f"ReplicatedReplacingMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}', {self.__version_column})"
+
+
+class Distributed(TableEngine):
+    def __init__(self, local_table_name: str, sharding_key: Optional[str]) -> None:
+        self.__local_table_name = local_table_name
+        self.__sharding_key = sharding_key
+
+    def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
+        cluster = get_cluster(storage_set_key)
+        cluster_name = cluster.get_cluster_name()
+        assert (
+            cluster_name is not None
+        ), "Cluster name must be set for Distributed engine"
+        database_name = cluster.get_database()
+        optional_sharding_key = (
+            f", {self.__sharding_key}" if self.__sharding_key else ""
+        )
+
+        return f"Distributed({cluster_name}, {database_name}, {self.__local_table_name}{optional_sharding_key})"

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -94,7 +94,7 @@ class Distributed(TableEngine):
         self.__sharding_key = sharding_key
 
     def get_sql(self, cluster: ClickhouseCluster, table_name: str) -> str:
-        cluster_name = cluster.get_cluster_name()
+        cluster_name = cluster.get_clickhouse_cluster_name()
         assert not cluster.is_single_node()
         assert cluster_name is not None
         database_name = cluster.get_database()

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -97,9 +97,8 @@ class Distributed(TableEngine):
     def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
         cluster = get_cluster(storage_set_key)
         cluster_name = cluster.get_cluster_name()
-        assert (
-            cluster_name is not None
-        ), "Cluster name must be set for Distributed engine"
+        assert not cluster.is_single_node()
+        assert cluster_name is not None
         database_name = cluster.get_database()
         optional_sharding_key = (
             f", {self.__sharding_key}" if self.__sharding_key else ""

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -2,8 +2,7 @@ from abc import ABC, abstractmethod
 
 from typing import Mapping, Optional
 
-from snuba.clusters.cluster import get_cluster
-from snuba.clusters.storage_sets import StorageSetKey
+from snuba.clusters.cluster import ClickhouseCluster
 
 
 class TableEngine(ABC):
@@ -15,7 +14,7 @@ class TableEngine(ABC):
     """
 
     @abstractmethod
-    def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
+    def get_sql(self, cluster: ClickhouseCluster, table_name: str) -> str:
         raise NotImplementedError
 
 
@@ -44,8 +43,8 @@ class MergeTree(TableEngine):
         self.__ttl = ttl
         self.__settings = settings
 
-    def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
-        sql = f"{self._get_engine_type(storage_set_key, table_name)} ORDER BY {self.__order_by}"
+    def get_sql(self, cluster: ClickhouseCluster, table_name: str) -> str:
+        sql = f"{self._get_engine_type(cluster, table_name)} ORDER BY {self.__order_by}"
 
         if self.__partition_by:
             sql += f" PARTITION BY {self.__partition_by}"
@@ -62,8 +61,8 @@ class MergeTree(TableEngine):
 
         return sql
 
-    def _get_engine_type(self, storage_set_key: StorageSetKey, table_name: str) -> str:
-        if get_cluster(storage_set_key).is_single_node():
+    def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
+        if cluster.is_single_node():
             return "MergeTree()"
         else:
             return f"ReplicatedMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}')"
@@ -82,8 +81,8 @@ class ReplacingMergeTree(MergeTree):
         super().__init__(order_by, partition_by, sample_by, ttl, settings)
         self.__version_column = version_column
 
-    def _get_engine_type(self, storage_set_key: StorageSetKey, table_name: str) -> str:
-        if get_cluster(storage_set_key).is_single_node():
+    def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
+        if cluster.is_single_node():
             return f"ReplacingMergeTree({self.__version_column})"
         else:
             return f"ReplicatedReplacingMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}', {self.__version_column})"
@@ -94,8 +93,7 @@ class Distributed(TableEngine):
         self.__local_table_name = local_table_name
         self.__sharding_key = sharding_key
 
-    def get_sql(self, storage_set_key: StorageSetKey, table_name: str) -> str:
-        cluster = get_cluster(storage_set_key)
+    def get_sql(self, cluster: ClickhouseCluster, table_name: str) -> str:
         cluster_name = cluster.get_cluster_name()
         assert not cluster.is_single_node()
         assert cluster_name is not None

--- a/tests/migrations/test_table_engines.py
+++ b/tests/migrations/test_table_engines.py
@@ -1,39 +1,82 @@
 import pytest
+from typing import Any
+from unittest.mock import patch
 
-from snuba.migrations.table_engines import MergeTree, ReplacingMergeTree, TableEngine
+from snuba.clusters.cluster import ClickhouseCluster
+from snuba.clusters.storage_sets import StorageSetKey
 
 
-test_cases = [
-    pytest.param(
-        MergeTree(order_by="timestamp"),
-        "MergeTree() ORDER BY timestamp",
-        "ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard})/test_table', '{replica}') ORDER BY timestamp",
-        id="Merge tree",
-    ),
-    pytest.param(
-        MergeTree(order_by="date", settings={"index_granularity": "256"}),
-        "MergeTree() ORDER BY date SETTINGS index_granularity=256",
-        "ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard})/test_table', '{replica}') ORDER BY date SETTINGS index_granularity=256",
-        id="Merge tree with settings",
-    ),
-    pytest.param(
-        ReplacingMergeTree(
-            version_column="timestamp",
-            order_by="timestamp",
-            partition_by="(toMonday(timestamp))",
-            sample_by="id",
-            ttl="timestamp + INTERVAL 1 MONTH",
+@patch("snuba.clusters.cluster.get_cluster")
+def test_table_engines(get_cluster_mock: Any) -> None:
+    single_node_cluster = ClickhouseCluster(
+        "host", 9000, "user", "pass", "default", 3000, {"events"}, True
+    )
+    multi_node_cluster = ClickhouseCluster(
+        "host",
+        9000,
+        "user",
+        "pass",
+        "default",
+        3000,
+        {"transactions"},
+        False,
+        "cluster_1",
+        "dist_cluster_1",
+    )
+
+    get_cluster_mock.side_effect = (
+        lambda storage_set: single_node_cluster
+        if storage_set == StorageSetKey.EVENTS
+        else multi_node_cluster
+    )
+
+    from snuba.migrations.table_engines import (
+        Distributed,
+        MergeTree,
+        ReplacingMergeTree,
+    )
+
+    for merge_test_case in [
+        (
+            MergeTree(order_by="timestamp"),
+            "MergeTree() ORDER BY timestamp",
+            "ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard})/test_table', '{replica}') ORDER BY timestamp",
         ),
-        "ReplacingMergeTree(timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp)) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH",
-        "ReplicatedReplacingMergeTree('/clickhouse/tables/{layer}-{shard})/test_table', '{replica}', timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp)) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH",
-        id="Replicated merge tree with partition, sample, ttl clauses",
-    ),
-]
+        (
+            MergeTree(order_by="date", settings={"index_granularity": "256"}),
+            "MergeTree() ORDER BY date SETTINGS index_granularity=256",
+            "ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard})/test_table', '{replica}') ORDER BY date SETTINGS index_granularity=256",
+        ),
+        (
+            ReplacingMergeTree(
+                version_column="timestamp",
+                order_by="timestamp",
+                partition_by="(toMonday(timestamp))",
+                sample_by="id",
+                ttl="timestamp + INTERVAL 1 MONTH",
+            ),
+            "ReplacingMergeTree(timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp)) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH",
+            "ReplicatedReplacingMergeTree('/clickhouse/tables/{layer}-{shard})/test_table', '{replica}', timestamp) ORDER BY timestamp PARTITION BY (toMonday(timestamp)) SAMPLE BY id TTL timestamp + INTERVAL 1 MONTH",
+        ),
+    ]:
+        assert (
+            merge_test_case[0].get_sql(StorageSetKey.EVENTS, "test_table")
+            == merge_test_case[1]
+        )
+        assert (
+            merge_test_case[0].get_sql(StorageSetKey.TRANSACTIONS, "test_table")
+            == merge_test_case[2]
+        )
 
-
-@pytest.mark.parametrize("engine, single_node_sql, multi_node_sql", test_cases)
-def test_table_engines(
-    engine: TableEngine, single_node_sql: str, multi_node_sql: str
-) -> None:
-    assert engine.get_sql(True, "test_table") == single_node_sql
-    assert engine.get_sql(False, "test_table") == multi_node_sql
+    for dist_test_case in [
+        (
+            Distributed(local_table_name="test_table_local", sharding_key="event_id"),
+            "Distributed(cluster_1, default, test_table_local, event_id)",
+        )
+    ]:
+        with pytest.raises(AssertionError):
+            dist_test_case[0].get_sql(StorageSetKey.EVENTS, "test_table")
+        assert (
+            dist_test_case[0].get_sql(StorageSetKey.TRANSACTIONS, "test_table")
+            == dist_test_case[1]
+        )

--- a/tests/migrations/test_table_engines.py
+++ b/tests/migrations/test_table_engines.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import table_engines
 
 
-def test_setup_function() -> None:
+def setup_function() -> None:
     from snuba import settings
     from snuba.clusters import cluster
 
@@ -39,6 +39,14 @@ def test_setup_function() -> None:
             "distributed_cluster_name": "dist_hosts",
         },
     ]
+    importlib.reload(cluster)
+
+
+def teardown_function() -> None:
+    from snuba import settings
+    from snuba.clusters import cluster
+
+    importlib.reload(settings)
     importlib.reload(cluster)
 
 


### PR DESCRIPTION
Also adds the __forwards_dist and __backwards_dist methods for the
migration of the migration system. These are not currently being run
since multi node clusters are not yet supported.