### PR TITLE
feat(migrations): Add create materialized view operation

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -86,12 +86,12 @@ class CreateMaterializedView(SqlOperation):
     def __init__(
         self,
         storage_set: StorageSetKey,
-        table_name: str,
+        view_name: str,
         destination_table_name: str,
         columns: Sequence[Column],
         query: str,
     ) -> None:
-        self.__table_name = table_name
+        self.__view_name = view_name
         self.__destination_table_name = destination_table_name
         self.__columns = columns
         self.__query = query
@@ -100,4 +100,4 @@ class CreateMaterializedView(SqlOperation):
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
 
-        return f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.__table_name} TO {self.__destination_table_name} ({columns}) AS {self.__query};"
+        return f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.__view_name} TO {self.__destination_table_name} ({columns}) AS {self.__query};"

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -80,3 +80,24 @@ class CreateTable(SqlOperation):
         )
 
         return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns}) ENGINE {engine};"
+
+
+class CreateMaterializedView(SqlOperation):
+    def __init__(
+        self,
+        storage_set: StorageSetKey,
+        table_name: str,
+        destination_table_name: str,
+        columns: Sequence[Column],
+        query: str,
+    ) -> None:
+        self.__table_name = table_name
+        self.__destination_table_name = destination_table_name
+        self.__columns = columns
+        self.__query = query
+        super().__init__(storage_set)
+
+    def format_sql(self) -> str:
+        columns = ", ".join([col.for_schema() for col in self.__columns])
+
+        return f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.__table_name} TO {self.__destination_table_name} ({columns}) AS {self.__query};"

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1,6 +1,7 @@
 from snuba.clickhouse.columns import Column, Nullable, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.operations import (
+    CreateMaterializedView,
     CreateTable,
     DropTable,
 )
@@ -26,6 +27,19 @@ def test_create_table() -> None:
             ),
         ).format_sql()
         == "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64) ENGINE ReplacingMergeTree(version) ORDER BY version SETTINGS index_granularity=256;"
+    )
+
+
+def test_create_materialized_view() -> None:
+    assert (
+        CreateMaterializedView(
+            StorageSetKey.EVENTS,
+            "test_table_mv",
+            "test_table_dest",
+            [Column("id", String())],
+            "SELECT id, count() as count FROM test_table_local GROUP BY id",
+        ).format_sql()
+        == "CREATE MATERIALIZED VIEW IF NOT EXISTS test_table_mv TO test_table_dest (id String) AS SELECT id, count() as count FROM test_table_local GROUP BY id;"
     )
 
 


### PR DESCRIPTION
This is pretty much a copy of how the materialized view schema
works now. The entire select query has to be provided as a string.