### PR TITLE
ref(streams): Remove codec from Kafka consumer and producer classes

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -78,11 +78,9 @@ def replacer(
 ) -> None:
 
     from snuba.replacer import ReplacerWorker
-    from snuba.utils.codecs import PassthroughCodec
     from snuba.utils.streams.batching import BatchingConsumer
     from snuba.utils.streams.kafka import (
         KafkaConsumer,
-        KafkaPayload,
         TransportError,
         build_kafka_consumer_configuration,
     )
@@ -104,7 +102,6 @@ def replacer(
 
     metrics = MetricsWrapper(environment.metrics, "replacer", tags=metrics_tags,)
 
-    codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
     replacer = BatchingConsumer(
         KafkaConsumer(
             build_kafka_consumer_configuration(
@@ -114,7 +111,6 @@ def replacer(
                 queued_max_messages_kbytes=queued_max_messages_kbytes,
                 queued_min_messages=queued_min_messages,
             ),
-            codec=codec,
         ),
         Topic(replacements_topic),
         worker=ReplacerWorker(storage, metrics=metrics),

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -17,7 +17,6 @@ from snuba.subscriptions.data import PartitionId
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.worker import SubscriptionWorker
-from snuba.utils.codecs import PassthroughCodec
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.streams.batching import BatchingConsumer
 from snuba.utils.streams.kafka import (
@@ -138,7 +137,6 @@ def subscriptions(
                     consumer_group,
                     auto_offset_reset=auto_offset_reset,
                 ),
-                PassthroughCodec(),
             ),
             KafkaConsumer(
                 build_kafka_consumer_configuration(
@@ -146,7 +144,6 @@ def subscriptions(
                     f"subscriptions-commit-log-{uuid.uuid1().hex}",
                     auto_offset_reset="earliest",
                 ),
-                PassthroughCodec(),
             ),
             (
                 Topic(commit_log_topic)

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -16,15 +16,11 @@ from snuba.subscriptions.consumer import TickConsumer
 from snuba.subscriptions.data import PartitionId
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
-from snuba.subscriptions.worker import (
-    SubscriptionTaskResultCodec,
-    SubscriptionWorker,
-)
+from snuba.subscriptions.worker import SubscriptionWorker
 from snuba.utils.codecs import PassthroughCodec
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.streams.batching import BatchingConsumer
 from snuba.utils.streams.kafka import (
-    CommitCodec,
     KafkaConsumer,
     KafkaProducer,
     build_kafka_consumer_configuration,
@@ -150,7 +146,7 @@ def subscriptions(
                     f"subscriptions-commit-log-{uuid.uuid1().hex}",
                     auto_offset_reset="earliest",
                 ),
-                CommitCodec(),
+                PassthroughCodec(),
             ),
             (
                 Topic(commit_log_topic)
@@ -166,8 +162,7 @@ def subscriptions(
             "bootstrap.servers": ",".join(bootstrap_servers),
             "partitioner": "consistent",
             "message.max.bytes": 50000000,  # 50MB, default is 1MB
-        },
-        SubscriptionTaskResultCodec(),
+        }
     )
 
     executor = ThreadPoolExecutor(max_workers=max_query_workers)

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -9,7 +9,6 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
-from snuba.utils.codecs import PassthroughCodec
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.retries import BasicRetryPolicy, RetryPolicy, constant_delay
 from snuba.utils.streams.batching import BatchingConsumer
@@ -130,17 +129,13 @@ class ConsumerBuilder:
             queued_min_messages=self.queued_min_messages,
         )
 
-        codec: PassthroughCodec[KafkaPayload] = PassthroughCodec()
         if self.commit_log_topic is None:
             consumer = KafkaConsumer(
-                configuration,
-                codec=codec,
-                commit_retry_policy=self.__commit_retry_policy,
+                configuration, commit_retry_policy=self.__commit_retry_policy,
             )
         else:
             consumer = KafkaConsumerWithCommitLog(
                 configuration,
-                codec=codec,
                 producer=self.producer,
                 commit_log_topic=self.commit_log_topic,
                 commit_retry_policy=self.__commit_retry_policy,

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -1,3 +1,4 @@
+import json
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Iterable, Iterator, MutableMapping, Optional, Tuple
@@ -15,10 +16,15 @@ from snuba.subscriptions.data import (
 )
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import SubscriptionDataStore
-from snuba.subscriptions.worker import SubscriptionTaskResult, SubscriptionWorker
+from snuba.subscriptions.worker import (
+    SubscriptionWorker,
+    SubscriptionTaskResult,
+    subscription_task_result_codec,
+)
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.consumer import Consumer
 from snuba.utils.streams.dummy import DummyBroker, DummyConsumer, DummyProducer
+from snuba.utils.streams.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.utils.types import Interval
 from tests.base import dataset_manager
@@ -57,7 +63,7 @@ def dataset() -> Iterator[Dataset]:
 def test_subscription_worker(dataset: Dataset, time_shift: Optional[timedelta]) -> None:
     result_topic = Topic("subscription-results")
 
-    broker: DummyBroker[SubscriptionTaskResult] = DummyBroker()
+    broker: DummyBroker[KafkaPayload] = DummyBroker()
     broker.create_topic(result_topic, partitions=1)
 
     frequency = timedelta(minutes=1)
@@ -101,18 +107,18 @@ def test_subscription_worker(dataset: Dataset, time_shift: Optional[timedelta]) 
     if time_shift is not None:
         tick = tick.time_shift(time_shift * -1)
 
-    results = worker.process_message(
+    result_futures = worker.process_message(
         Message(Partition(Topic("events"), 0), 0, tick, now)
     )
 
-    assert results is not None and len(results) == evaluations
+    assert result_futures is not None and len(result_futures) == evaluations
 
     # Publish the results.
-    worker.flush_batch([results])
+    worker.flush_batch([result_futures])
 
     # Check to make sure the results were published.
     # NOTE: This does not cover the ``SubscriptionTaskResultCodec``!
-    consumer: Consumer[SubscriptionTaskResult] = DummyConsumer(broker, "group")
+    consumer: Consumer[KafkaPayload] = DummyConsumer(broker, "group")
     consumer.subscribe([result_topic])
 
     for i in range(evaluations):
@@ -121,16 +127,29 @@ def test_subscription_worker(dataset: Dataset, time_shift: Optional[timedelta]) 
         message = consumer.poll()
         assert message is not None
         assert message.partition.topic == result_topic
-        assert message.payload.task == results[i].task
-        assert message.payload.task.timestamp == timestamp
-        assert message.payload.result == results[i].future.result()
-        request, result = message.payload.result
-        assert request.extensions["timeseries"] == {
-            "from_date": (timestamp - subscription.data.time_window).isoformat(),
-            "to_date": timestamp.isoformat(),
-            "granularity": 3600,  # XXX: unused, no time grouping
-        }
-        assert result == {
+
+        task_result_future = result_futures[i]
+        expected_payload = subscription_task_result_codec.encode(
+            SubscriptionTaskResult(
+                task_result_future.task, task_result_future.future.result()
+            )
+        )
+
+        assert message.payload == expected_payload
+
+        decoded_payload = json.loads(expected_payload.value)["payload"]
+        assert decoded_payload["timestamp"] == timestamp.isoformat()
+        assert (
+            # NOTE: The time series extension is folded back into the request
+            # body, ideally this would reference the timeseries options in
+            # isolation.
+            decoded_payload["request"].items()
+            > {
+                "from_date": (timestamp - subscription.data.time_window).isoformat(),
+                "to_date": timestamp.isoformat(),
+            }.items()
+        )
+        assert decoded_payload["result"] == {
             "meta": [{"name": "count", "type": "UInt64"}],
             "data": [{"count": 0}],
         }

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -78,8 +78,8 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
             self.codec,
         )
 
-    def get_producer(self) -> KafkaProducer[KafkaPayload]:
-        return KafkaProducer(self.configuration, self.codec)
+    def get_producer(self) -> KafkaProducer:
+        return KafkaProducer(self.configuration)
 
     def get_payloads(self) -> Iterator[KafkaPayload]:
         for i in itertools.count():


### PR DESCRIPTION
This binds the `TPayload` type variable to `KafkaPayload` when using `KafkaConsumer` and `KafkaProducer`.

The rationale for this change was described in #1055, and I've added some additional context inline:

> 1. In practice, we usually just end up using `Message[KafkaPayload]` and not some other payload type.

There are two (fairly obvious) places in this change where this is not true: when dealing with `SubscriptionTaskResult`, and when dealing with `Commit`. This change does increase coupling with Kafka (or at least with the `KafkaPayload` structure) when interacting with these consumers and producers. I don't think this is a _problem_ per se but it is not really good design and should be cleaned up at some point (probably by introducing the wrapper described below.)

> 2. In retrospect, making the codec eagerly decode the payload contents was probably not the right call. There are several places where we want to access the payload _before_ decoding it to make some decision about how (or if) the message should be processed (such as [pre-filtering](https://github.com/getsentry/snuba/blob/120fac00a62981aaf5de973da27c52e720682397/snuba/consumer.py#L56-L57)) which don't really mesh with the current approach. Another forward-looking example is the multiprocessing/parallel consumer, which will take the raw message payload and place it into shared memory, making a child process responsible for the decoding.

This will eventually result in a `ParallelBatchingConsumer[KafkaPayload]` which accepts a `Consumer[KafkaPayload]` similar to how the current batching consumer accepts `Consumer[TPayload]`. I'm hoping that the general `BatchWorker` abstraction (or something similar) can be shared between both consumer implementations, so the next steps will likely be more refactoring oriented around making this a practical reality.

> 3. It's relatively easy to add a wrapper class around `KafkaConsumer[KafkaPayload]` (or producer) that satisfies `Consumer[T]` by transforming `KafkaPayload` -> `T` if necessary — this doesn't need to be coupled to the `KafkaConsumer` implementation itself.

See above. If the increased coupling here is bothersome enough, I can include this as part of this change.