### PR TITLE
ref(consumer): Always use rapidjson for {,de}serialization

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -73,18 +73,6 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
     type=bool,
     help="Runs a stateful consumer (that manages snapshots) instead of a basic one.",
 )
-@click.option(
-    "--rapidjson-deserialize",
-    default=True,
-    type=bool,
-    help="Uses rapidjson to deserialize messages",
-)
-@click.option(
-    "--rapidjson-serialize",
-    default=True,
-    type=bool,
-    help="Uses rapidjson to serialize messages",
-)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -100,8 +88,6 @@ def consumer(
     queued_max_messages_kbytes: int,
     queued_min_messages: int,
     stateful_consumer: bool,
-    rapidjson_deserialize: bool,
-    rapidjson_serialize: bool,
     log_level: Optional[str] = None,
 ) -> None:
 
@@ -127,8 +113,6 @@ def consumer(
         auto_offset_reset=auto_offset_reset,
         queued_max_messages_kbytes=queued_max_messages_kbytes,
         queued_min_messages=queued_min_messages,
-        rapidjson_deserialize=rapidjson_deserialize,
-        rapidjson_serialize=rapidjson_serialize,
     )
 
     if stateful_consumer:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -44,8 +44,6 @@ class ConsumerBuilder:
         auto_offset_reset: str,
         queued_max_messages_kbytes: int,
         queued_min_messages: int,
-        rapidjson_deserialize: bool,
-        rapidjson_serialize: bool,
         commit_retry_policy: Optional[RetryPolicy] = None,
     ) -> None:
         self.storage = get_writable_storage(storage_key)
@@ -116,8 +114,6 @@ class ConsumerBuilder:
             )
 
         self.__commit_retry_policy = commit_retry_policy
-        self.__rapidjson_deserialize = rapidjson_deserialize
-        self.__rapidjson_serialize = rapidjson_serialize
 
     def __build_consumer(
         self, worker: ConsumerWorker
@@ -166,8 +162,6 @@ class ConsumerBuilder:
                 producer=self.producer,
                 replacements_topic=self.replacements_topic,
                 metrics=self.metrics,
-                rapidjson_deserialize=self.__rapidjson_deserialize,
-                rapidjson_serialize=self.__rapidjson_serialize,
             )
         )
 

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
-import json
-import rapidjson
-
 from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence
+
+import rapidjson
 
 from snuba import settings
 from snuba.clickhouse import DATETIME_FORMAT
@@ -131,9 +130,7 @@ class TableWriter:
     def get_schema(self) -> WritableTableSchema:
         return self.__table_schema
 
-    def get_writer(
-        self, options=None, table_name=None, rapidjson_serialize=False
-    ) -> BatchWriter:
+    def get_writer(self, options=None, table_name=None) -> BatchWriter:
         from snuba import settings
 
         def default(value):
@@ -148,11 +145,7 @@ class TableWriter:
 
         return self.__cluster.get_writer(
             table_name,
-            lambda row: (
-                rapidjson.dumps(row, default=default)
-                if rapidjson_serialize
-                else json.dumps(row, default=default)
-            ).encode("utf-8"),
+            lambda row: rapidjson.dumps(row, default=default).encode("utf-8"),
             options,
             chunk_size=settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
         )


### PR DESCRIPTION
This has been running without issue for some time and removing this branch will simplify the consumer refactoring work a little bit.