### PR TITLE
ref(tests): Restructure and consolidate event creation in tests

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -6,7 +6,7 @@ import uuid
 
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.events_format import extract_user
-from snuba.datasets.events_processor_base import EventsProcessorBase
+from snuba.datasets.events_processor_base import EventsProcessorBase, InsertEvent
 from snuba.processor import (
     _as_dict_safe,
     _ensure_valid_ip,
@@ -30,13 +30,13 @@ class ErrorsProcessor(EventsProcessorBase):
             }
         )
 
-    def _should_process(self, event: Mapping[str, Any]) -> bool:
+    def _should_process(self, event: InsertEvent) -> bool:
         # This is to convince mypy that we actually return a bool
         data: Mapping[str, Any] = event["data"]
         return data.get("type") != "transaction"
 
     def _extract_event_id(
-        self, output: MutableMapping[str, Any], event: Mapping[str, Any],
+        self, output: MutableMapping[str, Any], event: InsertEvent,
     ) -> None:
         output["event_id"] = str(uuid.UUID(event["event_id"]))
         output["event_string"] = event["event_id"]
@@ -44,7 +44,7 @@ class ErrorsProcessor(EventsProcessorBase):
     def extract_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
         data = event.get("data", {})
@@ -86,7 +86,7 @@ class ErrorsProcessor(EventsProcessorBase):
     def extract_tags_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         tags: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
@@ -101,7 +101,7 @@ class ErrorsProcessor(EventsProcessorBase):
     def extract_contexts_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         contexts: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:

--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -31,9 +31,7 @@ class ErrorsProcessor(EventsProcessorBase):
         )
 
     def _should_process(self, event: InsertEvent) -> bool:
-        # This is to convince mypy that we actually return a bool
-        data: Mapping[str, Any] = event["data"]
-        return data.get("type") != "transaction"
+        return event["data"].get("type") != "transaction"
 
     def _extract_event_id(
         self, output: MutableMapping[str, Any], event: InsertEvent,

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -6,7 +6,7 @@ import _strptime  # NOQA fixes _strptime deferred import issue
 from snuba.clickhouse.columns import ColumnSet
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.events_format import extract_user
-from snuba.datasets.events_processor_base import EventsProcessorBase
+from snuba.datasets.events_processor_base import EventsProcessorBase, InsertEvent
 from snuba.processor import (
     _as_dict_safe,
     _boolify,
@@ -32,18 +32,18 @@ class EventsProcessor(EventsProcessorBase):
             }
         )
 
-    def _should_process(self, event: Mapping[str, Any]) -> bool:
+    def _should_process(self, event: InsertEvent) -> bool:
         return True
 
     def _extract_event_id(
-        self, output: MutableMapping[str, Any], event: Mapping[str, Any],
+        self, output: MutableMapping[str, Any], event: InsertEvent,
     ) -> None:
         output["event_id"] = event["event_id"]
 
     def extract_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
         data = event.get("data", {})
@@ -85,7 +85,7 @@ class EventsProcessor(EventsProcessorBase):
     def extract_tags_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         tags: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
@@ -145,7 +145,7 @@ class EventsProcessor(EventsProcessorBase):
     def extract_contexts_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         tags: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
+from typing_extensions import TypedDict
+
 from snuba import settings
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.events_format import (
@@ -29,18 +31,31 @@ from snuba.processor import (
 logger = logging.getLogger(__name__)
 
 
+class InsertEvent(TypedDict):
+    group_id: int
+    event_id: str
+    organization_id: int
+    project_id: int
+    message: str
+    platform: str
+    datetime: str  # snuba.settings.PAYLOAD_DATETIME_FORMAT
+    data: Mapping[str, Any]
+    primary_hash: str
+    retention_days: int
+
+
 class EventsProcessorBase(MessageProcessor, ABC):
     """
     Base class for events and errors processors.
     """
 
     @abstractmethod
-    def _should_process(self, event: Mapping[str, Any]) -> bool:
+    def _should_process(self, event: InsertEvent) -> bool:
         raise NotImplementedError
 
     @abstractmethod
     def _extract_event_id(
-        self, output: MutableMapping[str, Any], event: Mapping[str, Any],
+        self, output: MutableMapping[str, Any], event: InsertEvent,
     ) -> None:
         raise NotImplementedError
 
@@ -48,7 +63,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
     def extract_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
         raise NotImplementedError
@@ -63,7 +78,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
     def extract_tags_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         tags: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
@@ -82,14 +97,14 @@ class EventsProcessorBase(MessageProcessor, ABC):
     def extract_contexts_custom(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         contexts: Mapping[str, Any],
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
         raise NotImplementedError
 
     def extract_required(
-        self, output: MutableMapping[str, Any], event: Mapping[str, Any]
+        self, output: MutableMapping[str, Any], event: InsertEvent,
     ) -> None:
         output["group_id"] = event["group_id"] or 0
 
@@ -193,7 +208,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         return ProcessedMessage(action=action_type, data=[processed])
 
     def process_insert(
-        self, event: Mapping[str, Any], metadata: Optional[KafkaMessageMetadata] = None
+        self, event: InsertEvent, metadata: Optional[KafkaMessageMetadata] = None
     ) -> Optional[Mapping[str, Any]]:
         if not self._should_process(event):
             return None
@@ -249,7 +264,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
     def extract_common(
         self,
         output: MutableMapping[str, Any],
-        event: Mapping[str, Any],
+        event: InsertEvent,
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
         # Properties we get from the top level of the message payload

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -31,6 +31,9 @@ from snuba.processor import (
 logger = logging.getLogger(__name__)
 
 
+EventData = Mapping[str, Any]
+
+
 class InsertEvent(TypedDict):
     group_id: int
     event_id: str
@@ -39,7 +42,7 @@ class InsertEvent(TypedDict):
     message: str
     platform: str
     datetime: str  # snuba.settings.PAYLOAD_DATETIME_FORMAT
-    data: Mapping[str, Any]
+    data: EventData
     primary_hash: str
     retention_days: int
 

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -50,7 +50,7 @@ EventData = Mapping[str, Any]
 
 
 class InsertEvent(TypedDict):
-    group_id: int
+    group_id: Optional[int]
     event_id: str
     organization_id: int
     project_id: int
@@ -58,7 +58,7 @@ class InsertEvent(TypedDict):
     platform: str
     datetime: str  # snuba.settings.PAYLOAD_DATETIME_FORMAT
     data: EventData
-    primary_hash: str
+    primary_hash: str  # empty string represents None
     retention_days: int
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,6 +14,7 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.processor import ProcessorAction, ProcessedMessage
 from snuba.redis import redis_client
+from snuba.writer import WriterTableRow
 
 
 # A "raw event" is only the ``data`` member of ``InsertEvent``.
@@ -88,9 +89,7 @@ class BaseDatasetTest(BaseTest):
             rows.extend(message.data)
         self.write_rows(rows)
 
-    def write_rows(self, rows):
-        if not isinstance(rows, (list, tuple)):
-            rows = [rows]
+    def write_rows(self, rows: Sequence[WriterTableRow]) -> None:
         enforce_table_writer(self.dataset).get_writer().write(rows)
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -94,18 +94,20 @@ class BaseEventsTest(BaseDatasetTest):
         unique = "%s:%s" % (str(data["project"]), data["id"])
         primary_hash = md5(unique.encode("utf-8")).hexdigest()
 
-        return {
-            "event_id": data["id"],
-            "group_id": int(primary_hash[:16], 16),
-            "primary_hash": primary_hash,
-            "project_id": data["project"],
-            "message": data["message"],
-            "platform": data["platform"],
-            "datetime": data["datetime"],
-            "data": data,
-            "organization_id": data["organization_id"],
-            "retention_days": settings.DEFAULT_RETENTION_DAYS,
-        }
+        return InsertEvent(
+            {
+                "event_id": data["id"],
+                "group_id": int(primary_hash[:16], 16),
+                "primary_hash": primary_hash,
+                "project_id": data["project"],
+                "message": data["message"],
+                "platform": data["platform"],
+                "datetime": data["datetime"],
+                "data": data,
+                "organization_id": data["organization_id"],
+                "retention_days": settings.DEFAULT_RETENTION_DAYS,
+            }
+        )
 
     def __get_event(self) -> InsertEvent:
         from tests.fixtures import raw_event

--- a/tests/base.py
+++ b/tests/base.py
@@ -68,16 +68,6 @@ class BaseTest(object):
 
 
 class BaseDatasetTest(BaseTest):
-    def write_processed_records(self, records):
-        if not isinstance(records, (list, tuple)):
-            records = [records]
-
-        rows = []
-        for event in records:
-            rows.append(event)
-
-        return self.write_rows(rows)
-
     def write_processed_messages(self, messages: Sequence[ProcessedMessage]) -> None:
         rows = []
         for message in messages:
@@ -133,16 +123,17 @@ class BaseEventsTest(BaseDatasetTest):
             }
         )
 
-    def create_event_for_date(self, dt, retention_days=settings.DEFAULT_RETENTION_DAYS):
-        event = {
+    def create_event_row_for_date(
+        self, dt: datetime, retention_days=settings.DEFAULT_RETENTION_DAYS
+    ):
+        return {
             "event_id": uuid.uuid4().hex,
             "project_id": 1,
             "group_id": 1,
             "deleted": 0,
+            "timestamp": dt,
+            "retention_days": retention_days,
         }
-        event["timestamp"] = dt
-        event["retention_days"] = retention_days
-        return event
 
     def write_events(self, events: Sequence[Union[EventData, InsertEvent]]) -> None:
         processor = (

--- a/tests/base.py
+++ b/tests/base.py
@@ -157,19 +157,11 @@ class BaseEventsTest(BaseDatasetTest):
 
         self.write_processed_events(out)
 
-    def write_processed_events(
-        self, events: Union[ProcessedMessage, Sequence[ProcessedMessage]]
-    ) -> None:
-        if not isinstance(events, (list, tuple)) or isinstance(
-            events, ProcessedMessage
-        ):
-            events = [events]
-
+    def write_processed_events(self, events: Sequence[ProcessedMessage]) -> None:
         rows = []
         for event in events:
             assert event.action is ProcessorAction.INSERT
             rows.extend(event.data)
-
         self.write_rows(rows)
 
     def write_rows(self, rows) -> None:

--- a/tests/base.py
+++ b/tests/base.py
@@ -138,9 +138,6 @@ class BaseEventsTest(BaseDatasetTest):
         return event
 
     def write_raw_events(self, events):
-        if not isinstance(events, (list, tuple)):
-            events = [events]
-
         out = []
         for event in events:
             if is_raw_event(event):

--- a/tests/base.py
+++ b/tests/base.py
@@ -166,12 +166,6 @@ class BaseEventsTest(BaseDatasetTest):
             rows.extend(event.data)
         self.write_rows(rows)
 
-    def write_rows(self, rows) -> None:
-        if not isinstance(rows, (list, tuple)):
-            rows = [rows]
-
-        enforce_table_writer(self.dataset).get_writer().write(rows)
-
 
 class BaseApiTest(BaseEventsTest):
     def setup_method(self, test_method, dataset_name="events"):

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -238,7 +238,7 @@ class TestReplacer(BaseEventsTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -274,7 +274,7 @@ class TestReplacer(BaseEventsTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -312,7 +312,7 @@ class TestReplacer(BaseEventsTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -238,7 +238,7 @@ class TestReplacer(BaseEventsTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -274,7 +274,7 @@ class TestReplacer(BaseEventsTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -312,7 +312,7 @@ class TestReplacer(BaseEventsTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -120,7 +120,7 @@ class TestGroupassignee(BaseDatasetTest):
         insert_msg = json.loads(self.INSERT_MSG)
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
-        self.write_processed_records(ret.data)
+        self.write_processed_messages([ret])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)
@@ -179,7 +179,7 @@ class TestGroupassignee(BaseDatasetTest):
                 "team_id": "",
             }
         )
-        self.write_processed_records(row.to_clickhouse())
+        self.write_rows([row.to_clickhouse()])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 import uuid
 
 from snuba import settings
+from snuba.datasets.events_processor_base import InsertEvent
 from tests.base import BaseEventsTest
 
 
@@ -19,24 +20,26 @@ class BaseSubscriptionTest(BaseEventsTest):
 
         self.write_events(
             [
-                {
-                    "event_id": uuid.uuid4().hex,
-                    "group_id": tick,
-                    "primary_hash": uuid.uuid4().hex,
-                    "project_id": self.project_id,
-                    "message": "a message",
-                    "platform": self.platforms[tick % len(self.platforms)],
-                    "datetime": (self.base_time + timedelta(minutes=tick)).strftime(
-                        settings.PAYLOAD_DATETIME_FORMAT
-                    ),
-                    "data": {
-                        "received": calendar.timegm(
-                            (self.base_time + timedelta(minutes=tick)).timetuple()
+                InsertEvent(
+                    {
+                        "event_id": uuid.uuid4().hex,
+                        "group_id": tick,
+                        "primary_hash": uuid.uuid4().hex,
+                        "project_id": self.project_id,
+                        "message": "a message",
+                        "platform": self.platforms[tick % len(self.platforms)],
+                        "datetime": (self.base_time + timedelta(minutes=tick)).strftime(
+                            settings.PAYLOAD_DATETIME_FORMAT
                         ),
-                    },
-                    "organization_id": 1,
-                    "retention_days": settings.DEFAULT_RETENTION_DAYS,
-                }
+                        "data": {
+                            "received": calendar.timegm(
+                                (self.base_time + timedelta(minutes=tick)).timetuple()
+                            ),
+                        },
+                        "organization_id": 1,
+                        "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                    }
+                )
                 for tick in range(self.minutes)
             ]
         )

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -17,7 +17,7 @@ class BaseSubscriptionTest(BaseEventsTest):
             minute=0, second=0, microsecond=0
         ) - timedelta(minutes=self.minutes)
 
-        self.write_raw_events(
+        self.write_events(
             [
                 {
                     "event_id": uuid.uuid4().hex,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,14 +64,14 @@ class TestApi(BaseApiTest):
                         enforce_table_writer(self.dataset)
                         .get_stream_loader()
                         .get_processor()
-                        .process_insert(
+                        .process_message(
                             {
                                 "project_id": p,
                                 "event_id": uuid.uuid4().hex,
                                 "deleted": 0,
                                 "datetime": (
                                     self.base_time + timedelta(minutes=tick)
-                                ).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                                ).strftime(settings.PAYLOAD_DATETIME_FORMAT),
                                 "message": "a message",
                                 "search_message": "a long search message"
                                 if p == 3
@@ -129,7 +129,7 @@ class TestApi(BaseApiTest):
                             }
                         )
                     )
-        self.write_processed_records(events)
+        self.write_processed_messages(events)
 
     def redis_db_size(self):
         # dbsize could be an integer for a single node cluster or a dictionary
@@ -1171,7 +1171,7 @@ class TestApi(BaseApiTest):
         }
         result1 = json.loads(self.app.post("/query", data=json.dumps(query)).data)
 
-        self.write_processed_records(
+        self.write_rows(
             [
                 {
                     "event_id": "9" * 32,

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -25,7 +25,7 @@ class TestCleanup(BaseEventsTest):
         assert parts == []
 
         # base, 90 retention
-        self.write_processed_records(self.create_event_for_date(base))
+        self.write_rows([self.create_event_row_for_date(base)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
         assert parts == [(to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
@@ -33,7 +33,7 @@ class TestCleanup(BaseEventsTest):
 
         # -40 days, 90 retention
         three_weeks_ago = base - timedelta(days=7 * 3)
-        self.write_processed_records(self.create_event_for_date(three_weeks_ago))
+        self.write_rows([self.create_event_row_for_date(three_weeks_ago)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
         assert parts == [(to_monday(three_weeks_ago), 90), (to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
@@ -41,7 +41,7 @@ class TestCleanup(BaseEventsTest):
 
         # -100 days, 90 retention
         thirteen_weeks_ago = base - timedelta(days=7 * 13)
-        self.write_processed_records(self.create_event_for_date(thirteen_weeks_ago))
+        self.write_rows([self.create_event_row_for_date(thirteen_weeks_ago)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
@@ -53,7 +53,7 @@ class TestCleanup(BaseEventsTest):
 
         # -1 week, 30 retention
         one_week_ago = base - timedelta(days=7)
-        self.write_processed_records(self.create_event_for_date(one_week_ago, 30))
+        self.write_rows([self.create_event_row_for_date(one_week_ago, 30)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
@@ -66,7 +66,7 @@ class TestCleanup(BaseEventsTest):
 
         # -5 weeks, 30 retention
         five_weeks_ago = base - timedelta(days=7 * 5)
-        self.write_processed_records(self.create_event_for_date(five_weeks_ago, 30))
+        self.write_rows([self.create_event_row_for_date(five_weeks_ago, 30)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -24,7 +24,7 @@ class TestDiscoverApi(BaseApiTest):
             self.__dataset_manager.enter_context(dataset_manager(dataset_name))
 
         self.app.post = partial(self.app.post, headers={"referer": "test"})
-        self.project_id = 70156
+        self.project_id = self.event["project_id"]
 
         self.base_time = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
         self.generate_event()
@@ -35,15 +35,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def generate_event(self):
         self.dataset = get_dataset("events")
-        assert self.event["project_id"] == self.project_id
-        self.write_processed_messages(
-            [
-                enforce_table_writer(self.dataset)
-                .get_stream_loader()
-                .get_processor()
-                .process_message(self.event)
-            ]
-        )
+        self.write_events([self.event])
 
     def generate_transaction(self):
         self.dataset = get_dataset("transactions")

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -127,7 +127,7 @@ class TestDiscoverApi(BaseApiTest):
             )
         )
 
-        self.write_processed_events(processed.data)
+        self.write_processed_events(processed)
 
     def test_raw_data(self):
         response = self.app.post(

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -36,13 +36,14 @@ class TestDiscoverApi(BaseApiTest):
     def generate_event(self):
         self.dataset = get_dataset("events")
         assert self.event["project_id"] == self.project_id
-        event = (
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_processor()
-            .process_insert(self.event)
+        self.write_processed_messages(
+            [
+                enforce_table_writer(self.dataset)
+                .get_stream_loader()
+                .get_processor()
+                .process_message(self.event)
+            ]
         )
-        self.write_processed_records([event])
 
     def generate_transaction(self):
         self.dataset = get_dataset("transactions")

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -126,7 +126,7 @@ class TestDiscoverApi(BaseApiTest):
             )
         )
 
-        self.write_processed_events([processed])
+        self.write_processed_messages([processed])
 
     def test_raw_data(self):
         response = self.app.post(

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -127,7 +127,7 @@ class TestDiscoverApi(BaseApiTest):
             )
         )
 
-        self.write_processed_events(processed)
+        self.write_processed_events([processed])
 
     def test_raw_data(self):
         response = self.app.post(

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -131,7 +131,7 @@ class TestGroupedMessage(BaseDatasetTest):
         insert_msg = json.loads(self.INSERT_MSG)
         ret = processor.process_message(insert_msg, metadata)
         assert ret.data == [self.PROCESSED]
-        self.write_processed_records(ret.data)
+        self.write_processed_messages([ret])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.INSERT)
@@ -186,7 +186,7 @@ class TestGroupedMessage(BaseDatasetTest):
                 "first_release_id": "26",
             }
         )
-        self.write_processed_records(row.to_clickhouse())
+        self.write_rows([row.to_clickhouse()])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -25,21 +25,21 @@ class TestOptimize(BaseEventsTest):
         base_monday = base - timedelta(days=base.weekday())
 
         # 1 event, 0 unoptimized parts
-        self.write_processed_records(self.create_event_for_date(base))
+        self.write_rows([self.create_event_row_for_date(base)])
         parts = optimize.get_partitions_to_optimize(
             clickhouse, self.database, self.table
         )
         assert parts == []
 
         # 2 events in the same part, 1 unoptimized part
-        self.write_processed_records(self.create_event_for_date(base))
+        self.write_rows([self.create_event_row_for_date(base)])
         parts = optimize.get_partitions_to_optimize(
             clickhouse, self.database, self.table
         )
         assert parts == [(base_monday, 90)]
 
         # 3 events in the same part, 1 unoptimized part
-        self.write_processed_records(self.create_event_for_date(base))
+        self.write_rows([self.create_event_row_for_date(base)])
         parts = optimize.get_partitions_to_optimize(
             clickhouse, self.database, self.table
         )
@@ -50,8 +50,8 @@ class TestOptimize(BaseEventsTest):
         a_month_earlier_monday = a_month_earlier - timedelta(
             days=a_month_earlier.weekday()
         )
-        self.write_processed_records(self.create_event_for_date(a_month_earlier_monday))
-        self.write_processed_records(self.create_event_for_date(a_month_earlier_monday))
+        self.write_rows([self.create_event_row_for_date(a_month_earlier_monday)])
+        self.write_rows([self.create_event_row_for_date(a_month_earlier_monday)])
         parts = optimize.get_partitions_to_optimize(
             clickhouse, self.database, self.table
         )

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -52,7 +52,7 @@ class TestOutcomesApi(BaseApiTest):
 
             outcomes.append(processed)
 
-        self.write_processed_events(outcomes)
+        self.write_processed_messages(outcomes)
 
     def format_time(self, time: datetime) -> str:
         return time.replace(tzinfo=pytz.utc).isoformat()

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -50,7 +50,7 @@ class TestOutcomesApi(BaseApiTest):
                 )
             )
 
-            outcomes.extend(processed.data)
+            outcomes.append(processed)
 
         self.write_processed_events(outcomes)
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -239,7 +239,7 @@ class TestReplacer(BaseEventsTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -275,7 +275,7 @@ class TestReplacer(BaseEventsTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -313,7 +313,7 @@ class TestReplacer(BaseEventsTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -353,7 +353,7 @@ class TestReplacer(BaseEventsTest):
         self.event["group_id"] = 1
         self.event["data"]["tags"].append(["browser.name", "foo"])
         self.event["data"]["tags"].append(["notbrowser", "foo"])
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         project_id = self.project_id
 
@@ -415,7 +415,7 @@ class TestReplacer(BaseEventsTest):
         self.event["data"]["tags"].append(["browser|to_delete", "foo=2"])
         self.event["data"]["tags"].append(["notbrowser", "foo\\3"])
         self.event["data"]["tags"].append(["notbrowser2", "foo4"])
-        self.write_raw_events(self.event)
+        self.write_raw_events([self.event])
 
         project_id = self.project_id
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -239,7 +239,7 @@ class TestReplacer(BaseEventsTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -275,7 +275,7 @@ class TestReplacer(BaseEventsTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -313,7 +313,7 @@ class TestReplacer(BaseEventsTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -353,7 +353,7 @@ class TestReplacer(BaseEventsTest):
         self.event["group_id"] = 1
         self.event["data"]["tags"].append(["browser.name", "foo"])
         self.event["data"]["tags"].append(["notbrowser", "foo"])
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         project_id = self.project_id
 
@@ -415,7 +415,7 @@ class TestReplacer(BaseEventsTest):
         self.event["data"]["tags"].append(["browser|to_delete", "foo=2"])
         self.event["data"]["tags"].append(["notbrowser", "foo\\3"])
         self.event["data"]["tags"].append(["notbrowser2", "foo4"])
-        self.write_raw_events([self.event])
+        self.write_events([self.event])
 
         project_id = self.project_id
 

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -140,7 +140,7 @@ class TestTransactionsApi(BaseApiTest):
                         )
                     )
                     events.append(processed)
-        self.write_processed_events(events)
+        self.write_processed_messages(events)
 
     def test_read_ip(self):
         response = self.app.post(

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -139,7 +139,7 @@ class TestTransactionsApi(BaseApiTest):
                             )
                         )
                     )
-                    events.extend(processed.data)
+                    events.append(processed)
         self.write_processed_events(events)
 
     def test_read_ip(self):


### PR DESCRIPTION
This also nudges `EventsProcessorBase` in the direction of being more accurately typed.