### PR TITLE
ref(consumer): Remove version 0 and 1 event payload support

### DIFF
--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -29,6 +29,20 @@ from snuba.processor import (
 logger = logging.getLogger(__name__)
 
 
+REPLACEMENT_EVENT_TYPES = frozenset(
+    [
+        "start_delete_groups",
+        "start_merge",
+        "start_unmerge",
+        "start_delete_tag",
+        "end_delete_groups",
+        "end_merge",
+        "end_unmerge",
+        "end_delete_tag",
+    ]
+)
+
+
 class EventsProcessorBase(MessageProcessor, ABC):
     """
     Base class for events and errors processors.
@@ -135,57 +149,27 @@ class EventsProcessorBase(MessageProcessor, ABC):
                 return None
         elif isinstance(message, (list, tuple)) and len(message) >= 2:
             version = message[0]
+            if version != 2:
+                raise InvalidMessageVersion(f"Unsupported message version: {version}")
 
-            if version in (0, 1, 2):
-                # version 0: (0, 'insert', data)
-                # version 1: (1, type, data, [state])
-                #   NOTE: types 'delete_groups', 'merge' and 'unmerge' are ignored
-                # version 2: (2, type, data, [state])
-                type_, event = message[1:3]
-                if type_ == "insert":
-                    action_type = ProcessorAction.INSERT
-                    try:
-                        processed = self.process_insert(event, metadata)
-                    except EventTooOld:
-                        return None
+            # version 2: (2, type, data, [state])
+            type_, event = message[1:3]
+            if type_ == "insert":
+                action_type = ProcessorAction.INSERT
+                try:
+                    processed = self.process_insert(event, metadata)
+                except EventTooOld:
+                    return None
+            else:
+                if type_ in REPLACEMENT_EVENT_TYPES:
+                    # pass raw events along to republish
+                    action_type = ProcessorAction.REPLACE
+                    processed = (str(event["project_id"]), message)
                 else:
-                    if version == 0:
-                        raise InvalidMessageType(
-                            "Invalid message type: {}".format(type_)
-                        )
-                    elif version == 1:
-                        if type_ in ("delete_groups", "merge", "unmerge"):
-                            # these didn't contain the necessary data to handle replacements
-                            return None
-                        else:
-                            raise InvalidMessageType(
-                                "Invalid message type: {}".format(type_)
-                            )
-                    elif version == 2:
-                        # we temporarily sent these invalid message types from Sentry
-                        if type_ in ("delete_groups", "merge"):
-                            return None
-
-                        if type_ in (
-                            "start_delete_groups",
-                            "start_merge",
-                            "start_unmerge",
-                            "start_delete_tag",
-                            "end_delete_groups",
-                            "end_merge",
-                            "end_unmerge",
-                            "end_delete_tag",
-                        ):
-                            # pass raw events along to republish
-                            action_type = ProcessorAction.REPLACE
-                            processed = (str(event["project_id"]), message)
-                        else:
-                            raise InvalidMessageType(
-                                "Invalid message type: {}".format(type_)
-                            )
+                    raise InvalidMessageType(f"Invalid message type: {type_}")
 
         if action_type is None:
-            raise InvalidMessageVersion("Unknown message format: " + str(message))
+            raise InvalidMessageVersion(f"Unknown message format: {message}")
 
         if processed is None:
             return None

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -1,5 +1,4 @@
 import calendar
-import copy
 import pytest
 from collections import OrderedDict
 from datetime import datetime, timedelta
@@ -34,33 +33,6 @@ class TestEventsProcessor(BaseEventsTest):
 
         for field in ("event_id", "project_id", "message", "platform"):
             assert processed.data[0][field] == self.event[field]
-
-    def test_simple_version_0(self):
-        processed = (
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_processor()
-            .process_message((0, "insert", self.event))
-        )
-
-        for field in ("event_id", "project_id", "message", "platform"):
-            assert processed.data[0][field] == self.event[field]
-
-    def test_simple_version_1(self):
-        processor = (
-            enforce_table_writer(self.dataset).get_stream_loader().get_processor()
-        )
-        assert processor.process_message(
-            (0, "insert", copy.deepcopy(self.event))
-        ) == processor.process_message((1, "insert", copy.deepcopy(self.event), {}))
-
-    def test_invalid_type_version_0(self):
-        with pytest.raises(InvalidMessageType):
-            enforce_table_writer(
-                self.dataset
-            ).get_stream_loader().get_processor().process_message(
-                (0, "invalid", self.event)
-            )
 
     def test_invalid_version(self):
         with pytest.raises(InvalidMessageVersion):
@@ -201,33 +173,6 @@ class TestEventsProcessor(BaseEventsTest):
         processor.extract_custom(output, event)
         assert output["search_message"] == "the search message"
         assert output["message"] == "the short message"
-
-    def test_v1_delete_groups_skipped(self):
-        assert (
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_processor()
-            .process_message((1, "delete_groups", {}))
-            is None
-        )
-
-    def test_v1_merge_skipped(self):
-        assert (
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_processor()
-            .process_message((1, "merge", {}))
-            is None
-        )
-
-    def test_v1_unmerge_skipped(self):
-        assert (
-            enforce_table_writer(self.dataset)
-            .get_stream_loader()
-            .get_processor()
-            .process_message((1, "unmerge", {}))
-            is None
-        )
 
     def test_v2_invalid_type(self):
         with pytest.raises(InvalidMessageType):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -26,7 +26,7 @@ class TestConsumer(BaseEventsTest):
             Partition(Topic("events"), 456),
             123,
             KafkaPayload(
-                None, json.dumps((0, "insert", event)).encode("utf-8")
+                None, json.dumps((2, "insert", event)).encode("utf-8")
             ),  # event doesn't really matter
             datetime.now(),
         )
@@ -78,7 +78,7 @@ class TestConsumer(BaseEventsTest):
         message: Message[KafkaPayload] = Message(
             Partition(Topic("events"), 1),
             42,
-            KafkaPayload(None, json.dumps((0, "insert", event)).encode("utf-8")),
+            KafkaPayload(None, json.dumps((2, "insert", event)).encode("utf-8")),
             datetime.now(),
         )
 


### PR DESCRIPTION
This does not remove the unversioned payload, which is heavily used in tests. The unversioned payload can be easily removed after getsentry/snuba#1066 is merged.