### PR TITLE
ref(consumer): Remove `search_message` from event processor

### DIFF
--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -47,30 +47,8 @@ class EventsProcessor(EventsProcessorBase):
         metadata: Optional[KafkaMessageMetadata] = None,
     ) -> None:
         data = event.get("data", {})
-        # The following concerns the change to message/search_message
-        # There are 2 Scenarios:
-        #   Pre-rename:
-        #        - Payload contains:
-        #             "message": "a long search message"
-        #        - Does NOT contain a `search_message` property
-        #        - "message" value saved in `message` column
-        #        - `search_message` column nonexistent or Null
-        #   Post-rename:
-        #        - Payload contains:
-        #             "search_message": "a long search message"
-        #        - Optionally the payload's "data" dict (event body) contains:
-        #             "message": "short message"
-        #        - "search_message" value stored in `search_message` column
-        #        - "message" value stored in `message` column
-        #
-        output["search_message"] = _unicodify(event.get("search_message", None))
-        if output["search_message"] is None:
-            # Pre-rename scenario, we expect to find "message" at the top level
-            output["message"] = _unicodify(event["message"])
-        else:
-            # Post-rename scenario, we check in case we have the optional
-            # "message" in the event body.
-            output["message"] = _unicodify(data.get("message", None))
+
+        output["message"] = _unicodify(event["message"])
 
         # USER REQUEST GEO
         user = data.get("user", data.get("sentry.interfaces.User", None)) or {}

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -163,45 +163,6 @@ class TestEventsProcessor(BaseEventsTest):
             "location": "bar.py",
         }
 
-    def test_extract_common_search_message(self):
-        now = datetime.utcnow().replace(microsecond=0)
-        event = {
-            "primary_hash": "a" * 32,
-            "message": "the message",
-            "platform": "the_platform",
-            "search_message": "the search message",
-            "data": {"received": int(calendar.timegm(now.timetuple()))},
-        }
-        output = {}
-        processor = (
-            enforce_table_writer(self.dataset).get_stream_loader().get_processor()
-        )
-        processor.extract_common(output, event)
-        processor.extract_custom(output, event)
-
-        assert output["search_message"] == "the search message"
-
-        # with optional short message
-        now = datetime.utcnow().replace(microsecond=0)
-        event = {
-            "primary_hash": "a" * 32,
-            "message": "the message",
-            "platform": "the_platform",
-            "search_message": "the search message",
-            "data": {
-                "received": int(calendar.timegm(now.timetuple())),
-                "message": "the short message",
-            },
-        }
-        output = {}
-        processor = (
-            enforce_table_writer(self.dataset).get_stream_loader().get_processor()
-        )
-        processor.extract_common(output, event)
-        processor.extract_custom(output, event)
-        assert output["search_message"] == "the search message"
-        assert output["message"] == "the short message"
-
     def test_v1_delete_groups_skipped(self):
         assert (
             enforce_table_writer(self.dataset)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1672,39 +1672,6 @@ class TestApi(BaseApiTest):
         )
         assert response["stats"]["consistent"]
 
-    def test_message_is_search_message(self):
-        # all messages contain 'message'
-        response = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {
-                        "project": [1, 2, 3],
-                        "conditions": [["message", "LIKE", "%message%"]],
-                        "groupby": "project_id",
-                        "debug": True,
-                    }
-                ),
-            ).data
-        )
-        assert sorted(r["project_id"] for r in response["data"]) == [1, 2, 3]
-
-        # only project 3 has a search_message with 'long search' in it
-        response = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {
-                        "project": [1, 2, 3],
-                        "conditions": [["message", "LIKE", "%long search%"]],
-                        "groupby": "project_id",
-                        "debug": True,
-                    }
-                ),
-            ).data
-        )
-        assert sorted(r["project_id"] for r in response["data"]) == [3]
-
     def test_gracefully_handle_multiple_conditions_on_same_column(self):
         response = self.app.post(
             "/query",


### PR DESCRIPTION
Still not sure what a search message is but this code has been here since January 2019 and we've never written a single value in the column and it's not present in the event stream. This does not remove the column references from the schema or query processing logic.