### PR TITLE
feat(ast) Rollout tagstore.get_group_seen_values_for_environments

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -127,6 +127,7 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
         "tagstore.__get_tag_key_and_top_values": 100,
         "tagstore.__get_tag_keys_and_top_values": 100,
         "tagstore.__get_release": 100,
+        "tagstore.get_group_seen_values_for_environments": 100,
         # Eventstore
         "eventstore.get_next_or_prev_event_id": 100,
     },

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -127,6 +127,8 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
         "tagstore.__get_tag_key_and_top_values": 100,
         "tagstore.__get_tag_keys_and_top_values": 100,
         "tagstore.__get_release": 100,
+        # Eventstore
+        "eventstore.get_next_or_prev_event_id": 100,
     },
     "transactions": {
         # Simple time bucketed queries


### PR DESCRIPTION
This is a simple query with no tag resolution but with high volume.