### PR TITLE
feat(migrations): Add operations

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -134,7 +134,7 @@ class DropColumn(SqlOperation):
     Drops a column from a table.
 
     The data from that column will be removed from the filesystem, so this command
-    shouuld only be performed once the column is no longer being referenced anywhere.
+    should only be performed once the column is no longer being referenced anywhere.
 
     You cannot drop a column that is part of the the primary key or the sampling
     key in the engine expression.

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -106,6 +106,10 @@ class CreateMaterializedView(SqlOperation):
 class AddColumn(SqlOperation):
     """
     Adds a column to a table.
+
+    The `after` value represents the name of the existing column after which the
+    new column will be added. If no value is passed, it will be added in the last
+    position. There is no way to add a column at the start of the table.
     """
 
     def __init__(
@@ -122,9 +126,7 @@ class AddColumn(SqlOperation):
 
     def format_sql(self) -> str:
         column = self.__column.for_schema()
-        optional_after_clause = (
-            f" AFTER {self.__after}" if self.__after is not None else ""
-        )
+        optional_after_clause = f" AFTER {self.__after}" if self.__after else ""
         return f"ALTER TABLE {self.__table_name} ADD COLUMN IF NOT EXISTS {column}{optional_after_clause};"
 
 
@@ -193,9 +195,7 @@ class AddIndex(SqlOperation):
         self.__after = after
 
     def format_sql(self) -> str:
-        optional_after_clause = (
-            f" AFTER {self.__after}" if self.__after is not None else ""
-        )
+        optional_after_clause = f" AFTER {self.__after}" if self.__after else ""
         return f"ALTER TABLE {self.__table_name} ADD INDEX {self.__index_name} {self.__index_expression} TYPE {self.__index_type} GRANULARITY {self.__granularity}{optional_after_clause};"
 
 

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -39,10 +39,10 @@ class SqlOperation(Operation, ABC):
 class RunSql(SqlOperation):
     def __init__(self, storage_set: StorageSetKey, statement: str) -> None:
         super().__init__(storage_set)
-        self.statement = statement
+        self.__statement = statement
 
     def format_sql(self) -> str:
-        return self.statement
+        return self.__statement
 
 
 class DropTable(SqlOperation):
@@ -135,7 +135,7 @@ class DropColumn(SqlOperation):
     Drops a column from a table.
 
     The data from that column will be removed from the filesystem, so this command
-    shouuld only be performed once the column is no longer referenced anywhere else.
+    shouuld only be performed once the column is no longer being referenced anywhere.
 
     You cannot drop a column that is part of the the primary key or the sampling
     key in the engine expression.

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -134,6 +134,9 @@ class DropColumn(SqlOperation):
     """
     Drops a column from a table.
 
+    The data from that column will be removed from the filesystem, so this command
+    shouuld only be performed once the column is no longer referenced anywhere else.
+
     You cannot drop a column that is part of the the primary key or the sampling
     key in the engine expression.
     """


### PR DESCRIPTION
Adds support for the rest of the operations that are required to build
our tables and maintain compatibility with our existing migration
functions.
- Add column
- Drop column
- Modify column
- Add index
- Drop index