### PR TITLE
feat(migrations): Make storage set string instead of enum

### DIFF
--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -4,3 +4,7 @@ class MigrationInProgress(Exception):
 
 class InvalidMigrationState(Exception):
     pass
+
+
+class InvalidStorageSet(Exception):
+    pass

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -13,7 +13,6 @@ from snuba.clickhouse.columns import (
     UInt,
     UUID,
 )
-from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations, table_engines
 
 
@@ -59,7 +58,7 @@ class Migration(migration.MultiStepMigration):
 
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.QUERYLOG,
+                storage_set="querylog",
                 table_name="querylog_local",
                 columns=columns,
                 engine=table_engines.MergeTree(
@@ -72,7 +71,5 @@ class Migration(migration.MultiStepMigration):
 
     def backwards_local(self) -> Sequence[operations.Operation]:
         return [
-            operations.DropTable(
-                storage_set=StorageSetKey.QUERYLOG, table_name="querylog_local",
-            )
+            operations.DropTable(storage_set="querylog", table_name="querylog_local",)
         ]


### PR DESCRIPTION
This is a follow up to conversation in
https://github.com/getsentry/snuba/pull/1058#discussion_r447353998.

We want to support the possibility of storage sets being deprecated in
the future, therefore we should not reference the storage set enum
directly. Instead the migration operations provide the storage set
as a string. If the string does not match a currently valid storage
set, then the migration is skipped.