### PR TITLE
fix(ast) Actually rollout eventstore

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -106,6 +106,10 @@ AST_DATASET_ROLLOUT: Mapping[str, int] = {
     "outcomes": 100,
 }  # (dataset name: percentage)
 AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
+    "discover": {
+        # Eventstore
+        "eventstore.get_next_or_prev_event_id": 100,
+    },
     "events": {
         # Simple queries without splitting or user customizations
         "Group.filter_by_event_id": 100,
@@ -128,8 +132,6 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
         "tagstore.__get_tag_keys_and_top_values": 100,
         "tagstore.__get_release": 100,
         "tagstore.get_group_seen_values_for_environments": 100,
-        # Eventstore
-        "eventstore.get_next_or_prev_event_id": 100,
     },
     "transactions": {
         # Simple time bucketed queries


### PR DESCRIPTION
Well, this explains why I did not see any get_next_or_prev_event_id query on the events dataset happening. They are all on the discover dataset.