### PR TITLE
feat(migrations): Require forwards_dist and backward_dist methods

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -71,6 +71,14 @@ class MultiStepMigration(Migration, ABC):
     def backwards_local(self) -> Sequence[Operation]:
         raise NotImplementedError
 
+    @abstractmethod
+    def forwards_dist(self) -> Sequence[Operation]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def backwards_dist(self) -> Sequence[Operation]:
+        raise NotImplementedError
+
     def forwards(self, context: Context) -> None:
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -17,46 +17,46 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations, table_engines
 
 
+status_type = Enum([("success", 0), ("error", 1), ("rate-limited", 2)])
+
+columns = [
+    Column("request_id", UUID()),
+    Column("request_body", String()),
+    Column("referrer", LowCardinality(String())),
+    Column("dataset", LowCardinality(String())),
+    Column("projects", Array(UInt(64))),
+    Column("organization", Nullable(UInt(64))),
+    Column("timestamp", DateTime()),
+    Column("duration_ms", UInt(32)),
+    Column("status", status_type),
+    Column(
+        "clickhouse_queries",
+        Nested(
+            [
+                Column("sql", String()),
+                Column("status", status_type),
+                Column("trace_id", Nullable(UUID())),
+                Column("duration_ms", UInt(32)),
+                Column("stats", String()),
+                Column("final", UInt(8)),
+                Column("cache_hit", UInt(8)),
+                Column("sample", Float(32)),
+                Column("max_threads", UInt(8)),
+                Column("num_days", UInt(32)),
+                Column("clickhouse_table", LowCardinality(String())),
+                Column("query_id", String()),
+                Column("is_duplicate", UInt(8)),
+                Column("consistent", UInt(8)),
+            ]
+        ),
+    ),
+]
+
+
 class Migration(migration.MultiStepMigration):
-    # TODO: Provide the forwards_dist and backwards_dist methods for this migration
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.Operation]:
-        status_type = Enum([("success", 0), ("error", 1), ("rate-limited", 2)])
-
-        columns = [
-            Column("request_id", UUID()),
-            Column("request_body", String()),
-            Column("referrer", LowCardinality(String())),
-            Column("dataset", LowCardinality(String())),
-            Column("projects", Array(UInt(64))),
-            Column("organization", Nullable(UInt(64))),
-            Column("timestamp", DateTime()),
-            Column("duration_ms", UInt(32)),
-            Column("status", status_type),
-            Column(
-                "clickhouse_queries",
-                Nested(
-                    [
-                        Column("sql", String()),
-                        Column("status", status_type),
-                        Column("trace_id", Nullable(UUID())),
-                        Column("duration_ms", UInt(32)),
-                        Column("stats", String()),
-                        Column("final", UInt(8)),
-                        Column("cache_hit", UInt(8)),
-                        Column("sample", Float(32)),
-                        Column("max_threads", UInt(8)),
-                        Column("num_days", UInt(32)),
-                        Column("clickhouse_table", LowCardinality(String())),
-                        Column("query_id", String()),
-                        Column("is_duplicate", UInt(8)),
-                        Column("consistent", UInt(8)),
-                    ]
-                ),
-            ),
-        ]
-
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.QUERYLOG,
@@ -74,5 +74,24 @@ class Migration(migration.MultiStepMigration):
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.QUERYLOG, table_name="querylog_local",
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.Operation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="querylog_dist",
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="querylog_local", sharding_key=None,
+                ),
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.Operation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.QUERYLOG, table_name="querylog_dist",
             )
         ]


### PR DESCRIPTION
Adds the forwards_dist and backwards_dist methods to the querylog
migration, and require it for all future migations. Although these
methods are not yet being run, we should ensure they are always
provided alongside the operations that run on the local nodes as
they will be required later.