### PR TITLE
fix(processor): Handle `None` return type from `process_insert` correctly in events processors

### DIFF
--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -162,11 +162,14 @@ class EventsProcessorBase(MessageProcessor, ABC):
         type_, event = message[1:3]
         if type_ == "insert":
             try:
-                return ProcessedMessage(
-                    ProcessorAction.INSERT, [self.process_insert(event, metadata)]
-                )
+                row = self.process_insert(event, metadata)
             except EventTooOld:
                 return None
+
+            if row is None:  # the processor cannot/does not handle this input
+                return None
+
+            return ProcessedMessage(ProcessorAction.INSERT, [row])
         elif type_ in REPLACEMENT_EVENT_TYPES:
             # pass raw events along to republish
             return ProcessedMessage(


### PR DESCRIPTION
Fixes regression introduced with #1069.