### PR TITLE
feat(migrations): Add support for marking migrations as deprecated

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -32,6 +32,10 @@ class Migration(ABC):
     """
 
     @abstractproperty
+    def deprecated(self) -> bool:
+        raise NotImplementedError
+
+    @abstractproperty
     def blocking(self) -> bool:
         raise NotImplementedError
 

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -55,6 +55,7 @@ columns = [
 
 class Migration(migration.MultiStepMigration):
     blocking = False
+    deprecated = False
 
     def forwards_local(self) -> Sequence[operations.Operation]:
         return [

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -27,6 +27,7 @@ class Migration(migration.Migration):
     """
 
     blocking = False
+    deprecated = False
 
     def __forwards_local(self) -> Sequence[operations.Operation]:
         return [

--- a/tests/migrations/test_deprecated.py
+++ b/tests/migrations/test_deprecated.py
@@ -1,0 +1,45 @@
+from typing import Any, Sequence
+
+from unittest.mock import patch
+
+from snuba.migrations.groups import GroupLoader
+from snuba.migrations import context, migration
+from snuba.migrations.status import Status
+
+
+class DeprecatedMigration(migration.Migration):
+    blocking = False
+    deprecated = True
+
+    def forwards(self, context: context.Context) -> None:
+        context.update_status(Status.COMPLETED)
+
+    def backwards(self, context: context.Context) -> None:
+        pass
+
+
+class FakeEventsLoader(GroupLoader):
+    def get_migrations(self) -> Sequence[str]:
+        return ["test"]
+
+    def load_migration(self, migration_id: str) -> migration.Migration:
+        return DeprecatedMigration()
+
+
+@patch("snuba.migrations.groups.get_group_loader")
+def test_deprecated_migrations(get_group_loader: Any) -> None:
+    from snuba.migrations.groups import MigrationGroup, _REGISTERED_GROUPS
+    from snuba.migrations.runner import MigrationKey, Runner
+
+    get_group_loader.side_effect = (
+        lambda group: FakeEventsLoader()
+        if group == MigrationGroup.EVENTS
+        else _REGISTERED_GROUPS[group]
+    )
+    runner = Runner()
+    runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"))
+    runner.run_migration(MigrationKey(MigrationGroup.EVENTS, "test"))
+
+    assert runner._get_pending_migrations()[0] == [
+        MigrationKey(MigrationGroup.EVENTS, "test")
+    ]

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -29,15 +29,15 @@ def test_get_pending_migrations() -> None:
     total_migrations = get_total_migration_count()
     assert len(runner._get_pending_migrations()) == total_migrations
     runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"))
-    assert len(runner._get_pending_migrations()) == total_migrations - 1
+    assert len(runner._get_pending_migrations()[1]) == total_migrations - 1
 
 
 def test_run_all() -> None:
     runner = Runner()
-    assert len(runner._get_pending_migrations()) == get_total_migration_count()
+    assert len(runner._get_pending_migrations()[1]) == get_total_migration_count()
 
     runner.run_all()
-    assert runner._get_pending_migrations() == []
+    assert runner._get_pending_migrations()[1] == []
 
 
 def get_total_migration_count() -> int:


### PR DESCRIPTION
A migration can now be marked as deprecated. If a migration needs to
become deprecated in future, this will be done by editing the previously
created migration file and setting deprecated = True. If a migration is
deprecated, it will be reversed before any other migrations are run when
running all.

This allows us to avoid unnecessarily running every deprecated migration
in scenarios where we are running them all in sequence from the start
(such as a new Snuba installation of bringing up a new node). It also
ensures that nodes are brought back to a consistent state if the
deprecated migration was previously run.

Once a migration has been marked as deprecated, it can also be safely
deleted in a subsequent version of Snuba, if we wish to remove it from
the codebase entirely.

About deletion of entire migration groups: The process described here
provides the ability to target individual migrations within a group
for deprecation. If we want to drop an entire migration group (as is
proposed in #1074) we do not necessarily need to reverse out all of
the migrations of that group. We can just add a final migration that
cleans up any relevant tables then deprecate/delete the group completely.