### PR TITLE
test(migrations): Check migration state aligns to query schema

### DIFF
--- a/snuba/datasets/dataset_schemas.py
+++ b/snuba/datasets/dataset_schemas.py
@@ -28,7 +28,7 @@ class StorageSchemas(object):
     def get_write_schema(self) -> Optional[WritableTableSchema]:
         return self.__write_schema
 
-    def _get_unique_schemas(self) -> Sequence[Schema]:
+    def get_unique_schemas(self) -> Sequence[Schema]:
         unique_schemas: List[Schema] = []
 
         all_schemas_with_possible_duplicates = [self.__read_schema]
@@ -45,13 +45,13 @@ class StorageSchemas(object):
     def get_create_statements(self) -> Sequence[DDLStatement]:
         return [
             schema.get_local_table_definition()
-            for schema in self._get_unique_schemas()
+            for schema in self.get_unique_schemas()
             if isinstance(schema, TableSchema)
         ]
 
     def get_drop_statements(self) -> Sequence[DDLStatement]:
         return [
             schema.get_local_drop_table_statement()
-            for schema in self._get_unique_schemas()
+            for schema in self.get_unique_schemas()
             if isinstance(schema, TableSchema)
         ]

--- a/snuba/datasets/dataset_schemas.py
+++ b/snuba/datasets/dataset_schemas.py
@@ -28,7 +28,7 @@ class StorageSchemas(object):
     def get_write_schema(self) -> Optional[WritableTableSchema]:
         return self.__write_schema
 
-    def __get_unique_schemas(self) -> Sequence[Schema]:
+    def _get_unique_schemas(self) -> Sequence[Schema]:
         unique_schemas: List[Schema] = []
 
         all_schemas_with_possible_duplicates = [self.__read_schema]
@@ -45,13 +45,13 @@ class StorageSchemas(object):
     def get_create_statements(self) -> Sequence[DDLStatement]:
         return [
             schema.get_local_table_definition()
-            for schema in self.__get_unique_schemas()
+            for schema in self._get_unique_schemas()
             if isinstance(schema, TableSchema)
         ]
 
     def get_drop_statements(self) -> Sequence[DDLStatement]:
         return [
             schema.get_local_drop_table_statement()
-            for schema in self.__get_unique_schemas()
+            for schema in self._get_unique_schemas()
             if isinstance(schema, TableSchema)
         ]

--- a/snuba/migrations/parse_schema.py
+++ b/snuba/migrations/parse_schema.py
@@ -1,8 +1,9 @@
 import logging
 import re
 
-from parsimonious.grammar import Grammar  # type: ignore
-from parsimonious.nodes import Node, NodeVisitor  # type: ignore
+from clickhouse_driver import Client
+from parsimonious.grammar import Grammar
+from parsimonious.nodes import Node, NodeVisitor
 from typing import Any, Iterable, Mapping, Sequence, Tuple
 
 from snuba.clickhouse.columns import (
@@ -169,7 +170,7 @@ def _strip_cast(default_expr: str) -> str:
 def _get_column(
     column_type: str, default_type: str, default_expr: str, codec_expr: str
 ) -> ColumnType:
-    column = Visitor().visit(grammar.parse(column_type))
+    column: ColumnType = Visitor().visit(grammar.parse(column_type))
 
     if default_type == "MATERIALIZED":
         column = Materialized(column, _strip_cast(default_expr))
@@ -182,7 +183,7 @@ def _get_column(
     return column
 
 
-def get_local_schema(conn, table_name) -> Mapping[str, ColumnType]:
+def get_local_schema(conn: Client, table_name: str) -> Mapping[str, ColumnType]:
     return {
         column_name: _get_column(column_type, default_type, default_expr, codec_expr)
         for column_name, column_type, default_type, default_expr, _comment, codec_expr in [


### PR DESCRIPTION
Test that the tables generated by the new migrations are aligned
to the query schema. This checks that the tables generated by the old
migration system and the new migration system are the same.