### PR TITLE
fix: Skip non-error outcomes in snuba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pytz==2018.4
 python-rapidjson==0.8.0
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-relay>=0.5.7,<0.6.0
+sentry-relay>=0.5.11,<0.6.0
 sentry-sdk==0.13.5
 simplejson==3.15.0
 typing-extensions==3.7.4.1

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -59,7 +59,7 @@ def function_expr(fn: str, args_expr: str = "") -> str:
             return "countIf(notIn(transaction_status, tuple({ok}, {cancelled}, {unknown}))) / count()".format(
                 ok=SPAN_STATUS_NAME_TO_CODE["ok"],
                 cancelled=SPAN_STATUS_NAME_TO_CODE["cancelled"],
-                unknown=SPAN_STATUS_NAME_TO_CODE["unknown_error"],
+                unknown=SPAN_STATUS_NAME_TO_CODE["unknown"],
             )
         raise ValueError("Invalid format for failure_rate()")
     # For functions with no args, (or static args) we allow them to already

--- a/snuba/query/processors/failure_rate_processor.py
+++ b/snuba/query/processors/failure_rate_processor.py
@@ -19,7 +19,7 @@ from snuba.request.request_settings import RequestSettings
 class FailureRateProcessor(QueryProcessor):
     """
     A percentage of transactions with a bad status. "Bad" status is defined as anything other than "ok" and "unknown".
-    See here (https://github.com/getsentry/relay/blob/master/py/sentry_relay/consts.py) for the full list of errors.
+    See here (https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs) for the full list of errors.
     """
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
@@ -27,7 +27,7 @@ class FailureRateProcessor(QueryProcessor):
             if isinstance(exp, FunctionCall) and exp.function_name == "failure_rate":
                 assert len(exp.parameters) == 0
 
-                successful_codes = ["ok", "cancelled", "unknown_error"]
+                successful_codes = ["ok", "cancelled", "unknown"]
                 return divide(
                     countIf(
                         binary_condition(


### PR DESCRIPTION
Uses `DataCategory` from Relay to skip outcomes of non-error events. This fixes https://github.com/getsentry/snuba/pull/1008, which incorrectly compared the numeric data category with strings.

See https://github.com/getsentry/relay/pull/651