### PR TITLE
Revert "fix: Skip non-error outcomes in snuba"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ pytz==2018.4
 python-rapidjson==0.8.0
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-relay>=0.5.11,<0.6.0
+sentry-relay>=0.5.7,<0.6.0
 sentry-sdk==0.13.5
 simplejson==3.15.0
 typing-extensions==3.7.4.1

--- a/snuba/datasets/outcomes_processor.py
+++ b/snuba/datasets/outcomes_processor.py
@@ -2,8 +2,6 @@ import uuid
 from datetime import datetime
 from typing import Optional
 
-from sentry_relay import DataCategory
-
 from snuba import settings
 from snuba.processor import (
     InsertBatch,
@@ -18,11 +16,7 @@ class OutcomesProcessor(MessageProcessor):
     def process_message(self, value, metadata=None) -> Optional[ProcessedMessage]:
         assert isinstance(value, dict)
 
-        # Only record outcomes from traditional error tracking events, which
-        # excludes transactions, attachments and sessions. Once TSDB defines
-        # models for these, we can start recording again.
-        category = value.get("category")
-        if category is not None and category not in DataCategory.error_categories():
+        if value.get("category") in ("transaction", "attachment", "session"):
             return None
 
         v_uuid = value.get("event_id")

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -59,7 +59,7 @@ def function_expr(fn: str, args_expr: str = "") -> str:
             return "countIf(notIn(transaction_status, tuple({ok}, {cancelled}, {unknown}))) / count()".format(
                 ok=SPAN_STATUS_NAME_TO_CODE["ok"],
                 cancelled=SPAN_STATUS_NAME_TO_CODE["cancelled"],
-                unknown=SPAN_STATUS_NAME_TO_CODE["unknown"],
+                unknown=SPAN_STATUS_NAME_TO_CODE["unknown_error"],
             )
         raise ValueError("Invalid format for failure_rate()")
     # For functions with no args, (or static args) we allow them to already

--- a/snuba/query/processors/failure_rate_processor.py
+++ b/snuba/query/processors/failure_rate_processor.py
@@ -19,7 +19,7 @@ from snuba.request.request_settings import RequestSettings
 class FailureRateProcessor(QueryProcessor):
     """
     A percentage of transactions with a bad status. "Bad" status is defined as anything other than "ok" and "unknown".
-    See here (https://github.com/getsentry/relay/blob/master/relay-common/src/constants.rs) for the full list of errors.
+    See here (https://github.com/getsentry/relay/blob/master/py/sentry_relay/consts.py) for the full list of errors.
     """
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
@@ -27,7 +27,7 @@ class FailureRateProcessor(QueryProcessor):
             if isinstance(exp, FunctionCall) and exp.function_name == "failure_rate":
                 assert len(exp.parameters) == 0
 
-                successful_codes = ["ok", "cancelled", "unknown"]
+                successful_codes = ["ok", "cancelled", "unknown_error"]
                 return divide(
                     countIf(
                         binary_condition(


### PR DESCRIPTION
Aggregate numbers in TSDB seem too low for the sentry/sentry project, and they also dropped for a few others. Reverting to be safe.

Reverts getsentry/snuba#1099