### PR TITLE
feat(ast) Remove the disabled flag for infix query formatting

### DIFF
--- a/snuba/clickhouse/formatter.py
+++ b/snuba/clickhouse/formatter.py
@@ -1,7 +1,6 @@
 from datetime import date, datetime
 from typing import Optional, Sequence
 
-from snuba import state
 from snuba.clickhouse.escaping import escape_alias, escape_identifier, escape_string
 from snuba.query.conditions import (
     BooleanFunctions,
@@ -121,16 +120,13 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             # and work when they are passed as [1, 2, 3]
             return self.__alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
 
-        if state.get_config("infix_where_format", 0):
-            if exp.function_name == BooleanFunctions.AND:
-                formatted = (
-                    c.accept(self) for c in get_first_level_and_conditions(exp)
-                )
-                return " AND ".join(formatted)
+        elif exp.function_name == BooleanFunctions.AND:
+            formatted = (c.accept(self) for c in get_first_level_and_conditions(exp))
+            return " AND ".join(formatted)
 
-            elif exp.function_name == BooleanFunctions.OR:
-                formatted = (c.accept(self) for c in get_first_level_or_conditions(exp))
-                return f"({' OR '.join(formatted)})"
+        elif exp.function_name == BooleanFunctions.OR:
+            formatted = (c.accept(self) for c in get_first_level_or_conditions(exp))
+            return f"({' OR '.join(formatted)})"
 
         ret = f"{escape_identifier(exp.function_name)}({self.__visit_params(exp.parameters)})"
         return self.__alias(ret, exp.alias)

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -1,6 +1,5 @@
 import pytest
 
-from snuba import state
 from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
 from snuba.query.conditions import (
     BooleanFunctions,
@@ -167,7 +166,6 @@ test_expressions = [
 
 @pytest.mark.parametrize("expression, expected", test_expressions)
 def test_format_expressions(expression: Expression, expected: str) -> None:
-    state.set_config("infix_where_format", 1)
     visitor = ClickhouseExpressionFormatter()
     assert expression.accept(visitor) == expected
 

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -2,7 +2,6 @@ from typing import List, Tuple
 
 import pytest
 
-from snuba import state
 from snuba.clickhouse.astquery import AstSqlQuery
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
@@ -210,7 +209,6 @@ test_cases = [
 
 @pytest.mark.parametrize("query, data", test_cases)
 def test_format_expressions(query: Query, data: List[Tuple[str, str]]) -> None:
-    state.set_config("infix_where_format", 1)
     request_settings = HTTPRequestSettings()
     clickhouse_query = AstSqlQuery(query, request_settings)
     assert clickhouse_query.sql_data() == data

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -1,6 +1,5 @@
 import pytest
 
-from snuba import state
 from snuba.clickhouse.astquery import AstSqlQuery
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.schemas.tables import TableSource
@@ -145,7 +144,6 @@ test_cases = [
 
 @pytest.mark.parametrize("query, formatted", test_cases)
 def test_format_expressions(query: Query, formatted: str) -> None:
-    state.set_config("infix_where_format", 1)
     request_settings = HTTPRequestSettings()
     clickhouse_query = AstSqlQuery(query, request_settings)
     assert clickhouse_query.format_sql() == formatted

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -1,4 +1,3 @@
-from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
 from snuba.datasets.schemas.tables import TableSource
@@ -15,7 +14,6 @@ from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_apdex_format_expressions() -> None:
-    state.set_config("infix_where_format", 1)
     unprocessed = Query(
         {},
         TableSource("events", ColumnSet([])),

--- a/tests/query/processors/test_impact.py
+++ b/tests/query/processors/test_impact.py
@@ -1,4 +1,3 @@
-from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter import ClickhouseExpressionFormatter
 from snuba.datasets.schemas.tables import TableSource
@@ -15,7 +14,6 @@ from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_impact_format_expressions() -> None:
-    state.set_config("infix_where_format", 1)
     unprocessed = Query(
         {},
         TableSource("events", ColumnSet([])),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,6 @@ from tests.base import BaseApiTest
 class TestApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="events"):
         super().setup_method(test_method, dataset_name)
-        state.set_config("infix_where_format", 1)
         self.app.post = partial(self.app.post, headers={"referer": "test"})
 
         # values for test data

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -7,7 +7,7 @@ from functools import partial
 import pytest
 import simplejson as json
 
-from snuba import settings, state
+from snuba import settings
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from tests.base import BaseApiTest, dataset_manager
 
@@ -16,7 +16,6 @@ from tests.base import BaseApiTest, dataset_manager
 class TestDiscoverApi(BaseApiTest):
     def setup_method(self, test_method):
         super().setup_method(test_method)
-        state.set_config("infix_where_format", 1)
 
         # XXX: This should use the ``discover`` dataset directly, but that will
         # require some updates to the test base classes to work correctly.

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -17,7 +17,6 @@ class TestTransactionsApi(BaseApiTest):
     def setup_method(self, test_method, dataset_name="transactions"):
         super().setup_method(test_method, dataset_name)
         self.app.post = partial(self.app.post, headers={"referer": "test"})
-        state.set_config("infix_where_format", 1)
 
         # values for test data
         self.project_ids = [1, 2]  # 2 projects


### PR DESCRIPTION
This is rolled out in production. Removing the flag.