### PR TITLE
ref: Refactor drop dataset API to not drop entire tables

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -453,11 +453,11 @@ if application.debug or application.testing:
             clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
             database = cluster.get_database()
 
-            tables_to_empty = set()
-
-            for schema in storage.get_schemas().get_unique_schemas():
-                if isinstance(schema, TableSchema):
-                    tables_to_empty.add(schema.get_local_table_name())
+            tables_to_empty = {
+                schema.get_local_table_name()
+                for schema in storage.get_schemas().get_unique_schemas()
+                if isinstance(schema, TableSchema)
+            }
 
             for table in tables_to_empty:
                 clickhouse.execute(f"TRUNCATE TABLE {database}.{table}")

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -459,21 +459,8 @@ if application.debug or application.testing:
                 if isinstance(schema, TableSchema):
                     tables_to_empty.add(schema.get_local_table_name())
 
-            parts = clickhouse.execute(
-                """
-                SELECT partition, table
-                FROM system.parts
-                WHERE database = %(database)s
-                AND table IN (%(tables)s)
-                AND active = 1
-                """,
-                {"database": database, "tables": ", ".join(tables_to_empty)},
-            )
-
-            for (part, table) in parts:
-                clickhouse.execute(
-                    f"ALTER TABLE {database}.{table} DROP PARTITION {part}"
-                )
+            for table in tables_to_empty:
+                clickhouse.execute(f"TRUNCATE TABLE {database}.{table}")
 
         redis_client.flushdb()
         return ("ok", 200, {"Content-Type": "text/plain"})

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -2,7 +2,7 @@ import logging
 import os
 import time
 from datetime import datetime
-from typing import Any, Mapping, MutableMapping, MutableSequence
+from typing import Any, Mapping, MutableMapping, MutableSequence, Tuple
 from uuid import UUID
 
 import jsonschema
@@ -369,9 +369,9 @@ if application.debug or application.testing:
 
     _ensured = False
 
-    def ensure_tables_migrated(force: bool = False) -> None:
+    def ensure_tables_migrated() -> None:
         global _ensured
-        if not force and _ensured:
+        if _ensured:
             return
 
         from snuba.migrations import migrate
@@ -447,15 +447,34 @@ if application.debug or application.testing:
         return ("ok", 200, {"Content-Type": "text/plain"})
 
     @application.route("/tests/<dataset:dataset>/drop", methods=["POST"])
-    def drop(*, dataset: Dataset):
+    def drop(*, dataset: Dataset) -> Tuple[str, int, Mapping[str, str]]:
         for storage in dataset.get_all_storages():
-            clickhouse = storage.get_cluster().get_query_connection(
-                ClickhouseClientSettings.MIGRATE
-            )
-            for statement in storage.get_schemas().get_drop_statements():
-                clickhouse.execute(statement.statement)
+            cluster = storage.get_cluster()
+            clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+            database = cluster.get_database()
 
-        ensure_tables_migrated(force=True)
+            tables_to_empty = set()
+
+            for schema in storage.get_schemas().get_unique_schemas():
+                if isinstance(schema, TableSchema):
+                    tables_to_empty.add(schema.get_local_table_name())
+
+            parts = clickhouse.execute(
+                """
+                SELECT partition, table
+                FROM system.parts
+                WHERE database = %(database)s
+                AND table IN (%(tables)s)
+                AND active = 1
+                """,
+                {"database": database, "tables": ", ".join(tables_to_empty)},
+            )
+
+            for (part, table) in parts:
+                clickhouse.execute(
+                    f"ALTER TABLE {database}.{table} DROP PARTITION {part}"
+                )
+
         redis_client.flushdb()
         return ("ok", 200, {"Content-Type": "text/plain"})
 
@@ -466,5 +485,5 @@ if application.debug or application.testing:
 
 else:
 
-    def ensure_tables_migrated(force: bool = False) -> None:
+    def ensure_tables_migrated() -> None:
         pass

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,7 +14,6 @@ from sentry_sdk import Client, Hub
 from snuba import settings, state
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.events_processor_base import InsertEvent
-from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
 from snuba.redis import redis_client
@@ -1316,18 +1315,23 @@ class TestApi(BaseApiTest):
         # make sure redis has _something_ before we go about dropping all the keys in it
         assert self.redis_db_size() > 0
 
-        assert self.app.post("/tests/events/drop").status_code == 200
-        dataset = get_dataset("events")
-        storage = dataset.get_writable_storage()
-        assert storage is not None
-        writer = storage.get_table_writer()
-        table = writer.get_schema().get_table_name()
         storage = get_storage(StorageKey.EVENTS)
         clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.QUERY
         )
+
+        # There is data in the events table
+        assert len(clickhouse.execute("SELECT * FROM sentry_local")) > 0
+
+        assert self.app.post("/tests/events/drop").status_code == 200
+        writer = storage.get_table_writer()
+        table = writer.get_schema().get_table_name()
+
         assert table not in clickhouse.execute("SHOW TABLES")
         assert self.redis_db_size() == 0
+
+        # No data in events table
+        assert len(clickhouse.execute("SELECT * FROM sentry_local")) == 0
 
     @pytest.mark.xfail
     def test_row_stats(self):


### PR DESCRIPTION
The drop endpoint now deletes all partitions of a table instead of
dropping the entire table and then rerunning migrations. This prevents
us from getting into a state where migrations have already been run
but some tables are subsequently dropped and need to be added back.