### PR TITLE
ref(writer): Make `BatchWriter` properly abstract and generic

### DIFF
--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -15,7 +15,7 @@ CLICKHOUSE_ERROR_RE = re.compile(
 )
 
 
-class HTTPBatchWriter(BatchWriter):
+class HTTPBatchWriter(BatchWriter[WriterTableRow]):
     def __init__(
         self,
         table_name: str,
@@ -54,7 +54,7 @@ class HTTPBatchWriter(BatchWriter):
         if chunk:
             yield b"".join(chunk)
 
-    def write(self, rows: Iterable[WriterTableRow]) -> None:
+    def write(self, values: Iterable[WriterTableRow]) -> None:
         response = self.__pool.urlopen(
             "POST",
             "/?"
@@ -70,7 +70,7 @@ class HTTPBatchWriter(BatchWriter):
                 "Connection": "keep-alive",
                 "Accept-Encoding": "gzip,deflate",
             },
-            body=self._prepare_chunks(rows),
+            body=self._prepare_chunks(values),
             chunked=True,
         )
 

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -112,7 +112,7 @@ class Cluster(ABC, Generic[TQuery, TWriterOptions]):
         encoder: Callable[[WriterTableRow], bytes],
         options: TWriterOptions,
         chunk_size: Optional[int],
-    ) -> BatchWriter:
+    ) -> BatchWriter[WriterTableRow]:
         raise NotImplementedError
 
 
@@ -220,7 +220,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
         encoder: Callable[[WriterTableRow], bytes],
         options: ClickhouseWriterOptions,
         chunk_size: Optional[int],
-    ) -> BatchWriter:
+    ) -> BatchWriter[WriterTableRow]:
         return HTTPBatchWriter(
             table_name,
             self.__query_node.host_name,

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -19,7 +19,7 @@ from snuba.snapshots import BulkLoadSource
 from snuba.snapshots.loaders import BulkLoader
 from snuba.snapshots.loaders.single_table import RowProcessor, SingleTableBulkLoader
 from snuba.utils.streams.kafka import KafkaPayload
-from snuba.writer import BatchWriter
+from snuba.writer import BatchWriter, WriterTableRow
 
 
 @dataclass(frozen=True)
@@ -130,7 +130,7 @@ class TableWriter:
     def get_schema(self) -> WritableTableSchema:
         return self.__table_schema
 
-    def get_writer(self, options=None, table_name=None) -> BatchWriter:
+    def get_writer(self, options=None, table_name=None) -> BatchWriter[WriterTableRow]:
         from snuba import settings
 
         def default(value):
@@ -150,7 +150,9 @@ class TableWriter:
             chunk_size=settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
         )
 
-    def get_bulk_writer(self, options=None, table_name=None) -> BatchWriter:
+    def get_bulk_writer(
+        self, options=None, table_name=None
+    ) -> BatchWriter[WriterTableRow]:
         """
         This is a stripped down verison of the writer designed
         for better performance when loading data in bulk.

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Iterable, List, Mapping
+from typing import Any, Generic, Iterable, List, Mapping, TypeVar
 
 logger = logging.getLogger("snuba.writer")
 
 WriterTableRow = Mapping[str, Any]
 
 
-class BatchWriter(ABC):
+T = TypeVar("T")
+
+
+class BatchWriter(ABC, Generic[T]):
     @abstractmethod
-    def write(self, rows: Iterable[WriterTableRow]) -> None:
+    def write(self, values: Iterable[T]) -> None:
         raise NotImplementedError
 
 
@@ -23,7 +28,7 @@ class BufferedWriterWrapper:
     This is not thread safe. Don't try to do parallel flush hoping in the GIL.
     """
 
-    def __init__(self, writer: BatchWriter, buffer_size: int):
+    def __init__(self, writer: BatchWriter[WriterTableRow], buffer_size: int):
         self.__writer = writer
         self.__buffer_size = buffer_size
         self.__buffer: List[WriterTableRow] = []
@@ -33,14 +38,14 @@ class BufferedWriterWrapper:
         self.__writer.write(self.__buffer)
         self.__buffer = []
 
-    def __enter__(self):
+    def __enter__(self) -> BufferedWriterWrapper:
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type: Any, value: Any, traceback: Any) -> None:
         if self.__buffer:
             self.__flush()
 
-    def write(self, row: WriterTableRow):
+    def write(self, row: WriterTableRow) -> None:
         self.__buffer.append(row)
         if len(self.__buffer) >= self.__buffer_size:
             self.__flush()

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Mapping
 
 logger = logging.getLogger("snuba.writer")
@@ -6,11 +7,9 @@ logger = logging.getLogger("snuba.writer")
 WriterTableRow = Mapping[str, Any]
 
 
-class BatchWriter(object):
-    def __init__(self, schema):
-        raise NotImplementedError
-
-    def write(self, rows: Iterable[WriterTableRow]):
+class BatchWriter(ABC):
+    @abstractmethod
+    def write(self, rows: Iterable[WriterTableRow]) -> None:
         raise NotImplementedError
 
 


### PR DESCRIPTION
This is a minor and non-functional change, but one easily made independent of some larger changes to come so I figured it'd be simpler to review on its own. This also cleans up some type annotations in `snuba.writer`.