### PR TITLE
ref(codecs): Split `Codec` into `Decoder` and `Encoder` interfaces

### DIFF
--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -129,7 +129,7 @@ class SubscriptionWorker(
         for future in as_completed(
             [
                 self.__producer.produce(
-                    self.__topic, subscription_task_result_codec.encode(result)
+                    self.__topic, subscription_task_result_encoder.encode(result)
                 )
                 for result in results
             ]
@@ -157,4 +157,4 @@ class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult
         )
 
 
-subscription_task_result_codec = SubscriptionTaskResultEncoder()
+subscription_task_result_encoder = SubscriptionTaskResultEncoder()

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -14,7 +14,7 @@ from snuba.request import Request
 from snuba.subscriptions.consumer import Tick
 from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.scheduler import ScheduledTask, Scheduler
-from snuba.utils.codecs import Codec
+from snuba.utils.codecs import Encoder
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge
 from snuba.utils.metrics.timer import Timer
@@ -137,7 +137,7 @@ class SubscriptionWorker(
             future.result()
 
 
-class SubscriptionTaskResultCodec(Codec[KafkaPayload, SubscriptionTaskResult]):
+class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult]):
     def encode(self, value: SubscriptionTaskResult) -> KafkaPayload:
         subscription_id = str(value.task.task.identifier)
         request, result = value.result
@@ -156,8 +156,5 @@ class SubscriptionTaskResultCodec(Codec[KafkaPayload, SubscriptionTaskResult]):
             ).encode("utf-8"),
         )
 
-    def decode(self, value: KafkaPayload) -> SubscriptionTaskResult:
-        raise NotImplementedError
 
-
-subscription_task_result_codec = SubscriptionTaskResultCodec()
+subscription_task_result_codec = SubscriptionTaskResultEncoder()

--- a/snuba/utils/codecs.py
+++ b/snuba/utils/codecs.py
@@ -8,14 +8,22 @@ TEncoded = TypeVar("TEncoded")
 TDecoded = TypeVar("TDecoded")
 
 
-class Codec(Generic[TEncoded, TDecoded], ABC):
+class Encoder(Generic[TEncoded, TDecoded], ABC):
     @abstractmethod
     def encode(self, value: TDecoded) -> TEncoded:
         raise NotImplementedError
 
+
+class Decoder(Generic[TEncoded, TDecoded], ABC):
     @abstractmethod
     def decode(self, value: TEncoded) -> TDecoded:
         raise NotImplementedError
+
+
+class Codec(
+    Encoder[TEncoded, TDecoded], Decoder[TEncoded, TDecoded],
+):
+    pass
 
 
 T = TypeVar("T")

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -19,7 +19,7 @@ from snuba.subscriptions.store import SubscriptionDataStore
 from snuba.subscriptions.worker import (
     SubscriptionWorker,
     SubscriptionTaskResult,
-    subscription_task_result_codec,
+    subscription_task_result_encoder,
 )
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.consumer import Consumer
@@ -129,7 +129,7 @@ def test_subscription_worker(dataset: Dataset, time_shift: Optional[timedelta]) 
         assert message.partition.topic == result_topic
 
         task_result_future = result_futures[i]
-        expected_payload = subscription_task_result_codec.encode(
+        expected_payload = subscription_task_result_encoder.encode(
             SubscriptionTaskResult(
                 task_result_future.task, task_result_future.future.result()
             )


### PR DESCRIPTION
This allows for one-way encoding or decoding operations to be defined without having to fill the opposite method with a runtime error to satisfy the type checker. Some examples where this is more appropriate than a bijective `Codec`:

1. subscription task results, as information is discarded during encoding so a fully representative Python object cannot be reconstructive
2. converting a Python representation of a row to be inserted into ClickHouse into a JSON representation (this is in an upcoming change, technically this _could_ be bijective but I don't see a use case for it at this point so I'm intentionally avoiding it)