### PR TITLE
fix(ast) Temporarily disable the ast on sessions

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -106,7 +106,6 @@ TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 AST_DATASET_ROLLOUT: Mapping[str, int] = {
     "events": 100,
     "outcomes": 100,
-    "sessions": 100,
     "transactions": 100,
 }  # (dataset name: percentage)
 AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {


### PR DESCRIPTION
We noticed this error when using `crashed_users` into another function in the AST 
```
Error running query: SELECT release, project_id, project_id, release FROM sessions_hourly_dist PREWHERE in(project_id, tuple(1247208)) WHERE equals(org_id, 98855) AND greaterOrEquals(started, toDateTime('2020-07-01T00:30:02', 'Universal')) AND less(started, toDateTime('2020-07-15T00:30:03', 'Universal')) AND in(project_id, tuple(1247208)) GROUP BY (release, project_id) ORDER BY divide((uniqIfMerge(uniqIfMerge(users_crashed)) AS users_crashed), (uniqIfMerge(uniqIfMerge(users)) AS users)) ASC LIMIT 26 OFFSET 0
<ClickhouseError: [184] DB::Exception: Aggregate function uniqIfMerge(users_crashed) is found inside another aggregate function in query. Stack trace:
```

The `uniqIfMerge(uniqIfMerge(users_crashed)` comes from a bug in the translator 
https://github.com/getsentry/snuba/blob/master/snuba/datasets/plans/translator/query.py#L34

This applies the translator to all expressions of the tree instead of all the root expressions. This behavior was not visible elsewhere since all translations except for the sessions dataset are idempotent so applying twice does not generate any issue.

Will need some time to test the fix so disabling this in the meantime.