### PR TITLE
fix(ast) Apply translator to root expressions and not to all expressions

### DIFF
--- a/snuba/datasets/plans/translator/query.py
+++ b/snuba/datasets/plans/translator/query.py
@@ -1,12 +1,10 @@
 import copy
 
-from snuba.clickhouse.query import Expression as ClickhouseExpression
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.translators.snuba.mapping import (
     SnubaClickhouseMappingTranslator,
     TranslationMappers,
 )
-from snuba.query.expressions import Expression as SnubaExpression
 from snuba.query.logical import Query as LogicalQuery
 
 
@@ -27,9 +25,6 @@ class QueryTranslator:
         self.__expression_translator = SnubaClickhouseMappingTranslator(mappers)
 
     def translate(self, query: LogicalQuery) -> ClickhouseQuery:
-        def translate_expression(expr: SnubaExpression) -> ClickhouseExpression:
-            return expr.accept(self.__expression_translator)
-
         translated = ClickhouseQuery(copy.deepcopy(query))
-        translated.transform_expressions(translate_expression)
+        translated.transform(self.__expression_translator)
         return translated

--- a/tests/datasets/plans/translator/test_mapping.py
+++ b/tests/datasets/plans/translator/test_mapping.py
@@ -1,5 +1,6 @@
 import pytest
 
+from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.translators.snuba.mappers import (
@@ -7,7 +8,6 @@ from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToFunction,
     SubscriptableMapper,
 )
-from snuba.query.logical import SelectedExpression
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.plans.translator.query import QueryTranslator
 from snuba.datasets.schemas.tables import TableSource
@@ -18,6 +18,7 @@ from snuba.query.expressions import (
     SubscriptableReference,
 )
 from snuba.query.logical import Query as SnubaQuery
+from snuba.query.logical import SelectedExpression
 
 test_cases = [
     pytest.param(
@@ -208,6 +209,7 @@ test_cases = [
 def test_translation(
     mappers: TranslationMappers, query: SnubaQuery, expected: ClickhouseQuery
 ) -> None:
+    state.set_config("ast_root_level_translator", 1)
     translated = QueryTranslator(mappers).translate(query)
 
     # TODO: consider providing an __eq__ method to the Query class. Or turn it into

--- a/tests/datasets/plans/translator/test_mapping.py
+++ b/tests/datasets/plans/translator/test_mapping.py
@@ -149,7 +149,7 @@ test_cases = [
                     None,
                     "users_crashed",
                     "uniqIfMerge",
-                    (Column(None, None, "users_crashed"),),
+                    (Column(alias=None, table_name=None, column_name="users_crashed"),),
                 )
             ],
         ),
@@ -159,7 +159,15 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "alias",
-                    FunctionCall("alias", "f", (Column(None, None, "users_crashed"),)),
+                    FunctionCall(
+                        "alias",
+                        "f",
+                        (
+                            Column(
+                                alias=None, table_name=None, column_name="users_crashed"
+                            ),
+                        ),
+                    ),
                 ),
             ],
         ),
@@ -177,7 +185,13 @@ test_cases = [
                                 FunctionCall(
                                     None,
                                     "uniqIfMerge",
-                                    (Column(None, None, "users_crashed"),),
+                                    (
+                                        Column(
+                                            alias=None,
+                                            table_name=None,
+                                            column_name="users_crashed",
+                                        ),
+                                    ),
                                 ),
                             ),
                         ),


### PR DESCRIPTION
`QueryTranslator` is supposed to apply the translator to all root expression in the query (like each expression in the select statement). The translator itself navigates each tree.
That's not what the translator was doing (sigh), it was using the transform method on the query, which applies a transformation function to all expressions in all trees. Applying the full translator to all expressions (instead of the roots only) means that some expressions will be translated twice.

This effect was not visible so far because all the translation rules we use (both in unit tests ad real datasets) are idempotent, and if they are applied twice the result will be the same. There is an exception in the sessions dataset: https://github.com/getsentry/snuba/blob/master/snuba/datasets/sessions.py#L57-L64. 

Those rules apply this transformation: `column_name -> function(column_name)` which, when applied twice could cause `function(function(column_name))`. Thus this is what was happening on the sessions dataset:
```
query: f(crashed_users)

the whole translator was applied both to:
crashed_users
f(uniqIfMerge(crashed_users)

producing 
f(uniqIfMerge(uniqIfMerge(crashed_users)))
```

This fixes the translator by ensuring it is applied only to the root expressions, so no duplicate translation happens anymore.
Added a test for this specific condition and ran all sentry tests against the fix.