### PR TITLE
feat(slo) Enforce AST parsing and formatting is successful.

### DIFF
--- a/tests/clickhouse/query_dsl/test_project_id.py
+++ b/tests/clickhouse/query_dsl/test_project_id.py
@@ -107,14 +107,23 @@ test_cases = [
             "selected_columns": ["column1"],
             "conditions": [
                 [
-                    ["and", [["project_id", "=", 100], ["column1", "=", "something"]]],
+                    [
+                        "and",
+                        [
+                            ["equals", ["project_id", 100]],
+                            ["equals", ["column1", "'something'"]],
+                        ],
+                    ],
                     "=",
                     1,
                 ],
                 [
                     [
                         "and",
-                        [["project_id", "=", 200], ["column3", "=", "something_else"]],
+                        [
+                            ["equals", ["project_id", 200]],
+                            ["equals", ["column3", "'something_else'"]],
+                        ],
                     ],
                     "=",
                     1,

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -345,7 +345,6 @@ def test_format_expressions(
 
 
 def test_shadowing() -> None:
-    state.set_config("query_parsing_enforce_validity", 1)
     with pytest.raises(ValueError):
         parse_query(
             {
@@ -362,7 +361,6 @@ def test_shadowing() -> None:
 
 
 def test_circular_aliases() -> None:
-    state.set_config("query_parsing_enforce_validity", 1)
     with pytest.raises(CyclicAliasException):
         parse_query(
             {


### PR DESCRIPTION
More than 90% of snuba queries run via the AST, we do not need anymore to only log warnings when the parsing fails. If parsing fails the query should fail at parsing time, instead of failing later when we try to format it  or run it. 
I did not observe, in production, any warning from failure in parsing the AST that were not also fatal errors when running the query. Earlier on we were used to have these cases and the query could still safely run on the legacy representations but I did not observe any case like this in more than a month.

This also will stop counting those queries as system errors but as client error. Next step will be returning the proper HTTP response.