### PR TITLE
fix(ast) Cleanup the translator rollout flag

### DIFF
--- a/snuba/datasets/plans/translator/query.py
+++ b/snuba/datasets/plans/translator/query.py
@@ -1,13 +1,10 @@
 import copy
 
-from snuba import state
-from snuba.clickhouse.query import Expression as ClickhouseExpression
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.translators.snuba.mapping import (
     SnubaClickhouseMappingTranslator,
     TranslationMappers,
 )
-from snuba.query.expressions import Expression as SnubaExpression
 from snuba.query.logical import Query as LogicalQuery
 
 
@@ -28,12 +25,6 @@ class QueryTranslator:
         self.__expression_translator = SnubaClickhouseMappingTranslator(mappers)
 
     def translate(self, query: LogicalQuery) -> ClickhouseQuery:
-        def translate_expression(expr: SnubaExpression) -> ClickhouseExpression:
-            return expr.accept(self.__expression_translator)
-
         translated = ClickhouseQuery(copy.deepcopy(query))
-        if state.get_config("ast_root_level_translator", 0):
-            translated.transform(self.__expression_translator)
-        else:
-            translated.transform_expressions(translate_expression)
+        translated.transform(self.__expression_translator)
         return translated

--- a/tests/datasets/plans/translator/test_mapping.py
+++ b/tests/datasets/plans/translator/test_mapping.py
@@ -1,6 +1,5 @@
 import pytest
 
-from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.translators.snuba.mappers import (
@@ -209,7 +208,6 @@ test_cases = [
 def test_translation(
     mappers: TranslationMappers, query: SnubaQuery, expected: ClickhouseQuery
 ) -> None:
-    state.set_config("ast_root_level_translator", 1)
     translated = QueryTranslator(mappers).translate(query)
 
     # TODO: consider providing an __eq__ method to the Query class. Or turn it into


### PR DESCRIPTION
This is done and rolled out successfully
https://github.com/getsentry/snuba/pull/1129

We can remove the flag.