### PR TITLE
fix(consumer): Correct order of operations on consumer shutdown

### DIFF
--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -305,12 +305,11 @@ class BatchingConsumer(Generic[TPayload]):
         self.__shutdown_requested = True
 
     def _shutdown(self) -> None:
-        if self.__processor is not None:
-            logger.debug("Stopping processor")
-            self.__processor.close()
-            self.__processor = None
-
         # close the consumer
         logger.debug("Stopping consumer")
         self.__consumer.close()
         logger.debug("Stopped")
+
+        # if there was an active processor, it should be shut down and unset
+        # when the partitions are revoked during consumer close
+        assert self.__processor is None, "processor was not closed on shutdown"


### PR DESCRIPTION
Another embarrassing oversight out of #1114, similar to #1132 and #1133.

Closing the consumer triggers the revocation callback if the consumer already has an assignment, which will shut down any active processor. Shutting down the processor before closing the consumer causes the processor to be shut down multiple times, and only the first attempt succeeds.