### PR TITLE
ref(writer): Split apart writing and write row encoding responsibilities

### DIFF
--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -4,6 +4,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Iterable, List, Mapping, TypeVar
 
+from snuba.utils.codecs import Encoder, TDecoded, TEncoded
+
 logger = logging.getLogger("snuba.writer")
 
 WriterTableRow = Mapping[str, Any]
@@ -16,6 +18,17 @@ class BatchWriter(ABC, Generic[T]):
     @abstractmethod
     def write(self, values: Iterable[T]) -> None:
         raise NotImplementedError
+
+
+class BatchWriterEncoderWrapper(BatchWriter[TDecoded]):
+    def __init__(
+        self, writer: BatchWriter[TEncoded], encoder: Encoder[TEncoded, TDecoded]
+    ) -> None:
+        self.__writer = writer
+        self.__encoder = encoder
+
+    def write(self, values: Iterable[TDecoded]) -> None:
+        return self.__writer.write(map(self.__encoder.encode, values))
 
 
 class BufferedWriterWrapper:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,16 +1,15 @@
-import pytest
-
 from typing import Iterable
 
-from tests.base import BaseEventsTest
+import pytest
+
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.http import HTTPBatchWriter
 from snuba.datasets.factory import enforce_table_writer
-from snuba.writer import WriterTableRow
+from tests.base import BaseEventsTest
 
 
 class FakeHTTPWriter(HTTPBatchWriter):
-    def chunk(self, rows: Iterable[WriterTableRow]) -> Iterable[bytes]:
+    def chunk(self, rows: Iterable[bytes]) -> Iterable[bytes]:
         return self._prepare_chunks(rows)
 
 
@@ -52,7 +51,6 @@ class TestHTTPBatchWriter(BaseEventsTest):
             "default",
             "",
             "default",
-            lambda a: a,
             None,
             chunk_size,
         )


### PR DESCRIPTION
`HTTPBatchWriter` now subclasses `BatchWriter[JSONRow]` (`JSONRow` is an alias for `bytes`) instead of `BatchWriter[WriterTableRow]`, in preparation for the output of the multiprocess processor to return bytes instead of `WriterTableRow` (`Mapping`) instances. The existing `get_writer` methods now use a `BatchWriterEncoderWrapper` that uses a `Encoder[JSONRow, WriterTableRow]` which uses `rapidjson` to return a `BatchWriter[WriterTableRow]` where one was previously expected.