### PR TITLE
ref(tests): Replace ad-hoc `DummyBroker` instantiation with global fixture

### DIFF
--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -45,7 +45,7 @@ class DummyBroker(Generic[TPayload]):
         self.__lock = Lock()
 
     def get_consumer(
-        self, group: str, enable_end_of_partition: bool = True
+        self, group: str, enable_end_of_partition: bool = False
     ) -> Consumer[TPayload]:
         return DummyConsumer(
             self, group, enable_end_of_partition=enable_end_of_partition

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -22,11 +22,9 @@ from snuba.utils.streams.consumer import Consumer, ConsumerError, EndOfPartition
 from snuba.utils.streams.producer import Producer
 from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 
-epoch = datetime(2019, 12, 19)
-
 
 class DummyBroker(Generic[TPayload]):
-    def __init__(self, clock: Clock = TestingClock(epoch.timestamp())) -> None:
+    def __init__(self, clock: Clock = TestingClock()) -> None:
         self.__clock = clock
         self.__topics: MutableMapping[
             Topic, Sequence[MutableSequence[Tuple[TPayload, datetime]]]

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -44,8 +44,12 @@ class DummyBroker(Generic[TPayload]):
 
         self.__lock = Lock()
 
-    def get_consumer(self, group: str) -> Consumer[TPayload]:
-        return DummyConsumer(self, group)
+    def get_consumer(
+        self, group: str, enable_end_of_partition: bool = True
+    ) -> Consumer[TPayload]:
+        return DummyConsumer(
+            self, group, enable_end_of_partition=enable_end_of_partition
+        )
 
     def get_producer(self) -> Producer[TPayload]:
         return DummyProducer(self)

--- a/snuba/utils/streams/dummy.py
+++ b/snuba/utils/streams/dummy.py
@@ -44,6 +44,12 @@ class DummyBroker(Generic[TPayload]):
 
         self.__lock = Lock()
 
+    def get_consumer(self, group: str) -> Consumer[TPayload]:
+        return DummyConsumer(self, group)
+
+    def get_producer(self) -> Producer[TPayload]:
+        return DummyProducer(self)
+
     def create_topic(self, topic: Topic, partitions: int) -> None:
         with self.__lock:
             if topic in self.__topics:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from snuba.clickhouse.native import ClickhousePool
 from snuba.environment import setup_sentry
 from snuba.state import delete_config, set_config
 from snuba.utils.clock import Clock, TestingClock
-from snuba.utils.streams.dummy import DummyBroker, epoch
+from snuba.utils.streams.dummy import DummyBroker
 from snuba.utils.streams.types import TPayload
 from snuba.web.ast_rollout import ROLLOUT_RATE_CONFIG
 
@@ -40,7 +40,7 @@ def query_type(request) -> None:
 
 @pytest.fixture
 def clock() -> Iterator[Clock]:
-    yield TestingClock(epoch.timestamp())
+    yield TestingClock()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
+from typing import Iterator
+
 import pytest
 
 from snuba import settings
 from snuba.clickhouse.native import ClickhousePool
 from snuba.environment import setup_sentry
 from snuba.state import delete_config, set_config
+from snuba.utils.clock import Clock, TestingClock
+from snuba.utils.streams.dummy import DummyBroker, epoch
+from snuba.utils.streams.types import TPayload
 from snuba.web.ast_rollout import ROLLOUT_RATE_CONFIG
 
 
@@ -31,3 +36,13 @@ def query_type(request) -> None:
     set_config(ROLLOUT_RATE_CONFIG, request.param)
     yield
     delete_config(ROLLOUT_RATE_CONFIG)
+
+
+@pytest.fixture
+def clock() -> Iterator[Clock]:
+    yield TestingClock(epoch.timestamp())
+
+
+@pytest.fixture
+def broker(clock: TestingClock) -> Iterator[DummyBroker[TPayload]]:
+    yield DummyBroker(clock)

--- a/tests/subscriptions/test_consumer.py
+++ b/tests/subscriptions/test_consumer.py
@@ -5,7 +5,7 @@ import pytest
 from snuba.subscriptions.consumer import Tick, TickConsumer
 from snuba.utils.clock import Clock
 from snuba.utils.streams.consumer import ConsumerError
-from snuba.utils.streams.dummy import DummyBroker, epoch
+from snuba.utils.streams.dummy import DummyBroker
 from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.utils.types import Interval
 from tests.assertions import assert_changes, assert_does_not_change
@@ -19,7 +19,9 @@ def test_tick_time_shift() -> None:
     )
 
 
-def test_tick_consumer(broker: DummyBroker[int]) -> None:
+def test_tick_consumer(clock: Clock, broker: DummyBroker[int]) -> None:
+    epoch = datetime.fromtimestamp(clock.time())
+
     topic = Topic("messages")
 
     broker.create_topic(topic, partitions=2)
@@ -168,6 +170,8 @@ def test_tick_consumer(broker: DummyBroker[int]) -> None:
 
 
 def test_tick_consumer_non_monotonic(clock: Clock, broker: DummyBroker[int]) -> None:
+    epoch = datetime.fromtimestamp(clock.time())
+
     topic = Topic("messages")
     partition = Partition(topic, 0)
 

--- a/tests/subscriptions/test_consumer.py
+++ b/tests/subscriptions/test_consumer.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timedelta
-from typing import Iterator
 
 import pytest
 
 from snuba.subscriptions.consumer import Tick, TickConsumer
-from snuba.utils.clock import Clock, TestingClock
+from snuba.utils.clock import Clock
 from snuba.utils.streams.consumer import ConsumerError
 from snuba.utils.streams.dummy import DummyBroker, epoch
 from snuba.utils.streams.types import Message, Partition, Topic
@@ -18,16 +17,6 @@ def test_tick_time_shift() -> None:
     assert tick.time_shift(timedelta(hours=24)) == Tick(
         offsets, Interval(datetime(1970, 1, 2), datetime(1970, 1, 3))
     )
-
-
-@pytest.fixture
-def clock() -> Iterator[Clock]:
-    yield TestingClock(epoch.timestamp())
-
-
-@pytest.fixture
-def broker(clock: TestingClock) -> Iterator[DummyBroker[int]]:
-    yield DummyBroker(clock)
 
 
 def test_tick_consumer(broker: DummyBroker[int]) -> None:

--- a/tests/subscriptions/test_consumer.py
+++ b/tests/subscriptions/test_consumer.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timedelta
+from typing import Iterator
 
 import pytest
 
 from snuba.subscriptions.consumer import Tick, TickConsumer
-from snuba.utils.clock import TestingClock
-from snuba.utils.streams.consumer import Consumer, ConsumerError
-from snuba.utils.streams.dummy import DummyBroker, DummyConsumer, DummyProducer, epoch
+from snuba.utils.clock import Clock, TestingClock
+from snuba.utils.streams.consumer import ConsumerError
+from snuba.utils.streams.dummy import DummyBroker, epoch
 from snuba.utils.streams.types import Message, Partition, Topic
 from snuba.utils.types import Interval
 from tests.assertions import assert_changes, assert_does_not_change
@@ -19,18 +20,27 @@ def test_tick_time_shift() -> None:
     )
 
 
-def test_tick_consumer() -> None:
+@pytest.fixture
+def clock() -> Iterator[Clock]:
+    yield TestingClock(epoch.timestamp())
+
+
+@pytest.fixture
+def broker(clock: TestingClock) -> Iterator[DummyBroker[int]]:
+    yield DummyBroker(clock)
+
+
+def test_tick_consumer(broker: DummyBroker[int]) -> None:
     topic = Topic("messages")
 
-    broker: DummyBroker[int] = DummyBroker()
     broker.create_topic(topic, partitions=2)
 
-    producer: DummyProducer[int] = DummyProducer(broker)
+    producer = broker.get_producer()
     for partition, payloads in enumerate([[0, 1, 2], [0]]):
         for payload in payloads:
             producer.produce(Partition(topic, partition), payload).result()
 
-    inner_consumer: Consumer[int] = DummyConsumer(broker, "group")
+    inner_consumer = broker.get_consumer("group")
 
     consumer = TickConsumer(inner_consumer)
 
@@ -168,17 +178,15 @@ def test_tick_consumer() -> None:
         consumer.seek({Partition(topic, -1): 0})
 
 
-def test_tick_consumer_non_monotonic() -> None:
+def test_tick_consumer_non_monotonic(clock: Clock, broker: DummyBroker[int]) -> None:
     topic = Topic("messages")
     partition = Partition(topic, 0)
 
-    clock = TestingClock(epoch.timestamp())
-    broker: DummyBroker[int] = DummyBroker(clock)
     broker.create_topic(topic, partitions=1)
 
-    producer: DummyProducer[int] = DummyProducer(broker)
+    producer = broker.get_producer()
 
-    inner_consumer: Consumer[int] = DummyConsumer(broker, "group")
+    inner_consumer = broker.get_consumer("group")
 
     consumer = TickConsumer(inner_consumer)
 

--- a/tests/utils/streams/test_dummy.py
+++ b/tests/utils/streams/test_dummy.py
@@ -28,14 +28,13 @@ class DummyStreamsTestCase(StreamsTestMixin[int], TestCase):
     def get_consumer(
         self, group: Optional[str] = None, enable_end_of_partition: bool = True
     ) -> DummyConsumer[int]:
-        return DummyConsumer(
-            self.broker,
+        return self.broker.get_consumer(
             group if group is not None else uuid.uuid1().hex,
             enable_end_of_partition=enable_end_of_partition,
         )
 
     def get_producer(self) -> DummyProducer[int]:
-        return DummyProducer(self.broker)
+        return self.broker.get_producer()
 
     def get_payloads(self) -> Iterator[int]:
         return itertools.count()

--- a/tests/utils/streams/test_synchronized.py
+++ b/tests/utils/streams/test_synchronized.py
@@ -6,9 +6,8 @@ from typing import Optional, TypeVar
 import pytest
 
 from snuba.utils.streams.consumer import Consumer
-from snuba.utils.streams.dummy import DummyBroker, DummyConsumer, DummyProducer
+from snuba.utils.streams.dummy import DummyBroker, DummyConsumer
 from snuba.utils.streams.kafka import KafkaPayload
-from snuba.utils.streams.producer import Producer
 from snuba.utils.streams.synchronized import Commit, SynchronizedConsumer, commit_codec
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
@@ -31,19 +30,16 @@ def wait_for_consumer(consumer: Consumer[T], message: Message[T], attempts: int 
     )
 
 
-def test_synchronized_consumer() -> None:
+def test_synchronized_consumer(broker: DummyBroker[KafkaPayload]) -> None:
     topic = Topic("topic")
     commit_log_topic = Topic("commit-log")
 
-    broker: DummyBroker[KafkaPayload] = DummyBroker()
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
 
-    consumer: Consumer[KafkaPayload] = DummyConsumer(broker, "consumer")
-    producer: Producer[KafkaPayload] = DummyProducer(broker)
-    commit_log_consumer: Consumer[KafkaPayload] = DummyConsumer(
-        broker, "commit-log-consumer"
-    )
+    consumer = broker.get_consumer("consumer")
+    producer = broker.get_producer()
+    commit_log_consumer = broker.get_consumer("commit-log-consumer")
 
     messages = [
         producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"))).result(1.0)
@@ -191,19 +187,16 @@ def test_synchronized_consumer() -> None:
             assert synchronized_consumer.poll(0.0) == messages[4]
 
 
-def test_synchronized_consumer_pause_resume() -> None:
+def test_synchronized_consumer_pause_resume(broker: DummyBroker[KafkaPayload]) -> None:
     topic = Topic("topic")
     commit_log_topic = Topic("commit-log")
 
-    broker: DummyBroker[KafkaPayload] = DummyBroker()
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
 
-    consumer: Consumer[KafkaPayload] = DummyConsumer(broker, "consumer")
-    producer: Producer[KafkaPayload] = DummyProducer(broker)
-    commit_log_consumer: Consumer[KafkaPayload] = DummyConsumer(
-        broker, "commit-log-consumer"
-    )
+    consumer = broker.get_consumer("consumer")
+    producer = broker.get_producer()
+    commit_log_consumer = broker.get_consumer("commit-log-consumer")
 
     messages = [
         producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"))).result(1.0)
@@ -273,21 +266,18 @@ def test_synchronized_consumer_pause_resume() -> None:
             synchronized_consumer.resume([Partition(topic, 0)])
 
 
-def test_synchronized_consumer_handles_end_of_partition() -> None:
+def test_synchronized_consumer_handles_end_of_partition(
+    broker: DummyBroker[KafkaPayload],
+) -> None:
     topic = Topic("topic")
     commit_log_topic = Topic("commit-log")
 
-    broker: DummyBroker[KafkaPayload] = DummyBroker()
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
 
-    consumer: Consumer[KafkaPayload] = DummyConsumer(
-        broker, "consumer", enable_end_of_partition=True
-    )
-    producer: Producer[KafkaPayload] = DummyProducer(broker)
-    commit_log_consumer: Consumer[KafkaPayload] = DummyConsumer(
-        broker, "commit-log-consumer"
-    )
+    consumer = broker.get_consumer("consumer", enable_end_of_partition=True)
+    producer = broker.get_producer()
+    commit_log_consumer = broker.get_consumer("commit-log-consumer")
 
     messages = [
         producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"))).result(1.0)
@@ -335,11 +325,10 @@ def test_synchronized_consumer_handles_end_of_partition() -> None:
         assert synchronized_consumer.poll(0) == messages[1]
 
 
-def test_synchronized_consumer_worker_crash() -> None:
+def test_synchronized_consumer_worker_crash(broker: DummyBroker[KafkaPayload]) -> None:
     topic = Topic("topic")
     commit_log_topic = Topic("commit-log")
 
-    broker: DummyBroker[KafkaPayload] = DummyBroker()
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
 
@@ -357,7 +346,7 @@ def test_synchronized_consumer_worker_crash() -> None:
             finally:
                 poll_called.set()
 
-    consumer: Consumer[KafkaPayload] = DummyConsumer(broker, "consumer")
+    consumer = broker.get_consumer("consumer")
     commit_log_consumer: Consumer[KafkaPayload] = BrokenDummyConsumer(
         broker, "commit-log-consumer"
     )


### PR DESCRIPTION
This also adds `get_consumer` and `get_producer` methods to `DummyBroker` so that if we wanted to factor out some sort of `Cluster` interface from `DummyBroker` into the abstract streams API we could parameterize these tests on multiple stream backends. This also reduces the necessary amount of explicit type annotations and ensures the consumer and producer used in tests conform to the abstract `Consumer`/`Producer` API.