### PR TITLE
ref(codecs): Use `rapidjson` with `JSONCodec`

### DIFF
--- a/snuba/utils/codecs.py
+++ b/snuba/utils/codecs.py
@@ -1,6 +1,7 @@
-import json
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
+
+import rapidjson
 
 
 TEncoded = TypeVar("TEncoded")
@@ -37,9 +38,12 @@ class PassthroughCodec(Generic[T], Codec[T, T]):
         return value
 
 
-class JSONCodec(Codec[str, Any]):
-    def encode(self, value: Any) -> str:
-        return json.dumps(value)
+JSONData = Any
 
-    def decode(self, value: str) -> Any:
-        return json.loads(value)
+
+class JSONCodec(Codec[str, JSONData]):
+    def encode(self, value: JSONData) -> str:
+        return rapidjson.dumps(value)
+
+    def decode(self, value: str) -> JSONData:
+        return rapidjson.loads(value)

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -28,12 +28,13 @@ from snuba.state.rate_limit import (
     RateLimitExceeded,
 )
 from snuba.util import force_bytes, with_span
-from snuba.utils.codecs import JSONCodec
+from snuba.utils.codecs import JSONCodec, JSONData
 from snuba.utils.metrics.timer import Timer
 from snuba.web import QueryException, QueryResult
 from snuba.web.query_metadata import ClickhouseQueryMetadata, SnubaQueryMetadata
 
-cache: Cache[Any] = RedisCache(
+
+cache: Cache[JSONData] = RedisCache(
     redis_client, "snuba-query-cache:", JSONCodec(), ThreadPoolExecutor()
 )
 


### PR DESCRIPTION
This switches the `JSONCodec` to use `rapidjson` rather than standard library `json` for consistency with other parts of the codebase. The only place that `JSONCodec` is currently used is the query cache. This also adds `JSONData` as a type alias for `Any` so that the datatype usage is a bit more self-documenting (even though there is no type checking benefit.)