### PR TITLE
ref(processors): Make `KafkaMessageMetadata` a non-optional parameter

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping
 
 import logging
 import _strptime  # NOQA fixes _strptime deferred import issue
@@ -43,7 +43,7 @@ class ErrorsProcessor(EventsProcessorBase):
         self,
         output: MutableMapping[str, Any],
         event: InsertEvent,
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         data = event.get("data", {})
         user_dict = data.get("user", data.get("sentry.interfaces.User", None)) or {}
@@ -86,7 +86,7 @@ class ErrorsProcessor(EventsProcessorBase):
         output: MutableMapping[str, Any],
         event: InsertEvent,
         tags: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         output["release"] = tags.get("sentry:release")
         output["dist"] = tags.get("sentry:dist")
@@ -101,7 +101,7 @@ class ErrorsProcessor(EventsProcessorBase):
         output: MutableMapping[str, Any],
         event: InsertEvent,
         contexts: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         output["_contexts_flattened"] = ""
 

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping
 
 import logging
 import _strptime  # NOQA fixes _strptime deferred import issue
@@ -44,7 +44,7 @@ class EventsProcessor(EventsProcessorBase):
         self,
         output: MutableMapping[str, Any],
         event: InsertEvent,
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         data = event.get("data", {})
 
@@ -65,7 +65,7 @@ class EventsProcessor(EventsProcessorBase):
         output: MutableMapping[str, Any],
         event: InsertEvent,
         tags: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         pass
 
@@ -125,7 +125,7 @@ class EventsProcessor(EventsProcessorBase):
         output: MutableMapping[str, Any],
         event: InsertEvent,
         tags: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         pass
 

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -79,7 +79,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         self,
         output: MutableMapping[str, Any],
         event: InsertEvent,
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         raise NotImplementedError
 
@@ -95,7 +95,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         output: MutableMapping[str, Any],
         event: InsertEvent,
         tags: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         raise NotImplementedError
 
@@ -114,7 +114,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         output: MutableMapping[str, Any],
         event: InsertEvent,
         contexts: Mapping[str, Any],
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         raise NotImplementedError
 
@@ -146,7 +146,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         output["sdk_integrations"] = sdk_integrations
 
     def process_message(
-        self, message, metadata: Optional[KafkaMessageMetadata] = None
+        self, message, metadata: KafkaMessageMetadata
     ) -> Optional[ProcessedMessage]:
         """\
         Process a raw message into an insertion or replacement batch. Returns
@@ -175,7 +175,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
             raise InvalidMessageType(f"Invalid message type: {type_}")
 
     def process_insert(
-        self, event: InsertEvent, metadata: Optional[KafkaMessageMetadata] = None
+        self, event: InsertEvent, metadata: KafkaMessageMetadata
     ) -> Optional[Mapping[str, Any]]:
         if not self._should_process(event):
             return None
@@ -221,10 +221,9 @@ class EventsProcessorBase(MessageProcessor, ABC):
         stacks = exception.get("values", None) or []
         self.extract_stacktraces(processed, stacks)
 
-        if metadata is not None:
-            processed["offset"] = metadata.offset
-            processed["partition"] = metadata.partition
-            processed["message_timestamp"] = metadata.timestamp
+        processed["offset"] = metadata.offset
+        processed["partition"] = metadata.partition
+        processed["message_timestamp"] = metadata.timestamp
 
         return processed
 
@@ -232,7 +231,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         self,
         output: MutableMapping[str, Any],
         event: InsertEvent,
-        metadata: Optional[KafkaMessageMetadata] = None,
+        metadata: KafkaMessageMetadata,
     ) -> None:
         # Properties we get from the top level of the message payload
         output["platform"] = _unicodify(event["platform"])

--- a/snuba/datasets/outcomes_processor.py
+++ b/snuba/datasets/outcomes_processor.py
@@ -15,7 +15,7 @@ from snuba.processor import (
 
 
 class OutcomesProcessor(MessageProcessor):
-    def process_message(self, value, metadata=None) -> Optional[ProcessedMessage]:
+    def process_message(self, value, metadata) -> Optional[ProcessedMessage]:
         assert isinstance(value, dict)
 
         # Only record outcomes from traditional error tracking events, which

--- a/snuba/datasets/querylog_processor.py
+++ b/snuba/datasets/querylog_processor.py
@@ -74,7 +74,7 @@ class QuerylogProcessor(MessageProcessor):
             "clickhouse_queries.consistent": consistent,
         }
 
-    def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
+    def process_message(self, message, metadata) -> Optional[ProcessedMessage]:
         projects = message["request"]["body"].get("project", [])
         if not isinstance(projects, (list, tuple)):
             projects = [projects]

--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -26,7 +26,7 @@ metrics = MetricsWrapper(environment.metrics, "sessions.processor")
 
 
 class SessionsProcessor(MessageProcessor):
-    def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
+    def process_message(self, message, metadata) -> Optional[ProcessedMessage]:
         # some old relays accidentally emit rows without release
         if message["release"] is None:
             return None

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -45,7 +45,7 @@ class TransactionsMessageProcessor(MessageProcessor):
         milliseconds = int(timestamp.microsecond / 1000)
         return (timestamp, milliseconds)
 
-    def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
+    def process_message(self, message, metadata) -> Optional[ProcessedMessage]:
         processed = {"deleted": 0}
         if not (isinstance(message, (list, tuple)) and len(message) >= 2):
             return None
@@ -147,9 +147,8 @@ class TransactionsMessageProcessor(MessageProcessor):
             elif ip_address.version == 6:
                 processed["ip_address_v6"] = str(ip_address)
 
-        if metadata is not None:
-            processed["partition"] = metadata.partition
-            processed["offset"] = metadata.offset
+        processed["partition"] = metadata.partition
+        processed["offset"] = metadata.offset
 
         sdk = data.get("sdk", None) or {}
         processed["sdk_name"] = _unicodify(sdk.get("name") or "")

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -36,7 +36,7 @@ class MessageProcessor(ABC):
     """
 
     @abstractmethod
-    def process_message(self, message, metadata=None) -> Optional[ProcessedMessage]:
+    def process_message(self, message, metadata) -> Optional[ProcessedMessage]:
         raise NotImplementedError
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,6 +9,7 @@ from typing import Iterator, MutableSequence, Optional, Sequence
 
 from snuba import settings
 from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import enforce_table_writer, get_dataset
@@ -135,8 +136,10 @@ class BaseEventsTest(BaseDatasetTest):
         )
 
         processed_messages = []
-        for event in events:
-            processed_message = processor.process_message((2, "insert", event, {}))
+        for i, event in enumerate(events):
+            processed_message = processor.process_message(
+                (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
+            )
             assert processed_message is not None
             processed_messages.append(processed_message)
 

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -6,6 +6,7 @@ from typing import Optional
 import pytest
 
 from snuba import settings
+from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.events_format import (
     enforce_retention,
     extract_base,
@@ -26,12 +27,15 @@ from tests.base import BaseEventsTest
 
 
 class TestEventsProcessor(BaseEventsTest):
+
+    metadata = KafkaMessageMetadata(0, 0, datetime.now())
+
     def test_invalid_version(self) -> None:
         with pytest.raises(InvalidMessageVersion):
             enforce_table_writer(
                 self.dataset
             ).get_stream_loader().get_processor().process_message(
-                (2 ** 32 - 1, "insert", self.event)
+                (2 ** 32 - 1, "insert", self.event), self.metadata,
             )
 
     def test_invalid_format(self) -> None:
@@ -39,7 +43,7 @@ class TestEventsProcessor(BaseEventsTest):
             enforce_table_writer(
                 self.dataset
             ).get_stream_loader().get_processor().process_message(
-                (-1, "insert", self.event)
+                (-1, "insert", self.event), self.metadata,
             )
 
     def __process_insert_event(self, event: InsertEvent) -> Optional[ProcessedMessage]:
@@ -47,7 +51,7 @@ class TestEventsProcessor(BaseEventsTest):
             enforce_table_writer(self.dataset)
             .get_stream_loader()
             .get_processor()
-            .process_message((2, "insert", event, {}))
+            .process_message((2, "insert", event, {}), self.metadata)
         )
 
     def test_unexpected_obj(self) -> None:
@@ -111,7 +115,9 @@ class TestEventsProcessor(BaseEventsTest):
 
         enforce_table_writer(
             self.dataset
-        ).get_stream_loader().get_processor().extract_common(output, event)
+        ).get_stream_loader().get_processor().extract_common(
+            output, event, self.metadata
+        )
         assert output == {
             "platform": u"the_platform",
             "primary_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -131,7 +137,7 @@ class TestEventsProcessor(BaseEventsTest):
                 enforce_table_writer(self.dataset)
                 .get_stream_loader()
                 .get_processor()
-                .process_message((2, "__invalid__", {}))
+                .process_message((2, "__invalid__", {}), self.metadata)
                 == 1
             )
 
@@ -141,7 +147,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -151,7 +157,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -161,7 +167,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -171,7 +177,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -181,7 +187,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -191,7 +197,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -201,7 +207,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 
@@ -211,7 +217,7 @@ class TestEventsProcessor(BaseEventsTest):
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )
-        assert processor.process_message(message) == ReplacementBatch(
+        assert processor.process_message(message, self.metadata) == ReplacementBatch(
             str(project_id), [message]
         )
 

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -1,5 +1,7 @@
 import uuid
+from datetime import datetime
 
+from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.processor import InsertBatch
@@ -59,7 +61,9 @@ def test_simple():
         .get_processor()
     )
 
-    assert processor.process_message(message) == InsertBatch(
+    assert processor.process_message(
+        message, KafkaMessageMetadata(0, 0, datetime.now())
+    ) == InsertBatch(
         [
             {
                 "request_id": str(uuid.UUID("a" * 32)),

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -8,6 +8,7 @@ import pytest
 import simplejson as json
 
 from snuba import settings
+from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.factory import enforce_table_writer, get_dataset
 from tests.base import BaseApiTest, dataset_manager
 
@@ -115,7 +116,8 @@ class TestDiscoverApi(BaseApiTest):
                             ],
                         },
                     },
-                )
+                ),
+                KafkaMessageMetadata(0, 0, self.base_time),
             )
         )
 

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -8,6 +8,7 @@ import pytz
 import simplejson as json
 
 from snuba import settings, state
+from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.factory import enforce_table_writer
 from tests.base import BaseApiTest
 
@@ -136,7 +137,8 @@ class TestTransactionsApi(BaseApiTest):
                                         ],
                                     },
                                 },
-                            )
+                            ),
+                            KafkaMessageMetadata(0, 0, self.base_time),
                         )
                     )
                     events.append(processed)


### PR DESCRIPTION
This is an intermediate step on the path towards passing a `Message` instance to the `MessageProcessor`, rather than the same data broken into two separate parameters: `message` (which is really the payload) and `metadata`, as described here: https://github.com/getsentry/snuba/pull/1152#issuecomment-661350875