### PR TITLE
feat(ast) Rollout part of the performance view

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -113,6 +113,11 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
     "discover": {
         # Eventstore
         "eventstore.get_next_or_prev_event_id": 100,
+        # Performance view
+        "api.performance.durationpercentilechart": 100,
+        "api.organization-event-stats.key-transactions": 100,
+        "discover.key_transactions": 100,
+        "api.performance.latencychart": 100,
     },
 }  # (dataset name: (referrer: percentage))
 


### PR DESCRIPTION
This rolls out some of the low volume performance view queries (like a handful per day):
"api.performance.durationpercentilechart"
"api.organization-event-stats.key-transactions"
"discover.key_transactions"
"api.performance.latencychart"

These are fairly complex queries but not customizable. Tested the equivalent locally and the result is equivalent to the legacy query representation.