### PR TITLE
feat(parser): Expand Existing Arithmetic Expression Parser

### DIFF
--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -273,9 +273,7 @@ def parse_aggregation(
         return FunctionCall(alias, aggregation_function, tuple(columns_expr))
 
     expression_tree = minimal_clickhouse_grammar.parse(aggregation_function)
-    print(expression_tree)
     parsed_expression = ClickhouseVisitor().visit(expression_tree)
-    print(parsed_expression)
 
     if (
         # Simple Clickhouse expression with no snuba syntax

--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -10,7 +10,6 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
-    Type,
     Union,
 )
 
@@ -103,13 +102,11 @@ def get_arithmetic_function(
 
 
 def get_arithmetic_expression(
-    term: Expression,
-    exp: Union[LowPriArithmetic, HighPriArithmetic],
-    node_type: Union[Type[LowPriTuple], Type[HighPriTuple]],
+    term: Expression, exp: Union[LowPriArithmetic, HighPriArithmetic],
 ) -> Expression:
     if isinstance(exp, Node):
         return term
-    if isinstance(exp, node_type):
+    if isinstance(exp, (LowPriTuple, HighPriTuple)):
         return get_arithmetic_function(exp.op)(term, exp.arithm, None)
     elif isinstance(exp, list):
         for elem in exp:
@@ -168,7 +165,7 @@ class ClickhouseVisitor(NodeVisitor):
     ) -> Expression:
         _, term, _, exp = visited_children
 
-        return get_arithmetic_expression(term, exp, LowPriTuple)
+        return get_arithmetic_expression(term, exp)
 
     def visit_high_pri_arithmetic(
         self,
@@ -177,7 +174,7 @@ class ClickhouseVisitor(NodeVisitor):
     ) -> Expression:
         _, term, _, exp = visited_children
 
-        return get_arithmetic_expression(term, exp, HighPriTuple)
+        return get_arithmetic_expression(term, exp)
 
     def visit_numeric_literal(
         self, node: Node, visited_children: Iterable[Any]

--- a/tests/query/parser/test_expressions.py
+++ b/tests/query/parser/test_expressions.py
@@ -10,17 +10,17 @@ from snuba.query.parser.expressions import parse_aggregation
 
 test_data = [
     (
-        ["f('2020*07+16')", None, None],
-        FunctionCall(None, "f", (Literal(None, "2020*07+16"),),),
+        ["f('2020/07/16')", None, None],
+        FunctionCall(None, "f", (Literal(None, "2020/07/16"),),),
     ),  # String (that looks like arithmetic) nested in function call
     (
-        ["f(a * b, g(c * 3))", None, None],
+        ["f(a/b, g(c*3))", None, None],
         FunctionCall(
             None,
             "f",
             (
                 FunctionCall(
-                    None, "multiply", (Column(None, None, "a"), Column(None, None, "b"))
+                    None, "divide", (Column(None, None, "a"), Column(None, None, "b"))
                 ),
                 FunctionCall(
                     None,
@@ -37,10 +37,10 @@ test_data = [
         ),
     ),  # Arithmetic expressions nested inside function calls
     (
-        ["f(a, b) + 3 * g(c)", None, None],
+        ["f(a,b)-3*g(c)", None, None],
         FunctionCall(
             None,
-            "plus",
+            "minus",
             (
                 FunctionCall(
                     None, "f", (Column(None, None, "a"), Column(None, None, "b"))
@@ -61,62 +61,69 @@ test_data = [
         FunctionCall(None, "plus", (Column(None, None, "a"), Column(None, None, "b"))),
     ),  # Simple addition with Columns
     (
-        ["1 + 2 + 3", None, None],
+        ["1+2-3", None, None],
         FunctionCall(
             None,
-            "plus",
+            "minus",
             (
-                Literal(None, 1),
-                FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 3))),
+                FunctionCall(None, "plus", (Literal(None, 1), Literal(None, 2))),
+                Literal(None, 3),
             ),
         ),
     ),  # Addition with more than 2 terms
     (
-        ["5+4*3", None, None],
+        [" 5 +4 * 3/6  ", None, None],
         FunctionCall(
             None,
             "plus",
             (
                 Literal(None, 5),
-                FunctionCall(None, "multiply", (Literal(None, 4), Literal(None, 3))),
-            ),
-        ),
-    ),  # Combination of multiplication, addition
-    (
-        ["7  *5*4*3+2 *1+ 6", None, None],
-        FunctionCall(
-            None,
-            "plus",
-            (
                 FunctionCall(
                     None,
-                    "multiply",
-                    (
-                        Literal(None, 7),
-                        FunctionCall(
-                            None,
-                            "multiply",
-                            (
-                                Literal(None, 5),
-                                FunctionCall(
-                                    None,
-                                    "multiply",
-                                    (Literal(None, 4), Literal(None, 3)),
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-                FunctionCall(
-                    None,
-                    "plus",
+                    "divide",
                     (
                         FunctionCall(
-                            None, "multiply", (Literal(None, 2), Literal(None, 1))
+                            None, "multiply", (Literal(None, 4), Literal(None, 3))
                         ),
                         Literal(None, 6),
                     ),
                 ),
+            ),
+        ),
+    ),  # Combination of multiplication, addition
+    (
+        [" 3  +6 * 2 /5*7- 4/1   ", None, None],
+        FunctionCall(
+            None,
+            "minus",
+            (
+                FunctionCall(
+                    None,
+                    "plus",
+                    (
+                        Literal(None, 3),
+                        FunctionCall(
+                            None,
+                            "multiply",
+                            (
+                                FunctionCall(
+                                    None,
+                                    "divide",
+                                    (
+                                        FunctionCall(
+                                            None,
+                                            "multiply",
+                                            (Literal(None, 6), Literal(None, 2)),
+                                        ),
+                                        Literal(None, 5),
+                                    ),
+                                ),
+                                Literal(None, 7),
+                            ),
+                        ),
+                    ),
+                ),
+                FunctionCall(None, "divide", (Literal(None, 4), Literal(None, 1))),
             ),
         ),
     ),  # More complicated Combination of operators


### PR DESCRIPTION
Updates to integrated arithmetic expression parser:

- Added support for subtraction/division operators ("-"/ "/").
- In order to do so, grammar was modified to replace right recursive elements with regex expressions in the format of: operand (operator operand)*.
- This is due to the fact that Parsimonious uses PEG grammars (LL/LR grammar, and no left recursion allowed) and left associativity (necessary for arithmetic expression parsing) is not achievable with right recursion. 
- Operators have their own grammar rule in order to return only the node text (which is the operator string).

Next steps:

- Revision as applicable.
- Support parenthetical expressions to indicate priority (i.e. 2+5 * (4-3) ).
- Work towards a general grammar for SnQL language.