### PR TITLE
feat(slo) Consolidate invalid query exceptions

### DIFF
--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -76,7 +76,9 @@ def parse_conditions(
         try:
             lhs, op, lit = dataset.process_condition(conditions)
         except Exception as cause:
-            raise ParsingException() from cause
+            raise ParsingException(
+                f"Cannot process condition {conditions}", cause
+            ) from cause
 
         # facilitate deduping IN conditions by sorting them.
         if op in ("IN", "NOT IN") and isinstance(lit, tuple):

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -150,7 +150,7 @@ def parse_conditions_to_expr(
             if op not in ["IN", "NOT IN"]:
                 raise ParsingException(
                     (
-                        f"Invalid opperator {op} for literal {literal}. Literal is a sequence. "
+                        f"Invalid operator {op} for literal {literal}. Literal is a sequence. "
                         "Operator must be IN/NOT IN"
                     )
                 )
@@ -160,7 +160,7 @@ def parse_conditions_to_expr(
             if op in ["IN", "NOT IN"]:
                 raise ParsingException(
                     (
-                        f"Invalid opperator {op} for literal {literal}. Literal is not a sequence. "
+                        f"Invalid operator {op} for literal {literal}. Literal is not a sequence. "
                         "Operator cannot be IN/NOT IN"
                     )
                 )

--- a/snuba/query/parser/exceptions.py
+++ b/snuba/query/parser/exceptions.py
@@ -1,6 +1,18 @@
-class ParsingException(Exception):
+class QueryBuildingException(Exception):
     pass
 
 
-class CyclicAliasException(ParsingException):
+class ParsingException(QueryBuildingException):
+    pass
+
+
+class ValidationException(QueryBuildingException):
+    pass
+
+
+class CyclicAliasException(ValidationException):
+    pass
+
+
+class AliasShadowingException(ValidationException):
     pass

--- a/snuba/query/parser/exceptions.py
+++ b/snuba/query/parser/exceptions.py
@@ -1,12 +1,18 @@
-class QueryBuildingException(Exception):
+class InvalidQueryException(Exception):
+    """
+    Common parent class used for invalid queries during parsing
+    and validation.
+    This should not be used for system errors.
+    """
+
     pass
 
 
-class ParsingException(QueryBuildingException):
+class ParsingException(InvalidQueryException):
     pass
 
 
-class ValidationException(QueryBuildingException):
+class ValidationException(InvalidQueryException):
     pass
 
 

--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -5,7 +5,6 @@ from typing import Any, Iterable, List, Optional, Tuple, Union
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor
 
-from snuba.query.parser.exceptions import ParsingException
 from snuba.query.dsl import multiply, plus
 from snuba.query.expressions import (
     Column,
@@ -14,6 +13,7 @@ from snuba.query.expressions import (
     FunctionCall,
     Literal,
 )
+from snuba.query.parser.exceptions import ParsingException
 from snuba.query.parser.functions import parse_function_to_expr
 from snuba.query.parser.strings import parse_string_to_expr
 from snuba.util import is_function

--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -215,9 +215,12 @@ def parse_aggregation(
 
     try:
         expression_tree = minimal_clickhouse_grammar.parse(aggregation_function)
-        parsed_expression = ClickhouseVisitor().visit(expression_tree)
-    except Exception as e:
-        raise ParsingException() from e
+    except Exception as cause:
+        raise ParsingException(
+            f"Cannot parse aggregation {aggregation_function}", cause
+        ) from cause
+
+    parsed_expression = ClickhouseVisitor().visit(expression_tree)
 
     if (
         # Simple Clickhouse expression with no snuba syntax

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -7,6 +7,7 @@ from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
 from snuba.clickhouse.escaping import escape_identifier
 from snuba.query.expressions import Expression, FunctionCall, Literal
+from snuba.query.parser.exceptions import ParsingException
 from snuba.query.parser.strings import parse_string_to_expr
 from snuba.state import get_config
 from snuba.util import is_function
@@ -117,7 +118,7 @@ def parse_function(
     """
     function_tuple = is_function(expr, depth)
     if function_tuple is None:
-        raise ValueError(
+        raise ParsingException(
             "complex_column_expr was given an expr %s that is not a function at depth %d."
             % (expr, depth)
         )

--- a/tests/query/parser/test_invalid_queries.py
+++ b/tests/query/parser/test_invalid_queries.py
@@ -1,0 +1,52 @@
+from typing import Any, MutableMapping, Type
+
+import pytest
+
+from snuba.datasets.factory import get_dataset
+from snuba.query.parser.exceptions import (
+    AliasShadowingException,
+    QueryBuildingException,
+    ParsingException,
+)
+from snuba.query.parser import parse_query
+
+test_cases = [
+    pytest.param(
+        {"aggregations": [["f(i(am)bad((at(parentheses)+3", None, "alias"]]},
+        ParsingException,
+        id="Aggregation string cannot be parsed",
+    ),
+    pytest.param(
+        {"orderby": [[[[["column"]]]]]}, ParsingException, id="Nonsensical order by",
+    ),
+    pytest.param(
+        {"conditions": [["timestamp", "=", ""]]},
+        ParsingException,
+        id="Invalid date in a condition",
+    ),
+    pytest.param(
+        {"conditions": [["timestamp", "IS NOT NULL", "this makes no sense"]]},
+        ParsingException,
+        id="Binary condition with unary operator",
+    ),
+    pytest.param(
+        {"conditions": [["project_id", "IN", "2"]]},
+        ParsingException,
+        id="IN condition without a sequence as right hand side",
+    ),
+    pytest.param(
+        {"selected_columns": [["f", [1], "alias"], ["f", [2], "alias"]]},
+        AliasShadowingException,
+        id="Alias shadowing",
+    ),
+]
+
+
+@pytest.mark.parametrize("query_body, expected_exception", test_cases)
+def test_failures(
+    query_body: MutableMapping[str, Any],
+    expected_exception: Type[QueryBuildingException],
+) -> None:
+    with pytest.raises(expected_exception):
+        events = get_dataset("events")
+        parse_query(query_body, events)

--- a/tests/query/parser/test_invalid_queries.py
+++ b/tests/query/parser/test_invalid_queries.py
@@ -5,7 +5,7 @@ import pytest
 from snuba.datasets.factory import get_dataset
 from snuba.query.parser.exceptions import (
     AliasShadowingException,
-    QueryBuildingException,
+    InvalidQueryException,
     ParsingException,
 )
 from snuba.query.parser import parse_query
@@ -45,7 +45,7 @@ test_cases = [
 @pytest.mark.parametrize("query_body, expected_exception", test_cases)
 def test_failures(
     query_body: MutableMapping[str, Any],
-    expected_exception: Type[QueryBuildingException],
+    expected_exception: Type[InvalidQueryException],
 ) -> None:
     with pytest.raises(expected_exception):
         events = get_dataset("events")

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -15,7 +15,7 @@ from snuba.query.expressions import (
 )
 from snuba.query.logical import OrderBy, OrderByDirection, Query, SelectedExpression
 from snuba.query.parser import parse_query
-from snuba.query.parser.exceptions import CyclicAliasException
+from snuba.query.parser.exceptions import AliasShadowingException, CyclicAliasException
 
 test_cases = [
     pytest.param(
@@ -363,7 +363,7 @@ def test_format_expressions(
 
 
 def test_shadowing() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(AliasShadowingException):
         parse_query(
             {
                 "selected_columns": [


### PR DESCRIPTION
This refactoring introduces some specific exceptions with a common parent to identify invalid queries instead of relying on assertions and ValueError.
This will allow us to make a proper distinction between system errors and invalid queries during parsing both when deciding which HTTP error code to return and how to log the query.

This approach implies that parsing and validation code needs to explicitly identify client errors (by default an assertion error would still be a system error). This way it would be harder to accidentally flag bugs as client errors.