### PR TITLE
ref(streams): Split general case `StreamProcessor` out of `streams.batching`

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -102,18 +102,16 @@ def replacer(
 
     metrics = MetricsWrapper(environment.metrics, "replacer", tags=metrics_tags,)
 
-    consumer = KafkaConsumer(
-        build_kafka_consumer_configuration(
-            bootstrap_servers=bootstrap_server,
-            group_id=consumer_group,
-            auto_offset_reset=auto_offset_reset,
-            queued_max_messages_kbytes=queued_max_messages_kbytes,
-            queued_min_messages=queued_min_messages,
-        ),
-    )
-
     replacer = BatchingConsumer(
-        consumer,
+        KafkaConsumer(
+            build_kafka_consumer_configuration(
+                bootstrap_servers=bootstrap_server,
+                group_id=consumer_group,
+                auto_offset_reset=auto_offset_reset,
+                queued_max_messages_kbytes=queued_max_messages_kbytes,
+                queued_min_messages=queued_min_messages,
+            ),
+        ),
         Topic(replacements_topic),
         BatchProcessorFactory(
             worker=ReplacerWorker(storage, metrics=metrics),

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -84,7 +84,7 @@ def replacer(
         TransportError,
         build_kafka_consumer_configuration,
     )
-    from snuba.utils.streams.processing import BatchingConsumer
+    from snuba.utils.streams.processing import StreamProcessor
     from snuba.utils.streams.types import Topic
 
     setup_logging(log_level)
@@ -103,7 +103,7 @@ def replacer(
 
     metrics = MetricsWrapper(environment.metrics, "replacer", tags=metrics_tags,)
 
-    replacer = BatchingConsumer(
+    replacer = StreamProcessor(
         KafkaConsumer(
             build_kafka_consumer_configuration(
                 bootstrap_servers=bootstrap_server,

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -78,12 +78,13 @@ def replacer(
 ) -> None:
 
     from snuba.replacer import ReplacerWorker
-    from snuba.utils.streams.batching import BatchingConsumer, BatchProcessorFactory
+    from snuba.utils.streams.batching import BatchProcessorFactory
     from snuba.utils.streams.kafka import (
         KafkaConsumer,
         TransportError,
         build_kafka_consumer_configuration,
     )
+    from snuba.utils.streams.processing import BatchingConsumer
     from snuba.utils.streams.types import Topic
 
     setup_logging(log_level)

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -78,7 +78,7 @@ def replacer(
 ) -> None:
 
     from snuba.replacer import ReplacerWorker
-    from snuba.utils.streams.batching import BatchProcessorFactory
+    from snuba.utils.streams.batching import BatchProcessingStrategyFactory
     from snuba.utils.streams.kafka import (
         KafkaConsumer,
         TransportError,
@@ -114,7 +114,7 @@ def replacer(
             ),
         ),
         Topic(replacements_topic),
-        BatchProcessorFactory(
+        BatchProcessingStrategyFactory(
             worker=ReplacerWorker(storage, metrics=metrics),
             max_batch_size=max_batch_size,
             max_batch_time=max_batch_time_ms,

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -116,7 +116,6 @@ def replacer(
         consumer,
         Topic(replacements_topic),
         BatchProcessorFactory(
-            consumer,
             worker=ReplacerWorker(storage, metrics=metrics),
             max_batch_size=max_batch_size,
             max_batch_time=max_batch_time_ms,

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -24,7 +24,7 @@ from snuba.utils.streams.kafka import (
     KafkaProducer,
     build_kafka_consumer_configuration,
 )
-from snuba.utils.streams.processing import BatchingConsumer
+from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.streams.synchronized import SynchronizedConsumer
 from snuba.utils.streams.types import Topic
 
@@ -168,7 +168,7 @@ def subscriptions(
     metrics.gauge("executor.workers", executor._max_workers)
 
     with closing(consumer), executor, closing(producer):
-        batching_consumer = BatchingConsumer(
+        batching_consumer = StreamProcessor(
             consumer,
             (
                 Topic(topic)

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -18,12 +18,13 @@ from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.worker import SubscriptionWorker
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
-from snuba.utils.streams.batching import BatchingConsumer, BatchProcessorFactory
+from snuba.utils.streams.batching import BatchProcessorFactory
 from snuba.utils.streams.kafka import (
     KafkaConsumer,
     KafkaProducer,
     build_kafka_consumer_configuration,
 )
+from snuba.utils.streams.processing import BatchingConsumer
 from snuba.utils.streams.synchronized import SynchronizedConsumer
 from snuba.utils.streams.types import Topic
 

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -18,7 +18,7 @@ from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.worker import SubscriptionWorker
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
-from snuba.utils.streams.batching import BatchProcessorFactory
+from snuba.utils.streams.batching import BatchProcessingStrategyFactory
 from snuba.utils.streams.kafka import (
     KafkaConsumer,
     KafkaProducer,
@@ -175,7 +175,7 @@ def subscriptions(
                 if topic is not None
                 else Topic(loader.get_default_topic_spec().topic_name)
             ),
-            BatchProcessorFactory(
+            BatchProcessingStrategyFactory(
                 SubscriptionWorker(
                     dataset,
                     executor,

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -175,7 +175,6 @@ def subscriptions(
                 else Topic(loader.get_default_topic_spec().topic_name)
             ),
             BatchProcessorFactory(
-                consumer,
                 SubscriptionWorker(
                     dataset,
                     executor,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -141,7 +141,6 @@ class ConsumerBuilder:
             consumer,
             self.raw_topic,
             BatchProcessorFactory(
-                consumer,
                 worker=worker,
                 max_batch_size=self.max_batch_size,
                 max_batch_time=self.max_batch_time_ms,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -11,7 +11,7 @@ from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.retries import BasicRetryPolicy, RetryPolicy, constant_delay
-from snuba.utils.streams.batching import BatchProcessorFactory
+from snuba.utils.streams.batching import BatchProcessingStrategyFactory
 from snuba.utils.streams.kafka import (
     KafkaConsumer,
     KafkaConsumerWithCommitLog,
@@ -138,7 +138,7 @@ class ConsumerBuilder:
         return StreamProcessor(
             consumer,
             self.raw_topic,
-            BatchProcessorFactory(
+            BatchProcessingStrategyFactory(
                 worker=worker,
                 max_batch_size=self.max_batch_size,
                 max_batch_time=self.max_batch_time_ms,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -19,7 +19,7 @@ from snuba.utils.streams.kafka import (
     TransportError,
     build_kafka_consumer_configuration,
 )
-from snuba.utils.streams.processing import BatchingConsumer
+from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.streams.types import Topic
 
 
@@ -115,9 +115,7 @@ class ConsumerBuilder:
 
         self.__commit_retry_policy = commit_retry_policy
 
-    def __build_consumer(
-        self, worker: ConsumerWorker
-    ) -> BatchingConsumer[KafkaPayload]:
+    def __build_consumer(self, worker: ConsumerWorker) -> StreamProcessor[KafkaPayload]:
         configuration = build_kafka_consumer_configuration(
             bootstrap_servers=self.bootstrap_servers,
             group_id=self.group_id,
@@ -138,7 +136,7 @@ class ConsumerBuilder:
                 commit_retry_policy=self.__commit_retry_policy,
             )
 
-        return BatchingConsumer(
+        return StreamProcessor(
             consumer,
             self.raw_topic,
             BatchProcessorFactory(
@@ -150,7 +148,7 @@ class ConsumerBuilder:
             recoverable_errors=[TransportError],
         )
 
-    def build_base_consumer(self) -> BatchingConsumer[KafkaPayload]:
+    def build_base_consumer(self) -> StreamProcessor[KafkaPayload]:
         """
         Builds the consumer with a ConsumerWorker.
         """
@@ -165,7 +163,7 @@ class ConsumerBuilder:
 
     def build_snapshot_aware_consumer(
         self, snapshot_id: SnapshotId, transaction_data: TransactionData,
-    ) -> BatchingConsumer[KafkaPayload]:
+    ) -> StreamProcessor[KafkaPayload]:
         """
         Builds the consumer with a ConsumerWorker able to handle snapshots.
         """

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -11,7 +11,7 @@ from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.retries import BasicRetryPolicy, RetryPolicy, constant_delay
-from snuba.utils.streams.batching import BatchingConsumer
+from snuba.utils.streams.batching import BatchingConsumer, BatchProcessorFactory
 from snuba.utils.streams.kafka import (
     KafkaConsumer,
     KafkaConsumerWithCommitLog,
@@ -140,10 +140,13 @@ class ConsumerBuilder:
         return BatchingConsumer(
             consumer,
             self.raw_topic,
-            worker=worker,
-            max_batch_size=self.max_batch_size,
-            max_batch_time=self.max_batch_time_ms,
-            metrics=self.metrics,
+            BatchProcessorFactory(
+                consumer,
+                worker=worker,
+                max_batch_size=self.max_batch_size,
+                max_batch_time=self.max_batch_time_ms,
+                metrics=self.metrics,
+            ),
             recoverable_errors=[TransportError],
         )
 

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -25,10 +25,9 @@ from snuba.utils.streams.types import Topic
 
 class ConsumerBuilder:
     """
-    Simplifies the initialization of a batching consumer by merging
-    parameters that generally come from the command line with defaults
-    that come from the dataset class and defaults that come from the
-    settings file.
+    Simplifies the initialization of a consumer by merging parameters that
+    generally come from the command line with defaults that come from the
+    dataset class and defaults that come from the settings file.
     """
 
     def __init__(

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -11,7 +11,7 @@ from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.backends.wrapper import MetricsWrapper
 from snuba.utils.retries import BasicRetryPolicy, RetryPolicy, constant_delay
-from snuba.utils.streams.batching import BatchingConsumer, BatchProcessorFactory
+from snuba.utils.streams.batching import BatchProcessorFactory
 from snuba.utils.streams.kafka import (
     KafkaConsumer,
     KafkaConsumerWithCommitLog,
@@ -19,6 +19,7 @@ from snuba.utils.streams.kafka import (
     TransportError,
     build_kafka_consumer_configuration,
 )
+from snuba.utils.streams.processing import BatchingConsumer
 from snuba.utils.streams.types import Topic
 
 

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -31,7 +31,7 @@ class StrictConsumer:
     It waits for a partition to be assigned before actually consuming. If no
     partition is assigned within a timeout it fails.
     It also moves the responsibility of deciding what to commit to the user
-    compared to the BatchingConsumer
+    compared to other stream processing implementations.
 
     This is not supposed to be used for continuously consume a topic but to
     catch up on a topic from the beginning to the state it is at the time we start.

--- a/snuba/stateful_consumer/states/catching_up.py
+++ b/snuba/stateful_consumer/states/catching_up.py
@@ -3,8 +3,8 @@ from typing import Optional, Tuple
 
 from snuba.consumers.consumer_builder import ConsumerBuilder
 from snuba.stateful_consumer import ConsumerStateData, ConsumerStateCompletionEvent
-from snuba.utils.streams.batching import BatchingConsumer
 from snuba.utils.streams.kafka import KafkaPayload
+from snuba.utils.streams.processing import BatchingConsumer
 from snuba.utils.state_machine import State
 
 logger = logging.getLogger("snuba.snapshot-catchup")

--- a/snuba/stateful_consumer/states/catching_up.py
+++ b/snuba/stateful_consumer/states/catching_up.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple
 from snuba.consumers.consumer_builder import ConsumerBuilder
 from snuba.stateful_consumer import ConsumerStateData, ConsumerStateCompletionEvent
 from snuba.utils.streams.kafka import KafkaPayload
-from snuba.utils.streams.processing import BatchingConsumer
+from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.state_machine import State
 
 logger = logging.getLogger("snuba.snapshot-catchup")
@@ -22,7 +22,7 @@ class CatchingUpState(State[ConsumerStateCompletionEvent, Optional[ConsumerState
     def __init__(self, consumer_builder: ConsumerBuilder) -> None:
         super().__init__()
         self.__consumer_builder = consumer_builder
-        self.__consumer: Optional[BatchingConsumer[KafkaPayload]] = None
+        self.__consumer: Optional[StreamProcessor[KafkaPayload]] = None
 
     def signal_shutdown(self) -> None:
         if self.__consumer:

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -80,31 +80,6 @@ class Batch(Generic[TResult]):
     processing_time_ms: float = 0.0
 
 
-class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
-    def __init__(
-        self,
-        worker: AbstractBatchWorker[TPayload, TResult],
-        max_batch_size: int,
-        max_batch_time: int,
-        metrics: MetricsBackend,
-    ) -> None:
-        self.__worker = worker
-        self.__max_batch_size = max_batch_size
-        self.__max_batch_time = max_batch_time
-        self.__metrics = metrics
-
-    def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
-    ) -> ProcessingStrategy[TPayload]:
-        return BatchProcessingStrategy(
-            commit,
-            self.__worker,
-            self.__max_batch_size,
-            self.__max_batch_time,
-            self.__metrics,
-        )
-
-
 class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
     """
     The ``BatchProcessingStrategy`` is a processing strategy that accumulates
@@ -241,3 +216,28 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
         logger.debug("Offset commit took %dms", commit_duration)
 
         self.__batch = None
+
+
+class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
+    def __init__(
+        self,
+        worker: AbstractBatchWorker[TPayload, TResult],
+        max_batch_size: int,
+        max_batch_time: int,
+        metrics: MetricsBackend,
+    ) -> None:
+        self.__worker = worker
+        self.__max_batch_size = max_batch_size
+        self.__max_batch_time = max_batch_time
+        self.__metrics = metrics
+
+    def create(
+        self, commit: Callable[[Mapping[Partition, int]], None]
+    ) -> ProcessingStrategy[TPayload]:
+        return BatchProcessingStrategy(
+            commit,
+            self.__worker,
+            self.__max_batch_size,
+            self.__max_batch_time,
+            self.__metrics,
+        )

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
-from snuba.utils.streams.processing import ProcessingStrategy, ProcessorFactory
+from snuba.utils.streams.processing import ProcessingStrategy, ProcessingStrategyFactory
 from snuba.utils.streams.types import Message, Partition, TPayload
 
 
@@ -80,7 +80,7 @@ class Batch(Generic[TResult]):
     processing_time_ms: float = 0.0
 
 
-class BatchProcessorFactory(ProcessorFactory[TPayload]):
+class BatchProcessingStrategyFactory(ProcessingStrategyFactory[TPayload]):
     def __init__(
         self,
         worker: AbstractBatchWorker[TPayload, TResult],

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -16,7 +16,7 @@ from typing import (
 )
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
-from snuba.utils.streams.processing import Processor, ProcessorFactory
+from snuba.utils.streams.processing import ProcessingStrategy, ProcessorFactory
 from snuba.utils.streams.types import Message, Partition, TPayload
 
 
@@ -95,7 +95,7 @@ class BatchProcessorFactory(ProcessorFactory[TPayload]):
 
     def create(
         self, commit: Callable[[Mapping[Partition, int]], None]
-    ) -> Processor[TPayload]:
+    ) -> ProcessingStrategy[TPayload]:
         return BatchProcessor(
             commit,
             self.__worker,
@@ -105,9 +105,9 @@ class BatchProcessorFactory(ProcessorFactory[TPayload]):
         )
 
 
-class BatchProcessor(Processor[TPayload]):
+class BatchProcessor(ProcessingStrategy[TPayload]):
     """
-    The ``BatchProcessor`` is a message processor that accumulates processed
+    The ``BatchProcessor`` is a processing strategy that accumulates processed
     message values, periodically flushing them after a given duration of time
     has passed or number of output values have been accumulated. Users need
     only provide an implementation of what it means to process a raw message

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -12,13 +12,13 @@ from typing import (
     MutableSequence,
     Optional,
     Sequence,
-    Type,
     TypeVar,
 )
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
-from snuba.utils.streams.consumer import Consumer, ConsumerError
-from snuba.utils.streams.types import Message, Partition, Topic, TPayload
+from snuba.utils.streams.processing import Processor, ProcessorFactory
+from snuba.utils.streams.types import Message, Partition, TPayload
+
 
 logger = logging.getLogger(__name__)
 
@@ -74,24 +74,6 @@ class Batch(Generic[TResult]):
     # the messages in this batch (does not included time spent waiting for
     # new messages)
     processing_time_ms: float = 0.0
-
-
-class ProcessorFactory(ABC, Generic[TPayload]):
-    @abstractmethod
-    def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
-    ) -> Processor[TPayload]:
-        raise NotImplementedError
-
-
-class Processor(ABC, Generic[TPayload]):
-    @abstractmethod
-    def process(self, message: Optional[Message[TPayload]]) -> None:
-        raise NotImplementedError
-
-    @abstractmethod
-    def close(self) -> None:
-        raise NotImplementedError
 
 
 class BatchProcessorFactory(ProcessorFactory[TPayload]):
@@ -246,106 +228,3 @@ class BatchProcessor(Processor[TPayload]):
         logger.debug("Offset commit took %dms", commit_duration)
 
         self.__batch = None
-
-
-class BatchingConsumer(Generic[TPayload]):
-    """The `BatchingConsumer` is an abstraction over the abstract Consumer's main event
-    loop. For this reason it uses inversion of control: the user provides an implementation
-    for the `AbstractBatchWorker` and then the `BatchingConsumer` handles the rest.
-
-    * Messages are processed locally (e.g. not written to an external datastore!) as they are
-      read from the consumer, then added to an in-memory batch
-    * Batches are flushed based on the batch size or time sent since the first message
-      in the batch was recieved (e.g. "500 items or 1000ms")
-    * Consumer offsets are not automatically committed! If they were, offsets might be committed
-      for messages that are still sitting in an in-memory batch, or they might *not* be committed
-      when messages are sent to an external datastore right before the consumer process dies
-    * Instead, when a batch of items is flushed they are written to the external datastore and
-      then consumer offsets are immediately committed (in the same thread/loop)
-    * Users need only provide an implementation of what it means to process a raw message
-      and flush a batch of events
-
-    NOTE: This does not eliminate the possibility of duplicates if the consumer process
-    crashes between writing to its backend and commiting offsets. This should eliminate
-    the possibility of *losing* data though. An "exactly once" consumer would need to store
-    offsets in the external datastore and reconcile them on any partition rebalance.
-    """
-
-    def __init__(
-        self,
-        consumer: Consumer[TPayload],
-        topic: Topic,
-        processor_factory: ProcessorFactory[TPayload],
-        recoverable_errors: Optional[Sequence[Type[ConsumerError]]] = None,
-    ) -> None:
-        self.__consumer = consumer
-        self.__processor_factory = processor_factory
-
-        # The types passed to the `except` clause must be a tuple, not a Sequence.
-        self.__recoverable_errors = tuple(recoverable_errors or [])
-
-        self.__processor: Optional[Processor[TPayload]] = None
-        self.__shutdown_requested = False
-
-        def on_partitions_assigned(partitions: Mapping[Partition, int]) -> None:
-            assert (
-                self.__processor is None
-            ), "received unexpected assignment with existing active processor"
-
-            logger.info("New partitions assigned: %r", partitions)
-            self.__processor = self.__processor_factory.create(self.__commit)
-
-        def on_partitions_revoked(partitions: Sequence[Partition]) -> None:
-            "Reset the current in-memory batch, letting the next consumer take over where we left off."
-            assert (
-                self.__processor is not None
-            ), "received unexpected revocation without active processor"
-
-            logger.info("Partitions revoked: %r", partitions)
-            self.__processor.close()
-            self.__processor = None
-
-        self.__consumer.subscribe(
-            [topic], on_assign=on_partitions_assigned, on_revoke=on_partitions_revoked
-        )
-
-    def __commit(self, offsets: Mapping[Partition, int]) -> None:
-        self.__consumer.stage_offsets(offsets)
-        self.__consumer.commit_offsets()
-
-    def run(self) -> None:
-        "The main run loop, see class docstring for more information."
-
-        logger.debug("Starting")
-        while not self.__shutdown_requested:
-            self._run_once()
-
-        self._shutdown()
-
-    def _run_once(self) -> None:
-        try:
-            msg = self.__consumer.poll(timeout=1.0)
-        except self.__recoverable_errors:
-            return
-
-        if self.__processor is not None:
-            self.__processor.process(msg)
-        else:
-            assert msg is None, "received message without active processor"
-
-    def signal_shutdown(self) -> None:
-        """Tells the batching consumer to shutdown on the next run loop iteration.
-        Typically called from a signal handler."""
-        logger.debug("Shutdown signalled")
-
-        self.__shutdown_requested = True
-
-    def _shutdown(self) -> None:
-        # close the consumer
-        logger.debug("Stopping consumer")
-        self.__consumer.close()
-        logger.debug("Stopped")
-
-        # if there was an active processor, it should be shut down and unset
-        # when the partitions are revoked during consumer close
-        assert self.__processor is None, "processor was not closed on shutdown"

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -28,9 +28,9 @@ TResult = TypeVar("TResult")
 
 class AbstractBatchWorker(ABC, Generic[TPayload, TResult]):
     """
-    The ``BatchProcessor`` requires an instance of this class to handle user
-    provided work such as processing raw messages and flushing processed
-    batches to a custom backend.
+    The ``BatchProcessingStrategy`` requires an instance of this class to
+    handle user provided work such as processing raw messages and flushing
+    processed batches to a custom backend.
     """
 
     @abstractmethod
@@ -38,7 +38,7 @@ class AbstractBatchWorker(ABC, Generic[TPayload, TResult]):
         """
         Called with each raw message, allowing the worker to do incremental
         (preferably local!) work on events. The object returned is put into
-        the batch maintained internally by the ``BatchProcessor``.
+        the batch maintained internally by the ``BatchProcessingStrategy``.
 
         If this method returns `None` it is not added to the batch.
 
@@ -53,7 +53,7 @@ class AbstractBatchWorker(ABC, Generic[TPayload, TResult]):
         Called with a list of processed (by ``process_message``) objects.
         The worker should write the batch of processed messages into whatever
         store(s) it is maintaining. Afterwards the offsets are committed by
-        the ``BatchProcessor``.
+        the ``BatchProcessingStrategy``.
 
         A simple example would be writing the batch to another topic.
         """
@@ -96,7 +96,7 @@ class BatchProcessorFactory(ProcessorFactory[TPayload]):
     def create(
         self, commit: Callable[[Mapping[Partition, int]], None]
     ) -> ProcessingStrategy[TPayload]:
-        return BatchProcessor(
+        return BatchProcessingStrategy(
             commit,
             self.__worker,
             self.__max_batch_size,
@@ -105,13 +105,14 @@ class BatchProcessorFactory(ProcessorFactory[TPayload]):
         )
 
 
-class BatchProcessor(ProcessingStrategy[TPayload]):
+class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
     """
-    The ``BatchProcessor`` is a processing strategy that accumulates processed
-    message values, periodically flushing them after a given duration of time
-    has passed or number of output values have been accumulated. Users need
-    only provide an implementation of what it means to process a raw message
-    and flush a batch of events via an ``AbstractBatchWorker`` instance.
+    The ``BatchProcessingStrategy`` is a processing strategy that accumulates
+    processed message values, periodically flushing them after a given
+    duration of time has passed or number of output values have been
+    accumulated. Users need only provide an implementation of what it means
+    to process a raw message and flush a batch of events via an
+    ``AbstractBatchWorker`` instance.
 
     Messages are processed as they are read from the consumer, then added to
     an in-memory batch. These batches are flushed based on the batch size or

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -278,24 +278,17 @@ class BatchingConsumer(Generic[TPayload]):
         self,
         consumer: Consumer[TPayload],
         topic: Topic,
-        worker: AbstractBatchWorker[TPayload, TResult],
-        max_batch_size: int,
-        max_batch_time: int,
-        metrics: MetricsBackend,
+        processor_factory: ProcessorFactory[TPayload],
         recoverable_errors: Optional[Sequence[Type[ConsumerError]]] = None,
     ) -> None:
         self.__consumer = consumer
-
-        self.__processor_factory: ProcessorFactory[TPayload] = BatchProcessorFactory(
-            consumer, worker, max_batch_size, max_batch_time, metrics
-        )
-
-        self.__processor: Optional[Processor[TPayload]] = None
-
-        self.__shutdown_requested = False
+        self.__processor_factory = processor_factory
 
         # The types passed to the `except` clause must be a tuple, not a Sequence.
         self.__recoverable_errors = tuple(recoverable_errors or [])
+
+        self.__processor: Optional[Processor[TPayload]] = None
+        self.__shutdown_requested = False
 
         def on_partitions_assigned(partitions: Mapping[Partition, int]) -> None:
             assert (

--- a/snuba/utils/streams/processing.py
+++ b/snuba/utils/streams/processing.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import (
+    Callable,
+    Generic,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+)
+
+from snuba.utils.streams.consumer import Consumer, ConsumerError
+from snuba.utils.streams.types import Message, Partition, Topic, TPayload
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessorFactory(ABC, Generic[TPayload]):
+    @abstractmethod
+    def create(
+        self, commit: Callable[[Mapping[Partition, int]], None]
+    ) -> Processor[TPayload]:
+        raise NotImplementedError
+
+
+class Processor(ABC, Generic[TPayload]):
+    @abstractmethod
+    def process(self, message: Optional[Message[TPayload]]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def close(self) -> None:
+        raise NotImplementedError
+
+
+class BatchingConsumer(Generic[TPayload]):
+    """The `BatchingConsumer` is an abstraction over the abstract Consumer's main event
+    loop. For this reason it uses inversion of control: the user provides an implementation
+    for the `AbstractBatchWorker` and then the `BatchingConsumer` handles the rest.
+
+    * Messages are processed locally (e.g. not written to an external datastore!) as they are
+      read from the consumer, then added to an in-memory batch
+    * Batches are flushed based on the batch size or time sent since the first message
+      in the batch was recieved (e.g. "500 items or 1000ms")
+    * Consumer offsets are not automatically committed! If they were, offsets might be committed
+      for messages that are still sitting in an in-memory batch, or they might *not* be committed
+      when messages are sent to an external datastore right before the consumer process dies
+    * Instead, when a batch of items is flushed they are written to the external datastore and
+      then consumer offsets are immediately committed (in the same thread/loop)
+    * Users need only provide an implementation of what it means to process a raw message
+      and flush a batch of events
+
+    NOTE: This does not eliminate the possibility of duplicates if the consumer process
+    crashes between writing to its backend and commiting offsets. This should eliminate
+    the possibility of *losing* data though. An "exactly once" consumer would need to store
+    offsets in the external datastore and reconcile them on any partition rebalance.
+    """
+
+    def __init__(
+        self,
+        consumer: Consumer[TPayload],
+        topic: Topic,
+        processor_factory: ProcessorFactory[TPayload],
+        recoverable_errors: Optional[Sequence[Type[ConsumerError]]] = None,
+    ) -> None:
+        self.__consumer = consumer
+        self.__processor_factory = processor_factory
+
+        # The types passed to the `except` clause must be a tuple, not a Sequence.
+        self.__recoverable_errors = tuple(recoverable_errors or [])
+
+        self.__processor: Optional[Processor[TPayload]] = None
+        self.__shutdown_requested = False
+
+        def on_partitions_assigned(partitions: Mapping[Partition, int]) -> None:
+            assert (
+                self.__processor is None
+            ), "received unexpected assignment with existing active processor"
+
+            logger.info("New partitions assigned: %r", partitions)
+            self.__processor = self.__processor_factory.create(self.__commit)
+
+        def on_partitions_revoked(partitions: Sequence[Partition]) -> None:
+            "Reset the current in-memory batch, letting the next consumer take over where we left off."
+            assert (
+                self.__processor is not None
+            ), "received unexpected revocation without active processor"
+
+            logger.info("Partitions revoked: %r", partitions)
+            self.__processor.close()
+            self.__processor = None
+
+        self.__consumer.subscribe(
+            [topic], on_assign=on_partitions_assigned, on_revoke=on_partitions_revoked
+        )
+
+    def __commit(self, offsets: Mapping[Partition, int]) -> None:
+        self.__consumer.stage_offsets(offsets)
+        self.__consumer.commit_offsets()
+
+    def run(self) -> None:
+        "The main run loop, see class docstring for more information."
+
+        logger.debug("Starting")
+        while not self.__shutdown_requested:
+            self._run_once()
+
+        self._shutdown()
+
+    def _run_once(self) -> None:
+        try:
+            msg = self.__consumer.poll(timeout=1.0)
+        except self.__recoverable_errors:
+            return
+
+        if self.__processor is not None:
+            self.__processor.process(msg)
+        else:
+            assert msg is None, "received message without active processor"
+
+    def signal_shutdown(self) -> None:
+        """Tells the batching consumer to shutdown on the next run loop iteration.
+        Typically called from a signal handler."""
+        logger.debug("Shutdown signalled")
+
+        self.__shutdown_requested = True
+
+    def _shutdown(self) -> None:
+        # close the consumer
+        logger.debug("Stopping consumer")
+        self.__consumer.close()
+        logger.debug("Stopped")
+
+        # if there was an active processor, it should be shut down and unset
+        # when the partitions are revoked during consumer close
+        assert self.__processor is None, "processor was not closed on shutdown"

--- a/snuba/utils/streams/processing.py
+++ b/snuba/utils/streams/processing.py
@@ -18,14 +18,6 @@ from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 logger = logging.getLogger(__name__)
 
 
-class ProcessingStrategyFactory(ABC, Generic[TPayload]):
-    @abstractmethod
-    def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
-    ) -> ProcessingStrategy[TPayload]:
-        raise NotImplementedError
-
-
 class ProcessingStrategy(ABC, Generic[TPayload]):
     @abstractmethod
     def process(self, message: Optional[Message[TPayload]]) -> None:
@@ -33,6 +25,14 @@ class ProcessingStrategy(ABC, Generic[TPayload]):
 
     @abstractmethod
     def close(self) -> None:
+        raise NotImplementedError
+
+
+class ProcessingStrategyFactory(ABC, Generic[TPayload]):
+    @abstractmethod
+    def create(
+        self, commit: Callable[[Mapping[Partition, int]], None]
+    ) -> ProcessingStrategy[TPayload]:
         raise NotImplementedError
 
 

--- a/snuba/utils/streams/processing.py
+++ b/snuba/utils/streams/processing.py
@@ -18,7 +18,7 @@ from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 logger = logging.getLogger(__name__)
 
 
-class ProcessorFactory(ABC, Generic[TPayload]):
+class ProcessingStrategyFactory(ABC, Generic[TPayload]):
     @abstractmethod
     def create(
         self, commit: Callable[[Mapping[Partition, int]], None]
@@ -41,7 +41,7 @@ class StreamProcessor(Generic[TPayload]):
         self,
         consumer: Consumer[TPayload],
         topic: Topic,
-        processor_factory: ProcessorFactory[TPayload],
+        processor_factory: ProcessingStrategyFactory[TPayload],
         recoverable_errors: Optional[Sequence[Type[ConsumerError]]] = None,
     ) -> None:
         self.__consumer = consumer

--- a/snuba/utils/streams/processing.py
+++ b/snuba/utils/streams/processing.py
@@ -36,7 +36,7 @@ class Processor(ABC, Generic[TPayload]):
         raise NotImplementedError
 
 
-class BatchingConsumer(Generic[TPayload]):
+class StreamProcessor(Generic[TPayload]):
     """The `BatchingConsumer` is an abstraction over the abstract Consumer's main event
     loop. For this reason it uses inversion of control: the user provides an implementation
     for the `AbstractBatchWorker` and then the `BatchingConsumer` handles the rest.

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -34,8 +34,8 @@ class BatchWriterEncoderWrapper(BatchWriter[TDecoded]):
 class BufferedWriterWrapper:
     """
     This is a wrapper that adds a buffer around a BatchWriter.
-    When consuming data from Kafka, the buffering logic is performed by the
-    batching consumer.
+    When consuming data from Kafka, the buffering logic is generally
+    performed by the batch processor.
     This is for the use cases that are not Kafka related.
 
     This is not thread safe. Don't try to do parallel flush hoping in the GIL.

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -4,12 +4,9 @@ from typing import Any, MutableSequence, Sequence
 from unittest.mock import patch
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.batching import (
-    AbstractBatchWorker,
-    BatchingConsumer,
-    BatchProcessorFactory,
-)
+from snuba.utils.streams.batching import AbstractBatchWorker, BatchProcessorFactory
 from snuba.utils.streams.dummy import DummyBroker
+from snuba.utils.streams.processing import BatchingConsumer
 from snuba.utils.streams.types import Message, Topic
 
 

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams.batching import AbstractBatchWorker, BatchProcessorFactory
 from snuba.utils.streams.dummy import DummyBroker
-from snuba.utils.streams.processing import BatchingConsumer
+from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.streams.types import Message, Topic
 
 
@@ -34,7 +34,7 @@ class TestConsumer(object):
         consumer = broker.get_consumer("group")
 
         worker = FakeWorker()
-        batching_consumer = BatchingConsumer(
+        batching_consumer = StreamProcessor(
             consumer,
             topic,
             BatchProcessorFactory(
@@ -63,7 +63,7 @@ class TestConsumer(object):
         consumer = broker.get_consumer("group")
 
         worker = FakeWorker()
-        batching_consumer = BatchingConsumer(
+        batching_consumer = StreamProcessor(
             consumer,
             topic,
             BatchProcessorFactory(

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -41,7 +41,6 @@ class TestConsumer(object):
             consumer,
             topic,
             BatchProcessorFactory(
-                consumer,
                 worker=worker,
                 max_batch_size=2,
                 max_batch_time=100,
@@ -71,7 +70,6 @@ class TestConsumer(object):
             consumer,
             topic,
             BatchProcessorFactory(
-                consumer,
                 worker=worker,
                 max_batch_size=100,
                 max_batch_time=2000,

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -4,7 +4,10 @@ from typing import Any, MutableSequence, Sequence
 from unittest.mock import patch
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.batching import AbstractBatchWorker, BatchProcessorFactory
+from snuba.utils.streams.batching import (
+    AbstractBatchWorker,
+    BatchProcessingStrategyFactory,
+)
 from snuba.utils.streams.dummy import DummyBroker
 from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.streams.types import Message, Topic
@@ -37,7 +40,7 @@ class TestConsumer(object):
         batching_consumer = StreamProcessor(
             consumer,
             topic,
-            BatchProcessorFactory(
+            BatchProcessingStrategyFactory(
                 worker=worker,
                 max_batch_size=2,
                 max_batch_time=100,
@@ -66,7 +69,7 @@ class TestConsumer(object):
         batching_consumer = StreamProcessor(
             consumer,
             topic,
-            BatchProcessorFactory(
+            BatchProcessingStrategyFactory(
                 worker=worker,
                 max_batch_size=100,
                 max_batch_time=2000,

--- a/tests/utils/streams/test_batching.py
+++ b/tests/utils/streams/test_batching.py
@@ -1,14 +1,14 @@
 import time
 from datetime import datetime
-from typing import (
-    Any,
-    MutableSequence,
-    Sequence,
-)
+from typing import Any, MutableSequence, Sequence
 from unittest.mock import patch
 
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.utils.streams.batching import AbstractBatchWorker, BatchingConsumer
+from snuba.utils.streams.batching import (
+    AbstractBatchWorker,
+    BatchingConsumer,
+    BatchProcessorFactory,
+)
 from snuba.utils.streams.dummy import DummyBroker
 from snuba.utils.streams.types import Message, Topic
 
@@ -40,10 +40,13 @@ class TestConsumer(object):
         batching_consumer = BatchingConsumer(
             consumer,
             topic,
-            worker=worker,
-            max_batch_size=2,
-            max_batch_time=100,
-            metrics=DummyMetricsBackend(strict=True),
+            BatchProcessorFactory(
+                consumer,
+                worker=worker,
+                max_batch_size=2,
+                max_batch_time=100,
+                metrics=DummyMetricsBackend(strict=True),
+            ),
         )
 
         for _ in range(3):
@@ -67,10 +70,13 @@ class TestConsumer(object):
         batching_consumer = BatchingConsumer(
             consumer,
             topic,
-            worker=worker,
-            max_batch_size=100,
-            max_batch_time=2000,
-            metrics=DummyMetricsBackend(strict=True),
+            BatchProcessorFactory(
+                consumer,
+                worker=worker,
+                max_batch_size=100,
+                max_batch_time=2000,
+                metrics=DummyMetricsBackend(strict=True),
+            ),
         )
 
         mock_time.return_value = time.mktime(datetime(2018, 1, 1, 0, 0, 0).timetuple())

--- a/tests/utils/streams/test_processing.py
+++ b/tests/utils/streams/test_processing.py
@@ -1,0 +1,68 @@
+from datetime import datetime
+from unittest import mock
+
+import pytest
+
+from snuba.utils.streams.processing import InvalidStateError, StreamProcessor
+from snuba.utils.streams.types import Message, Partition, Topic
+from tests.assertions import assert_changes
+
+
+def test_stream_processor_lifecycle() -> None:
+    topic = Topic("topic")
+
+    consumer = mock.Mock()
+    strategy = mock.Mock()
+    factory = mock.Mock()
+    factory.create.return_value = strategy
+
+    with assert_changes(lambda: consumer.subscribe.call_count, 0, 1):
+        processor: StreamProcessor[int] = StreamProcessor(consumer, topic, factory)
+
+    # The processor should accept heartbeat messages without an assignment or
+    # active processor.
+    consumer.poll.return_value = None
+    processor._run_once()
+
+    # The processor should not accept non-heartbeat messages without an
+    # assignment or active processor.
+    message = Message(Partition(topic, 0), 0, 0, datetime.now())
+    consumer.poll.return_value = message
+    with pytest.raises(InvalidStateError):
+        processor._run_once()
+
+    # XXX: ``call().args``, ``call().kwargs`` are not available until 3.8
+    subscribe_args, subscribe_kwargs = consumer.subscribe.call_args
+    assert subscribe_args[0] == [topic]
+
+    assignment_callback = subscribe_kwargs["on_assign"]
+    revocation_callback = subscribe_kwargs["on_revoke"]
+
+    # Assignment should succeed if no assignment already exxists.
+    assignment_callback({Partition(topic, 0): 0})
+
+    with assert_changes(lambda: strategy.process.call_count, 0, 1):
+        consumer.poll.return_value = None
+        processor._run_once()
+        assert strategy.process.call_args_list[-1] == mock.call(None)
+
+    with assert_changes(lambda: strategy.process.call_count, 1, 2):
+        consumer.poll.return_value = message
+        processor._run_once()
+        assert strategy.process.call_args_list[-1] == mock.call(message)
+
+    # Assignment should fail if one already exists.
+    with pytest.raises(InvalidStateError):
+        assignment_callback({Partition(topic, 0): 0})
+
+    # Revocation should succeed with an active assignment, and cause the
+    # strategy instance to be closed.
+    with assert_changes(lambda: strategy.close.call_count, 0, 1):
+        revocation_callback([Partition(topic, 0)])
+
+    # Revocation should fail without an active assignment.
+    with pytest.raises(InvalidStateError):
+        revocation_callback([Partition(topic, 0)])
+
+    with assert_changes(lambda: consumer.close.call_count, 0, 1):
+        processor._shutdown()


### PR DESCRIPTION
This extracts the remaining non-batching stream processing behavior out of the existing `streams.batching` module. Specifically, this change:

1. Moves non-batching code from `utils.streams.batching` into `utils.streams.processing`
2. Introduces `Processor` and `ProcessorFactory` abstract base classes
3. Removes the remaining aspects of `BatchingConsumer` that were coupled to batch processing, and renames it `StreamProcessor`
4. Updates documentation and types in several places to reflect the updated structure