### PR TITLE
ref(storage-schemas): Remove get_drop_statements method

### DIFF
--- a/snuba/datasets/dataset_schemas.py
+++ b/snuba/datasets/dataset_schemas.py
@@ -48,10 +48,3 @@ class StorageSchemas(object):
             for schema in self.get_unique_schemas()
             if isinstance(schema, TableSchema)
         ]
-
-    def get_drop_statements(self) -> Sequence[DDLStatement]:
-        return [
-            schema.get_local_drop_table_statement()
-            for schema in self.get_unique_schemas()
-            if isinstance(schema, TableSchema)
-        ]

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -137,12 +137,6 @@ class TableSchemaWithDDL(TableSchema, ABC):
         # the current schema and the CREATE statement for a storage are separate.
         self.__skipped_cols_on_creation = skipped_cols_on_creation or set()
 
-    def get_local_drop_table_statement(self) -> DDLStatement:
-        return DDLStatement(
-            self.get_local_table_name(),
-            "DROP TABLE IF EXISTS %s" % self.get_local_table_name(),
-        )
-
     def _get_columnset_to_create(self) -> ColumnSet:
         """
         Returns the ColumnSet to be created.

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -92,7 +92,7 @@ def check_clickhouse() -> bool:
         return False
 
 
-def drop_dataset(dataset: Dataset) -> None:
+def truncate_dataset(dataset: Dataset) -> None:
     for storage in dataset.get_all_storages():
         cluster = storage.get_cluster()
         clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
@@ -106,8 +106,6 @@ def drop_dataset(dataset: Dataset) -> None:
 
         for table in tables_to_empty:
             clickhouse.execute(f"TRUNCATE TABLE IF EXISTS {database}.{table}")
-
-    redis_client.flushdb()
 
 
 application = Flask(__name__, static_url_path="")
@@ -480,7 +478,9 @@ if application.debug or application.testing:
 
     @application.route("/tests/<dataset:dataset>/drop", methods=["POST"])
     def drop(*, dataset: Dataset) -> Tuple[str, int, Mapping[str, str]]:
-        drop_dataset(dataset)
+        truncate_dataset(dataset)
+        redis_client.flushdb()
+
         return ("ok", 200, {"Content-Type": "text/plain"})
 
     @application.route("/tests/error")

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -92,6 +92,24 @@ def check_clickhouse() -> bool:
         return False
 
 
+def drop_dataset(dataset: Dataset) -> None:
+    for storage in dataset.get_all_storages():
+        cluster = storage.get_cluster()
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+        database = cluster.get_database()
+
+        tables_to_empty = {
+            schema.get_local_table_name()
+            for schema in storage.get_schemas().get_unique_schemas()
+            if isinstance(schema, TableSchema)
+        }
+
+        for table in tables_to_empty:
+            clickhouse.execute(f"TRUNCATE TABLE IF EXISTS {database}.{table}")
+
+    redis_client.flushdb()
+
+
 application = Flask(__name__, static_url_path="")
 application.testing = settings.TESTING
 application.debug = settings.DEBUG
@@ -462,21 +480,7 @@ if application.debug or application.testing:
 
     @application.route("/tests/<dataset:dataset>/drop", methods=["POST"])
     def drop(*, dataset: Dataset) -> Tuple[str, int, Mapping[str, str]]:
-        for storage in dataset.get_all_storages():
-            cluster = storage.get_cluster()
-            clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
-            database = cluster.get_database()
-
-            tables_to_empty = {
-                schema.get_local_table_name()
-                for schema in storage.get_schemas().get_unique_schemas()
-                if isinstance(schema, TableSchema)
-            }
-
-            for table in tables_to_empty:
-                clickhouse.execute(f"TRUNCATE TABLE IF EXISTS {database}.{table}")
-
-        redis_client.flushdb()
+        drop_dataset(dataset)
         return ("ok", 200, {"Content-Type": "text/plain"})
 
     @application.route("/tests/error")

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,16 +22,16 @@ from tests.fixtures import raw_event
 @contextmanager
 def dataset_manager(name: str) -> Iterator[Dataset]:
     from snuba.migrations.migrate import run
-    from snuba.web.views import drop_dataset
+    from snuba.web.views import truncate_dataset
 
     dataset = get_dataset(name)
     run()
-    drop_dataset(dataset)
+    truncate_dataset(dataset)
 
     try:
         yield dataset
     finally:
-        drop_dataset(dataset)
+        truncate_dataset(dataset)
 
 
 class BaseTest(object):


### PR DESCRIPTION
We should truncate the relevant tables instead of dropping them entirely
in tests. This simplifies StorageSchemas a bit and removes the need to
selectively migrate back certain tables later.