### PR TITLE
Rollout api.organization-event-stats.find-topn

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -118,6 +118,8 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
         "api.organization-event-stats.key-transactions": 100,
         "discover.key_transactions": 100,
         "api.performance.latencychart": 100,
+        # Main view
+        "api.organization-event-stats.find-topn": 100,
     },
 }  # (dataset name: (referrer: percentage))
 


### PR DESCRIPTION
This query is displays the topn results in the discover main chart. It is a relatively small volume query, but that starts introducing the complex discover filtering (without adding too complex group by).