### PR TITLE
feat(ast) Rollout tag facet queries on discover

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -121,6 +121,7 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
         # Main view
         "api.organization-event-stats.find-topn": 100,
         "tagstore.get_tag_value_paginator_for_projects": 100,
+        "api.organization-events-facets.top-tags": 100,
     },
 }  # (dataset name: (referrer: percentage))
 


### PR DESCRIPTION
This rolls out the query used by discover to build the tag facet.
It has lower volume than the other discover queries, it involves complex custom conditions tested with api.organization-event-stats.find-topn and relatively simple selects. 
All the tag unpacking logic has been already extensively tested and used in prod on the events dataset.