### PR TITLE
ref(metrics): Avoid race condition in concurrent gauge tests

### DIFF
--- a/tests/utils/metrics/test_gauge.py
+++ b/tests/utils/metrics/test_gauge.py
@@ -1,3 +1,5 @@
+import random
+import time
 from concurrent.futures import wait
 from threading import Event
 from snuba.utils.concurrent import execute
@@ -32,6 +34,7 @@ def test_gauge_concurrent() -> None:
     event = Event()
 
     def waiter() -> None:
+        time.sleep(random.random() * 3)
         with gauge:
             event.wait()
 

--- a/tests/utils/metrics/test_gauge.py
+++ b/tests/utils/metrics/test_gauge.py
@@ -1,5 +1,3 @@
-import random
-import time
 from concurrent.futures import wait
 from threading import Barrier, Event
 from snuba.utils.concurrent import execute
@@ -36,7 +34,6 @@ def test_gauge_concurrent() -> None:
     event = Event()
 
     def waiter() -> None:
-        time.sleep(random.random() * 3)
         with gauge:
             barrier.wait()
             event.wait()


### PR DESCRIPTION
This test relied on an incorrect assumption that all threads would enter the gauge context manager before being blocked until the event is set. This turns that assumption into a guarantee using a barrier.