### PR TITLE
feat(migrations): Add unsharded option to MergeTree tables

### DIFF
--- a/snuba/migrations/snuba_migrations/events/0001_events_initial.py
+++ b/snuba/migrations/snuba_migrations/events/0001_events_initial.py
@@ -126,6 +126,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="sentry_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
+                    storage_set=StorageSetKey.EVENTS,
                     version_column="deleted",
                     order_by="(project_id, toStartOfDay(timestamp), %s)" % sample_expr,
                     partition_by="(toMonday(timestamp), if(equals(retention_days, 30), 30, 90))",

--- a/snuba/migrations/snuba_migrations/events/0003_errors.py
+++ b/snuba/migrations/snuba_migrations/events/0003_errors.py
@@ -112,6 +112,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="errors_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
+                    storage_set=StorageSetKey.EVENTS,
                     version_column="deleted",
                     order_by="(org_id, project_id, toStartOfDay(timestamp), primary_hash_hex, event_hash)",
                     partition_by="(toMonday(timestamp), if(retention_days = 30, 30, 90))",

--- a/snuba/migrations/snuba_migrations/outcomes/0001_outcomes.py
+++ b/snuba/migrations/snuba_migrations/outcomes/0001_outcomes.py
@@ -53,6 +53,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="outcomes_raw_local",
                 columns=raw_columns,
                 engine=table_engines.MergeTree(
+                    storage_set=StorageSetKey.OUTCOMES,
                     order_by="(org_id, project_id, timestamp)",
                     partition_by="(toMonday(timestamp))",
                     settings={"index_granularity": "16384"},
@@ -63,6 +64,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="outcomes_hourly_local",
                 columns=hourly_columns,
                 engine=table_engines.SummingMergeTree(
+                    storage_set=StorageSetKey.OUTCOMES,
                     order_by="(org_id, project_id, key_id, outcome, reason, timestamp)",
                     partition_by="(toMonday(timestamp))",
                     settings={"index_granularity": "256"},

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -63,6 +63,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="querylog_local",
                 columns=columns,
                 engine=table_engines.MergeTree(
+                    storage_set=StorageSetKey.QUERYLOG,
                     order_by="(toStartOfDay(timestamp), request_id)",
                     partition_by="(toMonday(timestamp))",
                     sample_by="request_id",

--- a/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
+++ b/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
@@ -62,6 +62,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="sessions_raw_local",
                 columns=raw_columns,
                 engine=table_engines.MergeTree(
+                    storage_set=StorageSetKey.SESSIONS,
                     order_by="(org_id, project_id, release, environment, started)",
                     partition_by="(toMonday(started))",
                     settings={"index_granularity": "16384"},
@@ -72,6 +73,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="sessions_hourly_local",
                 columns=aggregate_columns,
                 engine=table_engines.AggregatingMergeTree(
+                    storage_set=StorageSetKey.SESSIONS,
                     order_by="(org_id, project_id, release, environment, started)",
                     partition_by="(toMonday(started))",
                     settings={"index_granularity": "256"},

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -35,7 +35,9 @@ class Migration(migration.Migration):
                 table_name="migrations_local",
                 columns=columns,
                 engine=ReplacingMergeTree(
-                    version_column="version", order_by="(group, migration_id)"
+                    storage_set=StorageSetKey.MIGRATIONS,
+                    version_column="version",
+                    order_by="(group, migration_id)",
                 ),
             ),
         ]

--- a/snuba/migrations/snuba_migrations/transactions/0001_transactions.py
+++ b/snuba/migrations/snuba_migrations/transactions/0001_transactions.py
@@ -70,6 +70,7 @@ class Migration(migration.MultiStepMigration):
                 table_name="transactions_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
+                    storage_set=StorageSetKey.TRANSACTIONS,
                     version_column="deleted",
                     order_by="(project_id, toStartOfDay(finish_ts), transaction_name, cityHash64(span_id))",
                     partition_by="(retention_days, toMonday(finish_ts))",

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from typing import Mapping, Optional
 
 from snuba.clusters.cluster import ClickhouseCluster
+from snuba.clusters.storage_sets import StorageSetKey
 
 
 class TableEngine(ABC):
@@ -25,23 +26,29 @@ class MergeTree(TableEngine):
     If the operation is being performed on a cluster marked as multi node, the
     replicated versions of the tables will be created instead of the regular ones.
 
-    The layer, shard and replica values will be taken from the macros configuration
-    for multi node clusters, so these need to be set prior to running the migration.
+    The shard and replica values will be taken from the macros configuration for
+    multi node clusters, so these need to be set prior to running the migration.
+
+    If unsharded=True is passed, data will be replicated on every shard of the cluster.
     """
 
     def __init__(
         self,
+        storage_set: StorageSetKey,
         order_by: str,
         partition_by: Optional[str] = None,
         sample_by: Optional[str] = None,
         ttl: Optional[str] = None,
         settings: Optional[Mapping[str, str]] = None,
+        unsharded: bool = False,
     ) -> None:
+        self._storage_set_value = storage_set.value
         self.__order_by = order_by
         self.__partition_by = partition_by
         self.__sample_by = sample_by
         self.__ttl = ttl
         self.__settings = settings
+        self._unsharded = unsharded
 
     def get_sql(self, cluster: ClickhouseCluster, table_name: str) -> str:
         sql = f"{self._get_engine_type(cluster, table_name)} ORDER BY {self.__order_by}"
@@ -64,44 +71,56 @@ class MergeTree(TableEngine):
     def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
         if cluster.is_single_node():
             return "MergeTree()"
+        elif self._unsharded is True:
+            return f"ReplicatedMergeTree('/clickhouse/tables/{self._storage_set_value}/all/{table_name}', '{{replica}}')"
         else:
-            return f"ReplicatedMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}')"
+            return f"ReplicatedMergeTree('/clickhouse/tables/{self._storage_set_value}/{{shard}}/{table_name}', '{{replica}}')"
 
 
 class ReplacingMergeTree(MergeTree):
     def __init__(
         self,
+        storage_set: StorageSetKey,
         version_column: str,
         order_by: str,
         partition_by: Optional[str] = None,
         sample_by: Optional[str] = None,
         ttl: Optional[str] = None,
         settings: Optional[Mapping[str, str]] = None,
+        unsharded: bool = False,
     ) -> None:
-        super().__init__(order_by, partition_by, sample_by, ttl, settings)
+        super().__init__(
+            storage_set, order_by, partition_by, sample_by, ttl, settings, unsharded
+        )
         self.__version_column = version_column
 
     def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
         if cluster.is_single_node():
             return f"ReplacingMergeTree({self.__version_column})"
+        elif self._unsharded is True:
+            return f"ReplicatedReplacingMergeTree('/clickhouse/tables/{self._storage_set_value}/all/{table_name}', '{{replica}}', {self.__version_column})"
         else:
-            return f"ReplicatedReplacingMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}', {self.__version_column})"
+            return f"ReplicatedReplacingMergeTree('/clickhouse/tables/{self._storage_set_value}/{{shard}}/{table_name}', '{{replica}}', {self.__version_column})"
 
 
 class SummingMergeTree(MergeTree):
     def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
         if cluster.is_single_node():
             return f"SummingMergeTree()"
+        elif self._unsharded is True:
+            return f"SummingMergeTree('/clickhouse/tables/{self._storage_set_value}/all/{table_name}', '{{replica}}')"
         else:
-            return f"ReplicatedSummingMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}')"
+            return f"ReplicatedSummingMergeTree('/clickhouse/tables/{self._storage_set_value}/{{shard}}/{table_name}', '{{replica}}')"
 
 
 class AggregatingMergeTree(MergeTree):
     def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
         if cluster.is_single_node():
             return f"AggregatingMergeTree()"
+        elif self._unsharded is True:
+            return f"ReplicatedAggregatingMergeTree('/clickhouse/tables/{self._storage_set_value}/all/{table_name}', '{{replica}}')"
         else:
-            return f"ReplicatedAggregatingMergeTree('/clickhouse/tables/{{layer}}-{{shard}})/{table_name}', '{{replica}}')"
+            return f"ReplicatedAggregatingMergeTree('/clickhouse/tables/{self._storage_set_value}/{{shard}}/{table_name}', '{{replica}}')"
 
 
 class Distributed(TableEngine):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -27,6 +27,7 @@ def test_create_table() -> None:
             "test_table",
             columns,
             ReplacingMergeTree(
+                storage_set=StorageSetKey.EVENTS,
                 version_column="version",
                 order_by="version",
                 settings={"index_granularity": "256"},


### PR DESCRIPTION
Add an unsharded option for merge tree tables that replicates the same
table across all shards of a cluster instead of actually sharding the
table. This will be needed for the grouped message and group assignee
tables.

Updates the path to use the storage set name instead of requiring the
user to provide a "layer" macro. Also updates the format of the path
to make it more readable in Zookeeper.

This is not quite the format we have in prod on our existing tables.
Since our previously defined paths cannot be changed, we will need to
add some escape hatch where we can override these with our actual path
values later.