### PR TITLE
ref(joins): Joined storages do not have a storage key

### DIFF
--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -37,13 +37,10 @@ from snuba.util import qualified_column
 
 class JoinedStorage(ReadableStorage):
     def __init__(
-        self,
-        storage_key: StorageKey,
-        storage_set_key: StorageSetKey,
-        join_structure: JoinClause,
+        self, storage_set_key: StorageSetKey, join_structure: JoinClause,
     ) -> None:
         self.__structure = join_structure
-        super().__init__(storage_key, storage_set_key, JoinedSchema(self.__structure))
+        super().__init__(storage_set_key, JoinedSchema(self.__structure))
 
     def get_table_writer(self) -> Optional[TableWriter]:
         return None
@@ -133,7 +130,7 @@ class Groups(TimeSeriesDataset):
         )
 
         schema = JoinedSchema(join_structure)
-        storage = JoinedStorage(StorageKey.GROUPS, StorageSetKey.EVENTS, join_structure)
+        storage = JoinedStorage(StorageSetKey.EVENTS, join_structure)
         self.__time_group_columns = {"events.time": "events.timestamp"}
         super().__init__(
             storages=[storage],

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -31,15 +31,9 @@ class Storage(ABC):
     for more useful abstractions.
     """
 
-    def __init__(
-        self, storage_key: StorageKey, storage_set_key: StorageSetKey, schema: Schema
-    ):
-        self.__storage_key = storage_key
+    def __init__(self, storage_set_key: StorageSetKey, schema: Schema):
         self.__storage_set_key = storage_set_key
         self.__schema = schema
-
-    def get_storage_key(self) -> StorageKey:
-        return self.__storage_key
 
     def get_storage_set_key(self) -> StorageSetKey:
         return self.__storage_set_key
@@ -110,9 +104,13 @@ class ReadableTableStorage(ReadableStorage):
         query_processors: Optional[Sequence[QueryProcessor]] = None,
         query_splitters: Optional[Sequence[QuerySplitStrategy]] = None,
     ) -> None:
+        self.__storage_key = storage_key
         self.__query_processors = query_processors or []
         self.__query_splitters = query_splitters or []
-        super().__init__(storage_key, storage_set_key, schema)
+        super().__init__(storage_set_key, schema)
+
+    def get_storage_key(self) -> StorageKey:
+        return self.__storage_key
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return self.__query_processors

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -17,5 +17,3 @@ class StorageKey(Enum):
     SESSIONS_RAW = "sessions_raw"
     SESSIONS_HOURLY = "sessions_hourly"
     TRANSACTIONS = "transactions"
-    # TODO: Remove once joins are no longer storages
-    GROUPS = "group"


### PR DESCRIPTION
Joined storages should not have a storage key (and possibly shouldn't be
considered a storage at all).