### PR TITLE
ci: upgrade clickhouse 19.11 -> 19.17.4.11

### DIFF
--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -46,7 +46,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
       KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
   clickhouse:
-    image: 'yandex/clickhouse-server:19.11'
+    image: 'yandex/clickhouse-server:19.17.4.11'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test
   clickhouse:
-    image: yandex/clickhouse-server:19.11
+    image: yandex/clickhouse-server:19.17.4.11
     ports:
       - "9000:9000"
       - "9009:9009"


### PR DESCRIPTION
Sentry's had this new version in dev env for [a while now](https://github.com/getsentry/sentry/pull/18988).

In fact following the discussion [here](https://github.com/getsentry/getsentry/pull/4273#discussion_r461812685), clickhouse is due for another upgrade across sentry + snuba CI soon, once sentry prod settles the upgrade.