### PR TITLE
feat(migrations): Add support for optional migration groups

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -18,8 +18,6 @@ class MigrationGroup(Enum):
 
 # Migration groups are mandatory by default, unless they are on this list
 OPTIONAL_GROUPS = {
-    MigrationGroup.TRANSACTIONS,
-    MigrationGroup.OUTCOMES,
     MigrationGroup.SESSIONS,
     MigrationGroup.QUERYLOG,
 }

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -3,6 +3,7 @@ from enum import Enum
 from importlib import import_module
 from typing import Sequence
 
+from snuba import settings
 from snuba.migrations.migration import Migration
 
 
@@ -13,6 +14,23 @@ class MigrationGroup(Enum):
     OUTCOMES = "outcomes"
     SESSIONS = "sessions"
     QUERYLOG = "querylog"
+
+
+# Migration groups are mandatory by default, unless they are on this list
+OPTIONAL_GROUPS = {
+    MigrationGroup.TRANSACTIONS,
+    MigrationGroup.OUTCOMES,
+    MigrationGroup.SESSIONS,
+    MigrationGroup.QUERYLOG,
+}
+
+ACTIVE_MIGRATION_GROUPS = [
+    group
+    for group in MigrationGroup
+    if not (
+        group in OPTIONAL_GROUPS and group.value in settings.SKIPPED_MIGRATION_GROUPS
+    )
+]
 
 
 class GroupLoader(ABC):

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -10,7 +10,11 @@ from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster, CLUSTE
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.context import Context
 from snuba.migrations.errors import InvalidMigrationState, MigrationInProgress
-from snuba.migrations.groups import get_group_loader, MigrationGroup
+from snuba.migrations.groups import (
+    ACTIVE_MIGRATION_GROUPS,
+    get_group_loader,
+    MigrationGroup,
+)
 from snuba.migrations.status import Status
 
 logger = logging.getLogger("snuba.migrations")
@@ -48,7 +52,7 @@ class Runner:
         def get_status(migration_key: MigrationKey) -> Status:
             return migration_status.get(migration_key, Status.NOT_STARTED)
 
-        for group in MigrationGroup:
+        for group in ACTIVE_MIGRATION_GROUPS:
             group_loader = get_group_loader(group)
             group_migrations: List[MigrationKey] = []
 

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -129,6 +129,9 @@ AST_REFERRER_ROLLOUT: Mapping[str, Mapping[Optional[str], int]] = {
 COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 
+# Migrations in skipped groups will not be run
+SKIPPED_MIGRATION_GROUPS: Set[str] = {"querylog"}
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/settings_test.py
+++ b/snuba/settings_test.py
@@ -1,4 +1,5 @@
 import os
+from typing import Set
 
 TESTING = True
 
@@ -10,3 +11,5 @@ RECORD_QUERIES = True
 USE_RESULT_CACHE = True
 
 SENTRY_DSN = os.getenv("SENTRY_DSN")
+
+SKIPPED_MIGRATION_GROUPS: Set[str] = set()

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -1,3 +1,6 @@
+import importlib
+from unittest.mock import patch
+
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.consumer import KafkaMessageMetadata
@@ -11,11 +14,16 @@ from snuba.migrations.status import Status
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 
 
-def setup_function() -> None:
+def teardown_function() -> None:
     connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
         ClickhouseClientSettings.MIGRATE
     )
-    for table in ["migrations_local", "sentry_local", "transactions_local"]:
+    for table in [
+        "migrations_local",
+        "sentry_local",
+        "transactions_local",
+        "querylog_local",
+    ]:
         connection.execute(f"DROP TABLE IF EXISTS {table};")
 
 
@@ -225,3 +233,17 @@ def generate_transactions(count: int) -> None:
         rows.extend(processed.rows)
 
     table_writer.get_writer(metrics=DummyMetricsBackend(strict=True)).write(rows)
+
+
+def test_settings_skipped_group() -> None:
+    from snuba.migrations import groups, runner
+
+    with patch("snuba.settings.SKIPPED_MIGRATION_GROUPS", {"querylog"}):
+        importlib.reload(groups)
+        importlib.reload(runner)
+        runner.Runner().run_all()
+
+    connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
+        ClickhouseClientSettings.MIGRATE
+    )
+    assert connection.execute("SHOW TABLES LIKE 'querylog_local'") == []


### PR DESCRIPTION
Allows migration groups to be marked as optional and disabled via
settings.

The migration groups that are currently allowed to be optional are:
transactions, outcomes, sessions and querylog.

Only querylog is turned off by default.