### PR TITLE
fix(hackweek): Use the correct event Typed Dict in event processor base.

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -46,7 +46,7 @@ class ErrorsProcessor(EventsProcessorBase):
         metadata: KafkaMessageMetadata,
     ) -> None:
         data = event.get("data", {})
-        user_dict = data.get("user", data.get("user", None)) or {}
+        user_dict = data.get("user", data.get("sentry.interfaces.User", None)) or {}
         user_data: MutableMapping[str, Any] = {}
         extract_user(user_data, user_dict)
         output["user_name"] = user_data["username"]

--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -46,8 +46,7 @@ class ErrorsProcessor(EventsProcessorBase):
         metadata: KafkaMessageMetadata,
     ) -> None:
         data = event.get("data", {})
-        user_dict = data.get("user", data.get("sentry.interfaces.User", None)) or {}
-
+        user_dict = data.get("user", data.get("user", None)) or {}
         user_data: MutableMapping[str, Any] = {}
         extract_user(user_data, user_dict)
         output["user_name"] = user_data["username"]


### PR DESCRIPTION
When I merged master I forgot to remove the duplicate Event type. Now there is only one and it has the right structure.