### PR TITLE
feat(hackweek) Pick the jsonschma from the new schema repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ install-python-dependencies:
 
 fetchschemas:
 	mkdir -p schema
-	curl https://getsentry.github.io/relay/event-schema/event.schema.json -o schema/event.schema.json
+	curl https://raw.githubusercontent.com/getsentry/sentry-data-schemas/main/relay/event.schema.json -o schema/event.schema.json
 .PHONY: fetchschemas


### PR DESCRIPTION
We now have a repo for schemas: https://github.com/getsentry/sentry-data-schemas.
This is still not a really scalable solution, but at least we can do versioning since we can pin the version of the schema we want when we will tag releases.

Still it would require some manual work to test schema changes locally.