### PR TITLE
chore: clickhouse upgrade 19.17.4.11 -> 20.3.9.70

### DIFF
--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -46,7 +46,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
       KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
   clickhouse:
-    image: 'yandex/clickhouse-server:19.17.4.11'
+    image: 'yandex/clickhouse-server:20.3.9.70'
     ulimits:
       nofile:
         soft: 262144

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test
   clickhouse:
-    image: yandex/clickhouse-server:19.17.4.11
+    image: yandex/clickhouse-server:20.3.9.70
     ports:
       - "9000:9000"
       - "9009:9009"


### PR DESCRIPTION
Follow up to https://github.com/getsentry/snuba/pull/1188.
