### PR TITLE
ref(migrations): Remove table migration in test endpoints

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -394,24 +394,9 @@ if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
 
-    _ensured = False
-
-    def ensure_tables_migrated() -> None:
-        global _ensured
-        if _ensured:
-            return
-
-        from snuba.migrations import migrate
-
-        migrate.run()
-
-        _ensured = True
-
     @application.route("/tests/<dataset:dataset>/insert", methods=["POST"])
     def write(*, dataset: Dataset):
         from snuba.processor import InsertBatch
-
-        ensure_tables_migrated()
 
         rows: MutableSequence[WriterTableRow] = []
         offset_base = int(round(time.time() * 1000))
@@ -438,7 +423,6 @@ if application.debug or application.testing:
 
     @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])
     def eventstream(*, dataset: Dataset):
-        ensure_tables_migrated()
         record = json.loads(http_request.data)
 
         version = record[0]
@@ -483,9 +467,3 @@ if application.debug or application.testing:
     @application.route("/tests/error")
     def error():
         1 / 0
-
-
-else:
-
-    def ensure_tables_migrated() -> None:
-        pass


### PR DESCRIPTION
We no longer need to rely on table migration in our test endpoints since
migrations should be performed before Sentry tests run, and we are no longer
dropping tables between every test.