### PR TITLE
ref(streams): Enable pickling `Message` and `KafkaPayload` instances

### DIFF
--- a/snuba/utils/streams/types.py
+++ b/snuba/utils/streams/types.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from typing import Generic, TypeVar
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(order=True, unsafe_hash=True)
 class Topic:
     __slots__ = ["name"]
 
@@ -15,7 +15,7 @@ class Topic:
         return partition.topic == self
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(order=True, unsafe_hash=True)
 class Partition:
     __slots__ = ["topic", "index"]
 
@@ -26,7 +26,7 @@ class Partition:
 TPayload = TypeVar("TPayload")
 
 
-@dataclass(frozen=True)
+@dataclass(unsafe_hash=True)
 class Message(Generic[TPayload]):
     """
     Represents a single message within a partition.
@@ -40,9 +40,11 @@ class Message(Generic[TPayload]):
     timestamp: datetime
 
     def __repr__(self) -> str:
-        return (
-            f"{type(self).__name__}(partition={self.partition}, offset={self.offset})"
-        )
+        # XXX: Field values can't be excluded from ``__repr__`` with
+        # ``dataclasses.field(repr=False)`` as this class is defined with
+        # ``__slots__`` for performance reasons. The class variable names
+        # would conflict with the instance slot names, causing an error.
+        return f"{type(self).__name__}(partition={self.partition!r}, offset={self.offset!r})"
 
     def get_next_offset(self) -> int:
         return self.offset + 1

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -1,10 +1,12 @@
 import contextlib
 import itertools
+import sys
 import uuid
 from contextlib import closing
-from typing import Iterator, Optional
+from typing import Iterator, MutableSequence, Optional
 from unittest import TestCase
 
+import pickle
 import pytest
 from confluent_kafka.admin import AdminClient, NewTopic
 
@@ -17,10 +19,10 @@ from snuba.utils.streams.kafka import (
     KafkaProducer,
     as_kafka_configuration_bool,
 )
-from snuba.utils.streams.synchronized import Commit, commit_codec
 from snuba.utils.streams.types import Message, Partition, Topic
-from tests.utils.streams.mixins import StreamsTestMixin
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
+from tests.utils.streams.mixins import StreamsTestMixin
+from snuba.utils.streams.synchronized import Commit, commit_codec
 
 
 def test_payload_equality() -> None:
@@ -34,6 +36,21 @@ def test_payload_equality() -> None:
     assert not KafkaPayload(None, b"", [("key", b"this")]) == KafkaPayload(
         None, b"", [("key", b"that")]
     )
+
+
+def test_payload_pickle_simple() -> None:
+    payload = KafkaPayload(b"key", b"value", [])
+    assert pickle.loads(pickle.dumps(payload)) == payload
+
+
+@pytest.mark.xfail(not sys.version_info >= (3, 8), reason="python >= 3.8 required")
+def test_payload_pickle_out_of_band() -> None:
+    from pickle import PickleBuffer
+
+    payload = KafkaPayload(b"key", b"value", [])
+    buffers: MutableSequence[PickleBuffer] = []
+    data = pickle.dumps(payload, protocol=5, buffer_callback=buffers.append)
+    assert pickle.loads(data, buffers=[b.raw() for b in buffers]) == payload
 
 
 class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):

--- a/tests/utils/streams/test_kafka.py
+++ b/tests/utils/streams/test_kafka.py
@@ -1,12 +1,12 @@
 import contextlib
 import itertools
+import pickle
 import sys
 import uuid
 from contextlib import closing
 from typing import Iterator, MutableSequence, Optional
 from unittest import TestCase
 
-import pickle
 import pytest
 from confluent_kafka.admin import AdminClient, NewTopic
 
@@ -19,10 +19,10 @@ from snuba.utils.streams.kafka import (
     KafkaProducer,
     as_kafka_configuration_bool,
 )
+from snuba.utils.streams.synchronized import Commit, commit_codec
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 from tests.utils.streams.mixins import StreamsTestMixin
-from snuba.utils.streams.synchronized import Commit, commit_codec
 
 
 def test_payload_equality() -> None:

--- a/tests/utils/streams/test_types.py
+++ b/tests/utils/streams/test_types.py
@@ -1,10 +1,15 @@
-from snuba.utils.streams.types import (
-    Partition,
-    Topic,
-)
+import pickle
+from datetime import datetime
+
+from snuba.utils.streams.types import Message, Partition, Topic
 
 
 def test_topic_contains_partition() -> None:
     assert Partition(Topic("topic"), 0) in Topic("topic")
     assert Partition(Topic("topic"), 0) not in Topic("other-topic")
     assert Partition(Topic("other-topic"), 0) not in Topic("topic")
+
+
+def test_message_pickling() -> None:
+    message = Message(Partition(Topic("topic"), 0), 0, b"", datetime.now())
+    assert pickle.loads(pickle.dumps(message)) == message


### PR DESCRIPTION
This also enables [out-of-band buffer transfer](https://docs.python.org/3/library/pickle.html#out-of-band-buffers) for `KafkaPayload.value` when using the version 5 protocol that was introduced in Python 3.8.