### PR TITLE
ref(writer): Consolidate writer entrypoints on `TableStorage`

### DIFF
--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -51,7 +51,11 @@ def bulk_load(
     )
     # TODO: see whether we need to pass options to the writer
     writer = BufferedWriterWrapper(
-        table_writer.get_bulk_writer(environment.metrics, table_name=dest_table),
+        table_writer.get_writer(
+            environment.metrics,
+            table_name=dest_table,
+            chunk_size=settings.BULK_CLICKHOUSE_BUFFER,
+        ),
         settings.BULK_CLICKHOUSE_BUFFER,
     )
 

--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import click
 
-from snuba import settings
+from snuba import environment, settings
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_cdc_storage, CDC_STORAGES
 from snuba.environment import setup_logging, setup_sentry
@@ -51,7 +51,7 @@ def bulk_load(
     )
     # TODO: see whether we need to pass options to the writer
     writer = BufferedWriterWrapper(
-        table_writer.get_bulk_writer(table_name=dest_table),
+        table_writer.get_bulk_writer(environment.metrics, table_name=dest_table),
         settings.BULK_CLICKHOUSE_BUFFER,
     )
 

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -128,36 +128,18 @@ class TableWriter:
         return self.__table_schema
 
     def get_writer(
-        self, metrics: MetricsBackend, options=None, table_name=None
+        self,
+        metrics: MetricsBackend,
+        options=None,
+        table_name=None,
+        chunk_size: int = settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
     ) -> BatchWriter[WriterTableRow]:
-        from snuba import settings
-
         table_name = table_name or self.__table_schema.get_table_name()
 
         options = self.__update_writer_options(options)
 
         return self.__cluster.get_writer(
-            table_name,
-            metrics,
-            options,
-            chunk_size=settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
-        )
-
-    def get_bulk_writer(
-        self, metrics: MetricsBackend, options=None, table_name=None
-    ) -> BatchWriter[WriterTableRow]:
-        """
-        This is a stripped down verison of the writer designed
-        for better performance when loading data in bulk.
-        """
-        from snuba import settings
-
-        table_name = table_name or self.__table_schema.get_table_name()
-
-        options = self.__update_writer_options(options)
-
-        return self.__cluster.get_writer(
-            table_name, metrics, options, chunk_size=settings.BULK_CLICKHOUSE_BUFFER,
+            table_name, metrics, options, chunk_size=chunk_size,
         )
 
     def get_bulk_loader(


### PR DESCRIPTION
This removes the `get_bulk_writer` method which had essentially converged with `get_writer`, the only difference being the `chunk_size` parameter. This parameterizes the chunk size instead.