### PR TITLE
ref(writer): Make the writer expect `JSONRow` instances

### DIFF
--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence
 
 from snuba import settings
+from snuba.clickhouse.http import JSONRow
 from snuba.clusters.cluster import (
     ClickhouseClientSettings,
     ClickhouseCluster,
@@ -16,7 +17,7 @@ from snuba.snapshots.loaders import BulkLoader
 from snuba.snapshots.loaders.single_table import RowProcessor, SingleTableBulkLoader
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.streams.kafka import KafkaPayload
-from snuba.writer import BatchWriter, WriterTableRow
+from snuba.writer import BatchWriter
 
 
 @dataclass(frozen=True)
@@ -133,7 +134,7 @@ class TableWriter:
         options=None,
         table_name=None,
         chunk_size: int = settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
-    ) -> BatchWriter[WriterTableRow]:
+    ) -> BatchWriter[JSONRow]:
         table_name = table_name or self.__table_schema.get_table_name()
 
         options = self.__update_writer_options(options)

--- a/tests/base.py
+++ b/tests/base.py
@@ -8,6 +8,7 @@ from hashlib import md5
 from typing import Iterator, MutableSequence, Optional, Sequence
 
 from snuba import settings
+from snuba.clickhouse.http import JSONRowEncoder
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.events_processor_base import InsertEvent
@@ -15,7 +16,7 @@ from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.processor import InsertBatch, ProcessedMessage
 from snuba.redis import redis_client
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.writer import WriterTableRow
+from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
 from tests.fixtures import raw_event
 
 
@@ -68,8 +69,11 @@ class BaseDatasetTest(BaseTest):
         self.write_rows(rows)
 
     def write_rows(self, rows: Sequence[WriterTableRow]) -> None:
-        enforce_table_writer(self.dataset).get_writer(
-            metrics=DummyMetricsBackend(strict=True)
+        BatchWriterEncoderWrapper(
+            enforce_table_writer(self.dataset).get_writer(
+                metrics=DummyMetricsBackend(strict=True)
+            ),
+            JSONRowEncoder(),
         ).write(rows)
 
 

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -2,6 +2,7 @@ import importlib
 import pytest
 from unittest.mock import patch
 
+from snuba.clickhouse.http import JSONRowEncoder
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.consumer import KafkaMessageMetadata
@@ -14,6 +15,7 @@ from snuba.migrations.parse_schema import get_local_schema
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
+from snuba.writer import BatchWriterEncoderWrapper
 
 
 def teardown_function() -> None:
@@ -270,7 +272,10 @@ def generate_transactions(count: int) -> None:
         )
         rows.extend(processed.rows)
 
-    table_writer.get_writer(metrics=DummyMetricsBackend(strict=True)).write(rows)
+    BatchWriterEncoderWrapper(
+        table_writer.get_writer(metrics=DummyMetricsBackend(strict=True)),
+        JSONRowEncoder(),
+    ).write(rows)
 
 
 def test_settings_skipped_group() -> None:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,4 +1,5 @@
 import pytest
+import rapidjson
 
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.http import HTTPBatchWriter
@@ -13,7 +14,7 @@ class TestHTTPBatchWriter(BaseEventsTest):
         try:
             enforce_table_writer(self.dataset).get_writer(
                 table_name="invalid", metrics=DummyMetricsBackend(strict=True)
-            ).write([{"x": "y"}])
+            ).write([rapidjson.dumps({"x": "y"}).encode("utf-8")])
         except ClickhouseError as error:
             assert error.code == 60
         else:
@@ -22,7 +23,7 @@ class TestHTTPBatchWriter(BaseEventsTest):
         try:
             enforce_table_writer(self.dataset).get_writer(
                 metrics=DummyMetricsBackend(strict=True)
-            ).write([{"timestamp": "invalid"}])
+            ).write([rapidjson.dumps({"timestamp": "invalid"}).encode("utf-8")])
         except ClickhouseError as error:
             assert error.code == 41
         else:


### PR DESCRIPTION
This is where some of the abstractions start to get leaky. The parallel consumer will be outputting rows that are already serialized as `JSONRow`, rather than the semi-structured `WriterTableRow` instances. This allows the serialization of the output data to be parallelized, rather than serialized during `Writer.write`. To maintain compatibility with all of the _existing_ usages of `Writer.write`, the writer needs to be wrapped with an encoder wrapper, which was previously happening as part of `get_writer`. This now means that a lot of the codebase has some level of awareness of how rows are encoded where it probably shouldn't.