### PR TITLE
fix(migrations) Fix failure in 0002_transactions_onpremise_fix_orderby_and_partitionby

### DIFF
--- a/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
+++ b/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
@@ -53,7 +53,7 @@ def forwards() -> None:
 
         new_create_table_statement = (
             new_create_table_statement[:idx]
-            + f"SAMPLE BY {new_sampling_key} "
+            + f" SAMPLE BY {new_sampling_key} "
             + new_create_table_statement[idx:]
         )
 


### PR DESCRIPTION
Fixes this:
```
snuba.clickhouse.errors.ClickhouseError: [62] DB::Exception: Syntax error: failed at position 1528: 819SAMPLE BY cityHash64(span_id) 2. Wrong number. Stack trace:
```