### PR TITLE
feat(validation) Removed rolled out flag.

### DIFF
--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -9,7 +9,6 @@ from snuba.query.expressions import Expression, FunctionCall
 from snuba.query.parser.validation import ExpressionValidator
 from snuba.query.validation import FunctionCallValidator, InvalidFunctionCall
 from snuba.query.validation.signature import Any, Column, SignatureValidator
-from snuba.state import get_config
 
 logger = logging.getLogger(__name__)
 
@@ -53,10 +52,6 @@ class FunctionCallsValidator(ExpressionValidator):
             if validator is not None:
                 validator.validate(exp.parameters, dataset.get_abstract_columnset())
         except InvalidFunctionCall as exception:
-            if get_config("enforce_expression_validation", 0):
-                raise InvalidExpressionException(
-                    exp,
-                    f"Illegal call to function {exp.function_name}: {str(exception)}",
-                ) from exception
-            else:
-                logger.warning("Query validation exception", exc_info=True)
+            raise InvalidExpressionException(
+                exp, f"Illegal call to function {exp.function_name}: {str(exception)}",
+            ) from exception

--- a/tests/query/parser/validation/test_functions.py
+++ b/tests/query/parser/validation/test_functions.py
@@ -11,7 +11,6 @@ from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Column, Expression, FunctionCall
 from snuba.query.parser.validation.functions import FunctionCallsValidator
 from snuba.query.validation import FunctionCallValidator, InvalidFunctionCall
-from snuba.state import set_config
 
 
 class FakeValidator(FunctionCallValidator):
@@ -56,7 +55,6 @@ def test_functions(
     dataset_validators: Mapping[str, FunctionCallValidator],
     exception: Optional[Type[InvalidExpressionException]],
 ) -> None:
-    set_config("enforce_expression_validation", 1)
     functions.default_validators = default_validators
     dataset = MagicMock()
     dataset.get_function_call_validators.return_value = dataset_validators

--- a/tests/query/test_query_validation.py
+++ b/tests/query/test_query_validation.py
@@ -2,11 +2,9 @@ from typing import Any, MutableMapping
 
 import pytest
 
-from snuba import state
 from snuba.datasets.factory import get_dataset
 from snuba.query.exceptions import ValidationException
 from snuba.query.parser import parse_query
-from snuba.state import set_config
 
 test_cases = [
     pytest.param(
@@ -21,8 +19,6 @@ test_cases = [
 
 @pytest.mark.parametrize("query_body", test_cases)
 def test_validation(query_body: MutableMapping[str, Any]) -> None:
-    set_config("enforce_expression_validation", 1)
-    state.set_config("query_parsing_expand_aliases", 1)
     events = get_dataset("events")
     with pytest.raises(ValidationException):
         parse_query(query_body, events)


### PR DESCRIPTION
Query validation has been rolled out for a while in production. Having this flag still laround is actually error prone because the default value is 0.