### PR TITLE
fix(migrations): Fix bug in sharding key for events table

### DIFF
--- a/snuba/migrations/snuba_migrations/events/0001_events_initial.py
+++ b/snuba/migrations/snuba_migrations/events/0001_events_initial.py
@@ -150,7 +150,7 @@ class Migration(migration.MultiStepMigration):
                 columns=columns,
                 engine=table_engines.Distributed(
                     local_table_name="sentry_local",
-                    sharding_key="cityHash64(toString(event_id)))",
+                    sharding_key="cityHash64(toString(event_id))",
                 ),
             ),
             operations.CreateTable(
@@ -159,7 +159,7 @@ class Migration(migration.MultiStepMigration):
                 columns=columns,
                 engine=table_engines.Distributed(
                     local_table_name="sentry_local",
-                    sharding_key="cityHash64(toString(event_id)))",
+                    sharding_key="cityHash64(toString(event_id))",
                 ),
             ),
         ]


### PR DESCRIPTION
Noticed an extra paren in the sharding key when attempting to run these
operations locally.