### PR TITLE
fix(consumer): Pass batch time as correct units to streaming strategy

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -278,7 +278,7 @@ class StreamingConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         processor: MessageProcessor,
         writer: BatchWriter[WriterTableRow],
         max_batch_size: int,
-        max_batch_time: int,
+        max_batch_time: float,
         replacements_producer: Optional[ConfluentKafkaProducer] = None,
         replacements_topic: Optional[Topic] = None,
     ) -> None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -181,7 +181,7 @@ class ConsumerBuilder:
                 JSONRowEncoder(),
             ),
             max_batch_size=self.max_batch_size,
-            max_batch_time=self.max_batch_time_ms,
+            max_batch_time=self.max_batch_time_ms / 1000.0,
             replacements_producer=(
                 self.producer if self.replacements_topic is not None else None
             ),

--- a/snuba/utils/streams/streaming.py
+++ b/snuba/utils/streams/streaming.py
@@ -152,7 +152,7 @@ class CollectStep(ProcessingStep[TPayload]):
         step_factory: Callable[[], ProcessingStep[TPayload]],
         commit_function: Callable[[Mapping[Partition, int]], None],
         max_batch_size: int,
-        max_batch_time: int,
+        max_batch_time: float,
     ) -> None:
         self.__step_factory = step_factory
         self.__commit_function = commit_function


### PR DESCRIPTION
This also allows expressing the `max_batch_time` as a float instead of an integer to represent subsecond values.