### PR TITLE
ref(consumer): Use streaming processing strategy by default

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -76,7 +76,7 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
 @click.option(
     "--strategy",
     type=click.Choice([k.lower() for k in StrategyFactoryType.__members__.keys()]),
-    default="batching",
+    default="streaming",
 )
 def consumer(
     *,

--- a/snuba/utils/streams/streaming.py
+++ b/snuba/utils/streams/streaming.py
@@ -201,6 +201,7 @@ class CollectStep(ProcessingStep[TPayload]):
         self.__closed = True
 
         if self.__batch is not None:
+            logger.debug("Closing %r...", self.__batch)
             self.__batch.close()
 
     def join(self, timeout: Optional[float] = None) -> None:


### PR DESCRIPTION
Also adds some additional logging per @JTCunning's request:

```
(.venv) ted@veneno % snuba consumer --log-level debug --strategy streaming
2020-08-27 11:20:26,566 Starting
2020-08-27 11:20:29,719 New partitions assigned: {Partition(topic=Topic(name='events'), index=0): 4345395}
2020-08-27 11:20:29,720 Initialized processing strategy: <snuba.utils.streams.streaming.TransformStep object at 0x10a39e1c0>
2020-08-27 11:20:31,745 Time limit reached, closing <Batch: 3336 messages, open for 2.00 seconds>...
2020-08-27 11:20:31,746 Starting new HTTP connection (1): localhost:8123
2020-08-27 11:20:31,936 http://localhost:8123 "POST /?load_balancing=in_order&insert_distributed_sync=1&query=INSERT+INTO+default.sentry_local+FORMAT+JSONEachRow HTTP/1.1" 200 None
2020-08-27 11:20:31,937 Committing offsets: {Partition(topic=Topic(name='events'), index=0): 4348731}
2020-08-27 11:20:31,976 Completed processing <Batch: 3336 messages, open for 2.23 seconds>.
2020-08-27 11:20:33,982 Time limit reached, closing <Batch: 3364 messages, open for 2.00 seconds>...
2020-08-27 11:20:34,149 http://localhost:8123 "POST /?load_balancing=in_order&insert_distributed_sync=1&query=INSERT+INTO+default.sentry_local+FORMAT+JSONEachRow HTTP/1.1" 200 None
2020-08-27 11:20:34,150 Committing offsets: {Partition(topic=Topic(name='events'), index=0): 4352095}
2020-08-27 11:20:34,160 Completed processing <Batch: 3364 messages, open for 2.18 seconds>.
^C2020-08-27 11:20:35,010 Shutdown signalled
2020-08-27 11:20:35,011 Stopping consumer
2020-08-27 11:20:35,044 Partitions revoked: [Partition(topic=Topic(name='events'), index=0)]
2020-08-27 11:20:35,045 Closing <snuba.utils.streams.streaming.TransformStep object at 0x10a39e1c0>...
2020-08-27 11:20:35,045 Waiting for <snuba.utils.streams.streaming.TransformStep object at 0x10a39e1c0> to exit...
2020-08-27 11:20:35,166 http://localhost:8123 "POST /?load_balancing=in_order&insert_distributed_sync=1&query=INSERT+INTO+default.sentry_local+FORMAT+JSONEachRow HTTP/1.1" 200 None
2020-08-27 11:20:35,167 Committing offsets: {Partition(topic=Topic(name='events'), index=0): 4353712}
2020-08-27 11:20:35,171 Completed processing <Batch: 1617 messages, open for 1.01 seconds>.
2020-08-27 11:20:35,174 <snuba.utils.streams.streaming.TransformStep object at 0x10a39e1c0> exited successfully, releasing assignment.
2020-08-27 11:20:35,199 Stopped
```