### PR TITLE
fix(migrations): fix the primary key to match ClickHouse formatting

### DIFF
--- a/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
+++ b/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
@@ -26,7 +26,7 @@ def forwards() -> None:
     new_sampling_key = "cityHash64(span_id)"
     new_partition_key = "(retention_days, toMonday(finish_ts))"
     new_primary_key = (
-        "(project_id, toStartOfDay(finish_ts), transaction_name, cityHash64(span_id))"
+        "project_id, toStartOfDay(finish_ts), transaction_name, cityHash64(span_id)"
     )
 
     ((curr_sampling_key, curr_partition_key, curr_primary_key),) = clickhouse.execute(


### PR DESCRIPTION
The previous value resulted in this migration creating a new table when it
shouldn't be since ClickHouse omits the parentheses in formatting the
primary key.