### PR TITLE
feat(migrations): Rebuild groupedmessages table if old version

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -94,6 +94,7 @@ class EventsLoader(DirectoryLoader):
             "0007_groupedmessages",
             "0008_groupassignees",
             "0009_errors_add_http_fields",
+            "0010_groupedmessages_onpremise_compatibility",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -23,7 +23,10 @@ def fix_order_by() -> None:
         f"SELECT primary_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     )
 
-    assert curr_primary_key in [new_primary_key, old_primary_key]
+    assert curr_primary_key in [
+        new_primary_key,
+        old_primary_key,
+    ], "Groupmessage table has invalid primary key"
 
     if curr_primary_key != old_primary_key:
         return

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -23,6 +23,8 @@ def fix_order_by() -> None:
         f"SELECT primary_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
     )
 
+    assert curr_primary_key in [new_primary_key, old_primary_key]
+
     if curr_primary_key != old_primary_key:
         return
 

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -1,0 +1,89 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+TABLE_NAME = "groupedmessage_local"
+TABLE_NAME_NEW = "groupedmessage_local_new"
+TABLE_NAME_OLD = "groupedmessage_local_old"
+
+
+def fix_order_by() -> None:
+    cluster = get_cluster(StorageSetKey.EVENTS)
+    clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+    database = cluster.get_database()
+
+    new_primary_key = "project_id, id"
+    old_primary_key = "id"
+
+    ((curr_primary_key,),) = clickhouse.execute(
+        f"SELECT primary_key FROM system.tables WHERE name = '{TABLE_NAME}' AND database = '{database}'"
+    )
+
+    if curr_primary_key != old_primary_key:
+        return
+
+    # There shouldn't be any data in the table yet
+    assert (
+        clickhouse.execute(f"SELECT COUNT() FROM {TABLE_NAME} FINAL;")[0][0] == 0
+    ), f"{TABLE_NAME} is not empty"
+
+    new_order_by = f"ORDER BY ({new_primary_key})"
+    old_order_by = f"ORDER BY {old_primary_key}"
+
+    ((curr_create_table_statement,),) = clickhouse.execute(
+        f"SHOW CREATE TABLE {database}.{TABLE_NAME}"
+    )
+
+    new_create_table_statement = curr_create_table_statement.replace(
+        TABLE_NAME, TABLE_NAME_NEW
+    ).replace(old_order_by, new_order_by)
+
+    clickhouse.execute(new_create_table_statement)
+
+    clickhouse.execute(f"RENAME TABLE {TABLE_NAME} TO {TABLE_NAME_OLD};")
+
+    clickhouse.execute(f"RENAME TABLE {TABLE_NAME_NEW} TO {TABLE_NAME};")
+
+    clickhouse.execute(f"DROP TABLE {TABLE_NAME_OLD};")
+
+
+class Migration(migration.MultiStepMigration):
+    """
+    An earlier version of the groupedmessage table (pre September 2019) did not
+    include the project ID. This migration adds the column and rebuilds that table
+    if the user has the old version with the incorrect primary key.
+    """
+
+    blocking = True
+
+    def forwards_local(self) -> Sequence[operations.Operation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name=TABLE_NAME,
+                column=Column("project_id", UInt(64)),
+                after="record_deleted",
+            ),
+            operations.RunPython(func=fix_order_by),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.Operation]:
+        # Drop the temporary tables used by forwards_local if they exist
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.EVENTS, table_name=TABLE_NAME_NEW,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.EVENTS, table_name=TABLE_NAME_OLD,
+            ),
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.Operation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.Operation]:
+        return []

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -300,6 +300,43 @@ def generate_transactions(count: int) -> None:
     ).write(rows)
 
 
+def test_groupedmessages_compatibility() -> None:
+    cluster = get_cluster(StorageSetKey.EVENTS)
+    database = cluster.get_database()
+    connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+
+    # Create old style table witihout project ID
+    connection.execute(
+        """
+        CREATE TABLE groupedmessage_local (`offset` UInt64, `record_deleted` UInt8,
+        `id` UInt64, `status` Nullable(UInt8), `last_seen` Nullable(DateTime),
+        `first_seen` Nullable(DateTime), `active_at` Nullable(DateTime),
+        `first_release_id` Nullable(UInt64)) ENGINE = ReplacingMergeTree(offset)
+        ORDER BY id SAMPLE BY id SETTINGS index_granularity = 8192
+        """
+    )
+
+    migration_id = "0010_groupedmessages_onpremise_compatibility"
+
+    runner = Runner()
+    runner.run_migration(MigrationKey(MigrationGroup.SYSTEM, "0001_migrations"))
+    events_migrations = get_group_loader(MigrationGroup.EVENTS).get_migrations()
+
+    # Mark prior migrations complete
+    for migration in events_migrations[: (events_migrations.index(migration_id))]:
+        runner._update_migration_status(
+            MigrationKey(MigrationGroup.EVENTS, migration), Status.COMPLETED
+        )
+
+    runner.run_migration(
+        MigrationKey(MigrationGroup.EVENTS, migration_id), force=True,
+    )
+
+    assert connection.execute(
+        f"SELECT primary_key FROM system.tables WHERE name = 'groupedmessage_local' AND database = '{database}'"
+    ) == [("project_id, id",)]
+
+
 def test_settings_skipped_group() -> None:
     from snuba.migrations import groups, runner
 


### PR DESCRIPTION
The primary key on the groupedmessage table was changed in
https://github.com/getsentry/snuba/pull/453. Users that had a
version of this table prior to September 2019 will still have
a missing project ID column and an incorrect primary key. This
migration fixes the schema. The migration throws an error if an
incorrect primary key is found and the user has data in the table.
This shouldn't be the case since this table should never have been
filled in onpremise, single tenant and development environments.