### PR TITLE
feat(streams): Add `terminate` method to processing strategy interface

### DIFF
--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -185,6 +185,9 @@ class InsertBatchWriter(ProcessingStep[JSONRowInsertBatch]):
             self.__writer,
         )
 
+    def terminate(self) -> None:
+        self.__closed = True
+
     def join(self, timeout: Optional[float] = None) -> None:
         pass
 
@@ -226,6 +229,9 @@ class ReplacementBatchWriter(ProcessingStep[ReplacementBatch]):
                     value=rapidjson.dumps(value).encode("utf-8"),
                     on_delivery=self.__delivery_callback,
                 )
+
+    def terminate(self) -> None:
+        self.__closed = True
 
     def join(self, timeout: Optional[float] = None) -> None:
         args = []
@@ -291,6 +297,14 @@ class ProcessedMessageBatchWriter(
 
         if self.__replacement_batch_writer is not None:
             self.__replacement_batch_writer.close()
+
+    def terminate(self) -> None:
+        self.__closed = True
+
+        self.__insert_batch_writer.terminate()
+
+        if self.__replacement_batch_writer is not None:
+            self.__replacement_batch_writer.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         start = time.time()

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -168,6 +168,9 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
     def close(self) -> None:
         self.__closed = True
 
+    def terminate(self) -> None:
+        self.__closed = True
+
     def join(self, timeout: Optional[float] = None) -> None:
         # The active batch is discarded when exiting without attempting to
         # write or commit, so this method can exit immediately without

--- a/snuba/utils/streams/processing.py
+++ b/snuba/utils/streams/processing.py
@@ -81,6 +81,15 @@ class ProcessingStrategy(ABC, Generic[TPayload]):
         raise NotImplementedError
 
     @abstractmethod
+    def terminate(self) -> None:
+        """
+        Close the processing strategy immediately, abandoning any work in
+        progress. No more messages should be accepted by the instance after
+        this method has been called.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def join(self, timeout: Optional[float] = None) -> None:
         """
         Block until the processing strategy has completed all previously
@@ -192,10 +201,23 @@ class StreamProcessor(Generic[TPayload]):
         "The main run loop, see class docstring for more information."
 
         logger.debug("Starting")
-        while not self.__shutdown_requested:
-            self._run_once()
+        try:
+            while not self.__shutdown_requested:
+                self._run_once()
 
-        self._shutdown()
+            self._shutdown()
+        except Exception as error:
+            logger.warning("Caught %r, shutting down...", error)
+
+            if self.__processing_strategy is not None:
+                logger.debug("Terminating %r...", self.__processing_strategy)
+                self.__processing_strategy.terminate()
+                self.__processing_strategy = None
+
+            logger.debug("Closing %r...", self.__consumer)
+            self.__consumer.close()
+
+            raise
 
     def _run_once(self) -> None:
         message_carried_over = self.__message is not None

--- a/snuba/utils/streams/streaming.py
+++ b/snuba/utils/streams/streaming.py
@@ -60,6 +60,12 @@ class FilterStep(ProcessingStep[TPayload]):
     def close(self) -> None:
         self.__closed = True
 
+    def terminate(self) -> None:
+        self.__closed = True
+
+        logger.debug("Terminating %r...", self.__next_step)
+        self.__next_step.terminate()
+
     def join(self, timeout: Optional[float] = None) -> None:
         self.__next_step.close()
         self.__next_step.join(timeout)
@@ -101,6 +107,12 @@ class TransformStep(ProcessingStep[TPayload]):
 
     def close(self) -> None:
         self.__closed = True
+
+    def terminate(self) -> None:
+        self.__closed = True
+
+        logger.debug("Terminating %r...", self.__next_step)
+        self.__next_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         self.__next_step.close()
@@ -374,6 +386,18 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
         if self.__batch_builder is not None and len(self.__batch_builder) > 0:
             self.__submit_batch()
 
+    def terminate(self) -> None:
+        self.__closed = True
+
+        logger.debug("Terminating %r...", self.__pool)
+        self.__pool.terminate()
+
+        logger.debug("Shutting down %r...", self.__shared_memory_manager)
+        self.__shared_memory_manager.shutdown()
+
+        logger.debug("Terminating %r...", self.__next_step)
+        self.__next_step.terminate()
+
     def join(self, timeout: Optional[float] = None) -> None:
         deadline = time.time() + timeout if timeout is not None else None
 
@@ -450,6 +474,12 @@ class Batch(Generic[TPayload]):
         self.__closed = True
         self.__step.close()
 
+    def terminate(self) -> None:
+        self.__closed = True
+
+        logger.debug("Terminating %r...", self.__step)
+        self.__step.terminate()
+
     def join(self, timeout: Optional[float] = None) -> None:
         self.__step.join(timeout)
         offsets = {
@@ -516,6 +546,12 @@ class CollectStep(ProcessingStep[TPayload]):
         if self.__batch is not None:
             logger.debug("Closing %r...", self.__batch)
             self.__batch.close()
+
+    def terminate(self) -> None:
+        self.__closed = True
+
+        if self.__batch is not None:
+            self.__batch.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         if self.__batch is not None:

--- a/tests/utils/streams/test_streaming.py
+++ b/tests/utils/streams/test_streaming.py
@@ -284,5 +284,5 @@ def test_parallel_transform_step_terminate_workers() -> None:
         get_subprocess_count,
         starting_processes + worker_processes + manager_processes,
         starting_processes,
-    ):
+    ), assert_changes(lambda: next_step.terminate.call_count, 0, 1):
         transform_step.terminate()

--- a/tests/utils/streams/test_streaming.py
+++ b/tests/utils/streams/test_streaming.py
@@ -235,7 +235,7 @@ def test_parallel_transform_step() -> None:
         transform_step = ParallelTransformStep(
             transform_payload_expand,
             next_step,
-            processes=2,
+            processes=worker_processes,
             max_batch_size=5,
             max_batch_time=60,
             input_block_size=4096,

--- a/tests/utils/streams/test_streaming.py
+++ b/tests/utils/streams/test_streaming.py
@@ -1,4 +1,5 @@
 import itertools
+import multiprocessing
 import pytest
 from datetime import datetime
 from multiprocessing.managers import SharedMemoryManager
@@ -205,6 +206,10 @@ def test_parallel_transform_worker_apply() -> None:
             )
 
 
+def get_subprocess_count() -> int:
+    return len(multiprocessing.active_children())
+
+
 def test_parallel_transform_step() -> None:
     next_step = Mock()
 
@@ -218,21 +223,66 @@ def test_parallel_transform_step() -> None:
         for i, size in enumerate([1000, 1000, 2000, 2000])
     ]
 
-    transform_step = ParallelTransformStep(
-        transform_payload_expand,
-        next_step,
-        processes=2,
-        max_batch_size=5,
-        max_batch_time=60,
-        input_block_size=4096,
-        output_block_size=4096,
-    )
+    starting_processes = get_subprocess_count()
+    worker_processes = 2
+    manager_processes = 1
 
-    for message in messages:
-        transform_step.poll()
-        transform_step.submit(message)
+    with assert_changes(
+        get_subprocess_count,
+        starting_processes,
+        starting_processes + worker_processes + manager_processes,
+    ):
+        transform_step = ParallelTransformStep(
+            transform_payload_expand,
+            next_step,
+            processes=2,
+            max_batch_size=5,
+            max_batch_time=60,
+            input_block_size=4096,
+            output_block_size=4096,
+        )
 
-    transform_step.close()
-    transform_step.join()
+        for message in messages:
+            transform_step.poll()
+            transform_step.submit(message)
+
+        transform_step.close()
+
+    with assert_changes(
+        get_subprocess_count,
+        starting_processes + worker_processes + manager_processes,
+        starting_processes,
+    ):
+        transform_step.join()
 
     assert next_step.submit.call_count == len(messages)
+
+
+def test_parallel_transform_step_terminate_workers() -> None:
+    next_step = Mock()
+
+    starting_processes = get_subprocess_count()
+    worker_processes = 2
+    manager_processes = 1
+
+    with assert_changes(
+        get_subprocess_count,
+        starting_processes,
+        starting_processes + worker_processes + manager_processes,
+    ):
+        transform_step = ParallelTransformStep(
+            transform_payload_expand,  # doesn't matter
+            next_step,
+            processes=worker_processes,
+            max_batch_size=5,
+            max_batch_time=60,
+            input_block_size=4096,
+            output_block_size=4096,
+        )
+
+    with assert_changes(
+        get_subprocess_count,
+        starting_processes + worker_processes + manager_processes,
+        starting_processes,
+    ):
+        transform_step.terminate()


### PR DESCRIPTION
This adds a `terminate` method to the processing strategy interface, and uses it to tear down the processing strategy instance when an uncaught exception is thrown during the stream processor run loop. This gives the processing strategy the opportunity to clean up any resources that may prevent the interpreter from exiting cleanly (e.g. `multiprocessing.Pool` instances, [see warning](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool)) without attempting to flush any in-flight work as happens with `close`/`join`.