### PR TITLE
feat(query_profile) Make table primary key available through the query RelationalSource.

### DIFF
--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -71,6 +71,7 @@ class Groups(TimeSeriesDataset):
             left_node=TableJoinNode(
                 table_name=groupedmessage_source.format_from(),
                 columns=groupedmessage_source.get_columns(),
+                primary_key_columns=groupedmessage_source.get_primary_key_columns(),
                 mandatory_conditions=[
                     MandatoryCondition(
                         (qualified_column("record_deleted", self.GROUPS_ALIAS), "=", 0),
@@ -91,6 +92,7 @@ class Groups(TimeSeriesDataset):
             right_node=TableJoinNode(
                 table_name=events_source.format_from(),
                 columns=events_source.get_columns(),
+                primary_key_columns=events_source.get_primary_key_columns(),
                 mandatory_conditions=[
                     MandatoryCondition(
                         (qualified_column("deleted", self.EVENTS_ALIAS), "=", 0),

--- a/snuba/datasets/schemas/join.py
+++ b/snuba/datasets/schemas/join.py
@@ -77,11 +77,18 @@ class TableJoinNode(TableSource, JoinNode):
         self,
         table_name: str,
         columns: ColumnSet,
+        primary_key_columns: Optional[Sequence[str]],
         mandatory_conditions: Optional[Sequence[MandatoryCondition]],
         prewhere_candidates: Optional[Sequence[str]],
         alias: str,
     ) -> None:
-        super().__init__(table_name, columns, mandatory_conditions, prewhere_candidates)
+        super().__init__(
+            table_name,
+            columns,
+            primary_key_columns,
+            mandatory_conditions,
+            prewhere_candidates,
+        )
         self.__alias = alias
 
     def format_from(self) -> str:

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -31,7 +31,7 @@ from snuba.datasets.storages.processors.replaced_groups import (
 from snuba.datasets.storages.tags_hash_map import TAGS_HASH_MAP_COLUMN
 from snuba.datasets.table_storage import KafkaStreamLoader
 from snuba.query.conditions import ConditionFunctions, binary_condition
-from snuba.query.expressions import Column, Literal
+from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
 )
@@ -188,7 +188,13 @@ schema = ReplacingMergeTreeSchema(
         "environment",
         "project_id",
     ],
-    order_by="(org_id, project_id, toStartOfDay(timestamp), primary_hash_hex, event_hash)",
+    order_by=[
+        Column(None, None, "org_id"),
+        Column(None, None, "project_id"),
+        FunctionCall(None, "toStartOfDay", (Column(None, None, "timestamp"),)),
+        Column(None, None, "primary_hash_hex"),
+        Column(None, None, "event_hash"),
+    ],
     partition_by="(toMonday(timestamp), if(retention_days = 30, 30, 90))",
     version_column="deleted",
     sample_expr="event_hash",

--- a/snuba/datasets/storages/events_ro.py
+++ b/snuba/datasets/storages/events_ro.py
@@ -17,6 +17,7 @@ schema = TableSchema(
     local_table_name="sentry_local",
     dist_table_name="sentry_dist_ro",
     storage_set_key=StorageSetKey.EVENTS_RO,
+    primary_key_columns=["project_id", "timestamp", "event_id"],
     mandatory_conditions=mandatory_conditions,
     prewhere_candidates=prewhere_candidates,
 )

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -1,16 +1,16 @@
 from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.cdc import CdcStorage
 from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeProcessor,
     GroupAssigneeRow,
 )
 from snuba.datasets.cdc.message_filters import CdcTableNameMessageFilter
 from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
-from snuba.datasets.cdc import CdcStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.query.expressions import Column
 from snuba.query.processors.prewhere import PrewhereProcessor
-
 
 columns = ColumnSet(
     [
@@ -32,7 +32,7 @@ schema = ReplacingMergeTreeSchema(
     local_table_name="groupassignee_local",
     dist_table_name="groupassignee_dist",
     storage_set_key=StorageSetKey.EVENTS,
-    order_by="(project_id, group_id)",
+    order_by=[Column(None, None, "project_id"), Column(None, None, "group_id")],
     partition_by=None,
     version_column="offset",
 )

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -51,7 +51,7 @@ schema = ReplacingMergeTreeSchema(
         )
     ],
     prewhere_candidates=["project_id", "id"],
-    order_by="(project_id, id)",
+    order_by=[Column(None, None, "project_id"), Column(None, None, "id")],
     partition_by=None,
     version_column="offset",
     sample_expr="id",

--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -64,6 +64,7 @@ schema = WritableTableSchema(
     local_table_name="querylog_local",
     dist_table_name="querylog_dist",
     storage_set_key=StorageSetKey.QUERYLOG,
+    primary_key_columns=[],
 )
 
 storage = WritableTableStorage(

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -31,6 +31,7 @@ from snuba.datasets.transactions_processor import (
     UNKNOWN_SPAN_STATUS,
     TransactionsMessageProcessor,
 )
+from snuba.query.expressions import Column, FunctionCall
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
 )
@@ -200,7 +201,12 @@ schema = ReplacingMergeTreeSchema(
     storage_set_key=StorageSetKey.TRANSACTIONS,
     mandatory_conditions=[],
     prewhere_candidates=["event_id", "transaction_name", "transaction", "title"],
-    order_by="(project_id, toStartOfDay(finish_ts), transaction_name, cityHash64(span_id))",
+    order_by=[
+        Column(None, None, "project_id"),
+        FunctionCall(None, "toStartOfDay", (Column(None, None, "finish_ts"),)),
+        Column(None, None, "transaction_name"),
+        FunctionCall(None, "cityHash", (Column(None, None, "span_id"),)),
+    ],
     partition_by="(retention_days, toMonday(finish_ts))",
     version_column="deleted",
     sample_expr="cityHash64(span_id)",

--- a/tests/datasets/schemas/join_examples.py
+++ b/tests/datasets/schemas/join_examples.py
@@ -26,7 +26,7 @@ table1 = MergeTreeSchema(
     local_table_name="table1",
     dist_table_name="table1",
     storage_set_key=StorageSetKey.EVENTS,
-    order_by="",
+    order_by=[],
     partition_by="",
 ).get_data_source()
 
@@ -41,7 +41,7 @@ table2 = MergeTreeSchema(
     local_table_name="table2",
     dist_table_name="table2",
     storage_set_key=StorageSetKey.EVENTS,
-    order_by="",
+    order_by=[],
     partition_by="",
 ).get_data_source()
 
@@ -56,14 +56,14 @@ table3 = MergeTreeSchema(
     local_table_name="table3",
     dist_table_name="table3",
     storage_set_key=StorageSetKey.EVENTS,
-    order_by="",
+    order_by=[],
     partition_by="",
 ).get_data_source()
 
 
 simple_join_structure = JoinClause(
-    TableJoinNode(table1.format_from(), table1.get_columns(), [], [], "t1"),
-    TableJoinNode(table2.format_from(), table2.get_columns(), [], [], "t2"),
+    TableJoinNode(table1.format_from(), table1.get_columns(), [], [], [], "t1"),
+    TableJoinNode(table2.format_from(), table2.get_columns(), [], [], [], "t2"),
     [
         JoinCondition(
             left=JoinConditionExpression(table_alias="t1", column="t1c1"),
@@ -79,8 +79,8 @@ simple_join_structure = JoinClause(
 
 complex_join_structure = JoinClause(
     JoinClause(
-        TableJoinNode(table1.format_from(), table1.get_columns(), [], [], "t1"),
-        TableJoinNode(table2.format_from(), table2.get_columns(), [], [], "t2"),
+        TableJoinNode(table1.format_from(), table1.get_columns(), [], [], [], "t1"),
+        TableJoinNode(table2.format_from(), table2.get_columns(), [], [], [], "t2"),
         [
             JoinCondition(
                 left=JoinConditionExpression(table_alias="t1", column="t1c1"),
@@ -89,7 +89,7 @@ complex_join_structure = JoinClause(
         ],
         JoinType.FULL,
     ),
-    TableJoinNode(table3.format_from(), table3.get_columns(), [], [], "t3"),
+    TableJoinNode(table3.format_from(), table3.get_columns(), [], [], [], "t3"),
     [
         JoinCondition(
             left=JoinConditionExpression(table_alias="t1", column="t1c1"),

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -67,7 +67,7 @@ def test_mand_conditions(table: str, mand_conditions: List[MandatoryCondition]) 
 
     query = Query(
         copy.deepcopy(body),
-        TableSource(table, None, mand_conditions, ["c1"]),
+        TableSource(table, None, [], mand_conditions, ["c1"]),
         None,
         None,
         binary_condition(

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -166,7 +166,7 @@ def test_prewhere(
     settings.MAX_PREWHERE_CONDITIONS = 2
     events = get_dataset("events")
     query = parse_query(query_body, events)
-    query.set_data_source(TableSource("my_table", ColumnSet([]), None, keys))
+    query.set_data_source(TableSource("my_table", ColumnSet([]), [], None, keys))
 
     request_settings = HTTPRequestSettings()
     processor = PrewhereProcessor()


### PR DESCRIPTION
Depends on https://github.com/getsentry/snuba/pull/1283

In order to capture query profile information we need to know the primary key during query execution. This is because we should capture metrics of which columns in the WHERE clause are  not in the primary key.
Thus this makes the primary key available to the Query through the TableSource (which is the data structure that represents the table/join we are querying).

In theory this may be useful beyond observability and also for optimizations, even though the need has not shown up yet.