### PR TITLE
ref(clusters): Rename `get_writer` to `get_batch_writer`

### DIFF
--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -51,7 +51,7 @@ def bulk_load(
     )
     # TODO: see whether we need to pass options to the writer
     writer = BufferedWriterWrapper(
-        table_writer.get_writer(
+        table_writer.get_batch_writer(
             environment.metrics,
             table_name=dest_table,
             chunk_size=settings.BULK_CLICKHOUSE_BUFFER,

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -106,7 +106,7 @@ class Cluster(ABC, Generic[TQuery, TWriterOptions]):
         raise NotImplementedError
 
     @abstractmethod
-    def get_writer(
+    def get_batch_writer(
         self,
         table_name: str,
         metrics: MetricsBackend,
@@ -214,7 +214,7 @@ class ClickhouseCluster(Cluster[SqlQuery, ClickhouseWriterOptions]):
             )
         return self.__reader
 
-    def get_writer(
+    def get_batch_writer(
         self,
         table_name: str,
         metrics: MetricsBackend,

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -70,7 +70,7 @@ class ConsumerWorker(AbstractBatchWorker[KafkaPayload, ProcessedMessage]):
         self.metrics = metrics
         table_writer = storage.get_table_writer()
         self.__writer = BatchWriterEncoderWrapper(
-            table_writer.get_writer(
+            table_writer.get_batch_writer(
                 metrics, {"load_balancing": "in_order", "insert_distributed_sync": 1}
             ),
             JSONRowEncoder(),

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -185,7 +185,7 @@ class ConsumerBuilder:
         return StreamingConsumerStrategyFactory(
             stream_loader.get_pre_filter(),
             stream_loader.get_processor(),
-            table_writer.get_writer(
+            table_writer.get_batch_writer(
                 self.metrics,
                 {"load_balancing": "in_order", "insert_distributed_sync": 1},
             ),

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -128,7 +128,7 @@ class TableWriter:
     def get_schema(self) -> WritableTableSchema:
         return self.__table_schema
 
-    def get_writer(
+    def get_batch_writer(
         self,
         metrics: MetricsBackend,
         options=None,
@@ -139,7 +139,7 @@ class TableWriter:
 
         options = self.__update_writer_options(options)
 
-        return self.__cluster.get_writer(
+        return self.__cluster.get_batch_writer(
             table_name, metrics, options, chunk_size=chunk_size,
         )
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -419,7 +419,7 @@ if application.debug or application.testing:
                 rows.extend(processed_message.rows)
 
         BatchWriterEncoderWrapper(
-            enforce_table_writer(dataset).get_writer(metrics), JSONRowEncoder(),
+            enforce_table_writer(dataset).get_batch_writer(metrics), JSONRowEncoder(),
         ).write(rows)
 
         return ("ok", 200, {"Content-Type": "text/plain"})

--- a/tests/base.py
+++ b/tests/base.py
@@ -70,7 +70,7 @@ class BaseDatasetTest(BaseTest):
 
     def write_rows(self, rows: Sequence[WriterTableRow]) -> None:
         BatchWriterEncoderWrapper(
-            enforce_table_writer(self.dataset).get_writer(
+            enforce_table_writer(self.dataset).get_batch_writer(
                 metrics=DummyMetricsBackend(strict=True)
             ),
             JSONRowEncoder(),

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -310,7 +310,7 @@ def generate_transactions(count: int) -> None:
         rows.extend(processed.rows)
 
     BatchWriterEncoderWrapper(
-        table_writer.get_writer(metrics=DummyMetricsBackend(strict=True)),
+        table_writer.get_batch_writer(metrics=DummyMetricsBackend(strict=True)),
         JSONRowEncoder(),
     ).write(rows)
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -12,7 +12,7 @@ from tests.base import BaseEventsTest
 class TestHTTPBatchWriter(BaseEventsTest):
     def test_error_handling(self):
         try:
-            enforce_table_writer(self.dataset).get_writer(
+            enforce_table_writer(self.dataset).get_batch_writer(
                 table_name="invalid", metrics=DummyMetricsBackend(strict=True)
             ).write([rapidjson.dumps({"x": "y"}).encode("utf-8")])
         except ClickhouseError as error:
@@ -21,7 +21,7 @@ class TestHTTPBatchWriter(BaseEventsTest):
             assert False, "expected error"
 
         try:
-            enforce_table_writer(self.dataset).get_writer(
+            enforce_table_writer(self.dataset).get_batch_writer(
                 metrics=DummyMetricsBackend(strict=True)
             ).write([rapidjson.dumps({"timestamp": "invalid"}).encode("utf-8")])
         except ClickhouseError as error:


### PR DESCRIPTION
I'm working on a change that implements a writer that does not require the entire write batch to be contained within a single iterable, so renaming this to disambiguate between the different implementations and submitting separately to reduce noise there (and this name is a bit more accurate anyway, since the return type is `BatchWriter`, after all.)