### PR TITLE
fix(query): Remove `pass` statement.

### DIFF
--- a/snuba/query/logical.py
+++ b/snuba/query/logical.py
@@ -433,7 +433,6 @@ class Query:
     def __get_columns_referenced_in_expressions(
         self, expressions: Iterable[Expression]
     ) -> Set[Column]:
-        pass
         ret: Set[Column] = set()
 
         for expression in expressions or []:


### PR DESCRIPTION
That pass is certainly there by mistake.