### PR TITLE
fix(discover) Move http_method and http_referer to common fields

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -291,6 +291,8 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("geo_country_code", Nullable(String())),
                 ("geo_region", Nullable(String())),
                 ("geo_city", Nullable(String())),
+                ("http_method", Nullable(String())),
+                ("http_referer", Nullable(String())),
                 # Other tags and context
                 ("tags", Nested([("key", String()), ("value", String())])),
                 ("contexts", Nested([("key", String()), ("value", String())])),
@@ -313,8 +315,6 @@ class DiscoverDataset(TimeSeriesDataset):
                 ("received", Nullable(DateTime())),
                 ("sdk_integrations", Nullable(Array(String()))),
                 ("version", Nullable(String())),
-                ("http_method", Nullable(String())),
-                ("http_referer", Nullable(String())),
                 # exception interface
                 (
                     "exception_stacks",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -18,6 +18,19 @@ raw_event = {
         "name": "sentry-java",
         "version": "1.6.1-d1e3a",
     },
+    "request": {
+        "url": "http://127.0.0.1:/query",
+        "headers": [
+            ["Accept-Encoding", "identity"],
+            ["Content-Length", "398"],
+            ["Host", "127.0.0.1:"],
+            ["Referer", "tagstore.something"],
+            ["Trace", "8fa73032d-1"],
+        ],
+        "data": "",
+        "method": "POST",
+        "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
+    },
     "contexts": {"device": {"online": True, "charging": True, "model_id": "Galaxy"}},
     "sentry.interfaces.Exception": {
         "exc_omitted": None,
@@ -102,6 +115,7 @@ raw_event = {
         ["server_name", "localhost.localdomain"],
         ["level", "error"],
         ["custom_tag", "custom_value"],
+        ["url", "http://127.0.0.1:/query"],
     ],
     "time_spent": None,
     "type": "error",


### PR DESCRIPTION
These columns are now present in events and transactions (and errors) so move
them to the common columns so they can be properly accessed by Discover.