### PR TITLE
perf(streams): Enable profiling processing strategy directly via consumer

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -87,6 +87,9 @@ from snuba.stateful_consumer.consumer_state_machine import ConsumerStateMachine
 @click.option(
     "--output-block-size", type=int,
 )
+@click.option(
+    "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
+)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -107,6 +110,7 @@ def consumer(
     input_block_size: Optional[int],
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
+    profile_path: Optional[str] = None,
 ) -> None:
 
     if not bootstrap_server:
@@ -135,6 +139,7 @@ def consumer(
         processes=processes,
         input_block_size=input_block_size,
         output_block_size=output_block_size,
+        profile_path=profile_path,
     )
 
     if stateful_consumer:

--- a/snuba/utils/streams/profiler.py
+++ b/snuba/utils/streams/profiler.py
@@ -1,0 +1,70 @@
+import logging
+import time
+from cProfile import Profile
+from pathlib import Path
+from typing import Callable, Mapping, Optional
+
+from snuba.utils.streams.processing import ProcessingStrategy, ProcessingStrategyFactory
+from snuba.utils.streams.types import Message, Partition, TPayload
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProcessingStrategyProfilerWrapper(ProcessingStrategy[TPayload]):
+    def __init__(
+        self,
+        strategy: ProcessingStrategy[TPayload],
+        profiler: Profile,
+        output_path: str,
+    ) -> None:
+        self.__strategy = strategy
+        self.__profiler = profiler
+        self.__output_path = output_path
+
+    def poll(self) -> None:
+        self.__strategy.poll()
+
+    def submit(self, message: Message[TPayload]) -> None:
+        self.__strategy.submit(message)
+
+    def close(self) -> None:
+        self.__strategy.close()
+
+    def terminate(self) -> None:
+        self.__strategy.terminate()
+        self.__profiler.disable()  # not sure if necessary
+        logger.info(
+            "Writing profile data from %r to %r...", self.__profiler, self.__output_path
+        )
+        self.__profiler.dump_stats(self.__output_path)
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self.__strategy.join(timeout)
+        self.__profiler.disable()  # not sure if necessary
+        logger.info(
+            "Writing profile data from %r to %r...", self.__profiler, self.__output_path
+        )
+        self.__profiler.dump_stats(self.__output_path)
+
+
+class ProcessingStrategyProfilerWrapperFactory(ProcessingStrategyFactory[TPayload]):
+    def __init__(
+        self,
+        strategy_factory: ProcessingStrategyFactory[TPayload],
+        output_directory: str,
+    ) -> None:
+        self.__strategy_factory = strategy_factory
+        self.__output_directory = Path(output_directory)
+        assert self.__output_directory.exists() and self.__output_directory.is_dir()
+
+    def create(
+        self, commit: Callable[[Mapping[Partition, int]], None]
+    ) -> ProcessingStrategy[TPayload]:
+        profiler = Profile()
+        profiler.enable()
+        return ProcessingStrategyProfilerWrapper(
+            self.__strategy_factory.create(commit),
+            profiler,
+            str(self.__output_directory / f"{int(time.time() * 1000)}.prof"),
+        )


### PR DESCRIPTION
This adds a `ProcessingStrategyProfilerWrapper` and corresponding factory class that sets up a profiler when a processing strategy is instantiated by the stream processor (on assignment) and profiles the execution of the running process until the stream processor is joined (on revocation) or terminated (on error), upon which the profile data is dumped so that it can be later analyzed with the `pstats` tool.

The profiler can be enabled on any running consumer in any environment (development or production) using the `--profile-path` argument.

This does not currently add any additional profiling to subprocesses when using `ParallelTransform` (`--processes` via the command line arguments), though I would like to do this later.