### PR TITLE
fix(migrations): Make groupedmessage migration work in ClickHouse 19.x

### DIFF
--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -31,6 +31,16 @@ def fix_order_by() -> None:
     if curr_primary_key != old_primary_key:
         return
 
+    # Add the project_id column
+    add_column_sql = operations.AddColumn(
+        storage_set=StorageSetKey.EVENTS,
+        table_name=TABLE_NAME,
+        column=Column("project_id", UInt(64)),
+        after="record_deleted",
+    ).format_sql()
+
+    clickhouse.execute(add_column_sql)
+
     # There shouldn't be any data in the table yet
     assert (
         clickhouse.execute(f"SELECT COUNT() FROM {TABLE_NAME} FINAL;")[0][0] == 0
@@ -67,12 +77,6 @@ class Migration(migration.MultiStepMigration):
 
     def forwards_local(self) -> Sequence[operations.Operation]:
         return [
-            operations.AddColumn(
-                storage_set=StorageSetKey.EVENTS,
-                table_name=TABLE_NAME,
-                column=Column("project_id", UInt(64)),
-                after="record_deleted",
-            ),
             operations.RunPython(func=fix_order_by),
         ]
 


### PR DESCRIPTION
For ClickHouse versions 19.x we discovered that atttempting to alter on
a column that was already part of the primary key throws an error, even
if the operation is no-op. We should skip this step if the user already
has the column and it's in the primary key.