### PR TITLE
build: separate requirements.txt for better layering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,9 @@ RUN set -ex; \
     '; \
     apt-get update; \
     apt-get install -y $buildDeps --no-install-recommends; \
+    \
     pip install -r requirements.txt; \
+    \
     mkdir /tmp/uwsgi-dogstatsd; \
     wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \
         | tar -xvz -C /tmp/uwsgi-dogstatsd --strip-components=1; \
@@ -66,7 +68,7 @@ RUN set -ex; \
     mkdir -p /var/lib/uwsgi; \
     mv dogstatsd_plugin.so /var/lib/uwsgi/; \
     uwsgi --need-plugin=/var/lib/uwsgi/dogstatsd --help > /dev/null; \
-    snuba --help; \
+    \
     apt-get purge -y --auto-remove $buildDeps; \
     rm -rf /var/lib/apt/lists/*;
 
@@ -77,7 +79,8 @@ RUN set -ex; \
     groupadd -r snuba; \
     useradd -r -g snuba snuba; \
     chown -R snuba:snuba ./; \
-    pip install -e .
+    pip install -e .; \
+    snuba --help;
 
 ARG SNUBA_VERSION_SHA
 ENV SNUBA_RELEASE=$SNUBA_VERSION_SHA \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,13 @@ RUN set -ex; \
 RUN set -x \
     && export GOSU_VERSION=1.11 \
     && fetchDeps=" \
-        curl \
         dirmngr \
         gnupg \
+        wget \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $fetchDeps \
-    && curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
-    && curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && for key in \
       B42F6819007F00F88E364FD4036A9C25BF357DD4 \
@@ -49,17 +49,17 @@ COPY requirements.txt ./
 RUN set -ex; \
     \
     buildDeps=' \
-        curl \
         gcc \
         libc6-dev \
         liblz4-dev \
         libpcre3-dev \
+        wget \
     '; \
     apt-get update; \
     apt-get install -y $buildDeps --no-install-recommends; \
     pip install -r requirements.txt; \
     mkdir /tmp/uwsgi-dogstatsd; \
-    curl -L https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \
+    wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \
         | tar -xvz -C /tmp/uwsgi-dogstatsd --strip-components=1; \
     uwsgi --build-plugin /tmp/uwsgi-dogstatsd; \
     rm -rf /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ ENV PIP_NO_CACHE_DIR=off \
 RUN set -ex; \
     \
     buildDeps=' \
-        git \
         gcc \
         libc6-dev \
         liblz4-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,14 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
+# TODO: this won't be needed if we build a separate image for testing only.
 RUN set -x \
     && export GOSU_VERSION=1.11 \
     && fetchDeps=" \
         dirmngr \
         gnupg \
     " \
-    && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
+    && apt-get update && apt-get install -y --no-install-recommends $fetchDeps \
     && curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
     && curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
@@ -46,7 +47,8 @@ RUN set -x \
     && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true \
-    && apt-get purge -y --auto-remove $fetchDeps
+    && apt-get purge -y --auto-remove $fetchDeps \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/snuba
 # Layer cache is pretty much invalidated here all the time,

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN set -x \
         gnupg \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
-    && curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+    && curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && for key in \
       B42F6819007F00F88E364FD4036A9C25BF357DD4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /usr/src/snuba
 RUN set -ex; \
     apt-get update; \
     apt-get install --no-install-recommends -y \
+        curl \
         libexpat1 \
         libffi6 \
         liblz4-1 \
@@ -24,11 +25,10 @@ RUN set -x \
     && fetchDeps=" \
         dirmngr \
         gnupg \
-        wget \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $fetchDeps && rm -rf /var/lib/apt/lists/* \
-    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && for key in \
       B42F6819007F00F88E364FD4036A9C25BF357DD4 \
@@ -59,7 +59,6 @@ RUN set -ex; \
         libc6-dev \
         liblz4-dev \
         libpcre3-dev \
-        wget \
     '; \
     apt-get update; \
     apt-get install -y $buildDeps --no-install-recommends; \
@@ -67,7 +66,7 @@ RUN set -ex; \
     \
     pip install -e .; \
     mkdir /tmp/uwsgi-dogstatsd; \
-    wget -O - https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \
+    curl -L https://github.com/DataDog/uwsgi-dogstatsd/archive/bc56a1b5e7ee9e955b7a2e60213fc61323597a78.tar.gz \
         | tar -xvz -C /tmp/uwsgi-dogstatsd --strip-components=1; \
     uwsgi --build-plugin /tmp/uwsgi-dogstatsd; \
     rm -rf /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder; \


### PR DESCRIPTION
The `COPY . /usr/src/snuba` layer is pretty much invalidated all the time, and the build step that follows fetches ~50 MB (227 MB unpacked) system packages. This will happen on like, every update commit to a PR which is pretty painful.

It's fixed by first installing requirements.txt before. To my knowledge at least uwsgi and the dogstatsd SO requires those packages to build.

The typical build time right now is a consistent 5m 30s, I'm not actually sure how much faster this is yet because `--cache-from getsentry/snuba:latest` and Cloud Build only pushes to the registry if it's a commit on master.  It probably won't be much faster, because the extra pip noop step is going to take a bit of time and Travis network is reasonably fast. But this is indeed way more respectful to Debian repositories.

Also includes some refactors from https://github.com/getsentry/getsentry/pull/4408, but most of those don't apply since this is a prod image.