### PR TITLE
ref(streams): Make logger a bit less noisy when terminating

### DIFF
--- a/snuba/utils/streams/processing.py
+++ b/snuba/utils/streams/processing.py
@@ -207,7 +207,7 @@ class StreamProcessor(Generic[TPayload]):
 
             self._shutdown()
         except Exception as error:
-            logger.warning("Caught %r, shutting down...", error)
+            logger.info("Caught %r, shutting down...", error)
 
             if self.__processing_strategy is not None:
                 logger.debug("Terminating %r...", self.__processing_strategy)


### PR DESCRIPTION
See SNUBA-21B. This exception is reraised later and will be logged independently, so downgrading this statement level to reduce noise.