### PR TITLE
feat: Add strip_top_level_identity_condition function

### DIFF
--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -193,7 +193,13 @@ def _get_first_level_conditions(
     """
     # Ignore the identity pattern, e.g. cond = 1 or 1 = cond since Sentry uses this
     # format frequently (in Discover) as a workaround to current schema limitations.
-    nested_func_call = Param("nested_func", FunctionCallPattern())
+    nested_func_call = Param(
+        "nested_func",
+        FunctionCallPattern(
+            None, Or([String(BooleanFunctions.AND), String(BooleanFunctions.OR)])
+        ),
+    )
+
     lit = LiteralPattern(None, Int(1))
 
     id_pattern = Or(

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -194,10 +194,7 @@ def _get_first_level_conditions(
     # Ignore the identity pattern, e.g. cond = 1 or 1 = cond since Sentry uses this
     # format frequently (in Discover) as a workaround to current schema limitations.
     nested_func_call = Param(
-        "nested_func",
-        FunctionCallPattern(
-            None, Or([String(BooleanFunctions.AND), String(BooleanFunctions.OR)])
-        ),
+        "nested_func", FunctionCallPattern(None, String(function)),
     )
 
     lit = LiteralPattern(None, Int(1))

--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -210,6 +210,18 @@ class AnyOptionalString(Pattern[Optional[str]]):
 
 
 @dataclass(frozen=True)
+class Int(Pattern[int]):
+    """
+    Matches one specific int.
+    """
+
+    value: int
+
+    def match(self, node: AnyType) -> Optional[MatchResult]:
+        return MatchResult() if node == self.value else None
+
+
+@dataclass(frozen=True)
 class Or(Pattern[TMatchedType]):
     """
     Union of multiple patterns. Matches if at least one is a valid match

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -225,21 +225,36 @@ def test_first_level_conditions() -> None:
         Literal(None, "test"),
     )
 
-    cond = binary_condition(
+    cond_and = binary_condition(
         None,
         BooleanFunctions.AND,
         binary_condition(None, BooleanFunctions.AND, c1, c2),
         c3,
     )
-    assert get_first_level_and_conditions(cond) == [c1, c2, c3]
+    assert get_first_level_and_conditions(cond_and) == [c1, c2, c3]
 
-    cond = binary_condition(
+    cond_or = binary_condition(
         None,
         BooleanFunctions.OR,
         binary_condition(None, BooleanFunctions.AND, c1, c2),
         c3,
     )
-    assert get_first_level_or_conditions(cond) == [
+    assert get_first_level_or_conditions(cond_or) == [
+        binary_condition(None, BooleanFunctions.AND, c1, c2),
+        c3,
+    ]
+
+    cond_identity_and = binary_condition(
+        None, ConditionFunctions.EQ, cond_and, Literal(None, 1)
+    )
+
+    assert get_first_level_and_conditions(cond_identity_and) == [c1, c2, c3]
+
+    cond_identity_or = binary_condition(
+        None, ConditionFunctions.EQ, cond_or, Literal(None, 1)
+    )
+
+    assert get_first_level_or_conditions(cond_identity_or) == [
         binary_condition(None, BooleanFunctions.AND, c1, c2),
         c3,
     ]


### PR DESCRIPTION
Since Sentry currently uses the syntax `equals(or(x, y), 1)` as a
workaround for OR conditions we need to be able to strip the outer
equals condition in some cases and treat the nested boolean condition
as the top one.

A previous version of this PR changed the `get_first_level_and_conditions`
and `get_first_level_or_conditions` functions to do this automatically however
I don't think it's a good idea to apply this everywhere since those functions
are used widely, and the old behaviour would be expected in some cases.
For example it would cause the query formatting to be wrong.

Instead we add a new function that strips the outer identity condition which
will only be called in specific scenarios - such as in https://github.com/getsentry/snuba/pull/1289