### PR TITLE
build: even more caching

### DIFF
--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -38,6 +38,7 @@ services:
       - zookeeper
     image: 'confluentinc/cp-kafka:5.1.2'
     build:
+      context: .
       cache_from:
         - 'confluentinc/cp-kafka:5.1.2'
     environment:
@@ -51,6 +52,7 @@ services:
   clickhouse:
     image: 'yandex/clickhouse-server:20.3.9.70'
     build:
+      context: .
       cache_from:
         - 'yandex/clickhouse-server:20.3.9.70'
     ulimits:
@@ -60,6 +62,7 @@ services:
   redis1: &redis_config
     image: 'redis:5.0-alpine'
     build:
+      context: .
       cache_from:
         - 'redis:5.0-alpine'
     command:

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -37,6 +37,9 @@ services:
     depends_on:
       - zookeeper
     image: 'confluentinc/cp-kafka:5.1.2'
+    build:
+      cache_from:
+        - 'confluentinc/cp-kafka:5.1.2'
     environment:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
       KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:9092'
@@ -47,12 +50,18 @@ services:
       KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
   clickhouse:
     image: 'yandex/clickhouse-server:20.3.9.70'
+    build:
+      cache_from:
+        - 'yandex/clickhouse-server:20.3.9.70'
     ulimits:
       nofile:
         soft: 262144
         hard: 262144
   redis1: &redis_config
-    image: redis:5.0-alpine
+    image: 'redis:5.0-alpine'
+    build:
+      cache_from:
+        - 'redis:5.0-alpine'
     command:
       - redis-server
       - '--appendonly'


### PR DESCRIPTION
just testing for now, pls ignore

`SNUBA_IMAGE=getsentry/snuba docker-compose -f docker-compose.gcb.yml run --rm snuba-test`

Always pulls images:

```
Pulling zookeeper (confluentinc/cp-zookeeper:5.1.2)...

5.1.2: Pulling from confluentinc/cp-zookeeper

Pulling kafka (confluentinc/cp-kafka:5.1.2)...

5.1.2: Pulling from confluentinc/cp-kafka

Pulling clickhouse (yandex/clickhouse-server:20.3.9.70)...

20.3.9.70: Pulling from yandex/clickhouse-server

Pulling redis1 (redis:5.0-alpine)...

5.0-alpine: Pulling from library/redis

Pulling redis2 (redis:5.0-alpine)...

5.0-alpine: Pulling from library/redis
```

This takes 140 - 90 = ~50 seconds.

I was surprised that `--cache-from` seems to work on Travis (only reference I could find is [here](https://github.com/travis-ci/travis-ci/issues/5358#issuecomment-523205080) and not entirely sure how cached layers are stored/persisted internal to Travis), now if only docker-compose could build from cache.
