### PR TITLE
ref(streams): Make `next_offset` an attribute of `Message`

### DIFF
--- a/snuba/utils/streams/backends/dummy.py
+++ b/snuba/utils/streams/backends/dummy.py
@@ -252,7 +252,7 @@ class DummyConsumer(Consumer[TPayload]):
                         self.__last_eof_at[partition] = offset
                         raise EndOfPartition(partition, offset)
                 else:
-                    self.__offsets[partition] = message.get_next_offset()
+                    self.__offsets[partition] = message.next_offset
                     return message
 
             return None

--- a/snuba/utils/streams/backends/kafka.py
+++ b/snuba/utils/streams/backends/kafka.py
@@ -435,7 +435,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             datetime.utcfromtimestamp(message.timestamp()[1] / 1000.0),
         )
 
-        self.__offsets[result.partition] = result.get_next_offset()
+        self.__offsets[result.partition] = result.next_offset
 
         return result
 

--- a/snuba/utils/streams/batching.py
+++ b/snuba/utils/streams/batching.py
@@ -159,10 +159,10 @@ class BatchProcessingStrategy(ProcessingStrategy[TPayload]):
         self.__metrics.timing("process_message", duration)
 
         if message.partition in self.__batch.offsets:
-            self.__batch.offsets[message.partition].hi = message.get_next_offset()
+            self.__batch.offsets[message.partition].hi = message.next_offset
         else:
             self.__batch.offsets[message.partition] = Offsets(
-                message.offset, message.get_next_offset()
+                message.offset, message.next_offset
             )
 
     def close(self) -> None:

--- a/snuba/utils/streams/streaming.py
+++ b/snuba/utils/streams/streaming.py
@@ -508,10 +508,10 @@ class Batch(Generic[TPayload]):
         self.__length += 1
 
         if message.partition in self.__offsets:
-            self.__offsets[message.partition].hi = message.get_next_offset()
+            self.__offsets[message.partition].hi = message.next_offset
         else:
             self.__offsets[message.partition] = OffsetRange(
-                message.offset, message.get_next_offset()
+                message.offset, message.next_offset
             )
 
     def close(self) -> None:

--- a/snuba/utils/streams/types.py
+++ b/snuba/utils/streams/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Generic, TypeVar
+from typing import Generic, Optional, TypeVar
 
 
 @dataclass(order=True, unsafe_hash=True)
@@ -32,12 +32,30 @@ class Message(Generic[TPayload]):
     Represents a single message within a partition.
     """
 
-    __slots__ = ["partition", "offset", "payload", "timestamp"]
+    __slots__ = ["partition", "offset", "payload", "timestamp", "next_offset"]
 
     partition: Partition
     offset: int
     payload: TPayload
     timestamp: datetime
+    next_offset: int
+
+    def __init__(
+        self,
+        partition: Partition,
+        offset: int,
+        payload: TPayload,
+        timestamp: datetime,
+        next_offset: Optional[int] = None,
+    ) -> None:
+        if next_offset is None:
+            next_offset = offset + 1
+
+        self.partition = partition
+        self.offset = offset
+        self.payload = payload
+        self.timestamp = timestamp
+        self.next_offset = next_offset
 
     def __repr__(self) -> str:
         # XXX: Field values can't be excluded from ``__repr__`` with
@@ -45,6 +63,3 @@ class Message(Generic[TPayload]):
         # ``__slots__`` for performance reasons. The class variable names
         # would conflict with the instance slot names, causing an error.
         return f"{type(self).__name__}(partition={self.partition!r}, offset={self.offset!r})"
-
-    def get_next_offset(self) -> int:
-        return self.offset + 1

--- a/tests/utils/streams/backends/mixins.py
+++ b/tests/utils/streams/backends/mixins.py
@@ -82,7 +82,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(
                 lambda: assignment_callback.called, False, True
             ), assert_changes(
-                consumer.tell, {}, {Partition(topic, 0): messages[1].get_next_offset()}
+                consumer.tell, {}, {Partition(topic, 0): messages[1].next_offset}
             ):
                 message = consumer.poll(10.0)  # XXX: getting the subcription is slow
 
@@ -115,13 +115,13 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
 
             assert consumer.commit_offsets() == {}
 
-            consumer.stage_offsets({message.partition: message.get_next_offset()})
+            consumer.stage_offsets({message.partition: message.next_offset})
 
             with pytest.raises(ConsumerError):
                 consumer.stage_offsets({Partition(Topic("invalid"), 0): 0})
 
             assert consumer.commit_offsets() == {
-                Partition(topic, 0): message.get_next_offset()
+                Partition(topic, 0): message.next_offset
             }
 
             assert consumer.tell() == {Partition(topic, 0): messages[1].offset}
@@ -194,7 +194,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
                 assert consumer.poll(1.0) is None
             except EndOfPartition as error:
                 assert error.partition == Partition(topic, 0)
-                assert error.offset == message.get_next_offset()
+                assert error.offset == message.next_offset
             else:
                 raise AssertionError("expected EndOfPartition error")
 
@@ -235,20 +235,20 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             # should be otherwise be safe to try to read the first missing
             # offset (index) in the partition.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.get_next_offset()}
+                consumer.tell, {message.partition: message.next_offset}
             ), pytest.raises(EndOfPartition):
                 consumer.poll(1.0) is None
 
             # It should be otherwise be safe to try to read the first missing
             # offset (index) in the partition.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.get_next_offset()}
+                consumer.tell, {message.partition: message.next_offset}
             ):
                 assert consumer.poll(1.0) is None
 
             with assert_changes(
                 consumer.tell,
-                {message.partition: message.get_next_offset()},
+                {message.partition: message.next_offset},
                 {message.partition: message.offset},
             ):
                 consumer.seek({message.partition: message.offset})
@@ -256,7 +256,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             with assert_changes(
                 consumer.tell,
                 {message.partition: message.offset},
-                {message.partition: message.get_next_offset()},
+                {message.partition: message.next_offset},
             ):
                 assert consumer.poll(1.0) == messages[0]
 
@@ -265,26 +265,26 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             # until we try to fetch a message.)
             with assert_changes(
                 consumer.tell,
-                {message.partition: message.get_next_offset()},
-                {message.partition: message.get_next_offset() + 1},
+                {message.partition: message.next_offset},
+                {message.partition: message.next_offset + 1},
             ):
-                consumer.seek({message.partition: message.get_next_offset() + 1})
+                consumer.seek({message.partition: message.next_offset + 1})
 
             # Offsets should not be advanced after a failed poll.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.get_next_offset() + 1}
+                consumer.tell, {message.partition: message.next_offset + 1}
             ), pytest.raises(ConsumerError):
                 consumer.poll(1.0)
 
             # Trying to seek on an unassigned partition should error.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.get_next_offset() + 1}
+                consumer.tell, {message.partition: message.next_offset + 1}
             ), pytest.raises(ConsumerError):
                 consumer.seek({message.partition: 0, Partition(topic, -1): 0})
 
             # Trying to seek to a negative offset should error.
             with assert_does_not_change(
-                consumer.tell, {message.partition: message.get_next_offset() + 1}
+                consumer.tell, {message.partition: message.next_offset + 1}
             ), pytest.raises(ConsumerError):
                 consumer.seek({message.partition: -1})
 
@@ -321,7 +321,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             # are consumed before calling ``pause``.
             with assert_changes(
                 consumer.tell,
-                {Partition(topic, 0): messages[1].get_next_offset()},
+                {Partition(topic, 0): messages[1].next_offset},
                 {Partition(topic, 0): messages[3].offset},
             ):
                 consumer.seek({Partition(topic, 0): messages[3].offset})
@@ -337,7 +337,7 @@ class StreamsTestMixin(ABC, Generic[TPayload]):
             consumer.pause([Partition(topic, 0)])
             with assert_changes(
                 consumer.tell,
-                {Partition(topic, 0): messages[3].get_next_offset()},
+                {Partition(topic, 0): messages[3].next_offset},
                 {Partition(topic, 0): messages[0].offset},
             ):
                 consumer.seek({Partition(topic, 0): messages[0].offset})

--- a/tests/utils/streams/backends/test_kafka.py
+++ b/tests/utils/streams/backends/test_kafka.py
@@ -163,10 +163,10 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
             message = consumer.poll(10.0)  # XXX: getting the subscription is slow
             assert isinstance(message, Message)
 
-            consumer.stage_offsets({message.partition: message.get_next_offset()})
+            consumer.stage_offsets({message.partition: message.next_offset})
 
             assert consumer.commit_offsets() == {
-                Partition(topic, 0): message.get_next_offset()
+                Partition(topic, 0): message.next_offset
             }
 
             assert len(commit_log_producer.messages) == 1
@@ -175,7 +175,7 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
 
             assert commit_codec.decode(
                 KafkaPayload(commit_message.key(), commit_message.value())
-            ) == Commit("test", Partition(topic, 0), message.get_next_offset())
+            ) == Commit("test", Partition(topic, 0), message.next_offset)
 
 
 def test_commit_codec() -> None:

--- a/tests/utils/streams/test_synchronized.py
+++ b/tests/utils/streams/test_synchronized.py
@@ -20,7 +20,7 @@ def wait_for_consumer(consumer: Consumer[T], message: Message[T], attempts: int 
     """Block until the provided consumer has received the provided message."""
     for i in range(attempts):
         part = consumer.tell().get(message.partition)
-        if part is not None and part >= message.get_next_offset():
+        if part is not None and part >= message.next_offset:
             return
 
         time.sleep(0.1)
@@ -68,9 +68,7 @@ def test_synchronized_consumer(broker: DummyBroker[KafkaPayload]) -> None:
             producer.produce(
                 commit_log_topic,
                 commit_codec.encode(
-                    Commit(
-                        "leader-a", Partition(topic, 0), messages[0].get_next_offset()
-                    )
+                    Commit("leader-a", Partition(topic, 0), messages[0].next_offset)
                 ),
             ).result(),
         )
@@ -89,9 +87,7 @@ def test_synchronized_consumer(broker: DummyBroker[KafkaPayload]) -> None:
             producer.produce(
                 commit_log_topic,
                 commit_codec.encode(
-                    Commit(
-                        "leader-b", Partition(topic, 0), messages[0].get_next_offset()
-                    )
+                    Commit("leader-b", Partition(topic, 0), messages[0].next_offset)
                 ),
             ).result(),
         )
@@ -101,7 +97,7 @@ def test_synchronized_consumer(broker: DummyBroker[KafkaPayload]) -> None:
         with assert_changes(consumer.paused, [Partition(topic, 0)], []), assert_changes(
             consumer.tell,
             {Partition(topic, 0): messages[0].offset},
-            {Partition(topic, 0): messages[0].get_next_offset()},
+            {Partition(topic, 0): messages[0].next_offset},
         ):
             assert synchronized_consumer.poll(0.0) == messages[0]
 
@@ -141,7 +137,7 @@ def test_synchronized_consumer(broker: DummyBroker[KafkaPayload]) -> None:
         with assert_changes(consumer.paused, [Partition(topic, 0)], []), assert_changes(
             consumer.tell,
             {Partition(topic, 0): messages[1].offset},
-            {Partition(topic, 0): messages[1].get_next_offset()},
+            {Partition(topic, 0): messages[1].next_offset},
         ):
             assert synchronized_consumer.poll(0.0) == messages[1]
 
@@ -178,7 +174,7 @@ def test_synchronized_consumer(broker: DummyBroker[KafkaPayload]) -> None:
         with assert_changes(consumer.paused, [Partition(topic, 0)], []), assert_changes(
             consumer.tell,
             {Partition(topic, 0): messages[4].offset},
-            {Partition(topic, 0): messages[4].get_next_offset()},
+            {Partition(topic, 0): messages[4].next_offset},
         ):
             assert synchronized_consumer.poll(0.0) == messages[4]
 
@@ -225,7 +221,7 @@ def test_synchronized_consumer_pause_resume(broker: DummyBroker[KafkaPayload]) -
             producer.produce(
                 commit_log_topic,
                 commit_codec.encode(
-                    Commit("leader", Partition(topic, 0), messages[0].get_next_offset())
+                    Commit("leader", Partition(topic, 0), messages[0].next_offset)
                 ),
             ).result(),
         )
@@ -297,9 +293,7 @@ def test_synchronized_consumer_handles_end_of_partition(
             producer.produce(
                 commit_log_topic,
                 commit_codec.encode(
-                    Commit(
-                        "leader", Partition(topic, 0), messages[0].get_next_offset()
-                    ),
+                    Commit("leader", Partition(topic, 0), messages[0].next_offset),
                 ),
             ).result(),
         )
@@ -313,9 +307,7 @@ def test_synchronized_consumer_handles_end_of_partition(
             producer.produce(
                 commit_log_topic,
                 commit_codec.encode(
-                    Commit(
-                        "leader", Partition(topic, 0), messages[1].get_next_offset()
-                    ),
+                    Commit("leader", Partition(topic, 0), messages[1].next_offset),
                 ),
             ).result(),
         )


### PR DESCRIPTION
This makes `next_offset` an attribute of `Message` (rather than it always being arithmetically derived from `offset`) enabling stream backends to support non-sequential offsets.