### PR TITLE
fix(ast) Handle different types of literals in arrayjoin

### DIFF
--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -233,7 +233,10 @@ def parse_function_to_expr(
                         "Function cannot be in()/notIn()"
                     )
                 )
-            return parse_string_to_expr(literal)
+            if isinstance(literal, str):
+                return parse_string_to_expr(literal)
+            else:
+                return Literal(None, literal)
 
     def unpack_array_condition_builder(
         lhs: Expression, func: str, literal: Any, alias: Optional[str],

--- a/tests/query/parser/test_functions.py
+++ b/tests/query/parser/test_functions.py
@@ -310,6 +310,53 @@ test_data = [
             ),
         ),
     ),
+    (
+        tuplify(
+            [
+                "or",
+                [
+                    ["equals", ["exception_stacks.mechanism_handled", 0]],
+                    ["equals", [["ifNull", ["tags[handled]", "''"]], "'no'"]],
+                ],
+            ]
+        ),
+        binary_condition(
+            None,
+            BooleanFunctions.OR,
+            FunctionCall(
+                None,
+                "arrayExists",
+                (
+                    Lambda(
+                        None,
+                        ("x",),
+                        transformation=FunctionCall(
+                            None,
+                            "assumeNotNull",
+                            (
+                                FunctionCall(
+                                    None,
+                                    "equals",
+                                    (Argument(None, name="x"), Literal(None, 0)),
+                                ),
+                            ),
+                        ),
+                    ),
+                    Column(None, None, "exception_stacks.mechanism_handled"),
+                ),
+            ),
+            binary_condition(
+                None,
+                ConditionFunctions.EQ,
+                FunctionCall(
+                    None,
+                    "ifNull",
+                    (Column(None, None, "tags[handled]",), Literal(None, "")),
+                ),
+                Literal(None, "no"),
+            ),
+        ),
+    ),
 ]
 
 


### PR DESCRIPTION
When functions are passed in with literal arguments, they are not necessarily
strings. Fix the function parser to handle different literal types, particularly
when unpacking array join conditions.