### PR TITLE
feat(migrations): Add post merge hook to warn about new migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 develop: install-python-dependencies setup-git
 
 setup-git:
+	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./
 	pip install 'pre-commit==2.4.0'
 	pre-commit install --install-hooks
 

--- a/config/hooks/post-merge
+++ b/config/hooks/post-merge
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+red="$(tput setaf 1)"
+bold="$(tput bold)"
+reset="$(tput sgr0)"
+
+
+files_changed_upstream="$(mktemp)"
+trap "rm -f ${files_changed_upstream}" EXIT
+
+git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD > "$files_changed_upstream"
+
+grep -E --quiet 'migrations/groups.py' "$files_changed_upstream"          && needs_update=1
+
+[[ "$needs_update" ]] && cat <<EOF
+
+[${red}${bold}!!!${reset}] Some migrations may have changed, you may need to run:
+
+  snuba migrations migrate --force
+
+EOF
+
+if [[ "$needs_update" ]]; then
+  $update_command
+fi


### PR DESCRIPTION
Not needed if snuba devserver is being used, but might be a useful warning for anyone not running the devserver command.

Mostly copied from https://github.com/getsentry/sentry/blob/master/config/hooks/post-merge