### PR TITLE
perf(final) Collect metrics of how often FINAL is caused by unmerge

### DIFF
--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -46,6 +46,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
             final, exclude_group_ids = get_projects_query_flags(
                 list(project_ids), self.__replacer_state_name,
             )
+            if final:
+                metrics.increment("final", tags={"cause": "final_flag"})
             if not final and exclude_group_ids:
                 # If the number of groups to exclude exceeds our limit, the query
                 # should just use final instead of the exclusion set.
@@ -53,6 +55,7 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     "max_group_ids_exclude", settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE
                 )
                 if len(exclude_group_ids) > max_group_ids_exclude:
+                    metrics.increment("final", tags={"cause": "max_groups"})
                     set_final = True
                 else:
                     condition_to_add = (


### PR DESCRIPTION
I'd like to gather some data about the distribution of FINAL between unmerge and cases where the list of group ids is too long.