### PR TITLE
fix(subscriptions): Move `time_shift` constructor parameter from worker to consumer

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -154,7 +154,10 @@ def subscriptions(
                 else Topic(loader.get_commit_log_topic_spec().topic_name)
             ),
             set(commit_log_groups),
-        )
+        ),
+        time_shift=(
+            timedelta(seconds=delay_seconds * -1) if delay_seconds is not None else None
+        ),
     )
 
     producer = ProducerEncodingWrapper(
@@ -202,11 +205,6 @@ def subscriptions(
                     producer,
                     Topic(result_topic),
                     metrics,
-                    time_shift=(
-                        timedelta(seconds=delay_seconds * -1)
-                        if delay_seconds is not None
-                        else None
-                    ),
                 ),
                 max_batch_size,
                 max_batch_time_ms,


### PR DESCRIPTION
Fixes regression introduced in #1323