### PR TITLE
ci(release): Simplify and align with Sentry release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: release
 on:
   workflow_dispatch:
     inputs:
@@ -28,34 +29,37 @@ jobs:
               echo "Open release-blocking issues found, cancelling release...";
               curl -sf -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/cancel;
             fi
-        - id: calver
-          if: ${{ !github.event.inputs.version }}
-          run: echo "::set-output name=version::$(date +'%y.%-m.0')"
+        - id: set-version
+          run: |
+            if [[ -n '${{ github.event.inputs.version }}' ]]; then
+              echo '::set-env name=RELEASE_VERSION::${{ github.event.inputs.version }}';
+            else
+              DATE_PART=$(date +'%y.%-m')
+              declare -i PATCH_VERSION=0
+              while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
+                PATCH_VERSION+=1
+              done
+              echo "::set-env name=RELEASE_VERSION::${DATE_PART}.${PATCH_VERSION}"
+            fi
         - uses: actions/checkout@v2
           with:
             token: ${{ secrets.GH_SENTRY_BOT_PAT }}
+        - id: set-git-user
+          run: |
+            git config user.name getsentry-bot
+            git config user.email bot@getsentry.com
         - uses: getsentry/craft@master
           if: ${{ !github.event.inputs.skip_prepare }}
           with:
             action: prepare
-            version: ${{ github.event.inputs.version || steps.calver.outputs.version }}
+            version: ${{ env.RELEASE_VERSION }}
           env:
             DRY_RUN: ${{ github.event.inputs.dry_run }}
-            GIT_COMMITTER_NAME: getsentry-bot
-            GIT_AUTHOR_NAME: getsentry-bot
-            EMAIL: bot@getsentry.com
-        # Wait until the builds start. Craft should do this automatically
-        # but it is broken now.
-        # TODO: Remove this once getsentry/craft#111 is fixed
-        - run: sleep 10
         - uses: getsentry/craft@master
           with:
             action: publish
-            version: ${{ github.event.inputs.version || steps.calver.outputs.version }}
+            version: ${{ env.RELEASE_VERSION }}
           env:
             DRY_RUN: ${{ github.event.inputs.dry_run }}
-            GIT_COMMITTER_NAME: getsentry-bot
-            GIT_AUTHOR_NAME: getsentry-bot
-            EMAIL: bot@getsentry.com
             DOCKER_USERNAME: 'sentrybuilder'
             DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Mostly a port of getsentry/sentry#20796 along with adding a name for aesthetics and removing the obsolete `sleep 10` step.
