### PR TITLE
perf(streams): Convert `KafkaPayload` to `NamedTuple`

### DIFF
--- a/snuba/perf.py
+++ b/snuba/perf.py
@@ -29,7 +29,7 @@ def get_messages(events_file) -> Sequence[Message[KafkaPayload]]:
             Message(
                 Partition(Topic("events"), 1),
                 0,
-                KafkaPayload(None, raw_event.encode("utf-8")),
+                KafkaPayload(None, raw_event.encode("utf-8"), []),
                 datetime.now(),
             ),
         )

--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -47,4 +47,5 @@ class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult
                     },
                 }
             ).encode("utf-8"),
+            [],
         )

--- a/snuba/utils/streams/backends/kafka.py
+++ b/snuba/utils/streams/backends/kafka.py
@@ -71,26 +71,14 @@ class KafkaPayload:
     # objects, it's probably more important to preserve their performance and
     # memory impact than it is their developer friendliness (unfortunately.)
 
-    __slots__ = ["__key", "__value", "__headers"]
+    __slots__ = ["key", "value", "headers"]
 
     def __init__(
         self, key: Optional[bytes], value: bytes, headers: Optional[Headers] = None
     ) -> None:
-        self.__key = key
-        self.__value = value
-        self.__headers = headers if headers is not None else []
-
-    @property
-    def key(self) -> Optional[bytes]:
-        return self.__key
-
-    @property
-    def value(self) -> bytes:
-        return self.__value
-
-    @property
-    def headers(self) -> Headers:
-        return self.__headers
+        self.key = key
+        self.value = value
+        self.headers = headers if headers is not None else []
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KafkaPayload):

--- a/snuba/utils/streams/backends/kafka.py
+++ b/snuba/utils/streams/backends/kafka.py
@@ -13,6 +13,7 @@ from typing import (
     Mapping,
     MutableMapping,
     MutableSequence,
+    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -65,30 +66,10 @@ class InvalidState(RuntimeError):
 Headers = Sequence[Tuple[str, bytes]]
 
 
-class KafkaPayload:
-    # XXX: This is not a dataclass since dataclasses do not support classes
-    # with __slots__ *and* default values. Since we create a lot of these
-    # objects, it's probably more important to preserve their performance and
-    # memory impact than it is their developer friendliness (unfortunately.)
-
-    __slots__ = ["key", "value", "headers"]
-
-    def __init__(
-        self, key: Optional[bytes], value: bytes, headers: Optional[Headers] = None
-    ) -> None:
-        self.key = key
-        self.value = value
-        self.headers = headers if headers is not None else []
-
-    def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, KafkaPayload):
-            return False
-        else:
-            return (
-                self.key == other.key
-                and self.value == other.value
-                and self.headers == other.headers
-            )
+class KafkaPayload(NamedTuple):
+    key: Optional[bytes]
+    value: bytes
+    headers: Headers
 
     def __reduce_ex__(self, protocol: int):
         if protocol >= 5:

--- a/snuba/utils/streams/synchronized.py
+++ b/snuba/utils/streams/synchronized.py
@@ -33,6 +33,7 @@ class CommitCodec(Codec[KafkaPayload, Commit]):
                 "utf-8"
             ),
             f"{value.offset}".encode("utf-8"),
+            [],
         )
 
     def decode(self, value: KafkaPayload) -> Commit:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -435,7 +435,7 @@ if application.debug or application.testing:
         message: Message[KafkaPayload] = Message(
             Partition(Topic("topic"), 0),
             0,
-            KafkaPayload(None, http_request.data),
+            KafkaPayload(None, http_request.data, []),
             datetime.now(),
         )
 

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -36,7 +36,7 @@ class TestReplacer(BaseEventsTest):
         return Message(
             Partition(Topic("replacements"), 0),
             0,
-            KafkaPayload(None, json.dumps(msg).encode("utf-8")),
+            KafkaPayload(None, json.dumps(msg).encode("utf-8"), []),
             datetime.now(),
         )
 
@@ -262,6 +262,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )
@@ -299,6 +300,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )
@@ -338,6 +340,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -39,7 +39,7 @@ class TestConsumer(BaseEventsTest):
             Partition(Topic("events"), 456),
             123,
             KafkaPayload(
-                None, json.dumps((2, "insert", event)).encode("utf-8")
+                None, json.dumps((2, "insert", event)).encode("utf-8"), []
             ),  # event doesn't really matter
             datetime.now(),
         )
@@ -91,7 +91,7 @@ class TestConsumer(BaseEventsTest):
         message: Message[KafkaPayload] = Message(
             Partition(Topic("events"), 1),
             42,
-            KafkaPayload(None, json.dumps((2, "insert", event)).encode("utf-8")),
+            KafkaPayload(None, json.dumps((2, "insert", event)).encode("utf-8"), []),
             datetime.now(),
         )
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -39,7 +39,7 @@ class TestReplacer(BaseEventsTest):
         return Message(
             Partition(Topic("replacements"), 0),
             0,
-            KafkaPayload(None, json.dumps(msg).encode("utf-8")),
+            KafkaPayload(None, json.dumps(msg).encode("utf-8"), []),
             datetime.now(),
         )
 
@@ -263,6 +263,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )
@@ -300,6 +301,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )
@@ -339,6 +341,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )
@@ -395,6 +398,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )
@@ -454,6 +458,7 @@ class TestReplacer(BaseEventsTest):
                         },
                     )
                 ).encode("utf-8"),
+                [],
             ),
             datetime.now(),
         )

--- a/tests/utils/streams/backends/test_kafka.py
+++ b/tests/utils/streams/backends/test_kafka.py
@@ -26,13 +26,13 @@ from tests.utils.streams.backends.mixins import StreamsTestMixin
 
 
 def test_payload_equality() -> None:
-    assert KafkaPayload(None, b"") == KafkaPayload(None, b"")
-    assert KafkaPayload(b"key", b"value") == KafkaPayload(b"key", b"value")
+    assert KafkaPayload(None, b"", []) == KafkaPayload(None, b"", [])
+    assert KafkaPayload(b"key", b"value", []) == KafkaPayload(b"key", b"value", [])
     assert KafkaPayload(None, b"", [("key", b"value")]) == KafkaPayload(
         None, b"", [("key", b"value")]
     )
-    assert not KafkaPayload(None, b"a") == KafkaPayload(None, b"b")
-    assert not KafkaPayload(b"this", b"") == KafkaPayload(b"that", b"")
+    assert not KafkaPayload(None, b"a", []) == KafkaPayload(None, b"b", [])
+    assert not KafkaPayload(b"this", b"", []) == KafkaPayload(b"that", b"", [])
     assert not KafkaPayload(None, b"", [("key", b"this")]) == KafkaPayload(
         None, b"", [("key", b"that")]
     )
@@ -93,7 +93,7 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
 
     def get_payloads(self) -> Iterator[KafkaPayload]:
         for i in itertools.count():
-            yield KafkaPayload(None, f"{i}".encode("utf8"))
+            yield KafkaPayload(None, f"{i}".encode("utf8"), [])
 
     def test_auto_offset_reset_earliest(self) -> None:
         with self.get_topic() as topic:
@@ -174,7 +174,11 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
             assert commit_message.topic() == "commit-log"
 
             assert commit_codec.decode(
-                KafkaPayload(commit_message.key(), commit_message.value())
+                KafkaPayload(
+                    commit_message.key(),
+                    commit_message.value(),
+                    commit_message.headers(),
+                )
             ) == Commit("test", Partition(topic, 0), message.next_offset)
 
 

--- a/tests/utils/streams/test_synchronized.py
+++ b/tests/utils/streams/test_synchronized.py
@@ -42,7 +42,9 @@ def test_synchronized_consumer(broker: Broker[KafkaPayload]) -> None:
     commit_log_consumer = broker.get_consumer("commit-log-consumer")
 
     messages = [
-        producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"))).result(1.0)
+        producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"), [])).result(
+            1.0
+        )
         for i in range(6)
     ]
 
@@ -191,7 +193,9 @@ def test_synchronized_consumer_pause_resume(broker: Broker[KafkaPayload]) -> Non
     commit_log_consumer = broker.get_consumer("commit-log-consumer")
 
     messages = [
-        producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"))).result(1.0)
+        producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"), [])).result(
+            1.0
+        )
         for i in range(2)
     ]
 
@@ -274,7 +278,9 @@ def test_synchronized_consumer_handles_end_of_partition(
     commit_log_consumer = broker.get_consumer("commit-log-consumer")
 
     messages = [
-        producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"))).result(1.0)
+        producer.produce(topic, KafkaPayload(None, f"{i}".encode("utf8"), [])).result(
+            1.0
+        )
         for i in range(2)
     ]
 


### PR DESCRIPTION
This removes the performance hit caused by exposing `key`, `value`, and `headers` as immutable properties while retaining the immutability of the data structure.