### PR TITLE
perf(cdc): Remove dropped message metric from filter

### DIFF
--- a/snuba/datasets/cdc/message_filters.py
+++ b/snuba/datasets/cdc/message_filters.py
@@ -31,9 +31,7 @@ class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
         )
 
         if table_name:
-            table_name = table_name.decode("utf-8")
-            if table_name != self.__postgres_table:
-                metrics.increment("cdc_message_dropped", tags={"table": table_name})
+            if table_name.decode("utf-8") != self.__postgres_table:
                 return True
 
         return False

--- a/snuba/datasets/cdc/message_filters.py
+++ b/snuba/datasets/cdc/message_filters.py
@@ -30,8 +30,4 @@ class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
             (value for key, value in message.payload.headers if key == "table"), None
         )
 
-        if table_name:
-            if table_name.decode("utf-8") != self.__postgres_table:
-                return True
-
-        return False
+        return table_name and table_name.decode("utf-8") != self.__postgres_table


### PR DESCRIPTION
Consumers that use this filter spend a substantial amount of time waiting on `socket.send` for these individual metrics.

The filtration ratio for these consumers is a useful metric, but we will need to find a different method of reporting these metrics moving forward that aggregates the data in-process rather than sending each metric individually. (My hope is to add this in the future to the streaming package so that this is automatically instrumented on the step.)

In the meantime, this will allow us to get a better sense of the consumer performance without the overhead from recording this high density metric.