### PR TITLE
feat(ast) Remove dependency on legacy query from splitter

### DIFF
--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -159,14 +159,9 @@ class TimeSplitQueryStrategy(QuerySplitStrategy):
             logger.warning(
                 "Mismatch in start date on time splitter.",
                 extra={"ast": str(from_date_ast), "legacy": str(from_date)},
+                exc_info=True,
             )
             metrics.increment("mismatch.ast_from_date")
-        if to_date != to_date_ast:
-            logger.warning(
-                "Mismatch in end date on time splitter.",
-                extra={"ast": str(to_date_ast), "legacy": str(to_date)},
-            )
-            metrics.increment("mismatch.ast_to_date")
 
         remaining_offset = query.get_offset()
 
@@ -290,22 +285,13 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             if match:
                 return None
 
-        total_legacy_cols = query.get_all_referenced_columns()
-        total_col_count = len(total_legacy_cols)
         # We need to count the number of table/column name pairs
         # not the number of distinct Column objects in the query
         # so to avoid counting aliased columns multiple times.
-        total_ast_cols = {
+        total_columns = {
             (col.table_name, col.column_name)
             for col in query.get_all_ast_referenced_columns()
         }
-        total_ast_count = len(total_ast_cols)
-        if total_col_count != total_ast_count:
-            logger.warning(
-                "Mismatch in original query referenced column when splitting",
-                extra={"ast": total_ast_cols, "legacy": total_legacy_cols},
-            )
-            metrics.increment("mismatch.total_referenced_columns")
 
         minimal_query = copy.deepcopy(query)
         minimal_query.set_selected_columns(
@@ -340,21 +326,11 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
                     exc_info=True,
                 )
 
-        minimal_ast_cols = {
+        minimal_columns = {
             (col.table_name, col.column_name)
             for col in minimal_query.get_all_ast_referenced_columns()
         }
-        minimal_ast_count = len(minimal_ast_cols)
-        minimal_legacy_cols = minimal_query.get_all_referenced_columns()
-        minimal_count = len(minimal_legacy_cols)
-        if minimal_count != minimal_ast_count:
-            logger.warning(
-                "Mismatch in minimal query referenced column when splitting",
-                extra={"ast": minimal_ast_cols, "legacy": minimal_legacy_cols},
-            )
-            metrics.increment("mismatch.minimal_query_referenced_columns")
-
-        if total_col_count <= minimal_count:
+        if len(total_columns) <= len(minimal_columns):
             return None
 
         # Ensures the AST minimal query is actually runnable on its own.


### PR DESCRIPTION
Three of the four metrics we collected around discrepancies in managing the legacy query on query splitter turned out to be expected. So removing that log and the related dependency.

The fourth seems fine (actually it was a bug in the legacy system) but I need to do one last verification, thus logging the stack trace.