### PR TITLE
perf(cdc): Filter out all non-change messages when filtering by table name

### DIFF
--- a/snuba/datasets/cdc/message_filters.py
+++ b/snuba/datasets/cdc/message_filters.py
@@ -13,9 +13,11 @@ KAFKA_ONLY_PARTITION = (
 
 class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
     """
-    Filters CDC messages not related with the table this filter is interested into.
-    This filtering happens based on the table header when present and without
-    parsing the message payload.
+    Removes all messages from the stream that are not change events (insert,
+    update, delete) on the specified table. (This also removes transactional
+    events, such as begin and commit events, as they are not directed at a
+    specific table.) This filtering utilizes the table header and does not
+    require parsing the payload value.
     """
 
     def __init__(self, postgres_table: str) -> None:
@@ -30,4 +32,4 @@ class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):
             (value for key, value in message.payload.headers if key == "table"), None
         )
 
-        return table_name and table_name.decode("utf-8") != self.__postgres_table
+        return not table_name or table_name.decode("utf-8") != self.__postgres_table

--- a/tests/datasets/test_groupassignee.py
+++ b/tests/datasets/test_groupassignee.py
@@ -100,19 +100,9 @@ class TestGroupassignee(BaseDatasetTest):
             offset=42, partition=0, timestamp=datetime(1970, 1, 1)
         )
 
-        assert not message_filter.should_drop(
-            self.__make_msg(0, 42, self.BEGIN_MSG, [])
-        )
-        begin_msg = json.loads(self.BEGIN_MSG)
-        ret = processor.process_message(begin_msg, metadata)
-        assert ret is None
+        assert message_filter.should_drop(self.__make_msg(0, 42, self.BEGIN_MSG, []))
 
-        assert not message_filter.should_drop(
-            self.__make_msg(0, 42, self.COMMIT_MSG, [])
-        )
-        commit_msg = json.loads(self.COMMIT_MSG)
-        ret = processor.process_message(commit_msg, metadata)
-        assert ret is None
+        assert message_filter.should_drop(self.__make_msg(0, 42, self.COMMIT_MSG, []))
 
         assert not message_filter.should_drop(
             self.__make_msg(
@@ -165,7 +155,9 @@ class TestGroupassignee(BaseDatasetTest):
         assert ret == InsertBatch([self.DELETED, self.PROCESSED_UPDATE])
 
         assert not message_filter.should_drop(
-            self.__make_msg(0, 42, self.DELETE_MSG, [])
+            self.__make_msg(
+                0, 42, self.DELETE_MSG, [("table", POSTGRES_TABLE.encode())],
+            )
         )
         delete_msg = json.loads(self.DELETE_MSG)
         ret = processor.process_message(delete_msg, metadata)

--- a/tests/test_groupedmessage.py
+++ b/tests/test_groupedmessage.py
@@ -110,19 +110,9 @@ class TestGroupedMessage(BaseDatasetTest):
             offset=42, partition=0, timestamp=datetime(1970, 1, 1)
         )
 
-        assert not message_filter.should_drop(
-            self.__make_msg(0, 42, self.BEGIN_MSG, [])
-        )
-        begin_msg = json.loads(self.BEGIN_MSG)
-        ret = processor.process_message(begin_msg, metadata)
-        assert ret is None
+        assert message_filter.should_drop(self.__make_msg(0, 42, self.BEGIN_MSG, []))
 
-        assert not message_filter.should_drop(
-            self.__make_msg(0, 42, self.COMMIT_MSG, [])
-        )
-        commit_msg = json.loads(self.COMMIT_MSG)
-        ret = processor.process_message(commit_msg, metadata)
-        assert ret is None
+        assert message_filter.should_drop(self.__make_msg(0, 42, self.COMMIT_MSG, []))
 
         assert not message_filter.should_drop(
             self.__make_msg(
@@ -160,7 +150,9 @@ class TestGroupedMessage(BaseDatasetTest):
         assert ret == InsertBatch([self.PROCESSED])
 
         assert not message_filter.should_drop(
-            self.__make_msg(0, 42, self.DELETE_MSG, [])
+            self.__make_msg(
+                0, 42, self.DELETE_MSG, [("table", "sentry_groupedmessage".encode())]
+            )
         )
         delete_msg = json.loads(self.DELETE_MSG)
         ret = processor.process_message(delete_msg, metadata)


### PR DESCRIPTION
Removing messages that are not directed at a specific table when filtering the CDC stream should prevent sending a large amount of messages to the processing pool that are otherwise discarded at that stage. Specifically when dealing the the parallel transformation, this will remove begin and commit events that have had all of their contents filtered out since they do not affect relevant tables. I suspect we send a lot of these transactional events due to our use of autocommit creating implicit single change transactions.