### PR TITLE
test: Refactor tests

### DIFF
--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -1,7 +1,7 @@
 import simplejson as json
 import pytest
 from typing import Any, MutableMapping
-from tests.base import BaseDatasetTest
+from tests.base import BaseTest
 
 from snuba.datasets.factory import get_dataset
 from snuba.query.parser import parse_query
@@ -9,7 +9,7 @@ from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
 
 
-def get_dataset_source(dataset_name):
+def get_dataset_source(dataset_name: str):
     return (
         get_dataset(dataset_name).get_all_storages()[0].get_schema().get_data_source()
     )
@@ -142,7 +142,7 @@ test_data = [
 ]
 
 
-class TestDiscover(BaseDatasetTest):
+class TestDiscover(BaseTest):
     @pytest.mark.parametrize("query_body, expected_table", test_data)
     def test_data_source(
         self, query_body: MutableMapping[str, Any], expected_table: str,

--- a/tests/migrations/test_migrate.py
+++ b/tests/migrations/test_migrate.py
@@ -4,8 +4,7 @@ import pytest
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.factory import DATASET_NAMES
-from tests.base import dataset_manager
+from snuba.datasets.factory import DATASET_NAMES, get_dataset
 
 
 def test_runs_all_migrations_without_errors() -> None:
@@ -16,8 +15,7 @@ def test_runs_all_migrations_without_errors() -> None:
 
 @pytest.fixture(params=DATASET_NAMES)
 def dataset(request) -> Iterator[Dataset]:
-    with dataset_manager(request.param) as instance:
-        yield instance
+    yield get_dataset(request.param)
 
 
 def test_no_schema_diffs(dataset: Dataset) -> None:

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -14,10 +14,10 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.scheduler import ScheduledTask
 from snuba.utils.types import Interval
-from tests.base import BaseTest
+from tests.base import BaseDatasetTest
 
 
-class TestSubscriptionScheduler(BaseTest):
+class TestSubscriptionScheduler(BaseDatasetTest):
     def setup_method(self, test_method, dataset_name="events") -> None:
         super().setup_method(test_method, dataset_name)
         self.now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -1,11 +1,9 @@
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
-from typing import Iterable, Iterator, MutableMapping, Tuple
+from typing import Iterable, MutableMapping, Tuple
 from uuid import UUID, uuid1
 
-import pytest
-
-from snuba.datasets.dataset import Dataset
+from snuba.datasets.factory import get_dataset
 from snuba.subscriptions.consumer import Tick
 from snuba.subscriptions.data import (
     PartitionId,
@@ -23,7 +21,12 @@ from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.local.backend import LocalBroker as Broker
 from snuba.utils.types import Interval
-from tests.base import dataset_manager
+
+
+def setup_function() -> None:
+    from snuba.migrations.runner import Runner
+
+    Runner().run_all(force=True)
 
 
 class DummySubscriptionDataStore(SubscriptionDataStore):
@@ -43,15 +46,8 @@ class DummySubscriptionDataStore(SubscriptionDataStore):
         return [*self.__subscriptions.items()]
 
 
-@pytest.fixture
-def dataset() -> Iterator[Dataset]:
-    with dataset_manager("events") as dataset:
-        yield dataset
-
-
-def test_subscription_worker(
-    dataset: Dataset, broker: Broker[SubscriptionTaskResult],
-) -> None:
+def test_subscription_worker(broker: Broker[SubscriptionTaskResult],) -> None:
+    dataset = get_dataset("events")
     result_topic = Topic("subscription-results")
 
     broker.create_topic(result_topic, partitions=1)

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -9,24 +9,23 @@ from snuba.datasets.storages.factory import get_storage
 
 
 class TestCleanup(BaseEventsTest):
-    def test(self):
+    def test(self) -> None:
         def to_monday(d):
             return d - timedelta(days=d.weekday())
 
         base = datetime(1999, 12, 26)  # a sunday
 
-        clickhouse = (
-            get_storage(StorageKey.EVENTS)
-            .get_cluster()
-            .get_query_connection(ClickhouseClientSettings.CLEANUP)
-        )
+        cluster = get_storage(StorageKey.EVENTS).get_cluster()
+        database = cluster.get_database()
 
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.CLEANUP)
+
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == []
 
         # base, 90 retention
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == [(to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
         assert stale == []
@@ -34,7 +33,7 @@ class TestCleanup(BaseEventsTest):
         # -40 days, 90 retention
         three_weeks_ago = base - timedelta(days=7 * 3)
         self.write_rows([self.create_event_row_for_date(three_weeks_ago)])
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == [(to_monday(three_weeks_ago), 90), (to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
         assert stale == []
@@ -42,7 +41,7 @@ class TestCleanup(BaseEventsTest):
         # -100 days, 90 retention
         thirteen_weeks_ago = base - timedelta(days=7 * 13)
         self.write_rows([self.create_event_row_for_date(thirteen_weeks_ago)])
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
             (to_monday(three_weeks_ago), 90),
@@ -54,7 +53,7 @@ class TestCleanup(BaseEventsTest):
         # -1 week, 30 retention
         one_week_ago = base - timedelta(days=7)
         self.write_rows([self.create_event_row_for_date(one_week_ago, 30)])
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
             (to_monday(three_weeks_ago), 90),
@@ -67,7 +66,7 @@ class TestCleanup(BaseEventsTest):
         # -5 weeks, 30 retention
         five_weeks_ago = base - timedelta(days=7 * 5)
         self.write_rows([self.create_event_row_for_date(five_weeks_ago, 30)])
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
             (to_monday(five_weeks_ago), 30),
@@ -81,11 +80,9 @@ class TestCleanup(BaseEventsTest):
             (to_monday(five_weeks_ago), 30),
         ]
 
-        cleanup.drop_partitions(
-            clickhouse, self.database, self.table, stale, dry_run=False
-        )
+        cleanup.drop_partitions(clickhouse, database, self.table, stale, dry_run=False)
 
-        parts = cleanup.get_active_partitions(clickhouse, self.database, self.table)
+        parts = cleanup.get_active_partitions(clickhouse, database, self.table)
         assert parts == [
             (to_monday(three_weeks_ago), 90),
             (to_monday(one_week_ago), 30),

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1,6 +1,5 @@
 import calendar
 import uuid
-from contextlib import ExitStack
 from datetime import datetime
 from functools import partial
 
@@ -9,18 +8,12 @@ import simplejson as json
 from snuba import settings
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.factory import enforce_table_writer, get_dataset
-from tests.base import BaseApiTest, dataset_manager
+from tests.base import BaseApiTest
 
 
 class TestDiscoverApi(BaseApiTest):
     def setup_method(self, test_method):
         super().setup_method(test_method)
-
-        # XXX: This should use the ``discover`` dataset directly, but that will
-        # require some updates to the test base classes to work correctly.
-        self.__dataset_manager = ExitStack()
-        for dataset_name in ["events", "transactions"]:
-            self.__dataset_manager.enter_context(dataset_manager(dataset_name))
 
         self.app.post = partial(self.app.post, headers={"referer": "test"})
         self.project_id = self.event["project_id"]
@@ -30,9 +23,6 @@ class TestDiscoverApi(BaseApiTest):
         self.span_id = "8841662216cc598b"
         self.generate_event()
         self.generate_transaction()
-
-    def teardown_method(self, test_method):
-        self.__dataset_manager.__exit__(None, None, None)
 
     def generate_event(self):
         self.dataset = get_dataset("events")

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -9,16 +9,12 @@ from snuba.datasets.storages.factory import get_storage
 
 
 class TestOptimize(BaseEventsTest):
-    def test(self):
-        clickhouse = (
-            get_storage(StorageKey.EVENTS)
-            .get_cluster()
-            .get_query_connection(ClickhouseClientSettings.OPTIMIZE)
-        )
+    def test(self) -> None:
+        cluster = get_storage(StorageKey.EVENTS).get_cluster()
+        database = cluster.get_database()
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
         # no data, 0 partitions to optimize
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, self.table)
         assert parts == []
 
         base = datetime(1999, 12, 26)  # a sunday
@@ -26,23 +22,17 @@ class TestOptimize(BaseEventsTest):
 
         # 1 event, 0 unoptimized parts
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, self.table)
         assert parts == []
 
         # 2 events in the same part, 1 unoptimized part
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, self.table)
         assert parts == [(base_monday, 90)]
 
         # 3 events in the same part, 1 unoptimized part
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, self.table)
         assert parts == [(base_monday, 90)]
 
         # 3 events in one part, 2 in another, 2 unoptimized parts
@@ -52,22 +42,18 @@ class TestOptimize(BaseEventsTest):
         )
         self.write_rows([self.create_event_row_for_date(a_month_earlier_monday)])
         self.write_rows([self.create_event_row_for_date(a_month_earlier_monday)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, self.table)
         assert parts == [(base_monday, 90), (a_month_earlier_monday, 90)]
 
         # respects before (base is properly excluded)
         assert list(
             optimize.get_partitions_to_optimize(
-                clickhouse, self.database, self.table, before=base
+                clickhouse, database, self.table, before=base
             )
         ) == [(a_month_earlier_monday, 90)]
 
-        optimize.optimize_partitions(clickhouse, self.database, self.table, parts)
+        optimize.optimize_partitions(clickhouse, database, self.table, parts)
 
         # all parts should be optimized
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, self.table)
         assert parts == []


### PR DESCRIPTION
This PR introduces BaseStorageTest to make it easier to test a storage
without an accompanying dataset (not used yet but intended to allow for
the deletion of the errors dataset). It also simplifies BaseTest and
ensures that migrations run before every test that inherits from this,
not just those for which a dataset name is passed in the setup_method.