### PR TITLE
feat(errors): Simplify schema, turn off errors migrations via old system

### DIFF
--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -22,7 +22,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.errors_processor import ErrorsProcessor
 from snuba.datasets.errors_replacer import ErrorsReplacer, ReplacerState
 from snuba.datasets.schemas import MandatoryCondition
-from snuba.datasets.schemas.tables import ReplacingMergeTreeSchema
+from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.processors.replaced_groups import (
@@ -164,7 +164,7 @@ promoted_tag_columns = {
     "level": "level",
 }
 
-schema = ReplacingMergeTreeSchema(
+schema = WritableTableSchema(
     columns=all_columns,
     local_table_name="errors_local",
     dist_table_name="errors_dist",
@@ -188,23 +188,9 @@ schema = ReplacingMergeTreeSchema(
         "environment",
         "project_id",
     ],
-    order_by="(org_id, project_id, toStartOfDay(timestamp), primary_hash_hex, event_hash)",
-    partition_by="(toMonday(timestamp), if(retention_days = 30, 30, 90))",
-    version_column="deleted",
-    sample_expr="event_hash",
-    ttl_expr="timestamp + toIntervalDay(retention_days)",
-    settings={"index_granularity": "8192"},
-    migration_function=errors_migrations,
-    # Tags hashmap is a materialized column. Clickhouse does not allow
-    # us to create a materialized column that references a nested one
-    # during create statement
-    # (https://github.com/ClickHouse/ClickHouse/issues/12586), so the
-    # materialization is added with a migration.
-    skipped_cols_on_creation={"_tags_hash_map"},
 )
 
 required_columns = [
-    "org_id",
     "event_id",
     "project_id",
     "group_id",

--- a/snuba/migrations/migrate.py
+++ b/snuba/migrations/migrate.py
@@ -14,7 +14,6 @@ logger = logging.getLogger("snuba.migrate")
 
 STORAGES_TO_MIGRATE = [
     StorageKey.EVENTS,
-    StorageKey.ERRORS,
     StorageKey.GROUPEDMESSAGES,
     StorageKey.GROUPASSIGNEES,
     StorageKey.OUTCOMES_RAW,

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -79,8 +79,8 @@ class TestReplacer(BaseEventsTest):
         assert replacement.query_args == {
             "group_ids": "1, 2, 3",
             "project_id": self.project_id,
-            "required_columns": "org_id, event_id, project_id, group_id, timestamp, deleted, retention_days",
-            "select_columns": "org_id, event_id, project_id, group_id, timestamp, 1, retention_days",
+            "required_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days",
+            "select_columns": "event_id, project_id, group_id, timestamp, 1, retention_days",
             "timestamp": timestamp.strftime(DATETIME_FORMAT),
         }
         assert replacement.query_time_flags == (


### PR DESCRIPTION
This stops migrating the errors table via the old migration system,
as we will be rebuilding this table soon. Keeping migrations in both
the old and the new system in sync is something I want to avoid doing
in this case. This table is currently unused.

It also removes org_id from the required_column list since this column
will be dropped in the new version of the table.