### PR TITLE
fix(measurements): Ignore measurement values that may be null

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,4 +1,5 @@
 import logging
+import numbers
 import uuid
 from datetime import datetime
 from typing import Any, MutableMapping, Optional
@@ -133,7 +134,12 @@ class TransactionsMessageProcessor(MessageProcessor):
                 (
                     processed["measurements.key"],
                     processed["measurements.value"],
-                ) = extract_nested(measurements, lambda value: float(value["value"]))
+                ) = extract_nested(
+                    measurements,
+                    lambda value: float(value["value"])
+                    if isinstance(value["value"], numbers.Number)
+                    else None,
+                )
             except Exception:
                 # Not failing the event in this case just yet, because we are still
                 # developing this feature.

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -104,6 +104,7 @@ class TransactionEvent:
                     "measurements": {
                         "lcp": {"value": 32.129},
                         "lcp.elementSize": {"value": 4242},
+                        "fid": {"value": None},
                     },
                     "contexts": {
                         "trace": {


### PR DESCRIPTION
When Relay validates a measurement, Relay will preserve the key, `null` the value, and attach a processing error. 

Thus, Snuba may receive measurement values that are `null`.