### PR TITLE
fix(measurements): Ignore measurement values that are not consistent

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -138,7 +138,7 @@ class TransactionsMessageProcessor(MessageProcessor):
                     measurements,
                     lambda value: float(value["value"])
                     if (
-                        isinstance(value, dict)
+                        value is not None
                         and isinstance(value.get("value"), numbers.Number)
                     )
                     else None,

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -137,7 +137,10 @@ class TransactionsMessageProcessor(MessageProcessor):
                 ) = extract_nested(
                     measurements,
                     lambda value: float(value["value"])
-                    if isinstance(value["value"], numbers.Number)
+                    if (
+                        isinstance(value, dict)
+                        and isinstance(value.get("value"), numbers.Number)
+                    )
                     else None,
                 )
             except Exception:

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -105,6 +105,8 @@ class TransactionEvent:
                         "lcp": {"value": 32.129},
                         "lcp.elementSize": {"value": 4242},
                         "fid": {"value": None},
+                        "invalid": None,
+                        "invalid2": {},
                     },
                     "contexts": {
                         "trace": {


### PR DESCRIPTION
Continuation of https://github.com/getsentry/snuba/pull/1364

----

I recently learned from @untitaker that Relay may not guarantee that the expected shape is non-nullable.