### PR TITLE
ref: Remove NullableOld

### DIFF
--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -92,27 +92,6 @@ class ColumnTypeWithModifier(ABC, ColumnType):
         return self.inner_type.get_raw()
 
 
-class NullableOld(ColumnTypeWithModifier):
-    # Old version of Nullable that inherits from ColumnTypeWithModifier, will be
-    # removed after old migration system is gone.
-    def __init__(self, inner_type: ColumnType) -> None:
-        super().__init__(inner_type)
-
-    def __repr__(self) -> str:
-        return "Nullable({})".format(repr(self.inner_type))
-
-    def __eq__(self, other: object) -> bool:
-        return (
-            self.__class__ == other.__class__ or isinstance(other, Nullable)
-        ) and self.inner_type == cast(NullableOld, other).inner_type
-
-    def for_schema(self) -> str:
-        return "Nullable({})".format(self.inner_type.for_schema())
-
-    def get_raw(self) -> ColumnType:
-        return Nullable(self.inner_type.get_raw())
-
-
 class Materialized(ColumnTypeWithModifier):
     def __init__(self, inner_type: ColumnType, expression: str) -> None:
         super().__init__(inner_type)
@@ -191,9 +170,9 @@ class Nullable(ColumnType):
         return "Nullable({})".format(repr(self.inner_type))
 
     def __eq__(self, other: object) -> bool:
-        return (
-            self.__class__ == other.__class__ or isinstance(other, NullableOld)
-        ) and self.inner_type == cast(Nullable, other).inner_type
+        return (self.__class__ == other.__class__) and self.inner_type == cast(
+            Nullable, other
+        ).inner_type
 
     def for_schema(self) -> str:
         return "Nullable({})".format(self.inner_type.for_schema())

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -9,7 +9,7 @@ from snuba.clickhouse.columns import (
     Float,
     Materialized,
     Nested,
-    NullableOld as Nullable,
+    Nullable,
     ReadOnly,
     String,
     UInt,

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -1,4 +1,4 @@
-from snuba.clickhouse.columns import ColumnSet, DateTime, NullableOld as Nullable, UInt
+from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeProcessor,

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -1,4 +1,4 @@
-from snuba.clickhouse.columns import ColumnSet, DateTime, NullableOld as Nullable, UInt
+from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.cdc import CdcStorage
 from snuba.datasets.cdc.groupedmessage_processor import (

--- a/snuba/datasets/storages/outcomes.py
+++ b/snuba/datasets/storages/outcomes.py
@@ -2,7 +2,7 @@ from snuba.clickhouse.columns import (
     ColumnSet,
     DateTime,
     LowCardinality,
-    NullableOld as Nullable,
+    Nullable,
     String,
     UInt,
     UUID,

--- a/snuba/datasets/storages/spans.py
+++ b/snuba/datasets/storages/spans.py
@@ -6,7 +6,7 @@ from snuba.clickhouse.columns import (
     LowCardinality,
     Materialized,
     Nested,
-    NullableOld as Nullable,
+    Nullable,
     String,
     UInt,
     WithDefault,

--- a/tests/query/validation/test_signature.py
+++ b/tests/query/validation/test_signature.py
@@ -2,7 +2,7 @@ from typing import Sequence
 
 import pytest
 
-from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, NullableOld, String
+from snuba.clickhouse.columns import ColumnSet, DateTime, Nullable, String
 from snuba.query.expressions import (
     Column as ColumnExpr,
     Expression,
@@ -126,7 +126,7 @@ def test_like_validator(
             ("level", Nullable(String())),
             ("str_col", String()),
             ("timestamp", DateTime()),
-            ("received", NullableOld(DateTime())),
+            ("received", Nullable(DateTime())),
         ]
     )
 


### PR DESCRIPTION
Replace NullableOld with Nullable everywhere. NullableOld was only
needed to preserve the behavior of the old migration system where
Nullable was treated as a column type modifier.