### PR TITLE
ref(discover): Remove search_message from Discover data model

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -394,7 +394,6 @@ class DiscoverEntity(Entity):
                 ("server_name", Nullable(String())),
                 ("site", Nullable(String())),
                 ("url", Nullable(String())),
-                ("search_message", Nullable(String())),
                 ("location", Nullable(String())),
                 ("culprit", Nullable(String())),
                 ("received", Nullable(DateTime())),


### PR DESCRIPTION
The `search_message` column is never being populated, we should remove
it from the Discover data model.