### PR TITLE
test: Ensure migrations are run before all tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -22,17 +22,7 @@ from tests.fixtures import raw_event
 
 @contextmanager
 def dataset_manager(name: str) -> Iterator[Dataset]:
-    from snuba.migrations.runner import Runner
-    from snuba.web.views import truncate_dataset
-
-    Runner().run_all(force=True)
-    dataset = get_dataset(name)
-    truncate_dataset(dataset)
-
-    try:
-        yield dataset
-    finally:
-        truncate_dataset(dataset)
+    yield get_dataset(name)
 
 
 class BaseTest(object):

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -8,88 +8,91 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
 
 
-class TestClusters:
-    def setup_class(self) -> None:
-        settings.CLUSTERS = [
-            {
-                "host": "host_1",
-                "port": 9000,
-                "user": "default",
-                "password": "",
-                "database": "default",
-                "http_port": 8123,
-                "storage_sets": {
-                    "events",
-                    "events_ro",
-                    "migrations",
-                    "outcomes",
-                    "querylog",
-                    "sessions",
-                },
-                "single_node": True,
+def setup_function() -> None:
+    settings.CLUSTERS = [
+        {
+            "host": "host_1",
+            "port": 9000,
+            "user": "default",
+            "password": "",
+            "database": "default",
+            "http_port": 8123,
+            "storage_sets": {
+                "events",
+                "events_ro",
+                "migrations",
+                "outcomes",
+                "querylog",
+                "sessions",
             },
-            {
-                "host": "host_2",
-                "port": 9000,
-                "user": "default",
-                "password": "",
-                "database": "default",
-                "http_port": 8123,
-                "storage_sets": {"transactions"},
-                "single_node": False,
-                "cluster_name": "clickhouse_hosts",
-                "distributed_cluster_name": "dist_hosts",
-            },
+            "single_node": True,
+        },
+        {
+            "host": "host_2",
+            "port": 9000,
+            "user": "default",
+            "password": "",
+            "database": "default",
+            "http_port": 8123,
+            "storage_sets": {"transactions"},
+            "single_node": False,
+            "cluster_name": "clickhouse_hosts",
+            "distributed_cluster_name": "dist_hosts",
+        },
+    ]
+    importlib.reload(cluster)
+
+
+def teardown_function() -> None:
+    importlib.reload(settings)
+    importlib.reload(cluster)
+
+
+def test_clusters() -> None:
+    assert (
+        get_storage(StorageKey("events")).get_cluster()
+        == get_storage(StorageKey("errors")).get_cluster()
+    )
+
+    assert (
+        get_storage(StorageKey("events")).get_cluster()
+        != get_storage(StorageKey("transactions")).get_cluster()
+    )
+
+
+def test_get_local_nodes() -> None:
+    with patch.object(ClickhousePool, "execute") as execute:
+        execute.return_value = [
+            ("host_1", 9000, 1, 1),
+            ("host_2", 9000, 2, 1),
         ]
-        importlib.reload(cluster)
 
-    def teardown_class(self) -> None:
-        importlib.reload(settings)
-        importlib.reload(cluster)
+        local_cluster = get_storage(StorageKey("events")).get_cluster()
+        assert len(local_cluster.get_local_nodes()) == 1
+        assert local_cluster.get_local_nodes()[0].host_name == "host_1"
+        assert local_cluster.get_local_nodes()[0].port == 9000
+        assert local_cluster.get_local_nodes()[0].shard is None
+        assert local_cluster.get_local_nodes()[0].replica is None
 
-    def test_clusters(self) -> None:
-        assert (
-            get_storage(StorageKey("events")).get_cluster()
-            == get_storage(StorageKey("errors")).get_cluster()
-        )
+        distributed_cluster = get_storage(StorageKey("transactions")).get_cluster()
+        assert len(distributed_cluster.get_local_nodes()) == 2
+        assert distributed_cluster.get_local_nodes()[0].host_name == "host_1"
+        assert distributed_cluster.get_local_nodes()[1].host_name == "host_2"
 
-        assert (
-            get_storage(StorageKey("events")).get_cluster()
-            != get_storage(StorageKey("transactions")).get_cluster()
-        )
 
-    def test_get_local_nodes(self) -> None:
-        with patch.object(ClickhousePool, "execute") as execute:
-            execute.return_value = [
-                ("host_1", 9000, 1, 1),
-                ("host_2", 9000, 2, 1),
-            ]
+def test_cache_connections() -> None:
+    cluster_1 = cluster.ClickhouseCluster(
+        "localhost", 8000, "default", "", "default", 8001, {"events"}, True
+    )
 
-            local_cluster = get_storage(StorageKey("events")).get_cluster()
-            assert len(local_cluster.get_local_nodes()) == 1
-            assert local_cluster.get_local_nodes()[0].host_name == "host_1"
-            assert local_cluster.get_local_nodes()[0].port == 9000
-            assert local_cluster.get_local_nodes()[0].shard is None
-            assert local_cluster.get_local_nodes()[0].replica is None
+    assert cluster_1.get_query_connection(
+        cluster.ClickhouseClientSettings.QUERY
+    ) == cluster_1.get_query_connection(cluster.ClickhouseClientSettings.QUERY)
 
-            distributed_cluster = get_storage(StorageKey("transactions")).get_cluster()
-            assert len(distributed_cluster.get_local_nodes()) == 2
-            assert distributed_cluster.get_local_nodes()[0].host_name == "host_1"
-            assert distributed_cluster.get_local_nodes()[1].host_name == "host_2"
-
-    def test_cache_connections(self) -> None:
-        cluster_1 = cluster.ClickhouseCluster(
-            "localhost", 8000, "default", "", "default", 8001, {"events"}, True
-        )
-
-        assert cluster_1.get_query_connection(
-            cluster.ClickhouseClientSettings.QUERY
-        ) == cluster_1.get_query_connection(cluster.ClickhouseClientSettings.QUERY)
-
-        assert cluster_1.get_node_connection(
-            cluster.ClickhouseClientSettings.OPTIMIZE,
-            cluster.ClickhouseNode("localhost", 8002),
-        ) == cluster_1.get_node_connection(
-            cluster.ClickhouseClientSettings.OPTIMIZE,
-            cluster.ClickhouseNode("localhost", 8002),
-        )
+    assert cluster_1.get_node_connection(
+        cluster.ClickhouseClientSettings.OPTIMIZE,
+        cluster.ClickhouseNode("localhost", 8002),
+    ) == cluster_1.get_node_connection(
+        cluster.ClickhouseClientSettings.OPTIMIZE,
+        cluster.ClickhouseNode("localhost", 8002),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,7 @@ from typing import Iterator
 
 import pytest
 
-from snuba import settings
-from snuba.clickhouse.native import ClickhousePool
-from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.clusters.cluster import ClickhouseClientSettings, CLUSTERS
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
@@ -22,12 +20,9 @@ def pytest_configure() -> None:
     """
     setup_sentry()
 
-    for cluster in settings.CLUSTERS:
-        connection = ClickhousePool(
-            cluster["host"], cluster["port"], "default", "", "default",
-        )
-
-        database_name = cluster["database"]
+    for cluster in CLUSTERS:
+        connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+        database_name = cluster.get_database()
         connection.execute(f"DROP DATABASE IF EXISTS {database_name};")
         connection.execute(f"CREATE DATABASE {database_name};")
 

--- a/tests/datasets/test_factory.py
+++ b/tests/datasets/test_factory.py
@@ -1,8 +1,6 @@
 from snuba.datasets.factory import get_dataset, get_dataset_name
-from tests.base import BaseTest
 
 
-class TestGetDatasetName(BaseTest):
-    def test(self):
-        dataset_name = "events"
-        assert get_dataset_name(get_dataset(dataset_name)) == dataset_name
+def test_get_dataset_name() -> None:
+    dataset_name = "events"
+    assert get_dataset_name(get_dataset(dataset_name)) == dataset_name

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -19,7 +19,7 @@ from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.writer import BatchWriterEncoderWrapper
 
 
-def setup_function() -> None:
+def _drop_all_tables() -> None:
     for cluster in CLUSTERS:
         connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
         database = cluster.get_database()
@@ -29,6 +29,14 @@ def setup_function() -> None:
         )
         for (table,) in data:
             connection.execute(f"DROP TABLE IF EXISTS {table}")
+
+
+def setup_function() -> None:
+    _drop_all_tables()
+
+
+def teardown_function() -> None:
+    _drop_all_tables()
 
 
 def test_get_status() -> None:


### PR DESCRIPTION
Thi ensures that migrations are run before any tests, not just those
that inherit from the BaseTest class. This should enable us to simplify
the way we write tests and deprecate BaseTest in future.