### PR TITLE
test: Kill BaseTest

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -17,12 +17,8 @@ from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
 from tests.fixtures import raw_event
 
 
-class BaseTest(object):
+class BaseDatasetTest:
     def setup_method(self, test_method, dataset_name: Optional[str] = None):
-        assert (
-            settings.TESTING
-        ), "settings.TESTING is False, try `SNUBA_SETTINGS=test` or `make test`"
-
         self.database = os.environ.get("CLICKHOUSE_DATABASE", "default")
         self.dataset_name = dataset_name
 
@@ -31,8 +27,6 @@ class BaseTest(object):
         else:
             self.dataset = None
 
-
-class BaseDatasetTest(BaseTest):
     def write_processed_messages(self, messages: Sequence[ProcessedMessage]) -> None:
         rows: MutableSequence[WriterTableRow] = []
         for message in messages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from typing import Iterator
 
 import pytest
 
+from snuba import settings
 from snuba.clusters.cluster import ClickhouseClientSettings, CLUSTERS
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages import StorageKey
@@ -19,6 +20,10 @@ def pytest_configure() -> None:
     Set up the Sentry SDK to avoid errors hidden by configuration.
     Ensure the snuba_test database exists
     """
+    assert (
+        settings.TESTING
+    ), "settings.TESTING is False, try `SNUBA_SETTINGS=test` or `make test`"
+
     setup_sentry()
 
     for cluster in CLUSTERS:

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -1,5 +1,3 @@
-from tests.base import BaseTest
-
 from datetime import datetime, timedelta, timezone
 
 from snuba.datasets.sessions_processor import SessionsProcessor
@@ -7,7 +5,7 @@ from snuba.consumer import KafkaMessageMetadata
 from snuba.processor import InsertBatch
 
 
-class TestSessionProcessor(BaseTest):
+class TestSessionProcessor:
     def test_ingest_session_event_max_sample_rate(self):
         timestamp = datetime.now(timezone.utc)
         started = timestamp - timedelta(hours=1)

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -6,7 +6,6 @@ from typing import Any, Mapping, Optional, Tuple
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.processor import InsertBatch
-from tests.base import BaseTest
 
 
 @dataclass
@@ -223,7 +222,7 @@ class TransactionEvent:
         return ret
 
 
-class TestTransactionsProcessor(BaseTest):
+class TestTransactionsProcessor:
     def __get_timestamps(slef) -> Tuple[float, float]:
         timestamp = datetime.now(tz=timezone.utc) - timedelta(seconds=5)
         start_timestamp = timestamp - timedelta(seconds=5)

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -2,7 +2,6 @@ import pytest
 from unittest.mock import patch
 import uuid
 
-from tests.base import BaseTest
 from snuba import state
 from snuba.state.rate_limit import (
     rate_limit,
@@ -14,7 +13,7 @@ from snuba.state.rate_limit import (
 )
 
 
-class TestRateLimit(BaseTest):
+class TestRateLimit:
     def test_concurrent_limit(self):
         # No concurrent limit should not raise
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -17,10 +17,9 @@ from snuba.subscriptions.data import (
 from snuba.subscriptions.worker import SubscriptionTaskResult
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.scheduler import ScheduledTask
-from tests.base import BaseTest
 
 
-class TestSubscriptionCodec(BaseTest):
+class TestSubscriptionCodec:
     def build_subscription_data(self) -> SubscriptionData:
         return SubscriptionData(
             project_id=5,

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Collection, Tuple
 
+from snuba.datasets.factory import get_dataset
 from snuba.redis import redis_client
 from snuba.subscriptions.data import (
     PartitionId,
@@ -14,14 +15,13 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.scheduler import ScheduledTask
 from snuba.utils.types import Interval
-from tests.base import BaseTest
 
 
-class TestSubscriptionScheduler(BaseTest):
-    def setup_method(self, test_method, dataset_name="events") -> None:
-        super().setup_method(test_method, dataset_name)
+class TestSubscriptionScheduler:
+    def setup_method(self) -> None:
         self.now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
         self.partition_id = PartitionId(1)
+        self.dataset = get_dataset("events")
 
     def build_subscription(self, resolution: timedelta) -> Subscription:
         return Subscription(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,39 +2,39 @@ from datetime import date, datetime
 
 from snuba.clickhouse.escaping import escape_alias, escape_identifier
 from snuba.util import escape_literal
-from tests.base import BaseTest
 
 
-class TestUtil(BaseTest):
-    def test_escape(self):
-        assert escape_literal(r"'") == r"'\''"
-        assert escape_literal(r"\'") == r"'\\\''"
-        assert escape_literal(date(2001, 1, 1)) == "toDate('2001-01-01', 'Universal')"
-        assert (
-            escape_literal(datetime(2001, 1, 1, 1, 1, 1))
-            == "toDateTime('2001-01-01T01:01:01', 'Universal')"
-        )
-        assert (
-            escape_literal([1, "a", date(2001, 1, 1)])
-            == "(1, 'a', toDate('2001-01-01', 'Universal'))"
-        )
+def test_escape() -> None:
+    assert escape_literal(r"'") == r"'\''"
+    assert escape_literal(r"\'") == r"'\\\''"
+    assert escape_literal(date(2001, 1, 1)) == "toDate('2001-01-01', 'Universal')"
+    assert (
+        escape_literal(datetime(2001, 1, 1, 1, 1, 1))
+        == "toDateTime('2001-01-01T01:01:01', 'Universal')"
+    )
+    assert (
+        escape_literal([1, "a", date(2001, 1, 1)])
+        == "(1, 'a', toDate('2001-01-01', 'Universal'))"
+    )
 
-    def test_escape_identifier(self):
-        assert escape_identifier(None) is None
-        assert escape_identifier("") == ""
-        assert escape_identifier("foo") == "foo"
-        assert escape_identifier("foo.bar") == "foo.bar"
-        assert escape_identifier("foo:bar") == "`foo:bar`"
 
-        # Even though backtick characters in columns should be
-        # disallowed by the query schema, make sure we dont allow
-        # injection anyway.
-        assert escape_identifier("`") == r"`\``"
-        assert escape_identifier("production`; --") == r"`production\`; --`"
+def test_escape_identifier() -> None:
+    assert escape_identifier(None) is None
+    assert escape_identifier("") == ""
+    assert escape_identifier("foo") == "foo"
+    assert escape_identifier("foo.bar") == "foo.bar"
+    assert escape_identifier("foo:bar") == "`foo:bar`"
 
-    def test_escape_alias(self):
-        assert escape_alias(None) is None
-        assert escape_alias("") == ""
-        assert escape_alias("foo") == "foo"
-        assert escape_alias("foo.bar") == "`foo.bar`"
-        assert escape_alias("foo:bar") == "`foo:bar`"
+    # Even though backtick characters in columns should be
+    # disallowed by the query schema, make sure we dont allow
+    # injection anyway.
+    assert escape_identifier("`") == r"`\``"
+    assert escape_identifier("production`; --") == r"`production\`; --`"
+
+
+def test_escape_alias() -> None:
+    assert escape_alias(None) is None
+    assert escape_alias("") == ""
+    assert escape_alias("foo") == "foo"
+    assert escape_alias("foo.bar") == "`foo.bar`"
+    assert escape_alias("foo:bar") == "`foo:bar`"


### PR DESCRIPTION
Most of what BaseTest does has now being moved into either
pytest_configure or BaseDatasetTest, we no longer need this class.