### PR TITLE
feat: Stop reading from search_message

### DIFF
--- a/snuba/datasets/storages/events_column_processor.py
+++ b/snuba/datasets/storages/events_column_processor.py
@@ -21,18 +21,6 @@ class EventsColumnProcessor(QueryProcessor):
                             Literal(None, 0),
                         ),
                     )
-                elif exp.column_name == "message":
-                    # Because of the rename from message->search_message without backfill,
-                    # records will have one or the other of these fields.
-                    # TODO this can be removed once all data has search_message filled in.
-                    return FunctionCall(
-                        exp.alias,
-                        "coalesce",
-                        (
-                            Column(None, exp.table_name, "search_message"),
-                            Column(None, exp.table_name, exp.column_name),
-                        ),
-                    )
 
             return exp
 

--- a/tests/query/processors/test_events_column_processor.py
+++ b/tests/query/processors/test_events_column_processor.py
@@ -32,17 +32,7 @@ def test_events_column_format_expressions() -> None:
                     (Column(None, None, "group_id"), Literal(None, 0),),
                 ),
             ),
-            SelectedExpression(
-                "the_message",
-                FunctionCall(
-                    "the_message",
-                    "coalesce",
-                    (
-                        Column(None, None, "search_message"),
-                        Column(None, None, "message"),
-                    ),
-                ),
-            ),
+            SelectedExpression("the_message", Column("the_message", None, "message"),),
         ],
     )
 
@@ -54,7 +44,7 @@ def test_events_column_format_expressions() -> None:
 
     expected = (
         "(nullIf(group_id, 0) AS the_group_id)",
-        "(coalesce(search_message, message) AS the_message)",
+        "(message AS the_message)",
     )
 
     for idx, column in enumerate(unprocessed.get_selected_columns_from_ast()[1:]):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -770,11 +770,11 @@ class TestApi(BaseApiTest):
         )
         assert (
             # legacy representation
-            "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc') != 0"
+            "PREWHERE positionCaseInsensitive(message, 'abc') != 0"
             in result["sql"]
         ) or (
             # ast representation
-            "PREWHERE notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc'), 0)"
+            "PREWHERE notEquals(positionCaseInsensitive(message, 'abc'), 0)"
             in result["sql"]
         )
 
@@ -800,11 +800,11 @@ class TestApi(BaseApiTest):
         )
         assert (
             # legacy representation
-            "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message"
+            "PREWHERE positionCaseInsensitive(message"
             in result["sql"]
         ) or (
             # ast representation
-            "PREWHERE notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message"
+            "PREWHERE notEquals(positionCaseInsensitive(message"
             in result["sql"]
         )
 
@@ -828,11 +828,11 @@ class TestApi(BaseApiTest):
         )
         assert (
             # legacy representation
-            "PREWHERE positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc') != 0 AND project_id IN (1)"
+            "PREWHERE positionCaseInsensitive(message, 'abc') != 0 AND project_id IN (1)"
             in result["sql"]
         ) or (
             # ast representation
-            "PREWHERE notEquals(positionCaseInsensitive((coalesce(search_message, message) AS message), 'abc'), 0) AND in(project_id, tuple(1))"
+            "PREWHERE notEquals(positionCaseInsensitive(message, 'abc'), 0) AND in(project_id, tuple(1))"
             in result["sql"]
         )
 


### PR DESCRIPTION
This removes the last place where we read from the search_message column.
A query for `message` in the events dataset now simply translates to `message`
instead of `coalesce(search_message, message)`. Since `search_message` is
always Null, the result doesn't change.