### PR TITLE
feat(ast) Legacy query demolition step 8: Remove legacy query path from prewhere processor

### DIFF
--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -1,28 +1,28 @@
-from typing import Iterable, Optional, Sequence, Tuple
+from typing import Optional
 
 from snuba import settings
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.accessors import get_columns_in_expression
 from snuba.query.conditions import (
-    OPERATOR_TO_FUNCTION,
+    ConditionFunctions,
     combine_and_conditions,
     get_first_level_and_conditions,
 )
-from snuba.query.expressions import Column, FunctionCall
+from snuba.query.expressions import FunctionCall
 from snuba.request.request_settings import RequestSettings
 
 ALLOWED_OPERATORS = [
-    ">",
-    "<",
-    ">=",
-    "<=",
-    "=",
-    "!=",
-    "IN",
-    "IS NULL",
-    "IS NOT NULL",
-    "LIKE",
+    ConditionFunctions.GT,
+    ConditionFunctions.LT,
+    ConditionFunctions.GTE,
+    ConditionFunctions.LTE,
+    ConditionFunctions.EQ,
+    ConditionFunctions.NEQ,
+    ConditionFunctions.IN,
+    ConditionFunctions.IS_NULL,
+    ConditionFunctions.IS_NOT_NULL,
+    ConditionFunctions.LIKE,
 ]
 
 
@@ -48,83 +48,42 @@ class PrewhereProcessor(QueryProcessor):
         if not prewhere_keys:
             return
 
-        PrewhereProcessorDelegate().process_query(
-            query, max_prewhere_conditions, prewhere_keys
-        )
+        ast_condition = query.get_condition_from_ast()
+        if ast_condition is None:
+            return
 
+        prewhere_candidates = [
+            (get_columns_in_expression(cond), cond)
+            for cond in get_first_level_and_conditions(ast_condition)
+            if isinstance(cond, FunctionCall)
+            and cond.function_name in ALLOWED_OPERATORS
+            and any(
+                col.column_name in prewhere_keys
+                for col in get_columns_in_expression(cond)
+            )
+        ]
+        if not prewhere_candidates:
+            return
 
-class PrewhereProcessorDelegate:
-    """
-    Runs the prewhere generation algorithm on behalf of PrewhereProcessor.
-    There are two implementation following a template method pattern. One
-    for the AST and one for the legacy query representation so that the
-    prewhere generation code does not have to be duplicated.
-    """
-
-    allowed_ast_operators = [OPERATOR_TO_FUNCTION[o] for o in ALLOWED_OPERATORS]
-
-    def process_query(
-        self, query: Query, max_prewhere_conditions: int, prewhere_keys: Sequence[str]
-    ) -> None:
         # Use the condition that has the highest priority (based on the
         # position of its columns in the prewhere keys list)
         sorted_candidates = sorted(
             [
                 (
                     min(
-                        prewhere_keys.index(self._get_column_name(col))
+                        prewhere_keys.index(col.column_name)
                         for col in cols
-                        if self._get_column_name(col) in prewhere_keys
+                        if col.column_name in prewhere_keys
                     ),
                     cond,
                 )
-                for cols, cond in self._get_prewhere_candidates(query, prewhere_keys)
+                for cols, cond in prewhere_candidates
             ],
             key=lambda priority_and_col: priority_and_col[0],
         )
-
         prewhere_conditions = [cond for _, cond in sorted_candidates][
             :max_prewhere_conditions
         ]
-
-        if prewhere_conditions:
-            self._update_conditions(query, prewhere_conditions)
-
-    def _get_prewhere_candidates(
-        self, query: Query, prewhere_keys: Sequence[str]
-    ) -> Sequence[Tuple[Iterable[Column], FunctionCall]]:
-        # Add any condition to PREWHERE if:
-        # - It is a single top-level condition (not OR-nested), and
-        # - Any of its referenced columns are in prewhere_keys
-        ast_condition = query.get_condition_from_ast()
-        return (
-            [
-                (get_columns_in_expression(cond), cond)
-                for cond in get_first_level_and_conditions(ast_condition)
-                if isinstance(cond, FunctionCall)
-                and cond.function_name in self.allowed_ast_operators
-                and any(
-                    col.column_name in prewhere_keys
-                    for col in get_columns_in_expression(cond)
-                )
-            ]
-            if ast_condition is not None
-            else []
-        )
-
-    def _get_column_name(self, column: Column) -> str:
-        return column.column_name
-
-    def _update_conditions(
-        self, query: Query, prewhere_conditions: Sequence[FunctionCall]
-    ) -> None:
-        """
-        Updates the query with the new pre-where conditions by removing them
-        from the main condition clause and adding them to the pre-where clause.
-        """
-        ast_condition = query.get_condition_from_ast()
-        # This should never be None at this point, but for mypy this can be None.
-        assert ast_condition is not None
 
         new_conditions = [
             cond

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -15,7 +15,6 @@ from snuba.query.conditions import (
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.parser import parse_query
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.types import Condition
 from snuba.request.request_settings import HTTPRequestSettings
 
 test_data = [
@@ -29,9 +28,7 @@ test_data = [
             "environment",
             "project_id",
         ],
-        [],
         None,
-        [[["positionCaseInsensitive", ["message", "'abc'"]], "!=", 0]],
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["!="],
@@ -56,7 +53,6 @@ test_data = [
             ],
         },
         ["a", "b", "c"],
-        [["d", "=", "1"], ["c", "=", "3"]],
         FunctionCall(
             None,
             BooleanFunctions.AND,
@@ -73,7 +69,6 @@ test_data = [
                 ),
             ),
         ),
-        [["a", "=", "1"], ["b", "=", "2"]],
         FunctionCall(
             None,
             BooleanFunctions.AND,
@@ -95,7 +90,6 @@ test_data = [
         # Do not add conditions that are parts of an OR
         {"conditions": [[["a", "=", "1"], ["b", "=", "2"]], ["c", "=", "3"]]},
         ["a", "b", "c"],
-        [[["a", "=", "1"], ["b", "=", "2"]]],
         FunctionCall(
             None,
             BooleanFunctions.OR,
@@ -112,7 +106,6 @@ test_data = [
                 ),
             ),
         ),
-        [["c", "=", "3"]],
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["="],
@@ -124,7 +117,6 @@ test_data = [
         # most of the dataset.
         {"conditions": [["a", "NOT IN", [1, 2, 3]], ["b", "=", "2"], ["c", "=", "3"]]},
         ["a", "b"],
-        [["a", "NOT IN", [1, 2, 3]], ["c", "=", "3"]],
         FunctionCall(
             None,
             BooleanFunctions.AND,
@@ -141,7 +133,6 @@ test_data = [
                 ),
             ),
         ),
-        [["b", "=", "2"]],
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["="],
@@ -152,15 +143,12 @@ test_data = [
 
 
 @pytest.mark.parametrize(
-    "query_body, keys, new_conditions, new_ast_condition, prewhere_conditions, new_prewhere_ast_condition",
-    test_data,
+    "query_body, keys, new_ast_condition, new_prewhere_ast_condition", test_data,
 )
 def test_prewhere(
     query_body: MutableMapping[str, Any],
     keys: Sequence[str],
-    new_conditions: Sequence[Condition],
     new_ast_condition: Optional[Expression],
-    prewhere_conditions: Sequence[Condition],
     new_prewhere_ast_condition: Optional[Expression],
 ) -> None:
     settings.MAX_PREWHERE_CONDITIONS = 2
@@ -172,7 +160,5 @@ def test_prewhere(
     processor = PrewhereProcessor()
     processor.process_query(Query(query), request_settings)
 
-    assert query.get_conditions() == new_conditions
     assert query.get_condition_from_ast() == new_ast_condition
-    assert query.get_prewhere() == prewhere_conditions
     assert query.get_prewhere_ast() == new_prewhere_ast_condition


### PR DESCRIPTION
![demolition5](https://user-images.githubusercontent.com/1626430/95277497-bedc5680-0802-11eb-8bbd-5567093bd230.gif)
