### PR TITLE
test: get_raw_event provides the entire event not just event data

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,6 @@
 import os
 import uuid
 from datetime import datetime
-from hashlib import md5
 from typing import MutableSequence, Optional, Sequence
 
 from snuba import settings
@@ -51,28 +50,7 @@ class BaseEventsTest(BaseDatasetTest):
     def setup_method(self, test_method, dataset_name="events"):
         super(BaseEventsTest, self).setup_method(test_method, dataset_name)
         self.table = enforce_table_writer(self.dataset).get_schema().get_table_name()
-        self.event = self.__get_event()
-
-    def __get_event(self) -> InsertEvent:
-        data = get_raw_event()
-
-        unique = "%s:%s" % (str(data["project"]), data["id"])
-        primary_hash = md5(unique.encode("utf-8")).hexdigest()
-
-        return InsertEvent(
-            {
-                "event_id": data["id"],
-                "group_id": int(primary_hash[:16], 16),
-                "primary_hash": primary_hash,
-                "project_id": data["project"],
-                "message": data["message"],
-                "platform": data["platform"],
-                "datetime": data["datetime"],
-                "data": data,
-                "organization_id": data["organization_id"],
-                "retention_days": settings.DEFAULT_RETENTION_DAYS,
-            }
-        )
+        self.event = InsertEvent(get_raw_event())
 
     def create_event_row_for_date(
         self, dt: datetime, retention_days=settings.DEFAULT_RETENTION_DAYS

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,141 +1,161 @@
 import calendar
 import uuid
 from datetime import datetime, timedelta, timezone
+from hashlib import md5
 from typing import Any, Mapping
 from snuba import settings
+
+PROJECT_ID = 70156
 
 
 def get_raw_event() -> Mapping[str, Any]:
     now = datetime.utcnow()
 
+    event_id = str(uuid.uuid4().hex)
+    message = "Caught exception!"
+    unique = "%s:%s" % (str(PROJECT_ID), event_id)
+    primary_hash = md5(unique.encode("utf-8")).hexdigest()
+    platform = "java"
+    event_datetime = (now - timedelta(seconds=2)).strftime(
+        settings.PAYLOAD_DATETIME_FORMAT,
+    )
+
     return {
-        "datetime": (now - timedelta(seconds=2)).strftime(
-            settings.PAYLOAD_DATETIME_FORMAT,
-        ),
-        "received": int(calendar.timegm((now - timedelta(seconds=1)).timetuple())),
-        "culprit": "io.sentry.example.Application in main",
+        "project_id": PROJECT_ID,
+        "event_id": event_id,
+        "group_id": int(primary_hash[:16], 16),
+        "primary_hash": primary_hash,
+        "message": message,
+        "platform": platform,
+        "datetime": event_datetime,
         "organization_id": 3,
-        "errors": [],
-        "title": "Exception!",
-        "extra": {"Sentry-Threadname": "io.sentry.example.Application.main()"},
-        "fingerprint": ["{{ default }}"],
-        "id": "bce76c2473324fa387b33564eacf34a0",
-        "key_id": 113866,
-        "message": "Caught exception!",
-        "metadata": {"type": "ArithmeticException", "value": "/ by zero"},
-        "platform": "java",
-        "project": 70156,
-        "release": "1.0",
-        "dist": None,
-        "sdk": {
-            "integrations": ["logback"],
-            "name": "sentry-java",
-            "version": "1.6.1-d1e3a",
-        },
-        "request": {
-            "url": "http://127.0.0.1:/query",
-            "headers": [
-                ["Accept-Encoding", "identity"],
-                ["Content-Length", "398"],
-                ["Host", "127.0.0.1:"],
-                ["Referer", "tagstore.something"],
-                ["Trace", "8fa73032d-1"],
+        "retention_days": settings.DEFAULT_RETENTION_DAYS,
+        "data": {
+            "datetime": event_datetime,
+            "received": int(calendar.timegm((now - timedelta(seconds=1)).timetuple())),
+            "culprit": "io.sentry.example.Application in main",
+            "errors": [],
+            "title": "Exception!",
+            "extra": {"Sentry-Threadname": "io.sentry.example.Application.main()"},
+            "fingerprint": ["{{ default }}"],
+            "id": event_id,
+            "key_id": 113866,
+            "message": message,
+            "metadata": {"type": "ArithmeticException", "value": "/ by zero"},
+            "platform": platform,
+            "project": PROJECT_ID,
+            "release": "1.0",
+            "dist": None,
+            "sdk": {
+                "integrations": ["logback"],
+                "name": "sentry-java",
+                "version": "1.6.1-d1e3a",
+            },
+            "request": {
+                "url": "http://127.0.0.1:/query",
+                "headers": [
+                    ["Accept-Encoding", "identity"],
+                    ["Content-Length", "398"],
+                    ["Host", "127.0.0.1:"],
+                    ["Referer", "tagstore.something"],
+                    ["Trace", "8fa73032d-1"],
+                ],
+                "data": "",
+                "method": "POST",
+                "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
+            },
+            "contexts": {
+                "device": {"online": True, "charging": True, "model_id": "Galaxy"}
+            },
+            "sentry.interfaces.Exception": {
+                "exc_omitted": None,
+                "values": [
+                    {
+                        "module": "java.lang",
+                        "mechanism": {
+                            "type": "promise",
+                            "description": "globally unhandled promise rejection",
+                            "help_link": "http://example.com",
+                            "handled": False,
+                            "data": {"polyfill": "Bluebird"},
+                            "meta": {"errno": {"number": 123112, "name": ""}},
+                        },
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "Thread.java",
+                                    "filename": "Thread.java",
+                                    "function": "run",
+                                    "in_app": False,
+                                    "lineno": 748,
+                                    "module": "java.lang.Thread",
+                                },
+                                {
+                                    "abs_path": "ExecJavaMojo.java",
+                                    "filename": "ExecJavaMojo.java",
+                                    "function": "run",
+                                    "in_app": False,
+                                    "lineno": 293,
+                                    "module": "org.codehaus.mojo.exec.ExecJavaMojo$1",
+                                },
+                                {
+                                    "abs_path": "Method.java",
+                                    "filename": "Method.java",
+                                    "function": "invoke",
+                                    "in_app": False,
+                                    "lineno": 498,
+                                    "module": "java.lang.reflect.Method",
+                                },
+                                {
+                                    "abs_path": "DelegatingMethodAccessorImpl.java",
+                                    "filename": "DelegatingMethodAccessorImpl.java",
+                                    "function": "invoke",
+                                    "in_app": False,
+                                    "lineno": 43,
+                                    "module": "sun.reflect.DelegatingMethodAccessorImpl",
+                                },
+                                {
+                                    "abs_path": "NativeMethodAccessorImpl.java",
+                                    "filename": "NativeMethodAccessorImpl.java",
+                                    "function": "invoke",
+                                    "in_app": False,
+                                    "lineno": 62,
+                                    "module": "sun.reflect.NativeMethodAccessorImpl",
+                                },
+                                {
+                                    "abs_path": "NativeMethodAccessorImpl.java",
+                                    "filename": "NativeMethodAccessorImpl.java",
+                                    "function": "invoke0",
+                                    "in_app": False,
+                                    "module": "sun.reflect.NativeMethodAccessorImpl",
+                                },
+                                {
+                                    "abs_path": "Application.java",
+                                    "filename": "Application.java",
+                                    "function": "main",
+                                    "in_app": True,
+                                    "lineno": 17,
+                                    "module": "io.sentry.example.Application",
+                                },
+                            ]
+                        },
+                        "type": "ArithmeticException",
+                        "value": "/ by zero",
+                    }
+                ],
+            },
+            "sentry.interfaces.Message": {"message": "Caught exception!"},
+            "tags": [
+                ["logger", "example.Application"],
+                ["server_name", "localhost.localdomain"],
+                ["level", "error"],
+                ["custom_tag", "custom_value"],
+                ["url", "http://127.0.0.1:/query"],
             ],
-            "data": "",
-            "method": "POST",
-            "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
+            "time_spent": None,
+            "type": "error",
+            "version": "6",
         },
-        "contexts": {
-            "device": {"online": True, "charging": True, "model_id": "Galaxy"}
-        },
-        "sentry.interfaces.Exception": {
-            "exc_omitted": None,
-            "values": [
-                {
-                    "module": "java.lang",
-                    "mechanism": {
-                        "type": "promise",
-                        "description": "globally unhandled promise rejection",
-                        "help_link": "http://example.com",
-                        "handled": False,
-                        "data": {"polyfill": "Bluebird"},
-                        "meta": {"errno": {"number": 123112, "name": ""}},
-                    },
-                    "stacktrace": {
-                        "frames": [
-                            {
-                                "abs_path": "Thread.java",
-                                "filename": "Thread.java",
-                                "function": "run",
-                                "in_app": False,
-                                "lineno": 748,
-                                "module": "java.lang.Thread",
-                            },
-                            {
-                                "abs_path": "ExecJavaMojo.java",
-                                "filename": "ExecJavaMojo.java",
-                                "function": "run",
-                                "in_app": False,
-                                "lineno": 293,
-                                "module": "org.codehaus.mojo.exec.ExecJavaMojo$1",
-                            },
-                            {
-                                "abs_path": "Method.java",
-                                "filename": "Method.java",
-                                "function": "invoke",
-                                "in_app": False,
-                                "lineno": 498,
-                                "module": "java.lang.reflect.Method",
-                            },
-                            {
-                                "abs_path": "DelegatingMethodAccessorImpl.java",
-                                "filename": "DelegatingMethodAccessorImpl.java",
-                                "function": "invoke",
-                                "in_app": False,
-                                "lineno": 43,
-                                "module": "sun.reflect.DelegatingMethodAccessorImpl",
-                            },
-                            {
-                                "abs_path": "NativeMethodAccessorImpl.java",
-                                "filename": "NativeMethodAccessorImpl.java",
-                                "function": "invoke",
-                                "in_app": False,
-                                "lineno": 62,
-                                "module": "sun.reflect.NativeMethodAccessorImpl",
-                            },
-                            {
-                                "abs_path": "NativeMethodAccessorImpl.java",
-                                "filename": "NativeMethodAccessorImpl.java",
-                                "function": "invoke0",
-                                "in_app": False,
-                                "module": "sun.reflect.NativeMethodAccessorImpl",
-                            },
-                            {
-                                "abs_path": "Application.java",
-                                "filename": "Application.java",
-                                "function": "main",
-                                "in_app": True,
-                                "lineno": 17,
-                                "module": "io.sentry.example.Application",
-                            },
-                        ]
-                    },
-                    "type": "ArithmeticException",
-                    "value": "/ by zero",
-                }
-            ],
-        },
-        "sentry.interfaces.Message": {"message": "Caught exception!"},
-        "tags": [
-            ["logger", "example.Application"],
-            ["server_name", "localhost.localdomain"],
-            ["level", "error"],
-            ["custom_tag", "custom_value"],
-            ["url", "http://127.0.0.1:/query"],
-        ],
-        "time_spent": None,
-        "type": "error",
-        "version": "6",
     }
 
 
@@ -150,7 +170,7 @@ def get_raw_transaction() -> Mapping[str, Any]:
     span_id = "8841662216cc598b"
 
     return {
-        "project_id": 70156,
+        "project_id": PROJECT_ID,
         "event_id": uuid.uuid4().hex,
         "deleted": 0,
         "datetime": end_timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),


### PR DESCRIPTION
Previously only the event data was returned by get_raw_event. Now we
return the entire raw event. This makes `get_raw_event` more reusable.
It is also consistent with how `get_raw_transaction` behaves.