### PR TITLE
test: Stop using BaseEventsTest

### DIFF
--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -5,12 +5,10 @@ from functools import partial
 
 from snuba import state
 from snuba.state import safe_dumps
-from tests.base import BaseEventsTest
 
 
-class TestState(BaseEventsTest):
-    def setup_method(self, test_method):
-        super(TestState, self).setup_method(test_method)
+class TestState:
+    def setup_method(self):
         from snuba.web.views import application
 
         assert application.testing == True
@@ -37,13 +35,13 @@ class TestState(BaseEventsTest):
 
     def test_memoize(self):
         @state.memoize(0.1)
-        def rand():
+        def rand() -> float:
             return random.random()
 
         assert rand() == rand()
         rand1 = rand()
         assert rand1 == rand()
-        time.sleep(0.1)
+        time.sleep(1)
         assert rand1 != rand()
 
     def test_abtest(self):

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -41,7 +41,7 @@ class TestState:
         assert rand() == rand()
         rand1 = rand()
         assert rand1 == rand()
-        time.sleep(1)
+        time.sleep(0.1)
         assert rand1 != rand()
 
     def test_abtest(self):

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -4,33 +4,40 @@ from clickhouse_driver import errors
 
 from snuba.clickhouse.columns import Array, Nullable, UInt
 from snuba.clickhouse.native import ClickhousePool
-from snuba.datasets.factory import enforce_table_writer
-from tests.base import BaseEventsTest
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
 
 
-class TestClickhouse(BaseEventsTest):
-    def test_flattened(self):
-        columns = enforce_table_writer(self.dataset).get_schema().get_columns()
-        assert columns["group_id"].type == UInt(64)
-        assert columns["group_id"].name == "group_id"
-        assert columns["group_id"].base_name is None
-        assert columns["group_id"].flattened == "group_id"
+def test_flattened() -> None:
+    columns = (
+        get_writable_storage(StorageKey.EVENTS)
+        .get_table_writer()
+        .get_schema()
+        .get_columns()
+    )
 
-        assert columns["exception_frames.in_app"].type == Array(Nullable(UInt(8)))
-        assert columns["exception_frames.in_app"].name == "in_app"
-        assert columns["exception_frames.in_app"].base_name == "exception_frames"
-        assert columns["exception_frames.in_app"].flattened == "exception_frames.in_app"
+    # columns = enforce_table_writer(self.dataset).get_schema().get_columns()
+    assert columns["group_id"].type == UInt(64)
+    assert columns["group_id"].name == "group_id"
+    assert columns["group_id"].base_name is None
+    assert columns["group_id"].flattened == "group_id"
 
-    @patch("snuba.clickhouse.native.Client")
-    def test_reconnect(self, FakeClient):
-        # If the connection NetworkErrors a first time, make sure we call it a second time.
-        FakeClient.return_value.execute.side_effect = [
-            errors.NetworkError,
-            '{"data": "to my face"}',
-        ]
-        cp = ClickhousePool("0:0:0:0", 9000, "default", "", "default")
-        cp.execute("SHOW TABLES")
-        assert FakeClient.return_value.execute.mock_calls == [
-            call("SHOW TABLES"),
-            call("SHOW TABLES"),
-        ]
+    assert columns["exception_frames.in_app"].type == Array(Nullable(UInt(8)))
+    assert columns["exception_frames.in_app"].name == "in_app"
+    assert columns["exception_frames.in_app"].base_name == "exception_frames"
+    assert columns["exception_frames.in_app"].flattened == "exception_frames.in_app"
+
+
+@patch("snuba.clickhouse.native.Client")
+def test_reconnect(FakeClient) -> None:
+    # If the connection NetworkErrors a first time, make sure we call it a second time.
+    FakeClient.return_value.execute.side_effect = [
+        errors.NetworkError,
+        '{"data": "to my face"}',
+    ]
+    cp = ClickhousePool("0:0:0:0", 9000, "default", "", "default")
+    cp.execute("SHOW TABLES")
+    assert FakeClient.return_value.execute.mock_calls == [
+        call("SHOW TABLES"),
+        call("SHOW TABLES"),
+    ]

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,24 +1,27 @@
-from tests.base import BaseEventsTest
-
+import uuid
 from datetime import datetime, timedelta
+from typing import Any, Mapping
 
-from snuba import optimize
+from snuba import optimize, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.factory import get_writable_storage
+from tests.base import BaseDatasetTest
 
 
-class TestOptimize(BaseEventsTest):
-    def test(self):
-        clickhouse = (
-            get_storage(StorageKey.EVENTS)
-            .get_cluster()
-            .get_query_connection(ClickhouseClientSettings.OPTIMIZE)
-        )
+class TestOptimize(BaseDatasetTest):
+    def setup_method(self, test_method):
+        super(TestOptimize, self).setup_method(test_method, "events")
+
+    def test(self) -> None:
+        storage = get_writable_storage(StorageKey.EVENTS)
+        cluster = storage.get_cluster()
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
+        table = storage.get_table_writer().get_schema().get_table_name()
+        database = cluster.get_database()
+
         # no data, 0 partitions to optimize
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
         assert parts == []
 
         base = datetime(1999, 12, 26)  # a sunday
@@ -26,23 +29,17 @@ class TestOptimize(BaseEventsTest):
 
         # 1 event, 0 unoptimized parts
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
         assert parts == []
 
         # 2 events in the same part, 1 unoptimized part
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
         assert parts == [(base_monday, 90)]
 
         # 3 events in the same part, 1 unoptimized part
         self.write_rows([self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
         assert parts == [(base_monday, 90)]
 
         # 3 events in one part, 2 in another, 2 unoptimized parts
@@ -52,22 +49,28 @@ class TestOptimize(BaseEventsTest):
         )
         self.write_rows([self.create_event_row_for_date(a_month_earlier_monday)])
         self.write_rows([self.create_event_row_for_date(a_month_earlier_monday)])
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
         assert parts == [(base_monday, 90), (a_month_earlier_monday, 90)]
 
         # respects before (base is properly excluded)
         assert list(
             optimize.get_partitions_to_optimize(
-                clickhouse, self.database, self.table, before=base
+                clickhouse, database, table, before=base
             )
         ) == [(a_month_earlier_monday, 90)]
 
-        optimize.optimize_partitions(clickhouse, self.database, self.table, parts)
+        optimize.optimize_partitions(clickhouse, database, table, parts)
 
         # all parts should be optimized
-        parts = optimize.get_partitions_to_optimize(
-            clickhouse, self.database, self.table
-        )
+        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
         assert parts == []
+
+    def create_event_row_for_date(self, dt: datetime) -> Mapping[str, Any]:
+        return {
+            "event_id": uuid.uuid4().hex,
+            "project_id": 1,
+            "group_id": 1,
+            "deleted": 0,
+            "timestamp": dt,
+            "retention_days": settings.DEFAULT_RETENTION_DAYS,
+        }

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2,13 +2,12 @@ import pytest
 import rapidjson
 
 from snuba.clickhouse.errors import ClickhouseWriterError
-from snuba.datasets.factory import enforce_table_writer
+from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from tests.base import BaseEventsTest
 
 
-class TestHTTPBatchWriter(BaseEventsTest):
-
+class TestHTTPBatchWriter:
+    dataset = get_dataset("events")
     metrics = DummyMetricsBackend(strict=True)
 
     def test_empty_batch(self) -> None:


### PR DESCRIPTION
Updates a number of tests to not inherit from BaseEventsTest.
We should move away from needing to have a base class in order to
test a specific dataset, and eventually remove BaseEventsTest.