### PR TITLE
test: BaseApiTest does not extend BaseEventsTest

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -74,7 +74,7 @@ class BaseEventsTest(BaseDatasetTest):
         self.write_processed_messages(processed_messages)
 
 
-class BaseApiTest(BaseEventsTest):
+class BaseApiTest(BaseDatasetTest):
     def setup_method(self, test_method, dataset_name="events"):
         super().setup_method(test_method, dataset_name)
         from snuba.web.views import application


### PR DESCRIPTION
Our API tests should not assume that the dataset under test is the
events dataset. Some time ago there was only one dataset that could be
queried, but this is no longer the case.