### PR TITLE
test: Update all tests to use BaseDatasetTest instead of BaseEventsTest

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -39,6 +39,21 @@ class BaseDatasetTest:
             JSONRowEncoder(),
         ).write(rows)
 
+    def write_events(self, events: Sequence[InsertEvent]) -> None:
+        processor = (
+            enforce_table_writer(self.dataset).get_stream_loader().get_processor()
+        )
+
+        processed_messages = []
+        for i, event in enumerate(events):
+            processed_message = processor.process_message(
+                (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
+            )
+            assert processed_message is not None
+            processed_messages.append(processed_message)
+
+        self.write_processed_messages(processed_messages)
+
 
 class BaseEventsTest(BaseDatasetTest):
     def setup_method(self, test_method, dataset_name="events"):
@@ -57,21 +72,6 @@ class BaseEventsTest(BaseDatasetTest):
             "timestamp": dt,
             "retention_days": retention_days,
         }
-
-    def write_events(self, events: Sequence[InsertEvent]) -> None:
-        processor = (
-            enforce_table_writer(self.dataset).get_stream_loader().get_processor()
-        )
-
-        processed_messages = []
-        for i, event in enumerate(events):
-            processed_message = processor.process_message(
-                (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
-            )
-            assert processed_message is not None
-            processed_messages.append(processed_message)
-
-        self.write_processed_messages(processed_messages)
 
 
 class BaseApiTest(BaseEventsTest):

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -12,10 +12,11 @@ from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.kafka import KafkaPayload
-from tests.base import BaseEventsTest
+from tests.base import BaseDatasetTest
+from tests.fixtures import get_raw_event
 
 
-class TestReplacer(BaseEventsTest):
+class TestReplacer(BaseDatasetTest):
     def setup_method(self, test_method):
         super(TestReplacer, self).setup_method(test_method, "events_migration")
 
@@ -31,6 +32,7 @@ class TestReplacer(BaseEventsTest):
         )
 
         self.project_id = 1
+        self.event = get_raw_event()
 
     def _wrap(self, msg: str) -> Message[KafkaPayload]:
         return Message(

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -5,16 +5,20 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
 from snuba.query.logical import Query
 from snuba.request.request_settings import HTTPRequestSettings
-from tests.base import BaseEventsTest
+from tests.base import BaseDatasetTest
+from tests.fixtures import get_raw_event
 
 
-class TestEventsDataset(BaseEventsTest):
+class TestEventsDataset(BaseDatasetTest):
+    def setup_method(self, test_method):
+        super().setup_method(test_method, "events")
+
     def test_tags_hash_map(self) -> None:
         """
         Adds an event and ensures the tags_hash_map is properly populated
         including escaping.
         """
-
+        self.event = get_raw_event()
         self.event["data"]["tags"].append(["test_tag1", "value1"])
         self.event["data"]["tags"].append(["test_tag=2", "value2"])  # Requires escaping
         self.write_events([self.event])

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -24,12 +24,15 @@ from snuba.processor import (
     ProcessedMessage,
     ReplacementBatch,
 )
-from tests.base import BaseEventsTest
+from tests.base import BaseDatasetTest
+from tests.fixtures import get_raw_event
 
 
-class TestEventsProcessor(BaseEventsTest):
-
-    metadata = KafkaMessageMetadata(0, 0, datetime.now())
+class TestEventsProcessor(BaseDatasetTest):
+    def setup_method(self, test_method):
+        super().setup_method(test_method, "events")
+        self.metadata = KafkaMessageMetadata(0, 0, datetime.now())
+        self.event = get_raw_event()
 
     def test_invalid_version(self) -> None:
         with pytest.raises(InvalidMessageVersion):

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -4,10 +4,10 @@ import uuid
 
 from snuba import settings
 from snuba.datasets.events_processor_base import InsertEvent
-from tests.base import BaseEventsTest
+from tests.base import BaseDatasetTest
 
 
-class BaseSubscriptionTest(BaseEventsTest):
+class BaseSubscriptionTest(BaseDatasetTest):
     def setup_method(self, test_method, dataset_name="events"):
         super().setup_method(test_method, dataset_name)
         self.project_id = 1

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -15,9 +15,8 @@ from snuba.consumer import (
     JSONRowInsertBatch,
     StreamingConsumerStrategyFactory,
 )
-from snuba.datasets.factory import enforce_table_writer
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.factory import get_writable_storage
 from snuba.processor import InsertBatch, ReplacementBatch
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams import Message, Partition, Topic
@@ -25,12 +24,14 @@ from snuba.utils.streams.backends.kafka import KafkaPayload
 from tests.assertions import assert_changes
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 from tests.backends.metrics import TestingMetricsBackend, Timing
-from tests.base import BaseEventsTest
+from tests.fixtures import get_raw_event
 
 
-class TestConsumer(BaseEventsTest):
-
+class TestConsumer:
+    storage = get_writable_storage(StorageKey.EVENTS)
     metrics = DummyMetricsBackend()
+    event = get_raw_event()
+    table = storage.get_table_writer().get_schema().get_table_name()
 
     def test_offsets(self):
         event = self.event
@@ -45,10 +46,10 @@ class TestConsumer(BaseEventsTest):
         )
 
         test_worker = ConsumerWorker(
-            self.dataset.get_writable_storage(),
+            self.storage,
             producer=FakeConfluentKafkaProducer(),
             replacements_topic=Topic(
-                enforce_table_writer(self.dataset)
+                self.storage.get_table_writer()
                 .get_stream_loader()
                 .get_replacement_topic_spec()
                 .topic_name
@@ -58,10 +59,8 @@ class TestConsumer(BaseEventsTest):
         batch = [test_worker.process_message(message)]
         test_worker.flush_batch(batch)
 
-        clickhouse = (
-            get_storage(StorageKey.EVENTS)
-            .get_cluster()
-            .get_query_connection(ClickhouseClientSettings.QUERY)
+        clickhouse = self.storage.get_cluster().get_query_connection(
+            ClickhouseClientSettings.QUERY
         )
 
         assert clickhouse.execute(
@@ -70,10 +69,10 @@ class TestConsumer(BaseEventsTest):
 
     def test_skip_too_old(self):
         test_worker = ConsumerWorker(
-            self.dataset.get_writable_storage(),
+            self.storage,
             producer=FakeConfluentKafkaProducer(),
             replacements_topic=Topic(
-                enforce_table_writer(self.dataset)
+                self.storage.get_table_writer()
                 .get_stream_loader()
                 .get_replacement_topic_spec()
                 .topic_name
@@ -100,10 +99,10 @@ class TestConsumer(BaseEventsTest):
     def test_produce_replacement_messages(self):
         producer = FakeConfluentKafkaProducer()
         test_worker = ConsumerWorker(
-            self.dataset.get_writable_storage(),
+            self.storage,
             producer=producer,
             replacements_topic=Topic(
-                enforce_table_writer(self.dataset)
+                self.storage.get_table_writer()
                 .get_stream_loader()
                 .get_replacement_topic_spec()
                 .topic_name

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -1,26 +1,19 @@
-from tests.base import BaseEventsTest
-
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.factory import get_dataset
-from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_storage
 from snuba import perf
 
 
-class TestPerf(BaseEventsTest):
-    def test(self):
-        dataset = get_dataset("events")
-        storage = dataset.get_writable_storage()
-        assert storage is not None
-        table = storage.get_table_writer().get_schema().get_local_table_name()
-        clickhouse = (
-            get_storage(StorageKey.EVENTS)
-            .get_cluster()
-            .get_query_connection(ClickhouseClientSettings.QUERY)
-        )
+def test_perf() -> None:
+    dataset = get_dataset("events")
+    storage = dataset.get_writable_storage()
+    assert storage is not None
+    table = storage.get_table_writer().get_schema().get_local_table_name()
+    clickhouse = storage.get_cluster().get_query_connection(
+        ClickhouseClientSettings.QUERY
+    )
 
-        assert clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 0
+    assert clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 0
 
-        perf.run("tests/perf-event.json", dataset)
+    perf.run("tests/perf-event.json", dataset)
 
-        assert clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 1
+    assert clickhouse.execute("SELECT COUNT() FROM %s" % table)[0][0] == 1

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -14,10 +14,11 @@ from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.kafka import KafkaPayload
-from tests.base import BaseEventsTest
+from tests.base import BaseDatasetTest
+from tests.fixtures import get_raw_event
 
 
-class TestReplacer(BaseEventsTest):
+class TestReplacer(BaseDatasetTest):
     def setup_method(self, test_method):
         super(TestReplacer, self).setup_method(test_method, "events")
 
@@ -34,6 +35,7 @@ class TestReplacer(BaseEventsTest):
         )
 
         self.project_id = 1
+        self.event = get_raw_event()
 
     def _wrap(self, msg: str) -> Message[KafkaPayload]:
         return Message(


### PR DESCRIPTION
BaseEventsTest will be removed soon, update all remaining tests that used
this class to BaseDatasetTest instead.