### PR TITLE
feat(spans) Remove transaction tags from spans

### DIFF
--- a/snuba/datasets/spans_processor.py
+++ b/snuba/datasets/spans_processor.py
@@ -74,9 +74,6 @@ class SpansMessageProcessor(MessageProcessor):
         # duration is in milliseconds
         span["duration_ms"] = max(int(duration_secs * 1000), 0)
 
-        tags = _as_dict_safe(data.get("tags", None))
-        span["tags.key"], span["tags.value"] = extract_extra_tags(tags)
-
     def process_message(self, message, metadata) -> Optional[ProcessedMessage]:
         if not (isinstance(message, (list, tuple)) and len(message) >= 2):
             return None
@@ -128,6 +125,8 @@ class SpansMessageProcessor(MessageProcessor):
             processed["parent_span_id"] = int(span["parent_span_id"], 16)
             processed["description"] = span.get("description", "") or ""
             processed["op"] = span["op"]
+            tags = _as_dict_safe(span.get("tags", None))
+            processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
 
             status = span.get("status", None)
             self.__fill_status(processed, status)

--- a/tests/datasets/test_spans_processor.py
+++ b/tests/datasets/test_spans_processor.py
@@ -22,12 +22,12 @@ class SpanData(NamedTuple):
             "start_timestamp": self.start_timestamp.timestamp(),
             "same_process_as_parent": None,
             "description": "GET /api/0/organizations/sentry/tags/?project=1",
-            "tags": None,
             "timestamp": self.timestamp.timestamp(),
             "parent_span_id": self.parent_span_id,
             "trace_id": self.trace_id,
             "span_id": self.span_id,
             "op": self.op,
+            "tags": [["some_tag", "some_val"]],
         }
 
 
@@ -140,8 +140,8 @@ class SpanEvent:
                     "duration_ms": int(
                         (s.timestamp - s.start_timestamp).total_seconds() * 1000
                     ),
-                    "tags.key": [],
-                    "tags.value": [],
+                    "tags.key": ["some_tag"],
+                    "tags.value": ["some_val"],
                     "retention_days": 90,
                 }
             )


### PR DESCRIPTION
The root span tags are already present in the transactions table, there is no need to duplicate them here.