### PR TITLE
test: Remove BaseDatasetTest.write_rows()

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -30,12 +30,12 @@ class BaseDatasetTest:
             assert isinstance(message, InsertBatch)
             rows.extend(message.rows)
 
-            BatchWriterEncoderWrapper(
-                enforce_table_writer(self.dataset).get_batch_writer(
-                    metrics=DummyMetricsBackend(strict=True)
-                ),
-                JSONRowEncoder(),
-            ).write(rows)
+        BatchWriterEncoderWrapper(
+            enforce_table_writer(self.dataset).get_batch_writer(
+                metrics=DummyMetricsBackend(strict=True)
+            ),
+            JSONRowEncoder(),
+        ).write(rows)
 
     def write_unprocessed_events(self, events: Sequence[InsertEvent]) -> None:
         processor = (

--- a/tests/base.py
+++ b/tests/base.py
@@ -29,17 +29,15 @@ class BaseDatasetTest:
         for message in messages:
             assert isinstance(message, InsertBatch)
             rows.extend(message.rows)
-        self.write_rows(rows)
 
-    def write_rows(self, rows: Sequence[WriterTableRow]) -> None:
-        BatchWriterEncoderWrapper(
-            enforce_table_writer(self.dataset).get_batch_writer(
-                metrics=DummyMetricsBackend(strict=True)
-            ),
-            JSONRowEncoder(),
-        ).write(rows)
+            BatchWriterEncoderWrapper(
+                enforce_table_writer(self.dataset).get_batch_writer(
+                    metrics=DummyMetricsBackend(strict=True)
+                ),
+                JSONRowEncoder(),
+            ).write(rows)
 
-    def write_events(self, events: Sequence[InsertEvent]) -> None:
+    def write_unprocessed_events(self, events: Sequence[InsertEvent]) -> None:
         processor = (
             enforce_table_writer(self.dataset).get_stream_loader().get_processor()
         )

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -204,7 +204,7 @@ class TestGroupassignee(BaseDatasetTest):
                 "team_id": "",
             }
         )
-        self.write_rows([row.to_clickhouse()])
+        self.write_processed_messages([InsertBatch([row.to_clickhouse()])])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -16,9 +16,7 @@ from tests.base import BaseDatasetTest
 
 class TestGroupedMessage(BaseDatasetTest):
     def setup_method(self, test_method):
-        super(TestGroupedMessage, self).setup_method(
-            test_method, "groupedmessage",
-        )
+        super().setup_method(test_method, "groupedmessage")
 
     UPDATE_MSG = UpdateEvent(
         {
@@ -268,7 +266,7 @@ class TestGroupedMessage(BaseDatasetTest):
                 "first_release_id": "26",
             }
         )
-        self.write_rows([row.to_clickhouse()])
+        self.write_processed_messages([InsertBatch([row.to_clickhouse()])])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -240,7 +240,7 @@ class TestReplacer(BaseDatasetTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -277,7 +277,7 @@ class TestReplacer(BaseDatasetTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -316,7 +316,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -21,7 +21,7 @@ class TestEventsDataset(BaseDatasetTest):
         self.event = get_raw_event()
         self.event["data"]["tags"].append(["test_tag1", "value1"])
         self.event["data"]["tags"].append(["test_tag=2", "value2"])  # Requires escaping
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         clickhouse = (
             get_storage(StorageKey.EVENTS)

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -18,7 +18,7 @@ class BaseSubscriptionTest(BaseDatasetTest):
             minute=0, second=0, microsecond=0
         ) - timedelta(minutes=self.minutes)
 
-        self.write_events(
+        self.write_unprocessed_events(
             [
                 InsertEvent(
                     {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,7 +141,7 @@ class TestApi(BaseApiTest):
                             }
                         )
                     )
-        self.write_unprocessed_events(events)
+        self.write_events(events)
 
     def redis_db_size(self):
         # dbsize could be an integer for a single node cluster or a dictionary
@@ -675,7 +675,7 @@ class TestApi(BaseApiTest):
                     }
                 )
             )
-        self.write_unprocessed_events(events)
+        self.write_events(events)
 
         result = json.loads(
             self.app.post(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import enforce_table_writer
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
+from snuba.processor import InsertBatch
 from snuba.redis import redis_client
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from tests.base import BaseApiTest
@@ -140,7 +141,7 @@ class TestApi(BaseApiTest):
                             }
                         )
                     )
-        self.write_events(events)
+        self.write_unprocessed_events(events)
 
     def redis_db_size(self):
         # dbsize could be an integer for a single node cluster or a dictionary
@@ -674,7 +675,7 @@ class TestApi(BaseApiTest):
                     }
                 )
             )
-        self.write_events(events)
+        self.write_unprocessed_events(events)
 
         result = json.loads(
             self.app.post(
@@ -1280,16 +1281,20 @@ class TestApi(BaseApiTest):
         }
         result1 = json.loads(self.app.post("/query", data=json.dumps(query)).data)
 
-        self.write_rows(
+        self.write_processed_messages(
             [
-                {
-                    "event_id": "9" * 32,
-                    "project_id": 1,
-                    "group_id": 1,
-                    "timestamp": self.base_time,
-                    "deleted": 1,
-                    "retention_days": settings.DEFAULT_RETENTION_DAYS,
-                }
+                InsertBatch(
+                    [
+                        {
+                            "event_id": "9" * 32,
+                            "project_id": 1,
+                            "group_id": 1,
+                            "timestamp": self.base_time,
+                            "deleted": 1,
+                            "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                        }
+                    ]
+                )
             ]
         )
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -6,6 +6,7 @@ from snuba import cleanup, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
+from snuba.processor import InsertBatch
 from tests.base import BaseDatasetTest
 
 
@@ -30,7 +31,7 @@ class TestCleanup(BaseDatasetTest):
         assert parts == []
 
         # base, 90 retention
-        self.write_rows([self.create_event_row_for_date(base)])
+        self.write_processed_messages([self.create_event_row_for_date(base)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, table)
         assert parts == [(to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
@@ -38,7 +39,7 @@ class TestCleanup(BaseDatasetTest):
 
         # -40 days, 90 retention
         three_weeks_ago = base - timedelta(days=7 * 3)
-        self.write_rows([self.create_event_row_for_date(three_weeks_ago)])
+        self.write_processed_messages([self.create_event_row_for_date(three_weeks_ago)])
         parts = cleanup.get_active_partitions(clickhouse, self.database, table)
         assert parts == [(to_monday(three_weeks_ago), 90), (to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
@@ -46,7 +47,9 @@ class TestCleanup(BaseDatasetTest):
 
         # -100 days, 90 retention
         thirteen_weeks_ago = base - timedelta(days=7 * 13)
-        self.write_rows([self.create_event_row_for_date(thirteen_weeks_ago)])
+        self.write_processed_messages(
+            [self.create_event_row_for_date(thirteen_weeks_ago)]
+        )
         parts = cleanup.get_active_partitions(clickhouse, self.database, table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
@@ -58,7 +61,9 @@ class TestCleanup(BaseDatasetTest):
 
         # -1 week, 30 retention
         one_week_ago = base - timedelta(days=7)
-        self.write_rows([self.create_event_row_for_date(one_week_ago, 30)])
+        self.write_processed_messages(
+            [self.create_event_row_for_date(one_week_ago, 30)]
+        )
         parts = cleanup.get_active_partitions(clickhouse, self.database, table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
@@ -71,7 +76,9 @@ class TestCleanup(BaseDatasetTest):
 
         # -5 weeks, 30 retention
         five_weeks_ago = base - timedelta(days=7 * 5)
-        self.write_rows([self.create_event_row_for_date(five_weeks_ago, 30)])
+        self.write_processed_messages(
+            [self.create_event_row_for_date(five_weeks_ago, 30)]
+        )
         parts = cleanup.get_active_partitions(clickhouse, self.database, table)
         assert parts == [
             (to_monday(thirteen_weeks_ago), 90),
@@ -98,11 +105,15 @@ class TestCleanup(BaseDatasetTest):
     def create_event_row_for_date(
         self, dt: datetime, retention_days: int = settings.DEFAULT_RETENTION_DAYS
     ) -> Mapping[str, Any]:
-        return {
-            "event_id": uuid.uuid4().hex,
-            "project_id": 1,
-            "group_id": 1,
-            "deleted": 0,
-            "timestamp": dt,
-            "retention_days": retention_days,
-        }
+        return InsertBatch(
+            [
+                {
+                    "event_id": uuid.uuid4().hex,
+                    "project_id": 1,
+                    "group_id": 1,
+                    "deleted": 0,
+                    "timestamp": dt,
+                    "retention_days": retention_days,
+                }
+            ]
+        )

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -241,7 +241,7 @@ class TestReplacer(BaseDatasetTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -278,7 +278,7 @@ class TestReplacer(BaseDatasetTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -317,7 +317,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -358,7 +358,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["group_id"] = 1
         self.event["data"]["tags"].append(["browser.name", "foo"])
         self.event["data"]["tags"].append(["notbrowser", "foo"])
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         project_id = self.project_id
 
@@ -421,7 +421,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["data"]["tags"].append(["browser|to_delete", "foo=2"])
         self.event["data"]["tags"].append(["notbrowser", "foo\\3"])
         self.event["data"]["tags"].append(["notbrowser2", "foo4"])
-        self.write_events([self.event])
+        self.write_unprocessed_events([self.event])
 
         project_id = self.project_id
 


### PR DESCRIPTION
Removes the write_rows method from BaseDatasetTest.
This simplifies BaseDatasetTest which now only provides two methods:
`write_unprocessed_events` which processes and writes raw events, and
`write_processed_messages` which writes processed insert or replacement
messages.