### PR TITLE
test: Extract helpers

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,16 +1,13 @@
 import uuid
 from datetime import datetime
-from typing import MutableSequence, Optional, Sequence
+from typing import Optional, Sequence
 
 from snuba import settings
-from snuba.clickhouse.http import JSONRowEncoder
-from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import enforce_table_writer, get_dataset
-from snuba.processor import InsertBatch, ProcessedMessage
-from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
-from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
+from snuba.processor import ProcessedMessage
 from tests.fixtures import get_raw_event
+from tests.helpers import write_processed_messages, write_unprocessed_events
 
 
 class BaseDatasetTest:
@@ -23,32 +20,15 @@ class BaseDatasetTest:
             self.dataset = None
 
     def write_processed_messages(self, messages: Sequence[ProcessedMessage]) -> None:
-        rows: MutableSequence[WriterTableRow] = []
-        for message in messages:
-            assert isinstance(message, InsertBatch)
-            rows.extend(message.rows)
-
-        BatchWriterEncoderWrapper(
-            enforce_table_writer(self.dataset).get_batch_writer(
-                metrics=DummyMetricsBackend(strict=True)
-            ),
-            JSONRowEncoder(),
-        ).write(rows)
+        storage = self.dataset.get_writable_storage()
+        assert storage is not None
+        write_processed_messages(storage, messages)
 
     def write_unprocessed_events(self, events: Sequence[InsertEvent]) -> None:
-        processor = (
-            enforce_table_writer(self.dataset).get_stream_loader().get_processor()
-        )
+        storage = self.dataset.get_writable_storage()
+        assert storage is not None
 
-        processed_messages = []
-        for i, event in enumerate(events):
-            processed_message = processor.process_message(
-                (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
-            )
-            assert processed_message is not None
-            processed_messages.append(processed_message)
-
-        self.write_processed_messages(processed_messages)
+        write_unprocessed_events(storage, events)
 
 
 class BaseEventsTest(BaseDatasetTest):

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -1,23 +1,21 @@
 from datetime import datetime
 
 import pytz
-from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
-from snuba.clusters.storage_sets import StorageSetKey
+from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumer import KafkaMessageMetadata
 from snuba.datasets.cdc.groupassignee_processor import (
     GroupAssigneeProcessor,
     GroupAssigneeRow,
 )
 from snuba.datasets.cdc.types import DeleteEvent, InsertEvent, UpdateEvent
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
 from snuba.processor import InsertBatch
-from tests.base import BaseDatasetTest
+from tests.helpers import write_processed_messages
 
 
-class TestGroupassignee(BaseDatasetTest):
-    def setup_method(self, test_method):
-        super().setup_method(
-            test_method, "groupassignee",
-        )
+class TestGroupassignee:
+    storage = get_writable_storage(StorageKey.GROUPASSIGNEES)
 
     UPDATE_MSG_NO_KEY_CHANGE = UpdateEvent(
         {
@@ -167,9 +165,9 @@ class TestGroupassignee(BaseDatasetTest):
 
         ret = processor.process_message(self.INSERT_MSG, metadata)
         assert ret == InsertBatch([self.PROCESSED])
-        self.write_processed_messages([ret])
+        write_processed_messages(self.storage, [ret])
         ret = (
-            get_cluster(StorageSetKey.EVENTS)
+            self.storage.get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)
             .execute("SELECT * FROM groupassignee_local;")
         )
@@ -204,9 +202,9 @@ class TestGroupassignee(BaseDatasetTest):
                 "team_id": "",
             }
         )
-        self.write_processed_messages([InsertBatch([row.to_clickhouse()])])
+        write_processed_messages(self.storage, [InsertBatch([row.to_clickhouse()])])
         ret = (
-            get_cluster(StorageSetKey.EVENTS)
+            self.storage.get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)
             .execute("SELECT * FROM groupassignee_local;")
         )

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -6,20 +6,22 @@ import simplejson as json
 
 from snuba import replacer
 from snuba.clickhouse import DATETIME_FORMAT
-from snuba.datasets.errors_replacer import FLATTENED_COLUMN_TEMPLATE
 from snuba.datasets import errors_replacer
+from snuba.datasets.errors_replacer import FLATTENED_COLUMN_TEMPLATE
+from snuba.datasets.events_processor_base import InsertEvent
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.kafka import KafkaPayload
-from tests.base import BaseDatasetTest
+
 from tests.fixtures import get_raw_event
+from tests.helpers import write_unprocessed_events
 
 
-class TestReplacer(BaseDatasetTest):
-    def setup_method(self, test_method):
-        super(TestReplacer, self).setup_method(test_method, "events_migration")
-
+class TestReplacer:
+    def setup_method(self):
         from snuba.web.views import application
 
         assert application.testing is True
@@ -27,12 +29,13 @@ class TestReplacer(BaseDatasetTest):
         self.app = application.test_client()
         self.app.post = partial(self.app.post, headers={"referer": "test"})
 
+        self.storage = get_writable_storage(StorageKey.ERRORS)
         self.replacer = replacer.ReplacerWorker(
-            self.dataset.get_writable_storage(), DummyMetricsBackend(strict=True)
+            self.storage, DummyMetricsBackend(strict=True)
         )
 
         self.project_id = 1
-        self.event = get_raw_event()
+        self.event = InsertEvent(get_raw_event())
 
     def _wrap(self, msg: str) -> Message[KafkaPayload]:
         return Message(
@@ -240,7 +243,7 @@ class TestReplacer(BaseDatasetTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -277,7 +280,7 @@ class TestReplacer(BaseDatasetTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -316,7 +319,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -2,17 +2,14 @@ from snuba import state
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.entities.events import EventsQueryStorageSelector
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.query.logical import Query
 from snuba.request.request_settings import HTTPRequestSettings
-from tests.base import BaseDatasetTest
 from tests.fixtures import get_raw_event
+from tests.helpers import write_unprocessed_events
 
 
-class TestEventsDataset(BaseDatasetTest):
-    def setup_method(self, test_method):
-        super().setup_method(test_method, "events")
-
+class TestEventsDataset:
     def test_tags_hash_map(self) -> None:
         """
         Adds an event and ensures the tags_hash_map is properly populated
@@ -21,12 +18,11 @@ class TestEventsDataset(BaseDatasetTest):
         self.event = get_raw_event()
         self.event["data"]["tags"].append(["test_tag1", "value1"])
         self.event["data"]["tags"].append(["test_tag=2", "value2"])  # Requires escaping
-        self.write_unprocessed_events([self.event])
+        storage = get_writable_storage(StorageKey.EVENTS)
+        write_unprocessed_events(storage, [self.event])
 
-        clickhouse = (
-            get_storage(StorageKey.EVENTS)
-            .get_cluster()
-            .get_query_connection(ClickhouseClientSettings.QUERY)
+        clickhouse = storage.get_cluster().get_query_connection(
+            ClickhouseClientSettings.QUERY
         )
 
         hashed = clickhouse.execute(

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -16,7 +16,7 @@ from snuba.datasets.events_format import (
     extract_user,
 )
 from snuba.datasets.events_processor_base import InsertEvent
-from snuba.datasets.factory import enforce_table_writer
+from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.processor import (
     InsertBatch,
     InvalidMessageType,
@@ -24,13 +24,12 @@ from snuba.processor import (
     ProcessedMessage,
     ReplacementBatch,
 )
-from tests.base import BaseDatasetTest
 from tests.fixtures import get_raw_event
 
 
-class TestEventsProcessor(BaseDatasetTest):
+class TestEventsProcessor:
     def setup_method(self, test_method):
-        super().setup_method(test_method, "events")
+        self.dataset = get_dataset("events")
         self.metadata = KafkaMessageMetadata(0, 0, datetime.now())
         self.event = get_raw_event()
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from typing import MutableSequence, Sequence
+
+from snuba.consumer import KafkaMessageMetadata
+from snuba.clickhouse.http import JSONRowEncoder
+from snuba.datasets.events_processor_base import InsertEvent
+from snuba.datasets.storage import WritableStorage
+from snuba.processor import InsertBatch, ProcessedMessage
+from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
+from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
+
+
+def write_processed_messages(
+    storage: WritableStorage, messages: Sequence[ProcessedMessage]
+) -> None:
+    rows: MutableSequence[WriterTableRow] = []
+    for message in messages:
+        assert isinstance(message, InsertBatch)
+        rows.extend(message.rows)
+
+    BatchWriterEncoderWrapper(
+        storage.get_table_writer().get_batch_writer(
+            metrics=DummyMetricsBackend(strict=True)
+        ),
+        JSONRowEncoder(),
+    ).write(rows)
+
+
+def write_unprocessed_events(
+    storage: WritableStorage, events: Sequence[InsertEvent]
+) -> None:
+
+    processor = storage.get_table_writer().get_stream_loader().get_processor()
+
+    processed_messages = []
+    for i, event in enumerate(events):
+        processed_message = processor.process_message(
+            (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
+        )
+        assert processed_message is not None
+        processed_messages.append(processed_message)
+
+    write_processed_messages(storage, processed_messages)

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -3,22 +3,26 @@ from datetime import datetime, timedelta
 import uuid
 
 from snuba import settings
+from snuba.datasets.factory import get_dataset
 from snuba.datasets.events_processor_base import InsertEvent
-from tests.base import BaseDatasetTest
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
+from tests.helpers import write_unprocessed_events
 
 
-class BaseSubscriptionTest(BaseDatasetTest):
-    def setup_method(self, test_method, dataset_name="events"):
-        super().setup_method(test_method, dataset_name)
+class BaseSubscriptionTest:
+    def setup_method(self):
         self.project_id = 1
         self.platforms = ["a", "b"]
         self.minutes = 20
+        self.dataset = get_dataset("events")
 
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0
         ) - timedelta(minutes=self.minutes)
 
-        self.write_unprocessed_events(
+        write_unprocessed_events(
+            get_writable_storage(StorageKey.EVENTS),
             [
                 InsertEvent(
                     {
@@ -41,5 +45,5 @@ class BaseSubscriptionTest(BaseDatasetTest):
                     }
                 )
                 for tick in range(self.minutes)
-            ]
+            ],
         )

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -8,34 +8,33 @@ from snuba import replacer
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.datasets.errors_replacer import FLATTENED_COLUMN_TEMPLATE, ReplacerState
 from snuba.datasets import errors_replacer
+from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.kafka import KafkaPayload
-from tests.base import BaseDatasetTest
 from tests.fixtures import get_raw_event
+from tests.helpers import write_unprocessed_events
 
 
-class TestReplacer(BaseDatasetTest):
-    def setup_method(self, test_method):
-        super(TestReplacer, self).setup_method(test_method, "events")
-
+class TestReplacer:
+    def setup_method(self):
         from snuba.web.views import application
 
         assert application.testing is True
 
         self.app = application.test_client()
         self.app.post = partial(self.app.post, headers={"referer": "test"})
-        storage = get_storage(StorageKey.EVENTS)
+        self.storage = get_storage(StorageKey.EVENTS)
 
         self.replacer = replacer.ReplacerWorker(
-            storage, DummyMetricsBackend(strict=True)
+            self.storage, DummyMetricsBackend(strict=True)
         )
 
         self.project_id = 1
-        self.event = get_raw_event()
+        self.event = InsertEvent(get_raw_event())
 
     def _wrap(self, msg: str) -> Message[KafkaPayload]:
         return Message(
@@ -241,7 +240,7 @@ class TestReplacer(BaseDatasetTest):
     def test_delete_groups_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -278,7 +277,7 @@ class TestReplacer(BaseDatasetTest):
     def test_merge_insert(self):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -317,7 +316,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
@@ -358,7 +357,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["group_id"] = 1
         self.event["data"]["tags"].append(["browser.name", "foo"])
         self.event["data"]["tags"].append(["notbrowser", "foo"])
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         project_id = self.project_id
 
@@ -421,7 +420,7 @@ class TestReplacer(BaseDatasetTest):
         self.event["data"]["tags"].append(["browser|to_delete", "foo=2"])
         self.event["data"]["tags"].append(["notbrowser", "foo\\3"])
         self.event["data"]["tags"].append(["notbrowser2", "foo4"])
-        self.write_unprocessed_events([self.event])
+        write_unprocessed_events(self.storage, [self.event])
 
         project_id = self.project_id
 


### PR DESCRIPTION
Extract write_processed_messages and write_unprocessed_events from
BaseDatasetTest to tests.helpers so that we can use these methods
outside of dataset specific tests. Refactor all tests to no longer use
BaseDatasetTest.