### PR TITLE
test: Remove BaseDatasetTest

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,35 +1,5 @@
-from typing import Optional, Sequence
-
-from snuba.datasets.events_processor_base import InsertEvent
-from snuba.datasets.factory import get_dataset
-from snuba.processor import ProcessedMessage
-from tests.helpers import write_processed_messages, write_unprocessed_events
-
-
-class BaseDatasetTest:
-    def setup_method(self, test_method, dataset_name: Optional[str] = None):
-        self.dataset_name = dataset_name
-
-        if dataset_name is not None:
-            self.dataset = get_dataset(dataset_name)
-        else:
-            self.dataset = None
-
-    def write_processed_messages(self, messages: Sequence[ProcessedMessage]) -> None:
-        storage = self.dataset.get_writable_storage()
-        assert storage is not None
-        write_processed_messages(storage, messages)
-
-    def write_unprocessed_events(self, events: Sequence[InsertEvent]) -> None:
-        storage = self.dataset.get_writable_storage()
-        assert storage is not None
-
-        write_unprocessed_events(storage, events)
-
-
-class BaseApiTest(BaseDatasetTest):
-    def setup_method(self, test_method, dataset_name="events"):
-        super().setup_method(test_method, dataset_name)
+class BaseApiTest:
+    def setup_method(self, test_method):
         from snuba.web.views import application
 
         assert application.testing is True

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -4,19 +4,22 @@ from datetime import datetime, timedelta
 import pytz
 import simplejson as json
 
-from snuba.datasets.factory import enforce_table_writer
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
 from tests.base import BaseApiTest
+from tests.helpers import write_processed_messages
 
 
 class TestOutcomesApi(BaseApiTest):
-    def setup_method(self, test_method, dataset_name="outcomes"):
-        super().setup_method(test_method, dataset_name)
+    def setup_method(self, test_method):
+        super().setup_method(test_method)
 
         self.skew_minutes = 180
         self.skew = timedelta(minutes=self.skew_minutes)
         self.base_time = (
             datetime.utcnow().replace(minute=0, second=0, microsecond=0) - self.skew
         )
+        self.storage = get_writable_storage(StorageKey.OUTCOMES_RAW)
 
     def generate_outcomes(
         self,
@@ -29,7 +32,7 @@ class TestOutcomesApi(BaseApiTest):
         outcomes = []
         for _ in range(num_outcomes):
             processed = (
-                enforce_table_writer(self.dataset)
+                self.storage.get_table_writer()
                 .get_stream_loader()
                 .get_processor()
                 .process_message(
@@ -50,7 +53,7 @@ class TestOutcomesApi(BaseApiTest):
 
             outcomes.append(processed)
 
-        self.write_processed_messages(outcomes)
+        write_processed_messages(self.storage, outcomes)
 
     def format_time(self, time: datetime) -> str:
         return time.replace(tzinfo=pytz.utc).isoformat()


### PR DESCRIPTION
Update BaseApiTest to no longer inherit from BaseDatasetTest. We can now
completely remove BaseDatasetTest.