### PR TITLE
feat: Store entity name in logical query

### DIFF
--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,5 +1,5 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class GroupAssigneeDataset(Dataset):
@@ -12,5 +12,4 @@ class GroupAssigneeDataset(Dataset):
     """
 
     def __init__(self) -> None:
-        groupassignees_entity = get_entity(EntityKey.GROUPASSIGNEE)
-        super().__init__(default_entity=groupassignees_entity)
+        super().__init__(default_entity=EntityKey.GROUPASSIGNEE)

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,8 +1,7 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class GroupedMessageDataset(Dataset):
     def __init__(self) -> None:
-        groupedmessages_entity = get_entity(EntityKey.GROUPEDMESSAGES)
-        super().__init__(default_entity=groupedmessages_entity)
+        super().__init__(default_entity=EntityKey.GROUPEDMESSAGES)

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -1,10 +1,10 @@
 from typing import Mapping, Optional, Sequence
 
 from snuba.datasets.entity import Entity
-from snuba.datasets.plans.query_plan import ClickhouseQueryPlanBuilder
 from snuba.datasets.storage import Storage, WritableTableStorage
 from snuba.query.extensions import QueryExtension
-from snuba.query.processors import QueryProcessor
+from snuba.query.logical import Query
+from snuba.datasets.entities.factory import get_entity, EntityKey
 
 
 class Dataset(object):
@@ -42,41 +42,26 @@ class Dataset(object):
     manipulate the lower layer objects.
     """
 
-    # TODO: Still not sure if the Dataset class really needs the actual Entity object
-    # or just the name.
-    def __init__(self, *, default_entity: Entity) -> None:
+    def __init__(self, *, default_entity: EntityKey) -> None:
         # TODO: This is a convenience while we slowly migrate everything to Entities. This way
         # every dataset can have a default entity which acts as a passthrough until we can
         # migrate the datasets to proper entities.
         self.__default_entity = default_entity
 
-    def get_entity(self, entity_name: Optional[str]) -> Entity:
+    def get_default_entity(self) -> Entity:
+        return get_entity(self.__default_entity)
+
+    # TODO: Remove once entity selection moves to Sentry
+    def select_entity(self, query: Query) -> EntityKey:
         return self.__default_entity
-
-    def get_query_plan_builder(
-        self, entity_name: Optional[str] = ""
-    ) -> ClickhouseQueryPlanBuilder:
-        """
-        Returns the component that transforms a Snuba query in a Storage query by selecting
-        the storage and provides the directions on how to run the query.
-        """
-        # TODO: If the query is being executed on a single entity, that entity will be used to determine
-        # the query plan. In cases such as a join, the dataset will something something and
-        # then build the join query.
-        entity = self.get_entity(entity_name)
-
-        return entity.get_query_plan_builder()
 
     # TODO: The following functions are shims to the Entity. They need to be evaluated one by one
     # to see which ones should exist at which level.
     def get_extensions(self) -> Mapping[str, QueryExtension]:
-        return self.__default_entity.get_extensions()
-
-    def get_query_processors(self) -> Sequence[QueryProcessor]:
-        return self.__default_entity.get_query_processors()
+        return self.get_default_entity().get_extensions()
 
     def get_all_storages(self) -> Sequence[Storage]:
-        return self.__default_entity.get_all_storages()
+        return self.get_default_entity().get_all_storages()
 
     def get_writable_storage(self) -> Optional[WritableTableStorage]:
-        return self.__default_entity.get_writable_storage()
+        return self.get_default_entity().get_writable_storage()

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -1,10 +1,9 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 # TODO: Clearly this is not the right model, I am just doing this for now
 # while I restructure the code, then I can move the entity selection logic back
 # out here
 class DiscoverDataset(Dataset):
     def __init__(self) -> None:
-        discover_entity = get_entity(EntityKey.DISCOVER)
-        super().__init__(default_entity=discover_entity)
+        super().__init__(default_entity=EntityKey.DISCOVER)

--- a/snuba/datasets/errors.py
+++ b/snuba/datasets/errors.py
@@ -1,8 +1,7 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class ErrorsDataset(Dataset):
     def __init__(self) -> None:
-        errors_entity = get_entity(EntityKey.ERRORS)
-        super().__init__(default_entity=errors_entity)
+        super().__init__(default_entity=EntityKey.ERRORS)

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,8 +1,7 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class EventsDataset(Dataset):
     def __init__(self) -> None:
-        events_entity = get_entity(EntityKey.EVENTS)
-        super().__init__(default_entity=events_entity)
+        super().__init__(default_entity=EntityKey.EVENTS)

--- a/snuba/datasets/groups.py
+++ b/snuba/datasets/groups.py
@@ -1,8 +1,7 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class Groups(Dataset):
     def __init__(self) -> None:
-        groups_entity = get_entity(EntityKey.GROUPS)
-        super().__init__(default_entity=groups_entity)
+        super().__init__(default_entity=EntityKey.GROUPS)

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,5 +1,5 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class OutcomesDataset(Dataset):
@@ -8,5 +8,4 @@ class OutcomesDataset(Dataset):
     """
 
     def __init__(self) -> None:
-        outcomes_entity = get_entity(EntityKey.OUTCOMES)
-        super().__init__(default_entity=outcomes_entity)
+        super().__init__(default_entity=EntityKey.OUTCOMES)

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,8 +1,7 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class SessionsDataset(Dataset):
     def __init__(self) -> None:
-        sessions_entity = get_entity(EntityKey.SESSIONS)
-        super().__init__(default_entity=sessions_entity)
+        super().__init__(default_entity=EntityKey.SESSIONS)

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,8 +1,7 @@
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import EntityKey, get_entity
+from snuba.datasets.entities.factory import EntityKey
 
 
 class TransactionsDataset(Dataset):
     def __init__(self) -> None:
-        transactions_entity = get_entity(EntityKey.TRANSACTIONS)
-        super().__init__(default_entity=transactions_entity)
+        super().__init__(default_entity=EntityKey.TRANSACTIONS)

--- a/snuba/query/logical.py
+++ b/snuba/query/logical.py
@@ -113,6 +113,7 @@ class Query:
         groupby: Optional[Sequence[Expression]] = None,
         having: Optional[Expression] = None,
         order_by: Optional[Sequence[OrderBy]] = None,
+        entity_name: Optional[str] = None,
     ):
         """
         Expects an already parsed query body.
@@ -649,3 +650,10 @@ class Query:
 
         declared_symbols |= {c.flattened for c in self.get_data_source().get_columns()}
         return not referenced_symbols - declared_symbols
+
+    def set_entity_name(self, entity_name: str) -> None:
+        self.__entity_name = entity_name
+
+    def get_entity_name(self) -> Optional[str]:
+        assert self.__entity_name is not None
+        return self.__entity_name

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -67,7 +67,7 @@ def parse_query(body: MutableMapping[str, Any], dataset: Dataset) -> Query:
       Alias references are packaged back at the end of processing.
     """
     # TODO: Parse the entity out of the query body and select the correct one from the dataset
-    entity = dataset.get_entity(None)
+    entity = dataset.get_default_entity()
 
     query = _parse_query_impl(body, entity)
     # These are the post processing phases
@@ -81,6 +81,12 @@ def parse_query(body: MutableMapping[str, Any], dataset: Dataset) -> Query:
     _deescape_aliases(query)
     _validate_arrayjoin(query)
     validate_query(query, entity)
+
+    # XXX: Select the entity to be used for the query. This step is temporary. Eventually
+    # entity selection will be moved to Sentry and specified for all SnQL queries.
+    selected_entity = dataset.select_entity(query)
+    query.set_entity_name(selected_entity.value)
+
     return query
 
 

--- a/tests/clickhouse/query_dsl/test_time_range.py
+++ b/tests/clickhouse/query_dsl/test_time_range.py
@@ -25,7 +25,7 @@ def test_get_time_range() -> None:
 
     events = get_dataset("events")
     query = parse_query(body, events)
-    processors = events.get_query_processors()
+    processors = events.get_default_entity().get_query_processors()
     for processor in processors:
         if isinstance(processor, TimeSeriesProcessor):
             processor.process_query(query, HTTPRequestSettings())

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -3,6 +3,7 @@ import pytest
 from typing import Any, MutableMapping
 
 from snuba.datasets.factory import get_dataset
+from snuba.datasets.entities.factory import EntityKey, get_entity
 from snuba.query.parser import parse_query
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
@@ -146,10 +147,11 @@ def test_data_source(
     dataset = get_dataset("discover")
     query = parse_query(query_body, dataset)
     request = Request("a", query, request_settings, {}, "r")
-    for processor in get_dataset("discover").get_query_processors():
+    entity = get_entity(EntityKey(query.get_entity_name()))
+    for processor in entity.get_query_processors():
         processor.process_query(request.query, request.settings)
 
-    plan = dataset.get_query_plan_builder().build_plan(request)
+    plan = entity.get_query_plan_builder().build_plan(request)
 
     for physical_processor in plan.plan_processors:
         physical_processor.process_query(plan.query, request.settings)

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -17,7 +17,9 @@ def test_events_processing() -> None:
     query = parse_query(query_body, events)
     request = Request("", query, HTTPRequestSettings(), {}, "")
 
-    query_plan = events.get_query_plan_builder().build_plan(request)
+    query_plan = (
+        events.get_default_entity().get_query_plan_builder().build_plan(request)
+    )
     for clickhouse_processor in query_plan.plan_processors:
         clickhouse_processor.process_query(query_plan.query, request.settings)
 

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -17,7 +17,9 @@ def test_sessions_processing() -> None:
     query = parse_query(query_body, sessions)
     request = Request("", query, HTTPRequestSettings(), {}, "")
 
-    query_plan = sessions.get_query_plan_builder().build_plan(request)
+    query_plan = (
+        sessions.get_default_entity().get_query_plan_builder().build_plan(request)
+    )
     for clickhouse_processor in query_plan.plan_processors:
         clickhouse_processor.process_query(query_plan.query, request.settings)
 

--- a/tests/query/processors/test_nested_optimizer.py
+++ b/tests/query/processors/test_nested_optimizer.py
@@ -229,7 +229,9 @@ def test_nested_optimizer(query_body, expected_condition) -> None:
     request_settings = HTTPRequestSettings()
     request = Request("", query, request_settings, {}, "")
 
-    query_plan = transactions.get_query_plan_builder().build_plan(request)
+    query_plan = (
+        transactions.get_default_entity().get_query_plan_builder().build_plan(request)
+    )
     processor = NestedFieldConditionOptimizer(
         nested_col="tags",
         flattened_col="tags_map",

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -215,8 +215,10 @@ def test_alias_validation(
 ) -> None:
     events = get_dataset("events")
     query = parse_query(query_body, events)
-    query_plan = events.get_query_plan_builder().build_plan(
-        Request("", query, HTTPRequestSettings(), {}, "")
+    query_plan = (
+        events.get_default_entity()
+        .get_query_plan_builder()
+        .build_plan(Request("", query, HTTPRequestSettings(), {}, ""))
     )
 
     assert query_plan.query.validate_aliases() == expected_result

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -9,6 +9,7 @@ from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.query_dsl.accessors import get_time_range
 from snuba.clickhouse.sql import SqlQuery
 from snuba.clusters.cluster import ClickhouseCluster
+from snuba.datasets.entities.factory import EntityKey, get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SimpleQueryPlanExecutionStrategy
 from snuba.query.expressions import Column
@@ -316,7 +317,8 @@ def test_col_split_conditions(
     query = parse_query(query, dataset)
     splitter = ColumnSplitQueryStrategy(id_column, project_column, timestamp_column)
     request = Request("a", query, HTTPRequestSettings(), {}, "r")
-    plan = dataset.get_query_plan_builder().build_plan(request)
+    entity = get_entity(EntityKey(query.get_entity_name()))
+    plan = entity.get_query_plan_builder().build_plan(request)
 
     def do_query(
         query: ClickhouseQuery, request_settings: RequestSettings,
@@ -376,10 +378,10 @@ def test_time_split_ast() -> None:
         "orderby": ["-timestamp"],
     }
 
-    events = get_dataset("events")
-    query = parse_query(body, events)
+    query = parse_query(body, get_dataset("events"))
+    entity = get_entity(EntityKey(query.get_entity_name()))
     settings = HTTPRequestSettings()
-    for p in events.get_entity(None).get_query_processors():
+    for p in entity.get_query_processors():
         p.process_query(query, settings)
 
     splitter = TimeSplitQueryStrategy("timestamp")


### PR DESCRIPTION
This change involves storing the entity name in the logical query,
and using that entity from the query in order to run the query pipeline,
instead of relying on the dataset's default entity. Dataset no longer has a
`get_query_plan_builder` or `get_query_processors` method, this should
always be used from the entity instead.

The Dataset now has a `select_entity` method, which allows a dataset to
provide custom entity selection behavior, so a non default entity can be
picked. Eventually, this entity selection will be done by Sentry and specified
as part of the SnQL query.

Most of these changes are included in https://github.com/getsentry/snuba/pull/1407,
I'm moving the non Discover specific changes that relate to query processing here
to hopefully keep things more focussed and easier to review.