### PR TITLE
fix(streams): Avoid problematic fork usage with parallel transform worker pool

### DIFF
--- a/snuba/utils/streams/processing/strategies/streaming/transform.py
+++ b/snuba/utils/streams/processing/strategies/streaming/transform.py
@@ -4,9 +4,8 @@ import pickle
 import signal
 import time
 from collections import deque
-from multiprocessing import Pool
 from multiprocessing.managers import SharedMemoryManager
-from multiprocessing.pool import AsyncResult
+from multiprocessing.pool import AsyncResult, Pool
 from multiprocessing.shared_memory import SharedMemory
 from pickle import PickleBuffer
 from typing import (
@@ -270,7 +269,11 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
         self.__shared_memory_manager = SharedMemoryManager()
         self.__shared_memory_manager.start()
 
-        self.__pool = Pool(processes, initializer=parallel_transform_worker_initializer)
+        self.__pool = Pool(
+            processes,
+            initializer=parallel_transform_worker_initializer,
+            context=multiprocessing.get_context("spawn"),
+        )
 
         self.__input_blocks = [
             self.__shared_memory_manager.SharedMemory(input_block_size)


### PR DESCRIPTION
The default multiprocessing context [differs between *nix and macOS](https://docs.python.org/3.8/library/multiprocessing.html#contexts-and-start-methods): macOS uses `spawn`, which starts a fresh interpreter for each subprocess, while *nix uses `fork`, which inherits resources from the parent process — including signal handlers.

When the stream processor encounters an error, it attempts to shut down immediately (abandoning all in-process work) by [terminating the processing strategy](https://github.com/getsentry/snuba/blob/1e426a650966bd37279a2646502da5fba96bbf42/snuba/utils/streams/processing/processor.py#L107-L121), which in the case of a streaming strategy cascades throughout all of the processing steps. For a parallel transform, this means [terminating the process pool](https://github.com/getsentry/snuba/blob/1e426a650966bd37279a2646502da5fba96bbf42/snuba/utils/streams/processing/strategies/streaming/transform.py#L411-L412), which is essentially shorthand for sending `SIGTERM` to all workers, which when using the default handler has a behavior similar to that of `SIGKILL` ([and is oddly undocumented](https://stackoverflow.com/questions/9930576/python-what-is-the-default-handling-of-sigterm) [edit: Python just delegates this to the operating system default, so I guess not documenting makes sense]), causing the process to exit immediately.

When using the fork context, if a `SIGTERM` handler is already defined by the parent process when the child is started, it inherits that same signal handler. In this case, the signal handler defined by the parent process [simply requests the stream processor to shut down](https://github.com/getsentry/snuba/blob/1e426a650966bd37279a2646502da5fba96bbf42/snuba/cli/consumer.py#L167-L171). Since the child process has effectively no control over the stream processor, `SIGTERM` sent to the child process has no meaningful effect (it appears as it may actually lock up the child process — `strace` showed the process endlessly stuck in `futex_wait`, I did not diagnose further) and the subprocess never exits, and consequently the stream processor never exits, and since the stream processor never exits, no error is ever reported.

This changes the multiprocessing context used by the process pool to `spawn` to avoid that scenario, and also make the behavior more consistent across environments (and in my opinion, is the more easily understood, expected, and less dangerous behavior.) We shouldn't get any meaningful performance benefits from forking in this case, as these processes should live a long time and their startup cost is amortized by their lifespan.