### PR TITLE
fix(discover): Fix processing timestamp column in transactions entity

### DIFF
--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -97,7 +97,9 @@ class TransactionsEntity(Entity):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
-            TimeSeriesProcessor({"time": "finish_ts"}, ("start_ts", "finish_ts")),
+            TimeSeriesProcessor(
+                {"time": "finish_ts"}, ("start_ts", "finish_ts", "timestamp")
+            ),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
             apdex_processor(self.get_data_model()),


### PR DESCRIPTION
Now that Discover is using the transactions entity, we need to support
properly processing any "timestamp" field in the query when we are using
the transactions entity since this field is referred to as "timestamp"
in Discover and not it's internal name "finish_ts".

I ran the Sentry test `SnubaEventStorageTest::test_transaction_get_next_prev_event_id`
locally and it seems to fix the issue.