### PR TITLE
feat: Align the Events and Discover column mapping

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -22,7 +22,7 @@ from snuba.clickhouse.translators.snuba.allowed import (
     FunctionCallMapper,
     SubscriptableReferenceMapper,
 )
-from snuba.clickhouse.translators.snuba.mappers import ColumnToLiteral, ColumnToMapping
+from snuba.clickhouse.translators.snuba.mappers import ColumnToLiteral
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entity import Entity
 from snuba.datasets.entities.events import event_translator
@@ -220,12 +220,7 @@ class DiscoverQueryStorageSelector(QueryStorageSelector):
 
         self.__event_translator = event_translator.concat(
             TranslationMappers(
-                columns=[
-                    ColumnToMapping(None, "release", None, "tags", "sentry:release"),
-                    ColumnToMapping(None, "dist", None, "tags", "sentry:dist"),
-                    ColumnToMapping(None, "user", None, "tags", "sentry:user"),
-                    DefaultNoneColumnMapper(self.__abstract_transactions_columns),
-                ],
+                columns=[DefaultNoneColumnMapper(self.__abstract_transactions_columns)],
                 curried_functions=[DefaultNoneCurriedFunctionMapper()],
                 functions=[DefaultNoneFunctionMapper()],
                 subscriptables=[DefaultNoneSubscriptMapper({"measurements"})],

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -2,7 +2,10 @@ from datetime import timedelta
 from typing import Mapping, Sequence
 
 from snuba import state
-from snuba.clickhouse.translators.snuba.mappers import SubscriptableMapper
+from snuba.clickhouse.translators.snuba.mappers import (
+    ColumnToMapping,
+    SubscriptableMapper,
+)
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entity import Entity
 from snuba.datasets.plans.single_storage import SelectedStorageQueryPlanBuilder
@@ -29,6 +32,11 @@ from snuba.request.request_settings import RequestSettings
 # storage. Now we do not have entities so it is between dataset and
 # storage.
 event_translator = TranslationMappers(
+    columns=[
+        ColumnToMapping(None, "release", None, "tags", "sentry:release"),
+        ColumnToMapping(None, "dist", None, "tags", "sentry:dist"),
+        ColumnToMapping(None, "user", None, "tags", "sentry:user"),
+    ],
     subscriptables=[
         SubscriptableMapper(None, "tags", None, "tags"),
         SubscriptableMapper(None, "contexts", None, "contexts"),

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -176,6 +176,10 @@ all_columns = (
         ("culprit", Nullable(String())),
         ("sdk_integrations", Array(String())),
         ("modules", Nested([("name", String()), ("version", String())])),
+        # Aliases
+        ("release", Nullable(String())),
+        ("dist", Nullable(String())),
+        ("user", Nullable(String())),
     ]
 )
 

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -177,9 +177,9 @@ all_columns = (
         ("sdk_integrations", Array(String())),
         ("modules", Nested([("name", String()), ("version", String())])),
         # Aliases
-        ("release", Nullable(String())),
-        ("dist", Nullable(String())),
-        ("user", Nullable(String())),
+        ("release", ReadOnly(Nullable(String()))),
+        ("dist", ReadOnly(Nullable(String()))),
+        ("user", ReadOnly(Nullable(String()))),
     ]
 )
 

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -176,7 +176,6 @@ all_columns = (
         ("culprit", Nullable(String())),
         ("sdk_integrations", Array(String())),
         ("modules", Nested([("name", String()), ("version", String())])),
-        # Aliases
         ("release", ReadOnly(Nullable(String()))),
         ("dist", ReadOnly(Nullable(String()))),
         ("user", ReadOnly(Nullable(String()))),


### PR DESCRIPTION
This aligns the columns of events and Discover so that the Discover
fields "release", "user" and "dist" are now supported on the Events
entity.

Ideally, these will be used by Sentry instead of `tags[sentry:release]`,
`tags[sentry:user]` and `tags[sentry:dist]` in the API, but both will
remain supported.

Note that this mapping won't be required when we switch to the errors
entity since "release", "user" and "dist" are already the same as the
underlying column names in errors.

The only remaining differences now between the Discover and Events
entity should relate to Null mapping of fields that are only present in
transactions.