### PR TITLE
feat(discover): Skip DefaultNoneFunctionMapper for transactions entity

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -414,7 +414,5 @@ class DiscoverTransactionsEntity(TransactionsEntity):
                     ColumnToLiteral(None, "group_id", 0),
                     DefaultNoneColumnMapper(EVENTS_COLUMNS),
                 ],
-                curried_functions=[DefaultNoneCurriedFunctionMapper()],
-                functions=[DefaultNoneFunctionMapper()],
             )
         )


### PR DESCRIPTION
I'm not sure if there's a reason we might want to run these everywhere
for consistency in Discover, but since impossible queries are never sent
to the transactions entity, there are not really needed here. Impossible
queries only use the Discover entity.