### PR TITLE
ci(release): Don't use set-env in GHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,14 +32,14 @@ jobs:
         - id: set-version
           run: |
             if [[ -n '${{ github.event.inputs.version }}' ]]; then
-              echo '::set-env name=RELEASE_VERSION::${{ github.event.inputs.version }}';
+              echo 'RELEASE_VERSION=${{ github.event.inputs.version }}' >> $GITHUB_ENV;
             else
               DATE_PART=$(date +'%y.%-m')
               declare -i PATCH_VERSION=0
               while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
                 PATCH_VERSION+=1
               done
-              echo "::set-env name=RELEASE_VERSION::${DATE_PART}.${PATCH_VERSION}"
+              echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
             fi
         - uses: actions/checkout@v2
           with:


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
