### PR TITLE
fix(consumer): Update arbitrarily renamed `KafkaError` in commit retry policy

### DIFF
--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -117,7 +117,7 @@ class ConsumerBuilder:
                 and e.args[0].code()
                 in (
                     KafkaError.REQUEST_TIMED_OUT,
-                    KafkaError.NOT_COORDINATOR_FOR_GROUP,
+                    KafkaError.NOT_COORDINATOR,
                     KafkaError._WAIT_COORD,
                 ),
             )


### PR DESCRIPTION
Seems as though we don't do a whole lot of retrying. Not sure when this changed, but it was prior to or with the 1.5.0 release which we use.

References confluentinc/confluent-kafka-python@18e1e737d2ec6dd4b0dc433df5b4c7874cf7cdac