### PR TITLE
fix(errors): Hashify primary hash

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -10,6 +10,7 @@ from snuba.datasets.events_processor_base import EventsProcessorBase, InsertEven
 from snuba.processor import (
     _as_dict_safe,
     _ensure_valid_ip,
+    _hashify,
     _unicodify,
 )
 
@@ -77,7 +78,7 @@ class ErrorsProcessor(EventsProcessorBase):
 
         output["message"] = _unicodify(event["message"])
 
-        output["primary_hash"] = str(uuid.UUID(event["primary_hash"]))
+        output["primary_hash"] = str(uuid.UUID(_hashify(event["primary_hash"])))
 
     def extract_tags_custom(
         self,


### PR DESCRIPTION
We need to _hashify the primary hash before inserting it to the errors
table in case we do not receive a valid primary hash. This is similar
to what we do for the events table.

Fixes SNUBA-22M