### PR TITLE
fix(discover): Handle custom events functions in Discover

### DIFF
--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -57,6 +57,10 @@ TRANSACTION_FUNCTIONS = FunctionCallMatch(
     Or([StringMatch("apdex"), StringMatch("failure_rate")]), None
 )
 
+EVENT_FUNCTIONS = FunctionCallMatch(
+    Or([StringMatch("isHandled"), StringMatch("notHandled")]), None
+)
+
 
 def match_query_to_entity(
     query: Query, events_only_columns: ColumnSet, transactions_only_columns: ColumnSet
@@ -112,6 +116,20 @@ def match_query_to_entity(
         if transactions_only_columns.get(schema_col_name):
             has_transaction_columns = True
 
+    # Check for apdex or failure rate
+    if has_event_columns is False:
+        for expr in query.get_all_expressions():
+            match = EVENT_FUNCTIONS.match(expr)
+            if match:
+                has_event_columns = True
+
+    # Check for isHandled/notHandled
+    if has_transaction_columns is False:
+        for expr in query.get_all_expressions():
+            match = TRANSACTION_FUNCTIONS.match(expr)
+            if match:
+                has_transaction_columns = True
+
     if has_event_columns and has_transaction_columns:
         # Impossible query, use the merge table
         return EVENTS_AND_TRANSACTIONS
@@ -120,12 +138,6 @@ def match_query_to_entity(
     elif has_transaction_columns:
         return TRANSACTIONS
     else:
-        # Check for apdex or failure rate
-        for expr in query.get_all_expressions():
-            match = TRANSACTION_FUNCTIONS.match(expr)
-            if match:
-                return TRANSACTIONS
-
         return EVENTS_AND_TRANSACTIONS
 
 

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -116,14 +116,14 @@ def match_query_to_entity(
         if transactions_only_columns.get(schema_col_name):
             has_transaction_columns = True
 
-    # Check for apdex or failure rate
+    # Check for isHandled/notHandled
     if has_event_columns is False:
         for expr in query.get_all_expressions():
             match = EVENT_FUNCTIONS.match(expr)
             if match:
                 has_event_columns = True
 
-    # Check for isHandled/notHandled
+    # Check for apdex or failure rate
     if has_transaction_columns is False:
         for expr in query.get_all_expressions():
             match = TRANSACTION_FUNCTIONS.match(expr)

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -286,7 +286,8 @@ transaction_translation_mappers = TranslationMappers(
     columns=[
         ColumnToLiteral(None, "group_id", 0),
         DefaultNoneColumnMapper(EVENTS_COLUMNS),
-    ]
+    ],
+    functions=[DefaultNoneFunctionMapper({"isHandled", "notHandled"})],
 )
 
 null_function_translation_mappers = TranslationMappers(

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -135,6 +135,8 @@ test_data = [
         {"aggregations": [["failure_rate()", None, "failure_rate"]]},
         "transactions_local",
     ),
+    ({"aggregations": [["isHandled()", None, "handled"]]}, "sentry_local",),
+    ({"aggregations": [["notHandled()", None, "handled"]]}, "sentry_local",),
     ({"selected_columns": ["measurements[lcp.elementSize]"]}, "transactions_local"),
 ]
 


### PR DESCRIPTION
This PR updates the select_entity function on the Discover dataset
to check for the presence of the isHandled and notHandled custom
functions. If they are present, we should attempt to use the Events
entity instead of the Discover entity.

If the Discover entity is still being picked (for example if other
transactions only columns are also present in the query), these functions
are mapped to Null.

This is equivalent to how we handle apdex and failure_rate in entity
selection and mapping.

This fixes SNUBA-22Q