### PR TITLE
feat: Remove special handling of promoted tags in errors replacer

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -160,7 +160,11 @@ class ErrorsReplacer(ReplacerProcessor):
             processed = process_unmerge(event, self.__all_columns, self.__state_name)
         elif type_ == "end_delete_tag":
             processed = process_delete_tag(
-                event, self.__all_columns, self.__tag_column_map, self.__promoted_tags,
+                event,
+                self.__all_columns,
+                self.__tag_column_map,
+                self.__promoted_tags,
+                self.__state_name,
             )
         else:
             raise InvalidMessageType("Invalid message type: {}".format(type_))
@@ -379,6 +383,7 @@ def process_delete_tag(
     all_columns: Sequence[FlattenedColumn],
     tag_column_map: Mapping[str, Mapping[str, str]],
     promoted_tags: Mapping[str, Sequence[str]],
+    state_name: Optional[ReplacerState],
 ) -> Optional[Replacement]:
     tag = message["tag"]
     if not tag:
@@ -395,7 +400,7 @@ def process_delete_tag(
         AND NOT deleted
     """
 
-    if is_promoted:
+    if is_promoted and state_name == ReplacerState.EVENTS:
         prewhere = " PREWHERE %(tag_column)s IS NOT NULL "
     else:
         prewhere = " PREWHERE has(`tags.key`, %(tag_str)s) "

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -167,5 +167,6 @@ storage = WritableTableStorage(
         tag_column_map={"tags": promoted_tag_columns, "contexts": {}},
         promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},
         state_name=ReplacerState.ERRORS,
+        use_promoted_prewhere=False,
     ),
 )

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -164,8 +164,8 @@ storage = WritableTableStorage(
     replacer_processor=ErrorsReplacer(
         schema=schema,
         required_columns=required_columns,
-        tag_column_map={"tags": {}, "contexts": {}},
-        promoted_tags={"tags": [], "contexts": []},
+        tag_column_map={"tags": promoted_tag_columns, "contexts": {}},
+        promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},
         state_name=ReplacerState.ERRORS,
     ),
 )

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -164,8 +164,8 @@ storage = WritableTableStorage(
     replacer_processor=ErrorsReplacer(
         schema=schema,
         required_columns=required_columns,
-        tag_column_map={"tags": promoted_tag_columns, "contexts": {}},
-        promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},
+        tag_column_map={"tags": {}, "contexts": {}},
+        promoted_tags={"tags": [], "contexts": []},
         state_name=ReplacerState.ERRORS,
     ),
 )

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -46,5 +46,6 @@ storage = WritableTableStorage(
         tag_column_map=get_tag_column_map(),
         promoted_tags=get_promoted_tags(),
         state_name=ReplacerState.EVENTS,
+        use_promoted_prewhere=True,
     ),
 )

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -166,7 +166,42 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_tag_process(self):
+    def test_delete_promoted_tag_process(self):
+        timestamp = datetime.now(tz=pytz.utc)
+        message = (
+            2,
+            "end_delete_tag",
+            {
+                "project_id": self.project_id,
+                "tag": "sentry:user",
+                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            },
+        )
+
+        replacement = self.replacer.process_message(self._wrap(message))
+
+        assert (
+            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
+            == "SELECT count() FROM %(table_name)s FINAL PREWHERE has(`tags.key`, %(tag_str)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
+        )
+        assert (
+            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
+            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE has(`tags.key`, %(tag_str)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
+        )
+        assert replacement.query_args == {
+            "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, sdk_integrations, modules.name, modules.version",
+            "select_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, NULL, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'sentry:user')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'sentry:user'), arrayEnumerate(`tags.value`))), contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, sdk_integrations, modules.name, modules.version",
+            "tag_column": "user",
+            "tag_str": "'sentry:user'",
+            "project_id": self.project_id,
+            "timestamp": timestamp.strftime(DATETIME_FORMAT),
+        }
+        assert replacement.query_time_flags == (
+            errors_replacer.NEEDS_FINAL,
+            self.project_id,
+        )
+
+    def test_delete_unpromoted_tag_process(self):
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,


### PR DESCRIPTION
This removes all special handling of promoted tags in the errors replacer
and instead uses the values from tags.key and tags.value like our
unpromoted tags.

Unlike in the events storage, most of our promoted tags are low cardinality
columns now. This is causing a bug in ClickHouse -
https://github.com/ClickHouse/ClickHouse/issues/16171.

Our workaround for now is to not use any of our promoted columns for
errors replacements; event replacements are unchanged.

This fixes SNUBA-22N in Sentry.