### PR TITLE
test: Fix creating test database

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,8 @@ from typing import Iterator
 import pytest
 
 from snuba import settings
-from snuba.clusters.cluster import ClickhouseClientSettings, CLUSTERS
+from snuba.clickhouse.native import ClickhousePool
+from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
@@ -26,9 +27,11 @@ def pytest_configure() -> None:
 
     setup_sentry()
 
-    for cluster in CLUSTERS:
-        connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
-        database_name = cluster.get_database()
+    for cluster in settings.CLUSTERS:
+        connection = ClickhousePool(
+            cluster["host"], cluster["port"], "default", "", "default",
+        )
+        database_name = cluster["database"]
         connection.execute(f"DROP DATABASE IF EXISTS {database_name};")
         connection.execute(f"CREATE DATABASE {database_name};")
 


### PR DESCRIPTION
This fixes a bug introduced in
https://github.com/getsentry/snuba/pull/1382, whereby the snuba_test
database is not created properly before running tests. We need to use
the default database in order to create other databases required for tests.