### PR TITLE
ref: Prevent arguments being passed to entities

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -31,8 +31,8 @@ from snuba.datasets.entity import Entity
 from snuba.datasets.plans.single_storage import SelectedStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
-from snuba.datasets.entities.events import EventsEntity, EventsQueryStorageSelector
-from snuba.datasets.entities.transactions import TransactionsEntity
+from snuba.datasets.entities.events import BaseEventsEntity, EventsQueryStorageSelector
+from snuba.datasets.entities.transactions import BaseTransactionsEntity
 from snuba.query.dsl import identity
 from snuba.query.expressions import (
     Column,
@@ -397,7 +397,7 @@ class DiscoverEntity(Entity):
         }
 
 
-class DiscoverEventsEntity(EventsEntity):
+class DiscoverEventsEntity(BaseEventsEntity):
     """
     Identical to EventsEntity except it maps columns and functions present in the
     transactions entity to null. This logic will eventually move to Sentry and this
@@ -412,7 +412,7 @@ class DiscoverEventsEntity(EventsEntity):
         )
 
 
-class DiscoverTransactionsEntity(TransactionsEntity):
+class DiscoverTransactionsEntity(BaseTransactionsEntity):
     """
     Identical to TransactionsEntity except it maps columns and functions present
     in the events entity to null. This logic will eventually move to Sentry and this

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from datetime import timedelta
 from typing import Mapping, Optional, Sequence
 
@@ -60,7 +61,7 @@ class EventsQueryStorageSelector(QueryStorageSelector):
         return StorageAndMappers(storage, self.__mappers)
 
 
-class BaseEventsEntity(Entity):
+class BaseEventsEntity(Entity, ABC):
     """
     Represents the collection of classic sentry "error" type events
     and the particular quirks of storing and querying them.

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -60,7 +60,7 @@ class EventsQueryStorageSelector(QueryStorageSelector):
         return StorageAndMappers(storage, self.__mappers)
 
 
-class EventsEntity(Entity):
+class BaseEventsEntity(Entity):
     """
     Represents the collection of classic sentry "error" type events
     and the particular quirks of storing and querying them.
@@ -105,3 +105,7 @@ class EventsEntity(Entity):
                 "exception_stacks.mechanism_handled", self.get_data_model()
             ),
         ]
+
+
+class EventsEntity(BaseEventsEntity):
+    pass

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -68,7 +68,7 @@ transaction_translator = TranslationMappers(
 )
 
 
-class TransactionsEntity(Entity):
+class BaseTransactionsEntity(Entity):
     def __init__(self, custom_mappers: Optional[TranslationMappers] = None) -> None:
         storage = get_writable_storage(StorageKey.TRANSACTIONS)
         schema = storage.get_table_writer().get_schema()
@@ -105,3 +105,7 @@ class TransactionsEntity(Entity):
             apdex_processor(self.get_data_model()),
             failure_rate_processor(self.get_data_model()),
         ]
+
+
+class TransactionsEntity(BaseTransactionsEntity):
+    pass

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from datetime import timedelta
 from typing import Mapping, Optional, Sequence
 
@@ -68,7 +69,7 @@ transaction_translator = TranslationMappers(
 )
 
 
-class BaseTransactionsEntity(Entity):
+class BaseTransactionsEntity(Entity, ABC):
     def __init__(self, custom_mappers: Optional[TranslationMappers] = None) -> None:
         storage = get_writable_storage(StorageKey.TRANSACTIONS)
         schema = storage.get_table_writer().get_schema()


### PR DESCRIPTION
Prevent custom mappers from being passed to EventEntity and
TransactionsEntity on initialization.