### PR TITLE
feat: Add QueryPlanDelegator (aka Snüplicator)

### DIFF
--- a/snuba/datasets/query_plan_delegator.py
+++ b/snuba/datasets/query_plan_delegator.py
@@ -1,0 +1,159 @@
+from concurrent.futures import ThreadPoolExecutor
+import sentry_sdk
+from typing import (
+    Callable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+)
+
+from snuba.clickhouse.query import Query
+from snuba.datasets.plans.query_plan import (
+    ClickhouseQueryPlan,
+    ClickhouseQueryPlanBuilder,
+    QueryPlanExecutionStrategy,
+    QueryRunner,
+)
+from snuba.datasets.plans.translator.query import identity_translate
+from snuba.request import Request
+from snuba.request.request_settings import RequestSettings
+from snuba.util import with_span
+from snuba.web import QueryResult
+
+
+BuilderId = str
+QueryResults = List[Tuple[BuilderId, QueryResult]]
+CallbackFunc = Callable[[QueryResults], None]
+
+
+class QueryPlanDelegator(ClickhouseQueryPlanBuilder):
+    """
+    QueryPlanDelegator is a query plan builder that delegates a request to one or
+    more other query plan builders.
+
+    It can be used as a way to switch between different query plan builders depending
+    on the query received and the selector function provided. It can also be used to
+    run a single query against multiple query plans annd their associated storages
+    in order to test and compare the results and performance of various query
+    plan builders before rolling them out to users.
+
+    The query plans that are built and executed on a particular query are determined
+    by the selector function which returns a sequence of query builder IDs. The
+    first item in the list corresponds to the query builder that will be used to
+    ultimately return a result. Hence the selector function must return
+    a list with at least one value in it.
+
+    Subsequent (if any) query plan builders that are also returned by the selector
+    function will be executed in separate threads. The results of these other queries
+    are provided to the callback function if one is provided.
+
+    TODO: Add metrics
+    """
+
+    def __init__(
+        self,
+        query_plan_builders: Mapping[BuilderId, ClickhouseQueryPlanBuilder],
+        selector_func: Callable[[Query], List[BuilderId]],
+        callback_func: Optional[CallbackFunc] = None,
+    ) -> None:
+        self.__query_plan_builders = query_plan_builders
+        self.__selector_func = selector_func
+        self.__callback_func = callback_func
+
+    def build_plan(self, request: Request) -> ClickhouseQueryPlan:
+        return ClickhouseQueryPlan(
+            query=identity_translate(request.query),
+            plan_processors=[],
+            execution_strategy=ThreadedQueryPlanExecutionStrategy(
+                request=request,
+                query_plan_builders=self.__query_plan_builders,
+                selector_func=self.__selector_func,
+                callback_func=self.__callback_func,
+            ),
+        )
+
+
+class ThreadedQueryPlanExecutionStrategy(QueryPlanExecutionStrategy):
+    def __init__(
+        self,
+        request: Request,
+        query_plan_builders: Mapping[BuilderId, ClickhouseQueryPlanBuilder],
+        selector_func: Callable[[Query], List[BuilderId]],
+        callback_func: Optional[CallbackFunc] = None,
+    ) -> None:
+        self.__request = request
+        self.__query_plan_builders = query_plan_builders
+        self.__selector_func = selector_func
+        self.__callback_func = callback_func
+
+    @with_span()
+    def execute(
+        self, query: Query, request_settings: RequestSettings, runner: QueryRunner
+    ) -> QueryResult:
+        def execute_query(
+            query_plan_builder: ClickhouseQueryPlanBuilder,
+        ) -> QueryResult:
+            query_plan = query_plan_builder.build_plan(self.__request)
+
+            for clickhouse_processor in query_plan.plan_processors:
+                with sentry_sdk.start_span(
+                    description=type(clickhouse_processor).__name__, op="processor"
+                ):
+                    clickhouse_processor.process_query(
+                        query_plan.query, request_settings
+                    )
+
+            return query_plan.execution_strategy.execute(
+                query_plan.query, request_settings, runner
+            )
+
+        def execute_queries() -> Iterator[Tuple[BuilderId, QueryResult]]:
+            builder_ids = self.__selector_func(query)
+            primary_builder_id = builder_ids.pop(0)
+
+            if len(builder_ids) == 0:
+                yield primary_builder_id, execute_query(
+                    self.__query_plan_builders[primary_builder_id]
+                )
+            else:
+                executor = ThreadPoolExecutor()
+
+                with executor:
+                    futures = [
+                        (
+                            builder_id,
+                            executor.submit(
+                                execute_query,
+                                query_plan_builder=self.__query_plan_builders[
+                                    builder_id
+                                ],
+                            ),
+                        )
+                        for builder_id in builder_ids
+                    ]
+
+                    yield primary_builder_id, execute_query(
+                        self.__query_plan_builders[primary_builder_id]
+                    )
+
+                    yield from [
+                        (builder_id, future.result())
+                        for (builder_id, future) in futures
+                    ]
+
+        generator = execute_queries()
+
+        query_results: QueryResults = []
+
+        try:
+            builder_id, query_result = next(generator)
+            query_results.append((builder_id, query_result))
+            return query_result
+        finally:
+            for builder_id, query_result in generator:
+                query_results.append((builder_id, query_result))
+
+            if self.__callback_func is not None:
+                self.__callback_func(query_results)

--- a/tests/datasets/test_query_plan_delegator.py
+++ b/tests/datasets/test_query_plan_delegator.py
@@ -1,0 +1,59 @@
+from unittest.mock import Mock, call
+
+from snuba.clickhouse.query import Query as ClickhouseQuery
+from snuba.datasets.factory import get_dataset
+from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.query_plan_delegator import QueryPlanDelegator
+from snuba.query.parser import parse_query
+from snuba.request import Request
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.web import QueryResult
+
+
+def test() -> None:
+    query_result = QueryResult({}, {"stats": {}, "sql": ""})
+    mock_query_runner = Mock(return_value=query_result)
+    mock_callback_func = Mock()
+    query_body = {
+        "selected_columns": ["type", "project_id"],
+    }
+
+    events = get_dataset("events")
+    query = parse_query(query_body, events)
+
+    events_query_plan_builder = SingleStorageQueryPlanBuilder(
+        storage=get_storage(StorageKey.EVENTS)
+    )
+    events_ro_query_plan_builder = SingleStorageQueryPlanBuilder(
+        storage=get_storage(StorageKey.EVENTS_RO)
+    )
+
+    delegator = QueryPlanDelegator(
+        query_plan_builders={
+            "events": events_query_plan_builder,
+            "events_ro": events_ro_query_plan_builder,
+        },
+        selector_func=lambda query: ["events", "events_ro"],
+        callback_func=mock_callback_func,
+    )
+
+    query_plan = delegator.build_plan(Request("", query, HTTPRequestSettings(), {}, ""))
+
+    clickhouse_query = ClickhouseQuery(
+        events.get_default_entity()
+        .get_all_storages()[0]
+        .get_schema()
+        .get_data_source(),
+    )
+
+    query_plan.execution_strategy.execute(
+        clickhouse_query, HTTPRequestSettings(), mock_query_runner
+    )
+
+    assert mock_query_runner.call_count == 2
+
+    assert mock_callback_func.call_args_list == [
+        call([("events", query_result), ("events_ro", query_result)])
+    ]


### PR DESCRIPTION
This adds a basic skeleton of the QueryPlanDelegator, which is a type
of query plan builder that is able to delegate a request to one or
more other query plan builders which are executed against a single
query.

All query plan builders apart from the "primary" one (i.e. the
the one whose results are actually returned to the user) are run
asynchronously to ensure results can be returned before all of the
all of the subsequent queries are necessarily completed.

Currently the primary use case for this is to support the upcoming
transition of events queries to the errors table and Discover queries
to the new merge table. It will allow us to compare the correctness
and relative performance of various different query plans (and their
associated storages) before rolling any risky changes out to end users.

Inspired by Sentry's ServiceDelegator.