### PR TITLE
feat: Add schema support for pre-aggregated sessions (1/4)

### DIFF
--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -33,6 +33,7 @@ all_columns = ColumnSet(
     [
         ("session_id", UUID()),
         ("distinct_id", UUID()),
+        ("quantity", UInt(32)),
         ("seq", UInt(64)),
         ("org_id", UInt(64)),
         ("project_id", UInt(64)),
@@ -44,6 +45,8 @@ all_columns = ColumnSet(
         ("started", DateTime()),
         ("release", String()),
         ("environment", String()),
+        ("user_agent", String()),
+        ("os", String()),
     ]
 )
 
@@ -61,15 +64,22 @@ read_columns = ColumnSet(
         ("started", DateTime()),
         ("release", String()),
         ("environment", String()),
+        ("user_agent", String()),
+        ("os", String()),
         (
             "duration_quantiles",
             AggregateFunction("quantilesIf(0.5, 0.9)", [UInt(32), UInt(8)]),
         ),
+        ("duration_avg", AggregateFunction("avgIf", [UInt(32), UInt(8)])),
         ("sessions", AggregateFunction("countIf", [UUID(), UInt(8)])),
-        ("users", AggregateFunction("uniqIf", [UUID(), UInt(8)])),
+        ("sessions_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)])),
         ("sessions_crashed", AggregateFunction("countIf", [UUID(), UInt(8)]),),
+        ("sessions_crashed_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)])),
         ("sessions_abnormal", AggregateFunction("countIf", [UUID(), UInt(8)]),),
+        ("sessions_abnormal_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)])),
         ("sessions_errored", AggregateFunction("uniqIf", [UUID(), UInt(8)])),
+        ("sessions_errored_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)])),
+        ("users", AggregateFunction("uniqIf", [UUID(), UInt(8)])),
         ("users_crashed", AggregateFunction("uniqIf", [UUID(), UInt(8)])),
         ("users_abnormal", AggregateFunction("uniqIf", [UUID(), UInt(8)])),
         ("users_errored", AggregateFunction("uniqIf", [UUID(), UInt(8)])),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -147,7 +147,7 @@ class SessionsLoader(DirectoryLoader):
         super().__init__("snuba.migrations.snuba_migrations.sessions")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_sessions"]
+        return ["0001_sessions", "0002_sessions_aggregates"]
 
 
 class QuerylogLoader(DirectoryLoader):

--- a/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
+++ b/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
@@ -1,0 +1,128 @@
+from typing import Sequence, Tuple
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+DEFAULT_QUANTITY = 1
+
+new_raw_columns: Sequence[Tuple[Column[Modifiers], str]] = [
+    (
+        Column("quantity", UInt(32, Modifiers(default=str(DEFAULT_QUANTITY)))),
+        "distinct_id",
+    ),
+    (Column("user_agent", String(Modifiers(low_cardinality=True))), "environment"),
+    (Column("os", String(Modifiers(low_cardinality=True))), "user_agent"),
+]
+
+new_dest_columns: Sequence[Tuple[Column[Modifiers], str]] = [
+    (Column("user_agent", String(Modifiers(low_cardinality=True))), "environment"),
+    (Column("os", String(Modifiers(low_cardinality=True))), "user_agent"),
+    (
+        Column("duration_avg", AggregateFunction("avgIf", [UInt(32), UInt(8)])),
+        "duration_quantiles",
+    ),
+    (
+        Column("sessions_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)])),
+        "sessions",
+    ),
+    (
+        Column(
+            "sessions_crashed_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)]),
+        ),
+        "sessions_crashed",
+    ),
+    (
+        Column(
+            "sessions_abnormal_preaggr",
+            AggregateFunction("sumIf", [UInt(32), UInt(8)]),
+        ),
+        "sessions_abnormal",
+    ),
+    (
+        Column(
+            "sessions_errored_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)]),
+        ),
+        "sessions_errored",
+    ),
+]
+
+
+class Migration(migration.MultiStepMigration):
+    """
+    This migration adds new columns to both the raw and aggregated sessions.
+    The new `X_preaggr` columns in the aggregated dataset will be used later on
+    when the consumer provides a `quantity`.
+    """
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.Operation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_raw_local",
+                column=column,
+                after=after,
+            )
+            for [column, after] in new_raw_columns
+        ] + [
+            operations.AddColumn(
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_hourly_local",
+                column=column,
+                after=after,
+            )
+            for [column, after] in new_dest_columns
+        ]
+
+    def backwards_local(self) -> Sequence[operations.Operation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.SESSIONS, "sessions_raw_local", column.name
+            )
+            for [column, after] in new_raw_columns
+        ] + [
+            operations.DropColumn(
+                StorageSetKey.SESSIONS, "sessions_hourly_local", column.name
+            )
+            for [column, after] in new_dest_columns
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.Operation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_raw_dist",
+                column=column,
+                after=after,
+            )
+            for [column, after] in new_raw_columns
+        ] + [
+            operations.AddColumn(
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_hourly_dist",
+                column=column,
+                after=after,
+            )
+            for [column, after] in new_dest_columns
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.Operation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.SESSIONS, "sessions_raw_dist", column.name
+            )
+            for [column, after] in new_raw_columns
+        ] + [
+            operations.DropColumn(
+                StorageSetKey.SESSIONS, "sessions_hourly_dist", column.name
+            )
+            for [column, after] in new_dest_columns
+        ]


### PR DESCRIPTION
This adds a new `quantity` column to the raw set, and `X_preaggr` columns to the
materialized view table.

Also adds the `user_agent` and `os` columns to both which will be normalized and
provided at a later point by relay.