### PR TITLE
feat: Add errors_ro storage

### DIFF
--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -9,6 +9,7 @@ class StorageKey(Enum):
     EVENTS = "events"
     EVENTS_RO = "events_ro"
     ERRORS = "errors"
+    ERRORS_RO = "errors_ro"
     GROUPEDMESSAGES = "groupedmessages"
     GROUPASSIGNEES = "groupassignees"
     OUTCOMES_RAW = "outcomes_raw"

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -1,160 +1,33 @@
-from snuba.clickhouse.columns import (
-    UUID,
-    Array,
-    ColumnSet,
-    DateTime,
-    IPv4,
-    IPv6,
-    Nested,
-    String,
-    UInt,
-)
-from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.errors_processor import ErrorsProcessor
 from snuba.datasets.errors_replacer import ErrorsReplacer, ReplacerState
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.processors.replaced_groups import (
-    PostReplacementConsistencyEnforcer,
+from snuba.datasets.storages.errors_common import (
+    all_columns,
+    mandatory_conditions,
+    prewhere_candidates,
+    promoted_tag_columns,
+    query_processors,
+    required_columns,
 )
 from snuba.datasets.table_storage import KafkaStreamLoader
-from snuba.query.conditions import ConditionFunctions, binary_condition
-from snuba.query.expressions import Column, Literal
-from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
-    ArrayJoinKeyValueOptimizer,
-)
-from snuba.query.processors.mapping_promoter import MappingColumnPromoter
-from snuba.query.processors.prewhere import PrewhereProcessor
-
-all_columns = ColumnSet(
-    [
-        ("project_id", UInt(64)),
-        ("timestamp", DateTime()),
-        ("event_id", UUID()),
-        ("platform", String()),
-        ("environment", String(Modifiers(nullable=True))),
-        ("release", String(Modifiers(nullable=True))),
-        ("dist", String(Modifiers(nullable=True))),
-        ("ip_address_v4", IPv4(Modifiers(nullable=True))),
-        ("ip_address_v6", IPv6(Modifiers(nullable=True))),
-        ("user", String()),
-        ("user_hash", UInt(64, Modifiers(readonly=True))),
-        ("user_id", String(Modifiers(nullable=True))),
-        ("user_name", String(Modifiers(nullable=True))),
-        ("user_email", String(Modifiers(nullable=True))),
-        ("sdk_name", String(Modifiers(nullable=True))),
-        ("sdk_version", String(Modifiers(nullable=True))),
-        ("http_method", String(Modifiers(nullable=True))),
-        ("http_referer", String(Modifiers(nullable=True))),
-        ("tags", Nested([("key", String()), ("value", String())])),
-        ("_tags_hash_map", Array(UInt(64), Modifiers(readonly=True))),
-        ("contexts", Nested([("key", String()), ("value", String())])),
-        ("transaction_name", String()),
-        ("transaction_hash", UInt(64, Modifiers(readonly=True))),
-        ("span_id", UInt(64, Modifiers(nullable=True))),
-        ("trace_id", UUID(Modifiers(nullable=True))),
-        ("partition", UInt(16)),
-        ("offset", UInt(64)),
-        ("message_timestamp", DateTime()),
-        ("retention_days", UInt(16)),
-        ("deleted", UInt(8)),
-        ("group_id", UInt(64)),
-        ("primary_hash", UUID()),
-        ("received", DateTime()),
-        ("message", String()),
-        ("title", String()),
-        ("culprit", String()),
-        ("level", String()),
-        ("location", String(Modifiers(nullable=True))),
-        ("version", String(Modifiers(nullable=True))),
-        ("type", String()),
-        (
-            "exception_stacks",
-            Nested(
-                [
-                    ("type", String(Modifiers(nullable=True))),
-                    ("value", String(Modifiers(nullable=True))),
-                    ("mechanism_type", String(Modifiers(nullable=True))),
-                    ("mechanism_handled", UInt(8, Modifiers(nullable=True))),
-                ]
-            ),
-        ),
-        (
-            "exception_frames",
-            Nested(
-                [
-                    ("abs_path", String(Modifiers(nullable=True))),
-                    ("colno", UInt(32, Modifiers(nullable=True))),
-                    ("filename", String(Modifiers(nullable=True))),
-                    ("function", String(Modifiers(nullable=True))),
-                    ("lineno", UInt(32, Modifiers(nullable=True))),
-                    ("in_app", UInt(8, Modifiers(nullable=True))),
-                    ("package", String(Modifiers(nullable=True))),
-                    ("module", String(Modifiers(nullable=True))),
-                    ("stack_level", UInt(16, Modifiers(nullable=True))),
-                ]
-            ),
-        ),
-        ("sdk_integrations", Array(String())),
-        ("modules", Nested([("name", String()), ("version", String())])),
-    ]
-)
-
-promoted_tag_columns = {
-    "environment": "environment",
-    "sentry:release": "release",
-    "sentry:dist": "dist",
-    "sentry:user": "user",
-    "transaction": "transaction_name",
-    "level": "level",
-}
 
 schema = WritableTableSchema(
     columns=all_columns,
     local_table_name="errors_local",
     dist_table_name="errors_dist",
     storage_set_key=StorageSetKey.EVENTS,
-    mandatory_conditions=[
-        binary_condition(
-            None,
-            ConditionFunctions.EQ,
-            Column(None, None, "deleted"),
-            Literal(None, 0),
-        ),
-    ],
-    prewhere_candidates=[
-        "event_id",
-        "group_id",
-        "tags[sentry:release]",
-        "message",
-        "environment",
-        "project_id",
-    ],
+    mandatory_conditions=mandatory_conditions,
+    prewhere_candidates=prewhere_candidates,
 )
-
-required_columns = [
-    "event_id",
-    "project_id",
-    "group_id",
-    "timestamp",
-    "deleted",
-    "retention_days",
-]
 
 storage = WritableTableStorage(
     storage_key=StorageKey.ERRORS,
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
-    query_processors=[
-        PostReplacementConsistencyEnforcer(
-            project_column="project_id", replacer_state_name=ReplacerState.ERRORS,
-        ),
-        MappingColumnPromoter(mapping_specs={"tags": promoted_tag_columns}),
-        ArrayJoinKeyValueOptimizer("tags"),
-        PrewhereProcessor(),
-    ],
+    query_processors=query_processors,
     stream_loader=KafkaStreamLoader(
         processor=ErrorsProcessor(promoted_tag_columns),
         default_topic="events",

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -1,0 +1,140 @@
+from snuba.clickhouse.columns import (
+    UUID,
+    Array,
+    ColumnSet,
+    DateTime,
+    IPv4,
+    IPv6,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clickhouse.columns import SchemaModifiers as Modifiers
+from snuba.datasets.errors_replacer import ReplacerState
+from snuba.datasets.storages.processors.replaced_groups import (
+    PostReplacementConsistencyEnforcer,
+)
+
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.expressions import Column, Literal
+from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
+    ArrayJoinKeyValueOptimizer,
+)
+from snuba.query.processors.mapping_promoter import MappingColumnPromoter
+from snuba.query.processors.prewhere import PrewhereProcessor
+
+required_columns = [
+    "event_id",
+    "project_id",
+    "group_id",
+    "timestamp",
+    "deleted",
+    "retention_days",
+]
+
+all_columns = ColumnSet(
+    [
+        ("project_id", UInt(64)),
+        ("timestamp", DateTime()),
+        ("event_id", UUID()),
+        ("platform", String()),
+        ("environment", String(Modifiers(nullable=True))),
+        ("release", String(Modifiers(nullable=True))),
+        ("dist", String(Modifiers(nullable=True))),
+        ("ip_address_v4", IPv4(Modifiers(nullable=True))),
+        ("ip_address_v6", IPv6(Modifiers(nullable=True))),
+        ("user", String()),
+        ("user_hash", UInt(64, Modifiers(readonly=True))),
+        ("user_id", String(Modifiers(nullable=True))),
+        ("user_name", String(Modifiers(nullable=True))),
+        ("user_email", String(Modifiers(nullable=True))),
+        ("sdk_name", String(Modifiers(nullable=True))),
+        ("sdk_version", String(Modifiers(nullable=True))),
+        ("http_method", String(Modifiers(nullable=True))),
+        ("http_referer", String(Modifiers(nullable=True))),
+        ("tags", Nested([("key", String()), ("value", String())])),
+        ("_tags_hash_map", Array(UInt(64), Modifiers(readonly=True))),
+        ("contexts", Nested([("key", String()), ("value", String())])),
+        ("transaction_name", String()),
+        ("transaction_hash", UInt(64, Modifiers(readonly=True))),
+        ("span_id", UInt(64, Modifiers(nullable=True))),
+        ("trace_id", UUID(Modifiers(nullable=True))),
+        ("partition", UInt(16)),
+        ("offset", UInt(64)),
+        ("message_timestamp", DateTime()),
+        ("retention_days", UInt(16)),
+        ("deleted", UInt(8)),
+        ("group_id", UInt(64)),
+        ("primary_hash", UUID()),
+        ("received", DateTime()),
+        ("message", String()),
+        ("title", String()),
+        ("culprit", String()),
+        ("level", String()),
+        ("location", String(Modifiers(nullable=True))),
+        ("version", String(Modifiers(nullable=True))),
+        ("type", String()),
+        (
+            "exception_stacks",
+            Nested(
+                [
+                    ("type", String(Modifiers(nullable=True))),
+                    ("value", String(Modifiers(nullable=True))),
+                    ("mechanism_type", String(Modifiers(nullable=True))),
+                    ("mechanism_handled", UInt(8, Modifiers(nullable=True))),
+                ]
+            ),
+        ),
+        (
+            "exception_frames",
+            Nested(
+                [
+                    ("abs_path", String(Modifiers(nullable=True))),
+                    ("colno", UInt(32, Modifiers(nullable=True))),
+                    ("filename", String(Modifiers(nullable=True))),
+                    ("function", String(Modifiers(nullable=True))),
+                    ("lineno", UInt(32, Modifiers(nullable=True))),
+                    ("in_app", UInt(8, Modifiers(nullable=True))),
+                    ("package", String(Modifiers(nullable=True))),
+                    ("module", String(Modifiers(nullable=True))),
+                    ("stack_level", UInt(16, Modifiers(nullable=True))),
+                ]
+            ),
+        ),
+        ("sdk_integrations", Array(String())),
+        ("modules", Nested([("name", String()), ("version", String())])),
+    ]
+)
+
+promoted_tag_columns = {
+    "environment": "environment",
+    "sentry:release": "release",
+    "sentry:dist": "dist",
+    "sentry:user": "user",
+    "transaction": "transaction_name",
+    "level": "level",
+}
+
+mandatory_conditions = [
+    binary_condition(
+        None, ConditionFunctions.EQ, Column(None, None, "deleted"), Literal(None, 0),
+    ),
+]
+
+prewhere_candidates = [
+    "event_id",
+    "group_id",
+    "tags[sentry:release]",
+    "message",
+    "environment",
+    "project_id",
+]
+
+query_processors = [
+    PostReplacementConsistencyEnforcer(
+        project_column="project_id", replacer_state_name=ReplacerState.ERRORS,
+    ),
+    MappingColumnPromoter(mapping_specs={"tags": promoted_tag_columns}),
+    ArrayJoinKeyValueOptimizer("tags"),
+    PrewhereProcessor(),
+]

--- a/snuba/datasets/storages/errors_ro.py
+++ b/snuba/datasets/storages/errors_ro.py
@@ -1,0 +1,28 @@
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storage import ReadableTableStorage
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storages import StorageKey
+
+from snuba.datasets.storages.errors_common import (
+    all_columns,
+    mandatory_conditions,
+    prewhere_candidates,
+    query_processors,
+)
+
+
+schema = TableSchema(
+    columns=all_columns,
+    local_table_name="errors_local",
+    dist_table_name="errors_dist_ro",
+    storage_set_key=StorageSetKey.EVENTS_RO,
+    mandatory_conditions=mandatory_conditions,
+    prewhere_candidates=prewhere_candidates,
+)
+
+storage = ReadableTableStorage(
+    storage_key=StorageKey.ERRORS_RO,
+    storage_set_key=StorageSetKey.EVENTS_RO,
+    schema=schema,
+    query_processors=query_processors,
+)

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -4,6 +4,7 @@ from snuba.datasets.cdc import CdcStorage
 from snuba.datasets.storage import ReadableTableStorage, WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors import storage as errors_storage
+from snuba.datasets.storages.errors_ro import storage as errors_ro_storage
 from snuba.datasets.storages.events import storage as events_storage
 from snuba.datasets.storages.events_ro import storage as events_ro_storage
 from snuba.datasets.storages.groupassignees import storage as groupassignees_storage
@@ -43,7 +44,12 @@ WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
 
 NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
     storage.get_storage_key(): storage
-    for storage in [events_ro_storage, outcomes_hourly_storage, sessions_hourly_storage]
+    for storage in [
+        errors_ro_storage,
+        events_ro_storage,
+        outcomes_hourly_storage,
+        sessions_hourly_storage,
+    ]
 }
 
 STORAGES: Mapping[StorageKey, ReadableTableStorage] = {


### PR DESCRIPTION
The errors readonly storage is the errors equivalent of the events
readonly storage, and will be used in the same scenarios where events_ro
is now - i.e. when `enable_events_readonly_table` is set and the request
is not required to be "consistent", allowing us to use other replicas than
the first one.

The errors_dist_ro table is already being created through the migration
system.