### PR TITLE
fix(col splitter): Set a minimal threshold of columns to be referenced in the query to apply column splitter

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -117,6 +117,7 @@ AST_REFERRER_ROLLOUT: Mapping[
     str, Mapping[Optional[str], int]
 ] = {}  # (dataset name: (referrer: percentage))
 
+COLUMN_SPLIT_MIN_COLS = 6
 COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -240,6 +240,9 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             for col in query.get_all_ast_referenced_columns()
         }
 
+        if len(total_columns) < settings.COLUMN_SPLIT_MIN_COLS:
+            return None
+
         minimal_query = copy.deepcopy(query)
 
         # TODO: provide the table alias name to this splitter if we ever use it
@@ -288,6 +291,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
         del minimal_query
 
         if not result.result["data"]:
+            metrics.increment("column_splitter.no_data_from_minimal_query")
             return None
 
         # Making a copy just in case runner returned None (which would drive the execution

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -241,6 +241,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
         }
 
         if len(total_columns) < settings.COLUMN_SPLIT_MIN_COLS:
+            metrics.increment("column_splitter.main_query_min_threshold")
             return None
 
         minimal_query = copy.deepcopy(query)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -227,13 +227,29 @@ column_split_tests = [
             "limit": 10,
         },
         False,
+    ),  # Valid query but same number of columns between minimal
+    # and original query.
+    (
+        "event_id",
+        "project_id",
+        "timestamp",
+        {
+            "selected_columns": ["event_id"],
+            "conditions": [
+                ("timestamp", ">=", "2019-09-19T10:00:00"),
+                ("timestamp", "<", "2019-09-19T12:00:00"),
+                ("project_id", "IN", [1, 2, 3]),
+            ],
+            "limit": 10,
+        },
+        False,
     ),  # Valid query but not enough columns to split.
     (
         "event_id",
         "project_id",
         "timestamp",
         {
-            "selected_columns": ["group_id"],
+            "selected_columns": ["group_id", "message", "tags.key", "level"],
             "conditions": [
                 ("timestamp", ">=", "2019-09-19T10:00:00"),
                 ("timestamp", "<", "2019-09-19T12:00:00"),
@@ -249,7 +265,7 @@ column_split_tests = [
         "project_id",
         "timestamp",
         {
-            "selected_columns": ["group_id"],
+            "selected_columns": ["group_id", "message", "tags.key", "level"],
             "conditions": [
                 ("timestamp", ">=", "2019-09-19T10:00:00"),
                 ("timestamp", "<", "2019-09-19T12:00:00"),
@@ -265,7 +281,7 @@ column_split_tests = [
         "project_id",
         "timestamp",
         {
-            "selected_columns": ["group_id"],
+            "selected_columns": ["group_id", "message", "tags.key", "level"],
             "conditions": [
                 ("timestamp", ">=", "2019-09-19T10:00:00"),
                 ("timestamp", "<", "2019-09-19T12:00:00"),


### PR DESCRIPTION
We are applying the column splitter on queries that reference only one column on top of the minimal query.
This is not gaining us much.
So setting up a minimal number of columns to be referenced in the query to apply the splitter.