### PR TITLE
feat(migrations): DropIndex uses IF EXISTS operator

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -231,7 +231,9 @@ class DropIndex(SqlOperation):
         self.__index_name = index_name
 
     def format_sql(self) -> str:
-        return f"ALTER TABLE {self.__table_name} DROP INDEX {self.__index_name};"
+        return (
+            f"ALTER TABLE {self.__table_name} DROP INDEX IF EXISTS {self.__index_name};"
+        )
 
 
 class InsertIntoSelect(SqlOperation):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -113,7 +113,7 @@ def test_add_index() -> None:
 def test_drop_index() -> None:
     assert (
         DropIndex(StorageSetKey.EVENTS, "test_table", "index_1").format_sql()
-        == "ALTER TABLE test_table DROP INDEX index_1;"
+        == "ALTER TABLE test_table DROP INDEX IF EXISTS index_1;"
     )
 
 


### PR DESCRIPTION
We should use `DROP INDEX IF EXISTS` instead of bare `DROP INDEX` so
that we can reverse migrations even if an index wasn't successfully
added. This came up recently in the migration 0008_transactions_add_timestamp_index.
If the original AddIndex command failed the migration will be marked "IN
PROGRESS" but not have the index present. The user would be stuck and
unable to run either the forwards or backwards migrations.