### PR TITLE
Fix transactions subscriptions in local dev.

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -106,7 +106,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--result-topic=transaction-subscription-results",
                 "--dataset=transactions",
                 "--commit-log-topic=snuba-commit-log",
-                "--commit-log-group=snuba-transactions-consumers",
+                "--commit-log-group=transactions_group",
                 "--delay-seconds=1",
                 "--schedule-ttl=10",
                 "--max-query-workers=1",

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -104,7 +104,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--max-batch-size=1",
                 "--consumer-group=snuba-transactions-subscriptions-consumers",
                 "--topic=events",
-                "--result-topic=transaction-subscription-results",
+                "--result-topic=transactions-subscription-results",
                 "--dataset=transactions",
                 "--commit-log-topic=snuba-commit-log",
                 "--commit-log-group=transactions_group",

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -41,6 +41,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--log-level=debug",
                 "--storage=transactions",
                 "--consumer-group=transactions_group",
+                "--commit-log-topic=snuba-commit-log",
             ],
         ),
         (


### PR DESCRIPTION
Fixing a few settings so that all the pins align correctly. We also have to explicitly specify `--commit-log-topic` on the transaction consumer because it's not defined on storage.