### PR TITLE
fix(query) Abstract query equality for tests

### DIFF
--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -68,9 +68,5 @@ class Query(AbstractQuery[Table]):
     def set_prewhere_ast_condition(self, condition: Optional[Expression]) -> None:
         self.__prewhere = condition
 
-    def __eq__(self, other: object) -> bool:
-        if not super().__eq__(other):
-            return False
-
-        assert isinstance(other, Query)  # mypy
-        return self.get_prewhere_ast() == other.get_prewhere_ast()
+    def _eq_functions(self) -> Sequence[str]:
+        return tuple(super()._eq_functions()) + ("get_prewhere_ast",)

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -387,26 +387,37 @@ class Query(DataSource, ABC):
         declared_symbols |= {c.flattened for c in self.get_from_clause().get_columns()}
         return not referenced_symbols - declared_symbols
 
-    def __eq__(self, other: object) -> bool:
-        if self.__class__ != other.__class__:
-            return False
+    def _eq_functions(self) -> Sequence[str]:
+        return (
+            "get_selected_columns_from_ast",
+            "get_groupby_from_ast",
+            "get_condition_from_ast",
+            "get_arrayjoin_from_ast",
+            "get_having_from_ast",
+            "get_orderby_from_ast",
+            "get_limitby",
+            "get_limit",
+            "get_offset",
+            "has_totals",
+            "get_granularity",
+        )
 
-        assert isinstance(other, Query)  # mypy
-        tests = [
-            self.get_selected_columns_from_ast()
-            == other.get_selected_columns_from_ast(),
-            self.get_groupby_from_ast() == other.get_groupby_from_ast(),
-            self.get_condition_from_ast() == other.get_condition_from_ast(),
-            self.get_arrayjoin_from_ast() == other.get_arrayjoin_from_ast(),
-            self.get_having_from_ast() == other.get_having_from_ast(),
-            self.get_orderby_from_ast() == other.get_orderby_from_ast(),
-            self.get_limitby() == other.get_limitby(),
-            self.get_limit() == other.get_limit(),
-            self.get_offset() == other.get_offset(),
-            self.has_totals() == other.has_totals(),
-            self.get_granularity() == other.get_granularity(),
-        ]
-        return all(tests)
+    def equals(self, other: object) -> Tuple[bool, str]:
+        if self.__class__ != other.__class__:
+            return False, f"{self.__class__} != {other.__class__}"
+
+        tests = self._eq_functions()
+        for func in tests:
+            if getattr(self, func)() != getattr(other, func)():
+                return (
+                    False,
+                    f"{func}: {getattr(self, func)()} != {getattr(other, func)()}",
+                )
+        return True, ""
+
+    def __eq__(self, other: object) -> bool:
+        eq, _ = self.equals(other)
+        return eq
 
 
 TSimpleDataSource = TypeVar("TSimpleDataSource", bound=SimpleDataSource)
@@ -458,9 +469,5 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
     def set_from_clause(self, from_clause: TSimpleDataSource) -> None:
         self.__from_clause = from_clause
 
-    def __eq__(self, other: object) -> bool:
-        if not super().__eq__(other):
-            return False
-
-        assert isinstance(other, ProcessableQuery)
-        return bool(self.get_from_clause() == other.get_from_clause())
+    def _eq_functions(self) -> Sequence[str]:
+        return tuple(super()._eq_functions()) + ("get_from_clause",)

--- a/snuba/query/composite.py
+++ b/snuba/query/composite.py
@@ -91,9 +91,5 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
     def _transform_impl(self, visitor: ExpressionVisitor[Expression]) -> None:
         pass
 
-    def __eq__(self, other: object) -> bool:
-        if not super().__eq__(other):
-            return False
-
-        assert isinstance(other, CompositeQuery)
-        return self.get_from_clause() == other.get_from_clause()
+    def _eq_functions(self) -> Sequence[str]:
+        return tuple(super()._eq_functions()) + ("get_from_clause",)

--- a/snuba/query/logical.py
+++ b/snuba/query/logical.py
@@ -88,15 +88,8 @@ class Query(AbstractQuery[Entity]):
     def set_sample(self, final: bool) -> None:
         self.__final = final
 
-    def __eq__(self, other: object) -> bool:
-        if not super().__eq__(other):
-            return False
-
-        assert isinstance(other, Query)  # mypy
-        return (
-            self.get_final() == other.get_final()
-            and self.get_sample() == other.get_sample()
-        )
+    def _eq_functions(self) -> Sequence[str]:
+        return tuple(super()._eq_functions()) + ("get_final", "get_sample")
 
     @deprecated(
         details="Do not access the internal query representation "

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -867,7 +867,8 @@ def test_format_expressions(
     events = get_dataset("events")
     query = parse_query(query_body, events)
 
-    assert query == expected_query
+    eq, reason = query.equals(expected_query)
+    assert eq, reason
 
 
 def test_shadowing() -> None:

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -298,20 +298,5 @@ def test_format_expressions(query_body: str, expected_query: Query) -> None:
     events = get_dataset("events")
     query = parse_snql_query(query_body, events)
 
-    # assert query == expected_query
-
-    assert (
-        query.get_selected_columns_from_ast()
-        == expected_query.get_selected_columns_from_ast()
-    )
-    assert query.get_groupby_from_ast() == expected_query.get_groupby_from_ast()
-    assert query.get_condition_from_ast() == expected_query.get_condition_from_ast()
-    assert query.get_arrayjoin_from_ast() == expected_query.get_arrayjoin_from_ast()
-    assert query.get_having_from_ast() == expected_query.get_having_from_ast()
-    assert query.get_orderby_from_ast() == expected_query.get_orderby_from_ast()
-    assert query.get_limitby() == expected_query.get_limitby()
-    assert query.get_sample() == expected_query.get_sample()
-    assert query.get_limit() == expected_query.get_limit()
-    assert query.get_offset() == expected_query.get_offset()
-    assert query.has_totals() == expected_query.has_totals()
-    assert query.get_granularity() == expected_query.get_granularity()
+    eq, reason = query.equals(expected_query)
+    assert eq, reason


### PR DESCRIPTION
While in general having query equality is useful, the __eq__ function provides
no insight into what part of the queries is not equal. Add a new equals function
that returns a useful error message and have the __eq__ function use that.