### PR TITLE
feat: Parse and transform limit by clause

### DIFF
--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -172,11 +172,15 @@ def _format_limitby(
     query: AbstractQuery, formatter: ClickhouseExpressionFormatter
 ) -> Optional[StringNode]:
     ast_limitby = query.get_limitby()
-    return (
-        StringNode("LIMIT {} BY {}".format(*ast_limitby))
-        if ast_limitby is not None
-        else None
-    )
+
+    if ast_limitby is not None:
+        return StringNode(
+            "LIMIT {} BY {}".format(
+                ast_limitby.limit, ast_limitby.expression.accept(formatter)
+            )
+        )
+
+    return None
 
 
 def _format_limit(

--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,6 +1,6 @@
 from typing import Callable, Iterable, Optional, Sequence
 
-from snuba.query import Limitby, OrderBy
+from snuba.query import LimitBy, OrderBy
 from snuba.query import ProcessableQuery as AbstractQuery
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
@@ -24,7 +24,7 @@ class Query(AbstractQuery[Table]):
         groupby: Optional[Sequence[Expression]] = None,
         having: Optional[Expression] = None,
         order_by: Optional[Sequence[OrderBy]] = None,
-        limitby: Optional[Limitby] = None,
+        limitby: Optional[LimitBy] = None,
         limit: Optional[int] = None,
         offset: int = 0,
         totals: bool = False,

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Sequence,
     Set,
+    Tuple,
     Type,
     TypeVar,
 )

--- a/snuba/query/composite.py
+++ b/snuba/query/composite.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Callable, Generic, Iterable, Optional, Sequence, Union
 
 from snuba.query import (
-    Limitby,
+    LimitBy,
     OrderBy,
     ProcessableQuery,
     Query,
@@ -41,7 +41,7 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
         groupby: Optional[Sequence[Expression]] = None,
         having: Optional[Expression] = None,
         order_by: Optional[Sequence[OrderBy]] = None,
-        limitby: Optional[Limitby] = None,
+        limitby: Optional[LimitBy] = None,
         limit: Optional[int] = None,
         offset: int = 0,
         totals: bool = False,

--- a/snuba/query/logical.py
+++ b/snuba/query/logical.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from deprecation import deprecated
-from snuba.query import Limitby, OrderBy
+from snuba.query import LimitBy, OrderBy
 from snuba.query import ProcessableQuery as AbstractQuery
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
@@ -45,7 +45,7 @@ class Query(AbstractQuery[Entity]):
         groupby: Optional[Sequence[Expression]] = None,
         having: Optional[Expression] = None,
         order_by: Optional[Sequence[OrderBy]] = None,
-        limitby: Optional[Limitby] = None,
+        limitby: Optional[LimitBy] = None,
         sample: Optional[float] = None,
         limit: Optional[int] = None,
         offset: int = 0,

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -8,7 +8,7 @@ from snuba.clickhouse.escaping import NEGATE_RE
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.entity import Entity
-from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import (
     Argument,
@@ -234,6 +234,15 @@ def _parse_query_impl(body: MutableMapping[str, Any], entity: Entity) -> Query:
             )
         )
 
+    limitby_clause: Optional[LimitBy] = None
+
+    if body.get("limitby"):
+        limitby_limit, limitby_expr = body["limitby"]
+        limitby_clause = LimitBy(
+            limitby_limit,
+            parse_expression(limitby_expr, entity.get_data_model(), set()),
+        )
+
     return Query(
         body,
         None,
@@ -243,7 +252,7 @@ def _parse_query_impl(body: MutableMapping[str, Any], entity: Entity) -> Query:
         groupby=[g.expression for g in groupby_clause],
         having=having_expr,
         order_by=orderby_exprs,
-        limitby=body.get("limitby"),
+        limitby=limitby_clause,
         sample=body.get("sample"),
         limit=body.get("limit", None),
         offset=body.get("offset", 0),

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -1,7 +1,7 @@
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query as ClickhouseQuery
-from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Literal
@@ -29,7 +29,7 @@ def test_format_clickhouse_specific_query() -> None:
         order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         array_join=Column(None, None, "column1"),
         totals=True,
-        limitby=(10, "environment"),
+        limitby=LimitBy(10, Column(None, None, "environment")),
     )
 
     query.set_offset(50)

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -5,7 +5,7 @@ from snuba.clickhouse.columns import UUID, ColumnSet, String, UInt
 from snuba.clickhouse.formatter.nodes import PaddingNode, SequenceNode, StringNode
 from snuba.clickhouse.formatter.query import JoinFormatter, format_query
 from snuba.clickhouse.query import Query
-from snuba.query import OrderBy, OrderByDirection, SelectedExpression
+from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import (
     BooleanFunctions,
@@ -527,7 +527,7 @@ def test_format_clickhouse_specific_query() -> None:
         order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         array_join=Column(None, None, "column1"),
         totals=True,
-        limitby=(10, "environment"),
+        limitby=LimitBy(10, Column(None, None, "environment")),
     )
 
     query.set_offset(50)


### PR DESCRIPTION
Rather than executing the limitby clause directly as it is provided by
the user on ClickHouse, we now parse limitby as an expression and apply
the same transformations that we do to the rest of the query in
`Query.transform_expressions()`

The immediate motivation for this is so that aliases that are mangled before
being run on ClickHouse then replaced later will be properly transformed
if they are being referenced in the limitby clause.