### PR TITLE
fix(release): Add missing GITHUB_API_TOKEN variable to craft/publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,5 +61,6 @@ jobs:
             version: ${{ env.RELEASE_VERSION }}
           env:
             DRY_RUN: ${{ github.event.inputs.dry_run }}
+            GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
             DOCKER_USERNAME: 'sentrybuilder'
             DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This fixes the recurring failure when merging the release branch to master when releasing Snuba. The failure happens because we have branch protection enabled and the default `github.token` is not an admin on the repo to by-pass these checks. This token was already added on Sentry and Relay repositories so this was not an issue there.
