### PR TITLE
fix(discover) Attempt to fix max(timestamp) + timestamp issue

### DIFF
--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -148,7 +148,7 @@ def _format_groupby(
     ast_groupby = query.get_groupby_from_ast()
     if ast_groupby:
         groupby_expressions = [e.accept(formatter) for e in ast_groupby]
-        group_clause_str = f"({', '.join(groupby_expressions)})"
+        group_clause_str = f"{', '.join(groupby_expressions)}"
         if query.has_totals():
             group_clause_str = f"{group_clause_str} WITH TOTALS"
         group_clause = StringNode(f"GROUP BY {group_clause_str}")

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -43,7 +43,7 @@ def test_format_clickhouse_specific_query() -> None:
         ["FROM", "my_table FINAL SAMPLE 0.1"],
         "ARRAY JOIN column1",
         "WHERE eq(column1, 'blabla')",
-        "GROUP BY (column1, table1.column2) WITH TOTALS",
+        "GROUP BY column1, table1.column2 WITH TOTALS",
         "HAVING eq(column1, 123)",
         "ORDER BY column1 ASC",
         "LIMIT 10 BY environment",

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -83,7 +83,7 @@ test_cases = [
             "SELECT column1, table1.column2, (column3 AS al)",
             ["FROM", "my_table"],
             "WHERE eq(al, 'blabla')",
-            "GROUP BY (column1, table1.column2, al, column4)",
+            "GROUP BY column1, table1.column2, al, column4",
             "HAVING eq(column1, 123)",
             "ORDER BY column1 ASC, table1.column2 DESC",
         ],
@@ -91,7 +91,7 @@ test_cases = [
             "SELECT column1, table1.column2, (column3 AS al) "
             "FROM my_table "
             "WHERE eq(al, 'blabla') "
-            "GROUP BY (column1, table1.column2, al, column4) "
+            "GROUP BY column1, table1.column2, al, column4 "
             "HAVING eq(column1, 123) "
             "ORDER BY column1 ASC, table1.column2 DESC"
         ),
@@ -160,14 +160,14 @@ test_cases = [
             "SELECT (doSomething(column1, table1.column2, (column3 AS al))(column1) AS my_complex_math)",
             ["FROM", "my_table"],
             "WHERE eq(al, 'blabla') AND neq(al, 'blabla')",
-            "GROUP BY (my_complex_math)",
+            "GROUP BY my_complex_math",
             "ORDER BY f(column1) ASC",
         ],
         (
             "SELECT (doSomething(column1, table1.column2, (column3 AS al))(column1) AS my_complex_math) "
             "FROM my_table "
             "WHERE eq(al, 'blabla') AND neq(al, 'blabla') "
-            "GROUP BY (my_complex_math) "
+            "GROUP BY my_complex_math "
             "ORDER BY f(column1) ASC"
         ),
         id="Query with complex functions",
@@ -188,13 +188,13 @@ test_cases = [
         [
             "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2)",
             ["FROM", "my_table"],
-            "GROUP BY (al1, al2)",
+            "GROUP BY al1, al2",
             "ORDER BY column1 ASC",
         ],
         (
             "SELECT (`field_##$$%` AS al1), (`t&^%$`.`f@!@` AS al2) "
             "FROM my_table "
-            "GROUP BY (al1, al2) "
+            "GROUP BY al1, al2 "
             "ORDER BY column1 ASC"
         ),
         id="Query with escaping",
@@ -300,10 +300,10 @@ test_cases = [
                     "SELECT column1, (avg(column2) AS sub_average), column3",
                     ["FROM", "my_table"],
                     "WHERE eq((column3 AS al), 'blabla')",
-                    "GROUP BY (column2)",
+                    "GROUP BY column2",
                 ],
             ],
-            "GROUP BY (alias)",
+            "GROUP BY alias",
         ],
         (
             "SELECT (avg(sub_average) AS average), (column3 AS alias) "
@@ -311,9 +311,9 @@ test_cases = [
             "SELECT column1, (avg(column2) AS sub_average), column3 "
             "FROM my_table "
             "WHERE eq((column3 AS al), 'blabla') "
-            "GROUP BY (column2)"
+            "GROUP BY column2"
             ") "
-            "GROUP BY (alias)"
+            "GROUP BY alias"
         ),
         id="Composite query",
     ),
@@ -477,7 +477,7 @@ test_cases = [
                     ["err.group_id=assignee.group_id"],
                 ],
             ],
-            "GROUP BY (groups.id)",
+            "GROUP BY groups.id",
         ],
         (
             "SELECT (err.group_id AS group_id), (count() AS events) "
@@ -489,7 +489,7 @@ test_cases = [
             "INNER JOIN "
             "(SELECT group_id FROM groupassignee_local WHERE eq(user, 'me')) assignee "
             "ON err.group_id=assignee.group_id "
-            "GROUP BY (groups.id)"
+            "GROUP BY groups.id"
         ),
         id="Join of multiple subqueries",
     ),
@@ -541,7 +541,7 @@ def test_format_clickhouse_specific_query() -> None:
         "FROM my_table FINAL SAMPLE 0.1 "
         "ARRAY JOIN column1 "
         "WHERE eq(column1, 'blabla') "
-        "GROUP BY (column1, table1.column2) WITH TOTALS "
+        "GROUP BY column1, table1.column2 WITH TOTALS "
         "HAVING eq(column1, 123) "
         "ORDER BY column1 ASC "
         "LIMIT 10 BY environment "

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -959,3 +959,23 @@ class TestDiscoverApi(BaseApiTest):
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 0, data
+
+    def test_max_timestamp_by_timestamp(self) -> None:
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [["max", "timestamp", "last_seen"]],
+                    "having": [],
+                    "selected_columns": ["title", "type", "timestamp"],
+                    "groupby": ["title", "type", "timestamp"],
+                    "limit": 1,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200, response.data
+        assert len(data["data"]) == 1, data
+        assert data["data"][0]["last_seen"] is not None


### PR DESCRIPTION
If a user selects timestamp and last_seen() (max(timestamp)), it causes
an error. This seems to be isolated to prod, but removing these brackets
were suggested as a fix. Going to try this out and see if it works.