### PR TITLE
fix(errors): Fix default values of non nullable columns

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -80,6 +80,10 @@ class ErrorsProcessor(EventsProcessorBase):
 
         output["primary_hash"] = str(uuid.UUID(_hashify(event["primary_hash"])))
 
+        output["culprit"] = _unicodify(data.get("culprit", ""))
+        output["type"] = _unicodify(data.get("type", ""))
+        output["title"] = _unicodify(data.get("title", ""))
+
     def extract_tags_custom(
         self,
         output: MutableMapping[str, Any],

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -10,6 +10,7 @@ from snuba.datasets.events_processor_base import EventsProcessorBase, InsertEven
 from snuba.processor import (
     _boolify,
     _floatify,
+    _hashify,
     _unicodify,
 )
 
@@ -61,6 +62,11 @@ class EventsProcessor(EventsProcessorBase):
         extract_http(http_data, request)
         output["http_method"] = http_data["http_method"]
         output["http_referer"] = http_data["http_referer"]
+
+        output["primary_hash"] = _hashify(event["primary_hash"])
+        output["culprit"] = _unicodify(data.get("culprit", None))
+        output["type"] = _unicodify(data.get("type", None))
+        output["title"] = _unicodify(data.get("title", None))
 
     def extract_tags_custom(
         self,

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -25,7 +25,6 @@ from snuba.processor import (
     _boolify,
     _collapse_uint32,
     _ensure_valid_date,
-    _hashify,
     _unicodify,
 )
 
@@ -225,7 +224,6 @@ class EventsProcessorBase(MessageProcessor, ABC):
     ) -> None:
         # Properties we get from the top level of the message payload
         output["platform"] = _unicodify(event["platform"])
-        output["primary_hash"] = _hashify(event["primary_hash"])
 
         # Properties we get from the "data" dict, which is the actual event body.
         data = event.get("data", {})
@@ -233,11 +231,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         output["received"] = (
             datetime.utcfromtimestamp(received) if received is not None else None
         )
-
-        output["culprit"] = _unicodify(data.get("culprit", None))
-        output["type"] = _unicodify(data.get("type", None))
         output["version"] = _unicodify(data.get("version", None))
-        output["title"] = _unicodify(data.get("title", None))
         output["location"] = _unicodify(data.get("location", None))
 
         module_names = []

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -123,14 +123,10 @@ class TestEventsProcessor:
         )
         assert output == {
             "platform": u"the_platform",
-            "primary_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "received": now,
-            "culprit": "the culprit",
-            "type": "error",
             "version": "6",
             "modules.name": [u"foo", u"bar", u"baz"],
             "modules.version": [u"1.0", u"2.0", u""],
-            "title": "FooError",
             "location": "bar.py",
         }
 


### PR DESCRIPTION
The columns `culprit`, `type` and `title` are nullable in the events
dataset but not in errors. Their default in errors should be empty
string and not None.

Also moves extracting the primary hash out of the base events processor
as this step is only relevant for events now.