### PR TITLE
feat(ast) Add a uuid optimizer for conditions with UUID columns

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -22,6 +22,7 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
 )
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.uuid_column_processor import UUIDColumnProcessor
 from snuba.web.split import TimeSplitQueryStrategy
 
 columns = ColumnSet(
@@ -91,6 +92,7 @@ storage = WritableTableStorage(
         EventIdColumnProcessor(),
         ArrayJoinKeyValueOptimizer("tags"),
         ArrayJoinKeyValueOptimizer("measurements"),
+        UUIDColumnProcessor(set(["event_id", "trace_id"])),
         PrewhereProcessor(),
     ],
     stream_loader=KafkaStreamLoader(

--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -28,6 +28,9 @@ class MatchResult:
 
     results: Mapping[str, MatchType] = field(default_factory=dict)
 
+    def contains(self, name: str) -> bool:
+        return name in self.results and self.results[name] is not None
+
     def expression(self, name: str) -> Expression:
         """
         Return an expression from the results given the name of the

--- a/snuba/query/processors/uuid_column_processor.py
+++ b/snuba/query/processors/uuid_column_processor.py
@@ -55,7 +55,13 @@ class UUIDColumnProcessor(QueryProcessor):
             ),
         )
         self.uuid_condition = FunctionCallMatch(
-            Or([String(op) for op in FUNCTION_TO_OPERATOR]),
+            Or(
+                [
+                    String(op)
+                    for op in FUNCTION_TO_OPERATOR
+                    if op not in (ConditionFunctions.IN, ConditionFunctions.NOT_IN)
+                ]
+            ),
             (
                 Or(
                     (

--- a/snuba/query/processors/uuid_column_processor.py
+++ b/snuba/query/processors/uuid_column_processor.py
@@ -1,0 +1,152 @@
+from typing import List, Set
+import uuid
+
+from snuba.query.conditions import (
+    binary_condition,
+    ConditionFunctions,
+    FUNCTION_TO_OPERATOR,
+)
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.query.matchers import (
+    AnyOptionalString,
+    Or,
+    Param,
+    String,
+)
+from snuba.query.matchers import Column as ColumnMatch
+from snuba.query.matchers import FunctionCall as FunctionCallMatch
+from snuba.query.matchers import Literal as LiteralMatch
+from snuba.query.processors import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+class UUIDColumnProcessor(QueryProcessor):
+    """
+    If a condition is being performed on a column that stores UUIDs (as defined in the constructor)
+    then change the condition to use a proper UUID instead of a string.
+    """
+
+    def formatted_uuid_pattern(self, suffix: str = "") -> FunctionCallMatch:
+        return FunctionCallMatch(
+            String("replaceAll"),
+            (
+                FunctionCallMatch(
+                    String("toString"),
+                    (
+                        Param(
+                            "formatted_uuid_column" + suffix,
+                            ColumnMatch(None, self.__uuid_column_match),
+                        ),
+                    ),
+                ),
+            ),
+            with_optionals=True,
+        )
+
+    def uuid_column_pattern(self, suffix: str = "") -> Param[Column]:
+        return Param(
+            "uuid_column" + suffix, ColumnMatch(None, self.__uuid_column_match)
+        )
+
+    def __init__(self, uuid_columns: Set[str]) -> None:
+        self.__unique_uuid_columns = set(uuid_columns)
+        self.__uuid_column_match = Or(
+            [String(u_col) for u_col in self.__unique_uuid_columns]
+        )
+        self.uuid_in_condition = FunctionCallMatch(
+            Or((String(ConditionFunctions.IN), String(ConditionFunctions.NOT_IN))),
+            (
+                Or((self.uuid_column_pattern(), self.formatted_uuid_pattern())),
+                Param("params", FunctionCallMatch(String("tuple"), None)),
+            ),
+        )
+        self.uuid_condition = FunctionCallMatch(
+            Or([String(op) for op in FUNCTION_TO_OPERATOR]),
+            (
+                Or(
+                    (
+                        Param("literal_0", LiteralMatch(AnyOptionalString())),
+                        self.uuid_column_pattern("_0"),
+                        self.formatted_uuid_pattern("_0"),
+                    )
+                ),
+                Or(
+                    (
+                        Param("literal_1", LiteralMatch(AnyOptionalString())),
+                        self.uuid_column_pattern("_1"),
+                        self.formatted_uuid_pattern("_1"),
+                    )
+                ),
+            ),
+        )
+
+    def parse_uuid(self, lit: Expression) -> Expression:
+        if not isinstance(lit, Literal):
+            return lit
+
+        try:
+            parsed = uuid.UUID(str(lit.value))
+            return Literal(lit.alias, str(parsed))
+        except Exception:
+            return lit
+
+    def process_condition(self, exp: Expression) -> Expression:
+        if not isinstance(exp, FunctionCall):
+            return exp
+
+        result = self.uuid_in_condition.match(exp)
+        if result is not None:
+            new_params: List[Expression] = []
+            if result.contains("formatted_uuid_column"):
+                column = result.expression("formatted_uuid_column")
+                assert isinstance(column, Column)
+                new_params.append(Column(None, column.table_name, column.column_name))
+            else:
+                column = result.expression("uuid_column")
+                assert isinstance(column, Column)
+                new_params.append(column)
+
+            params_fn = result.expression("params")
+            assert isinstance(params_fn, FunctionCall)
+            new_fn_params = []
+            for param in params_fn.parameters:
+                new_fn_params.append(self.parse_uuid(param))
+
+            new_params.append(
+                FunctionCall(
+                    params_fn.alias, params_fn.function_name, tuple(new_fn_params)
+                )
+            )
+
+            return binary_condition(
+                exp.alias, exp.function_name, new_params[0], new_params[1]
+            )
+
+        result = self.uuid_condition.match(exp)
+        if result is not None:
+            new_params = []
+            for suffix in ["_0", "_1"]:
+                if result.contains("literal" + suffix):
+                    new_params.append(
+                        self.parse_uuid(result.expression("literal" + suffix))
+                    )
+                elif result.contains("uuid_column" + suffix):
+                    new_params.append(result.expression("uuid_column" + suffix))
+                elif result.contains("formatted_uuid_column" + suffix):
+                    column = result.expression("formatted_uuid_column" + suffix)
+                    assert isinstance(column, Column)
+                    new_params.append(
+                        Column(None, column.table_name, column.column_name)
+                    )
+
+            return binary_condition(
+                exp.alias, exp.function_name, new_params[0], new_params[1]
+            )
+
+        return exp
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        condition = query.get_condition_from_ast()
+        if condition:
+            query.set_ast_condition(condition.transform(self.process_condition))

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -30,11 +30,12 @@ from snuba.query.expressions import (
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.logical import Query
 from snuba.query.parser import (
-    _validate_aliases,
-    _parse_subscriptables,
     _apply_column_aliases,
-    _expand_aliases,
     _deescape_aliases,
+    _expand_aliases,
+    _mangle_aliases,
+    _parse_subscriptables,
+    _validate_aliases,
 )
 from snuba.query.snql.expression_visitor import (
     HighPriArithmetic,
@@ -539,4 +540,5 @@ def parse_snql_query(body: str, dataset: Dataset) -> Query:
     _apply_column_aliases(query)
     _expand_aliases(query)
     _deescape_aliases(query)
+    _mangle_aliases(query)
     return query

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -1,18 +1,17 @@
 import pytest
 import uuid
 
+from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
-from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import get_entity
 from snuba.query import SelectedExpression
 from snuba.query.conditions import (
     binary_condition,
     BooleanFunctions,
     ConditionFunctions,
 )
-from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
-from snuba.query.logical import Query
+from snuba.clickhouse.query import Query
 from snuba.query.processors.uuid_column_processor import UUIDColumnProcessor
 from snuba.request.request_settings import HTTPRequestSettings
 
@@ -210,18 +209,12 @@ def test_uuid_column_processor(
     unprocessed: Expression, expected: Expression, formatted_value: str,
 ) -> None:
     unprocessed_query = Query(
-        {},
-        QueryEntity(
-            EntityKey.TRANSACTIONS, get_entity(EntityKey.TRANSACTIONS).get_data_model(),
-        ),
+        Table("transactions", ColumnSet([])),
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
         condition=unprocessed,
     )
     expected_query = Query(
-        {},
-        QueryEntity(
-            EntityKey.TRANSACTIONS, get_entity(EntityKey.TRANSACTIONS).get_data_model(),
-        ),
+        Table("transactions", ColumnSet([])),
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
         condition=expected,
     )

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -21,7 +21,15 @@ tests = [
         binary_condition(
             "mightaswell",
             ConditionFunctions.EQ,
-            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column1"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
         binary_condition(
@@ -37,24 +45,48 @@ tests = [
         binary_condition(
             "mightaswell",
             ConditionFunctions.EQ,
-            Column(None, None, "notauuid"),
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "notauuid"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
         binary_condition(
             "mightaswell",
             ConditionFunctions.EQ,
-            Column(None, None, "notauuid"),
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "notauuid"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
-        "(equals(notauuid, 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
-        id="(equals(notauuid, 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+        "(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+        id="(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
     ),
     pytest.param(
         binary_condition(
             "mightaswell",
             ConditionFunctions.EQ,
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
-            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column1"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
         ),
         binary_condition(
             "mightaswell",
@@ -69,7 +101,15 @@ tests = [
         binary_condition(
             "mightaswell",
             ConditionFunctions.IN,
-            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column1"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
             FunctionCall(
                 None,
                 "tuple",
@@ -178,7 +218,17 @@ tests = [
             binary_condition(
                 "mightaswell",
                 ConditionFunctions.EQ,
-                Column(None, None, "column1"),
+                FunctionCall(
+                    None,
+                    "replaceAll",
+                    (
+                        FunctionCall(
+                            None, "toString", (Column(None, None, "column1"),),
+                        ),
+                        Literal(None, "-"),
+                        Literal(None, ""),
+                    ),
+                ),
                 Literal(None, "a7d67cf796774551a95be6543cacd459"),
             ),
         ),

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -1,0 +1,239 @@
+import pytest
+import uuid
+
+from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query import SelectedExpression
+from snuba.query.conditions import (
+    binary_condition,
+    BooleanFunctions,
+    ConditionFunctions,
+)
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.query.processors.uuid_column_processor import UUIDColumnProcessor
+from snuba.request.request_settings import HTTPRequestSettings
+
+
+tests = [
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+        ),
+        "(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+        id="(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+    ),
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Column(None, None, "notauuid"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Column(None, None, "notauuid"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        "(equals(notauuid, 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+        id="(equals(notauuid, 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+    ),
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+            Column(None, None, "column1"),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+            Column(None, None, "column1"),
+        ),
+        "(equals('a7d67cf7-9677-4551-a95b-e6543cacd459', column1) AS mightaswell)",
+        id="(equals('a7d67cf7-9677-4551-a95b-e6543cacd459', column1) AS mightaswell)",
+    ),
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.IN,
+            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "tuple",
+                (
+                    Literal(None, "a7d67cf796774551a95be6543cacd459"),
+                    Literal(None, "a7d67cf796774551a95be6543cacd45a"),
+                ),
+            ),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.IN,
+            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "tuple",
+                (
+                    Literal(
+                        None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))
+                    ),
+                    Literal(
+                        None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd45a"))
+                    ),
+                ),
+            ),
+        ),
+        "(in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a')) AS mightaswell)",
+        id="(in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a')) AS mightaswell)",
+    ),
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column1"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+        ),
+        "(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+        id="(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+    ),
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "notauuid"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "notauuid"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        "(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+        id="(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+    ),
+    pytest.param(
+        binary_condition(
+            None,
+            BooleanFunctions.AND,
+            binary_condition(
+                "butfirst",
+                ConditionFunctions.EQ,
+                FunctionCall(
+                    None,
+                    "replaceAll",
+                    (
+                        FunctionCall(
+                            None, "toString", (Column(None, None, "column2"),),
+                        ),
+                        Literal(None, "-"),
+                        Literal(None, ""),
+                    ),
+                ),
+                Literal(None, "a7d67cf796774551a95be6543cacd460"),
+            ),
+            binary_condition(
+                "mightaswell",
+                ConditionFunctions.EQ,
+                Column(None, None, "column1"),
+                Literal(None, "a7d67cf796774551a95be6543cacd459"),
+            ),
+        ),
+        binary_condition(
+            None,
+            BooleanFunctions.AND,
+            binary_condition(
+                "butfirst",
+                ConditionFunctions.EQ,
+                Column(None, None, "column2"),
+                Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd460"))),
+            ),
+            binary_condition(
+                "mightaswell",
+                ConditionFunctions.EQ,
+                Column(None, None, "column1"),
+                Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+            ),
+        ),
+        "(equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AS butfirst) AND (equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+        id="(equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AS butfirst) AND (equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+    ),
+]
+
+
+@pytest.mark.parametrize("unprocessed, expected, formatted_value", tests)
+def test_uuid_column_processor(
+    unprocessed: Expression, expected: Expression, formatted_value: str,
+) -> None:
+    unprocessed_query = Query(
+        {},
+        QueryEntity(
+            EntityKey.TRANSACTIONS, get_entity(EntityKey.TRANSACTIONS).get_data_model(),
+        ),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=unprocessed,
+    )
+    expected_query = Query(
+        {},
+        QueryEntity(
+            EntityKey.TRANSACTIONS, get_entity(EntityKey.TRANSACTIONS).get_data_model(),
+        ),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=expected,
+    )
+
+    UUIDColumnProcessor(set(["column1", "column2"])).process_query(
+        unprocessed_query, HTTPRequestSettings()
+    )
+    assert (
+        expected_query.get_condition_from_ast()
+        == unprocessed_query.get_condition_from_ast()
+    )
+    condition = unprocessed_query.get_condition_from_ast()
+    assert condition is not None
+    ret = condition.accept(ClickhouseExpressionFormatter())
+    assert ret == formatted_value

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -37,14 +37,14 @@ test_cases = [
                         "multiply",
                         (
                             Literal(None, 3),
-                            FunctionCall(None, "g", (Column("c", None, "c"),),),
+                            FunctionCall(None, "g", (Column("_snuba_c", None, "c"),),),
                         ),
                     ),
                 ),
-                SelectedExpression("c", Column("c", None, "c"),),
+                SelectedExpression("c", Column("_snuba_c", None, "c"),),
             ],
             condition=binary_condition(
-                None, "less", Column("a", None, "a"), Literal(None, 3)
+                None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
             ),
         ),
         id="Basic query with no spaces and no ambiguous clause content",
@@ -80,23 +80,23 @@ test_cases = [
                     ),
                 ),
                 SelectedExpression(
-                    "g(c)", FunctionCall(None, "g", (Column("c", None, "c"),)),
+                    "g(c)", FunctionCall(None, "g", (Column("_snuba_c", None, "c"),)),
                 ),
-                SelectedExpression("c", Column("c", None, "c")),
-                SelectedExpression("d", Column("d", None, "d")),
+                SelectedExpression("c", Column("_snuba_c", None, "c")),
+                SelectedExpression("d", Column("_snuba_d", None, "d")),
                 SelectedExpression(
                     "2+7",
                     FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
                 ),
             ],
             condition=binary_condition(
-                None, "less", Column("a", None, "a"), Literal(None, 3)
+                None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
             ),
             groupby=[
-                Column("d", None, "d"),
+                Column("_snuba_d", None, "d"),
                 FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
             ],
-            order_by=[OrderBy(OrderByDirection.DESC, Column("f", None, "f"))],
+            order_by=[OrderBy(OrderByDirection.DESC, Column("_snuba_f", None, "f"))],
         ),
         id="Simple complete query with example of parenthesized arithmetic expression in COLLECT",
     ),
@@ -107,7 +107,7 @@ test_cases = [
             QueryEntity(
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
-            selected_columns=[SelectedExpression("a", Column("a", None, "a"))],
+            selected_columns=[SelectedExpression("a", Column("_snuba_a", None, "a"))],
             condition=FunctionCall(
                 None,
                 "and",
@@ -115,7 +115,10 @@ test_cases = [
                     FunctionCall(
                         None,
                         "less",
-                        (Column("time_seen", None, "time_seen"), Literal(None, 3)),
+                        (
+                            Column("_snuba_time_seen", None, "time_seen"),
+                            Literal(None, 3),
+                        ),
                     ),
                     FunctionCall(
                         None,
@@ -125,7 +128,7 @@ test_cases = [
                                 None,
                                 "equals",
                                 (
-                                    Column("last_seen", None, "last_seen"),
+                                    Column("_snuba_last_seen", None, "last_seen"),
                                     Literal(None, 2),
                                 ),
                             ),
@@ -136,12 +139,18 @@ test_cases = [
                                     FunctionCall(
                                         None,
                                         "equals",
-                                        (Column("c", None, "c"), Literal(None, 2)),
+                                        (
+                                            Column("_snuba_c", None, "c"),
+                                            Literal(None, 2),
+                                        ),
                                     ),
                                     FunctionCall(
                                         None,
                                         "equals",
-                                        (Column("d", None, "d"), Literal(None, 3)),
+                                        (
+                                            Column("_snuba_d", None, "d"),
+                                            Literal(None, 3),
+                                        ),
                                     ),
                                 ),
                             ),
@@ -159,7 +168,7 @@ test_cases = [
             QueryEntity(
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
-            selected_columns=[SelectedExpression("a", Column("a", None, "a"))],
+            selected_columns=[SelectedExpression("a", Column("_snuba_a", None, "a"))],
             condition=FunctionCall(
                 None,
                 "or",
@@ -172,7 +181,7 @@ test_cases = [
                                 None,
                                 "less",
                                 (
-                                    Column("time_seen", None, "time_seen"),
+                                    Column("_snuba_time_seen", None, "time_seen"),
                                     Literal(None, 3),
                                 ),
                             ),
@@ -180,8 +189,8 @@ test_cases = [
                                 None,
                                 "equals",
                                 (
-                                    Column("last_seen", None, "last_seen"),
-                                    Column("afternoon", None, "afternoon"),
+                                    Column("_snuba_last_seen", None, "last_seen"),
+                                    Column("_snuba_afternoon", None, "afternoon"),
                                 ),
                             ),
                         ),
@@ -189,7 +198,10 @@ test_cases = [
                     FunctionCall(
                         None,
                         "equals",
-                        (Column("name", None, "name"), Column("bob", None, "bob")),
+                        (
+                            Column("_snuba_name", None, "name"),
+                            Column("_snuba_bob", None, "bob"),
+                        ),
                     ),
                 ),
             ),
@@ -203,7 +215,7 @@ test_cases = [
             QueryEntity(
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
-            selected_columns=[SelectedExpression("a", Column("a", None, "a"),)],
+            selected_columns=[SelectedExpression("a", Column("_snuba_a", None, "a"),)],
             condition=FunctionCall(
                 None,
                 "or",
@@ -211,7 +223,10 @@ test_cases = [
                     FunctionCall(
                         None,
                         "notEquals",
-                        (Column("name", None, "name"), Column("bob", None, "bob")),
+                        (
+                            Column("_snuba_name", None, "name"),
+                            Column("_snuba_bob", None, "bob"),
+                        ),
                     ),
                     FunctionCall(
                         None,
@@ -221,8 +236,8 @@ test_cases = [
                                 None,
                                 "less",
                                 (
-                                    Column("last_seen", None, "last_seen"),
-                                    Column("afternoon", None, "afternoon"),
+                                    Column("_snuba_last_seen", None, "last_seen"),
+                                    Column("_snuba_afternoon", None, "afternoon"),
                                 ),
                             ),
                             FunctionCall(
@@ -233,14 +248,14 @@ test_cases = [
                                         None,
                                         "equals",
                                         (
-                                            Column("location", None, "location"),
+                                            Column("_snuba_location", None, "location"),
                                             FunctionCall(
                                                 None,
                                                 "gps",
                                                 (
-                                                    Column("x", None, "x"),
-                                                    Column("y", None, "y"),
-                                                    Column("z", None, "z"),
+                                                    Column("_snuba_x", None, "x"),
+                                                    Column("_snuba_y", None, "y"),
+                                                    Column("_snuba_z", None, "z"),
                                                 ),
                                             ),
                                         ),
@@ -249,7 +264,9 @@ test_cases = [
                                         None,
                                         "greater",
                                         (
-                                            Column("times_seen", None, "times_seen"),
+                                            Column(
+                                                "_snuba_times_seen", None, "times_seen"
+                                            ),
                                             Literal(None, 0),
                                         ),
                                     ),
@@ -270,11 +287,13 @@ test_cases = [
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
-                SelectedExpression("a", Column("a", None, "a")),
+                SelectedExpression("a", Column("_snuba_a", None, "a")),
                 SelectedExpression(
                     "b[c]",
                     SubscriptableReference(
-                        "b[c]", Column("b", None, "b"), key=Literal(None, "c")
+                        "_snuba_b[c]",
+                        Column("_snuba_b", None, "b"),
+                        key=Literal(None, "c"),
                     ),
                 ),
             ],
@@ -282,7 +301,7 @@ test_cases = [
                 None,
                 "in",
                 (
-                    Column("project_id", None, "project_id",),
+                    Column("_snuba_project_id", None, "project_id",),
                     FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 3))),
                 ),
             ),


### PR DESCRIPTION
First pass at trying to optimize queries with UUID columns. Right now the simple
case is to target conditions that contain UUID columns, and do a direct
comparison instead of converting the column to a string.