### PR TITLE
feat(errors): Make `level` nullable

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -73,7 +73,7 @@ all_columns = ColumnSet(
         ("message", String()),
         ("title", String()),
         ("culprit", String()),
-        ("level", String()),
+        ("level", String(Modifiers(nullable=True))),
         ("location", String(Modifiers(nullable=True))),
         ("version", String(Modifiers(nullable=True))),
         ("type", String()),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -99,6 +99,7 @@ class EventsLoader(DirectoryLoader):
             "0009_errors_add_http_fields",
             "0010_groupedmessages_onpremise_compatibility",
             "0011_rebuild_errors",
+            "0012_errors_make_level_nullable",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/events/0012_errors_make_level_nullable.py
+++ b/snuba/migrations/snuba_migrations/events/0012_errors_make_level_nullable.py
@@ -1,0 +1,40 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.MultiStepMigration):
+    blocking = False
+
+    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name=table_name,
+                column=Column("level", String(Modifiers(nullable=True))),
+            )
+        ]
+
+    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name=table_name,
+                column=Column("level", String()),
+            )
+        ]
+
+    def forwards_local(self) -> Sequence[operations.Operation]:
+        return self.__forward_migrations("errors_local")
+
+    def backwards_local(self) -> Sequence[operations.Operation]:
+        return self.__backwards_migrations("errors_local")
+
+    def forwards_dist(self) -> Sequence[operations.Operation]:
+        return self.__forward_migrations("errors_dist")
+
+    def backwards_dist(self) -> Sequence[operations.Operation]:
+        return self.__backwards_migrations("errors_dist")

--- a/snuba/migrations/snuba_migrations/events/0012_errors_make_level_nullable.py
+++ b/snuba/migrations/snuba_migrations/events/0012_errors_make_level_nullable.py
@@ -14,7 +14,9 @@ class Migration(migration.MultiStepMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.EVENTS,
                 table_name=table_name,
-                column=Column("level", String(Modifiers(nullable=True))),
+                column=Column(
+                    "level", String(Modifiers(low_cardinality=True, nullable=True))
+                ),
             )
         ]
 
@@ -23,7 +25,7 @@ class Migration(migration.MultiStepMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.EVENTS,
                 table_name=table_name,
-                column=Column("level", String()),
+                column=Column("level", String(Modifiers(low_cardinality=True))),
             )
         ]
 


### PR DESCRIPTION
The `level` column should be a nullable string because it is a promoted
tag. Non nullable promoted tags are problematic because the insertion will
fail if the tag is absent in the payload. If we attempted to use empty string
as a default instead, it would cause inconsistent query results.

Migration statement:
`ALTER TABLE errors_local MODIFY COLUMN level LowCardinality(Nullable(String));`