### PR TITLE
feat(join) Allow CompositeQuery in web/query

### DIFF
--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Union
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.simple import Table
 from snuba.query.logical import Query as LogicalQuery
 from snuba.reader import Reader
 from snuba.request.request_settings import RequestSettings
 from snuba.web import QueryResult
 
-QueryRunner = Callable[[Query, RequestSettings, Reader], QueryResult]
+QueryRunner = Callable[
+    [Union[Query, CompositeQuery[Table]], RequestSettings, Reader], QueryResult
+]
 
 
 @dataclass(frozen=True)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from datetime import datetime
 from functools import partial
-from typing import MutableMapping, Set
+from typing import MutableMapping, Optional, Set, Union
 
 from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
@@ -129,7 +129,7 @@ def _run_and_apply_column_names(
     from_date: datetime,
     to_date: datetime,
     referrer: str,
-    clickhouse_query: Query,
+    clickhouse_query: Union[Query, CompositeQuery[Table]],
     request_settings: RequestSettings,
     reader: Reader,
 ) -> QueryResult:
@@ -184,29 +184,51 @@ def _run_and_apply_column_names(
     return result
 
 
-class TablesCollector(DataSourceVisitor[Set[str], Table], JoinVisitor[Set[str], Table]):
+class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
     """
     Traverses the data source of a composite query and collects
-    all the referenced table names
+    all the referenced table names, final state and sampling rate
+    to fill stats.
     """
 
-    def _visit_simple_source(self, data_source: Table) -> Set[str]:
-        return {data_source.table_name}
+    def __init__(self) -> None:
+        self.__tables: Set[str] = set()
+        self.__final: bool = False
+        self.__sample_rate: Optional[float] = None
 
-    def _visit_join(self, data_source: JoinClause[Table]) -> Set[str]:
-        return self.visit_join_clause(data_source)
+    def get_tables(self) -> Set[str]:
+        return self.__tables
 
-    def _visit_simple_query(self, data_source: ProcessableQuery[Table]) -> Set[str]:
-        return self.visit(data_source.get_from_clause())
+    def any_final(self) -> bool:
+        return self.__final
 
-    def _visit_composite_query(self, data_source: CompositeQuery[Table]) -> Set[str]:
-        return self.visit(data_source.get_from_clause())
+    def get_sample_rate(self) -> Optional[float]:
+        return self.__sample_rate
 
-    def visit_individual_node(self, node: IndividualNode[Table]) -> Set[str]:
-        return self.visit(node.data_source)
+    def _visit_simple_source(self, data_source: Table) -> None:
+        self.__tables.add(data_source.table_name)
+        self.__sample_rate = data_source.sampling_rate
+        if data_source.final:
+            self.__final = True
 
-    def visit_join_clause(self, node: JoinClause[Table]) -> Set[str]:
-        return node.left_node.accept(self) | node.right_node.accept(self)
+    def _visit_join(self, data_source: JoinClause[Table]) -> None:
+        self.visit_join_clause(data_source)
+
+    def _visit_simple_query(self, data_source: ProcessableQuery[Table]) -> None:
+        self.visit(data_source.get_from_clause())
+
+    def _visit_composite_query(self, data_source: CompositeQuery[Table]) -> None:
+        self.visit(data_source.get_from_clause())
+        # stats do not yet support sampling rate (there is only one field)
+        # so if we have a composite query we set it to None.
+        self.__sample_rate = None
+
+    def visit_individual_node(self, node: IndividualNode[Table]) -> None:
+        self.visit(node.data_source)
+
+    def visit_join_clause(self, node: JoinClause[Table]) -> None:
+        node.left_node.accept(self)
+        node.right_node.accept(self)
 
 
 def _format_storage_query_and_run(
@@ -215,7 +237,7 @@ def _format_storage_query_and_run(
     from_date: datetime,
     to_date: datetime,
     referrer: str,
-    clickhouse_query: Query,
+    clickhouse_query: Union[Query, CompositeQuery[Table]],
     request_settings: RequestSettings,
     reader: Reader,
 ) -> QueryResult:
@@ -223,7 +245,9 @@ def _format_storage_query_and_run(
     Formats the Storage Query and pass it to the DB specific code for execution.
     """
     from_clause = clickhouse_query.get_from_clause()
-    table_names = ",".join(sorted(TablesCollector().visit(from_clause)))
+    visitor = TablesCollector()
+    visitor.visit(from_clause)
+    table_names = ",".join(sorted(visitor.get_tables()))
     with sentry_sdk.start_span(description="create_query", op="db") as span:
         formatted_query = format_query(clickhouse_query, request_settings)
         span.set_data("query", formatted_query.structured())
@@ -233,10 +257,10 @@ def _format_storage_query_and_run(
 
     stats = {
         "clickhouse_table": table_names,
-        "final": from_clause.final,
+        "final": visitor.any_final(),
         "referrer": referrer,
         "num_days": (to_date - from_date).days,
-        "sample": from_clause.sampling_rate,
+        "sample": visitor.get_sample_rate(),
     }
 
     with sentry_sdk.start_span(description=formatted_query.get_sql(), op="db") as span:

--- a/tests/web/test_count_columns.py
+++ b/tests/web/test_count_columns.py
@@ -1,4 +1,4 @@
-from typing import Set, Union
+from typing import Optional, Set, Union
 
 import pytest
 from snuba.clickhouse.columns import UUID, ColumnSet, String, UInt
@@ -36,7 +36,7 @@ GROUPS_SCHEMA = ColumnSet(
 )
 
 SIMPLE_QUERY = ClickhouseQuery(
-    Table("errors_local", ERRORS_SCHEMA),
+    Table("errors_local", ERRORS_SCHEMA, final=True, sampling_rate=0.1),
     selected_columns=[
         SelectedExpression(
             "alias",
@@ -62,7 +62,7 @@ SIMPLE_QUERY = ClickhouseQuery(
 )
 
 TEST_CASES = [
-    pytest.param(SIMPLE_QUERY, 3, {"errors_local"}, id="Simple Query",),
+    pytest.param(SIMPLE_QUERY, 3, {"errors_local"}, True, 0.1, id="Simple Query",),
     pytest.param(
         CompositeQuery(
             from_clause=SIMPLE_QUERY,
@@ -75,6 +75,8 @@ TEST_CASES = [
         ),
         3,
         {"errors_local"},
+        True,
+        None,
         id="Nested query. Count the inner query",
     ),
     pytest.param(
@@ -105,20 +107,30 @@ TEST_CASES = [
         ),
         5,  # 3 from errors and 2 from groups
         {"errors_local", "groups_local"},
+        True,
+        None,
         id="Join between a subquery and an individual table.",
     ),
 ]
 
 
-@pytest.mark.parametrize("query, expected_cols, expected_tables", TEST_CASES)
+@pytest.mark.parametrize(
+    "query, expected_cols, expected_tables, expected_final, expected_sampling",
+    TEST_CASES,
+)
 def test_count_columns(
     query: Union[ClickhouseQuery, CompositeQuery[Table]],
     expected_cols: int,
     expected_tables: Set[str],
+    expected_final: bool,
+    expected_sampling: Optional[float],
 ) -> None:
     counter = ReferencedColumnsCounter()
     counter.visit(query)
     assert counter.count_columns() == expected_cols
 
-    tables = TablesCollector().visit(query)
-    assert tables == expected_tables
+    tables_collector = TablesCollector()
+    tables_collector.visit(query)
+    assert tables_collector.get_tables() == expected_tables
+    assert tables_collector.any_final() == expected_final
+    assert tables_collector.get_sample_rate() == expected_sampling


### PR DESCRIPTION
Makes change to the visitor that extracts stats from a composite query to collect also final and sampling rate so that we can pass a ComposteQuery to web/query.py methods.