### PR TITLE
feat(snuplicator): Record time taken to execute each callable

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -61,6 +61,7 @@ from snuba.query.project_extension import ProjectExtension
 from snuba.query.timeseries_extension import TimeSeriesExtension
 from snuba.util import qualified_column
 from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.threaded_function_delegator import Result
 from snuba.web import QueryResult
 
 metrics = MetricsWrapper(environment.metrics, "api.discover.discover_entity")
@@ -387,11 +388,11 @@ class DiscoverEntity(Entity):
 
             return "events", []
 
-        def callback_func(results: List[Tuple[str, QueryResult]]) -> None:
-            _, primary_result = results.pop(0)
+        def callback_func(results: List[Result[QueryResult]]) -> None:
+            primary_result = results.pop(0)
 
-            for _, result in results:
-                if result.result["data"] == primary_result.result["data"]:
+            for result in results:
+                if result.result.result["data"] == primary_result.result.result["data"]:
                     metrics.increment("query_result", tags={"match": "true"})
                 else:
                     metrics.increment("query_result", tags={"match": "false"})

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -11,13 +11,13 @@ from snuba.query.logical import Query
 from snuba.query.logical import Query as LogicalQuery
 from snuba.request import Request
 from snuba.request.request_settings import RequestSettings
-from snuba.utils.threaded_function_delegator import ThreadedFunctionDelegator
+from snuba.utils.threaded_function_delegator import Result, ThreadedFunctionDelegator
 from snuba.web import QueryResult
 
 BuilderId = str
 Timing = float
 QueryPipelineBuilders = Mapping[BuilderId, QueryPipelineBuilder[ClickhouseQueryPlan]]
-QueryResults = List[Tuple[BuilderId, QueryResult, Timing]]
+QueryResults = List[Result[QueryResult]]
 SelectorFunc = Callable[[Query], Tuple[BuilderId, List[BuilderId]]]
 CallbackFunc = Callable[[QueryResults], None]
 

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -15,8 +15,9 @@ from snuba.utils.threaded_function_delegator import ThreadedFunctionDelegator
 from snuba.web import QueryResult
 
 BuilderId = str
+Timing = float
 QueryPipelineBuilders = Mapping[BuilderId, QueryPipelineBuilder[ClickhouseQueryPlan]]
-QueryResults = List[Tuple[BuilderId, QueryResult]]
+QueryResults = List[Tuple[BuilderId, QueryResult, Timing]]
 SelectorFunc = Callable[[Query], Tuple[BuilderId, List[BuilderId]]]
 CallbackFunc = Callable[[QueryResults], None]
 

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -11,6 +11,7 @@ from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 from snuba.query.parser import parse_query
 from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings
+from snuba.utils.threaded_function_delegator import Result
 from snuba.web import QueryResult
 
 
@@ -59,5 +60,5 @@ def test() -> None:
     assert mock_query_runner.call_count == 2
 
     assert mock_callback.call_args == call(
-        [("events", query_result, ANY), ("errors", query_result, ANY)]
+        [Result("events", query_result, ANY), Result("errors", query_result, ANY)]
     )

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -1,6 +1,6 @@
 import threading
 from typing import List, Tuple
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, ANY
 
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
@@ -59,5 +59,5 @@ def test() -> None:
     assert mock_query_runner.call_count == 2
 
     assert mock_callback.call_args == call(
-        [("events", query_result), ("errors", query_result)]
+        [("events", query_result, ANY), ("errors", query_result, ANY)]
     )

--- a/tests/utils/test_threaded_function_delegator.py
+++ b/tests/utils/test_threaded_function_delegator.py
@@ -2,7 +2,7 @@ import threading
 from typing import Any, List, Tuple
 from unittest.mock import Mock, call, ANY
 
-from snuba.utils.threaded_function_delegator import ThreadedFunctionDelegator
+from snuba.utils.threaded_function_delegator import Result, ThreadedFunctionDelegator
 
 
 def test() -> None:
@@ -46,4 +46,6 @@ def test() -> None:
     assert callables["one"].call_count == 1
     assert callables["two"].call_count == 1
     assert callables["three"].call_count == 0
-    assert mock_callback.call_args == call([("one", 1, ANY), ("two", 2, ANY)])
+    assert mock_callback.call_args == call(
+        [Result("one", 1, ANY), Result("two", 2, ANY)]
+    )

--- a/tests/utils/test_threaded_function_delegator.py
+++ b/tests/utils/test_threaded_function_delegator.py
@@ -1,6 +1,6 @@
 import threading
 from typing import Any, List, Tuple
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, ANY
 
 from snuba.utils.threaded_function_delegator import ThreadedFunctionDelegator
 
@@ -46,4 +46,4 @@ def test() -> None:
     assert callables["one"].call_count == 1
     assert callables["two"].call_count == 1
     assert callables["three"].call_count == 0
-    assert mock_callback.call_args == call([("one", 1), ("two", 2)])
+    assert mock_callback.call_args == call([("one", 1, ANY), ("two", 2, ANY)])


### PR DESCRIPTION
ThreadedFunctionDelegator records the time taken to execute each
callable and provides the value to the callback function if provided.
The purpose of this change is to make it easier to test the performance
impact of various changes before rolling them out.