### PR TITLE
fix(snql) Allow arbitrary characters in quotes

### DIFF
--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -65,8 +65,7 @@ parameter             = param_expression space* comma space*
 function_call         = function_name open_paren parameters_list? close_paren (open_paren parameters_list? close_paren)?
 simple_term           = quoted_literal / numeric_literal / column_name
 literal               = ~r"[a-zA-Z0-9_\.:-]+"
-quoted_literal        = "'" string_literal "'"
-string_literal        = ~r"[a-zA-Z0-9_\.\+\*\/:-]*"
+quoted_literal        = ~r"((?<!\\)')(.(?!(?<!\\)'))*.?'"
 numeric_literal       = ~r"-?[0-9]+(\.[0-9]+)?(e[\+\-][0-9]+)?"
 column_name           = ~r"[a-zA-Z_][a-zA-Z0-9_\.]*"
 function_name         = ~r"{FUNCTION_NAME_REGEX}"
@@ -136,7 +135,7 @@ class ClickhouseVisitor(NodeVisitor):
         return visit_numeric_literal(node, visited_children)
 
     def visit_quoted_literal(
-        self, node: Node, visited_children: Tuple[Any, Node, Any]
+        self, node: Node, visited_children: Tuple[Node]
     ) -> Literal:
         return visit_quoted_literal(node, visited_children)
 

--- a/snuba/query/snql/expression_visitor.py
+++ b/snuba/query/snql/expression_visitor.py
@@ -136,11 +136,11 @@ def visit_numeric_literal(node: Node, visited_children: Iterable[Any]) -> Litera
         return Literal(None, float(node.text))
 
 
-def visit_quoted_literal(
-    node: Node, visited_children: Tuple[Any, Node, Any]
-) -> Literal:
-    _, val, _ = visited_children
-    return Literal(None, val.text)
+def visit_quoted_literal(node: Node, visited_children: Tuple[Any]) -> Literal:
+    # In order to match any character except for \' there is a crazy regex that needs to be
+    # stripped and de-escaped.
+    match = node.text[1:-1].replace("\\'", "'")
+    return Literal(None, match)
 
 
 def visit_parameter(

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -129,8 +129,7 @@ snql_grammar = Grammar(
     function_call         = function_name open_paren parameters_list? close_paren (open_paren parameters_list? close_paren)? (space* "AS" space* string_literal)?
     simple_term           = quoted_literal / numeric_literal / column_name
     literal               = ~r"[a-zA-Z0-9_\.:-]+"
-    quoted_literal        = "'" quoted_text "'"
-    quoted_text           = ~r"[^']*"
+    quoted_literal        = ~r"((?<!\\)')(.(?!(?<!\\)'))*.?'"
     string_literal        = ~r"[a-zA-Z0-9_\.\+\*\/:\-]*"
     numeric_literal       = ~r"-?[0-9]+(\.[0-9]+)?(e[\+\-][0-9]+)?"
     integer_literal       = ~r"-?[0-9]+"
@@ -327,8 +326,9 @@ class SnQLVisitor(NodeVisitor):
         return Literal(None, False)
 
     def visit_quoted_literal(
-        self, node: Node, visited_children: Tuple[Any, Node, Any]
+        self, node: Node, visited_children: Tuple[Node]
     ) -> Literal:
+
         return visit_quoted_literal(node, visited_children)
 
     def visit_where_clause(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,8 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                 float(value)
                 return f"{value}"
             except ValueError:
-                return f"'{value}'"
+                escaped = value.replace("'", "\\'")
+                return f"'{escaped}'"
 
         sample = legacy.get("sample")
         sample_clause = f"SAMPLE {sample}" if sample else ""

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -445,3 +445,21 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][2]["value"] == 32.129
         assert data["data"][3]["key"] == "lcp.elementSize"
         assert data["data"][3]["value"] == 4242
+
+    def test_escaping_strings(self) -> None:
+        response = self.app.post(
+            self.endpoint,
+            data=json.dumps(
+                {
+                    "dataset": "transactions",
+                    "project": 1,
+                    "selected_columns": ["event_id"],
+                    "conditions": [["transaction", "LIKE", "stuff \\\" ' \\' stuff"]],
+                    "limit": 4,
+                    "orderby": ["event_id"],
+                }
+            ),
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200, response.data
+        assert len(data["data"]) == 0, data


### PR DESCRIPTION
Allow any character in quotes, including escaped quotes (\'). The one character
that still doesn't work is the newline character. That will require discussion
with product since it's not clear if it can be handled by the regex directly.