### PR TITLE
feat(snql) Discover tests using SnQL

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -84,7 +84,7 @@ from snuba.util import parse_datetime
 
 snql_grammar = Grammar(
     r"""
-    query_exp             = match_clause select_clause group_by_clause? array_join_clause? where_clause? having_clause? order_by_clause? limit_by_clause? limit_clause? offset_clause? granularity_clause? totals_clause? space*
+    query_exp             = match_clause select_clause group_by_clause? where_clause? having_clause? order_by_clause? limit_by_clause? limit_clause? offset_clause? granularity_clause? totals_clause? space*
 
     match_clause          = space* "MATCH" space+ entity_match
     select_clause         = space+ "SELECT" space+ select_list
@@ -136,7 +136,7 @@ snql_grammar = Grammar(
     function_call         = function_name open_paren parameters_list? close_paren (open_paren parameters_list? close_paren)? (space* "AS" space* string_literal)?
     simple_term           = quoted_literal / numeric_literal / column_name
     literal               = ~r"[a-zA-Z0-9_\.:-]+"
-    quoted_literal        = ~r"((?<!\\)')(.(?!(?<!\\)'))*.?'"
+    quoted_literal        = ~r"((?<!\\)')((?!(?<!\\)').)*.?'"
     string_literal        = ~r"[a-zA-Z0-9_\.\+\*\/:\-]*"
     numeric_literal       = ~r"-?[0-9]+(\.[0-9]+)?(e[\+\-][0-9]+)?"
     integer_literal       = ~r"-?[0-9]+"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,7 +102,9 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
 
         arrayjoin = legacy.get("arrayjoin")
         if arrayjoin:
-            array_join_clause = f"arrayJoin({arrayjoin})" if arrayjoin else ""
+            array_join_clause = (
+                f"arrayJoin({arrayjoin}) AS {arrayjoin}" if arrayjoin else ""
+            )
             select_clause = (
                 f"SELECT {array_join_clause}"
                 if not select_clause
@@ -204,7 +206,7 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                 extra_exps.append(f"{extra.upper()} {legacy.get(extra)}")
         extras_clause = " ".join(extra_exps)
 
-        query = f"{match_clause} {select_clause} {aggregation_clause} {groupby_clause} {array_join_clause} {where_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
+        query = f"{match_clause} {select_clause} {aggregation_clause} {groupby_clause} {where_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
         body = {"query": query}
         extensions = ["project", "from_date", "to_date", "organization"]
         for ext in extensions:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,7 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
         groupby = legacy.get("groupby", [])
         if groupby and not isinstance(groupby, list):
             groupby = [groupby]
+
         groupby = ", ".join(map(func, groupby))
         groupby_clause = f"BY {groupby}" if groupby else ""
 
@@ -147,7 +148,7 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
         if isinstance(project, int):
             conditions.append(f"project_id={project}")
         elif isinstance(project, list):
-            project = ",".join(project)
+            project = ",".join(map(str, project))
             conditions.append(f"project_id IN {project}")
 
         organization = legacy.get("organization")
@@ -186,6 +187,9 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
             limit, column = legacy.get("limitby")
             limit_by_clause = f"LIMIT {limit} BY {column}"
 
+        arrayjoin = legacy.get("arrayjoin")
+        array_join_clause = f"ARRAY JOIN {arrayjoin}" if arrayjoin else ""
+
         extras = ("limit", "offset", "granularity", "totals")
         extra_exps = []
         for extra in extras:
@@ -193,7 +197,7 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                 extra_exps.append(f"{extra.upper()} {legacy.get(extra)}")
         extras_clause = " ".join(extra_exps)
 
-        query = f"{match_clause} {select_clause} {aggregation_clause} {groupby_clause} {where_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
+        query = f"{match_clause} {select_clause} {aggregation_clause} {groupby_clause} {array_join_clause} {where_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
         body = {"query": query}
         extensions = ["project", "from_date", "to_date", "organization"]
         for ext in extensions:

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -564,7 +564,7 @@ test_cases = [
     pytest.param(
         """MATCH (e:events)
         SELECT 4-5,3*foo(c) AS foo,c
-        WHERE or(equals(arrayJoinExplode(a, '=', 'RuntimeException'), 1), equals(arrayJoinExplode(b, 'NOT IN', tuple('Stack', 'Arithmetic')), 1)) = 1""",
+        WHERE or(equals(arrayExists(a, '=', 'RuntimeException'), 1), equals(arrayAll(b, 'NOT IN', tuple('Stack', 'Arithmetic')), 1)) = 1""",
         LogicalQuery(
             {},
             QueryEntity(

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1055,7 +1055,8 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_invalid_event_id_condition(self) -> None:
         response = self.app.post(
-            "/query",
+            self.endpoint,
+            "discover_transactions",
             data=json.dumps(
                 {
                     "dataset": "discover",
@@ -1068,7 +1069,7 @@ class TestDiscoverApi(BaseApiTest):
                     "granularity": 3600,
                     "totals": False,
                     "conditions": [
-                        ["event_id", "=", "5897895914504192"],
+                        ["event_id", "=", "5897895a14504192"],
                         ["type", "=", "transaction"],
                     ],
                     "groupby": ["transaction"],


### PR DESCRIPTION
Have the discover tests use SnQL. This exposed a few missing cases, particularly
ARRAY JOIN. Add support for the ARRAY JOIN clause. The current language also
supports an implicit transformation on array columns, converting conditions to
be arrayExists or arrayAll functions if the condition is on an array column.

This is ambigious and hidden behaviour that we are trying to avoid in SnQL.
Instead, add a special function the client can use as syntactic sugar for the
same condition, forcing the client to explicitly declare when they are using a
condition on an array column. There are two discover tests that rely on this
behaviour, so xfail them in snql for now.