### PR TITLE
fix(split): Use standard column aliases in splitter

### DIFF
--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -248,19 +248,31 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
 
         # TODO: provide the table alias name to this splitter if we ever use it
         # in joins.
+        alias_prefix = "_snuba_"
+
         minimal_query.set_ast_selected_columns(
             [
                 SelectedExpression(
                     self.__id_column,
-                    ColumnExpr(self.__id_column, None, self.__id_column),
+                    ColumnExpr(
+                        f"{alias_prefix}{self.__id_column}", None, self.__id_column
+                    ),
                 ),
                 SelectedExpression(
                     self.__project_column,
-                    ColumnExpr(self.__project_column, None, self.__project_column),
+                    ColumnExpr(
+                        f"{alias_prefix}{self.__project_column}",
+                        None,
+                        self.__project_column,
+                    ),
                 ),
                 SelectedExpression(
                     self.__timestamp_column,
-                    ColumnExpr(self.__timestamp_column, None, self.__timestamp_column),
+                    ColumnExpr(
+                        f"{alias_prefix}{self.__timestamp_column}",
+                        None,
+                        self.__timestamp_column,
+                    ),
                 ),
             ]
         )


### PR DESCRIPTION
This is a quick and kinda dirty fix for the event_id alias shadowing
issue.

We changed the query parser to mangle column aliases so that we don't
shadow the actual column names and can reference them in processors,
however we forgot to also use the mangled aliases in the column
splitter, rather than apply the original column names.