### PR TITLE
fix(split): Do not perform column splitting on aggregations

### DIFF
--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -216,6 +216,11 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
         ):
             return None
 
+        # Do not run the splitter if we have any aggregations
+        for expr in query.get_selected_columns_from_ast():
+            if not isinstance(expr.expression, (ColumnExpr, LiteralExpr)):
+                return None
+
         if limit > settings.COLUMN_SPLIT_MAX_LIMIT:
             metrics.increment("column_splitter.query_above_limit")
             return None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1795,8 +1795,8 @@ class TestApi(BaseApiTest):
                                 "event_id",
                                 "title",
                                 "transaction",
-                                "tags[a]",
-                                "tags[b]",
+                                "culprit",
+                                "group_id",
                             ],
                             "limit": 5,
                         }


### PR DESCRIPTION
Do not do column splitting if we are attempting to select anything that
is not a column or a literal. This is to avoid column splitting when
there are aggregations present in the query, which can cause errors.

Unfortunately this means queries that reference selected tags no longer
use the column splitter as these have been translated to function calls.

Fixes SNUBA-20G