### PR TITLE
Revert "perf(transactions): Turn on column splitter (#1513)"

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -23,7 +23,7 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.uuid_column_processor import UUIDColumnProcessor
-from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
+from snuba.web.split import TimeSplitQueryStrategy
 
 columns = ColumnSet(
     [
@@ -98,13 +98,6 @@ storage = WritableTableStorage(
     stream_loader=KafkaStreamLoader(
         processor=TransactionsMessageProcessor(), default_topic="events",
     ),
-    query_splitters=[
-        ColumnSplitQueryStrategy(
-            id_column="event_id",
-            project_column="project_id",
-            timestamp_column="finish_ts",
-        ),
-        TimeSplitQueryStrategy(timestamp_col="finish_ts"),
-    ],
+    query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
     writer_options={"insert_allow_materialized_columns": 1},
 )


### PR DESCRIPTION
This reverts commit c035fe6f2aec554459f8a4d95e138a209e48289d.

This caused problems when there are aggregations (but no group by clause) in the query.
In that case the splitter should be skipped but is not. For some reason, this only commonly
happens in production on the transactions dataset.
Reverting first since fixing these turned out to be more involved than I originally thought.