### PR TITLE
fix(transactions) Fix query error in uuid processor

### DIFF
--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -251,6 +251,38 @@ tests = [
         "(equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AS butfirst) AND (equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
         id="(equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AS butfirst) AND (equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
     ),
+    pytest.param(
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column1"),)),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
+            Literal(None, "deadbeefabad"),
+        ),
+        binary_condition(
+            "mightaswell",
+            ConditionFunctions.EQ,
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column1"),)),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
+            Literal(None, "deadbeefabad"),
+        ),
+        "(equals(replaceAll(toString(column1), '-', ''), 'deadbeefabad') AS mightaswell)",
+        id="(equals(replaceAll(toString(column1), '-', ''), 'deadbeefabad') AS mightaswell)",
+    ),
 ]
 
 


### PR DESCRIPTION
If the client passes in an invalid event id, then the parser was leaving the
event id unchanged but still stripping the replaceAll(... from the left side.
This would cause errors in Clickhouse. Instead, if the event id is not a valid
UUID, bail out of the processor entirely and leave the expression unchanged.