### PR TITLE
feat(ast) Remove alias parameter from all condition functions.

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -120,7 +120,7 @@ promoted_tag_columns = {
 
 mandatory_conditions = [
     binary_condition(
-        None, ConditionFunctions.EQ, Column(None, None, "deleted"), Literal(None, 0),
+        ConditionFunctions.EQ, Column(None, None, "deleted"), Literal(None, 0),
     ),
 ]
 

--- a/snuba/datasets/storages/events_bool_contexts.py
+++ b/snuba/datasets/storages/events_bool_contexts.py
@@ -57,11 +57,10 @@ class EventsBooleanContextsProcessor(QueryProcessor):
                     "multiIf",
                     (
                         binary_condition(
-                            None, ConditionFunctions.EQ, inner, Literal(None, "")
+                            ConditionFunctions.EQ, inner, Literal(None, "")
                         ),
                         Literal(None, ""),
                         binary_condition(
-                            None,
                             ConditionFunctions.IN,
                             inner,
                             literals_tuple(

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -249,7 +249,7 @@ def get_promoted_tags() -> Mapping[str, Sequence[str]]:
 
 mandatory_conditions = [
     binary_condition(
-        None, ConditionFunctions.EQ, Column(None, None, "deleted"), Literal(None, 0),
+        ConditionFunctions.EQ, Column(None, None, "deleted"), Literal(None, 0),
     ),
 ]
 

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -42,7 +42,6 @@ schema = WritableTableSchema(
     storage_set_key=StorageSetKey.EVENTS,
     mandatory_conditions=[
         binary_condition(
-            None,
             ConditionFunctions.EQ,
             Column(None, None, "record_deleted"),
             Literal(None, 0),

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -60,7 +60,6 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                 else:
                     query.add_condition_to_ast(
                         not_in_condition(
-                            None,
                             FunctionCall(
                                 None, "assumeNotNull", (Column(None, None, "group_id"),)
                             ),

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -165,7 +165,7 @@ class Query(DataSource, ABC):
             self.__condition = condition
         else:
             self.__condition = binary_condition(
-                None, BooleanFunctions.AND, condition, self.__condition
+                BooleanFunctions.AND, condition, self.__condition
             )
 
     def get_arrayjoin_from_ast(self) -> Optional[Expression]:

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Sequence
 
 from snuba.query.dsl import literals_tuple
 from snuba.query.expressions import Expression, FunctionCall, Literal
@@ -68,9 +68,9 @@ BINARY_OPERATORS = [
 
 
 def __set_condition(
-    alias: Optional[str], function: str, lhs: Expression, rhs: Sequence[Literal]
+    function: str, lhs: Expression, rhs: Sequence[Literal]
 ) -> Expression:
-    return binary_condition(alias, function, lhs, literals_tuple(None, rhs))
+    return binary_condition(function, lhs, literals_tuple(None, rhs))
 
 
 def __set_condition_pattern(
@@ -102,10 +102,8 @@ def __is_set_condition(exp: Expression, operator: str) -> bool:
     return False
 
 
-def in_condition(
-    alias: Optional[str], lhs: Expression, rhs: Sequence[Literal],
-) -> Expression:
-    return __set_condition(alias, ConditionFunctions.IN, lhs, rhs)
+def in_condition(lhs: Expression, rhs: Sequence[Literal],) -> Expression:
+    return __set_condition(ConditionFunctions.IN, lhs, rhs)
 
 
 def is_in_condition(exp: Expression) -> bool:
@@ -116,10 +114,8 @@ def is_in_condition_pattern(lhs: Pattern[Expression]) -> FunctionCallPattern:
     return __set_condition_pattern(lhs, ConditionFunctions.IN)
 
 
-def not_in_condition(
-    alias: Optional[str], lhs: Expression, rhs: Sequence[Literal],
-) -> Expression:
-    return __set_condition(alias, ConditionFunctions.NOT_IN, lhs, rhs,)
+def not_in_condition(lhs: Expression, rhs: Sequence[Literal],) -> Expression:
+    return __set_condition(ConditionFunctions.NOT_IN, lhs, rhs,)
 
 
 def is_not_in_condition(exp: Expression) -> bool:
@@ -131,9 +127,9 @@ def is_not_in_condition_pattern(lhs: Pattern[Expression]) -> FunctionCallPattern
 
 
 def binary_condition(
-    alias: Optional[str], function_name: str, lhs: Expression, rhs: Expression
+    function_name: str, lhs: Expression, rhs: Expression
 ) -> FunctionCall:
-    return FunctionCall(alias, function_name, (lhs, rhs))
+    return FunctionCall(None, function_name, (lhs, rhs))
 
 
 binary_condition_patterns = {
@@ -149,10 +145,8 @@ def is_binary_condition(exp: Expression, operator: str) -> bool:
     return False
 
 
-def unary_condition(
-    alias: Optional[str], function_name: str, operand: Expression
-) -> FunctionCall:
-    return FunctionCall(alias, function_name, (operand,))
+def unary_condition(function_name: str, operand: Expression) -> FunctionCall:
+    return FunctionCall(None, function_name, (operand,))
 
 
 unary_condition_patterns = {
@@ -217,7 +211,7 @@ def _combine_conditions(conditions: Sequence[Expression], function: str) -> Expr
         return conditions[0]
 
     return binary_condition(
-        None, function, conditions[0], _combine_conditions(conditions[1:], function)
+        function, conditions[0], _combine_conditions(conditions[1:], function)
     )
 
 

--- a/snuba/query/organization_extension.py
+++ b/snuba/query/organization_extension.py
@@ -28,7 +28,6 @@ class OrganizationExtensionProcessor(ExtensionQueryProcessor):
         organization_id = extension_data["organization"]
         query.add_condition_to_ast(
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(None, None, "org_id"),
                 Literal(None, organization_id),

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -208,7 +208,7 @@ def parse_conditions_to_expr(
                 raise ParsingException(
                     f"Right hand side operand {literal} provided to unary operator {op}"
                 )
-            return unary_condition(None, OPERATOR_TO_FUNCTION[op], lhs)
+            return unary_condition(OPERATOR_TO_FUNCTION[op], lhs)
 
         else:
             if literal is None:
@@ -216,7 +216,7 @@ def parse_conditions_to_expr(
                     f"Missing right hand side operand for binary operator {op}"
                 )
             return binary_condition(
-                None, OPERATOR_TO_FUNCTION[op], lhs, preprocess_literal(op, literal)
+                OPERATOR_TO_FUNCTION[op], lhs, preprocess_literal(op, literal)
             )
 
     return parse_conditions(

--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -319,7 +319,6 @@ def filter_key_values(
                 None,
                 ("pair",),
                 in_condition(
-                    None,
                     # A pair here is a tuple with two elements (key
                     # and value) and the index of the first element in
                     # Clickhouse is 1 instead of 0.
@@ -339,8 +338,5 @@ def filter_keys(column: Expression, keys: Sequence[LiteralExpr]) -> Expression:
     return FunctionCallExpr(
         None,
         "arrayFilter",
-        (
-            Lambda(None, ("tag",), in_condition(None, Argument(None, "tag"), keys),),
-            column,
-        ),
+        (Lambda(None, ("tag",), in_condition(Argument(None, "tag"), keys),), column,),
     )

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -60,13 +60,11 @@ class HandledFunctionsProcessor(QueryProcessor):
                                 None,
                                 ("x",),
                                 binary_condition(
-                                    None,
                                     BooleanFunctions.OR,
                                     FunctionCall(
                                         None, "isNull", (Argument(None, "x"),)
                                     ),
                                     binary_condition(
-                                        None,
                                         ConditionFunctions.EQ,
                                         FunctionCall(
                                             None,
@@ -90,13 +88,11 @@ class HandledFunctionsProcessor(QueryProcessor):
                                 None,
                                 ("x",),
                                 binary_condition(
-                                    None,
                                     BooleanFunctions.AND,
                                     FunctionCall(
                                         None, "isNotNull", (Argument(None, "x"),)
                                     ),
                                     binary_condition(
-                                        None,
                                         ConditionFunctions.EQ,
                                         FunctionCall(
                                             None,

--- a/snuba/query/processors/uuid_column_processor.py
+++ b/snuba/query/processors/uuid_column_processor.py
@@ -118,9 +118,7 @@ class UUIDColumnProcessor(QueryProcessor):
             new_function = FunctionCall(
                 params_fn.alias, params_fn.function_name, tuple(new_fn_params)
             )
-            return binary_condition(
-                exp.alias, exp.function_name, new_column, new_function
-            )
+            return binary_condition(exp.function_name, new_column, new_function)
 
         result = self.uuid_condition.match(exp)
         if result is not None:
@@ -139,7 +137,7 @@ class UUIDColumnProcessor(QueryProcessor):
                     new_params.append(column)
 
             left_exp, right_exp = new_params
-            return binary_condition(exp.alias, exp.function_name, left_exp, right_exp)
+            return binary_condition(exp.function_name, left_exp, right_exp)
 
         return exp
 

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -75,7 +75,6 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
         if project_ids:
             query.add_condition_to_ast(
                 in_condition(
-                    None,
                     Column(None, None, self.__project_column),
                     [Literal(None, p) for p in project_ids],
                 )

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -389,7 +389,7 @@ class SnQLVisitor(NodeVisitor):
         visited_children: Tuple[Expression, Any, str, Any, Expression],
     ) -> Expression:
         exp, _, op, _, literal = visited_children
-        return binary_condition(None, op, exp, literal)
+        return binary_condition(op, exp, literal)
 
     def visit_condition_op(self, node: Node, visited_children: Iterable[Any]) -> str:
         return OPERATOR_TO_FUNCTION[node.text]

--- a/snuba/query/timeseries_extension.py
+++ b/snuba/query/timeseries_extension.py
@@ -87,16 +87,13 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
         query.set_granularity(extension_data["granularity"])
         query.add_condition_to_ast(
             binary_condition(
-                None,
                 BooleanFunctions.AND,
                 binary_condition(
-                    None,
                     ConditionFunctions.GTE,
                     Column(None, None, self.__timestamp_column),
                     Literal(None, from_date),
                 ),
                 binary_condition(
-                    None,
                     ConditionFunctions.LT,
                     Column(None, None, self.__timestamp_column),
                     Literal(None, to_date),

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -310,7 +310,6 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
 
         query.add_condition_to_ast(
             in_condition(
-                None,
                 ColumnExpr(None, None, self.__id_column),
                 [LiteralExpr(None, e_id) for e_id in event_ids],
             )

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -117,46 +117,36 @@ test_expressions = [
     ),  # Formatting an array as [...]
     (
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
                 BooleanFunctions.OR,
                 binary_condition(
-                    None,
                     BooleanFunctions.OR,
                     binary_condition(
-                        None,
                         BooleanFunctions.AND,
                         binary_condition(
-                            None,
                             ConditionFunctions.EQ,
                             Column(None, None, "c1"),
                             Literal(None, 1),
                         ),
                         binary_condition(
-                            None,
                             ConditionFunctions.EQ,
                             Column(None, None, "c2"),
                             Literal(None, 2),
                         ),
                     ),
                     binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         Column(None, None, "c3"),
                         Literal(None, 3),
                     ),
                 ),
                 binary_condition(
-                    None,
-                    ConditionFunctions.EQ,
-                    Column(None, None, "c4"),
-                    Literal(None, 4),
+                    ConditionFunctions.EQ, Column(None, None, "c4"), Literal(None, 4),
                 ),
             ),
             binary_condition(
-                None, ConditionFunctions.EQ, Column(None, None, "c5"), Literal(None, 5)
+                ConditionFunctions.EQ, Column(None, None, "c5"), Literal(None, 5)
             ),
         ),
         "(equals(c1, 1) AND equals(c2, 2) OR equals(c3, 3) OR equals(c4, 4)) AND equals(c5, 5)",

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -20,11 +20,11 @@ def test_format_clickhouse_specific_query() -> None:
             SelectedExpression("column2", Column(None, "table1", "column2")),
         ],
         condition=binary_condition(
-            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
+            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
         ),
         groupby=[Column(None, None, "column1"), Column(None, "table1", "column2")],
         having=binary_condition(
-            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
+            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
         ),
         order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         array_join=Column(None, None, "column1"),

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -60,10 +60,7 @@ test_cases = [
                 SelectedExpression("column3", Column("al", None, "column3")),
             ],
             condition=binary_condition(
-                None,
-                "eq",
-                lhs=Column("al", None, "column3"),
-                rhs=Literal(None, "blabla"),
+                "eq", lhs=Column("al", None, "column3"), rhs=Literal(None, "blabla"),
             ),
             groupby=[
                 Column(None, None, "column1"),
@@ -72,7 +69,7 @@ test_cases = [
                 Column(None, None, "column4"),
             ],
             having=binary_condition(
-                None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
+                "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
             ),
             order_by=[
                 OrderBy(OrderByDirection.ASC, Column(None, None, "column1")),
@@ -119,16 +116,13 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 "and",
                 lhs=binary_condition(
-                    None,
                     "eq",
                     lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
                 ),
                 rhs=binary_condition(
-                    None,
                     "neq",  # yes, not very smart
                     lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
@@ -207,35 +201,28 @@ test_cases = [
                 SelectedExpression("al2", Column("al2", None, "column4")),
             ],
             condition=binary_condition(
-                None,
                 BooleanFunctions.AND,
                 binary_condition(
-                    None,
                     BooleanFunctions.OR,
                     binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         lhs=Column("al", None, "column3"),
                         rhs=Literal(None, "blabla"),
                     ),
                     binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         lhs=Column("al2", None, "column4"),
                         rhs=Literal(None, "blabla2"),
                     ),
                 ),
                 binary_condition(
-                    None,
                     BooleanFunctions.OR,
                     binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         lhs=Column(None, None, "column5"),
                         rhs=Literal(None, "blabla3"),
                     ),
                     binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         lhs=Column(None, None, "column6"),
                         rhs=Literal(None, "blabla4"),
@@ -274,7 +261,6 @@ test_cases = [
                     SelectedExpression("column3", Column(None, None, "column3")),
                 ],
                 condition=binary_condition(
-                    None,
                     "eq",
                     lhs=Column("al", None, "column3"),
                     rhs=Literal(None, "blabla"),
@@ -335,7 +321,7 @@ test_cases = [
                 SelectedExpression("message", Column("message", "groups", "message")),
             ],
             condition=binary_condition(
-                None, "eq", Column(None, "groups", "id"), Literal(None, 1)
+                "eq", Column(None, "groups", "id"), Literal(None, 1)
             ),
         ),
         [
@@ -377,7 +363,6 @@ test_cases = [
                                 ),
                             ],
                             condition=binary_condition(
-                                None,
                                 "eq",
                                 Column(None, None, "project_id"),
                                 Literal(None, 1),
@@ -395,7 +380,6 @@ test_cases = [
                                 ),
                             ],
                             condition=binary_condition(
-                                None,
                                 "eq",
                                 Column(None, None, "project_id"),
                                 Literal(None, 1),
@@ -420,7 +404,7 @@ test_cases = [
                             ),
                         ],
                         condition=binary_condition(
-                            None, "eq", Column(None, None, "user"), Literal(None, "me"),
+                            "eq", Column(None, None, "user"), Literal(None, "me"),
                         ),
                     ),
                 ),
@@ -518,11 +502,11 @@ def test_format_clickhouse_specific_query() -> None:
             SelectedExpression("column2", Column(None, "table1", "column2")),
         ],
         condition=binary_condition(
-            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
+            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
         ),
         groupby=[Column(None, None, "column1"), Column(None, "table1", "column2")],
         having=binary_condition(
-            None, "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
+            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
         ),
         order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         array_join=Column(None, None, "column1"),

--- a/tests/clickhouse/test_query_profiler.py
+++ b/tests/clickhouse/test_query_profiler.py
@@ -30,25 +30,20 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 BooleanFunctions.AND,
                 binary_condition(
-                    None,
                     ConditionFunctions.GTE,
                     Column(None, None, "timestamp"),
                     Literal(None, datetime(2020, 8, 1)),
                 ),
                 binary_condition(
-                    None,
                     BooleanFunctions.AND,
                     binary_condition(
-                        None,
                         ConditionFunctions.LT,
                         Column(None, None, "timestamp"),
                         Literal(None, datetime(2020, 9, 1)),
                     ),
                     binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         build_mapping_expr(
                             "tags[asd]", None, "tags", Literal(None, "asd"),
@@ -90,16 +85,13 @@ test_cases = [
                 SelectedExpression("column2", Column("column2", None, "column2")),
             ],
             condition=binary_condition(
-                None,
                 BooleanFunctions.OR,
                 binary_condition(
-                    None,
                     ConditionFunctions.GTE,
                     Column(None, None, "timestamp"),
                     Literal(None, datetime(2020, 8, 1)),
                 ),
                 binary_condition(
-                    None,
                     ConditionFunctions.LT,
                     Column(None, None, "timestamp"),
                     Literal(None, datetime(2020, 9, 1)),

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -64,7 +64,6 @@ TEST_CASES = [
                 ],
                 groupby=[Column(None, None, "project_id")],
                 condition=binary_condition(
-                    None,
                     ConditionFunctions.EQ,
                     Column(None, None, "project_id"),
                     Literal(None, 1),
@@ -105,7 +104,6 @@ TEST_CASES = [
                     ],
                     groupby=[Column(None, None, "project_id")],
                     condition=binary_condition(
-                        None,
                         ConditionFunctions.EQ,
                         Column(None, None, "project_id"),
                         Literal(None, 1),
@@ -151,7 +149,6 @@ TEST_CASES = [
                 ],
                 groupby=[Column(None, None, "project_id")],
                 prewhere=binary_condition(
-                    None,
                     ConditionFunctions.EQ,
                     Column(None, None, "project_id"),
                     Literal(None, 1),
@@ -193,7 +190,6 @@ TEST_CASES = [
                             ),
                         ],
                         condition=binary_condition(
-                            None,
                             ConditionFunctions.EQ,
                             Column(None, None, "project_id"),
                             Literal(None, 1),
@@ -255,7 +251,6 @@ TEST_CASES = [
                                 ),
                             ],
                             condition=binary_condition(
-                                None,
                                 ConditionFunctions.EQ,
                                 Column(None, None, "project_id"),
                                 Literal(None, 1),
@@ -342,7 +337,6 @@ TEST_CASES = [
                             ),
                         ],
                         prewhere=binary_condition(
-                            None,
                             ConditionFunctions.EQ,
                             Column(None, None, "project_id"),
                             Literal(None, 1),

--- a/tests/query/parser/test_functions.py
+++ b/tests/query/parser/test_functions.py
@@ -63,13 +63,9 @@ test_data = [
     (
         tuplify(["or", [["or", ["a", "b"]], "c"]]),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             binary_condition(
-                None,
-                BooleanFunctions.OR,
-                Column(None, None, "a"),
-                Column(None, None, "b"),
+                BooleanFunctions.OR, Column(None, None, "a"), Column(None, None, "b"),
             ),
             Column(None, None, "c"),
         ),
@@ -77,13 +73,9 @@ test_data = [
     (
         tuplify(["and", [["and", ["a", "b"]], "c"]]),
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
-                BooleanFunctions.AND,
-                Column(None, None, "a"),
-                Column(None, None, "b"),
+                BooleanFunctions.AND, Column(None, None, "a"), Column(None, None, "b"),
             ),
             Column(None, None, "c"),
         ),
@@ -92,13 +84,9 @@ test_data = [
     (
         tuplify(["and", [["or", ["a", "b"]], "c"]]),
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
-                BooleanFunctions.OR,
-                Column(None, None, "a"),
-                Column(None, None, "b"),
+                BooleanFunctions.OR, Column(None, None, "a"), Column(None, None, "b"),
             ),
             Column(None, None, "c"),
         ),
@@ -107,13 +95,10 @@ test_data = [
     (
         tuplify(["or", [["or", [["or", ["c", "d"]], "b"]], "a"]]),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             binary_condition(
-                None,
                 BooleanFunctions.OR,
                 binary_condition(
-                    None,
                     BooleanFunctions.OR,
                     Column(None, None, "c"),
                     Column(None, None, "d"),
@@ -168,7 +153,6 @@ test_data = [
             ]
         ),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             FunctionCall(
                 alias=None,
@@ -182,7 +166,6 @@ test_data = [
                             function_name="assumeNotNull",
                             parameters=(
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.EQ,
                                     Argument(alias=None, name="x"),
                                     Literal(alias=None, value="b"),
@@ -207,7 +190,6 @@ test_data = [
                             function_name="assumeNotNull",
                             parameters=(
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.EQ,
                                     Argument(alias=None, name="x"),
                                     Literal(alias=None, value="c"),
@@ -233,7 +215,6 @@ test_data = [
             ]
         ),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             FunctionCall(
                 alias=None,
@@ -247,7 +228,6 @@ test_data = [
                             function_name="assumeNotNull",
                             parameters=(
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.EQ,
                                     Argument(alias=None, name="x"),
                                     Literal(alias=None, value="b"),
@@ -270,7 +250,6 @@ test_data = [
                             function_name="assumeNotNull",
                             parameters=(
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.EQ,
                                     Argument(alias=None, name="x"),
                                     Literal(alias=None, value="c"),
@@ -294,16 +273,13 @@ test_data = [
             ]
         ),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(alias=None, table_name=None, column_name="sdk_integrations"),
                 Literal(None, "b"),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(alias=None, table_name=None, column_name="sdk_integrations"),
                 Literal(None, "c"),
@@ -321,16 +297,13 @@ test_data = [
             ]
         ),
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(alias=None, table_name=None, column_name="sdk_integrations"),
                 Literal(None, "b"),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(alias=None, table_name=None, column_name="tags.key"),
                 Literal(None, "c"),
@@ -348,7 +321,6 @@ test_data = [
             ]
         ),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             FunctionCall(
                 None,
@@ -373,7 +345,6 @@ test_data = [
                 ),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -131,7 +131,6 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 "in",
                 SubscriptableReference(
                     "_snuba_tags[sentry:dist]",
@@ -143,7 +142,6 @@ test_cases = [
                 ),
             ),
             having=binary_condition(
-                None,
                 "greater",
                 Column("_snuba_times_seen", None, "times_seen"),
                 Literal(None, 1),
@@ -318,7 +316,6 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 "equals",
                 FunctionCall(
                     "_snuba_group_id",
@@ -594,7 +591,6 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -709,7 +705,6 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -796,7 +791,6 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -866,7 +860,6 @@ test_cases = [
             ],
             groupby=[Column("_snuba_tags_key", None, "tags_key")],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -43,7 +43,6 @@ def test_apdex_format_expressions() -> None:
                             "countIf",
                             (
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.LTE,
                                     Column(None, None, "column1"),
                                     Literal(None, 300),
@@ -56,16 +55,13 @@ def test_apdex_format_expressions() -> None:
                                 "countIf",
                                 (
                                     binary_condition(
-                                        None,
                                         BooleanFunctions.AND,
                                         binary_condition(
-                                            None,
                                             ConditionFunctions.GT,
                                             Column(None, None, "column1"),
                                             Literal(None, 300),
                                         ),
                                         binary_condition(
-                                            None,
                                             ConditionFunctions.LTE,
                                             Column(None, None, "column1"),
                                             multiply(

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -65,7 +65,6 @@ tags_filter_tests = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
@@ -84,7 +83,6 @@ tags_filter_tests = [
                 ),
             ],
             condition=in_condition(
-                None,
                 FunctionCall(
                     "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
                 ),
@@ -102,7 +100,6 @@ tags_filter_tests = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
@@ -110,7 +107,6 @@ tags_filter_tests = [
                 Literal(None, "tag"),
             ),
             having=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
@@ -129,13 +125,11 @@ tags_filter_tests = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 BooleanFunctions.OR,
                 FunctionCall(
                     "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
                 ),
                 in_condition(
-                    None,
                     FunctionCall(
                         "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
                     ),
@@ -143,7 +137,6 @@ tags_filter_tests = [
                 ),
             ),
             having=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
@@ -184,7 +177,6 @@ test_data = [
                 )
             ],
             condition=in_condition(
-                None,
                 arrayJoin("_snuba_tags_key", Column(None, None, "tags.key")),
                 [Literal(None, "t1"), Literal(None, "t2")],
             ),
@@ -231,7 +223,6 @@ test_data = [
                 ),
             ],
             condition=in_condition(
-                None,
                 Column("_snuba_col", None, "col"),
                 [Literal(None, "t1"), Literal(None, "t2")],
             ),
@@ -259,7 +250,6 @@ test_data = [
                 )
             ],
             condition=in_condition(
-                None,
                 arrayJoin(
                     "_snuba_tags_key",
                     filter_keys(Column(None, None, "tags.key"), [Literal(None, "t1")]),
@@ -315,7 +305,6 @@ test_data = [
                 ),
             ],
             condition=in_condition(
-                None,
                 tupleElement(
                     "_snuba_tags_key",
                     arrayJoin(

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -53,7 +53,6 @@ def test_events_boolean_context() -> None:
                     "multiIf",
                     (
                         binary_condition(
-                            None,
                             ConditionFunctions.EQ,
                             FunctionCall(
                                 None,
@@ -64,7 +63,6 @@ def test_events_boolean_context() -> None:
                         ),
                         Literal(None, ""),
                         binary_condition(
-                            None,
                             ConditionFunctions.IN,
                             FunctionCall(
                                 None,

--- a/tests/query/processors/test_custom_function.py
+++ b/tests/query/processors/test_custom_function.py
@@ -23,7 +23,6 @@ TEST_CASES = [
             ],
             groupby=[Column("column1", None, "column1")],
             condition=binary_condition(
-                None,
                 "equals",
                 FunctionCall(
                     "group_id", "f", (Column("something", None, "something"),)
@@ -39,7 +38,6 @@ TEST_CASES = [
             ],
             groupby=[Column("column1", None, "column1")],
             condition=binary_condition(
-                None,
                 "equals",
                 FunctionCall(
                     "group_id", "f", (Column("something", None, "something"),)

--- a/tests/query/processors/test_failure_rate.py
+++ b/tests/query/processors/test_failure_rate.py
@@ -39,7 +39,6 @@ def test_failure_rate_format_expressions() -> None:
                             combine_and_conditions(
                                 [
                                     binary_condition(
-                                        None,
                                         ConditionFunctions.NEQ,
                                         Column(None, None, "transaction_status"),
                                         Literal(None, code),

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -44,11 +44,9 @@ def test_handled_processor() -> None:
                             None,
                             ("x",),
                             binary_condition(
-                                None,
                                 BooleanFunctions.OR,
                                 FunctionCall(None, "isNull", (Argument(None, "x"),)),
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.EQ,
                                     FunctionCall(
                                         None, "assumeNotNull", (Argument(None, "x"),)
@@ -128,11 +126,9 @@ def test_not_handled_processor() -> None:
                             None,
                             ("x",),
                             binary_condition(
-                                None,
                                 BooleanFunctions.AND,
                                 FunctionCall(None, "isNotNull", (Argument(None, "x"),)),
                                 binary_condition(
-                                    None,
                                     ConditionFunctions.EQ,
                                     FunctionCall(
                                         None, "assumeNotNull", (Argument(None, "x"),)

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -21,7 +21,6 @@ test_data = [
         "table1",
         [
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column("deleted", None, "deleted"),
                 Literal(None, "0"),
@@ -33,13 +32,9 @@ test_data = [
         "table2",
         [
             binary_condition(
-                None,
-                ConditionFunctions.EQ,
-                Column("time", None, "time"),
-                Literal(None, "1"),
+                ConditionFunctions.EQ, Column("time", None, "time"), Literal(None, "1"),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column("time2", None, "time2"),
                 Literal(None, "2"),
@@ -65,19 +60,12 @@ def test_mand_conditions(table: str, mand_conditions: List[FunctionCall]) -> Non
         None,
         None,
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
-                OPERATOR_TO_FUNCTION["="],
-                Column("d", None, "d"),
-                Literal(None, "1"),
+                OPERATOR_TO_FUNCTION["="], Column("d", None, "d"), Literal(None, "1"),
             ),
             binary_condition(
-                None,
-                OPERATOR_TO_FUNCTION["="],
-                Column("c", None, "c"),
-                Literal(None, "3"),
+                OPERATOR_TO_FUNCTION["="], Column("c", None, "c"), Literal(None, "3"),
             ),
         ),
     )

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -50,7 +50,7 @@ def nested_condition(
     column_name: str, operator: str, key: str, val: str,
 ) -> Expression:
     return binary_condition(
-        None, operator, nested_expression(column_name, key), Literal(None, val),
+        operator, nested_expression(column_name, key), Literal(None, val),
     )
 
 
@@ -59,11 +59,11 @@ TEST_CASES = [
         build_query(
             selected_columns=[column("event_id"), nested_expression("tags", "my_tag")],
             condition=binary_condition(
-                None, ConditionFunctions.EQ, column("event_id"), Literal(None, "123123")
+                ConditionFunctions.EQ, column("event_id"), Literal(None, "123123")
             ),
         ),
         binary_condition(
-            None, ConditionFunctions.EQ, column("event_id"), Literal(None, "123123")
+            ConditionFunctions.EQ, column("event_id"), Literal(None, "123123")
         ),
         id="No tag condition",
     ),
@@ -111,7 +111,6 @@ TEST_CASES = [
         build_query(
             selected_columns=[column("event_id")],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -143,14 +142,12 @@ TEST_CASES = [
         build_query(
             selected_columns=[column("event_id")],
             condition=binary_condition(
-                None,
                 BooleanFunctions.OR,
                 nested_condition("tags", ConditionFunctions.EQ, "my_tag", "a"),
                 nested_condition("tags", ConditionFunctions.LIKE, "my_tag2", "b"),
             ),
         ),
         binary_condition(
-            None,
             BooleanFunctions.OR,
             nested_condition("tags", ConditionFunctions.EQ, "my_tag", "a"),
             nested_condition("tags", ConditionFunctions.LIKE, "my_tag2", "b"),
@@ -161,11 +158,9 @@ TEST_CASES = [
         build_query(
             selected_columns=[column("event_id")],
             condition=binary_condition(
-                None,
                 BooleanFunctions.AND,
                 nested_condition("tags", ConditionFunctions.EQ, "my_tag", "a"),
                 binary_condition(
-                    None,
                     ConditionFunctions.LIKE,
                     Column(None, None, "something_else"),
                     Literal(None, "123123"),
@@ -173,7 +168,6 @@ TEST_CASES = [
             ),
         ),
         binary_condition(
-            None,
             BooleanFunctions.AND,
             FunctionCall(
                 None,
@@ -184,7 +178,6 @@ TEST_CASES = [
                 ),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.LIKE,
                 Column(None, None, "something_else"),
                 Literal(None, "123123"),
@@ -196,7 +189,6 @@ TEST_CASES = [
         build_query(
             selected_columns=[column("event_id")],
             condition=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -207,7 +199,6 @@ TEST_CASES = [
             ),
         ),
         binary_condition(
-            None,
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -223,7 +214,6 @@ TEST_CASES = [
             selected_columns=[column("event_id")],
             condition=nested_condition("tags", ConditionFunctions.EQ, "my_tag", "a"),
             having=binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(None, "arrayjoin", (Column(None, None, "tags.key"),)),
                 Literal(None, "bla"),

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -121,7 +121,6 @@ test_data = [
             BooleanFunctions.AND,
             (
                 not_in_condition(
-                    None,
                     Column("_snuba_a", None, "a"),
                     [Literal(None, 1), Literal(None, 2), Literal(None, 3)],
                 ),

--- a/tests/query/processors/test_tags_expander.py
+++ b/tests/query/processors/test_tags_expander.py
@@ -71,14 +71,12 @@ def test_tags_expander() -> None:
     ]
 
     assert query.get_condition_from_ast() == binary_condition(
-        None,
         OPERATOR_TO_FUNCTION["="],
         FunctionCall("_snuba_tags_key", "arrayJoin", (Column(None, None, "tags.key"),)),
         Literal(None, "tags_key"),
     )
 
     assert query.get_having_from_ast() == in_condition(
-        None,
         FunctionCall(
             "_snuba_tags_value", "arrayJoin", (Column(None, None, "tags.value"),)
         ),

--- a/tests/query/processors/test_timeseries_processor.py
+++ b/tests/query/processors/test_timeseries_processor.py
@@ -24,7 +24,6 @@ tests = [
     pytest.param(
         3600,
         binary_condition(
-            None,
             ConditionFunctions.EQ,
             Column("my_time", None, "time"),
             Literal(None, "2020-01-01"),
@@ -35,7 +34,6 @@ tests = [
             (Column(None, None, "finish_ts"), Literal(None, "Universal")),
         ),
         binary_condition(
-            None,
             ConditionFunctions.EQ,
             FunctionCall(
                 "my_time",
@@ -51,16 +49,13 @@ tests = [
     pytest.param(
         60,
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column("my_time", None, "time"),
                 Literal(None, "2020-01-01"),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(None, None, "transaction"),
                 Literal(None, "something"),
@@ -72,10 +67,8 @@ tests = [
             (Column(None, None, "finish_ts"), Literal(None, "Universal")),
         ),
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 FunctionCall(
                     "my_time",
@@ -85,7 +78,6 @@ tests = [
                 Literal(None, parse_datetime("2020-01-01")),
             ),
             binary_condition(
-                None,
                 ConditionFunctions.EQ,
                 Column(None, None, "transaction"),
                 Literal(None, "something"),
@@ -208,10 +200,7 @@ def test_invalid_datetime() -> None:
             ),
         ],
         condition=binary_condition(
-            None,
-            ConditionFunctions.EQ,
-            Column("my_time", None, "time"),
-            Literal(None, ""),
+            ConditionFunctions.EQ, Column("my_time", None, "time"), Literal(None, ""),
         ),
     )
 

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -19,7 +19,6 @@ from snuba.request.request_settings import HTTPRequestSettings
 tests = [
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -33,17 +32,15 @@ tests = [
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             Column(None, None, "column1"),
             Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
         ),
-        "(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
-        id="(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+        "equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
     ),
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -57,7 +54,6 @@ tests = [
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -70,12 +66,11 @@ tests = [
             ),
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
-        "(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
-        id="(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+        "equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459')",
+        id="equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459')",
     ),
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
             FunctionCall(
@@ -89,17 +84,15 @@ tests = [
             ),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
             Column(None, None, "column1"),
         ),
-        "(equals('a7d67cf7-9677-4551-a95b-e6543cacd459', column1) AS mightaswell)",
-        id="(equals('a7d67cf7-9677-4551-a95b-e6543cacd459', column1) AS mightaswell)",
+        "equals('a7d67cf7-9677-4551-a95b-e6543cacd459', column1)",
+        id="equals('a7d67cf7-9677-4551-a95b-e6543cacd459', column1)",
     ),
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.IN,
             FunctionCall(
                 None,
@@ -120,7 +113,6 @@ tests = [
             ),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.IN,
             Column(None, None, "column1"),
             FunctionCall(
@@ -136,12 +128,11 @@ tests = [
                 ),
             ),
         ),
-        "(in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a')) AS mightaswell)",
-        id="(in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a')) AS mightaswell)",
+        "in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
+        id="in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
     ),
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -155,17 +146,15 @@ tests = [
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             Column(None, None, "column1"),
             Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
         ),
-        "(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
-        id="(equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+        "equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
     ),
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -179,7 +168,6 @@ tests = [
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -192,15 +180,13 @@ tests = [
             ),
             Literal(None, "a7d67cf796774551a95be6543cacd459"),
         ),
-        "(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
-        id="(equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459') AS mightaswell)",
+        "equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459')",
+        id="equals(replaceAll(toString(notauuid), '-', ''), 'a7d67cf796774551a95be6543cacd459')",
     ),
     pytest.param(
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                "butfirst",
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -216,7 +202,6 @@ tests = [
                 Literal(None, "a7d67cf796774551a95be6543cacd460"),
             ),
             binary_condition(
-                "mightaswell",
                 ConditionFunctions.EQ,
                 FunctionCall(
                     None,
@@ -233,27 +218,23 @@ tests = [
             ),
         ),
         binary_condition(
-            None,
             BooleanFunctions.AND,
             binary_condition(
-                "butfirst",
                 ConditionFunctions.EQ,
                 Column(None, None, "column2"),
                 Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd460"))),
             ),
             binary_condition(
-                "mightaswell",
                 ConditionFunctions.EQ,
                 Column(None, None, "column1"),
                 Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
             ),
         ),
-        "(equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AS butfirst) AND (equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
-        id="(equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AS butfirst) AND (equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459') AS mightaswell)",
+        "equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AND equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AND equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
     ),
     pytest.param(
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -267,7 +248,6 @@ tests = [
             Literal(None, "deadbeefabad"),
         ),
         binary_condition(
-            "mightaswell",
             ConditionFunctions.EQ,
             FunctionCall(
                 None,
@@ -280,8 +260,8 @@ tests = [
             ),
             Literal(None, "deadbeefabad"),
         ),
-        "(equals(replaceAll(toString(column1), '-', ''), 'deadbeefabad') AS mightaswell)",
-        id="(equals(replaceAll(toString(column1), '-', ''), 'deadbeefabad') AS mightaswell)",
+        "equals(replaceAll(toString(column1), '-', ''), 'deadbeefabad')",
+        id="equals(replaceAll(toString(column1), '-', ''), 'deadbeefabad')",
     ),
 ]
 

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -563,16 +563,13 @@ test_cases = [
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
             condition=binary_condition(
-                None,
                 "and",
                 binary_condition(
-                    None,
                     "less",
                     Column("_snuba_a", None, "a"),
                     Literal(None, """stuff' "\\" stuff"""),
                 ),
                 binary_condition(
-                    None,
                     "equals",
                     Column("_snuba_b", None, "b"),
                     Literal(None, """"💩\\" \t ''"""),

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -138,7 +138,7 @@ test_cases = [
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
             condition=binary_condition(
-                None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
+                "less", Column("_snuba_a", None, "a"), Literal(None, 3)
             ),
         ),
         id="Basic query with no spaces and no ambiguous clause content",
@@ -185,7 +185,7 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
+                "less", Column("_snuba_a", None, "a"), Literal(None, 3)
             ),
             groupby=[
                 Column("_snuba_d", None, "d"),
@@ -239,7 +239,7 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
+                "less", Column("_snuba_a", None, "a"), Literal(None, 3)
             ),
             groupby=[
                 Column("_snuba_d", None, "d"),
@@ -279,13 +279,11 @@ test_cases = [
             ],
             groupby=[Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0))],
             condition=binary_condition(
-                None,
                 "and",
                 binary_condition(
-                    None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
+                    "less", Column("_snuba_a", None, "a"), Literal(None, 3)
                 ),
                 binary_condition(
-                    None,
                     "greater",
                     Column("_snuba_timestamp", None, "timestamp"),
                     Literal(None, datetime.datetime(2020, 1, 1, 0, 0)),
@@ -532,7 +530,7 @@ test_cases = [
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
             condition=binary_condition(
-                None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
+                "less", Column("_snuba_a", None, "a"), Literal(None, 3)
             ),
         ),
         id="Basic query with new lines and no ambiguous clause content",

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -29,7 +29,7 @@ def test_expressions_from_basic_condition() -> None:
     f1 = FunctionCall(None, "f", (c,))
     c2 = Column(None, "t1", "c2")
 
-    condition = binary_condition(None, ConditionFunctions.EQ, f1, c2)
+    condition = binary_condition(ConditionFunctions.EQ, f1, c2)
     ret = list(condition)
     expected = [c, f1, c2, condition]
 
@@ -48,7 +48,7 @@ def test_aliased_expressions_from_basic_condition() -> None:
     f1 = FunctionCall("a", "f", (c,))
     c2 = Column("a2", "t1", "c2")
 
-    condition = binary_condition(None, ConditionFunctions.EQ, f1, c2)
+    condition = binary_condition(ConditionFunctions.EQ, f1, c2)
     ret = list(condition)
     expected = [c, f1, c2, condition]
 
@@ -70,11 +70,11 @@ def test_map_expressions_in_basic_condition() -> None:
             return c3
         return e
 
-    condition = binary_condition(None, ConditionFunctions.EQ, f1, c2)
+    condition = binary_condition(ConditionFunctions.EQ, f1, c2)
     condition = condition.transform(replace_col)
 
     condition_b = binary_condition(
-        None, ConditionFunctions.EQ, FunctionCall(None, "f", (c3,)), c2,
+        ConditionFunctions.EQ, FunctionCall(None, "f", (c3,)), c2,
     )
     ret = list(condition)
     expected = [c3, FunctionCall(None, "f", (c3,)), c2, condition_b]
@@ -90,35 +90,35 @@ def test_nested_simple_condition() -> None:
 
     c1 = Column(None, "t1", "c1")
     c2 = Column(None, "t1", "c2")
-    co1 = binary_condition(None, ConditionFunctions.EQ, c1, c2)
+    co1 = binary_condition(ConditionFunctions.EQ, c1, c2)
 
     c3 = Column(None, "t1", "c1")
     c4 = Column(None, "t1", "c2")
-    co2 = binary_condition(None, ConditionFunctions.EQ, c3, c4)
-    or1 = binary_condition(None, BooleanFunctions.OR, co1, co2)
+    co2 = binary_condition(ConditionFunctions.EQ, c3, c4)
+    or1 = binary_condition(BooleanFunctions.OR, co1, co2)
 
     c5 = Column(None, "t1", "c1")
     c6 = Column(None, "t1", "c2")
-    co4 = binary_condition(None, ConditionFunctions.EQ, c5, c6)
+    co4 = binary_condition(ConditionFunctions.EQ, c5, c6)
 
     c7 = Column(None, "t1", "c1")
     c8 = Column(None, "t1", "c2")
-    co5 = binary_condition(None, ConditionFunctions.EQ, c7, c8)
-    or2 = binary_condition(None, BooleanFunctions.OR, co4, co5)
-    and1 = binary_condition(None, BooleanFunctions.AND, or1, or2)
+    co5 = binary_condition(ConditionFunctions.EQ, c7, c8)
+    or2 = binary_condition(BooleanFunctions.OR, co4, co5)
+    and1 = binary_condition(BooleanFunctions.AND, or1, or2)
 
     ret = list(and1)
     expected = [c1, c2, co1, c3, c4, co2, or1, c5, c6, co4, c7, c8, co5, or2, and1]
     assert ret == expected
 
     cX = Column(None, "t1", "cX")
-    co1_b = binary_condition(None, ConditionFunctions.EQ, c1, cX)
-    co2_b = binary_condition(None, ConditionFunctions.EQ, c3, cX)
-    or1_b = binary_condition(None, BooleanFunctions.OR, co1_b, co2_b)
-    co4_b = binary_condition(None, ConditionFunctions.EQ, c5, cX)
-    co5_b = binary_condition(None, ConditionFunctions.EQ, c7, cX)
-    or2_b = binary_condition(None, BooleanFunctions.OR, co4_b, co5_b)
-    and1_b = binary_condition(None, BooleanFunctions.AND, or1_b, or2_b)
+    co1_b = binary_condition(ConditionFunctions.EQ, c1, cX)
+    co2_b = binary_condition(ConditionFunctions.EQ, c3, cX)
+    or1_b = binary_condition(BooleanFunctions.OR, co1_b, co2_b)
+    co4_b = binary_condition(ConditionFunctions.EQ, c5, cX)
+    co5_b = binary_condition(ConditionFunctions.EQ, c7, cX)
+    or2_b = binary_condition(BooleanFunctions.OR, co4_b, co5_b)
+    and1_b = binary_condition(BooleanFunctions.AND, or1_b, or2_b)
 
     def replace_col(e: Expression) -> Expression:
         if isinstance(e, Column) and e.column_name == "c2":
@@ -149,7 +149,6 @@ def test_nested_simple_condition() -> None:
 
 def test_in_condition() -> None:
     in_condition = binary_condition(
-        None,
         ConditionFunctions.IN,
         Column(None, None, "tags_key"),
         literals_tuple(None, [Literal(None, "t1"), Literal(None, "t2")]),
@@ -168,7 +167,6 @@ def test_in_condition() -> None:
 
 def test_not_in_condition() -> None:
     not_in_condition = binary_condition(
-        None,
         ConditionFunctions.NOT_IN,
         Column(None, None, "tags_key"),
         literals_tuple(None, [Literal(None, "t1"), Literal(None, "t2")]),
@@ -187,13 +185,13 @@ def test_not_in_condition() -> None:
 
 def test_is_x_condition_functions() -> None:
     eq_condition = binary_condition(
-        None, ConditionFunctions.EQ, Column(None, None, "test"), Literal(None, "1")
+        ConditionFunctions.EQ, Column(None, None, "test"), Literal(None, "1")
     )
     assert is_binary_condition(eq_condition, ConditionFunctions.EQ)
     assert not is_binary_condition(eq_condition, ConditionFunctions.NEQ)
 
     un_condition = unary_condition(
-        None, ConditionFunctions.IS_NOT_NULL, Column(None, None, "test")
+        ConditionFunctions.IS_NOT_NULL, Column(None, None, "test")
     )
     assert is_unary_condition(un_condition, ConditionFunctions.IS_NOT_NULL)
     assert not is_unary_condition(un_condition, ConditionFunctions.IS_NULL)
@@ -207,39 +205,24 @@ def test_is_x_condition_functions() -> None:
 
 def test_first_level_conditions() -> None:
     c1 = binary_condition(
-        None,
-        ConditionFunctions.EQ,
-        Column(None, "table1", "column1"),
-        Literal(None, "test"),
+        ConditionFunctions.EQ, Column(None, "table1", "column1"), Literal(None, "test"),
     )
     c2 = binary_condition(
-        None,
-        ConditionFunctions.EQ,
-        Column(None, "table2", "column2"),
-        Literal(None, "test"),
+        ConditionFunctions.EQ, Column(None, "table2", "column2"), Literal(None, "test"),
     )
     c3 = binary_condition(
-        None,
-        ConditionFunctions.EQ,
-        Column(None, "table3", "column3"),
-        Literal(None, "test"),
+        ConditionFunctions.EQ, Column(None, "table3", "column3"), Literal(None, "test"),
     )
 
     cond = binary_condition(
-        None,
-        BooleanFunctions.AND,
-        binary_condition(None, BooleanFunctions.AND, c1, c2),
-        c3,
+        BooleanFunctions.AND, binary_condition(BooleanFunctions.AND, c1, c2), c3,
     )
     assert get_first_level_and_conditions(cond) == [c1, c2, c3]
 
     cond = binary_condition(
-        None,
-        BooleanFunctions.OR,
-        binary_condition(None, BooleanFunctions.AND, c1, c2),
-        c3,
+        BooleanFunctions.OR, binary_condition(BooleanFunctions.AND, c1, c2), c3,
     )
     assert get_first_level_or_conditions(cond) == [
-        binary_condition(None, BooleanFunctions.AND, c1, c2),
+        binary_condition(BooleanFunctions.AND, c1, c2),
         c3,
     ]

--- a/tests/query/test_organization_extension.py
+++ b/tests/query/test_organization_extension.py
@@ -22,7 +22,7 @@ def test_organization_extension_query_processing_happy_path() -> None:
 
     extension.get_processor().process_query(query, valid_data, request_settings)
     assert query.get_condition_from_ast() == binary_condition(
-        None, ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 2)
+        ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 2)
     )
 
 

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -29,13 +29,9 @@ def test_iterate_over_query():
     function_1 = FunctionCall("alias", "f1", (column1, column2))
     function_2 = FunctionCall("alias", "f2", (column2,))
 
-    condition = binary_condition(
-        None, ConditionFunctions.EQ, column1, Literal(None, "1")
-    )
+    condition = binary_condition(ConditionFunctions.EQ, column1, Literal(None, "1"))
 
-    prewhere = binary_condition(
-        None, ConditionFunctions.EQ, column2, Literal(None, "2")
-    )
+    prewhere = binary_condition(ConditionFunctions.EQ, column2, Literal(None, "2"))
 
     orderby = OrderBy(OrderByDirection.ASC, function_2)
 
@@ -85,13 +81,9 @@ def test_replace_expression():
     function_1 = FunctionCall("alias", "f1", (column1, column2))
     function_2 = FunctionCall("alias", "f2", (column2,))
 
-    condition = binary_condition(
-        None, ConditionFunctions.EQ, function_1, Literal(None, "1")
-    )
+    condition = binary_condition(ConditionFunctions.EQ, function_1, Literal(None, "1"))
 
-    prewhere = binary_condition(
-        None, ConditionFunctions.EQ, function_1, Literal(None, "2")
-    )
+    prewhere = binary_condition(ConditionFunctions.EQ, function_1, Literal(None, "2"))
 
     orderby = OrderBy(OrderByDirection.ASC, function_2)
 
@@ -122,14 +114,12 @@ def test_replace_expression():
         ],
         array_join=None,
         condition=binary_condition(
-            None,
             ConditionFunctions.EQ,
             FunctionCall("alias", "tag", (Literal(None, "f1"),)),
             Literal(None, "1"),
         ),
         groupby=[FunctionCall("alias", "tag", (Literal(None, "f1"),))],
         prewhere=binary_condition(
-            None,
             ConditionFunctions.EQ,
             FunctionCall("alias", "tag", (Literal(None, "f1"),)),
             Literal(None, "2"),

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -22,16 +22,13 @@ def build_time_condition(
     time_columns: str, from_date: datetime, to_date: datetime
 ) -> Expression:
     return binary_condition(
-        None,
         BooleanFunctions.AND,
         binary_condition(
-            None,
             ConditionFunctions.GTE,
             Column(None, None, time_columns),
             Literal(None, from_date),
         ),
         binary_condition(
-            None,
             ConditionFunctions.LT,
             Column(None, None, time_columns),
             Literal(None, to_date),

--- a/tests/web/test_count_columns.py
+++ b/tests/web/test_count_columns.py
@@ -46,14 +46,12 @@ SIMPLE_QUERY = ClickhouseQuery(
     ],
     array_join=None,
     condition=binary_condition(
-        None,
         ConditionFunctions.EQ,
         FunctionCall("alias", "tag", (Column(None, None, "group_id"),)),
         Literal(None, "1"),
     ),
     groupby=[FunctionCall("alias", "tag", (Column(None, None, "message"),))],
     prewhere=binary_condition(
-        None,
         ConditionFunctions.EQ,
         FunctionCall("alias", "tag", (Column(None, None, "message"),)),
         Literal(None, "2"),


### PR DESCRIPTION
Conditions should not have an alias (basically never). So I am removing the alias parameter from all the dsl functions that build conditions.
Should we ever need an alias in a condition, we can build it with the standard FunctionCall class.