### PR TITLE
Add join/subquery support to MATCH clause

### DIFF
--- a/snuba/datasets/entity.py
+++ b/snuba/datasets/entity.py
@@ -1,25 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Mapping, NamedTuple, Optional, Sequence
+from typing import Mapping, Optional, Sequence
 
 from snuba.clickhouse.columns import ColumnSet
-from snuba.datasets.entities import EntityKey
 from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.storage import Storage, WritableStorage, WritableTableStorage
 from snuba.pipeline.query_pipeline import QueryPipelineBuilder
-from snuba.query.data_source.join import JoinClass, JoinCondition
+from snuba.query.data_source.join import JoinRelationship
 from snuba.query.extensions import QueryExtension
 from snuba.query.processors import QueryProcessor
 from snuba.query.validation import FunctionCallValidator
-
-
-class JoinRelationship(NamedTuple):
-    """
-    Represents the one way relationship between the owning Entity and another entity.
-    """
-
-    rhs_entity: EntityKey
-    keys: Sequence[JoinCondition]
-    join_class: JoinClass
 
 
 class Entity(ABC):

--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -45,7 +45,6 @@ class JoinRelationship(NamedTuple):
     """
 
     rhs_entity: EntityKey
-    join_class: JoinClass
     join_type: JoinType
     columns: Sequence[Tuple[str, str]]
 

--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -30,15 +30,6 @@ class JoinModifier(Enum):
     SEMI = "SEMI"
 
 
-class JoinClass(Enum):
-    ONE_2_ZERO_OR_ONE = "1-0/1"
-    ONE_2_ONE = "1-1"
-    ONE_2_N = "1-N"
-    N_2_ZERO_OR_ONE = "N-0/1"
-    N_2_ONE = "N-1"
-    N_2_N = "N-N"
-
-
 class JoinRelationship(NamedTuple):
     """
     Represent the join relationship between an entity and another entity.

--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -3,9 +3,19 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Generic, Mapping, NamedTuple, Optional, Sequence, TypeVar, Union
+from typing import (
+    Generic,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from snuba.clickhouse.columns import ColumnSet, QualifiedColumnSet
+from snuba.datasets.entities import EntityKey
 from snuba.query import ProcessableQuery, TSimpleDataSource
 from snuba.query.data_source import DataSource
 
@@ -27,6 +37,18 @@ class JoinClass(Enum):
     N_2_ZERO_OR_ONE = "N-0/1"
     N_2_ONE = "N-1"
     N_2_N = "N-N"
+
+
+class JoinRelationship(NamedTuple):
+    """
+    Represent the join relationship between an entity and another entity.
+    """
+
+    rhs_entity: EntityKey
+    join_class: JoinClass
+    join_type: JoinType
+    join_modifier: JoinModifier
+    columns: Sequence[Tuple[str, str]]
 
 
 @dataclass(frozen=True)

--- a/snuba/query/data_source/join.py
+++ b/snuba/query/data_source/join.py
@@ -47,7 +47,6 @@ class JoinRelationship(NamedTuple):
     rhs_entity: EntityKey
     join_class: JoinClass
     join_type: JoinType
-    join_modifier: JoinModifier
     columns: Sequence[Tuple[str, str]]
 
 

--- a/snuba/query/data_source/simple.py
+++ b/snuba/query/data_source/simple.py
@@ -31,7 +31,6 @@ class Entity(SimpleDataSource):
 
     key: EntityKey
     schema: ColumnSet
-    alias: Optional[str] = None
     sample: Optional[float] = None
 
     def get_columns(self) -> ColumnSet:

--- a/snuba/query/data_source/simple.py
+++ b/snuba/query/data_source/simple.py
@@ -31,6 +31,7 @@ class Entity(SimpleDataSource):
 
     key: EntityKey
     schema: ColumnSet
+    alias: Optional[str] = None
     sample: Optional[float] = None
 
     def get_columns(self) -> ColumnSet:

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -77,7 +77,7 @@ def parse_query(body: MutableMapping[str, Any], dataset: Dataset) -> Query:
     entity = dataset.get_default_entity()
 
     query = _parse_query_impl(body, entity)
-    # These are the post processing phases
+    # TODO: These should support composite queries.
     _validate_empty_table_names(query)
     _validate_aliases(query)
     _parse_subscriptables(query)

--- a/snuba/query/snql/joins.py
+++ b/snuba/query/snql/joins.py
@@ -48,7 +48,6 @@ class Node:
         return self.entity_data.data_source.key
 
     def push_child(self, node: Node) -> None:
-        # This happens here to ensure we use the correct alias in the columns.
         self.build_join_conditions(node)
         if not self.child:
             self.child = node
@@ -60,7 +59,6 @@ class Node:
             node.child = old_child
             return
 
-        # iterate down list and push old_child to end
         head = node.child
         while head.child is not None:
             head = head.child
@@ -89,6 +87,9 @@ class Node:
                 )
             )
 
+        # The join conditions are put into the right hand side since the left hand side
+        # can have many children, each with different join conditions. This way each child
+        # tracks how it is joined to its parent, since each child has exactly one parent.
         rhs.join_conditions = join_conditions
 
 
@@ -170,7 +171,6 @@ def build_join_clause_loop(
             right_node=rhs,
             keys=node_list.join_conditions,
             join_type=node_list.relationship.join_type,
-            join_modifier=node_list.relationship.join_modifier,
         )
 
     if node_list.child is None:

--- a/snuba/query/snql/joins.py
+++ b/snuba/query/snql/joins.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+from typing import MutableMapping, NamedTuple, Optional, Sequence, Union
+
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinRelationship,
+)
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.parser.exceptions import ParsingException
+
+
+class EntityTuple(NamedTuple):
+    alias: str
+    name: str
+    sample_rate: Optional[float] = None
+
+
+class RelationshipTuple(NamedTuple):
+    lhs: EntityTuple
+    relationship: str
+    rhs: EntityTuple
+    data: JoinRelationship
+
+
+class Leaf(object):
+    def __init__(
+        self,
+        entity: EntityKey,
+        entity_data: EntityTuple,
+        relationship: Optional[JoinRelationship] = None,
+    ) -> None:
+        self.entity = entity
+        self.entity_data = entity_data
+        self.relationship = relationship
+        self.child: Optional[Leaf] = None
+        self.join_conditions: Sequence[JoinCondition] = []
+
+    def push_leaf(self, leaf: Leaf) -> None:
+        # This happens here to ensure we use the correct alias in the columns.
+        self.build_join_conditions(leaf)
+        if not self.child:
+            self.child = leaf
+            return
+
+        old_child = self.child
+        self.child = leaf
+        if leaf.child is None:
+            leaf.child = old_child
+            return
+
+        # iterate down list and push old_child to end
+        head = leaf.child
+        while head.child is not None:
+            head = head.child
+
+        head.child = old_child
+
+    def has_child(self, entity: EntityKey) -> bool:
+        if self.entity == entity:
+            return True
+
+        if self.child:
+            return self.child.has_child(entity)
+
+        return False
+
+    def build_join_conditions(self, rhs: Leaf) -> None:
+        if rhs.relationship is None:
+            return
+
+        join_conditions = []
+        for lhs_column, rhs_column in rhs.relationship.columns:
+            join_conditions.append(
+                JoinCondition(
+                    left=JoinConditionExpression(self.entity_data.alias, lhs_column),
+                    right=JoinConditionExpression(rhs.entity_data.alias, rhs_column),
+                )
+            )
+
+        rhs.join_conditions = join_conditions
+
+
+def build_tree(relationships: Sequence[RelationshipTuple]) -> Leaf:
+    roots: MutableMapping[EntityKey, Leaf] = {}
+    leafs: MutableMapping[EntityKey, Leaf] = {}
+
+    def update_leafs(child: Optional[Leaf]) -> None:
+        while child is not None:
+            leafs[child.entity] = child
+            child = child.child
+
+    for rel in relationships:
+        lhs = Leaf(EntityKey(rel.lhs.name), rel.lhs)
+        rhs = Leaf(EntityKey(rel.rhs.name), rel.rhs, rel.data)
+        orphan = roots.get(rhs.entity)
+        if orphan:
+            if not orphan.has_child(lhs.entity):
+                # The orphan is a child of this join. Combine them.
+                if orphan.child:
+                    rhs.push_leaf(orphan.child)
+                del roots[orphan.entity]
+
+        if lhs.entity in roots:
+            roots[lhs.entity].push_leaf(rhs)
+            update_leafs(rhs)
+        else:
+            if lhs.entity in leafs:
+                leafs[lhs.entity].push_leaf(rhs)
+                update_leafs(rhs)
+            else:
+                lhs.push_leaf(rhs)
+                roots[lhs.entity] = lhs
+                update_leafs(rhs)
+
+    if len(roots) > 1:
+        raise ParsingException("invalid join: join is disconnected")
+    if len(roots) < 1:
+        raise ParsingException("invalid join: join is cyclical")
+
+    key = list(roots.keys())[0]
+    return roots[key]
+
+
+def build_join_clause_loop(
+    tree: Leaf,
+    lhs: Optional[Union[IndividualNode[QueryEntity], JoinClause[QueryEntity]]],
+) -> Union[IndividualNode[QueryEntity], JoinClause[QueryEntity]]:
+    rhs = IndividualNode(
+        tree.entity_data.alias,
+        QueryEntity(
+            tree.entity,
+            get_entity(tree.entity).get_data_model(),
+            tree.entity_data.alias,
+            tree.entity_data.sample_rate,
+        ),
+    )
+    if lhs is None:
+        lhs = rhs
+    else:
+        assert tree.relationship is not None  # mypy
+        lhs = JoinClause(
+            left_node=lhs,
+            right_node=rhs,
+            keys=tree.join_conditions,
+            join_type=tree.relationship.join_type,
+            join_modifier=tree.relationship.join_modifier,
+        )
+
+    if tree.child is None:
+        return lhs
+
+    return build_join_clause_loop(tree.child, lhs)
+
+
+def build_join_clause(
+    relationships: Sequence[RelationshipTuple],
+) -> JoinClause[QueryEntity]:
+    tree = build_tree(relationships)
+    clause = build_join_clause_loop(tree, None)
+    assert isinstance(clause, JoinClause)  # mypy
+    return clause

--- a/snuba/query/snql/joins.py
+++ b/snuba/query/snql/joins.py
@@ -27,7 +27,7 @@ class RelationshipTuple(NamedTuple):
     data: JoinRelationship
 
 
-class Leaf(object):
+class Leaf:
     def __init__(
         self,
         entity: EntityKey,

--- a/snuba/query/snql/joins.py
+++ b/snuba/query/snql/joins.py
@@ -93,6 +93,29 @@ class Node:
 
 
 def build_list(relationships: Sequence[RelationshipTuple]) -> Node:
+    """
+    Most of the complication of this algorithm is here. This takes a list of joins of the form
+    a -> b, b -> c etc. and converts it to a linked list, where the parent entity is the root node
+    and the children each keep a reference to their join parent.
+
+    Example:
+    [a -> b, b -> c] ==> a() -> b(a) -> c(b), where `b(a)` denotes entity `b` with a reference to `a` as a parent.
+
+    Since joins can be received in any order, we keep track of all the linked lists that are not connected (roots).
+    Once we find a connection between two lists, the child list is inserted into the parent list and removed
+    from the roots. Once all the joins have been added, there should be exactly one root left. New joins that are
+    children of existing roots are pushed into that roots children. We also keep a backreference of the children
+    which keeps a reference to the Node for a given entity. This is to avoid having to scan through the roots
+    every time we want to find a specific Node.
+
+    Example:
+    Input: [a -> b, c -> d, b -> c]
+    After processing the first two joins, we will have two roots: `a() -> b(a)` and `c() -> d(c)`. Once the third
+    join is processed, it will see that `c` is a child of `b`, and add it as a child: `b() -> c(b) -> d(c)`.
+    This tree will then be added to the root `a` list, and `c` will be removed from the roots, resulting in
+    one root: `a() -> b(a) -> c(b) -> d(c)`.
+    """
+
     roots: MutableMapping[EntityKey, Node] = {}
     children: MutableMapping[EntityKey, Node] = {}
 

--- a/snuba/query/snql/joins.py
+++ b/snuba/query/snql/joins.py
@@ -55,14 +55,13 @@ class Node:
 
         old_child = self.child
         self.child = node
-        if node.child is None:
+        if node.child is None:  # mypy
             node.child = old_child
             return
 
         head = node.child
         while head.child is not None:
             head = head.child
-
         head.child = old_child
 
     def has_child(self, entity: EntityKey) -> bool:

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1,5 +1,6 @@
 from typing import (
     Any,
+    Callable,
     Iterable,
     MutableMapping,
     NamedTuple,
@@ -15,12 +16,20 @@ from parsimonious.nodes import Node, NodeVisitor
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.query import (
+    LimitBy,
+    OrderBy,
+    OrderByDirection,
+    SelectedExpression,
+)
+from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,
     binary_condition,
     combine_and_conditions,
     combine_or_conditions,
 )
+from snuba.query.data_source.join import JoinClause
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import (
     Column,
@@ -36,21 +45,15 @@ from snuba.query.matchers import (
     Param,
     String as StringMatch,
 )
-from snuba.query import (
-    LimitBy,
-    OrderBy,
-    OrderByDirection,
-    SelectedExpression,
-)
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.parser import (
     _apply_column_aliases,
-    _deescape_aliases,
     _expand_aliases,
     _mangle_aliases,
     _parse_subscriptables,
     _validate_aliases,
 )
+from snuba.query.parser.exceptions import ParsingException
 from snuba.query.snql.expression_visitor import (
     HighPriArithmetic,
     HighPriOperator,
@@ -73,13 +76,18 @@ from snuba.query.snql.expression_visitor import (
     visit_parameters_list,
     visit_quoted_literal,
 )
+from snuba.query.snql.joins import (
+    EntityTuple,
+    RelationshipTuple,
+    build_join_clause,
+)
 from snuba.util import parse_datetime
 
 snql_grammar = Grammar(
     r"""
     query_exp             = match_clause select_clause group_by_clause? where_clause? having_clause? order_by_clause? limit_by_clause? limit_clause? offset_clause? granularity_clause? totals_clause? space*
 
-    match_clause          = space* "MATCH" space+ entity_match
+    match_clause          = space* "MATCH" space+ (relationships / entity_match / subquery)
     select_clause         = space+ "SELECT" space+ select_list
     group_by_clause       = space+ "BY" space+ group_list
     where_clause          = space+ "WHERE" space+ or_expression
@@ -92,6 +100,10 @@ snql_grammar = Grammar(
     totals_clause         = space+ "TOTALS" space+ boolean_literal
 
     entity_match          = open_paren entity_alias colon space* entity_name sample_clause? space* close_paren
+    relationship_link     = ~r"-\[" relationship_name ~r"\]->"
+    relationship_match    = space* entity_match space* relationship_link space* entity_match
+    relationships         = relationship_match (comma relationship_match)*
+    subquery              = open_brace query_exp close_brace
     sample_clause         = space+ "SAMPLE" space+ numeric_literal
 
     and_expression        = space* condition and_tuple*
@@ -141,6 +153,9 @@ snql_grammar = Grammar(
     function_name         = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
     entity_alias          = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
     entity_name           = ~r"[a-zA-Z_]+"
+    relationship_name     = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
+    open_brace            = "{"
+    close_brace           = "}"
     open_paren            = "("
     close_paren           = ")"
     open_square           = "["
@@ -163,12 +178,6 @@ class OrTuple(NamedTuple):
     exp: Expression
 
 
-class EntityTuple(NamedTuple):
-    alias: str
-    name: str
-    sample_rate: Optional[float]
-
-
 class SnQLVisitor(NodeVisitor):
     """
     Builds Snuba AST expressions from the Parsimonious parse tree.
@@ -176,7 +185,7 @@ class SnQLVisitor(NodeVisitor):
 
     def visit_query_exp(
         self, node: Node, visited_children: Iterable[Any]
-    ) -> LogicalQuery:
+    ) -> Union[LogicalQuery, CompositeQuery[QueryEntity]]:
         args: MutableMapping[str, Any] = {}
         (
             data_source,
@@ -198,6 +207,10 @@ class SnQLVisitor(NodeVisitor):
             if isinstance(args[k], Node):
                 del args[k]
 
+        if isinstance(data_source, (CompositeQuery, LogicalQuery, JoinClause)):
+            args["from_clause"] = data_source
+            return CompositeQuery(**args)
+
         args.update({"body": {}, "prewhere": None, "from_clause": data_source})
         if isinstance(data_source, QueryEntity):
             # TODO: How sample rate gets stored needs to be addressed in a future PR
@@ -213,11 +226,25 @@ class SnQLVisitor(NodeVisitor):
 
     def visit_match_clause(
         self, node: Node, visited_children: Tuple[Any, Any, Any, EntityTuple],
-    ) -> QueryEntity:
+    ) -> Union[
+        CompositeQuery[QueryEntity], LogicalQuery, QueryEntity, JoinClause[QueryEntity],
+    ]:
         _, _, _, match = visited_children
+        if isinstance(match, (CompositeQuery, LogicalQuery)):
+            return match
+        elif isinstance(match, RelationshipTuple):
+            join_clause = build_join_clause([match])
+            return join_clause
+        if isinstance(match, list) and all(
+            isinstance(m, RelationshipTuple) for m in match
+        ):
+            join_clause = build_join_clause(match)
+            return join_clause
+
+        assert isinstance(match, EntityTuple)
         key = EntityKey(match.name)
         query_entity = QueryEntity(
-            key, get_entity(key).get_data_model(), match.sample_rate
+            key, get_entity(key).get_data_model(), match.alias, match.sample_rate,
         )
         return query_entity
 
@@ -236,6 +263,53 @@ class SnQLVisitor(NodeVisitor):
 
     def visit_entity_name(self, node: Node, visited_children: Tuple[Any]) -> str:
         return str(node.text)
+
+    def visit_relationships(
+        self, node: Node, visited_children: Tuple[RelationshipTuple, Any],
+    ) -> Sequence[RelationshipTuple]:
+        relationships = [visited_children[0]]
+        if isinstance(visited_children[1], Node):
+            return relationships
+
+        for child in visited_children[1]:
+            if isinstance(child, RelationshipTuple):
+                relationships.append(child)
+            elif isinstance(child, list):
+                relationships.append(child[1])
+
+        return relationships
+
+    def visit_relationship_match(
+        self,
+        node: Node,
+        visited_children: Tuple[Any, EntityTuple, Any, Node, Any, EntityTuple],
+    ) -> RelationshipTuple:
+        _, lhs, _, relationship, _, rhs = visited_children
+        lhs_entity = get_entity(EntityKey(lhs.name))
+        data = lhs_entity.get_join_relationship(relationship)
+        if data is None:
+            raise ParsingException(
+                f"{lhs.name} does not have a join relationship {relationship}"
+            )
+        elif data.rhs_entity != EntityKey(rhs.name):
+            raise ParsingException(
+                f"-[{relationship}]-> cannot be used to join {lhs.name} to {rhs.name}"
+            )
+
+        return RelationshipTuple(lhs, relationship, rhs, data)
+
+    def visit_relationship_link(
+        self, node: Node, visited_children: Tuple[Any, Node, Any]
+    ) -> str:
+        _, relationship, _ = visited_children
+        return str(relationship.text)
+
+    def visit_subquery(
+        self, node: Node, visited_children: Tuple[Any, Node, Any]
+    ) -> Union[LogicalQuery, CompositeQuery[QueryEntity]]:
+        _, query, _ = visited_children
+        assert isinstance(query, (CompositeQuery, LogicalQuery))  # mypy
+        return query
 
     def visit_function_name(self, node: Node, visited_children: Iterable[Any]) -> str:
         return visit_function_name(node, visited_children)
@@ -601,7 +675,9 @@ class SnQLVisitor(NodeVisitor):
         return generic_visit(node, visited_children)
 
 
-def parse_snql_query_initial(body: str) -> LogicalQuery:
+def parse_snql_query_initial(
+    body: str,
+) -> Union[CompositeQuery[QueryEntity], LogicalQuery]:
     """
     Parses the query body generating the AST. This only takes into
     account the initial query body. Extensions are parsed by extension
@@ -609,7 +685,7 @@ def parse_snql_query_initial(body: str) -> LogicalQuery:
     """
     exp_tree = snql_grammar.parse(body)
     parsed = SnQLVisitor().visit(exp_tree)
-    assert isinstance(parsed, LogicalQuery)  # mypy
+    assert isinstance(parsed, (CompositeQuery, LogicalQuery))  # mypy
     return parsed
 
 
@@ -618,7 +694,9 @@ DATETIME_MATCH = FunctionCallMatch(
 )
 
 
-def _parse_datetime_literals(query: LogicalQuery) -> None:
+def _parse_datetime_literals(
+    query: Union[CompositeQuery[QueryEntity], LogicalQuery]
+) -> None:
     def parse(exp: Expression) -> Expression:
         result = DATETIME_MATCH.match(exp)
         if result is not None:
@@ -632,19 +710,35 @@ def _parse_datetime_literals(query: LogicalQuery) -> None:
     query.transform_expressions(parse)
 
 
-def parse_snql_query(body: str, dataset: Dataset) -> LogicalQuery:
+def _post_process(
+    query: Union[CompositeQuery[QueryEntity], LogicalQuery],
+    funcs: Sequence[Callable[[Union[CompositeQuery[QueryEntity], LogicalQuery]], None]],
+) -> None:
+    for func in funcs:
+        func(query)
+
+    if isinstance(query, CompositeQuery):
+        from_clause = query.get_from_clause()
+        if isinstance(from_clause, (LogicalQuery, CompositeQuery)):
+            _post_process(from_clause, funcs)
+
+
+def parse_snql_query(
+    body: str, dataset: Dataset
+) -> Union[CompositeQuery[QueryEntity], LogicalQuery]:
     query = parse_snql_query_initial(body)
 
     # These are the post processing phases
-    _parse_datetime_literals(query)
+    _post_process(
+        query,
+        [
+            _parse_datetime_literals,
+            _validate_aliases,
+            _parse_subscriptables,  # -> This should be part of the grammar
+            _apply_column_aliases,
+            _expand_aliases,
+            _mangle_aliases,
+        ],
+    )
 
-    # TODO: Update these functions to work with snql queries in a separate PR
-    _validate_aliases(query)  # -> needs to recurse through sub queries
-    _parse_subscriptables(query)  # -> This should be part of the grammar
-    _apply_column_aliases(query)  # -> needs to recurse through sub queries
-    _expand_aliases(query)  # -> needs to recurse through sub queries
-    _deescape_aliases(
-        query
-    )  # -> This should not be needed at all, assuming SnQL can properly accept escaped/unicode strings
-    _mangle_aliases(query)  # needs to recurse through sub queries
     return query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
 
         sample = legacy.get("sample")
         sample_clause = f"SAMPLE {sample}" if sample else ""
-        match_clause = f"MATCH ({entity[0].lower()}: {entity} {sample_clause})"
+        match_clause = f"MATCH ({entity} {sample_clause})"
 
         selected = ", ".join(map(func, legacy.get("selected_columns", [])))
         select_clause = f"SELECT {selected}" if selected else ""

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -8,27 +8,27 @@ test_cases = [
     # below are cases that are not parsed completely
     # i.e. the entire string is not consumed
     pytest.param(
-        "MATCH (e: events) SELECT 4-5,3*g(c),c BY d,2+7 WHEREa<3 ORDERBY f DESC",
+        "MATCH (events) SELECT 4-5,3*g(c),c BY d,2+7 WHEREa<3 ORDERBY f DESC",
         IncompleteParseError,
         id="ORDER BY is two words",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, 3*g(c), c BY d,2+7 WHERE a<3  ORDER BY fDESC",
+        "MATCH (events) SELECT 4-5, 3*g(c), c BY d,2+7 WHERE a<3  ORDER BY fDESC",
         IncompleteParseError,
         id="Expression before ASC / DESC needs to be separated from ASC / DESC keyword by space",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3  ORDER BY f DESC",
+        "MATCH (events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3  ORDER BY f DESC",
         IncompleteParseError,
         id="In a list, columns are separated by exactly one comma",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3ORb>2  ORDER BY f DESC",
+        "MATCH (events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3ORb>2  ORDER BY f DESC",
         IncompleteParseError,
         id="mandatory spacing",
     ),
     pytest.param(
-        "MATCH (e: Events) -[contains]-> (t: Transactions) SELECT 4-5, c",
+        "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, c",
         VisitationError,
         id="invalid relationship name",
     ),

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -1,5 +1,5 @@
 import pytest
-from parsimonious.exceptions import IncompleteParseError
+from parsimonious.exceptions import IncompleteParseError, VisitationError
 
 from snuba.datasets.factory import get_dataset
 from snuba.query.snql.parser import parse_snql_query
@@ -26,6 +26,11 @@ test_cases = [
         "MATCH (e: events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3ORb>2  ORDER BY f DESC",
         IncompleteParseError,
         id="mandatory spacing",
+    ),
+    pytest.param(
+        "MATCH (e: Events) -[contains]-> (t: Transactions) SELECT 4-5, c",
+        VisitationError,
+        id="invalid relationship name",
     ),
 ]
 

--- a/tests/query/snql/test_joins.py
+++ b/tests/query/snql/test_joins.py
@@ -1,0 +1,237 @@
+import pytest
+import uuid
+from typing import Sequence, Tuple, Union
+
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinClass,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinModifier,
+    JoinRelationship,
+    JoinType,
+)
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.snql.joins import build_join_clause, EntityTuple, RelationshipTuple
+
+###################################
+## Used to build expected result ##
+###################################
+
+
+def node(alias: str, name: str) -> IndividualNode[QueryEntity]:
+    return IndividualNode(
+        alias,
+        QueryEntity(
+            EntityKey(name), get_entity(EntityKey(name)).get_data_model(), alias
+        ),
+    )
+
+
+def join_clause(
+    lhs_alias: str, lhs: Union[str, JoinClause[QueryEntity]], rhs: str
+) -> JoinClause[QueryEntity]:
+    rhs_alias, rhs = rhs.split(":", 1)
+    return JoinClause(
+        left_node=node(lhs_alias, lhs) if isinstance(lhs, str) else lhs,
+        right_node=node(rhs_alias, rhs),
+        keys=[
+            JoinCondition(
+                left=JoinConditionExpression(lhs_alias, "event_id"),
+                right=JoinConditionExpression(rhs_alias, "event_id"),
+            )
+        ],
+        join_type=JoinType.INNER,
+        join_modifier=JoinModifier.SEMI,
+    )
+
+
+test_cases = [
+    pytest.param(
+        [("ev:events", "t:transactions")],
+        join_clause("ev", "events", "t:transactions"),
+        id="simple",
+    ),
+    pytest.param(
+        [("ev:events", "t:transactions"), ("t:transactions", "er:errors")],
+        join_clause("t", join_clause("ev", "events", "t:transactions"), "er:errors"),
+        id="depth=2",
+    ),
+    pytest.param(
+        [("t:transactions", "er:errors"), ("ev:events", "t:transactions")],
+        join_clause("t", join_clause("ev", "events", "t:transactions"), "er:errors"),
+        id="depth=2 bottom-up",
+    ),
+    pytest.param(
+        [
+            ("ev:events", "t:transactions"),
+            ("t:transactions", "er:errors"),
+            ("er:errors", "or:outcomes_raw"),
+        ],
+        join_clause(
+            "er",
+            join_clause(
+                "t", join_clause("ev", "events", "t:transactions"), "er:errors"
+            ),
+            "or:outcomes_raw",
+        ),
+        id="depth=3",
+    ),
+    pytest.param(
+        [
+            ("er:errors", "or:outcomes_raw"),
+            ("t:transactions", "er:errors"),
+            ("ev:events", "t:transactions"),
+        ],
+        join_clause(
+            "er",
+            join_clause(
+                "t", join_clause("ev", "events", "t:transactions"), "er:errors"
+            ),
+            "or:outcomes_raw",
+        ),
+        id="depth=3 bottom-up",
+    ),
+    pytest.param(
+        [
+            ("er:errors", "or:outcomes_raw"),
+            ("ev:events", "t:transactions"),
+            ("t:transactions", "er:errors"),
+        ],
+        join_clause(
+            "er",
+            join_clause(
+                "t", join_clause("ev", "events", "t:transactions"), "er:errors"
+            ),
+            "or:outcomes_raw",
+        ),
+        id="depth=3 orphan",
+    ),
+    pytest.param(
+        [("ev:events", "t:transactions"), ("ev:events", "er:errors")],
+        join_clause("ev", join_clause("ev", "events", "er:errors"), "t:transactions"),
+        id="breadth=2",
+    ),
+    pytest.param(
+        [
+            ("ev:events", "t:transactions"),
+            ("ev:events", "er:errors"),
+            ("ev:events", "or:outcomes_raw"),
+        ],
+        join_clause(
+            "ev",
+            join_clause(
+                "ev", join_clause("ev", "events", "or:outcomes_raw"), "er:errors"
+            ),
+            "t:transactions",
+        ),
+        id="breadth=3",
+    ),
+    pytest.param(
+        [
+            ("ev:events", "t:transactions"),
+            ("t:transactions", "er:errors"),
+            ("ev:events", "or:outcomes_raw"),
+            ("or:outcomes_raw", "de:discover_events"),
+        ],
+        join_clause(
+            "t",
+            join_clause(
+                "ev",
+                join_clause(
+                    "or",
+                    join_clause("ev", "events", "or:outcomes_raw"),
+                    "de:discover_events",
+                ),
+                "t:transactions",
+            ),
+            "er:errors",
+        ),
+        id="depth=2 breadth=2",
+    ),
+    pytest.param(
+        [
+            ("t:transactions", "er:errors"),
+            ("or:outcomes_raw", "de:discover_events"),
+            ("ev:events", "t:transactions"),
+            ("ev:events", "or:outcomes_raw"),
+        ],
+        join_clause(
+            "t",
+            join_clause(
+                "ev",
+                join_clause(
+                    "or",
+                    join_clause("ev", "events", "or:outcomes_raw"),
+                    "de:discover_events",
+                ),
+                "t:transactions",
+            ),
+            "er:errors",
+        ),
+        id="depth=2 breadth=2",
+    ),
+    pytest.param(
+        [
+            ("ev:events", "t:transactions"),
+            ("t:transactions", "er:errors"),
+            ("er:errors", "ev:events"),
+        ],
+        join_clause(
+            "er",
+            join_clause(
+                "t", join_clause("ev", "events", "t:transactions"), "er:errors"
+            ),
+            "ev:events",
+        ),
+        id="depth=3 cycle",
+    ),
+    pytest.param(
+        [
+            ("er:errors", "ev:events"),
+            ("t:transactions", "er:errors"),
+            ("ev:events", "t:transactions"),
+        ],
+        join_clause(
+            "ev",
+            join_clause(
+                "er", join_clause("t", "transactions", "er:errors"), "ev:events"
+            ),
+            "t:transactions",
+        ),
+        id="depth=3 cycle",
+    ),
+]
+
+
+@pytest.mark.parametrize("clauses, expected", test_cases)
+def test_joins(
+    clauses: Sequence[Tuple[str, str]], expected: JoinClause[QueryEntity]
+) -> None:
+    relationships = []
+
+    for clause in clauses:
+        lhs, rhs = clause
+        lhs_alias, lhs = lhs.split(":", 1)
+        rhs_alias, rhs = rhs.split(":", 1)
+        data = JoinRelationship(
+            rhs_entity=EntityKey(rhs),
+            join_class=JoinClass.ONE_2_ONE,
+            join_type=JoinType.INNER,
+            join_modifier=JoinModifier.SEMI,
+            columns=[("event_id", "event_id")],
+        )
+        relationships.append(
+            RelationshipTuple(
+                EntityTuple(lhs_alias, lhs),
+                uuid.uuid4().hex,
+                EntityTuple(rhs_alias, rhs),
+                data,
+            )
+        )
+
+    result = build_join_clause(relationships)
+    assert result == expected

--- a/tests/query/snql/test_joins.py
+++ b/tests/query/snql/test_joins.py
@@ -10,7 +10,6 @@ from snuba.query.data_source.join import (
     JoinClass,
     JoinCondition,
     JoinConditionExpression,
-    JoinModifier,
     JoinRelationship,
     JoinType,
 )
@@ -43,7 +42,6 @@ def join_clause(
             )
         ],
         join_type=JoinType.INNER,
-        join_modifier=JoinModifier.SEMI,
     )
 
 
@@ -219,7 +217,6 @@ def test_joins(
             rhs_entity=EntityKey(rhs),
             join_class=JoinClass.ONE_2_ONE,
             join_type=JoinType.INNER,
-            join_modifier=JoinModifier.SEMI,
             columns=[("event_id", "event_id")],
         )
         relationships.append(

--- a/tests/query/snql/test_joins.py
+++ b/tests/query/snql/test_joins.py
@@ -15,7 +15,7 @@ from snuba.query.data_source.join import (
     JoinType,
 )
 from snuba.query.data_source.simple import Entity as QueryEntity
-from snuba.query.snql.joins import build_join_clause, EntityTuple, RelationshipTuple
+from snuba.query.snql.joins import build_join_clause, RelationshipTuple
 
 ###################################
 ## Used to build expected result ##
@@ -25,9 +25,7 @@ from snuba.query.snql.joins import build_join_clause, EntityTuple, RelationshipT
 def node(alias: str, name: str) -> IndividualNode[QueryEntity]:
     return IndividualNode(
         alias,
-        QueryEntity(
-            EntityKey(name), get_entity(EntityKey(name)).get_data_model(), alias
-        ),
+        QueryEntity(EntityKey(name), get_entity(EntityKey(name)).get_data_model()),
     )
 
 
@@ -226,10 +224,7 @@ def test_joins(
         )
         relationships.append(
             RelationshipTuple(
-                EntityTuple(lhs_alias, lhs),
-                uuid.uuid4().hex,
-                EntityTuple(rhs_alias, rhs),
-                data,
+                node(lhs_alias, lhs), uuid.uuid4().hex, node(rhs_alias, rhs), data,
             )
         )
 

--- a/tests/query/snql/test_joins.py
+++ b/tests/query/snql/test_joins.py
@@ -7,7 +7,6 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.query.data_source.join import (
     IndividualNode,
     JoinClause,
-    JoinClass,
     JoinCondition,
     JoinConditionExpression,
     JoinRelationship,
@@ -215,7 +214,6 @@ def test_joins(
         rhs_alias, rhs = rhs.split(":", 1)
         data = JoinRelationship(
             rhs_entity=EntityKey(rhs),
-            join_class=JoinClass.ONE_2_ONE,
             join_type=JoinType.INNER,
             columns=[("event_id", "event_id")],
         )

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -11,7 +11,6 @@ from snuba.query.data_source.join import (
     IndividualNode,
     JoinClause,
     JoinType,
-    JoinClass,
     JoinCondition,
     JoinConditionExpression,
     JoinRelationship,
@@ -1157,7 +1156,6 @@ def test_format_expressions(query_body: str, expected_query: LogicalQuery) -> No
         entity_key, rhs_column = mapping[relationship]
         return JoinRelationship(
             rhs_entity=entity_key,
-            join_class=JoinClass.ONE_2_ONE,
             join_type=JoinType.INNER,
             columns=[("event_id", rhs_column)],
         )

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -31,11 +31,11 @@ from snuba.query.snql.parser import parse_snql_query
 
 test_cases = [
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, c GRANULARITY 60",
+        "MATCH (events) SELECT 4-5, c GRANULARITY 60",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -49,11 +49,11 @@ test_cases = [
         id="granularity on whole query",
     ),
     pytest.param(
-        "MATCH (e:events) SELECT 4-5, c TOTALS true",
+        "MATCH (events) SELECT 4-5, c TOTALS true",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -67,14 +67,11 @@ test_cases = [
         id="totals on whole query",
     ),
     pytest.param(
-        "MATCH (e: events SAMPLE 0.5) SELECT 4-5, c",
+        "MATCH (events SAMPLE 0.5) SELECT 4-5, c",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS,
-                get_entity(EntityKey.EVENTS).get_data_model(),
-                "e",
-                0.5,
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), 0.5,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -88,11 +85,11 @@ test_cases = [
         id="sample on entity",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, c LIMIT 5 BY c",
+        "MATCH (events) SELECT 4-5, c LIMIT 5 BY c",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -106,11 +103,11 @@ test_cases = [
         id="limit by column",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, c LIMIT 5 OFFSET 3",
+        "MATCH (events) SELECT 4-5, c LIMIT 5 OFFSET 3",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -125,11 +122,11 @@ test_cases = [
         id="limit and offset",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT 4-5, 3* foo(c) AS foo, c WHERE a<3",
+        "MATCH (events) SELECT 4-5, 3* foo(c) AS foo, c WHERE a<3",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -158,11 +155,11 @@ test_cases = [
         id="Basic query with no spaces and no ambiguous clause content",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT count() AS count BY tags[key], measurements[lcp.elementSize] WHERE a<3 AND measurements[lcp.elementSize] > 1",
+        "MATCH (events) SELECT count() AS count BY tags[key], measurements[lcp.elementSize] WHERE a<3 AND measurements[lcp.elementSize] > 1",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -198,13 +195,11 @@ test_cases = [
                 ),
             ],
             condition=binary_condition(
-                None,
                 "and",
                 binary_condition(
-                    None, "less", Column("_snuba_a", None, "a"), Literal(None, 3)
+                    "less", Column("_snuba_a", None, "a"), Literal(None, 3)
                 ),
                 binary_condition(
-                    None,
                     "greater",
                     SubscriptableReference(
                         "_snuba_measurements[lcp.elementSize]",
@@ -218,11 +213,11 @@ test_cases = [
         id="Basic query with subscriptables",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT (2*(4-5)+3), g(c) AS goo, c BY d, 2+7 WHERE a<3  ORDER BY f DESC",
+        "MATCH (events) SELECT (2*(4-5)+3), g(c) AS goo, c BY d, 2+7 WHERE a<3  ORDER BY f DESC",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -270,11 +265,11 @@ test_cases = [
         id="Simple complete query with example of parenthesized arithmetic expression in SELECT",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT (2*(4-5)+3), foo(c) AS thing2, c BY d, 2+7 WHERE a<3 ORDER BY f DESC",
+        "MATCH (events) SELECT (2*(4-5)+3), foo(c) AS thing2, c BY d, 2+7 WHERE a<3 ORDER BY f DESC",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -324,11 +319,11 @@ test_cases = [
         id="Simple complete query with aliased function in SELECT",
     ),
     pytest.param(
-        "MATCH (e:events) SELECT toDateTime('2020-01-01') AS now, 3*foo(c) AS foo BY toDateTime('2020-01-01') AS now WHERE a<3 AND timestamp>toDateTime('2020-01-01')",
+        "MATCH (events) SELECT toDateTime('2020-01-01') AS now, 3*foo(c) AS foo BY toDateTime('2020-01-01') AS now WHERE a<3 AND timestamp>toDateTime('2020-01-01')",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -367,11 +362,11 @@ test_cases = [
         id="Basic query with date literals",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT a WHERE time_seen<3 AND last_seen=2 AND c=2 AND d=3",
+        "MATCH (events) SELECT a WHERE time_seen<3 AND last_seen=2 AND c=2 AND d=3",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[SelectedExpression("a", Column("_snuba_a", None, "a"))],
             condition=FunctionCall(
@@ -428,11 +423,11 @@ test_cases = [
         id="Query with multiple conditions joined by AND",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT a WHERE (time_seen<3 OR last_seen=afternoon) OR name=bob",
+        "MATCH (events) SELECT a WHERE (time_seen<3 OR last_seen=afternoon) OR name=bob",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[SelectedExpression("a", Column("_snuba_a", None, "a"))],
             condition=FunctionCall(
@@ -475,11 +470,11 @@ test_cases = [
         id="Query with multiple conditions joined by OR / parenthesized OR",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT a WHERE name!=bob OR last_seen<afternoon AND (location=gps(x,y,z) OR times_seen>0)",
+        "MATCH (events) SELECT a WHERE name!=bob OR last_seen<afternoon AND (location=gps(x,y,z) OR times_seen>0)",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[SelectedExpression("a", Column("_snuba_a", None, "a"),)],
             condition=FunctionCall(
@@ -546,11 +541,11 @@ test_cases = [
         id="Query with multiple / complex conditions joined by parenthesized / regular AND / OR",
     ),
     pytest.param(
-        "MATCH (e: events) SELECT a, b[c] WHERE project_id IN tuple( 2 , 3)",
+        "MATCH (events) SELECT a, b[c] WHERE project_id IN tuple( 2 , 3)",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression("a", Column("_snuba_a", None, "a")),
@@ -575,13 +570,13 @@ test_cases = [
         id="Query with IN condition",
     ),
     pytest.param(
-        """MATCH (e:events)
+        """MATCH (events)
         SELECT 4-5,3*foo(c) AS foo,c
         WHERE a<3""",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(
@@ -610,15 +605,13 @@ test_cases = [
         id="Basic query with new lines and no ambiguous clause content",
     ),
     pytest.param(
-        "MATCH (e: events) -[contains]-> (t: Transactions) SELECT 4-5, c",
+        "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, c",
         CompositeQuery(
             from_clause=JoinClause(
                 left_node=IndividualNode(
                     "e",
                     QueryEntity(
-                        EntityKey.EVENTS,
-                        get_entity(EntityKey.EVENTS).get_data_model(),
-                        "e",
+                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                 ),
                 right_node=IndividualNode(
@@ -626,7 +619,6 @@ test_cases = [
                     QueryEntity(
                         EntityKey.TRANSACTIONS,
                         get_entity(EntityKey.TRANSACTIONS).get_data_model(),
-                        "t",
                     ),
                 ),
                 keys=[
@@ -649,15 +641,13 @@ test_cases = [
         id="Basic join match",
     ),
     pytest.param(
-        "MATCH (e: Events) -[contains]-> (t: Transactions SAMPLE 0.5) SELECT 4-5, c",
+        "MATCH (e: events) -[contains]-> (t: transactions SAMPLE 0.5) SELECT 4-5, c",
         CompositeQuery(
             from_clause=JoinClause(
                 left_node=IndividualNode(
                     "e",
                     QueryEntity(
-                        EntityKey.EVENTS,
-                        get_entity(EntityKey.EVENTS).get_data_model(),
-                        "e",
+                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                 ),
                 right_node=IndividualNode(
@@ -665,7 +655,6 @@ test_cases = [
                     QueryEntity(
                         EntityKey.TRANSACTIONS,
                         get_entity(EntityKey.TRANSACTIONS).get_data_model(),
-                        "t",
                         0.5,
                     ),
                 ),
@@ -690,8 +679,8 @@ test_cases = [
     ),
     pytest.param(
         """MATCH
-            (e: events) -[contains]-> (t: Transactions),
-            (e: events) -[assigned]-> (ga: GroupAssignee)
+            (e: events) -[contains]-> (t: transactions),
+            (e: events) -[assigned]-> (ga: groupassignee)
         SELECT 4-5, c""",
         CompositeQuery(
             from_clause=JoinClause(
@@ -701,7 +690,6 @@ test_cases = [
                         QueryEntity(
                             EntityKey.EVENTS,
                             get_entity(EntityKey.EVENTS).get_data_model(),
-                            "e",
                         ),
                     ),
                     right_node=IndividualNode(
@@ -709,7 +697,6 @@ test_cases = [
                         QueryEntity(
                             EntityKey.GROUPASSIGNEE,
                             get_entity(EntityKey.GROUPASSIGNEE).get_data_model(),
-                            "ga",
                         ),
                     ),
                     keys=[
@@ -726,7 +713,6 @@ test_cases = [
                     QueryEntity(
                         EntityKey.TRANSACTIONS,
                         get_entity(EntityKey.TRANSACTIONS).get_data_model(),
-                        "t",
                     ),
                 ),
                 keys=[
@@ -750,10 +736,10 @@ test_cases = [
     ),
     pytest.param(
         """MATCH
-            (e: events) -[contains]-> (t: Transactions),
-            (e: events) -[assigned]-> (ga: GroupAssignee),
-            (e: events) -[bookmark]-> (gm: GroupedMessage),
-            (e: events) -[activity]-> (se: Sessions)
+            (e: events) -[contains]-> (t: transactions),
+            (e: events) -[assigned]-> (ga: groupassignee),
+            (e: events) -[bookmark]-> (gm: groupedmessage),
+            (e: events) -[activity]-> (se: sessions)
         SELECT 4-5, c""",
         CompositeQuery(
             from_clause=JoinClause(
@@ -765,7 +751,6 @@ test_cases = [
                                 QueryEntity(
                                     EntityKey.EVENTS,
                                     get_entity(EntityKey.EVENTS).get_data_model(),
-                                    "e",
                                 ),
                             ),
                             right_node=IndividualNode(
@@ -773,7 +758,6 @@ test_cases = [
                                 QueryEntity(
                                     EntityKey.SESSIONS,
                                     get_entity(EntityKey.SESSIONS).get_data_model(),
-                                    "se",
                                 ),
                             ),
                             keys=[
@@ -790,7 +774,6 @@ test_cases = [
                             QueryEntity(
                                 EntityKey.GROUPEDMESSAGES,
                                 get_entity(EntityKey.GROUPEDMESSAGES).get_data_model(),
-                                "gm",
                             ),
                         ),
                         keys=[
@@ -807,7 +790,6 @@ test_cases = [
                         QueryEntity(
                             EntityKey.GROUPASSIGNEE,
                             get_entity(EntityKey.GROUPASSIGNEE).get_data_model(),
-                            "ga",
                         ),
                     ),
                     keys=[
@@ -824,7 +806,6 @@ test_cases = [
                     QueryEntity(
                         EntityKey.TRANSACTIONS,
                         get_entity(EntityKey.TRANSACTIONS).get_data_model(),
-                        "t",
                     ),
                 ),
                 keys=[
@@ -847,14 +828,12 @@ test_cases = [
         id="Multi multi join match",
     ),
     pytest.param(
-        "MATCH { MATCH (e: events) SELECT count() AS count BY title } SELECT max(count) AS max_count",
+        "MATCH { MATCH (events) SELECT count() AS count BY title } SELECT max(count) AS max_count",
         CompositeQuery(
             from_clause=LogicalQuery(
                 {},
                 QueryEntity(
-                    EntityKey.EVENTS,
-                    get_entity(EntityKey.EVENTS).get_data_model(),
-                    "e",
+                    EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
                 ),
                 selected_columns=[
                     SelectedExpression(
@@ -878,15 +857,13 @@ test_cases = [
         id="sub query match",
     ),
     pytest.param(
-        "MATCH { MATCH { MATCH (e: events) SELECT count() AS count BY title } SELECT max(count) AS max_count } SELECT min(count) AS min_count",
+        "MATCH { MATCH { MATCH (events) SELECT count() AS count BY title } SELECT max(count) AS max_count } SELECT min(count) AS min_count",
         CompositeQuery(
             from_clause=CompositeQuery(
                 from_clause=LogicalQuery(
                     {},
                     QueryEntity(
-                        EntityKey.EVENTS,
-                        get_entity(EntityKey.EVENTS).get_data_model(),
-                        "e",
+                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                     selected_columns=[
                         SelectedExpression(
@@ -923,11 +900,11 @@ test_cases = [
         id="sub query of sub query match",
     ),
     pytest.param(
-        """MATCH (e:events) SELECT 4-5,3*foo(c) AS foo,c WHERE a<'stuff\\' "\\" stuff' AND b='"💩\\" \t \\'\\''""",
+        """MATCH (events) SELECT 4-5,3*foo(c) AS foo,c WHERE a<'stuff\\' "\\" stuff' AND b='"💩\\" \t \\'\\''""",
         LogicalQuery(
             {},
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), "e",
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
                 SelectedExpression(

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -14,7 +14,6 @@ from snuba.query.data_source.join import (
     JoinClass,
     JoinCondition,
     JoinConditionExpression,
-    JoinModifier,
     JoinRelationship,
 )
 from snuba.query.expressions import (
@@ -631,7 +630,7 @@ test_cases = [
         id="Basic query with new lines and no ambiguous clause content",
     ),
     pytest.param(
-        """MATCH (e:events)
+        """MATCH (events)
         SELECT 4-5,3*foo(c) AS foo,c
         WHERE or(equals(arrayExists(a, '=', 'RuntimeException'), 1), equals(arrayAll(b, 'NOT IN', tuple('Stack', 'Arithmetic')), 1)) = 1""",
         LogicalQuery(
@@ -760,7 +759,6 @@ test_cases = [
                     )
                 ],
                 join_type=JoinType.INNER,
-                join_modifier=JoinModifier.SEMI,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -797,7 +795,6 @@ test_cases = [
                     )
                 ],
                 join_type=JoinType.INNER,
-                join_modifier=JoinModifier.SEMI,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -838,7 +835,6 @@ test_cases = [
                         )
                     ],
                     join_type=JoinType.INNER,
-                    join_modifier=JoinModifier.SEMI,
                 ),
                 right_node=IndividualNode(
                     "t",
@@ -854,7 +850,6 @@ test_cases = [
                     )
                 ],
                 join_type=JoinType.INNER,
-                join_modifier=JoinModifier.SEMI,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -899,7 +894,6 @@ test_cases = [
                                 )
                             ],
                             join_type=JoinType.INNER,
-                            join_modifier=JoinModifier.SEMI,
                         ),
                         right_node=IndividualNode(
                             "gm",
@@ -915,7 +909,6 @@ test_cases = [
                             )
                         ],
                         join_type=JoinType.INNER,
-                        join_modifier=JoinModifier.SEMI,
                     ),
                     right_node=IndividualNode(
                         "ga",
@@ -931,7 +924,6 @@ test_cases = [
                         )
                     ],
                     join_type=JoinType.INNER,
-                    join_modifier=JoinModifier.SEMI,
                 ),
                 right_node=IndividualNode(
                     "t",
@@ -947,7 +939,6 @@ test_cases = [
                     )
                 ],
                 join_type=JoinType.INNER,
-                join_modifier=JoinModifier.SEMI,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -1075,7 +1066,7 @@ test_cases = [
         id="Basic query with crazy characters and escaping",
     ),
     pytest.param(
-        """MATCH (d: discover_events )
+        """MATCH (discover_events )
         SELECT count() AS count BY tags_key
         WHERE or(equals(ifNull(tags[foo],''),'baz'),equals(ifNull(tags[foo.bar],''),'qux'))=1
         ORDER BY count DESC,tags_key ASC  LIMIT 10""",
@@ -1168,7 +1159,6 @@ def test_format_expressions(query_body: str, expected_query: LogicalQuery) -> No
             rhs_entity=entity_key,
             join_class=JoinClass.ONE_2_ONE,
             join_type=JoinType.INNER,
-            join_modifier=JoinModifier.SEMI,
             columns=[("event_id", rhs_column)],
         )
 


### PR DESCRIPTION
Add support for join clauses in the MATCH clause, as well as support for sub
queries in the match clause. This required writing a complicated linked list
algorithm for the join clause, to ensure the joins were possible and to order
them correctly for clickhouse. It also required changing the post process query
functions to support composite and logical queries.

I know it seems like a big PR but it's 60% tests. Also I may refuse to make changes 
if I can't preserve the exact addition/deletion counts of this PR.