### PR TITLE
feat(settings): Respect SENTRY_EVENT_RETENTION_DAYS when using docker

### DIFF
--- a/snuba/settings_docker.py
+++ b/snuba/settings_docker.py
@@ -4,6 +4,8 @@ env = os.environ.get
 
 DEBUG = env("DEBUG", "0").lower() in ("1", "true")
 
+DEFAULT_RETENTION_DAYS = env("SENTRY_EVENT_RETENTION_DAYS", 90)
+
 REDIS_HOST = env("REDIS_HOST", "localhost")
 REDIS_PORT = int(env("REDIS_PORT", 6379))
 REDIS_PASSWORD = env("REDIS_PASSWORD")


### PR DESCRIPTION
Follow up to getsentry/onpremise#754
