### PR TITLE
fix(discover): The 'user' column should not be low cardinality

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -132,6 +132,7 @@ class DiscoverLoader(DirectoryLoader):
         return [
             "0001_discover_merge_table",
             "0002_discover_add_deleted_tags_hash_map",
+            "0003_discover_fix_user_column",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/discover/0003_discover_fix_user_column.py
+++ b/snuba/migrations/snuba_migrations/discover/0003_discover_fix_user_column.py
@@ -1,0 +1,45 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.MultiStepMigration):
+    """
+    The user column should not be low cardinality - it's not in the underlying errors
+    or transactions tables.
+    """
+
+    blocking = False
+
+    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column=Column("user", String(),),
+            )
+        ]
+
+    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column=Column("user", String(Modifiers(low_cardinality=True))),
+            )
+        ]
+
+    def forwards_local(self) -> Sequence[operations.Operation]:
+        return self.__forward_migrations("discover_local")
+
+    def backwards_local(self) -> Sequence[operations.Operation]:
+        return self.__backwards_migrations("discover_local")
+
+    def forwards_dist(self) -> Sequence[operations.Operation]:
+        return self.__forward_migrations("discover_dist")
+
+    def backwards_dist(self) -> Sequence[operations.Operation]:
+        return self.__backwards_migrations("discover_dist")


### PR DESCRIPTION
This fixes an error in the original Discover table definition - the
"user" column should be a regular string (not low cardinality string) -
in order to match the type of the column in the underlying errors and
transactions tables.