### PR TITLE
ci(release): Use action-prepare-release and rework dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,57 +13,40 @@ on:
         description: Do not actually cut the release
         required: false
         default: false
-  schedule:
-    # We want the release to be at 9-10am Pacific Time
-    # We also want it to be 1 hour before the on-prem release
-    - cron:  '0 17 15 * *'
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+schedule:
+  # We want the release to be at 9-10am Pacific Time
+  # We also want it to be 1 hour before the on-prem release
+  - cron: '0 17 15 * *'
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: "Release a new version"
+    name: 'Release a new version'
     steps:
-        - id: killswitch
-          if: ${{ !github.event.inputs.force }}
-          run: |
-            if curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/issues?state=open&labels=release-blocker" | grep -Pzvo '\[[\s\n\r]*\]'; then
-              echo "Open release-blocking issues found, cancelling release...";
-              curl -sf -X POST -H 'Accept: application/vnd.github.v3+json' -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/$GITHUB_REPOSITORY/actions/runs/${{ github.run_id }}/cancel;
-            fi
-        - id: set-version
-          run: |
-            if [[ -n '${{ github.event.inputs.version }}' ]]; then
-              echo 'RELEASE_VERSION=${{ github.event.inputs.version }}' >> $GITHUB_ENV;
-            else
-              DATE_PART=$(date +'%y.%-m')
-              declare -i PATCH_VERSION=0
-              while curl -sf -o /dev/null "https://api.github.com/repos/$GITHUB_REPOSITORY/git/ref/tags/$DATE_PART.$PATCH_VERSION"; do
-                PATCH_VERSION+=1
-              done
-              echo "RELEASE_VERSION=${DATE_PART}.${PATCH_VERSION}" >> $GITHUB_ENV;
-            fi
-        - uses: actions/checkout@v2
-          with:
-            token: ${{ secrets.GH_SENTRY_BOT_PAT }}
-        - id: set-git-user
-          run: |
-            git config user.name getsentry-bot
-            git config user.email bot@getsentry.com
-        - uses: getsentry/craft@master
-          if: ${{ !github.event.inputs.skip_prepare }}
-          with:
-            action: prepare
-            version: ${{ env.RELEASE_VERSION }}
-          env:
-            DRY_RUN: ${{ github.event.inputs.dry_run }}
-        # Wait until the builds start. Craft should do this automatically
-        # but it is broken now.
-        - run: sleep 10
-        - uses: getsentry/craft@master
-          with:
-            action: publish
-            version: ${{ env.RELEASE_VERSION }}
-          env:
-            DRY_RUN: ${{ github.event.inputs.dry_run }}
-            GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
-            DOCKER_USERNAME: 'sentrybuilder'
-            DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@main
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_SENTRY_BOT_PAT }}
+      - uses: getsentry/craft@master
+        if: ${{ !github.event.inputs.skip_prepare }}
+        with:
+          action: prepare
+          version: ${{ env.RELEASE_VERSION }}
+      # Wait until the builds start. Craft should do this automatically
+      # but it is broken now.
+      - run: sleep 10
+      - uses: getsentry/craft@master
+        with:
+          action: publish
+          version: ${{ env.RELEASE_VERSION }}
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          GITHUB_API_TOKEN: ${{ secrets.GH_SENTRY_BOT_PAT }}
+          DOCKER_USERNAME: 'sentrybuilder'
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
-schedule:
-  # We want the release to be at 9-10am Pacific Time
-  # We also want it to be 1 hour before the on-prem release
-  - cron: '0 17 15 * *'
+  schedule:
+    # We want the release to be at 9-10am Pacific Time
+    # We also want it to be 1 hour before the on-prem release
+    - cron: '0 17 15 * *'
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switches to using getsentry/action-prepare-release for common steps and removes the dry run option from the prepare stage as it prevents us from testing the publish step. Prepare step should be safe anyways and can be skipped with the `skip-prepare` input.

Related: https://app.asana.com/0/1198192131329257/1198192131329301, https://app.asana.com/0/1198192131329257/1198192573081717
