### PR TITLE
fix(discover) Use identity function as a marker for NULLed columns

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -82,14 +82,14 @@ class DefaultNoneColumnMapper(ColumnMapper):
 
     def attempt_map(
         self, expression: Column, children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[Literal]:
+    ) -> Optional[FunctionCall]:
         if expression.column_name in self.columns:
-            return Literal(
-                alias=expression.alias
+            return identity(
+                Literal(None, None),
+                expression.alias
                 or qualified_column(
                     expression.column_name, expression.table_name or ""
                 ),
-                value=None,
             )
         else:
             return None
@@ -135,13 +135,11 @@ class DefaultIfNullFunctionMapper(FunctionCallMapper):
     ) -> Optional[FunctionCall]:
         parameters = tuple(p.accept(children_translator) for p in expression.parameters)
         for param in parameters:
-            # Handle wrapped functions that have been converted already
+            # All impossible columns will have been converted to the identity function.
+            # So we know that if a function has the identity function as a parameter, we can
+            # collapse the entire expression.
             fmatch = self.function_match.match(param)
-            if fmatch is not None or (
-                isinstance(param, Literal) and param.alias != "" and param.value is None
-            ):
-                # Currently function mappers require returning other functions. So return this
-                # to keep the mapper happy.
+            if fmatch is not None:
                 return identity(Literal(None, None), expression.alias)
 
         return None
@@ -164,13 +162,12 @@ class DefaultIfNullCurriedFunctionMapper(CurriedFunctionCallMapper):
         internal_function = expression.internal_function.accept(children_translator)
         assert isinstance(internal_function, FunctionCall)  # mypy
         parameters = tuple(p.accept(children_translator) for p in expression.parameters)
-
         for param in parameters:
-            # Handle wrapped functions that have been converted already
+            # All impossible columns that have been converted to NULL will be the identity function.
+            # So we know that if a function has the identity function as a parameter, we can
+            # collapse the entire expression.
             fmatch = self.function_match.match(param)
-            if fmatch is not None or (
-                isinstance(param, Literal) and param.alias != "" and param.value is None
-            ):
+            if fmatch is not None:
                 return CurriedFunctionCall(
                     alias=expression.alias,
                     internal_function=FunctionCall(
@@ -199,9 +196,9 @@ class DefaultNoneSubscriptMapper(SubscriptableReferenceMapper):
         self,
         expression: SubscriptableReference,
         children_translator: SnubaClickhouseStrictTranslator,
-    ) -> Optional[Literal]:
+    ) -> Optional[FunctionCall]:
         if expression.column.column_name in self.subscript_names:
-            return Literal(alias=expression.alias, value=None)
+            return identity(Literal(None, None), expression.alias)
         else:
             return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,9 +76,14 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
 
         def func(value: Union[str, List[Any]]) -> str:
             if not isinstance(value, list):
-                return f"{value}"
+                return f"{value}" if value is not None else "NULL"
 
-            children = ",".join(map(func, value[1]))
+            children = ""
+            if isinstance(value[1], list):
+                children = ",".join(map(func, value[1]))
+            elif value[1]:
+                children = func(value[1])
+
             alias = f" AS {value[2]}" if len(value) > 2 else ""
             return f"{value[0]}({children}){alias}"
 
@@ -116,15 +121,8 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
             if a[0].endswith(")") and not a[1]:
                 aggregations.append(f"{a[0]} AS {a[2]}")
             else:
-                func_name = a[0]
-                params: List[str] = []
-                if isinstance(a[1], list):
-                    for p in a[1]:
-                        params.append(p)
-                elif isinstance(a[1], str) and a[1] != "":
-                    params.append(a[1])
-                params_str = ", ".join(params)
-                aggregations.append(f"{func_name}({params_str}) AS {a[2]}")
+                agg = func(a)
+                aggregations.append(agg)
 
         aggregations_str = ", ".join(aggregations)
         joined = ", " if select_clause else "SELECT "

--- a/tests/datasets/test_transaction_translations.py
+++ b/tests/datasets/test_transaction_translations.py
@@ -22,7 +22,7 @@ test_data = [
     ),
     pytest.param(
         Column(None, None, "primary_hash"),
-        Literal("primary_hash", None),
+        identity(Literal(None, None), "primary_hash"),
         id="basic event translation",
     ),
     pytest.param(


### PR DESCRIPTION
The test is a little overcomplicated since I took it from a production query, but the issue here is that if a user sends a query with an actual None in it (in the test case it's a parameter of the `if` function) we will incorrectly translate the entire expression to NULL, even if the columns in the expression match the table selected.

When we translate a column to NULL because it's not available in the chosen table, translate it to the identity function. Then, the function translators can look for the identity function to determine whether they should also be translated to NULL.