### PR TITLE
meta: Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,6 @@
+# Use owners-snuba by default
+* @getsentry/owners-snuba
+
 # Legal
 /LICENSE  @getsentry/owners-legal
 
@@ -8,6 +11,3 @@
 /docker-compose.yml             @getsentry/releases
 /docker_entrypoint.sh           @getsentry/releases
 /cloudbuild.yaml                @getsentry/releases
-
-# Everything else
-* @getsentry/owners-snuba


### PR DESCRIPTION
Based on https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file, the order matters and **the last line that matches** takes precedense. That makes all definitions above the `*` catch-all definition useless. This PR fixes that.
