### PR TITLE
build: Add VERSION and related bump scripts

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,4 +4,10 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $SCRIPT_DIR/..
 
+OLD_VERSION="$1"
+NEW_VERSION="$2"
+
+sed -i -e "s/^VERSION = "'".*"'"\$/VERSION = "'"'"$NEW_VERSION"'"'"/" setup.py
 sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
+
+echo "New version: $NEW_VERSION"

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+git checkout master
+./scripts/bump-version.sh '' $(date -d "$(echo $RELEASE_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
+git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull --rebase && git push

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 from setuptools import setup, find_packages
 
 
+VERSION = "21.1.0.dev0"
+
+
 def get_requirements():
     with open(u"requirements.txt") as fp:
         return [x.strip() for x in fp.read().split("\n") if not x.startswith("#")]


### PR DESCRIPTION
Today we needed to release a patch release right after a CalVer release. Since there is no hard-coded version in Snuba anywhere, Craft got confused when it ran the pre-release script as it did not change anything (it only updates the license date which limits this to 1 release per day). I think it is good practice to hard-code the version in at least `setup.py` even if it is not referenced by anything yet. This also resolves our problem with releases.
