### PR TITLE
fix(discover) Literal caching is not typed

### DIFF
--- a/snuba/clickhouse/translators/snuba/mapping.py
+++ b/snuba/clickhouse/translators/snuba/mapping.py
@@ -121,11 +121,11 @@ class SnubaClickhouseMappingTranslator(SnubaClickhouseStrictTranslator):
         self.__cache: MutableMapping[Expression, Expression] = {}
 
     def visit_literal(self, exp: Literal) -> Expression:
-        if exp in self.__cache:
-            return self.__cache[exp]
-
+        # We can't use the cache for literals because Python hashes
+        # Literal(None, 0) and Literal(None, 0.0) equivalently, which can then
+        # break Clickhouse since it expects the correct type. This isn't a major
+        # performance hit though since Literals can't contain other expressions.
         ret = apply_mappers(exp, self.__translation_rules.literals, self)
-        self.__cache[exp] = ret
         return ret
 
     def visit_column(self, exp: Column) -> Expression:

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -119,7 +119,7 @@ snql_grammar = Grammar(
 
     condition             = main_condition / parenthesized_cdn
     main_condition        = low_pri_arithmetic space* condition_op space* (function_call / column_name / quoted_literal / numeric_literal)
-    condition_op          = "!=" / ">=" / ">" / "<=" / "<" / "=" / "IN" / "LIKE"
+    condition_op          = "!=" / ">=" / ">" / "<=" / "<" / "=" / "NOT IN" / "NOT LIKE" / "IN" / "LIKE"
     parenthesized_cdn     = space* open_paren or_expression close_paren
 
     select_list          = select_columns* (selected_expression)
@@ -457,9 +457,9 @@ class SnQLVisitor(NodeVisitor):
         return conditions
 
     def visit_having_clause(
-        self, node: Node, visited_children: Tuple[Any, Any, Expression]
+        self, node: Node, visited_children: Tuple[Any, Any, Any, Expression]
     ) -> Expression:
-        _, _, conditions = visited_children
+        _, _, _, conditions = visited_children
         return conditions
 
     def visit_and_expression(

--- a/tests/datasets/test_transaction_translations.py
+++ b/tests/datasets/test_transaction_translations.py
@@ -220,6 +220,25 @@ test_data = [
         ),
         id="curried function call",
     ),
+    pytest.param(
+        FunctionCall(
+            None,
+            "plus",
+            (
+                Literal(None, 0),
+                FunctionCall(None, "multiply", (Literal(None, 0.0), Literal(None, 0),)),
+            ),
+        ),
+        FunctionCall(
+            None,
+            "plus",
+            (
+                Literal(None, 0),
+                FunctionCall(None, "multiply", (Literal(None, 0.0), Literal(None, 0),)),
+            ),
+        ),
+        id="literals aren't cached",
+    ),
 ]
 
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1147,3 +1147,36 @@ class TestDiscoverApi(BaseApiTest):
             ]
             == 1.0
         )
+
+    def test_zero_literal_caching(self) -> None:
+        response = self.app.post(
+            self.endpoint,
+            "discover_transactions",
+            data=json.dumps(
+                {
+                    "selected_columns": [],
+                    "having": [["count_unique_user", ">", 0.0]],
+                    "limit": 51,
+                    "offset": 0,
+                    "project": [self.project_id],
+                    "dataset": "discover",
+                    "groupby": [],
+                    "conditions": [
+                        ["type", "=", "transaction"],
+                        ["project_id", "IN", [self.project_id]],
+                    ],
+                    "aggregations": [
+                        [
+                            "countIf",
+                            [["greaterOrEquals", ["duration", 0.0]]],
+                            "count_at_least_transaction_duration_0",
+                        ],
+                        ["uniq", "user", "count_unique_user"],
+                    ],
+                    "consistent": False,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200, response.data
+        assert len(data["data"]) == 0, data


### PR DESCRIPTION
This actually fixes two bugs. The first is that we were incorrectly caching
Literals with equal int and float values as the same thing. This would break
the subsequent Clickhouse query since the typing wouldn't match.

The second is that the SnQL parser was not correctly handling the HAVING clause.