### PR TITLE
feat: Tweak Sentry logging for Discover

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -454,17 +454,16 @@ class DiscoverEntity(Entity):
                         break
 
                     # Avoid sending too much data to Sentry - just one row for now
-                    logger.warning(
-                        "Non matching Discover result - different result",
-                        extra={
-                            "discover_result": result_data[0]
-                            if len(result_data)
-                            else None,
-                            "events_result": primary_result_data[0]
-                            if len(primary_result_data)
-                            else None,
-                        },
-                    )
+                    for idx in range(len(result_data)):
+                        if result_data[idx] != primary_result_data[idx]:
+                            logger.warning(
+                                "Non matching Discover result - different result",
+                                extra={
+                                    "discover_result": result_data[idx],
+                                    "events_result": primary_result_data[idx],
+                                },
+                            )
+                            break
 
         super().__init__(
             storages=[events_storage, discover_storage],


### PR DESCRIPTION
This is a small tweak to the temporary Discover logging. We now send the
data for the row that is actually different to Sentry instead of just
the first one.