### PR TITLE
feat(consumer): Add support for writing to multiple storages from single consumer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ blinker==1.4
 black==19.10b0
 certifi==2018.4.16
 chardet==3.0.4
-click==6.7
+click==7.1.2
 clickhouse-driver==0.1.1
 colorama==0.3.9
 confluent-kafka==1.5.0

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -162,6 +162,10 @@ def multistorage_consumer(
     if commit_log_topic is None:
         consumer = KafkaConsumer(consumer_configuration)
     else:
+        # XXX: This relies on the assumptions that a.) the Kafka cluster where
+        # the commit log topic is located is the same as the input topic (there
+        # is no way to specify otherwise, at writing) and b.) all storages are
+        # located on the same Kafka cluster (validated above.)
         producer = ConfluentKafkaProducer(
             build_kafka_producer_configuration(storage_keys[0])
         )

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -1,0 +1,150 @@
+import logging
+import signal
+from typing import Any, Optional
+
+import click
+from snuba import environment, settings
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.consumer import MultistorageConsumerProcessingStrategyFactory
+from snuba.datasets.storages.factory import WRITABLE_STORAGES
+from snuba.environment import setup_logging, setup_sentry
+from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.streams.backends.kafka import (
+    KafkaConsumer,
+    KafkaConsumerWithCommitLog,
+    build_kafka_consumer_configuration,
+)
+from snuba.utils.streams.processing import StreamProcessor
+from snuba.utils.streams.types import Topic
+
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "--storage-set",
+    "storage_set_name",
+    default="events",
+    type=click.Choice([key.value for key in StorageSetKey]),
+)
+@click.option(
+    "--consumer-group", default="snuba-consumers",
+)
+@click.option(
+    "--max-batch-size",
+    default=settings.DEFAULT_MAX_BATCH_SIZE,
+    type=int,
+    help="Max number of messages to batch in memory before writing to Kafka.",
+)
+@click.option(
+    "--max-batch-time-ms",
+    default=settings.DEFAULT_MAX_BATCH_TIME_MS,
+    type=int,
+    help="Max length of time to buffer messages in memory before writing to Kafka.",
+)
+@click.option("--log-level")
+def multistorage_consumer(
+    storage_set_name: str,
+    consumer_group: str,
+    max_batch_size: int,
+    max_batch_time_ms: int,
+    log_level: Optional[str] = None,
+) -> None:
+
+    setup_logging(log_level)
+    setup_sentry()
+
+    # XXX: This makes the assumption that the enumeration name/value continue
+    # to be just upper/lowercase variants of the same string. This is not
+    # enforced anywhere and liable to break in the future.
+    storage_set_key = getattr(StorageSetKey, storage_set_name.upper())
+
+    storages = {
+        storage_key: storage
+        for storage_key, storage in WRITABLE_STORAGES.items()
+        if storage.get_storage_set_key() is storage_set_key
+    }
+
+    if not storages:
+        raise ValueError("storage set contains no writable storages")
+
+    topics = {
+        storage.get_table_writer()
+        .get_stream_loader()
+        .get_default_topic_spec()
+        .topic_name
+        for storage in storages.values()
+    }
+
+    # XXX: The ``StreamProcessor`` only supports a single topic at this time,
+    # but is easily modified. The topic routing in the processing strategy is a
+    # bit trickier (but also shouldn't be too bad.)
+    topic = Topic(topics.pop())
+    if topics:
+        raise NotImplementedError("only one topic is supported")
+
+    # XXX: The ``CommitLogConsumer`` also only supports a single topic at this
+    # time. (It is less easily modified.) This also assumes the commit log
+    # topic is on the same Kafka cluster as the input topic.
+    commit_log_topics = {
+        spec.topic_name
+        for spec in (
+            storage.get_table_writer().get_stream_loader().get_commit_log_topic_spec()
+            for storage in storages.values()
+        )
+        if spec is not None
+    }
+
+    commit_log_topic: Optional[Topic]
+    if commit_log_topics:
+        commit_log_topic = Topic(commit_log_topics.pop())
+    else:
+        commit_log_topic = None
+
+    if commit_log_topics:
+        raise NotImplementedError("only one commit log topic is supported")
+
+    # XXX: This requires that all storages are associated with the same Kafka
+    # cluster so that they can be consumed by the same consumer instance.
+    # Unfortunately, we don't have the concept of independently configurable
+    # Kafka clusters in settings, only consumer configurations that are
+    # associated with storages and/or global default configurations. To avoid
+    # implementing yet another method of configuring Kafka clusters, this just
+    # piggybacks on the existing configuration method(s), with the assumption
+    # that most deployments are going to be using the default configuration.
+    storage_keys = [*storages.keys()]
+    # TODO: Patch in ither configurations from command line arguments.
+    consumer_configuration = build_kafka_consumer_configuration(
+        storage_keys.pop(), consumer_group,
+    )
+    for storage_key in storage_keys:
+        pass  # TODO: actually check configuration equality
+
+    if commit_log_topic is None:
+        consumer = KafkaConsumer(consumer_configuration)
+    else:
+        producer = None  # TODO
+        consumer = KafkaConsumerWithCommitLog(
+            consumer_configuration,
+            producer=producer,
+            commit_log_topic=commit_log_topic,
+        )
+
+    metrics = MetricsWrapper(environment.metrics, "consumer")
+    processor = StreamProcessor(
+        consumer,
+        topic,
+        MultistorageConsumerProcessingStrategyFactory(
+            [*storages.values()], max_batch_size, max_batch_time_ms / 1000.0, metrics,
+        ),
+        metrics=metrics,
+    )
+
+    def handler(signum: int, frame: Any) -> None:
+        processor.signal_shutdown()
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+    processor.run()

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -24,7 +24,7 @@ from snuba.utils.streams.types import Topic
 logger = logging.getLogger(__name__)
 
 
-@click.command()
+@click.command(hidden=True)
 @click.option(
     "--storage",
     "storage_names",

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -156,6 +156,9 @@ class HTTPBatchWriter(BatchWriter[JSONRow]):
         self.__database = database
         self.__chunk_size = chunk_size
 
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__}: {self.__database}.{self.__table_name} on {self.__pool.host}:{self.__pool.port}>"
+
     def write(self, values: Iterable[JSONRow]) -> None:
         batch = HTTPWriteBatch(
             self.__executor,

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -476,11 +476,17 @@ class MultistorageConsumerProcessingStrategyFactory(
         storages: Sequence[WritableTableStorage],
         max_batch_size: int,
         max_batch_time: float,
+        processes: int,
+        input_block_size: int,
+        output_block_size: int,
         metrics: MetricsBackend,
     ):
         self.__storages = storages
         self.__max_batch_size = max_batch_size
         self.__max_batch_time = max_batch_time
+        self.__processes = processes
+        self.__input_block_size = input_block_size
+        self.__output_block_size = output_block_size
         self.__metrics = metrics
 
     def __find_destination_storages(
@@ -554,11 +560,11 @@ class MultistorageConsumerProcessingStrategyFactory(
                         self.__max_batch_size,
                         self.__max_batch_time,
                     ),
-                    2,
-                    10,
-                    10,
-                    512 * 1000,
-                    512 * 1000,
+                    self.__processes,
+                    self.__max_batch_size,
+                    self.__max_batch_time,
+                    self.__input_block_size,
+                    self.__output_block_size,
                     self.__metrics,
                 ),
             ),

--- a/snuba/consumer.py
+++ b/snuba/consumer.py
@@ -517,6 +517,8 @@ class MultistorageConsumerProcessingStrategyFactory(
         if replacement_topic_spec is not None:
             # XXX: The producer is flushed when closed on strategy teardown
             # after an assignment is revoked, but never explicitly closed.
+            # XXX: This assumes that the Kafka cluster used for the input topic
+            # to the storage is the same as the replacement topic.
             replacement_batch_writer = ReplacementBatchWriter(
                 ConfluentKafkaProducer(
                     build_kafka_producer_configuration(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -7,15 +7,17 @@ from typing import MutableSequence
 from unittest.mock import Mock, call
 
 import pytest
-
+from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumer import (
-    MultistorageConsumerProcessingStrategyFactory,
     JSONRowInsertBatch,
+    MultistorageConsumerProcessingStrategyFactory,
     StreamingConsumerStrategyFactory,
 )
+from snuba.datasets.storage import Storage
 from snuba.processor import InsertBatch, ReplacementBatch
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.kafka import KafkaPayload
+
 from tests.assertions import assert_changes
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 from tests.backends.metrics import TestingMetricsBackend, Timing
@@ -107,18 +109,28 @@ def test_json_row_batch_pickle_out_of_band() -> None:
     assert pickle.loads(data, buffers=[b.raw() for b in buffers]) == batch
 
 
+def get_row_count(storage: Storage) -> int:
+    return (
+        storage.get_cluster()
+        .get_query_connection(ClickhouseClientSettings.INSERT)
+        .execute(f"SELECT count() FROM {storage.get_schema().get_local_table_name()}")[
+            0
+        ][0]
+    )
+
+
 def test_multistorage_strategy() -> None:
     from snuba.datasets.storages import groupassignees, groupedmessages
+
     from tests.datasets.cdc.test_groupassignee import TestGroupassignee
     from tests.datasets.cdc.test_groupedmessage import TestGroupedMessage
 
     commit = Mock()
 
+    storages = [groupassignees.storage, groupedmessages.storage]
+
     strategy = MultistorageConsumerProcessingStrategyFactory(
-        [groupassignees.storage, groupedmessages.storage],
-        10,
-        10,
-        TestingMetricsBackend(),
+        storages, 10, 10, 1, int(32 * 1e6), int(64 * 1e6), TestingMetricsBackend(),
     ).create(commit)
 
     payloads = [
@@ -126,12 +138,12 @@ def test_multistorage_strategy() -> None:
         KafkaPayload(
             None,
             json.dumps(TestGroupassignee.INSERT_MSG).encode("utf8"),
-            [("table", b"sentry_groupedassignee")],
+            [("table", groupassignees.storage.get_postgres_table().encode("utf8"))],
         ),
         KafkaPayload(
             None,
             json.dumps(TestGroupedMessage.INSERT_MSG).encode("utf8"),
-            [("table", b"sentry_groupedmessage")],
+            [("table", groupedmessages.storage.get_postgres_table().encode("utf8"))],
         ),
     ]
 
@@ -142,13 +154,15 @@ def test_multistorage_strategy() -> None:
         for offset, payload in enumerate(payloads)
     ]
 
-    for message in messages:
-        strategy.submit(message)
-
     with assert_changes(
-        lambda: commit.call_args_list, [], [call({Partition(Topic("topic"), 0): 3})]
-    ):
-        strategy.close()
-        strategy.join()
+        lambda: get_row_count(groupassignees.storage), 0, 1
+    ), assert_changes(lambda: get_row_count(groupedmessages.storage), 0, 1):
 
-    # TODO: Ensure the data has been written as expeted.
+        for message in messages:
+            strategy.submit(message)
+
+        with assert_changes(
+            lambda: commit.call_args_list, [], [call({Partition(Topic("topic"), 0): 3})]
+        ):
+            strategy.close()
+            strategy.join()


### PR DESCRIPTION
This implements the minimum feature set necessary to support writing to multiple storages from a single consumer. It has several limitations and drawbacks (see comments in entrypoint for specific examples) and provides virtually no safety net to the end user to prevent them from running the consumer in a fashion that may cause problems in the short term (i.e. running a single storage and multiple storage consumer for the same storage simultaneously using the same consumer group) or long term (running specific sets of storages together that may not be supported in the future.) Caveat emptor.