### PR TITLE
feat: Remove scripts from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 */.gitignore
 docs
-scripts
 cloudbuild.*
 docker-compose.*
 CODEOWNERS


### PR DESCRIPTION
Snuba `scripts` are sometimes used in production, we want to include
them in our built Docker image.