### PR TITLE
ref(consumer): Add the ability to override storage topic names through settings

### DIFF
--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -31,7 +31,7 @@ storage = WritableTableStorage(
     query_processors=query_processors,
     query_splitters=query_splitters,
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.ERRORS.name,
+        StorageKey.ERRORS,
         processor=ErrorsProcessor(promoted_tag_columns),
         default_topic_name="events",
         replacement_topic_name="errors-replacements",

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -13,7 +13,7 @@ from snuba.datasets.storages.errors_common import (
     query_splitters,
     required_columns,
 )
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 
 schema = WritableTableSchema(
     columns=all_columns,
@@ -30,10 +30,11 @@ storage = WritableTableStorage(
     schema=schema,
     query_processors=query_processors,
     query_splitters=query_splitters,
-    stream_loader=KafkaStreamLoader(
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.ERRORS.name,
         processor=ErrorsProcessor(promoted_tag_columns),
-        default_topic="events",
-        replacement_topic="errors-replacements",
+        default_topic_name="events",
+        replacement_topic_name="errors-replacements",
     ),
     replacer_processor=ErrorsReplacer(
         schema=schema,

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -34,7 +34,7 @@ storage = WritableTableStorage(
     schema=schema,
     query_processors=query_processors,
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.EVENTS.name,
+        StorageKey.EVENTS,
         processor=EventsProcessor(promoted_tag_columns),
         default_topic_name="events",
         replacement_topic_name="event-replacements",

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -15,7 +15,7 @@ from snuba.datasets.storages.events_common import (
     query_splitters,
     required_columns,
 )
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 
 
 schema = WritableTableSchema(
@@ -33,11 +33,12 @@ storage = WritableTableStorage(
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
     query_processors=query_processors,
-    stream_loader=KafkaStreamLoader(
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.EVENTS.name,
         processor=EventsProcessor(promoted_tag_columns),
-        default_topic="events",
-        replacement_topic="event-replacements",
-        commit_log_topic="snuba-commit-log",
+        default_topic_name="events",
+        replacement_topic_name="event-replacements",
+        commit_log_topic_name="snuba-commit-log",
     ),
     query_splitters=query_splitters,
     replacer_processor=ErrorsReplacer(

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -43,7 +43,7 @@ storage = CdcStorage(
     schema=schema,
     query_processors=[PrewhereProcessor()],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.GROUPASSIGNEES.name,
+        StorageKey.GROUPASSIGNEES,
         processor=GroupAssigneeProcessor(POSTGRES_TABLE),
         default_topic_name="cdc",
         pre_filter=CdcTableNameMessageFilter(POSTGRES_TABLE),

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -10,7 +10,7 @@ from snuba.datasets.cdc.groupassignee_processor import (
 from snuba.datasets.cdc.message_filters import CdcTableNameMessageFilter
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.prewhere import PrewhereProcessor
 
 columns = ColumnSet(
@@ -42,9 +42,10 @@ storage = CdcStorage(
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
     query_processors=[PrewhereProcessor()],
-    stream_loader=KafkaStreamLoader(
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.GROUPASSIGNEES.name,
         processor=GroupAssigneeProcessor(POSTGRES_TABLE),
-        default_topic="cdc",
+        default_topic_name="cdc",
         pre_filter=CdcTableNameMessageFilter(POSTGRES_TABLE),
     ),
     default_control_topic="cdc_control",

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -58,7 +58,7 @@ storage = CdcStorage(
     schema=schema,
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.GROUPEDMESSAGES.name,
+        StorageKey.GROUPEDMESSAGES,
         processor=GroupedMessageProcessor(POSTGRES_TABLE),
         default_topic_name="cdc",
         pre_filter=CdcTableNameMessageFilter(POSTGRES_TABLE),

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -10,7 +10,7 @@ from snuba.datasets.cdc.groupedmessage_processor import (
 from snuba.datasets.cdc.message_filters import CdcTableNameMessageFilter
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.expressions import Column, Literal
 
@@ -57,9 +57,10 @@ storage = CdcStorage(
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
     query_processors=[],
-    stream_loader=KafkaStreamLoader(
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.GROUPEDMESSAGES.name,
         processor=GroupedMessageProcessor(POSTGRES_TABLE),
-        default_topic="cdc",
+        default_topic_name="cdc",
         pre_filter=CdcTableNameMessageFilter(POSTGRES_TABLE),
     ),
     default_control_topic="cdc_control",

--- a/snuba/datasets/storages/outcomes.py
+++ b/snuba/datasets/storages/outcomes.py
@@ -79,7 +79,7 @@ raw_storage = WritableTableStorage(
     schema=raw_schema,
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.OUTCOMES_RAW.name,
+        StorageKey.OUTCOMES_RAW,
         processor=OutcomesProcessor(),
         default_topic_name="outcomes",
     ),

--- a/snuba/datasets/storages/outcomes.py
+++ b/snuba/datasets/storages/outcomes.py
@@ -6,7 +6,7 @@ from snuba.datasets.outcomes_processor import OutcomesProcessor
 from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
 from snuba.datasets.storage import ReadableTableStorage, WritableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.prewhere import PrewhereProcessor
 
 WRITE_LOCAL_TABLE_NAME = "outcomes_raw_local"
@@ -78,8 +78,10 @@ raw_storage = WritableTableStorage(
     storage_set_key=StorageSetKey.OUTCOMES,
     schema=raw_schema,
     query_processors=[],
-    stream_loader=KafkaStreamLoader(
-        processor=OutcomesProcessor(), default_topic="outcomes",
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.OUTCOMES_RAW.name,
+        processor=OutcomesProcessor(),
+        default_topic_name="outcomes",
     ),
 )
 

--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -7,7 +7,7 @@ from snuba.datasets.querylog_processor import QuerylogProcessor
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 
 columns = ColumnSet(
     [
@@ -69,7 +69,9 @@ storage = WritableTableStorage(
     storage_set_key=StorageSetKey.QUERYLOG,
     schema=schema,
     query_processors=[],
-    stream_loader=KafkaStreamLoader(
-        processor=QuerylogProcessor(), default_topic=settings.QUERIES_TOPIC,
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.QUERYLOG.name,
+        processor=QuerylogProcessor(),
+        default_topic_name=settings.QUERIES_TOPIC,
     ),
 )

--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -70,7 +70,7 @@ storage = WritableTableStorage(
     schema=schema,
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.QUERYLOG.name,
+        StorageKey.QUERYLOG,
         processor=QuerylogProcessor(),
         default_topic_name=settings.QUERIES_TOPIC,
     ),

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -108,7 +108,7 @@ raw_storage = WritableTableStorage(
     schema=raw_schema,
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.SESSIONS_RAW.name,
+        StorageKey.SESSIONS_RAW,
         processor=SessionsProcessor(),
         default_topic_name="ingest-sessions",
     ),

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -17,7 +17,7 @@ from snuba.datasets.storage import (
     WritableTableStorage,
 )
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.prewhere import PrewhereProcessor
 
 
@@ -107,8 +107,10 @@ raw_storage = WritableTableStorage(
     storage_set_key=StorageSetKey.SESSIONS,
     schema=raw_schema,
     query_processors=[],
-    stream_loader=KafkaStreamLoader(
-        processor=SessionsProcessor(), default_topic="ingest-sessions",
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.SESSIONS_RAW.name,
+        processor=SessionsProcessor(),
+        default_topic_name="ingest-sessions",
     ),
 )
 # The materialized view we query aggregate data from.

--- a/snuba/datasets/storages/spans.py
+++ b/snuba/datasets/storages/spans.py
@@ -6,7 +6,7 @@ from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.spans_processor import SpansMessageProcessor
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.web.split import TimeSplitQueryStrategy
 
@@ -46,8 +46,10 @@ storage = WritableTableStorage(
     storage_set_key=StorageSetKey.TRANSACTIONS,
     schema=schema,
     query_processors=[PrewhereProcessor()],
-    stream_loader=KafkaStreamLoader(
-        processor=SpansMessageProcessor(), default_topic="events",
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.SPANS.name,
+        processor=SpansMessageProcessor(),
+        default_topic_name="events",
     ),
     query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
 )

--- a/snuba/datasets/storages/spans.py
+++ b/snuba/datasets/storages/spans.py
@@ -47,7 +47,7 @@ storage = WritableTableStorage(
     schema=schema,
     query_processors=[PrewhereProcessor()],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.SPANS.name,
+        StorageKey.SPANS,
         processor=SpansMessageProcessor(),
         default_topic_name="events",
     ),

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -15,7 +15,7 @@ from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.event_id_column_processor import EventIdColumnProcessor
-from snuba.datasets.table_storage import KafkaStreamLoader
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
@@ -95,8 +95,10 @@ storage = WritableTableStorage(
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
         PrewhereProcessor(),
     ],
-    stream_loader=KafkaStreamLoader(
-        processor=TransactionsMessageProcessor(), default_topic="events",
+    stream_loader=build_kafka_stream_loader_from_settings(
+        StorageKey.TRANSACTIONS.name,
+        processor=TransactionsMessageProcessor(),
+        default_topic_name="events",
     ),
     query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
     writer_options={"insert_allow_materialized_columns": 1},

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -96,7 +96,7 @@ storage = WritableTableStorage(
         PrewhereProcessor(),
     ],
     stream_loader=build_kafka_stream_loader_from_settings(
-        StorageKey.TRANSACTIONS.name,
+        StorageKey.TRANSACTIONS,
         processor=TransactionsMessageProcessor(),
         default_topic_name="events",
     ),

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -84,8 +84,8 @@ def build_kafka_topic_spec_from_settings(topic_name: str) -> KafkaTopicSpec:
 
 def build_kafka_stream_loader_from_settings(
     storage_name: str,
-    default_topic_name: str,
     processor: MessageProcessor,
+    default_topic_name: str,
     pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
     replacement_topic_name: Optional[str] = None,
     commit_log_topic_name: Optional[str] = None,

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -10,6 +10,7 @@ from snuba.clusters.cluster import (
 )
 from snuba.datasets.message_filters import StreamMessageFilter
 from snuba.datasets.schemas.tables import WritableTableSchema
+from snuba.datasets.storages import StorageKey
 from snuba.processor import MessageProcessor
 from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.snapshots import BulkLoadSource
@@ -83,14 +84,14 @@ def build_kafka_topic_spec_from_settings(topic_name: str) -> KafkaTopicSpec:
 
 
 def build_kafka_stream_loader_from_settings(
-    storage_name: str,
+    storage_key: StorageKey,
     processor: MessageProcessor,
     default_topic_name: str,
     pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
     replacement_topic_name: Optional[str] = None,
     commit_log_topic_name: Optional[str] = None,
 ) -> KafkaStreamLoader:
-    storage_topics = {**settings.STORAGE_TOPICS[storage_name]}
+    storage_topics = {**settings.STORAGE_TOPICS[storage_key.name]}
 
     default_topic_spec = build_kafka_topic_spec_from_settings(
         storage_topics.pop("default", default_topic_name)
@@ -103,7 +104,7 @@ def build_kafka_stream_loader_from_settings(
         )
     elif "replacements" in storage_topics:
         raise ValueError(
-            f"invalid topic configuration for {storage_name!r}: replacements unsupported"
+            f"invalid topic configuration for {storage_key!r}: replacements unsupported"
         )
     else:
         replacement_topic_spec = None
@@ -115,14 +116,14 @@ def build_kafka_stream_loader_from_settings(
         )
     elif "commit-log" in storage_topics:
         raise ValueError(
-            f"invalid topic configuration for {storage_name!r}: commit log unsupported"
+            f"invalid topic configuration for {storage_key!r}: commit log unsupported"
         )
     else:
         commit_log_topic_spec = None
 
     if storage_topics.keys():
         raise ValueError(
-            f"invalid topic configuration for {storage_name!r}: unknown keys {[*storage_topics.keys()]!r}"
+            f"invalid topic configuration for {storage_key!r}: unknown keys {[*storage_topics.keys()]!r}"
         )
 
     return KafkaStreamLoader(

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -36,36 +36,15 @@ class KafkaStreamLoader:
     def __init__(
         self,
         processor: MessageProcessor,
-        default_topic: str,
+        default_topic_spec: KafkaTopicSpec,
         pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
-        replacement_topic: Optional[str] = None,
-        commit_log_topic: Optional[str] = None,
+        replacement_topic_spec: Optional[KafkaTopicSpec] = None,
+        commit_log_topic_spec: Optional[KafkaTopicSpec] = None,
     ) -> None:
         self.__processor = processor
-        self.__default_topic_spec = KafkaTopicSpec(
-            topic_name=default_topic,
-            partitions_number=settings.TOPIC_PARTITION_COUNTS.get(default_topic, 1),
-        )
-        self.__replacement_topic_spec = (
-            KafkaTopicSpec(
-                topic_name=replacement_topic,
-                partitions_number=settings.TOPIC_PARTITION_COUNTS.get(
-                    replacement_topic, 1
-                ),
-            )
-            if replacement_topic
-            else None
-        )
-        self.__commit_log_topic_spec = (
-            KafkaTopicSpec(
-                topic_name=commit_log_topic,
-                partitions_number=settings.TOPIC_PARTITION_COUNTS.get(
-                    commit_log_topic, 1
-                ),
-            )
-            if commit_log_topic
-            else None
-        )
+        self.__default_topic_spec = default_topic_spec
+        self.__replacement_topic_spec = replacement_topic_spec
+        self.__commit_log_topic_spec = commit_log_topic_spec
         self.__pre_filter = pre_filter
 
     def get_processor(self) -> MessageProcessor:
@@ -89,11 +68,70 @@ class KafkaStreamLoader:
 
     def get_all_topic_specs(self) -> Sequence[KafkaTopicSpec]:
         ret = [self.__default_topic_spec]
-        if self.__replacement_topic_spec:
+        if self.__replacement_topic_spec is not None:
             ret.append(self.__replacement_topic_spec)
-        if self.__commit_log_topic_spec:
+        if self.__commit_log_topic_spec is not None:
             ret.append(self.__commit_log_topic_spec)
         return ret
+
+
+def build_kafka_topic_spec_from_settings(topic_name: str) -> KafkaTopicSpec:
+    return KafkaTopicSpec(
+        topic_name=topic_name,
+        partitions_number=settings.TOPIC_PARTITION_COUNTS.get(topic_name, 1),
+    )
+
+
+def build_kafka_stream_loader_from_settings(
+    storage_name: str,
+    default_topic_name: str,
+    processor: MessageProcessor,
+    pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
+    replacement_topic_name: Optional[str] = None,
+    commit_log_topic_name: Optional[str] = None,
+) -> KafkaStreamLoader:
+    storage_topics = {**settings.STORAGE_TOPICS[storage_name]}
+
+    default_topic_spec = build_kafka_topic_spec_from_settings(
+        storage_topics.pop("default", default_topic_name)
+    )
+
+    replacement_topic_spec: Optional[KafkaTopicSpec]
+    if replacement_topic_name is not None:
+        replacement_topic_spec = build_kafka_topic_spec_from_settings(
+            storage_topics.pop("replacements", replacement_topic_name)
+        )
+    elif "replacements" in storage_topics:
+        raise ValueError(
+            f"invalid topic configuration for {storage_name!r}: replacements unsupported"
+        )
+    else:
+        replacement_topic_spec = None
+
+    commit_log_topic_spec: Optional[KafkaTopicSpec]
+    if commit_log_topic_name is not None:
+        commit_log_topic_spec = build_kafka_topic_spec_from_settings(
+            storage_topics.pop("commit-log", commit_log_topic_name)
+        )
+    elif "commit-log" in storage_topics:
+        raise ValueError(
+            f"invalid topic configuration for {storage_name!r}: commit log unsupported"
+        )
+    else:
+        commit_log_topic_spec = None
+
+    if storage_topics.keys():
+        raise ValueError(
+            f"invalid topic configuration for {storage_name!r}: unknown keys {[*storage_topics.keys()]!r}"
+        )
+
+    return KafkaStreamLoader(
+        processor,
+        default_topic_spec,
+        pre_filter,
+        replacement_topic_spec,
+        commit_log_topic_spec,
+    )
 
 
 class TableWriter:

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -1,4 +1,5 @@
 import os
+from collections import defaultdict
 from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
 
@@ -80,6 +81,7 @@ BROKER_CONFIG: Mapping[str, Any] = {
     "bootstrap.servers": os.environ.get("DEFAULT_BROKERS", "localhost:9092"),
 }
 STORAGE_BROKER_CONFIG: Mapping[str, Mapping[str, Any]] = {}
+STORAGE_TOPICS: Mapping[str, Mapping[str, Any]] = defaultdict(dict)
 
 DEFAULT_MAX_BATCH_SIZE = 50000
 DEFAULT_MAX_BATCH_TIME_MS = 2 * 1000


### PR DESCRIPTION
This addresses the immediate issues raised in https://github.com/getsentry/snuba/pull/1551#discussion_r544642804 that prevented the multistorage consumer from being able to be used in our production configuration.