### PR TITLE
fix(snql) Qualify columns in JOIN queries

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -7,7 +7,6 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Union,
 )
@@ -743,20 +742,10 @@ def _qualify_columns(query: Union[CompositeQuery[QueryEntity], LogicalQuery]) ->
     """
 
     from_clause = query.get_from_clause()
-    if isinstance(query, LogicalQuery) or not isinstance(from_clause, JoinClause):
-        print("REJECTED")
+    if not isinstance(from_clause, JoinClause):
         return  # We don't qualify columns that have a single source
 
-    # mypy makes this difficult to do non-recursively
-    def find_aliases(aliases: Set[str], join_clause: JoinClause[QueryEntity]) -> None:
-        aliases.add(join_clause.right_node.alias)
-        if isinstance(join_clause.left_node, JoinClause):
-            find_aliases(aliases, join_clause.left_node)
-        elif isinstance(join_clause.left_node, IndividualNode):
-            aliases.add(join_clause.left_node.alias)
-
-    aliases: Set[str] = set()
-    find_aliases(aliases, from_clause)
+    aliases = set(from_clause.get_alias_node_map().keys())
 
     def transform(exp: Expression) -> Expression:
         if not isinstance(exp, Column):

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -28,7 +28,7 @@ test_cases = [
         id="mandatory spacing",
     ),
     pytest.param(
-        "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, c",
+        "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c",
         VisitationError,
         id="invalid relationship name",
     ),

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -735,7 +735,7 @@ test_cases = [
         id="Special array join functions",
     ),
     pytest.param(
-        "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, c",
+        "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c",
         CompositeQuery(
             from_clause=JoinClause(
                 left_node=IndividualNode(
@@ -764,13 +764,13 @@ test_cases = [
                     "4-5",
                     FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
                 ),
-                SelectedExpression("c", Column("_snuba_c", None, "c")),
+                SelectedExpression("e.c", Column("_snuba_e.c", "e", "c")),
             ],
         ),
         id="Basic join match",
     ),
     pytest.param(
-        "MATCH (e: events) -[contains]-> (t: transactions SAMPLE 0.5) SELECT 4-5, c",
+        "MATCH (e: events) -[contains]-> (t: transactions SAMPLE 0.5) SELECT 4-5, t.c",
         CompositeQuery(
             from_clause=JoinClause(
                 left_node=IndividualNode(
@@ -800,7 +800,7 @@ test_cases = [
                     "4-5",
                     FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
                 ),
-                SelectedExpression("c", Column("_snuba_c", None, "c")),
+                SelectedExpression("t.c", Column("_snuba_t.c", "t", "c")),
             ],
         ),
         id="Basic join match with sample",
@@ -809,7 +809,7 @@ test_cases = [
         """MATCH
             (e: events) -[contains]-> (t: transactions),
             (e: events) -[assigned]-> (ga: groupassignee)
-        SELECT 4-5, c""",
+        SELECT 4-5, ga.c""",
         CompositeQuery(
             from_clause=JoinClause(
                 left_node=JoinClause(
@@ -855,7 +855,7 @@ test_cases = [
                     "4-5",
                     FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
                 ),
-                SelectedExpression("c", Column("_snuba_c", None, "c")),
+                SelectedExpression("ga.c", Column("_snuba_ga.c", "ga", "c")),
             ],
         ),
         id="Multi join match",
@@ -866,7 +866,7 @@ test_cases = [
             (e: events) -[assigned]-> (ga: groupassignee),
             (e: events) -[bookmark]-> (gm: groupedmessage),
             (e: events) -[activity]-> (se: sessions)
-        SELECT 4-5, c""",
+        SELECT 4-5, e.a, t.b, ga.c, gm.d, se.e""",
         CompositeQuery(
             from_clause=JoinClause(
                 left_node=JoinClause(
@@ -944,7 +944,11 @@ test_cases = [
                     "4-5",
                     FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
                 ),
-                SelectedExpression("c", Column("_snuba_c", None, "c")),
+                SelectedExpression("e.a", Column("_snuba_e.a", "e", "a")),
+                SelectedExpression("t.b", Column("_snuba_t.b", "t", "b")),
+                SelectedExpression("ga.c", Column("_snuba_ga.c", "ga", "c")),
+                SelectedExpression("gm.d", Column("_snuba_gm.d", "gm", "d")),
+                SelectedExpression("se.e", Column("_snuba_se.e", "se", "e")),
             ],
         ),
         id="Multi multi join match",


### PR DESCRIPTION
In JOIN queries, ensure the columns are qualified with a valid entity alias,
and separate out that alias.