### PR TITLE
ref(storages): Add commit log to spans and transactions

### DIFF
--- a/snuba/datasets/storages/spans.py
+++ b/snuba/datasets/storages/spans.py
@@ -50,6 +50,7 @@ storage = WritableTableStorage(
         StorageKey.SPANS,
         processor=SpansMessageProcessor(),
         default_topic_name="events",
+        commit_log_topic_name="snuba-commit-log",
     ),
     query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
 )

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -99,6 +99,7 @@ storage = WritableTableStorage(
         StorageKey.TRANSACTIONS,
         processor=TransactionsMessageProcessor(),
         default_topic_name="events",
+        commit_log_topic_name="snuba-commit-log",
     ),
     query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
     writer_options={"insert_allow_materialized_columns": 1},


### PR DESCRIPTION
This matches the production configuration for these storages and ensures they are set (and/or able to be overridden) in all environments.