### PR TITLE
fix(snql) Mangle aliases in subqueries

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -844,6 +844,8 @@ def _mangle_query_aliases(
     selected expression values.
 
     So, we mangle the outer query column names to match the inner query aliases as well.
+    There's no way around this since the inner queries are not executed separately from
+    the outer queries in Clickhouse, so we only receive one set of results.
     """
 
     alias_prefix = "_snuba_"

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -867,9 +867,7 @@ def _mangle_query_aliases(
 
     # Check if this query has a subquery. If it does, we need to mangle the column name as well
     # and keep track of what we mangled by updating the mappings in memory.
-    if isinstance(query, CompositeQuery) and not isinstance(
-        query.get_from_clause(), JoinClause
-    ):
+    if isinstance(query.get_from_clause(), LogicalQuery):
         query.transform_expressions(mangle_column_value)
 
 

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -983,7 +983,7 @@ test_cases = [
         id="sub query match",
     ),
     pytest.param(
-        "MATCH { MATCH { MATCH (events) SELECT count() AS count BY title } SELECT max(count) AS max_count } SELECT min(count) AS min_count",
+        "MATCH { MATCH { MATCH (events) SELECT count() AS count BY title } SELECT max(count) AS max_count } SELECT min(max_count) AS min_count",
         CompositeQuery(
             from_clause=CompositeQuery(
                 from_clause=LogicalQuery(
@@ -1018,7 +1018,7 @@ test_cases = [
                     FunctionCall(
                         "_snuba_min_count",
                         "min",
-                        (Column("_snuba_count", None, "_snuba_count"),),
+                        (Column("_snuba_max_count", None, "max_count"),),
                     ),
                 ),
             ],

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -971,7 +971,7 @@ test_cases = [
                     FunctionCall(
                         "_snuba_max_count",
                         "max",
-                        (Column("_snuba_count", None, "count"),),
+                        (Column("_snuba_count", None, "_snuba_count"),),
                     ),
                 ),
             ],
@@ -1003,7 +1003,7 @@ test_cases = [
                         FunctionCall(
                             "_snuba_max_count",
                             "max",
-                            (Column("_snuba_count", None, "count"),),
+                            (Column("_snuba_count", None, "_snuba_count"),),
                         ),
                     ),
                 ],
@@ -1014,7 +1014,7 @@ test_cases = [
                     FunctionCall(
                         "_snuba_min_count",
                         "min",
-                        (Column("_snuba_count", None, "count"),),
+                        (Column("_snuba_count", None, "_snuba_count"),),
                     ),
                 ),
             ],


### PR DESCRIPTION
There is an issue with mangling aliases in subqueries. An outer query is
expecting its columns to match the select statement from the inner query.
I assumed this meant the outer query should match the SelectedExpression,
but that isn't correct in a subquery since the SelectedExpression is
essentially ignored. Instead, the outer query columns need to match the
aliases of the inner query. Since those aliases get mangled, we have to also
mangle the column names of the outer query to match that mangling.