### PR TITLE
feat(backfill): Update backfill to use insert into select

### DIFF
--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -35,9 +35,9 @@ arrayMap(
             t -> tupleElement(t, 2) IS NOT NULL,
             arrayConcat(
                 arrayZip(contexts.key, contexts.value),
-                [('geo_city', geo_city)]
+                [('geo_city', geo_city)],
                 [('geo_country_code', geo_country_code)],
-                [('geo_region', geo_region)],
+                [('geo_region', geo_region)]
             )
         )
     ) AS tuplesArray

--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -35,18 +35,18 @@ arrayMap(
             t -> t.2 IS NOT NULL,
             arrayConcat(
                 arrayZip(contexts.key, contexts.value),
-                [('geo_city', geo_city)],
-                [('geo_country_code', geo_country_code)],
-                [('geo_region', geo_region)],
-                [('os_build', os_build)],
-                [('os_kernel_version', os_kernel_version)],
-                [('device_name', device_name)],
-                [('device_brand', device_brand)],
-                [('device_locale', device_locale)],
-                [('device_uuid', device_uuid)],
-                [('device_model_id', device_model_id)],
-                [('device_arch', device_arch)],
-                [('device_battery_level', toString(device_battery_level))]
+                [('geo.city', geo_city)],
+                [('geo.country_code', geo_country_code)],
+                [('geo.region', geo_region)],
+                [('os.build', os_build)],
+                [('os.kernel_version', os_kernel_version)],
+                [('device.name', device_name)],
+                [('device.brand', device_brand)],
+                [('device.locale', device_locale)],
+                [('device.uuid', device_uuid)],
+                [('device.model_id', device_model_id)],
+                [('device.arch', device_arch)],
+                [('device.battery_level', toString(device_battery_level))]
             )
         )
     ) AS tuplesArray

--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -27,6 +27,31 @@ WINDOW = timedelta(days=7)
 BEGINNING_OF_TIME = get_monday((datetime.utcnow() - timedelta(days=90)).date())
 
 
+contexts_key = """
+arrayMap(
+    t -> tupleElement(t, 1),
+    arraySort(
+        arrayFilter(
+            t -> tupleElement(t, 2) IS NOT NULL,
+            arrayConcat(
+                arrayZip(contexts.key, contexts.value),
+                [('geo_city', geo_city)]
+                [('geo_country_code', geo_country_code)],
+                [('geo_region', geo_region)],
+            )
+        )
+    ) AS tuplesArray
+)
+"""
+
+contexts_value = """
+    arrayMap(
+        t -> tupleElement(t, 2),
+        tuplesArray
+    )
+"""
+
+
 COLUMNS = [
     ("project_id", "project_id"),
     ("timestamp", "timestamp"),
@@ -50,8 +75,8 @@ COLUMNS = [
     ("http_referer", "http_referer"),
     ("tags.key", "tags.key"),
     ("tags.value", "tags.value"),
-    ("contexts.key", "contexts.key"),
-    ("contexts.value", "contexts.value"),
+    ("contexts.key", contexts_key),
+    ("contexts.value", contexts_value),
     ("transaction_name", "ifNull(`transaction`, '')"),
     (
         "span_id",

--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -29,10 +29,10 @@ BEGINNING_OF_TIME = get_monday((datetime.utcnow() - timedelta(days=90)).date())
 
 contexts_key = """
 arrayMap(
-    t -> tupleElement(t, 1),
+    t -> t.1,
     arraySort(
         arrayFilter(
-            t -> tupleElement(t, 2) IS NOT NULL,
+            t -> t.2 IS NOT NULL,
             arrayConcat(
                 arrayZip(contexts.key, contexts.value),
                 [('geo_city', geo_city)],
@@ -48,7 +48,7 @@ arrayMap(
 
 contexts_value = """
     arrayMap(
-        t -> tupleElement(t, 2),
+        t -> t.2,
         tuplesArray
     )
 """

--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -39,7 +39,14 @@ arrayMap(
                 [('geo_country_code', geo_country_code)],
                 [('geo_region', geo_region)],
                 [('os_build', os_build)],
-                [('os_kernel_version', os_kernel_version)]
+                [('os_kernel_version', os_kernel_version)],
+                [('device_name', device_name)],
+                [('device_brand', device_brand)],
+                [('device_locale', device_locale)],
+                [('device_uuid', device_uuid)],
+                [('device_model_id', device_model_id)],
+                [('device_arch', device_arch)],
+                [('device_battery_level', toString(device_battery_level))]
             )
         )
     ) AS tuplesArray

--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -6,356 +6,96 @@ consumer running in all environments populating new events into both tables.
 
 Errors replacements should be turned off while this script is running.
 """
-import os
-from datetime import datetime, timedelta
-from typing import Any, Mapping, NamedTuple, Optional, Sequence, Union, cast
-from uuid import UUID
+from datetime import date, datetime, timedelta
 
-import simplejson as json
-
-from snuba.clickhouse.escaping import escape_identifier
 from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.processor import _ensure_valid_ip
-from snuba.util import escape_literal
-
-MAX_BATCH_SIZE = 50000
-MAX_BATCH_WINDOW_MINUTES = int(os.environ.get("ERRORS_BACKFILL_WINDOW_MINUTES", 60))
-MAX_BATCH_WINDOW = timedelta(minutes=MAX_BATCH_WINDOW_MINUTES)
-BEGINNING_OF_TIME = (datetime.utcnow() - timedelta(days=90)).replace(
-    hour=0, minute=0, second=0, microsecond=0
-)
+from snuba.migrations.operations import InsertIntoSelect
 
 
-class Event(NamedTuple):
-    event_id: str
-    project_id: int
-    timestamp: datetime
-    platform: Optional[str]
-    environment: Optional[str]
-    release: Optional[str]
-    dist: Optional[str]
-    ip_address: Optional[str]
-    user: Optional[str]
-    user_id: Optional[str]
-    user_name: Optional[str]
-    user_email: Optional[str]
-    sdk_name: Optional[str]
-    sdk_version: Optional[str]
-    http_method: Optional[str]
-    http_referer: Optional[str]
-    tags_key: Sequence[str]
-    tags_value: Sequence[str]
-    contexts_key: Sequence[str]
-    contexts_value: Sequence[str]
-    transaction_name: Optional[str]
-    partition: Optional[int]
-    offset: Optional[int]
-    message_timestamp: datetime
-    retention_days: int
-    deleted: int
-    group_id: int
-    primary_hash: str
-    received: Optional[datetime]
-    message: Optional[str]
-    title: Optional[str]
-    culprit: Optional[str]
-    level: Optional[str]
-    location: Optional[str]
-    version: Optional[str]
-    type: Optional[str]
-    exception_stacks_type: Sequence[Optional[str]]
-    exception_stacks_value: Sequence[Optional[str]]
-    exception_stacks_mechanism_type: Sequence[Optional[str]]
-    exception_stacks_mechanism_handled: Sequence[Optional[int]]
-    exception_frames_abs_path: Sequence[Optional[str]]
-    exception_frames_colno: Sequence[Optional[int]]
-    exception_frames_filename: Sequence[Optional[str]]
-    exception_frames_function: Sequence[Optional[str]]
-    exception_frames_lineno: Sequence[Optional[int]]
-    exception_frames_in_app: Sequence[Optional[int]]
-    exception_frames_package: Sequence[Optional[str]]
-    exception_frames_module: Sequence[Optional[str]]
-    exception_frames_stack_level: Sequence[Optional[int]]
-    sdk_integrations: Sequence[str]
-    modules_name: Sequence[str]
-    modules_version: Sequence[str]
-
-    @classmethod
-    def field_names(self) -> Sequence[str]:
-        return [
-            "event_id",
-            "project_id",
-            "timestamp",
-            "platform",
-            "environment",
-            "sentry:release",
-            "sentry:dist",
-            "ip_address",
-            "sentry:user",
-            "user_id",
-            "username",
-            "email",
-            "sdk_name",
-            "sdk_version",
-            "http_method",
-            "http_referer",
-            "tags.key",
-            "tags.value",
-            "contexts.key",
-            "contexts.value",
-            "transaction",
-            "partition",
-            "offset",
-            "message_timestamp",
-            "retention_days",
-            "deleted",
-            "group_id",
-            "primary_hash",
-            "received",
-            "message",
-            "title",
-            "culprit",
-            "level",
-            "location",
-            "version",
-            "type",
-            "exception_stacks.type",
-            "exception_stacks.value",
-            "exception_stacks.mechanism_type",
-            "exception_stacks.mechanism_handled",
-            "exception_frames.abs_path",
-            "exception_frames.colno",
-            "exception_frames.filename",
-            "exception_frames.function",
-            "exception_frames.lineno",
-            "exception_frames.in_app",
-            "exception_frames.package",
-            "exception_frames.module",
-            "exception_frames.stack_level",
-            "sdk_integrations",
-            "modules.name",
-            "modules.version",
-        ]
+def format_date(day: date) -> str:
+    return day.strftime("%Y-%m-%d")
 
 
-class Error(NamedTuple):
-    event_id: UUID
-    project_id: int
-    timestamp: datetime
-    platform: str
-    environment: Optional[str]
-    release: Optional[str]
-    dist: Optional[str]
-    ip_address_v4: Optional[str]
-    ip_address_v6: Optional[str]
-    user: str
-    user_id: Optional[str]
-    user_name: Optional[str]
-    user_email: Optional[str]
-    sdk_name: Optional[str]
-    sdk_version: Optional[str]
-    http_method: Optional[str]
-    http_referer: Optional[str]
-    tags_key: Sequence[str]
-    tags_value: Sequence[str]
-    contexts_key: Sequence[str]
-    contexts_value: Sequence[str]
-    transaction_name: str
-    span_id: Optional[int]
-    trace_id: Optional[UUID]
-    partition: int
-    offset: int
-    message_timestamp: datetime
-    retention_days: int
-    deleted: int
-    group_id: int
-    primary_hash: UUID
-    received: Union[datetime, int]
-    message: str
-    title: str
-    culprit: str
-    level: Optional[str]
-    location: Optional[str]
-    version: Optional[str]
-    type: str
-    exception_stacks_type: Sequence[Optional[str]]
-    exception_stacks_value: Sequence[Optional[str]]
-    exception_stacks_mechanism_type: Sequence[Optional[str]]
-    exception_stacks_mechanism_handled: Sequence[Optional[int]]
-    exception_frames_abs_path: Sequence[Optional[str]]
-    exception_frames_colno: Sequence[Optional[int]]
-    exception_frames_filename: Sequence[Optional[str]]
-    exception_frames_function: Sequence[Optional[str]]
-    exception_frames_lineno: Sequence[Optional[int]]
-    exception_frames_in_app: Sequence[Optional[int]]
-    exception_frames_package: Sequence[Optional[str]]
-    exception_frames_module: Sequence[Optional[str]]
-    exception_frames_stack_level: Sequence[Optional[int]]
-    sdk_integrations: Sequence[str]
-    modules_name: Sequence[str]
-    modules_version: Sequence[str]
-
-    @classmethod
-    def field_names(self) -> Sequence[str]:
-        return [
-            "event_id",
-            "project_id",
-            "timestamp",
-            "platform",
-            "environment",
-            "release",
-            "dist",
-            "ip_address_v4",
-            "ip_address_v6",
-            "user",
-            "user_id",
-            "user_name",
-            "user_email",
-            "sdk_name",
-            "sdk_version",
-            "http_method",
-            "http_referer",
-            "tags.key",
-            "tags.value",
-            "contexts.key",
-            "contexts.value",
-            "transaction_name",
-            "span_id",
-            "trace_id",
-            "partition",
-            "offset",
-            "message_timestamp",
-            "retention_days",
-            "deleted",
-            "group_id",
-            "primary_hash",
-            "received",
-            "message",
-            "title",
-            "culprit",
-            "level",
-            "location",
-            "version",
-            "type",
-            "exception_stacks.type",
-            "exception_stacks.value",
-            "exception_stacks.mechanism_type",
-            "exception_stacks.mechanism_handled",
-            "exception_frames.abs_path",
-            "exception_frames.colno",
-            "exception_frames.filename",
-            "exception_frames.function",
-            "exception_frames.lineno",
-            "exception_frames.in_app",
-            "exception_frames.package",
-            "exception_frames.module",
-            "exception_frames.stack_level",
-            "sdk_integrations",
-            "modules.name",
-            "modules.version",
-        ]
+def get_monday(day: date) -> date:
+    return day - timedelta(days=day.weekday())
 
 
-def process_event(event_data: Sequence[Any]) -> Mapping[str, Any]:
-    event = Event(*event_data)
-    ip_v4 = None
-    ip_v6 = None
-    ip_address = _ensure_valid_ip(event.ip_address)
-
-    if ip_address:
-        if ip_address.version == 4:
-            ip_v4 = str(ip_address)
-        elif ip_address.version == 6:
-            ip_v6 = str(ip_address)
-
-    # Extract promoted contexts
-    trace_id = None
-    span_id = None
-
-    try:
-        trace_idx = event.contexts_key.index("trace")
-        transaction_ctx = json.loads(event.contexts_value[trace_idx])
-    except ValueError:
-        transaction_ctx = {}
-
-    if transaction_ctx.get("trace_id", None):
-        trace_id = UUID(transaction_ctx["trace_id"])
-    if transaction_ctx.get("span_id", None):
-        span_id = int(transaction_ctx["span_id"], 16)
-
-    error = Error(
-        UUID(event.event_id),
-        event.project_id,
-        event.timestamp,
-        event.platform or "",
-        event.environment,
-        event.release,
-        event.dist,
-        ip_v4,
-        ip_v6,
-        event.user or "",
-        event.user_id,
-        event.user_name,
-        event.user_email,
-        event.sdk_name,
-        event.sdk_version,
-        event.http_method,
-        event.http_referer,
-        event.tags_key,
-        event.tags_value,
-        event.contexts_key,
-        event.contexts_value,
-        event.transaction_name or "",
-        span_id,
-        trace_id,
-        event.partition or 0,
-        event.offset or 0,
-        event.message_timestamp,
-        event.retention_days,
-        event.deleted,
-        event.group_id,
-        UUID(event.primary_hash),
-        event.received or 0,
-        event.message or "",
-        event.title or "",
-        event.culprit or "",
-        event.level,
-        event.location,
-        event.version,
-        event.type or "",
-        event.exception_stacks_type,
-        event.exception_stacks_value,
-        event.exception_stacks_mechanism_type,
-        event.exception_stacks_mechanism_handled,
-        event.exception_frames_abs_path,
-        event.exception_frames_colno,
-        event.exception_frames_filename,
-        event.exception_frames_function,
-        event.exception_frames_lineno,
-        event.exception_frames_in_app,
-        event.exception_frames_package,
-        event.exception_frames_module,
-        event.exception_frames_stack_level,
-        event.sdk_integrations,
-        event.modules_name,
-        event.modules_version,
-    )
-
-    return {
-        name: value
-        for name, value in zip(Error.field_names(), error._asdict().values())
-    }
+WINDOW = timedelta(days=7)
+BEGINNING_OF_TIME = get_monday((datetime.utcnow() - timedelta(days=90)).date())
 
 
-class MigratedEvent(NamedTuple):
-    event_id: str
-    project_id: int
-    timestamp: datetime
-
-    def __repr__(self) -> str:
-        return f"{self.event_id} {self.project_id} {self.timestamp}"
+COLUMNS = [
+    ("project_id", "project_id"),
+    ("timestamp", "timestamp"),
+    (
+        "event_id",
+        "toUUID(UUIDNumToString(toFixedString(unhex(toString(event_id)), 16)))",
+    ),
+    ("platform", "ifNull(`platform`, '')"),
+    ("environment", "environment"),
+    ("release", "`sentry:release`"),
+    ("dist", "`sentry:dist`"),
+    ("ip_address_v4", "if(position(ip_address, '.') > 0, toIPv4(`ip_address`), Null)"),
+    ("ip_address_v6", "if(position(ip_address, ':') > 0, toIPv6(`ip_address`), Null)"),
+    ("user", "ifNull(`sentry:user`, '')"),
+    ("user_id", "user_id"),
+    ("user_name", "username"),
+    ("user_email", "email"),
+    ("sdk_name", "sdk_name"),
+    ("sdk_version", "sdk_version"),
+    ("http_method", "http_method"),
+    ("http_referer", "http_referer"),
+    ("tags.key", "tags.key"),
+    ("tags.value", "tags.value"),
+    ("contexts.key", "contexts.key"),
+    ("contexts.value", "contexts.value"),
+    ("transaction_name", "ifNull(`transaction`, '')"),
+    (
+        "span_id",
+        "reinterpretAsUInt64(reverse(unhex(upper(contexts.value[indexOf(contexts.key, 'trace.span_id')]))))",
+    ),
+    (
+        "trace_id",
+        "toUUID(UUIDNumToString(toFixedString(unhex(contexts.value[indexOf(contexts.key, 'trace.trace_id')]), 16)))",
+    ),
+    ("partition", "ifNull(`partition`, 0)"),
+    ("offset", "ifNull(`offset`, 0)"),
+    ("message_timestamp", "message_timestamp"),
+    ("retention_days", "retention_days"),
+    ("deleted", "deleted"),
+    ("group_id", "group_id"),
+    (
+        "primary_hash",
+        "toUUID(UUIDNumToString(toFixedString(unhex(toString(primary_hash)), 16)))",
+    ),
+    ("received", "ifNull(`received`, now())"),
+    ("message", "ifNull(`message`, '')"),
+    ("title", "ifNull(`title`, '')"),
+    ("culprit", "ifNull(`culprit`, '')"),
+    ("level", "level"),
+    ("location", "location"),
+    ("version", "version"),
+    ("type", "ifNull(`type`, '')"),
+    ("exception_stacks.type", "exception_stacks.type"),
+    ("exception_stacks.value", "exception_stacks.value"),
+    ("exception_stacks.mechanism_type", "exception_stacks.mechanism_type"),
+    ("exception_stacks.mechanism_handled", "exception_stacks.mechanism_handled"),
+    ("exception_frames.abs_path", "exception_frames.abs_path"),
+    ("exception_frames.colno", "exception_frames.colno"),
+    ("exception_frames.filename", "exception_frames.filename"),
+    ("exception_frames.function", "exception_frames.function"),
+    ("exception_frames.lineno", "exception_frames.lineno"),
+    ("exception_frames.in_app", "exception_frames.in_app"),
+    ("exception_frames.package", "exception_frames.package"),
+    ("exception_frames.module", "exception_frames.module"),
+    ("exception_frames.stack_level", "exception_frames.stack_level"),
+    ("sdk_integrations", "sdk_integrations"),
+    ("modules.name", "modules.name"),
+    ("modules.version", "modules.version"),
+]
 
 
 def backfill_errors() -> None:
@@ -363,105 +103,72 @@ def backfill_errors() -> None:
     errors_storage = get_writable_storage(StorageKey.ERRORS)
 
     cluster = events_storage.get_cluster()
+    database_name = cluster.get_database()
 
     clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
 
     events_table_name = events_storage.get_table_writer().get_schema().get_table_name()
     errors_table_name = errors_storage.get_table_writer().get_schema().get_table_name()
 
-    # Either the last event that was migrated, or the last timestamp we've checked
-    # after which all events have already been migrated
-    last_migrated: Union[MigratedEvent, datetime]
-
     try:
-        (timestamp, project) = clickhouse.execute(
+        (ts,) = clickhouse.execute(
             f"""
-                SELECT timestamp, project_id FROM {errors_table_name}
+                SELECT timestamp FROM {errors_table_name}
                 WHERE NOT deleted
                 ORDER BY timestamp ASC, project_id ASC
                 LIMIT 1
             """
         )[0]
 
-        (event_id,) = clickhouse.execute(
-            f"""
-            SELECT replaceAll(toString(event_id), '-', '') FROM {errors_table_name}
-            WHERE NOT deleted
-            AND project_id = {escape_literal(project)}
-            AND timestamp = {escape_literal(timestamp)}
-            ORDER BY timestamp ASC, project_id ASC, replaceAll(toString(event_id), '-', '') ASC
-            LIMIT 1
-            """
-        )[0]
-
-        last_migrated = MigratedEvent(event_id, project, timestamp)
-
-        print(f"Error data was found; starting migration from {last_migrated}")
+        print("Error data was found")
     except IndexError:
-        last_migrated = datetime.utcnow()
+        ts = datetime.utcnow()
 
-    src_columns = ", ".join(
-        [cast(str, escape_identifier(field)) for field in Event.field_names()]
-    )
+    timestamp = get_monday(ts.date())
 
-    events_migrated = 0
+    print(f"Starting migration from {format_date(timestamp)}")
 
     while True:
-        if isinstance(last_migrated, MigratedEvent):
-            event_conditions = f"""
-            AND (
-                (
-                    timestamp = {escape_literal(last_migrated.timestamp)}
-                    AND (
-                        project_id < {escape_literal(last_migrated.project_id)}
-                        OR (
-                            project_id = {escape_literal(last_migrated.project_id)}
-                            AND event_id < {escape_literal(last_migrated.event_id)}
-                        )
-                    )
-                )
-                OR (
-                    timestamp < {escape_literal(last_migrated.timestamp)}
-                )
-            )
-            AND timestamp >= {escape_literal(last_migrated.timestamp - MAX_BATCH_WINDOW)}
-            """
-        else:
-            event_conditions = f"""
-            AND timestamp >= {escape_literal(last_migrated - MAX_BATCH_WINDOW)}
-            AND timestamp <= {escape_literal(last_migrated)}
-            """
+        where = f"toMonday(timestamp) = toDate('{format_date(timestamp)}') AND (deleted = 0)"
 
-        raw_events = clickhouse.execute(
-            f"""
-            SELECT {src_columns} FROM {events_table_name}
-            WHERE type != 'transaction'
-            AND NOT deleted
-            {event_conditions}
-            ORDER BY timestamp DESC, project_id DESC, event_id DESC
-            LIMIT {MAX_BATCH_SIZE}
+        operation = InsertIntoSelect(
+            storage_set=StorageSetKey.EVENTS,
+            dest_table_name=errors_table_name,
+            dest_columns=[c[0] for c in COLUMNS],
+            src_table_name=events_table_name,
+            src_columns=[c[1] for c in COLUMNS],
+            prewhere="type != 'transaction'",
+            where=where,
+        )
+        clickhouse.execute(operation.format_sql())
+
+        print(f"Migrated {format_date(timestamp)}.")
+
+        timestamp -= WINDOW
+
+        if timestamp < BEGINNING_OF_TIME:
+            print("Done. Optimizing.")
+            break
+
+    if cluster.is_single_node():
+        partitions = clickhouse.execute(
             """
+            SELECT partition, count() as c
+            FROM system.parts
+            WHERE active
+            AND database = %(database)s
+            AND table = %(table)s
+            GROUP BY partition
+            HAVING c > 1
+            ORDER BY c DESC, partition
+            """,
+            {"database": database_name, "table": errors_table_name},
         )
 
-        if len(raw_events) == 0:
-            if isinstance(last_migrated, datetime):
-                if last_migrated - MAX_BATCH_WINDOW < BEGINNING_OF_TIME:
-                    print(f"Done. Migrated {events_migrated} events")
-                    return
-                else:
-                    last_migrated -= MAX_BATCH_WINDOW
-            else:
-                last_migrated = last_migrated.timestamp - MAX_BATCH_WINDOW
-        else:
-            (event_id, project, timestamp,) = raw_events[-1][0:3]
-            last_migrated = MigratedEvent(event_id, project, timestamp)
-
-            data = [process_event(event) for event in raw_events]
-
+        for partition, _count in partitions:
             clickhouse.execute(
-                f"INSERT INTO {errors_table_name} FORMAT JSONEachRow", data
+                f"""
+                OPTIMIZE TABLE {database_name}.{errors_table_name}
+                PARTITION {partition} FINAL DEDUPLICATE
+                """
             )
-
-            print(f"Copied {len(data)} events; last migrated event: {last_migrated}")
-
-            events_migrated += len(data)

--- a/snuba/migrations/backfill_errors.py
+++ b/snuba/migrations/backfill_errors.py
@@ -37,7 +37,9 @@ arrayMap(
                 arrayZip(contexts.key, contexts.value),
                 [('geo_city', geo_city)],
                 [('geo_country_code', geo_country_code)],
-                [('geo_region', geo_region)]
+                [('geo_region', geo_region)],
+                [('os_build', os_build)],
+                [('os_kernel_version', os_kernel_version)]
             )
         )
     ) AS tuplesArray

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -253,17 +253,32 @@ class InsertIntoSelect(SqlOperation):
         dest_columns: Sequence[str],
         src_table_name: str,
         src_columns: Sequence[str],
+        prewhere: Optional[str] = None,
+        where: Optional[str] = None,
     ):
         super().__init__(storage_set)
         self.__dest_table_name = dest_table_name
         self.__dest_columns = dest_columns
         self.__src_table_name = src_table_name
         self.__src_columns = src_columns
+        self.__prewhere = prewhere
+        self.__where = where
 
     def format_sql(self) -> str:
         src_columns = ", ".join(self.__src_columns)
         dest_columns = ", ".join(self.__dest_columns)
-        return f"INSERT INTO {self.__dest_table_name} ({dest_columns}) SELECT {src_columns} FROM {self.__src_table_name};"
+
+        if self.__prewhere:
+            prewhere_clause = f" PREWHERE {self.__prewhere}"
+        else:
+            prewhere_clause = ""
+
+        if self.__where:
+            where_clause = f" WHERE {self.__where}"
+        else:
+            where_clause = ""
+
+        return f"INSERT INTO {self.__dest_table_name} ({dest_columns}) SELECT {src_columns} FROM {self.__src_table_name}{prewhere_clause}{where_clause};"
 
 
 class RunPython(Operation):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -64,6 +64,11 @@ def get_raw_event() -> InsertEvent:
                 "method": "POST",
                 "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
             },
+            "user": {
+                "email": "sally@example.org",
+                "ip_address": "8.8.8.8",
+                "geo": {"city": "San Francisco", "region": "CA", "country_code": "US"},
+            },
             "contexts": {
                 "device": {"online": True, "charging": True, "model_id": "Galaxy"}
             },

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -70,7 +70,8 @@ def get_raw_event() -> InsertEvent:
                 "geo": {"city": "San Francisco", "region": "CA", "country_code": "US"},
             },
             "contexts": {
-                "device": {"online": True, "charging": True, "model_id": "Galaxy"}
+                "device": {"online": True, "charging": True, "model_id": "Galaxy"},
+                "os": {"kernel_version": "1.1.1"},
             },
             "sentry.interfaces.Exception": {
                 "exc_omitted": None,

--- a/tests/migrations/test_backfill_errors.py
+++ b/tests/migrations/test_backfill_errors.py
@@ -35,11 +35,11 @@ def test_backfill_errors() -> None:
         f"SELECT contexts.key, contexts.value from {errors_table_name} LIMIT 1;"
     )[0] == (
         (
-            "device_model_id",
-            "geo_city",
-            "geo_country_code",
-            "geo_region",
-            "os_kernel_version",
+            "device.model_id",
+            "geo.city",
+            "geo.country_code",
+            "geo.region",
+            "os.kernel_version",
         ),
         ("Galaxy", "San Francisco", "US", "CA", "1.1.1"),
     )

--- a/tests/migrations/test_backfill_errors.py
+++ b/tests/migrations/test_backfill_errors.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
@@ -17,7 +15,6 @@ def get_errors_count() -> int:
     return clickhouse.execute(f"SELECT count() from {errors_table_name}")[0][0]
 
 
-@patch("snuba.migrations.backfill_errors.MAX_BATCH_SIZE", 5)
 def test_backfill_errors() -> None:
     raw_events = []
     for i in range(10):

--- a/tests/migrations/test_backfill_errors.py
+++ b/tests/migrations/test_backfill_errors.py
@@ -34,6 +34,6 @@ def test_backfill_errors() -> None:
     assert clickhouse.execute(
         f"SELECT contexts.key, contexts.value from {errors_table_name} LIMIT 1;"
     )[0] == (
-        ("geo_city", "geo_country_code", "geo_region"),
-        ("San Francisco", "US", "CA"),
+        ("geo_city", "geo_country_code", "geo_region", "os_kernel_version"),
+        ("San Francisco", "US", "CA", "1.1.1"),
     )

--- a/tests/migrations/test_backfill_errors.py
+++ b/tests/migrations/test_backfill_errors.py
@@ -34,6 +34,12 @@ def test_backfill_errors() -> None:
     assert clickhouse.execute(
         f"SELECT contexts.key, contexts.value from {errors_table_name} LIMIT 1;"
     )[0] == (
-        ("geo_city", "geo_country_code", "geo_region", "os_kernel_version"),
-        ("San Francisco", "US", "CA", "1.1.1"),
+        (
+            "device_model_id",
+            "geo_city",
+            "geo_country_code",
+            "geo_region",
+            "os_kernel_version",
+        ),
+        ("Galaxy", "San Francisco", "US", "CA", "1.1.1"),
     )


### PR DESCRIPTION
The backfill script now runs an INSERT INTO SELECT statement on
each partition to copy data from the events to errors table.
Once the migration is done OPTIMIZE TABLE will be run on each
part if the ClickHouse installation is single node. For distributed
tables, this should be performed manually on each node.