### PR TITLE
feat(joins) Ensure we always pick storages in the same storageSet step 1: Allow the QueryPlanBuilder to return more than one plan

### DIFF
--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -167,11 +167,23 @@ class ClickhouseQueryPlanBuilder(ABC):
     Embeds the dataset specific logic that selects which storage to use
     to execute the query and produces the storage query.
     This is provided by a dataset and, when executed, it returns a
-    ClickhouseQueryPlan that embeds what is needed to run the storage query.
+    sequence of valid ClickhouseQueryPlans that embeds what is needed to
+    run the storage query.
     """
 
     @abstractmethod
-    def build_plan(
+    def build_and_rank_plans(
+        self, query: LogicalQuery, request_settings: RequestSettings
+    ) -> Sequence[ClickhouseQueryPlan]:
+        """
+        Returns all the valid plans for this query sorted in ranking
+        order.
+        """
+        raise NotImplementedError
+
+    def build_best_plan(
         self, query: LogicalQuery, request_settings: RequestSettings
     ) -> ClickhouseQueryPlan:
-        raise NotImplementedError
+        plans = self.build_and_rank_plans(query, request_settings)
+        assert plans, "Query planner did not produce a plan"
+        return plans[0]

--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -112,9 +112,9 @@ class SingleStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
         self.__post_processors = post_processors or []
 
     @with_span()
-    def build_plan(
+    def build_and_rank_plans(
         self, query: LogicalQuery, settings: RequestSettings
-    ) -> ClickhouseQueryPlan:
+    ) -> Sequence[ClickhouseQueryPlan]:
         with sentry_sdk.start_span(
             op="build_plan.single_storage", description="translate"
         ):
@@ -141,17 +141,19 @@ class SingleStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
             MandatoryConditionApplier(),
         ]
 
-        return ClickhouseQueryPlan(
-            query=clickhouse_query,
-            plan_query_processors=[],
-            db_query_processors=db_query_processors,
-            storage_set_key=self.__storage.get_storage_set_key(),
-            execution_strategy=SimpleQueryPlanExecutionStrategy(
-                cluster=cluster,
+        return [
+            ClickhouseQueryPlan(
+                query=clickhouse_query,
+                plan_query_processors=[],
                 db_query_processors=db_query_processors,
-                splitters=self.__storage.get_query_splitters(),
-            ),
-        )
+                storage_set_key=self.__storage.get_storage_set_key(),
+                execution_strategy=SimpleQueryPlanExecutionStrategy(
+                    cluster=cluster,
+                    db_query_processors=db_query_processors,
+                    splitters=self.__storage.get_query_splitters(),
+                ),
+            )
+        ]
 
 
 class SelectedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
@@ -168,9 +170,9 @@ class SelectedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
         self.__post_processors = post_processors or []
 
     @with_span()
-    def build_plan(
+    def build_and_rank_plans(
         self, query: LogicalQuery, settings: RequestSettings
-    ) -> ClickhouseQueryPlan:
+    ) -> Sequence[ClickhouseQueryPlan]:
         with sentry_sdk.start_span(
             op="build_plan.selected_storage", description="select_storage"
         ):
@@ -202,14 +204,16 @@ class SelectedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
             MandatoryConditionApplier(),
         ]
 
-        return ClickhouseQueryPlan(
-            query=clickhouse_query,
-            plan_query_processors=[],
-            db_query_processors=db_query_processors,
-            storage_set_key=storage.get_storage_set_key(),
-            execution_strategy=SimpleQueryPlanExecutionStrategy(
-                cluster=cluster,
+        return [
+            ClickhouseQueryPlan(
+                query=clickhouse_query,
+                plan_query_processors=[],
                 db_query_processors=db_query_processors,
-                splitters=storage.get_query_splitters(),
-            ),
-        )
+                storage_set_key=storage.get_storage_set_key(),
+                execution_strategy=SimpleQueryPlanExecutionStrategy(
+                    cluster=cluster,
+                    db_query_processors=db_query_processors,
+                    splitters=storage.get_query_splitters(),
+                ),
+            )
+        ]

--- a/snuba/pipeline/query_pipeline.py
+++ b/snuba/pipeline/query_pipeline.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar, Union
+from typing import Generic, Sequence, TypeVar, Union
 
 from snuba.datasets.plans.query_plan import (
     ClickhouseQueryPlan,
@@ -27,7 +27,11 @@ class QueryPlanner(ABC, Generic[TPlan]):
     """
 
     @abstractmethod
-    def execute(self) -> TPlan:
+    def build_best_plan(self) -> TPlan:
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_and_rank_plans(self) -> Sequence[TPlan]:
         raise NotImplementedError
 
 

--- a/snuba/pipeline/simple_pipeline.py
+++ b/snuba/pipeline/simple_pipeline.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from snuba.datasets.plans.query_plan import (
     ClickhouseQueryPlan,
     ClickhouseQueryPlanBuilder,
@@ -39,10 +41,17 @@ class EntityQueryPlanner(QueryPlanner[ClickhouseQueryPlan]):
         self.__settings = settings
         self.__query_plan_builder = query_plan_builder
 
-    def execute(self) -> ClickhouseQueryPlan:
+    def build_best_plan(self) -> ClickhouseQueryPlan:
         execute_entity_processors(self.__query, self.__settings)
 
-        return self.__query_plan_builder.build_plan(self.__query, self.__settings)
+        return self.__query_plan_builder.build_best_plan(self.__query, self.__settings)
+
+    def build_and_rank_plans(self) -> Sequence[ClickhouseQueryPlan]:
+        execute_entity_processors(self.__query, self.__settings)
+
+        return self.__query_plan_builder.build_and_rank_plans(
+            self.__query, self.__settings
+        )
 
 
 class SimpleExecutionPipeline(QueryExecutionPipeline):
@@ -60,7 +69,7 @@ class SimpleExecutionPipeline(QueryExecutionPipeline):
     def execute(self) -> QueryResult:
         settings = self.__request.settings
 
-        query_plan = self.__query_planner.execute()
+        query_plan = self.__query_planner.build_best_plan()
         execute_plan_processors(query_plan, settings)
 
         return query_plan.execution_strategy.execute(

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -482,7 +482,7 @@ def test_composite_planner(
 
     plan = CompositeQueryPlanner(
         deepcopy(logical_query), HTTPRequestSettings()
-    ).execute()
+    ).build_best_plan()
     report = plan.query.equals(composite_plan.query)
     assert report[0], f"Mismatch: {report[1]}"
 

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -340,7 +340,7 @@ def parse_and_process(query_body: MutableMapping[str, Any]) -> ClickhouseQuery:
 
     query_plan = SingleStorageQueryPlanBuilder(
         storage=entity.get_writable_storage(), mappers=transaction_translator,
-    ).build_plan(query, request.settings)
+    ).build_and_rank_plans(query, request.settings)[0]
 
     return query_plan.query
 

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -227,7 +227,7 @@ def test_alias_validation(
         events.get_default_entity()
         .get_query_pipeline_builder()
         .build_planner(query, settings)
-    ).execute()
+    ).build_best_plan()
     execute_all_clickhouse_processors(query_plan, settings)
 
     assert query_plan.query.validate_aliases() == expected_result


### PR DESCRIPTION
When we execute join queries, each entity provides a query plan builder, this picks a storage and build a QueryPlan for that subquery. 
If an entity has multiple viable storages for a query on different StorageSet, the join planner needs to know about all of them (ranked from best to worst) to ensure we pick storages on the same storage set for all entities. 
If that does not happen the query would fail because the storages may be on different clusters. 

This changes the interface of the QueryPlanBuilder to build multiple plans and either return the best or return the whole list. Single query pipelines use the best directly, the join planner has access to all viable options.