### PR TITLE
feat: Add referrer to Snuplicator logging

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -431,7 +431,9 @@ class DiscoverEntity(Entity):
 
             return "events", []
 
-        def callback_func(query: Query, results: List[Result[QueryResult]]) -> None:
+        def callback_func(
+            query: Query, referrer: str, results: List[Result[QueryResult]]
+        ) -> None:
             primary_result = results.pop(0)
             primary_result_data = primary_result.result.result["data"]
 
@@ -448,6 +450,7 @@ class DiscoverEntity(Entity):
                             "Non matching Discover result - different length",
                             extra={
                                 "query": query.get_body(),
+                                "referrer": referrer,
                                 "discover_result": len(result_data),
                                 "events_result": len(primary_result_data),
                             },
@@ -461,6 +464,7 @@ class DiscoverEntity(Entity):
                                 "Non matching Discover result - different result",
                                 extra={
                                     "query": query.get_body(),
+                                    "referrer": referrer,
                                     "discover_result": result_data[idx],
                                     "events_result": primary_result_data[idx],
                                 },

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -18,7 +18,7 @@ Timing = float
 QueryPipelineBuilders = Mapping[BuilderId, QueryPipelineBuilder[ClickhouseQueryPlan]]
 QueryResults = List[Result[QueryResult]]
 SelectorFunc = Callable[[LogicalQuery], Tuple[BuilderId, List[BuilderId]]]
-CallbackFunc = Callable[[LogicalQuery, QueryResults], None]
+CallbackFunc = Callable[[LogicalQuery, str, QueryResults], None]
 
 
 class MultipleConcurrentPipeline(QueryExecutionPipeline):
@@ -58,7 +58,9 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
         self.__query_pipeline_builders = query_pipeline_builders
         self.__selector_func = selector_func
         self.__callback_func = (
-            partial(callback_func, self.__request.query) if callback_func else None
+            partial(callback_func, self.__request.query, self.__request.referrer)
+            if callback_func
+            else None
         )
 
     def execute(self) -> QueryResult:

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -53,7 +53,7 @@ def test() -> None:
 
     with cv:
         delegator.build_execution_pipeline(
-            Request("", query, HTTPRequestSettings(), {}, ""), mock_query_runner
+            Request("", query, HTTPRequestSettings(), {}, "ref"), mock_query_runner
         ).execute()
         cv.wait(timeout=5)
 
@@ -61,5 +61,6 @@ def test() -> None:
 
     assert mock_callback.call_args == call(
         query,
+        "ref",
         [Result("events", query_result, ANY), Result("errors", query_result, ANY)],
     )


### PR DESCRIPTION
Add the Sentry referrer to Snuplicator logging to help diagnose the underlying
cause of discrepancies.