### PR TITLE
feat(optimize): Enable optimize for errors and transactions

### DIFF
--- a/snuba/cleanup.py
+++ b/snuba/cleanup.py
@@ -32,7 +32,8 @@ def get_active_partitions(
         {"database": database, "table": table},
     )
 
-    return [util.decode_part_str(part) for part, in response]
+    events_part_format = [util.PartSegment.DATE, util.PartSegment.RETENTION_DAYS]
+    return [util.decode_part_str(part, events_part_format) for part, in response]
 
 
 def filter_stale_partitions(
@@ -45,7 +46,9 @@ def filter_stale_partitions(
         as_of = datetime.utcnow()
 
     stale_parts = []
-    for part_date, retention_days in parts:
+    for part in parts:
+        part_date = part.date
+        retention_days = part.retention_days
         part_last_day = part_date + timedelta(days=6 - part_date.weekday())
 
         if part_last_day < (as_of - timedelta(days=retention_days)):

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -69,5 +69,5 @@ def optimize(
             ClickhouseClientSettings.OPTIMIZE
         )
 
-    num_dropped = run_optimize(connection, storage_key, database, before=today)
+    num_dropped = run_optimize(connection, storage, database, before=today)
     logger.info("Optimized %s partitions on %s" % (num_dropped, clickhouse_host))

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -3,10 +3,9 @@ from typing import Optional
 import click
 
 from snuba.clusters.cluster import ClickhouseClientSettings
-from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import STORAGES, get_storage
+from snuba.datasets.storages.factory import get_storage
 from snuba.environment import setup_logging
 
 
@@ -22,7 +21,7 @@ from snuba.environment import setup_logging
     "--storage",
     "storage_name",
     default="events",
-    type=click.Choice([storage_key.value for storage_key in STORAGES.keys()]),
+    type=click.Choice(["events", "errors", "transactions"]),
     help="The storage to target",
 )
 @click.option("--log-level", help="Logging level to use.")
@@ -47,12 +46,6 @@ def optimize(
 
     (clickhouse_user, clickhouse_password) = storage.get_cluster().get_credentials()
 
-    schema = storage.get_schema()
-
-    assert isinstance(schema, TableSchema)
-
-    table_to_optimize = schema.get_local_table_name()
-
     today = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
 
     # TODO: In distributed mode, optimize currently must be run once for each node
@@ -76,5 +69,5 @@ def optimize(
             ClickhouseClientSettings.OPTIMIZE
         )
 
-    num_dropped = run_optimize(connection, database, table_to_optimize, before=today)
+    num_dropped = run_optimize(connection, storage_key, database, before=today)
     logger.info("Optimized %s partitions on %s" % (num_dropped, clickhouse_host))

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -30,7 +30,7 @@ class TestCleanup:
         # base, 90 retention
         write_processed_messages(storage, [self.create_event_row_for_date(base)])
         parts = cleanup.get_active_partitions(clickhouse, database, table)
-        assert parts == [(to_monday(base), 90)]
+        assert [(p.date, p.retention_days) for p in parts] == [(to_monday(base), 90)]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
         assert stale == []
 
@@ -40,7 +40,10 @@ class TestCleanup:
             storage, [self.create_event_row_for_date(three_weeks_ago)]
         )
         parts = cleanup.get_active_partitions(clickhouse, database, table)
-        assert parts == [(to_monday(three_weeks_ago), 90), (to_monday(base), 90)]
+        assert [(p.date, p.retention_days) for p in parts] == [
+            (to_monday(three_weeks_ago), 90),
+            (to_monday(base), 90),
+        ]
         stale = cleanup.filter_stale_partitions(parts, as_of=base)
         assert stale == []
 
@@ -50,7 +53,7 @@ class TestCleanup:
             storage, [self.create_event_row_for_date(thirteen_weeks_ago)]
         )
         parts = cleanup.get_active_partitions(clickhouse, database, table)
-        assert parts == [
+        assert [(p.date, p.retention_days) for p in parts] == [
             (to_monday(thirteen_weeks_ago), 90),
             (to_monday(three_weeks_ago), 90),
             (to_monday(base), 90),
@@ -64,7 +67,7 @@ class TestCleanup:
             storage, [self.create_event_row_for_date(one_week_ago, 30)]
         )
         parts = cleanup.get_active_partitions(clickhouse, database, table)
-        assert parts == [
+        assert [(p.date, p.retention_days) for p in parts] == [
             (to_monday(thirteen_weeks_ago), 90),
             (to_monday(three_weeks_ago), 90),
             (to_monday(one_week_ago), 30),
@@ -79,7 +82,7 @@ class TestCleanup:
             storage, [self.create_event_row_for_date(five_weeks_ago, 30)]
         )
         parts = cleanup.get_active_partitions(clickhouse, database, table)
-        assert parts == [
+        assert [(p.date, p.retention_days) for p in parts] == [
             (to_monday(thirteen_weeks_ago), 90),
             (to_monday(five_weeks_ago), 30),
             (to_monday(three_weeks_ago), 90),
@@ -95,7 +98,7 @@ class TestCleanup:
         cleanup.drop_partitions(clickhouse, database, table, stale, dry_run=False)
 
         parts = cleanup.get_active_partitions(clickhouse, database, table)
-        assert parts == [
+        assert [(p.date, p.retention_days) for p in parts] == [
             (to_monday(three_weeks_ago), 90),
             (to_monday(one_week_ago), 30),
             (to_monday(base), 90),

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -80,7 +80,7 @@ class TestOptimize:
 
         # no data, 0 partitions to optimize
         parts = optimize.get_partitions_to_optimize(
-            clickhouse, storage_key, database, table
+            clickhouse, storage, database, table
         )
         assert parts == []
 
@@ -90,21 +90,21 @@ class TestOptimize:
         # 1 event, 0 unoptimized parts
         write_processed_messages(storage, [create_event_row_for_date(base)])
         parts = optimize.get_partitions_to_optimize(
-            clickhouse, storage_key, database, table
+            clickhouse, storage, database, table
         )
         assert parts == []
 
         # 2 events in the same part, 1 unoptimized part
         write_processed_messages(storage, [create_event_row_for_date(base)])
         parts = optimize.get_partitions_to_optimize(
-            clickhouse, storage_key, database, table
+            clickhouse, storage, database, table
         )
         assert [(p.date, p.retention_days) for p in parts] == [(base_monday, 90)]
 
         # 3 events in the same part, 1 unoptimized part
         write_processed_messages(storage, [create_event_row_for_date(base)])
         parts = optimize.get_partitions_to_optimize(
-            clickhouse, storage_key, database, table
+            clickhouse, storage, database, table
         )
         assert [(p.date, p.retention_days) for p in parts] == [(base_monday, 90)]
 
@@ -120,7 +120,7 @@ class TestOptimize:
             storage, [create_event_row_for_date(a_month_earlier_monday)]
         )
         parts = optimize.get_partitions_to_optimize(
-            clickhouse, storage_key, database, table
+            clickhouse, storage, database, table
         )
         assert [(p.date, p.retention_days) for p in parts] == [
             (base_monday, 90),
@@ -132,15 +132,15 @@ class TestOptimize:
             (p.date, p.retention_days)
             for p in list(
                 optimize.get_partitions_to_optimize(
-                    clickhouse, storage_key, database, table, before=base
+                    clickhouse, storage, database, table, before=base
                 )
             )
         ] == [(a_month_earlier_monday, 90)]
 
-        optimize.optimize_partitions(clickhouse, storage_key, database, table, parts)
+        optimize.optimize_partitions(clickhouse, database, table, parts)
 
         # all parts should be optimized
         parts = optimize.get_partitions_to_optimize(
-            clickhouse, storage_key, database, table
+            clickhouse, storage, database, table
         )
         assert parts == []

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,6 +1,8 @@
 import uuid
 from datetime import datetime, timedelta
-from typing import Any, Mapping
+from typing import Callable
+
+import pytest
 
 from snuba import optimize, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
@@ -10,65 +12,10 @@ from snuba.processor import InsertBatch
 from tests.helpers import write_processed_messages
 
 
-class TestOptimize:
-    def test(self) -> None:
-        storage = get_writable_storage(StorageKey.EVENTS)
-        cluster = storage.get_cluster()
-        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
-        table = storage.get_table_writer().get_schema().get_table_name()
-        database = cluster.get_database()
-
-        # no data, 0 partitions to optimize
-        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
-        assert parts == []
-
-        base = datetime(1999, 12, 26)  # a sunday
-        base_monday = base - timedelta(days=base.weekday())
-
-        # 1 event, 0 unoptimized parts
-        write_processed_messages(storage, [self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
-        assert parts == []
-
-        # 2 events in the same part, 1 unoptimized part
-        write_processed_messages(storage, [self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
-        assert parts == [(base_monday, 90)]
-
-        # 3 events in the same part, 1 unoptimized part
-        write_processed_messages(storage, [self.create_event_row_for_date(base)])
-        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
-        assert parts == [(base_monday, 90)]
-
-        # 3 events in one part, 2 in another, 2 unoptimized parts
-        a_month_earlier = base_monday - timedelta(days=31)
-        a_month_earlier_monday = a_month_earlier - timedelta(
-            days=a_month_earlier.weekday()
-        )
-        write_processed_messages(
-            storage, [self.create_event_row_for_date(a_month_earlier_monday)]
-        )
-        write_processed_messages(
-            storage, [self.create_event_row_for_date(a_month_earlier_monday)]
-        )
-        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
-        assert parts == [(base_monday, 90), (a_month_earlier_monday, 90)]
-
-        # respects before (base is properly excluded)
-        assert list(
-            optimize.get_partitions_to_optimize(
-                clickhouse, database, table, before=base
-            )
-        ) == [(a_month_earlier_monday, 90)]
-
-        optimize.optimize_partitions(clickhouse, database, table, parts)
-
-        # all parts should be optimized
-        parts = optimize.get_partitions_to_optimize(clickhouse, database, table)
-        assert parts == []
-
-    def create_event_row_for_date(self, dt: datetime) -> Mapping[str, Any]:
-        return InsertBatch(
+test_data = [
+    pytest.param(
+        StorageKey.EVENTS,
+        lambda dt: InsertBatch(
             [
                 {
                     "event_id": uuid.uuid4().hex,
@@ -79,4 +26,115 @@ class TestOptimize:
                     "retention_days": settings.DEFAULT_RETENTION_DAYS,
                 }
             ]
+        ),
+        id="events",
+    ),
+    pytest.param(
+        StorageKey.ERRORS,
+        lambda dt: InsertBatch(
+            [
+                {
+                    "event_id": str(uuid.uuid4()),
+                    "project_id": 1,
+                    "group_id": 1,
+                    "deleted": 0,
+                    "timestamp": dt,
+                    "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                }
+            ]
+        ),
+        id="errors",
+    ),
+    pytest.param(
+        StorageKey.TRANSACTIONS,
+        lambda dt: InsertBatch(
+            [
+                {
+                    "event_id": str(uuid.uuid4()),
+                    "project_id": 1,
+                    "deleted": 0,
+                    "finish_ts": dt,
+                    "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                }
+            ]
+        ),
+        id="transactions",
+    ),
+]
+
+
+class TestOptimize:
+    @pytest.mark.parametrize(
+        "storage_key, create_event_row_for_date", test_data,
+    )
+    def test_optimize(
+        self,
+        storage_key: StorageKey,
+        create_event_row_for_date: Callable[[datetime], InsertBatch],
+    ) -> None:
+        storage = get_writable_storage(storage_key)
+        cluster = storage.get_cluster()
+        clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
+        table = storage.get_table_writer().get_schema().get_table_name()
+        database = cluster.get_database()
+
+        # no data, 0 partitions to optimize
+        parts = optimize.get_partitions_to_optimize(
+            clickhouse, storage_key, database, table
         )
+        assert parts == []
+
+        base = datetime(1999, 12, 26)  # a sunday
+        base_monday = base - timedelta(days=base.weekday())
+
+        # 1 event, 0 unoptimized parts
+        write_processed_messages(storage, [create_event_row_for_date(base)])
+        parts = optimize.get_partitions_to_optimize(
+            clickhouse, storage_key, database, table
+        )
+        assert parts == []
+
+        # 2 events in the same part, 1 unoptimized part
+        write_processed_messages(storage, [create_event_row_for_date(base)])
+        parts = optimize.get_partitions_to_optimize(
+            clickhouse, storage_key, database, table
+        )
+        assert parts == [(base_monday, 90)]
+
+        # 3 events in the same part, 1 unoptimized part
+        write_processed_messages(storage, [create_event_row_for_date(base)])
+        parts = optimize.get_partitions_to_optimize(
+            clickhouse, storage_key, database, table
+        )
+        assert parts == [(base_monday, 90)]
+
+        # 3 events in one part, 2 in another, 2 unoptimized parts
+        a_month_earlier = base_monday - timedelta(days=31)
+        a_month_earlier_monday = a_month_earlier - timedelta(
+            days=a_month_earlier.weekday()
+        )
+        write_processed_messages(
+            storage, [create_event_row_for_date(a_month_earlier_monday)]
+        )
+        write_processed_messages(
+            storage, [create_event_row_for_date(a_month_earlier_monday)]
+        )
+        parts = optimize.get_partitions_to_optimize(
+            clickhouse, storage_key, database, table
+        )
+        assert parts == [(base_monday, 90), (a_month_earlier_monday, 90)]
+
+        # respects before (base is properly excluded)
+        assert list(
+            optimize.get_partitions_to_optimize(
+                clickhouse, storage_key, database, table, before=base
+            )
+        ) == [(a_month_earlier_monday, 90)]
+
+        optimize.optimize_partitions(clickhouse, storage_key, database, table, parts)
+
+        # all parts should be optimized
+        parts = optimize.get_partitions_to_optimize(
+            clickhouse, storage_key, database, table
+        )
+        assert parts == []


### PR DESCRIPTION
Update the optimize script so it can be run on the errors and transactions tables.
Since these tables have differently formatted partitioning keys, this script currently
fails on anything other than events.