### PR TITLE
fix(snql) Remove extensions from SnQL queries

### DIFF
--- a/snuba/request/__init__.py
+++ b/snuba/request/__init__.py
@@ -3,12 +3,22 @@ from __future__ import annotations
 from collections import ChainMap
 from dataclasses import dataclass
 from deprecation import deprecated
+from enum import Enum
 from typing import Any, Mapping, Union
 
 from snuba.query.logical import Query
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Entity
 from snuba.request.request_settings import RequestSettings
+
+
+class Language(Enum):
+    """
+    Which language is being used in the Snuba request.
+    """
+
+    LEGACY = "legacy"
+    SNQL = "snql"
 
 
 @dataclass(frozen=True)
@@ -18,6 +28,7 @@ class Request:
     settings: RequestSettings  # settings provided by the request
     extensions: Mapping[str, Mapping[str, Any]]
     referrer: str
+    language: Language
 
     @property
     @deprecated(

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -1,4 +1,5 @@
 import sentry_sdk
+from typing import Any, MutableMapping
 
 from snuba.datasets.dataset import Dataset
 from snuba.query.exceptions import InvalidQueryException
@@ -10,7 +11,11 @@ from snuba.utils.metrics.timer import Timer
 
 
 def build_request(
-    body, schema: RequestSchema, timer: Timer, dataset: Dataset, referrer: str
+    body: MutableMapping[str, Any],
+    schema: RequestSchema,
+    timer: Timer,
+    dataset: Dataset,
+    referrer: str,
 ) -> Request:
     with sentry_sdk.start_span(description="build_request", op="validate") as span:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,10 +221,6 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
 
         query = f"{match_clause} {select_clause} {aggregation_clause} {groupby_clause} {where_clause} {having_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
         body = {"query": query}
-        extensions = ["project", "from_date", "to_date", "organization"]
-        for ext in extensions:
-            if ext in legacy:
-                body[ext] = legacy.get(ext)
 
         return json.dumps(body)
 

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -4,7 +4,7 @@ from snuba.query import SelectedExpression
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.parser import parse_query
 from snuba.reader import Reader
-from snuba.request import Request
+from snuba.request import Language, Request
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
@@ -14,7 +14,7 @@ def test_events_processing() -> None:
 
     events = get_dataset("events")
     query = parse_query(query_body, events)
-    request = Request("", query, HTTPRequestSettings(), {}, "")
+    request = Request("", query, HTTPRequestSettings(), {}, "", Language.LEGACY)
 
     def query_runner(
         query: Query, settings: RequestSettings, reader: Reader

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -13,7 +13,7 @@ from snuba.querylog.query_metadata import (
     QueryStatus,
     SnubaQueryMetadata,
 )
-from snuba.request import Request
+from snuba.request import Language, Request
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.clock import TestingClock
 from snuba.utils.metrics.timer import Timer
@@ -34,7 +34,12 @@ def test_simple() -> None:
     )
 
     request = Request(
-        uuid.UUID("a" * 32).hex, query, HTTPRequestSettings(), {}, "search"
+        uuid.UUID("a" * 32).hex,
+        query,
+        HTTPRequestSettings(),
+        {},
+        "search",
+        Language.LEGACY,
     )
 
     time = TestingClock()

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -4,7 +4,7 @@ from snuba.query import SelectedExpression
 from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
 from snuba.query.parser import parse_query
 from snuba.reader import Reader
-from snuba.request import Request
+from snuba.request import Language, Request
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
@@ -14,7 +14,7 @@ def test_sessions_processing() -> None:
 
     sessions = get_dataset("sessions")
     query = parse_query(query_body, sessions)
-    request = Request("", query, HTTPRequestSettings(), {}, "")
+    request = Request("", query, HTTPRequestSettings(), {}, "", Language.LEGACY)
 
     def query_runner(
         query: Query, settings: RequestSettings, reader: Reader

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -9,7 +9,7 @@ from snuba.datasets.storages.factory import get_storage
 from snuba.pipeline.pipeline_delegator import PipelineDelegator
 from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 from snuba.query.parser import parse_query
-from snuba.request import Request
+from snuba.request import Language, Request
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.threaded_function_delegator import Result
 from snuba.web import QueryResult
@@ -53,7 +53,8 @@ def test() -> None:
 
     with cv:
         delegator.build_execution_pipeline(
-            Request("", query, HTTPRequestSettings(), {}, "ref"), mock_query_runner
+            Request("", query, HTTPRequestSettings(), {}, "ref", Language.LEGACY),
+            mock_query_runner,
         ).execute()
         cv.wait(timeout=5)
 

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -25,7 +25,7 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     get_filtered_mapping_keys,
     zip_columns,
 )
-from snuba.request import Request
+from snuba.request import Language, Request
 from snuba.request.request_settings import HTTPRequestSettings
 
 
@@ -331,7 +331,7 @@ test_data = [
 def parse_and_process(query_body: MutableMapping[str, Any]) -> ClickhouseQuery:
     dataset = get_dataset("transactions")
     query = parse_query(query_body, dataset)
-    request = Request("a", query, HTTPRequestSettings(), {}, "r")
+    request = Request("a", query, HTTPRequestSettings(), {}, "r", Language.LEGACY)
     entity = get_entity(query.get_from_clause().key)
     for p in entity.get_query_processors():
         p.process_query(query, request.settings)

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -136,7 +136,12 @@ class TestOutcomesApi(BaseApiTest):
                     "selected_columns": [],
                     "to_date": to_date,
                     "organization": 1,
-                    "conditions": [["outcome", "=", 0], ["project_id", "IN", [1, 2]]],
+                    "conditions": [
+                        ["outcome", "=", 0],
+                        ["project_id", "IN", [1, 2]],
+                        ["timestamp", ">", from_date],
+                        ["timestamp", "<=", to_date],
+                    ],
                     "groupby": ["project_id", "time"],
                 }
             ),

--- a/tests/web/test_transform_names.py
+++ b/tests/web/test_transform_names.py
@@ -14,7 +14,7 @@ from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.reader import Column as MetaColumn
-from snuba.request import Request
+from snuba.request import Language, Request
 from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import parse_and_run_query
@@ -93,6 +93,7 @@ def test_transform_column_names() -> None:
                 "project": {"project": [1]},
             },
             referrer="asd",
+            language=Language.LEGACY,
         ),
         timer,
     )


### PR DESCRIPTION
When a SnQL query is made, the extension fields should already be part of the
query so we don't need the extensions parsed explicitly. Also remove the
timeseries extension call from the query file, since from_date and to_date
were only being used to populate num_days, which is not used anywhere.

I tested this locally with the querylog consumer and the sentry tests and saw
no errors.