### PR TITLE
fix(discover): Fix user column on Discover entity

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -409,6 +409,12 @@ class DiscoverEntity(Entity):
                             ColumnToMapping(
                                 None, "geo_city", None, "contexts", "geo.city"
                             ),
+                            ColumnToFunction(
+                                None,
+                                "user",
+                                "nullIf",
+                                (Column(None, None, "user"), Literal(None, "")),
+                            ),
                         ]
                     )
                 )


### PR DESCRIPTION
The user column should return None instead of an empty string. This aligns the user
field in the Discover entity with events, errors and transactions. The column is
nullable in events, and the same column mapping is already being performed on errors
and transactions entities.