### PR TITLE
feat(join) Plug the subquery generator into the query planner

### DIFF
--- a/snuba/pipeline/composite.py
+++ b/snuba/pipeline/composite.py
@@ -22,6 +22,8 @@ from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
 from snuba.query.data_source.simple import Entity, Table
 from snuba.query.data_source.visitor import DataSourceVisitor
+from snuba.query.joins.equivalence_adder import add_equivalent_conditions
+from snuba.query.joins.subquery_generator import generate_subqueries
 from snuba.query.logical import Query as LogicalQuery
 from snuba.request.request_settings import RequestSettings
 from snuba.web import QueryResult
@@ -57,6 +59,8 @@ class CompositeQueryPlanner(QueryPlanner[CompositeQueryPlan]):
         return self.build_and_rank_plans()[0]
 
     def build_and_rank_plans(self) -> Sequence[CompositeQueryPlan]:
+        add_equivalent_conditions(self.__query)
+        generate_subqueries(self.__query)
         return [_plan_composite_query(self.__query, self.__settings)]
 
 

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -221,47 +221,8 @@ TEST_CASES = [
     pytest.param(
         CompositeQuery(
             from_clause=JoinClause(
-                left_node=IndividualNode(
-                    alias="err",
-                    data_source=LogicalQuery(
-                        {},
-                        from_clause=events_ent,
-                        selected_columns=[
-                            SelectedExpression(
-                                "project_id", Column(None, None, "project_id")
-                            ),
-                            SelectedExpression(
-                                "group_id", Column(None, None, "group_id")
-                            ),
-                            SelectedExpression(
-                                "count_release",
-                                FunctionCall(
-                                    "count_release",
-                                    "uniq",
-                                    (Column(None, None, "release"),),
-                                ),
-                            ),
-                        ],
-                        condition=binary_condition(
-                            ConditionFunctions.EQ,
-                            Column(None, None, "project_id"),
-                            Literal(None, 1),
-                        ),
-                    ),
-                ),
-                right_node=IndividualNode(
-                    alias="groups",
-                    data_source=LogicalQuery(
-                        {},
-                        from_clause=groups_ent,
-                        selected_columns=[
-                            SelectedExpression(
-                                "project_id", Column(None, None, "project_id")
-                            ),
-                            SelectedExpression("id", Column(None, None, "id")),
-                        ],
-                    ),
-                ),
+                left_node=IndividualNode(alias="err", data_source=events_ent,),
+                right_node=IndividualNode(alias="groups", data_source=groups_ent,),
                 keys=[
                     JoinCondition(
                         left=JoinConditionExpression("err", "group_id"),
@@ -272,12 +233,15 @@ TEST_CASES = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "average",
-                    FunctionCall(
-                        "average", "avg", (Column(None, None, "count_release"),)
-                    ),
+                    "f_release",
+                    FunctionCall("f_release", "f", (Column(None, "err", "release"),),),
                 ),
             ],
+            condition=binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, "err", "project_id"),
+                Literal(None, 1),
+            ),
         ),
         CompositeQueryPlan(
             CompositeQuery(
@@ -288,30 +252,21 @@ TEST_CASES = [
                             from_clause=events_table,
                             selected_columns=[
                                 SelectedExpression(
-                                    "project_id", Column(None, None, "project_id")
+                                    "_snuba_group_id",
+                                    Column("_snuba_group_id", None, "group_id"),
                                 ),
                                 SelectedExpression(
-                                    "group_id", Column(None, None, "group_id")
-                                ),
-                                SelectedExpression(
-                                    "count_release",
+                                    "f_release",
                                     FunctionCall(
-                                        "count_release",
-                                        function_name="ifNull",
+                                        "f_release",
+                                        function_name="f",
                                         parameters=(
-                                            FunctionCall(
+                                            build_mapping_expr(
                                                 None,
-                                                "uniq",
-                                                (
-                                                    build_mapping_expr(
-                                                        None,
-                                                        None,
-                                                        "tags",
-                                                        Literal(None, "sentry:release"),
-                                                    ),
-                                                ),
+                                                None,
+                                                "tags",
+                                                Literal(None, "sentry:release"),
                                             ),
-                                            Literal(alias=None, value=0),
                                         ),
                                     ),
                                 ),
@@ -329,26 +284,22 @@ TEST_CASES = [
                             from_clause=groups_table,
                             selected_columns=[
                                 SelectedExpression(
-                                    "project_id", Column(None, None, "project_id")
+                                    "_snuba_id", Column("_snuba_id", None, "id")
                                 ),
-                                SelectedExpression("id", Column(None, None, "id")),
                             ],
                         ),
                     ),
                     keys=[
                         JoinCondition(
-                            left=JoinConditionExpression("err", "group_id"),
-                            right=JoinConditionExpression("groups", "id"),
+                            left=JoinConditionExpression("err", "_snuba_group_id"),
+                            right=JoinConditionExpression("groups", "_snuba_id"),
                         )
                     ],
                     join_type=JoinType.INNER,
                 ),
                 selected_columns=[
                     SelectedExpression(
-                        "average",
-                        FunctionCall(
-                            "average", "avg", (Column(None, None, "count_release"),)
-                        ),
+                        "f_release", Column("f_release", "err", "f_release"),
                     ),
                 ],
             ),
@@ -380,12 +331,9 @@ TEST_CASES = [
                         from_clause=events_table,
                         selected_columns=[
                             SelectedExpression(
-                                "project_id", Column(None, None, "project_id")
-                            ),
-                            SelectedExpression(
-                                "group_id",
+                                "_snuba_group_id",
                                 FunctionCall(
-                                    None,
+                                    "_snuba_group_id",
                                     function_name="nullIf",
                                     parameters=(
                                         Column(None, None, "group_id"),
@@ -394,18 +342,11 @@ TEST_CASES = [
                                 ),
                             ),
                             SelectedExpression(
-                                "count_release",
+                                "f_release",
                                 FunctionCall(
-                                    "count_release",
-                                    function_name="ifNull",
-                                    parameters=(
-                                        FunctionCall(
-                                            None,
-                                            "uniq",
-                                            (Column(None, None, "sentry:release"),),
-                                        ),
-                                        Literal(None, 0),
-                                    ),
+                                    "f_release",
+                                    function_name="f",
+                                    parameters=(Column(None, None, "sentry:release"),),
                                 ),
                             ),
                         ],
@@ -427,9 +368,8 @@ TEST_CASES = [
                         from_clause=groups_table,
                         selected_columns=[
                             SelectedExpression(
-                                "project_id", Column(None, None, "project_id")
+                                "_snuba_id", Column("_snuba_id", None, "id")
                             ),
-                            SelectedExpression("id", Column(None, None, "id")),
                         ],
                         condition=binary_condition(
                             ConditionFunctions.EQ,
@@ -444,22 +384,19 @@ TEST_CASES = [
                 ),
                 keys=[
                     JoinCondition(
-                        left=JoinConditionExpression("err", "group_id"),
-                        right=JoinConditionExpression("groups", "id"),
+                        left=JoinConditionExpression("err", "_snuba_group_id"),
+                        right=JoinConditionExpression("groups", "_snuba_id"),
                     )
                 ],
                 join_type=JoinType.INNER,
             ),
             selected_columns=[
                 SelectedExpression(
-                    "average",
-                    FunctionCall(
-                        "average", "avg", (Column(None, None, "count_release"),)
-                    ),
+                    "f_release", Column("f_release", "err", "f_release"),
                 ),
             ],
         ),
-        id="Join of two subqueries",
+        id="Simple join turned into a join of subqueries",
     ),
 ]
 
@@ -488,7 +425,7 @@ def test_composite_planner(
 
     # We cannot simply check the equality between the plans because
     # we need to verify processors are of the same type, they can
-    # be different innstances, thus making the simple equality fail.
+    # be different instances, thus making the simple equality fail.
     query_processors = plan.root_processors is not None
     expected_processors = composite_plan.root_processors is not None
     assert query_processors == expected_processors


### PR DESCRIPTION
This step was missing, the composite query planner was not triggering the two composite subquery generator.
This PR adds the semantically equivalent conditions and the generation of subqueries in the composite planner.

The test is updated because the query provided to the planner before was incorrect as it already contained subqueries.