### PR TITLE
fix(sessions) Explicitly set quantity to 1 in the sessions consumer

### DIFF
--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -58,6 +58,7 @@ class SessionsProcessor(MessageProcessor):
         processed = {
             "session_id": str(uuid.UUID(message["session_id"])),
             "distinct_id": str(uuid.UUID(message.get("distinct_id") or NIL_UUID)),
+            "quantity": 1,
             "seq": message["seq"],
             "org_id": message["org_id"],
             "project_id": message["project_id"],

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -36,6 +36,7 @@ class TestSessionProcessor:
             [
                 {
                     "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                    "quantity": 1,
                     "duration": 1947490,
                     "environment": "production",
                     "org_id": 1,
@@ -82,6 +83,7 @@ class TestSessionProcessor:
             [
                 {
                     "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                    "quantity": 1,
                     "duration": 1947490,
                     "environment": "production",
                     "org_id": 1,
@@ -129,6 +131,7 @@ class TestSessionProcessor:
             [
                 {
                     "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                    "quantity": 1,
                     "duration": 1947490,
                     "environment": "production",
                     "org_id": 1,


### PR DESCRIPTION
PR https://github.com/getsentry/snuba/pull/1455 added the quantity column to the sessions raw table with a DEFAULT = 1.
Turns out that on distributed tables we cannot trust the default value. When querying the distributed table the quantity is still 0.
This makes it impossible to apply the migration in https://github.com/getsentry/snuba/pull/1487 as it relies on the quantity to be 1 for individual sessions. 

In order to fix that we need to manually set the quantity value to `1` instead of leaving it empty.