### PR TITLE
feat(errors): Connect the events entity to errors storage

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -68,7 +68,7 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.threaded_function_delegator import Result
 from snuba.web import QueryResult
 
-metrics = MetricsWrapper(environment.metrics, "api.discover.discover_entity")
+metrics = MetricsWrapper(environment.metrics, "discover_entity")
 
 
 @dataclass(frozen=True)

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -1,11 +1,10 @@
 import random
 from dataclasses import dataclass
 from datetime import timedelta
+from functools import partial
 from typing import List, Mapping, Optional, Sequence, Set, Tuple
 
-import sentry_sdk
-
-from snuba import environment, state
+from snuba import state
 from snuba.clickhouse.columns import (
     UUID,
     Array,
@@ -32,7 +31,11 @@ from snuba.clickhouse.translators.snuba.mappers import (
     SubscriptableMapper,
 )
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
-from snuba.datasets.entities.events import BaseEventsEntity, EventsQueryStorageSelector
+from snuba.datasets.entities.events import (
+    BaseEventsEntity,
+    EventsQueryStorageSelector,
+    callback_func,
+)
 from snuba.datasets.entities.transactions import BaseTransactionsEntity
 from snuba.datasets.entity import Entity
 from snuba.datasets.plans.single_storage import (
@@ -64,11 +67,6 @@ from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
 from snuba.query.timeseries_extension import TimeSeriesExtension
 from snuba.util import qualified_column
-from snuba.utils.metrics.wrapper import MetricsWrapper
-from snuba.utils.threaded_function_delegator import Result
-from snuba.web import QueryResult
-
-metrics = MetricsWrapper(environment.metrics, "discover_entity")
 
 
 @dataclass(frozen=True)
@@ -436,52 +434,6 @@ class DiscoverEntity(Entity):
 
             return "events", []
 
-        def callback_func(
-            query: Query, referrer: str, results: List[Result[QueryResult]]
-        ) -> None:
-            primary_result = results.pop(0)
-            primary_result_data = primary_result.result.result["data"]
-
-            for result in results:
-                result_data = result.result.result["data"]
-
-                if result_data == primary_result_data:
-                    metrics.increment("query_result", tags={"match": "true"})
-                else:
-                    metrics.increment("query_result", tags={"match": "false"})
-
-                    if len(result_data) != len(primary_result_data):
-
-                        sentry_sdk.capture_message(
-                            "Non matching Discover result - different length",
-                            level="warning",
-                            tags={"referrer": referrer},
-                            extra={
-                                "query": query.get_body(),
-                                "discover_result": len(result_data),
-                                "events_result": len(primary_result_data),
-                            },
-                        )
-
-                        break
-
-                    # Avoid sending too much data to Sentry - just one row for now
-                    for idx in range(len(result_data)):
-                        if result_data[idx] != primary_result_data[idx]:
-
-                            sentry_sdk.capture_message(
-                                "Non matching Discover result - different result",
-                                level="warning",
-                                tags={"referrer": referrer},
-                                extra={
-                                    "query": query.get_body(),
-                                    "discover_result": result_data[idx],
-                                    "events_result": primary_result_data[idx],
-                                },
-                            )
-
-                            break
-
         super().__init__(
             storages=[events_storage, discover_storage],
             query_pipeline_builder=PipelineDelegator(
@@ -490,7 +442,7 @@ class DiscoverEntity(Entity):
                     "discover": discover_pipeline_builder,
                 },
                 selector_func=selector_func,
-                callback_func=callback_func,
+                callback_func=partial(callback_func, "discover"),
             ),
             abstract_column_set=(
                 self.__common_columns

--- a/snuba/datasets/entities/errors.py
+++ b/snuba/datasets/entities/errors.py
@@ -1,19 +1,12 @@
 from datetime import timedelta
 from typing import FrozenSet, Mapping, Sequence
 
-from snuba.clickhouse.translators.snuba.mappers import (
-    ColumnToFunction,
-    ColumnToMapping,
-    SubscriptableMapper,
-)
-from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entity import Entity
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors_common import promoted_tag_columns
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.query.expressions import Column, Literal
 from snuba.query.extensions import QueryExtension
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
@@ -22,29 +15,14 @@ from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
 from snuba.query.timeseries_extension import TimeSeriesExtension
+from snuba.datasets.entities.events import errors_translators
 
 
-errors_translators = TranslationMappers(
-    columns=[
-        ColumnToFunction(
-            None, "user", "nullIf", (Column(None, None, "user"), Literal(None, ""))
-        ),
-        ColumnToMapping(None, "geo_country_code", None, "contexts", "geo.country_code"),
-        ColumnToMapping(None, "geo_region", None, "contexts", "geo.region"),
-        ColumnToMapping(None, "geo_city", None, "contexts", "geo.city"),
-    ],
-    subscriptables=[
-        SubscriptableMapper(None, "tags", None, "tags"),
-        SubscriptableMapper(None, "contexts", None, "contexts"),
-    ],
-)
-
-
+# TODO: Remove this entity once it is no longer being used by tests.
+# The errors storage will be used via the existing events entity.
 class ErrorsEntity(Entity):
     """
     Represents the collections of all event types that are not transactions.
-
-    This is meant to replace Events. They will both exist during the migration.
     """
 
     def __init__(self) -> None:

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -5,6 +5,7 @@ from typing import List, Mapping, Optional, Sequence, Tuple
 
 import sentry_sdk
 
+from functools import partial
 from snuba import environment, state
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToFunction,
@@ -34,8 +35,6 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.threaded_function_delegator import Result
 from snuba.web import QueryResult
 
-metrics = MetricsWrapper(environment.metrics, "events_entity")
-
 event_translator = TranslationMappers(
     columns=[
         ColumnToMapping(None, "release", None, "tags", "sentry:release"),
@@ -62,6 +61,57 @@ errors_translators = TranslationMappers(
         SubscriptableMapper(None, "contexts", None, "contexts"),
     ],
 )
+
+metrics = MetricsWrapper(environment.metrics, "snuplicator")
+
+
+def callback_func(
+    storage: str, query: Query, referrer: str, results: List[Result[QueryResult]]
+) -> None:
+    primary_result = results.pop(0)
+    primary_result_data = primary_result.result.result["data"]
+
+    for result in results:
+        result_data = result.result.result["data"]
+
+        if result_data == primary_result_data:
+            metrics.increment(
+                "query_result", tags={"storage": storage, "match": "true"}
+            )
+        else:
+            metrics.increment(
+                "query_result", tags={"storage": storage, "match": "false"}
+            )
+
+            if len(result_data) != len(primary_result_data):
+                sentry_sdk.capture_message(
+                    f"Non matching {storage} result - different length",
+                    level="warning",
+                    tags={"referrer": referrer, "storage": storage},
+                    extras={
+                        "query": query.get_body(),
+                        "primary_result": len(primary_result_data),
+                        "other_result": len(result_data),
+                    },
+                )
+
+                break
+
+            # Avoid sending too much data to Sentry - just one row for now
+            for idx in range(len(result_data)):
+                if result_data[idx] != primary_result_data[idx]:
+                    sentry_sdk.capture_message(
+                        "Non matching result - different result",
+                        level="warning",
+                        tags={"referrer": referrer, "storage": storage},
+                        extras={
+                            "query": query.get_body(),
+                            "primary_result": primary_result_data[idx],
+                            "other_result": result_data[idx],
+                        },
+                    )
+
+                    break
 
 
 class EventsQueryStorageSelector(QueryStorageSelector):
@@ -141,50 +191,6 @@ class BaseEventsEntity(Entity, ABC):
 
             return "events", []
 
-        def callback_func(
-            query: Query, referrer: str, results: List[Result[QueryResult]]
-        ) -> None:
-            primary_result = results.pop(0)
-            primary_result_data = primary_result.result.result["data"]
-
-            for result in results:
-                result_data = result.result.result["data"]
-
-                if result_data == primary_result_data:
-                    metrics.increment("query_result", tags={"match": "true"})
-                else:
-                    metrics.increment("query_result", tags={"match": "false"})
-
-                    if len(result_data) != len(primary_result_data):
-                        sentry_sdk.capture_message(
-                            "Non matching Events result - different length",
-                            level="warning",
-                            tags={
-                                "referrer": referrer,
-                                "query": query.get_body(),
-                                "errors_result": len(result_data),
-                                "events_result": len(primary_result_data),
-                            },
-                        )
-
-                        break
-
-                    # Avoid sending too much data to Sentry - just one row for now
-                    for idx in range(len(result_data)):
-                        if result_data[idx] != primary_result_data[idx]:
-                            sentry_sdk.capture_message(
-                                "Non matching Events result - different result",
-                                level="warning",
-                                tags={
-                                    "referrer": referrer,
-                                    "query": query.get_body(),
-                                    "errors_result": result_data[idx],
-                                    "events_result": primary_result_data[idx],
-                                },
-                            )
-
-                            break
-
         super().__init__(
             storages=[storage],
             query_pipeline_builder=PipelineDelegator(
@@ -193,7 +199,7 @@ class BaseEventsEntity(Entity, ABC):
                     "errors": errors_pipeline_builder,
                 },
                 selector_func=selector_func,
-                callback_func=callback_func,
+                callback_func=partial(callback_func, "errors"),
             ),
             abstract_column_set=columns,
             join_relationships={},

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -1,22 +1,25 @@
+import random
 from abc import ABC
 from datetime import timedelta
-from typing import Mapping, Optional, Sequence
+from typing import List, Mapping, Optional, Sequence, Tuple
 
-from snuba import state
+import sentry_sdk
+
+from snuba import environment, state
 from snuba.clickhouse.translators.snuba.mappers import (
+    ColumnToFunction,
     ColumnToMapping,
     SubscriptableMapper,
 )
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entity import Entity
-from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 from snuba.datasets.plans.single_storage import SelectedStorageQueryPlanBuilder
-from snuba.datasets.storage import (
-    QueryStorageSelector,
-    StorageAndMappers,
-)
+from snuba.datasets.storage import QueryStorageSelector, StorageAndMappers
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
+from snuba.pipeline.pipeline_delegator import PipelineDelegator
+from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
+from snuba.query.expressions import Column, Literal
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
@@ -27,13 +30,32 @@ from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
 from snuba.query.timeseries_extension import TimeSeriesExtension
 from snuba.request.request_settings import RequestSettings
+from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.threaded_function_delegator import Result
+from snuba.web import QueryResult
 
+metrics = MetricsWrapper(environment.metrics, "events_entity")
 
 event_translator = TranslationMappers(
     columns=[
         ColumnToMapping(None, "release", None, "tags", "sentry:release"),
         ColumnToMapping(None, "dist", None, "tags", "sentry:dist"),
         ColumnToMapping(None, "user", None, "tags", "sentry:user"),
+    ],
+    subscriptables=[
+        SubscriptableMapper(None, "tags", None, "tags"),
+        SubscriptableMapper(None, "contexts", None, "contexts"),
+    ],
+)
+
+errors_translators = TranslationMappers(
+    columns=[
+        ColumnToFunction(
+            None, "user", "nullIf", (Column(None, None, "user"), Literal(None, ""))
+        ),
+        ColumnToMapping(None, "geo_country_code", None, "contexts", "geo.country_code"),
+        ColumnToMapping(None, "geo_region", None, "contexts", "geo.region"),
+        ColumnToMapping(None, "geo_city", None, "contexts", "geo.city"),
     ],
     subscriptables=[
         SubscriptableMapper(None, "tags", None, "tags"),
@@ -62,6 +84,26 @@ class EventsQueryStorageSelector(QueryStorageSelector):
         return StorageAndMappers(storage, self.__mappers)
 
 
+class ErrorsQueryStorageSelector(QueryStorageSelector):
+    def __init__(self, mappers: TranslationMappers) -> None:
+        self.__errors_table = get_writable_storage(StorageKey.ERRORS)
+        self.__errors_ro_table = get_storage(StorageKey.ERRORS_RO)
+        self.__mappers = mappers
+
+    def select_storage(
+        self, query: Query, request_settings: RequestSettings
+    ) -> StorageAndMappers:
+        use_readonly_storage = (
+            state.get_config("enable_events_readonly_table", False)
+            and not request_settings.get_consistent()
+        )
+
+        storage = (
+            self.__errors_ro_table if use_readonly_storage else self.__errors_table
+        )
+        return StorageAndMappers(storage, self.__mappers)
+
+
 class BaseEventsEntity(Entity, ABC):
     """
     Represents the collection of classic sentry "error" type events
@@ -73,16 +115,85 @@ class BaseEventsEntity(Entity, ABC):
         schema = storage.get_table_writer().get_schema()
         columns = schema.get_columns()
 
+        events_pipeline_builder = SimplePipelineBuilder(
+            query_plan_builder=SelectedStorageQueryPlanBuilder(
+                selector=EventsQueryStorageSelector(
+                    mappers=event_translator
+                    if custom_mappers is None
+                    else event_translator.concat(custom_mappers)
+                )
+            ),
+        )
+
+        errors_pipeline_builder = SimplePipelineBuilder(
+            query_plan_builder=SelectedStorageQueryPlanBuilder(
+                selector=ErrorsQueryStorageSelector(
+                    mappers=errors_translators
+                    if custom_mappers is None
+                    else errors_translators.concat(custom_mappers)
+                )
+            ),
+        )
+
+        def selector_func(_query: Query) -> Tuple[str, List[str]]:
+            if random.random() < float(state.get_config("errors_query_percentage", 0)):
+                return "events", ["errors"]
+
+            return "events", []
+
+        def callback_func(
+            query: Query, referrer: str, results: List[Result[QueryResult]]
+        ) -> None:
+            primary_result = results.pop(0)
+            primary_result_data = primary_result.result.result["data"]
+
+            for result in results:
+                result_data = result.result.result["data"]
+
+                if result_data == primary_result_data:
+                    metrics.increment("query_result", tags={"match": "true"})
+                else:
+                    metrics.increment("query_result", tags={"match": "false"})
+
+                    if len(result_data) != len(primary_result_data):
+                        sentry_sdk.capture_message(
+                            "Non matching Events result - different length",
+                            level="warning",
+                            tags={
+                                "referrer": referrer,
+                                "query": query.get_body(),
+                                "errors_result": len(result_data),
+                                "events_result": len(primary_result_data),
+                            },
+                        )
+
+                        break
+
+                    # Avoid sending too much data to Sentry - just one row for now
+                    for idx in range(len(result_data)):
+                        if result_data[idx] != primary_result_data[idx]:
+                            sentry_sdk.capture_message(
+                                "Non matching Events result - different result",
+                                level="warning",
+                                tags={
+                                    "referrer": referrer,
+                                    "query": query.get_body(),
+                                    "errors_result": result_data[idx],
+                                    "events_result": primary_result_data[idx],
+                                },
+                            )
+
+                            break
+
         super().__init__(
             storages=[storage],
-            query_pipeline_builder=SimplePipelineBuilder(
-                query_plan_builder=SelectedStorageQueryPlanBuilder(
-                    selector=EventsQueryStorageSelector(
-                        mappers=event_translator
-                        if custom_mappers is None
-                        else event_translator.concat(custom_mappers)
-                    )
-                ),
+            query_pipeline_builder=PipelineDelegator(
+                query_pipeline_builders={
+                    "events": events_pipeline_builder,
+                    "errors": errors_pipeline_builder,
+                },
+                selector_func=selector_func,
+                callback_func=callback_func,
             ),
             abstract_column_set=columns,
             join_relationships={},


### PR DESCRIPTION
The events entity now runs some queries simultaneously on the errors storage
using the pipieline delegator. The purpose of this is to start testing and
comparing results to events on the two storages.

The percentage of errors that are run on both storages is determined by the
`errors_query_percentage` config. Default is 0.