### PR TITLE
fix(discover): Fix transaction_name column on Discover merge table

### DIFF
--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -32,7 +32,7 @@ columns = ColumnSet(
         ("environment", String(Modifiers(nullable=True))),
         ("release", String(Modifiers(nullable=True))),
         ("dist", String(Modifiers(nullable=True))),
-        ("transaction_name", String(Modifiers(nullable=True))),
+        ("transaction_name", String()),
         ("message", String()),
         ("title", String()),
         ("user", String()),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -135,6 +135,7 @@ class DiscoverLoader(DirectoryLoader):
             "0002_discover_add_deleted_tags_hash_map",
             "0003_discover_fix_user_column",
             "0004_discover_fix_title_and_message",
+            "0005_discover_fix_transaction_name",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/discover/0005_discover_fix_transaction_name.py
+++ b/snuba/migrations/snuba_migrations/discover/0005_discover_fix_transaction_name.py
@@ -1,0 +1,49 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.MultiStepMigration):
+    """
+    The transaction_name column should not be nullable; it is not in either errors or transacions
+    """
+
+    blocking = False
+
+    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column=Column(
+                    "transaction_name", String(Modifiers(low_cardinality=True))
+                ),
+            ),
+        ]
+
+    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column=Column(
+                    "transaction_name",
+                    String(Modifiers(low_cardinality=True, nullable=True)),
+                ),
+            ),
+        ]
+
+    def forwards_local(self) -> Sequence[operations.Operation]:
+        return self.__forward_migrations("discover_local")
+
+    def backwards_local(self) -> Sequence[operations.Operation]:
+        return self.__backwards_migrations("discover_local")
+
+    def forwards_dist(self) -> Sequence[operations.Operation]:
+        return self.__forward_migrations("discover_dist")
+
+    def backwards_dist(self) -> Sequence[operations.Operation]:
+        return self.__backwards_migrations("discover_dist")


### PR DESCRIPTION
The transaction_name column was incorrectly defined as nullable in Discover.
This is incorrect since it is not nullable in the underlying errors or transactions
tables. Similarly to title and message earlier, this causes errors when attempting
to use an aggregate function over that field.