### PR TITLE
feat(joins) Introduce Composite Query Processors

### DIFF
--- a/snuba/clickhouse/processors.py
+++ b/snuba/clickhouse/processors.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
 from snuba.clickhouse.query import Query
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.simple import Table
 from snuba.request.request_settings import RequestSettings
 
 
@@ -22,4 +24,22 @@ class QueryProcessor(ABC):
     @abstractmethod
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         # TODO: Consider making the Query immutable.
+        raise NotImplementedError
+
+
+class CompositeQueryProcessor(ABC):
+    """
+    A transformation applied to a Clickhouse Composite Query.
+    This transformation mutates the Query object in place.
+
+    The same rules defined above for QueryProcessor still apply:
+    - composite query processor are stateless
+    - they are independent from each other
+    - they must keep the query in a valid state.
+    """
+
+    @abstractmethod
+    def process_query(
+        self, query: CompositeQuery[Table], request_settings: RequestSettings
+    ) -> None:
         raise NotImplementedError

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -157,7 +157,7 @@ TEST_CASES = [
                     ),
                 ],
             ),
-            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}),
+            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}, []),
             StorageSetKey.EVENTS,
             SubqueryProcessors(
                 [],
@@ -303,7 +303,7 @@ TEST_CASES = [
                     ),
                 ],
             ),
-            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}),
+            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}, []),
             StorageSetKey.EVENTS,
             None,
             {


### PR DESCRIPTION
Introduces an abstractions to encapsulates Clickhouse query optimizations done before the execution of the strategy.
This is not strictly needed (as instead it was for simple query processors) as those are defined by storages and entities. 

Composite processors are not provided by datasets. They will instead be the same for all datasets, though I can see this changing the more join optimizations we add. Adding an abstraction for such processing logic will thus ensure these optimization will be designed in a modular way.