### PR TITLE
fix(errors) Fix empty results bug

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -68,6 +68,10 @@ metrics = MetricsWrapper(environment.metrics, "snuplicator")
 def callback_func(
     storage: str, query: Query, referrer: str, results: List[Result[QueryResult]]
 ) -> None:
+    if len(results) == 0:
+        metrics.increment("query_result", tags={"storage": storage, "match": "empty"})
+        return
+
     primary_result = results.pop(0)
     primary_result_data = primary_result.result.result["data"]
 

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -68,7 +68,7 @@ metrics = MetricsWrapper(environment.metrics, "snuplicator")
 def callback_func(
     storage: str, query: Query, referrer: str, results: List[Result[QueryResult]]
 ) -> None:
-    if len(results) == 0:
+    if not results:
         metrics.increment("query_result", tags={"storage": storage, "match": "empty"})
         return
 


### PR DESCRIPTION
It's possible to receive an empty results set back, which can error out. It's
still an open question as to why the empty set is returned in the first place.