### PR TITLE
ci(release): Upgrade action-prepare-release to latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
       - name: Prepare release
-        uses: getsentry/action-prepare-release@2cfce9ae4b4ef7bf34e0b7f32869128e7c903e51
+        uses: getsentry/action-prepare-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,35 +11,20 @@ on:
   schedule:
     # We want the release to be at 9-10am Pacific Time
     # We also want it to be 1 hour before the on-prem release
-    - cron: '0 17 15 * *'
+    - cron: "0 17 15 * *"
 jobs:
   release:
     runs-on: ubuntu-latest
-    name: 'Release a new version'
+    name: "Release a new version"
     steps:
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@33507ed
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
           fetch-depth: 0
-      - uses: getsentry/craft@master
-        name: Craft Prepare
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@2cfce9ae4b4ef7bf34e0b7f32869128e7c903e51
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
-          action: prepare
-          version: ${{ env.RELEASE_VERSION }}
-      - name: Request publish
-        if: success()
-        uses: actions/github-script@v3
-        with:
-          github-token: ${{ secrets.GH_RELEASE_PAT }}
-          script: |
-            const repoInfo = context.repo;
-            await github.issues.create({
-              owner: repoInfo.owner,
-              repo: 'publish',
-              title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
-            });
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
This version reduces the boilerplate needed and offers much better publish request issue context.
