### PR TITLE
fix(coverage) Upgrade pytest-cov and coverage packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ click==7.1.2
 clickhouse-driver==0.1.3
 colorama==0.3.9
 confluent-kafka==1.5.0
-coverage==4.5.1
+coverage==5.0
 datadog==0.21.0
 deprecation==2.0.3
 docopt==0.6.2
@@ -31,7 +31,7 @@ parsimonious==0.8.1
 py==1.5.3
 pyparsing==2.2.0
 pytest==5.2.4
-pytest-cov==2.5.1
+pytest-cov==2.10.1
 pytest-watch==4.2.0
 pathtools==0.1.2
 pluggy==0.13.0


### PR DESCRIPTION
In a 2 lines PR I think I increased the code coverage to 90%. I guess I am done with technical debt for 2021 :D 

Still trying to figure out what specific change in the changelogs fixed our coverage. Before most covered lines were marked as non code (which I suspect has something to do with mypy annotations)