### PR TITLE
fix(errors): Add column mapping for user columns

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -8,6 +8,7 @@ import sentry_sdk
 from functools import partial
 from snuba import environment, state
 from snuba.clickhouse.translators.snuba.mappers import (
+    ColumnToColumn,
     ColumnToFunction,
     ColumnToMapping,
     SubscriptableMapper,
@@ -52,6 +53,8 @@ errors_translators = TranslationMappers(
         ColumnToFunction(
             None, "user", "nullIf", (Column(None, None, "user"), Literal(None, ""))
         ),
+        ColumnToColumn(None, "username", None, "user_name"),
+        ColumnToColumn(None, "email", None, "user_email"),
         ColumnToMapping(None, "geo_country_code", None, "contexts", "geo.country_code"),
         ColumnToMapping(None, "geo_region", None, "contexts", "geo.region"),
         ColumnToMapping(None, "geo_city", None, "contexts", "geo.city"),


### PR DESCRIPTION
User columns are being requested via the names in the events table,
which are not named the same thing in errors.
This maps "username" to "user_name" and "email" to "user_email" to
prevent these queries from failing.