### PR TITLE
feat(join) Semi join optimization

### DIFF
--- a/snuba/clickhouse/processors.py
+++ b/snuba/clickhouse/processors.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
 from snuba.clickhouse.query import Query
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.simple import Table
 from snuba.request.request_settings import RequestSettings
 
 
@@ -22,4 +24,22 @@ class QueryProcessor(ABC):
     @abstractmethod
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         # TODO: Consider making the Query immutable.
+        raise NotImplementedError
+
+
+class CompositeQueryProcessor(ABC):
+    """
+    A transformation applied to a Clickhouse Composite Query.
+    This transformation mutates the Query object in place.
+
+    The same rules defined above for QueryProcessor still apply:
+    - composite query processor are stateless
+    - they are independent from each other
+    - they must keep the query in a valid state.
+    """
+
+    @abstractmethod
+    def process_query(
+        self, query: CompositeQuery[Table], request_settings: RequestSettings
+    ) -> None:
         raise NotImplementedError

--- a/snuba/pipeline/composite.py
+++ b/snuba/pipeline/composite.py
@@ -16,6 +16,7 @@ from snuba.datasets.plans.query_plan import (
     SubqueryProcessors,
 )
 from snuba.pipeline.plans_selector import select_best_plans
+from snuba.query.joins.semi_joins import SemiJoinOptimizer
 from snuba.pipeline.query_pipeline import QueryExecutionPipeline, QueryPlanner
 from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
@@ -105,7 +106,7 @@ def _plan_composite_query(
             get_cluster(planned_data_source.storage_set_key),
             root_db_processors,
             aliased_db_processors,
-            composite_processors=[],
+            composite_processors=[SemiJoinOptimizer()],
         ),
         storage_set_key=planned_data_source.storage_set_key,
         root_processors=planned_data_source.root_processors,

--- a/snuba/query/joins/semi_joins.py
+++ b/snuba/query/joins/semi_joins.py
@@ -1,0 +1,57 @@
+from typing import Set
+
+from snuba.clickhouse.processors import CompositeQueryProcessor
+from snuba.query import ProcessableQuery
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.join import JoinClause, JoinModifier
+from snuba.query.data_source.simple import Table
+from snuba.query.expressions import Column
+from snuba.request.request_settings import RequestSettings
+
+
+class SemiJoinOptimizer(CompositeQueryProcessor):
+    """
+    Turn a join into a SEMI JOIN when possible.
+    """
+
+    def process_query(
+        self, query: CompositeQuery[Table], request_settings: RequestSettings
+    ) -> None:
+        from_clause = query.get_from_clause()
+        if isinstance(from_clause, CompositeQuery):
+            self.process_query(from_clause, request_settings)
+            return
+        elif isinstance(from_clause, ProcessableQuery):
+            return
+
+        # Now this has to be a join, so we can work with it.
+        query.set_from_clause(
+            self._process_clause(from_clause, query.get_all_ast_referenced_columns())
+        )
+
+    def _process_clause(
+        self, join_clause: JoinClause[Table], referenced_columns: Set[Column]
+    ) -> JoinClause[Table]:
+        join_cols = set()
+        for condition in join_clause.keys:
+            if condition.left.table_alias == join_clause.right_node.alias:
+                join_cols.add(condition.left.column)
+            elif condition.right.table_alias == join_clause.right_node.alias:
+                join_cols.add(condition.right.column)
+
+        for c in referenced_columns:
+            if (
+                c.table_name == join_clause.right_node.alias
+                and c.column_name not in join_cols
+            ):
+                return join_clause
+
+        return JoinClause(
+            left_node=self._process_clause(join_clause.left_node, referenced_columns)
+            if isinstance(join_clause.left_node, JoinClause)
+            else join_clause.left_node,
+            right_node=join_clause.right_node,
+            keys=join_clause.keys,
+            join_type=join_clause.join_type,
+            join_modifier=JoinModifier.SEMI,
+        )

--- a/snuba/query/joins/semi_joins.py
+++ b/snuba/query/joins/semi_joins.py
@@ -3,7 +3,13 @@ from typing import Set
 from snuba.clickhouse.processors import CompositeQueryProcessor
 from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
-from snuba.query.data_source.join import JoinClause, JoinModifier
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinModifier,
+    JoinNode,
+    JoinVisitor,
+)
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column
 from snuba.request.request_settings import RequestSettings
@@ -11,7 +17,25 @@ from snuba.request.request_settings import RequestSettings
 
 class SemiJoinOptimizer(CompositeQueryProcessor):
     """
-    Turn a join into a SEMI JOIN when possible.
+    Processes a composite query to find join clause that can be
+    executed as SEMI joins, instead of building the entire join
+    hashtable.
+
+    A semi join is a join where the query only references columns
+    from the left table (it can be used as an INNER join to filter
+    rows of the left table without referencing anything from the
+    right table.
+
+    For such queries the DB does not need to fetch all the rows
+    of the right table that correspond to each row of the left
+    table, thus reducing drastically the memory footprint of the
+    query.
+
+    So this processor navigates the leaves of the join tree from
+    left to right and turn all the join clauses that fit in the
+    conditions above into SEMI joins.
+    As soon as a join clause cannot be transformed we stop there
+
     """
 
     def process_query(
@@ -26,32 +50,44 @@ class SemiJoinOptimizer(CompositeQueryProcessor):
 
         # Now this has to be a join, so we can work with it.
         query.set_from_clause(
-            self._process_clause(from_clause, query.get_all_ast_referenced_columns())
+            SemiJoinGenerator(query.get_all_ast_referenced_columns()).visit_join_clause(
+                from_clause
+            )
         )
 
-    def _process_clause(
-        self, join_clause: JoinClause[Table], referenced_columns: Set[Column]
-    ) -> JoinClause[Table]:
+
+class SemiJoinGenerator(JoinVisitor[JoinNode[Table], Table]):
+    def __init__(self, referenced_columns: Set[Column]) -> None:
+        self.__referenced_columns = referenced_columns
+
+    def visit_individual_node(
+        self, node: IndividualNode[Table]
+    ) -> IndividualNode[Table]:
+        return node
+
+    def visit_join_clause(self, node: JoinClause[Table]) -> JoinClause[Table]:
+        # TODO: Introduce the cardinality in the relationship on the
+        # entities declaration so we can ensure we apply SEMI join
+        # only to n:1 relationship, which avoid some false positive
+        # on queries with aggregations on columns that are on the left
+        # side.
+
         join_cols = set()
-        for condition in join_clause.keys:
-            if condition.left.table_alias == join_clause.right_node.alias:
+
+        for condition in node.keys:
+            if condition.left.table_alias == node.right_node.alias:
                 join_cols.add(condition.left.column)
-            elif condition.right.table_alias == join_clause.right_node.alias:
+            elif condition.right.table_alias == node.right_node.alias:
                 join_cols.add(condition.right.column)
 
-        for c in referenced_columns:
-            if (
-                c.table_name == join_clause.right_node.alias
-                and c.column_name not in join_cols
-            ):
-                return join_clause
+        for c in self.__referenced_columns:
+            if c.table_name == node.right_node.alias and c.column_name not in join_cols:
+                return node
 
         return JoinClause(
-            left_node=self._process_clause(join_clause.left_node, referenced_columns)
-            if isinstance(join_clause.left_node, JoinClause)
-            else join_clause.left_node,
-            right_node=join_clause.right_node,
-            keys=join_clause.keys,
-            join_type=join_clause.join_type,
+            left_node=node.left_node.accept(self),
+            right_node=node.right_node,
+            keys=node.keys,
+            join_type=node.join_type,
             join_modifier=JoinModifier.SEMI,
         )

--- a/snuba/query/joins/semi_joins.py
+++ b/snuba/query/joins/semi_joins.py
@@ -66,11 +66,9 @@ class SemiJoinGenerator(JoinVisitor[JoinNode[Table], Table]):
         return node
 
     def visit_join_clause(self, node: JoinClause[Table]) -> JoinClause[Table]:
-        # TODO: Introduce the cardinality in the relationship on the
-        # entities declaration so we can ensure we apply SEMI join
-        # only to n:1 relationship, which avoid some false positive
-        # on queries with aggregations on columns that are on the left
-        # side.
+        # TODO: Skip this optimization if the left side of the query
+        # runs aggregations that imply the cardinality of the right
+        # side is important.
 
         join_cols = set()
 

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -236,6 +236,9 @@ TEST_CASES = [
                     "f_release",
                     FunctionCall("f_release", "f", (Column(None, "err", "release"),),),
                 ),
+                SelectedExpression(
+                    "_snuba_right", Column("_snuba_right", "groups", "right_col"),
+                ),
             ],
             condition=binary_condition(
                 ConditionFunctions.EQ,
@@ -286,6 +289,10 @@ TEST_CASES = [
                                 SelectedExpression(
                                     "_snuba_id", Column("_snuba_id", None, "id")
                                 ),
+                                SelectedExpression(
+                                    "_snuba_right",
+                                    Column("_snuba_right", None, "right_col"),
+                                ),
                             ],
                         ),
                     ),
@@ -300,6 +307,10 @@ TEST_CASES = [
                 selected_columns=[
                     SelectedExpression(
                         "f_release", Column("f_release", "err", "f_release"),
+                    ),
+                    SelectedExpression(
+                        "_snuba_right",
+                        Column("_snuba_right", "groups", "_snuba_right"),
                     ),
                 ],
             ),
@@ -370,6 +381,10 @@ TEST_CASES = [
                             SelectedExpression(
                                 "_snuba_id", Column("_snuba_id", None, "id")
                             ),
+                            SelectedExpression(
+                                "_snuba_right",
+                                Column("_snuba_right", None, "right_col"),
+                            ),
                         ],
                         condition=binary_condition(
                             ConditionFunctions.EQ,
@@ -393,6 +408,9 @@ TEST_CASES = [
             selected_columns=[
                 SelectedExpression(
                     "f_release", Column("f_release", "err", "f_release"),
+                ),
+                SelectedExpression(
+                    "_snuba_right", Column("_snuba_right", "groups", "_snuba_right"),
                 ),
             ],
         ),

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -157,7 +157,7 @@ TEST_CASES = [
                     ),
                 ],
             ),
-            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}),
+            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}, []),
             StorageSetKey.EVENTS,
             SubqueryProcessors(
                 [],
@@ -303,7 +303,7 @@ TEST_CASES = [
                     ),
                 ],
             ),
-            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}),
+            CompositeExecutionStrategy(get_cluster(StorageSetKey.EVENTS), [], {}, []),
             StorageSetKey.EVENTS,
             None,
             {

--- a/tests/query/joins/join_structures.py
+++ b/tests/query/joins/join_structures.py
@@ -1,0 +1,106 @@
+from typing import Optional, Sequence, TypeVar
+
+from snuba.clickhouse.query import Query as ClickhouseQuery
+from snuba.datasets.entities import EntityKey
+from snuba.query import SelectedExpression
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinType,
+)
+from snuba.query.data_source.simple import Entity, SimpleDataSource, Table
+from snuba.query.expressions import Expression
+from snuba.query.logical import Query as LogicalQuery
+from tests.query.joins.equivalence_schema import EVENTS_SCHEMA, GROUPS_SCHEMA
+
+TNode = TypeVar("TNode", bound=SimpleDataSource)
+
+
+def build_node(
+    alias: str,
+    from_clause: Entity,
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression],
+) -> IndividualNode[Entity]:
+    return IndividualNode(
+        alias=alias,
+        data_source=LogicalQuery(
+            {},
+            from_clause=from_clause,
+            selected_columns=selected_columns,
+            condition=condition,
+        ),
+    )
+
+
+def events_node(
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression] = None,
+) -> IndividualNode[Entity]:
+    return build_node(
+        "ev", Entity(EntityKey.EVENTS, EVENTS_SCHEMA), selected_columns, condition
+    )
+
+
+def groups_node(
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression] = None,
+) -> IndividualNode[Entity]:
+    return build_node(
+        "gr",
+        Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA),
+        selected_columns,
+        condition,
+    )
+
+
+def build_clickhouse_node(
+    alias: str,
+    from_clause: Table,
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression],
+) -> IndividualNode[Table]:
+    return IndividualNode(
+        alias=alias,
+        data_source=ClickhouseQuery(
+            from_clause=from_clause,
+            selected_columns=selected_columns,
+            condition=condition,
+        ),
+    )
+
+
+def clickhouse_events_node(
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression] = None,
+) -> IndividualNode[Table]:
+    return build_clickhouse_node(
+        "ev", Table("sentry_errors", EVENTS_SCHEMA), selected_columns, condition
+    )
+
+
+def clickhouse_groups_node(
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression] = None,
+) -> IndividualNode[Table]:
+    return build_clickhouse_node(
+        "gr", Table("groupedmessage_local", GROUPS_SCHEMA), selected_columns, condition,
+    )
+
+
+def events_groups_join(
+    left: IndividualNode[TNode], right: IndividualNode[TNode],
+) -> JoinClause[TNode]:
+    return JoinClause(
+        left_node=left,
+        right_node=right,
+        keys=[
+            JoinCondition(
+                left=JoinConditionExpression("ev", "_snuba_group_id"),
+                right=JoinConditionExpression("gr", "_snuba_id"),
+            )
+        ],
+        join_type=JoinType.INNER,
+    )

--- a/tests/query/joins/join_structures.py
+++ b/tests/query/joins/join_structures.py
@@ -13,7 +13,11 @@ from snuba.query.data_source.join import (
 from snuba.query.data_source.simple import Entity, SimpleDataSource, Table
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query as LogicalQuery
-from tests.query.joins.equivalence_schema import EVENTS_SCHEMA, GROUPS_SCHEMA
+from tests.query.joins.equivalence_schema import (
+    EVENTS_SCHEMA,
+    GROUPS_SCHEMA,
+    GROUPS_ASSIGNEE,
+)
 
 TNode = TypeVar("TNode", bound=SimpleDataSource)
 
@@ -87,6 +91,18 @@ def clickhouse_groups_node(
 ) -> IndividualNode[Table]:
     return build_clickhouse_node(
         "gr", Table("groupedmessage_local", GROUPS_SCHEMA), selected_columns, condition,
+    )
+
+
+def clickhouse_assignees_node(
+    selected_columns: Sequence[SelectedExpression],
+    condition: Optional[Expression] = None,
+) -> IndividualNode[Table]:
+    return build_clickhouse_node(
+        "as",
+        Table("groupassignee_local", GROUPS_ASSIGNEE),
+        selected_columns,
+        condition,
     )
 
 

--- a/tests/query/joins/test_semi_join.py
+++ b/tests/query/joins/test_semi_join.py
@@ -1,34 +1,25 @@
-import pytest
-
 from typing import Mapping, Optional, cast
 
-from snuba.request.request_settings import HTTPRequestSettings
-from snuba.query.joins.semi_joins import SemiJoinOptimizer
-from snuba.query.expressions import Column, FunctionCall, Literal
+import pytest
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
-from snuba.query.data_source.simple import Entity, SimpleDataSource, Table
-from tests.query.joins.equivalence_schema import (
-    GROUPS_ASSIGNEE,
-    Events,
-    GroupAssignee,
-    GroupedMessage,
-)
 from snuba.query.data_source.join import (
-    IndividualNode,
     JoinClause,
     JoinCondition,
     JoinConditionExpression,
-    JoinType,
     JoinModifier,
+    JoinType,
 )
+from snuba.query.data_source.simple import Table
+from snuba.query.expressions import Column
+from snuba.query.joins.semi_joins import SemiJoinOptimizer
+from snuba.request.request_settings import HTTPRequestSettings
 from tests.query.joins.join_structures import (
-    build_clickhouse_node,
-    events_groups_join,
+    clickhouse_assignees_node,
     clickhouse_events_node,
     clickhouse_groups_node,
+    events_groups_join,
 )
-
 
 TEST_CASES = [
     pytest.param(
@@ -131,6 +122,104 @@ TEST_CASES = [
         {"gr": None},
         id="Query with reference to columns on the right side. No semi join",
     ),
+    pytest.param(
+        CompositeQuery(
+            from_clause=JoinClause(
+                left_node=events_groups_join(
+                    clickhouse_events_node(
+                        [
+                            SelectedExpression(
+                                "_snuba_group_id",
+                                Column("_snuba_group_id", None, "group_id"),
+                            ),
+                        ]
+                    ),
+                    clickhouse_groups_node(
+                        [
+                            SelectedExpression(
+                                "_snuba_id", Column("_snuba_id", None, "id")
+                            ),
+                            SelectedExpression(
+                                "_snuba_col1", Column("_snuba_col1", None, "something")
+                            ),
+                        ]
+                    ),
+                ),
+                right_node=clickhouse_assignees_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "group_id"),
+                        ),
+                        SelectedExpression(
+                            "_snuba_col1", Column("_snuba_col1", None, "something")
+                        ),
+                    ]
+                ),
+                keys=[
+                    JoinCondition(
+                        left=JoinConditionExpression("ev", "_snuba_group_id"),
+                        right=JoinConditionExpression("as", "_snuba_group_id"),
+                    )
+                ],
+                join_type=JoinType.INNER,
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "group_id", Column("_snuba_col1", "gr", "_snuba_col1")
+                )
+            ],
+        ),
+        {"gr": None, "as": JoinModifier.SEMI},
+        id="Multi table join, make only the right one a semi join.",
+    ),
+    pytest.param(
+        CompositeQuery(
+            from_clause=JoinClause(
+                left_node=events_groups_join(
+                    clickhouse_events_node(
+                        [
+                            SelectedExpression(
+                                "_snuba_group_id",
+                                Column("_snuba_group_id", None, "group_id"),
+                            ),
+                        ]
+                    ),
+                    clickhouse_groups_node(
+                        [
+                            SelectedExpression(
+                                "_snuba_id", Column("_snuba_id", None, "id")
+                            ),
+                            SelectedExpression(
+                                "_snuba_col1", Column("_snuba_col1", None, "something")
+                            ),
+                        ]
+                    ),
+                ),
+                right_node=clickhouse_assignees_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "group_id"),
+                        ),
+                        SelectedExpression(
+                            "_snuba_col1", Column("_snuba_col1", None, "something")
+                        ),
+                    ]
+                ),
+                keys=[
+                    JoinCondition(
+                        left=JoinConditionExpression("ev", "_snuba_group_id"),
+                        right=JoinConditionExpression("as", "_snuba_group_id"),
+                    )
+                ],
+                join_type=JoinType.INNER,
+            ),
+            selected_columns=[],
+        ),
+        {"gr": JoinModifier.SEMI, "as": JoinModifier.SEMI},
+        id="Multi table join, make both joins semi join.",
+    ),
 ]
 
 
@@ -146,6 +235,8 @@ def test_subquery_generator(
         assert (
             right_alias in expected and clause.join_modifier == expected[right_alias]
         ), f"Invalid modifier for alias: {right_alias}, found: {clause.join_modifier}"
+        if isinstance(clause.left_node, JoinClause):
+            assert_transformation(clause.left_node, expected)
 
     SemiJoinOptimizer().process_query(query, HTTPRequestSettings())
     assert_transformation(

--- a/tests/query/joins/test_semi_join.py
+++ b/tests/query/joins/test_semi_join.py
@@ -1,0 +1,153 @@
+import pytest
+
+from typing import Mapping, Optional, cast
+
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.joins.semi_joins import SemiJoinOptimizer
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query import SelectedExpression
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.simple import Entity, SimpleDataSource, Table
+from tests.query.joins.equivalence_schema import (
+    GROUPS_ASSIGNEE,
+    Events,
+    GroupAssignee,
+    GroupedMessage,
+)
+from snuba.query.data_source.join import (
+    IndividualNode,
+    JoinClause,
+    JoinCondition,
+    JoinConditionExpression,
+    JoinType,
+    JoinModifier,
+)
+from tests.query.joins.join_structures import (
+    build_clickhouse_node,
+    events_groups_join,
+    clickhouse_events_node,
+    clickhouse_groups_node,
+)
+
+
+TEST_CASES = [
+    pytest.param(
+        CompositeQuery(
+            from_clause=events_groups_join(
+                clickhouse_events_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "group_id"),
+                        ),
+                    ]
+                ),
+                clickhouse_groups_node(
+                    [SelectedExpression("_snuba_id", Column("_snuba_id", None, "id"))],
+                ),
+            ),
+            selected_columns=[],
+        ),
+        {"gr": JoinModifier.SEMI},
+        id="Simple two table query with no reference. Semi join",
+    ),
+    pytest.param(
+        CompositeQuery(
+            from_clause=events_groups_join(
+                clickhouse_events_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "group_id"),
+                        ),
+                    ]
+                ),
+                clickhouse_groups_node(
+                    [SelectedExpression("_snuba_id", Column("_snuba_id", None, "id"))]
+                ),
+            ),
+            selected_columns=[
+                SelectedExpression("group_id", Column("_snuba_col1", "gr", "_snuba_id"))
+            ],
+        ),
+        {"gr": JoinModifier.SEMI},
+        id="Query with reference to the join key. Semi join",
+    ),
+    pytest.param(
+        CompositeQuery(
+            from_clause=events_groups_join(
+                clickhouse_events_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "group_id"),
+                        ),
+                        SelectedExpression(
+                            "_snuba_col1", Column("_snuba_col1", None, "something")
+                        ),
+                    ]
+                ),
+                clickhouse_groups_node(
+                    [SelectedExpression("_snuba_id", Column("_snuba_id", None, "id"))]
+                ),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "something", Column("_snuba_col1", "ev", "_snuba_col1")
+                )
+            ],
+        ),
+        {"gr": JoinModifier.SEMI},
+        id="Query with reference to columns on the left side. Semi join",
+    ),
+    pytest.param(
+        CompositeQuery(
+            from_clause=events_groups_join(
+                clickhouse_events_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "group_id"),
+                        ),
+                    ]
+                ),
+                clickhouse_groups_node(
+                    [
+                        SelectedExpression(
+                            "_snuba_id", Column("_snuba_id", None, "id")
+                        ),
+                        SelectedExpression(
+                            "_snuba_col1", Column("_snuba_col1", None, "something")
+                        ),
+                    ]
+                ),
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "group_id", Column("_snuba_col1", "gr", "_snuba_col1")
+                )
+            ],
+        ),
+        {"gr": None},
+        id="Query with reference to columns on the right side. No semi join",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, expected_semi_join", TEST_CASES)
+def test_subquery_generator(
+    query: CompositeQuery[Table],
+    expected_semi_join: Mapping[str, Optional[JoinModifier]],
+) -> None:
+    def assert_transformation(
+        clause: JoinClause[Table], expected: Mapping[str, Optional[JoinModifier]]
+    ) -> None:
+        right_alias = clause.right_node.alias
+        assert (
+            right_alias in expected and clause.join_modifier == expected[right_alias]
+        ), f"Invalid modifier for alias: {right_alias}, found: {clause.join_modifier}"
+
+    SemiJoinOptimizer().process_query(query, HTTPRequestSettings())
+    assert_transformation(
+        cast(JoinClause[Table], query.get_from_clause()), expected_semi_join
+    )

--- a/tests/query/joins/test_subqueries.py
+++ b/tests/query/joins/test_subqueries.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, cast
+from typing import cast
 
 import pytest
 from snuba.datasets.entities import EntityKey
@@ -18,7 +18,7 @@ from snuba.query.data_source.join import (
     JoinType,
 )
 from snuba.query.data_source.simple import Entity
-from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.joins.subquery_generator import generate_subqueries
 from snuba.query.logical import Query as LogicalQuery
 from tests.query.joins.equivalence_schema import (
@@ -28,6 +28,11 @@ from tests.query.joins.equivalence_schema import (
     Events,
     GroupAssignee,
     GroupedMessage,
+)
+from tests.query.joins.join_structures import (
+    events_groups_join,
+    events_node,
+    groups_node,
 )
 
 BASIC_JOIN = JoinClause(
@@ -45,61 +50,6 @@ BASIC_JOIN = JoinClause(
     ],
     join_type=JoinType.INNER,
 )
-
-
-def build_node(
-    alias: str,
-    from_clause: Entity,
-    selected_columns: Sequence[SelectedExpression],
-    condition: Optional[Expression],
-) -> IndividualNode[Entity]:
-    return IndividualNode(
-        alias=alias,
-        data_source=LogicalQuery(
-            {},
-            from_clause=from_clause,
-            selected_columns=selected_columns,
-            condition=condition,
-        ),
-    )
-
-
-def events_node(
-    selected_columns: Sequence[SelectedExpression],
-    condition: Optional[Expression] = None,
-) -> IndividualNode[Entity]:
-    return build_node(
-        "ev", Entity(EntityKey.EVENTS, EVENTS_SCHEMA), selected_columns, condition
-    )
-
-
-def groups_node(
-    selected_columns: Sequence[SelectedExpression],
-    condition: Optional[Expression] = None,
-) -> IndividualNode[Entity]:
-    return build_node(
-        "gr",
-        Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA),
-        selected_columns,
-        condition,
-    )
-
-
-def events_groups_join(
-    left: IndividualNode[Entity], right: IndividualNode[Entity],
-) -> JoinClause[Entity]:
-    return JoinClause(
-        left_node=left,
-        right_node=right,
-        keys=[
-            JoinCondition(
-                left=JoinConditionExpression("ev", "_snuba_group_id"),
-                right=JoinConditionExpression("gr", "_snuba_id"),
-            )
-        ],
-        join_type=JoinType.INNER,
-    )
-
 
 TEST_CASES = [
     pytest.param(


### PR DESCRIPTION
A query like this:
```
SELECT max(t.duration) FROM transactions t INNER JOIN span s
```

Does not need to build the entire hashtable as we do not reference anything on the right side. Thus in this case we can switch it to a SEMI join, which means clickhouse will return only the first row it can find from the right side instead of all of them. Which means fewer chances of out of memory.

This PR switches the join clause to semi join if the query does not need anything from the right side.

TODO: This still misses some cases (skip the optimization if werun aggregations on the left side that would depend on the content of the right side (like an avg(t.duration), which would be semantically wrong but still it should not be executed as a SEMI join if the user provided such query).