### PR TITLE
fix(errors): Make user column translation a processor

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -21,7 +21,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.pipeline.pipeline_delegator import PipelineDelegator
 from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
-from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.expressions import Column, FunctionCall
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
@@ -64,9 +64,6 @@ errors_translators = TranslationMappers(
             ),
         ),
         ColumnToColumn(None, "transaction", None, "transaction_name"),
-        ColumnToFunction(
-            None, "user", "nullIf", (Column(None, None, "user"), Literal(None, ""))
-        ),
         ColumnToMapping(None, "geo_country_code", None, "contexts", "geo.country_code"),
         ColumnToMapping(None, "geo_region", None, "contexts", "geo.region"),
         ColumnToMapping(None, "geo_city", None, "contexts", "geo.city"),

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -50,6 +50,9 @@ event_translator = TranslationMappers(
 
 errors_translators = TranslationMappers(
     columns=[
+        ColumnToMapping(None, "release", None, "tags", "sentry:release"),
+        ColumnToMapping(None, "dist", None, "tags", "sentry:dist"),
+        ColumnToMapping(None, "user", None, "tags", "sentry:user"),
         ColumnToFunction(
             None,
             "ip_address",

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -13,6 +13,7 @@ from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.datasets.errors_replacer import ReplacerState
 from snuba.datasets.storages.event_id_column_processor import EventIdColumnProcessor
 from snuba.datasets.storages.group_id_column_processor import GroupIdColumnProcessor
+from snuba.datasets.storages.user_column_processor import UserColumnProcessor
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
 )
@@ -138,6 +139,7 @@ query_processors = [
         project_column="project_id", replacer_state_name=ReplacerState.ERRORS,
     ),
     MappingColumnPromoter(mapping_specs={"tags": promoted_tag_columns}),
+    UserColumnProcessor(),
     EventIdColumnProcessor(),
     GroupIdColumnProcessor(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),

--- a/snuba/datasets/storages/user_column_processor.py
+++ b/snuba/datasets/storages/user_column_processor.py
@@ -1,0 +1,26 @@
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.request.request_settings import RequestSettings
+
+
+class UserColumnProcessor(QueryProcessor):
+    """
+    Return null instead of empty user to align errors to events storage behavior.
+    This translation is applied as a column processor rather than a translator, so
+    that it will be properly applied to the promoted sentry:user tag.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def process_column(exp: Expression) -> Expression:
+            if isinstance(exp, Column):
+                if exp.column_name == "user":
+                    return FunctionCall(
+                        exp.alias,
+                        "nullIf",
+                        (Column(None, None, "user"), Literal(None, "")),
+                    )
+
+            return exp
+
+        query.transform_expressions(process_column)


### PR DESCRIPTION
Make user column translation a query processor. This ensures that the
proper translation is applied to both queries to the "user" column as
well as those that reference the "tags[sentry:user]" promoted tag column.