### PR TITLE
ref: Simplify STORAGE_TOPICS and use storage key value instead of name

### DIFF
--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -91,7 +91,7 @@ def build_kafka_stream_loader_from_settings(
     replacement_topic_name: Optional[str] = None,
     commit_log_topic_name: Optional[str] = None,
 ) -> KafkaStreamLoader:
-    storage_topics = {**settings.STORAGE_TOPICS[storage_key.value]}
+    storage_topics = {**settings.STORAGE_TOPICS.get(storage_key.value, {})}
 
     default_topic_spec = build_kafka_topic_spec_from_settings(
         storage_topics.pop("default", default_topic_name)

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -91,7 +91,7 @@ def build_kafka_stream_loader_from_settings(
     replacement_topic_name: Optional[str] = None,
     commit_log_topic_name: Optional[str] = None,
 ) -> KafkaStreamLoader:
-    storage_topics = {**settings.STORAGE_TOPICS[storage_key.name]}
+    storage_topics = {**settings.STORAGE_TOPICS[storage_key.value]}
 
     default_topic_spec = build_kafka_topic_spec_from_settings(
         storage_topics.pop("default", default_topic_name)

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -1,5 +1,4 @@
 import os
-from collections import defaultdict
 from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
 
@@ -81,7 +80,7 @@ BROKER_CONFIG: Mapping[str, Any] = {
     "bootstrap.servers": os.environ.get("DEFAULT_BROKERS", "localhost:9092"),
 }
 STORAGE_BROKER_CONFIG: Mapping[str, Mapping[str, Any]] = {}
-STORAGE_TOPICS: Mapping[str, Mapping[str, Any]] = defaultdict(dict)
+STORAGE_TOPICS: Mapping[str, Mapping[str, Any]] = {}
 
 DEFAULT_MAX_BATCH_SIZE = 50000
 DEFAULT_MAX_BATCH_TIME_MS = 2 * 1000


### PR DESCRIPTION
Use the storage key's value in STORAGE_TOPICS rather than it's name.
This is consistent with the rest of our settings and APIs. Also updates
STORAGE_TOPICS to not use defaultdict so it is easier to override this
value in ops.