### PR TITLE
fix(snql) Fix some issues with SnQL and composite queries

### DIFF
--- a/snuba/query/composite.py
+++ b/snuba/query/composite.py
@@ -82,6 +82,9 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
     ) -> None:
         self.__from_clause = from_clause
 
+    def get_final(self) -> bool:
+        return False
+
     def _get_expressions_impl(self) -> Iterable[Expression]:
         return []
 

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -213,6 +213,12 @@ class SnQLVisitor(NodeVisitor):
             if isinstance(args[k], Node):
                 del args[k]
 
+        if "groupby" in args:
+            if "selected_columns" not in args:
+                args["selected_columns"] = []
+            args["selected_columns"] += args["groupby"]
+            args["groupby"] = map(lambda gb: gb.expression, args["groupby"])
+
         if isinstance(data_source, (CompositeQuery, LogicalQuery, JoinClause)):
             args["from_clause"] = data_source
             return CompositeQuery(**args)
@@ -221,12 +227,6 @@ class SnQLVisitor(NodeVisitor):
         if isinstance(data_source, QueryEntity):
             # TODO: How sample rate gets stored needs to be addressed in a future PR
             args["sample"] = data_source.sample
-
-        if "groupby" in args:
-            if "selected_columns" not in args:
-                args["selected_columns"] = []
-            args["selected_columns"] += args["groupby"]
-            args["groupby"] = map(lambda gb: gb.expression, args["groupby"])
 
         return LogicalQuery(**args)
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1,0 +1,74 @@
+import pytz
+import uuid
+from datetime import datetime, timedelta
+from functools import partial
+
+import simplejson as json
+
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
+from tests.base import BaseApiTest
+from tests.fixtures import get_raw_event, get_raw_transaction
+from tests.helpers import write_unprocessed_events
+
+
+class TestSnQLApi(BaseApiTest):
+    def setup_method(self, test_method):
+        super().setup_method(test_method)
+        self.app.post = partial(self.app.post, headers={"referer": "test"})
+        self.trace_id = uuid.UUID("7400045b-25c4-43b8-8591-4600aa83ad04")
+        self.event = get_raw_event()
+        self.project_id = self.event["project_id"]
+        self.skew = timedelta(minutes=180)
+        self.base_time = datetime.utcnow().replace(
+            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+        ) - timedelta(minutes=180)
+        write_unprocessed_events(get_writable_storage(StorageKey.EVENTS), [self.event])
+        write_unprocessed_events(
+            get_writable_storage(StorageKey.TRANSACTIONS), [get_raw_transaction()],
+        )
+
+    def test_simple_query(self) -> None:
+        response = self.app.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "query": """MATCH (discover_events )
+                    SELECT count() AS count BY project_id, tags[custom_tag]
+                    WHERE type != 'transaction' AND project_id = 70156
+                    ORDER BY count ASC
+                    LIMIT 1000""",
+                    "turbo": False,
+                    "consistent": False,
+                    "debug": True,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == [
+            {
+                "count": 1,
+                "tags[custom_tag]": "custom_value",
+                "project_id": self.project_id,
+            }
+        ]
+
+    def test_join_query(self) -> None:
+        response = self.app.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "query": """MATCH (s: spans) -[contained]-> (t: transactions)
+                    SELECT s.op, avg(s.duration_ms) AS avg BY s.op""",
+                    "turbo": False,
+                    "consistent": False,
+                    "debug": True,
+                }
+            ),
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == []


### PR DESCRIPTION
Composite queries haven't been tested end to end yet, so added some tests and
fixed a couple issues.

The query profiler will still fail on composite queries, but it will only log
a warning so it's not blocking.