### PR TITLE
fix(spans): Switch to utcfromtimestamp for spans

### DIFF
--- a/snuba/datasets/spans_processor.py
+++ b/snuba/datasets/spans_processor.py
@@ -23,7 +23,7 @@ metrics = MetricsWrapper(environment.metrics, "spans.processor")
 
 class SpansMessageProcessor(MessageProcessor):
     def __extract_timestamp(self, field: float) -> Tuple[datetime, int]:
-        timestamp = _ensure_valid_date(datetime.fromtimestamp(field))
+        timestamp = _ensure_valid_date(datetime.utcfromtimestamp(field))
         if timestamp is None:
             timestamp = datetime.utcnow()
         nanoseconds = int(timestamp.microsecond * 1000)
@@ -41,7 +41,7 @@ class SpansMessageProcessor(MessageProcessor):
             "project_id": event["project_id"],
             "transaction_id": str(uuid.UUID(event["event_id"])),
             "retention_days": enforce_retention(
-                event, datetime.fromtimestamp(data["timestamp"])
+                event, datetime.utcfromtimestamp(data["timestamp"])
             ),
             "transaction_span_id": int(transaction_ctx["span_id"], 16),
             "trace_id": str(uuid.UUID(transaction_ctx["trace_id"])),

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -217,7 +217,7 @@ class TransactionEvent:
 
 
 class TestTransactionsProcessor:
-    def __get_timestamps(slef) -> Tuple[float, float]:
+    def __get_timestamps(self) -> Tuple[float, float]:
         timestamp = datetime.now(tz=timezone.utc) - timedelta(seconds=5)
         start_timestamp = timestamp - timedelta(seconds=5)
         return (start_timestamp.timestamp(), timestamp.timestamp())


### PR DESCRIPTION
- This is so that both spans + transactions use the same method for
  timestamps, that way locally the timestamps of spans and transactions
  are comparable. (Basically #1336 but for spans)
  - Currently spans are being stored in local time, while the
    transactions are stored UTC
- Also noticed a spelling mistake