### PR TITLE
feat(snuplicator): Skip diffing results of sampled queries

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -83,7 +83,11 @@ metrics = MetricsWrapper(environment.metrics, "snuplicator")
 
 
 def callback_func(
-    storage: str, query: Query, referrer: str, results: List[Result[QueryResult]]
+    storage: str,
+    query: Query,
+    request_settings: RequestSettings,
+    referrer: str,
+    results: List[Result[QueryResult]],
 ) -> None:
     if not results:
         metrics.increment(
@@ -103,6 +107,10 @@ def callback_func(
             round((result.execution_time - primary_result.execution_time) * 1000),
             tags={"referrer": referrer},
         )
+
+        # Do not bother diffing the actual results of sampled queries
+        if request_settings.get_turbo() or query.get_sample() not in [None, 1.0]:
+            return
 
         if result_data == primary_result_data:
             metrics.increment(

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -58,7 +58,12 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
         self.__query_pipeline_builders = query_pipeline_builders
         self.__selector_func = selector_func
         self.__callback_func = (
-            partial(callback_func, self.__request.query, self.__request.referrer)
+            partial(
+                callback_func,
+                self.__request.query,
+                self.__request.settings,
+                self.__request.referrer,
+            )
             if callback_func
             else None
         )

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -52,9 +52,9 @@ def test() -> None:
     )
 
     with cv:
+        request_settings = HTTPRequestSettings()
         delegator.build_execution_pipeline(
-            Request("", query_body, query, HTTPRequestSettings(), "ref",),
-            mock_query_runner,
+            Request("", query_body, query, request_settings, "ref",), mock_query_runner,
         ).execute()
         cv.wait(timeout=5)
 
@@ -62,6 +62,7 @@ def test() -> None:
 
     assert mock_callback.call_args == call(
         query,
+        request_settings,
         "ref",
         [Result("events", query_result, ANY), Result("errors", query_result, ANY)],
     )


### PR DESCRIPTION
Since the events and errors tables have different sampling keys,
the differences in these queries are largely expected.