### PR TITLE
feat(migrations): Add --dry-run option to migrations tool

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -59,7 +59,8 @@ def migrate(force: bool) -> None:
 @click.option("--migration-id", required=True, help="Migration ID")
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
-def run(group: str, migration_id: str, force: bool, fake: bool) -> None:
+@click.option("--dry-run", is_flag=True)
+def run(group: str, migration_id: str, force: bool, fake: bool, dry_run: bool) -> None:
     """
     Runs a single migration.
     --force must be passed in order to run blocking migrations.
@@ -70,6 +71,10 @@ def run(group: str, migration_id: str, force: bool, fake: bool) -> None:
     runner = Runner()
     migration_group = MigrationGroup(group)
     migration_key = MigrationKey(migration_group, migration_id)
+
+    if dry_run:
+        runner.run_migration(migration_key, dry_run=True)
+        return
 
     try:
         if fake:
@@ -89,7 +94,10 @@ def run(group: str, migration_id: str, force: bool, fake: bool) -> None:
 @click.option("--migration-id", required=True, help="Migration ID")
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
-def reverse(group: str, migration_id: str, force: bool, fake: bool) -> None:
+@click.option("--dry-run", is_flag=True)
+def reverse(
+    group: str, migration_id: str, force: bool, fake: bool, dry_run: bool
+) -> None:
     """
     Reverses a single migration.
 
@@ -99,6 +107,10 @@ def reverse(group: str, migration_id: str, force: bool, fake: bool) -> None:
     runner = Runner()
     migration_group = MigrationGroup(group)
     migration_key = MigrationKey(migration_group, migration_id)
+
+    if dry_run:
+        runner.reverse_migration(migration_key, dry_run=True)
+        return
 
     try:
         if fake:

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -117,11 +117,21 @@ class MultiStepMigration(Migration, ABC):
         dist_operations: Sequence[Operation],
     ) -> None:
 
+        print("Local operations:")
+        if len(local_operations) == 0:
+            print("n/a")
+
         for op in local_operations:
             if isinstance(op, SqlOperation):
                 print(op.format_sql())
             else:
                 print("Non SQL operation")
+
+        print("\n")
+        print("Dist operations:")
+
+        if len(dist_operations) == 0:
+            print("n/a")
 
         for op in dist_operations:
             if isinstance(op, SqlOperation):
@@ -129,6 +139,7 @@ class MultiStepMigration(Migration, ABC):
 
                 if not cluster.is_single_node():
                     print(op.format_sql())
-                    break
+                else:
+                    print("Skipped dist operation - single node cluster")
             else:
                 print("Non SQL operation")

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -2,7 +2,10 @@ from abc import ABC, abstractmethod
 from typing import Callable, Optional, Sequence
 
 from snuba.clickhouse.columns import Column
-from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.cluster import (
+    ClickhouseClientSettings,
+    get_cluster,
+)
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.columns import MigrationModifiers
 from snuba.migrations.table_engines import TableEngine
@@ -21,6 +24,10 @@ class Operation(ABC):
 class SqlOperation(Operation, ABC):
     def __init__(self, storage_set: StorageSetKey):
         self._storage_set = storage_set
+
+    @property
+    def storage_set(self) -> StorageSetKey:
+        return self._storage_set
 
     def execute(self, local: bool) -> None:
         cluster = get_cluster(self._storage_set)

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -68,7 +68,7 @@ class Migration(migration.Migration):
             )
         ]
 
-    def forwards(self, context: Context) -> None:
+    def forwards(self, context: Context, dry_run: bool) -> None:
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
         for op in self.__forwards_local():
@@ -78,7 +78,7 @@ class Migration(migration.Migration):
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)
 
-    def backwards(self, context: Context) -> None:
+    def backwards(self, context: Context, dry_run: bool) -> None:
         migration_id, logger, update_status = context
         logger.info(f"Reversing migration: {migration_id}")
         update_status(Status.IN_PROGRESS)


### PR DESCRIPTION
Add the --dry-run option to the migrations run and reverse commands.
This outputs the SQL that will be run on the ClickHouse nodes. Non
SQL operations (like Python scripts) cannot be previewed with --dry-run.

The --dry-run option also works with distributed and replicated tables,
which are not yet otherwise supported via the automated migration tool.
This is determined by the CLUSTERS settings configuration - if a particular
cluster has single_node set to false then the DDL that will be output will
be the distributed and replicated variant.