### PR TITLE
test(multiprocess) Add some metrics to identify when the consumer is stuck waiting 

### DIFF
--- a/snuba/utils/streams/processing/strategies/streaming/transform.py
+++ b/snuba/utils/streams/processing/strategies/streaming/transform.py
@@ -393,7 +393,7 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
                             "Waited on the process pool longer than %d seconds. Waiting for %d results. Active processes %d.",
                             LOG_THRESHOLD_TIME,
                             len(self.__results),
-                            multiprocessing.active_children(),
+                            len(multiprocessing.active_children()),
                         )
                         self.__pool_waiting_time = current_time
                 break

--- a/snuba/utils/streams/processing/strategies/streaming/transform.py
+++ b/snuba/utils/streams/processing/strategies/streaming/transform.py
@@ -390,10 +390,10 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
                     current_time = time.time()
                     if current_time - self.__pool_waiting_time > LOG_THRESHOLD_TIME:
                         logger.warning(
-                            "Waited on the process pool longer than %d seconds. Waiting for %d results. Pool %r",
+                            "Waited on the process pool longer than %d seconds. Waiting for %d results. Active processes %d.",
                             LOG_THRESHOLD_TIME,
                             len(self.__results),
-                            self.__pool,
+                            multiprocessing.active_children(),
                         )
                         self.__pool_waiting_time = current_time
                 break

--- a/tests/utils/streams/processing/strategies/test_streaming.py
+++ b/tests/utils/streams/processing/strategies/test_streaming.py
@@ -6,7 +6,6 @@ from typing import Iterator
 from unittest.mock import Mock, call
 
 import pytest
-
 from snuba.utils.streams.backends.kafka import KafkaPayload
 from snuba.utils.streams.processing.strategies.streaming.collect import CollectStep
 from snuba.utils.streams.processing.strategies.streaming.filter import FilterStep
@@ -20,8 +19,8 @@ from snuba.utils.streams.processing.strategies.streaming.transform import (
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 from tests.backends.metrics import Gauge as GaugeCall
-from tests.backends.metrics import Timing as TimingCall
 from tests.backends.metrics import TestingMetricsBackend
+from tests.backends.metrics import Timing as TimingCall
 
 
 def test_filter() -> None:

--- a/tests/utils/streams/processing/strategies/test_streaming.py
+++ b/tests/utils/streams/processing/strategies/test_streaming.py
@@ -20,6 +20,7 @@ from snuba.utils.streams.processing.strategies.streaming.transform import (
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
 from tests.backends.metrics import Gauge as GaugeCall
+from tests.backends.metrics import Timing as TimingCall
 from tests.backends.metrics import TestingMetricsBackend
 
 
@@ -239,8 +240,13 @@ def test_parallel_transform_step() -> None:
         lambda: metrics.calls,
         [],
         [
-            GaugeCall("batches_in_progress", value, tags=None)
-            for value in [0.0, 1.0, 2.0]
+            GaugeCall("batches_in_progress", 0.0, tags=None),
+            GaugeCall("batches_in_progress", 1.0, tags=None),
+            TimingCall("batch.size.msg", 3, None),
+            TimingCall("batch.size.bytes", 4000, None),
+            GaugeCall("batches_in_progress", 2.0, tags=None),
+            TimingCall("batch.size.msg", 1, None),
+            TimingCall("batch.size.bytes", 2000, None),
         ],
     ):
         transform_step = ParallelTransformStep(


### PR DESCRIPTION
When running the multi process consumer with the INFO log level, we do not know when and if the consumer gets paused. This made the investigation of an incident harder.
This adds logging in two cases:
- the consumer was paused for more than 10 seconds. Not logging every pause events because under some circumstances that can happen more often than a batch being written.
- the consumer waited for results from the worker processes longer than 20 seconds without making progress.

It also records the size of the input batch to identify spikes in the size of the input batch that could justify a longer pause.