### PR TITLE
fix(multprocess) Fix logging. Do not depend on active_children

### DIFF
--- a/snuba/utils/streams/processing/strategies/streaming/transform.py
+++ b/snuba/utils/streams/processing/strategies/streaming/transform.py
@@ -390,10 +390,10 @@ class ParallelTransformStep(ProcessingStep[TPayload]):
                     current_time = time.time()
                     if current_time - self.__pool_waiting_time > LOG_THRESHOLD_TIME:
                         logger.warning(
-                            "Waited on the process pool longer than %d seconds. Waiting for %d results. Active processes %d.",
+                            "Waited on the process pool longer than %d seconds. Waiting for %d results. Pool: %r",
                             LOG_THRESHOLD_TIME,
                             len(self.__results),
-                            len(multiprocessing.active_children()),
+                            self.__pool,
                         )
                         self.__pool_waiting_time = current_time
                 break


### PR DESCRIPTION
active_children would also join completed processes. Which is not necessarily a good thing here. Still need to investigate that.