### PR TITLE
fix(migrations): Fix running first migration with --dry-run

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -44,27 +44,6 @@ class Migration(ABC):
     def backwards(self, context: Context, dry_run: bool) -> None:
         raise NotImplementedError
 
-
-class MultiStepMigration(Migration, ABC):
-    """
-    A MultiStepMigration consists of one or more forward operations which will be executed
-    on all of the local and distributed nodes of the cluster. Upon error, the backwards
-    methods will be executed. The backwards operations are responsible for returning
-    the system to its pre-migration state, so that the forwards methods can be safely
-    retried.
-
-    Once the migration has been completed, we shouldn't use the backwards methods
-    to try and go back to the prior state. Since migrations can delete data, attempting
-    to revert cannot always bring back the previous state completely.
-
-    The operations in a migration should bring the system from one consistent state to
-    the next. There isn't a hard and fast rule about when operations should be grouped
-    into a single migration vs having multiple migrations with a single operation
-    each. Generally if the intermediate state between operations is not considered to
-    be valid, they should be put into the same migration. If the operations are
-    completely unrelated, they are probably better as separate migrations.
-    """
-
     @abstractmethod
     def forwards_local(self) -> Sequence[Operation]:
         raise NotImplementedError
@@ -81,37 +60,7 @@ class MultiStepMigration(Migration, ABC):
     def backwards_dist(self) -> Sequence[Operation]:
         raise NotImplementedError
 
-    def forwards(self, context: Context, dry_run: bool = False) -> None:
-        if dry_run:
-            self.__dry_run(self.forwards_local(), self.forwards_dist())
-            return
-
-        migration_id, logger, update_status = context
-        logger.info(f"Running migration: {migration_id}")
-        update_status(Status.IN_PROGRESS)
-        for op in self.forwards_local():
-            op.execute(local=True)
-        for op in self.forwards_dist():
-            op.execute(local=False)
-        logger.info(f"Finished: {migration_id}")
-        update_status(Status.COMPLETED)
-
-    def backwards(self, context: Context, dry_run: bool) -> None:
-        if dry_run:
-            self.__dry_run(self.backwards_local(), self.backwards_dist())
-            return
-
-        migration_id, logger, update_status = context
-        logger.info(f"Reversing migration: {migration_id}")
-        update_status(Status.IN_PROGRESS)
-        for op in self.backwards_dist():
-            op.execute(local=False)
-        for op in self.backwards_local():
-            op.execute(local=True)
-        logger.info(f"Finished reversing: {migration_id}")
-        update_status(Status.NOT_STARTED)
-
-    def __dry_run(
+    def dry_run(
         self,
         local_operations: Sequence[Operation],
         dist_operations: Sequence[Operation],
@@ -143,3 +92,54 @@ class MultiStepMigration(Migration, ABC):
                     print("Skipped dist operation - single node cluster")
             else:
                 print("Non SQL operation")
+
+
+class MultiStepMigration(Migration, ABC):
+    """
+    A MultiStepMigration consists of one or more forward operations which will be executed
+    on all of the local and distributed nodes of the cluster. Upon error, the backwards
+    methods will be executed. The backwards operations are responsible for returning
+    the system to its pre-migration state, so that the forwards methods can be safely
+    retried.
+
+    Once the migration has been completed, we shouldn't use the backwards methods
+    to try and go back to the prior state. Since migrations can delete data, attempting
+    to revert cannot always bring back the previous state completely.
+
+    The operations in a migration should bring the system from one consistent state to
+    the next. There isn't a hard and fast rule about when operations should be grouped
+    into a single migration vs having multiple migrations with a single operation
+    each. Generally if the intermediate state between operations is not considered to
+    be valid, they should be put into the same migration. If the operations are
+    completely unrelated, they are probably better as separate migrations.
+    """
+
+    def forwards(self, context: Context, dry_run: bool = False) -> None:
+        if dry_run:
+            self.dry_run(self.forwards_local(), self.forwards_dist())
+            return
+
+        migration_id, logger, update_status = context
+        logger.info(f"Running migration: {migration_id}")
+        update_status(Status.IN_PROGRESS)
+        for op in self.forwards_local():
+            op.execute(local=True)
+        for op in self.forwards_dist():
+            op.execute(local=False)
+        logger.info(f"Finished: {migration_id}")
+        update_status(Status.COMPLETED)
+
+    def backwards(self, context: Context, dry_run: bool) -> None:
+        if dry_run:
+            self.dry_run(self.backwards_local(), self.backwards_dist())
+            return
+
+        migration_id, logger, update_status = context
+        logger.info(f"Reversing migration: {migration_id}")
+        update_status(Status.IN_PROGRESS)
+        for op in self.backwards_dist():
+            op.execute(local=False)
+        for op in self.backwards_local():
+            op.execute(local=True)
+        logger.info(f"Finished reversing: {migration_id}")
+        update_status(Status.NOT_STARTED)

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 from snuba.clickhouse.columns import Column, DateTime, Enum, String, UInt
+from snuba.clusters.cluster import get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -28,7 +29,7 @@ class Migration(migration.Migration):
 
     blocking = False
 
-    def __forwards_local(self) -> Sequence[operations.Operation]:
+    def __forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -42,14 +43,14 @@ class Migration(migration.Migration):
             ),
         ]
 
-    def __backwards_local(self) -> Sequence[operations.Operation]:
+    def __backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
             )
         ]
 
-    def __forwards_dist(self) -> Sequence[operations.Operation]:
+    def __forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -61,7 +62,7 @@ class Migration(migration.Migration):
             )
         ]
 
-    def __backwards_dist(self) -> Sequence[operations.Operation]:
+    def __backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_dist"
@@ -69,6 +70,10 @@ class Migration(migration.Migration):
         ]
 
     def forwards(self, context: Context, dry_run: bool) -> None:
+        if dry_run:
+            self.__dry_run(self.__forwards_local(), self.__forwards_dist())
+            return
+
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
         for op in self.__forwards_local():
@@ -79,6 +84,10 @@ class Migration(migration.Migration):
         update_status(Status.COMPLETED)
 
     def backwards(self, context: Context, dry_run: bool) -> None:
+        if dry_run:
+            self.__dry_run(self.__backwards_local(), self.__backwards_dist())
+            return
+
         migration_id, logger, update_status = context
         logger.info(f"Reversing migration: {migration_id}")
         update_status(Status.IN_PROGRESS)
@@ -87,3 +96,25 @@ class Migration(migration.Migration):
         for op in self.__backwards_local():
             op.execute(local=True)
         logger.info(f"Finished reversing: {migration_id}")
+
+    def __dry_run(
+        self,
+        local_operations: Sequence[operations.SqlOperation],
+        dist_operations: Sequence[operations.SqlOperation],
+    ) -> None:
+
+        print("Local operations:")
+
+        for op in local_operations:
+            print(op.format_sql())
+
+        print("\n")
+        print("Dist operations:")
+
+        for op in dist_operations:
+            cluster = get_cluster(op._storage_set)
+
+            if not cluster.is_single_node():
+                print(op.format_sql())
+            else:
+                print("Skipped dist operation - single node cluster")

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -1,7 +1,6 @@
 from typing import Sequence
 
 from snuba.clickhouse.columns import Column, DateTime, Enum, String, UInt
-from snuba.clusters.cluster import get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -29,7 +28,7 @@ class Migration(migration.Migration):
 
     blocking = False
 
-    def __forwards_local(self) -> Sequence[operations.SqlOperation]:
+    def forwards_local(self) -> Sequence[operations.Operation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -43,14 +42,14 @@ class Migration(migration.Migration):
             ),
         ]
 
-    def __backwards_local(self) -> Sequence[operations.SqlOperation]:
+    def backwards_local(self) -> Sequence[operations.Operation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
             )
         ]
 
-    def __forwards_dist(self) -> Sequence[operations.SqlOperation]:
+    def forwards_dist(self) -> Sequence[operations.Operation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -62,7 +61,7 @@ class Migration(migration.Migration):
             )
         ]
 
-    def __backwards_dist(self) -> Sequence[operations.SqlOperation]:
+    def backwards_dist(self) -> Sequence[operations.Operation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_dist"
@@ -71,50 +70,28 @@ class Migration(migration.Migration):
 
     def forwards(self, context: Context, dry_run: bool) -> None:
         if dry_run:
-            self.__dry_run(self.__forwards_local(), self.__forwards_dist())
+            self.dry_run(self.forwards_local(), self.forwards_dist())
             return
 
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
-        for op in self.__forwards_local():
+        for op in self.forwards_local():
             op.execute(local=True)
-        for op in self.__forwards_dist():
+        for op in self.forwards_dist():
             op.execute(local=False)
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)
 
     def backwards(self, context: Context, dry_run: bool) -> None:
         if dry_run:
-            self.__dry_run(self.__backwards_local(), self.__backwards_dist())
+            self.dry_run(self.backwards_local(), self.backwards_dist())
             return
 
         migration_id, logger, update_status = context
         logger.info(f"Reversing migration: {migration_id}")
         update_status(Status.IN_PROGRESS)
-        for op in self.__backwards_dist():
+        for op in self.backwards_dist():
             op.execute(local=False)
-        for op in self.__backwards_local():
+        for op in self.backwards_local():
             op.execute(local=True)
         logger.info(f"Finished reversing: {migration_id}")
-
-    def __dry_run(
-        self,
-        local_operations: Sequence[operations.SqlOperation],
-        dist_operations: Sequence[operations.SqlOperation],
-    ) -> None:
-
-        print("Local operations:")
-
-        for op in local_operations:
-            print(op.format_sql())
-
-        print("\n")
-        print("Dist operations:")
-
-        for op in dist_operations:
-            cluster = get_cluster(op._storage_set)
-
-            if not cluster.is_single_node():
-                print(op.format_sql())
-            else:
-                print("Skipped dist operation - single node cluster")


### PR DESCRIPTION
Fixes a bug that ignored the dry-run flag for the initial migration of the migration
system, causing this migration to be performed even when --dry-run was passed.

Also moves the `forwards_local`, `forwards_dist`, `backwards_local` and
`backwards_dist` abstract methods to the base migrations class. These need to
be defined for every migration in order to support the ability to bring up new local
and/or distributed ClickHouse nodes in the future.


