### PR TITLE
fix(joins): Fix querylog for join query step 1: Table names

### DIFF
--- a/snuba/clickhouse/query_inspector.py
+++ b/snuba/clickhouse/query_inspector.py
@@ -1,0 +1,54 @@
+from typing import Optional, Set
+
+from snuba.query import ProcessableQuery
+from snuba.query.composite import CompositeQuery
+from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
+from snuba.query.data_source.simple import Table
+from snuba.query.data_source.visitor import DataSourceVisitor
+
+
+class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
+    """
+    Traverses the data source of a composite query and collects
+    all the referenced table names, final state and sampling rate
+    to fill stats.
+    """
+
+    def __init__(self) -> None:
+        self.__tables: Set[str] = set()
+        self.__final: bool = False
+        self.__sample_rate: Optional[float] = None
+
+    def get_tables(self) -> Set[str]:
+        return self.__tables
+
+    def any_final(self) -> bool:
+        return self.__final
+
+    def get_sample_rate(self) -> Optional[float]:
+        return self.__sample_rate
+
+    def _visit_simple_source(self, data_source: Table) -> None:
+        self.__tables.add(data_source.table_name)
+        self.__sample_rate = data_source.sampling_rate
+        if data_source.final:
+            self.__final = True
+
+    def _visit_join(self, data_source: JoinClause[Table]) -> None:
+        self.visit_join_clause(data_source)
+
+    def _visit_simple_query(self, data_source: ProcessableQuery[Table]) -> None:
+        self.visit(data_source.get_from_clause())
+
+    def _visit_composite_query(self, data_source: CompositeQuery[Table]) -> None:
+        self.visit(data_source.get_from_clause())
+        # stats do not yet support sampling rate (there is only one field)
+        # so if we have a composite query we set it to None.
+        self.__sample_rate = None
+
+    def visit_individual_node(self, node: IndividualNode[Table]) -> None:
+        self.visit(node.data_source)
+
+    def visit_join_clause(self, node: JoinClause[Table]) -> None:
+        node.left_node.accept(self)
+        node.right_node.accept(self)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -1,12 +1,13 @@
 import copy
 import logging
 from functools import partial
-from typing import MutableMapping, Optional, Set, Union
+from typing import MutableMapping, Union
 
 import sentry_sdk
 from snuba import environment
 from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query
+from snuba.clickhouse.query_inspector import TablesCollector
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset_name
 from snuba.query import ProcessableQuery
@@ -168,53 +169,6 @@ def _run_and_apply_column_names(
     transform_column_names(result, alias_name_mapping)
 
     return result
-
-
-class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
-    """
-    Traverses the data source of a composite query and collects
-    all the referenced table names, final state and sampling rate
-    to fill stats.
-    """
-
-    def __init__(self) -> None:
-        self.__tables: Set[str] = set()
-        self.__final: bool = False
-        self.__sample_rate: Optional[float] = None
-
-    def get_tables(self) -> Set[str]:
-        return self.__tables
-
-    def any_final(self) -> bool:
-        return self.__final
-
-    def get_sample_rate(self) -> Optional[float]:
-        return self.__sample_rate
-
-    def _visit_simple_source(self, data_source: Table) -> None:
-        self.__tables.add(data_source.table_name)
-        self.__sample_rate = data_source.sampling_rate
-        if data_source.final:
-            self.__final = True
-
-    def _visit_join(self, data_source: JoinClause[Table]) -> None:
-        self.visit_join_clause(data_source)
-
-    def _visit_simple_query(self, data_source: ProcessableQuery[Table]) -> None:
-        self.visit(data_source.get_from_clause())
-
-    def _visit_composite_query(self, data_source: CompositeQuery[Table]) -> None:
-        self.visit(data_source.get_from_clause())
-        # stats do not yet support sampling rate (there is only one field)
-        # so if we have a composite query we set it to None.
-        self.__sample_rate = None
-
-    def visit_individual_node(self, node: IndividualNode[Table]) -> None:
-        self.visit(node.data_source)
-
-    def visit_join_clause(self, node: JoinClause[Table]) -> None:
-        node.left_node.accept(self)
-        node.right_node.accept(self)
 
 
 def _format_storage_query_and_run(


### PR DESCRIPTION
This prevents the query profiler from failing when it encounters a composite query.
It uses a visitor over the query to collect all table names instead of expecting a table name in the first level WHERE condition.

Following steps will take care of the other fields to fill through the same approach. Though at this point querylog does not throws anymore.