### PR TITLE
feat(migrations): Add truncate table operation

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -54,15 +54,6 @@ class RunSql(SqlOperation):
         return self.__statement
 
 
-class DropTable(SqlOperation):
-    def __init__(self, storage_set: StorageSetKey, table_name: str) -> None:
-        super().__init__(storage_set)
-        self.table_name = table_name
-
-    def format_sql(self) -> str:
-        return f"DROP TABLE IF EXISTS {self.table_name};"
-
-
 class CreateTable(SqlOperation):
     """
     The create table operation takes a table name, column list and table engine.
@@ -121,6 +112,25 @@ class RenameTable(SqlOperation):
 
     def format_sql(self) -> str:
         return f"RENAME TABLE {self.__old_table_name} TO {self.__new_table_name};"
+
+
+class DropTable(SqlOperation):
+    def __init__(self, storage_set: StorageSetKey, table_name: str) -> None:
+        super().__init__(storage_set)
+        self.table_name = table_name
+
+    def format_sql(self) -> str:
+        return f"DROP TABLE IF EXISTS {self.table_name};"
+
+
+class TruncateTable(SqlOperation):
+    def __init__(self, storage_set: StorageSetKey, table_name: str):
+        super().__init__(storage_set)
+        self.__storage_set = storage_set
+        self.__table_name = table_name
+
+    def format_sql(self) -> str:
+        return f"TRUNCATE TABLE IF EXISTS {self.__table_name};"
 
 
 class AddColumn(SqlOperation):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -13,6 +13,7 @@ from snuba.migrations.operations import (
     InsertIntoSelect,
     ModifyColumn,
     RenameTable,
+    TruncateTable,
 )
 from snuba.migrations.table_engines import ReplacingMergeTree
 
@@ -64,6 +65,13 @@ def test_drop_table() -> None:
     assert (
         DropTable(StorageSetKey.EVENTS, "test_table").format_sql()
         == "DROP TABLE IF EXISTS test_table;"
+    )
+
+
+def test_truncate_table() -> None:
+    assert (
+        TruncateTable(StorageSetKey.EVENTS, "test_table").format_sql()
+        == "TRUNCATE TABLE IF EXISTS test_table;"
     )
 
 


### PR DESCRIPTION
Add a potentially useful SQL operation. This will be used in the
future events -> errors backfill migration for the backwards method.