### PR TITLE
feat(snuplicator): Pass referrer to selector function

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -437,7 +437,7 @@ class DiscoverEntity(Entity):
             )
         )
 
-        def selector_func(_query: Query) -> Tuple[str, List[str]]:
+        def selector_func(_query: Query, referrer: str) -> Tuple[str, List[str]]:
             config = state.get_config("discover_query_percentage", 0)
             assert isinstance(config, (float, int, str))
             if random.random() < float(config):

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -234,7 +234,7 @@ class BaseEventsEntity(Entity, ABC):
             ),
         )
 
-        def selector_func(_query: Query) -> Tuple[str, List[str]]:
+        def selector_func(_query: Query, referrer: str) -> Tuple[str, List[str]]:
             config = state.get_config("errors_query_percentage", 0)
             assert isinstance(config, (float, int, str))
             if random.random() < float(config):

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -47,7 +47,7 @@ def test() -> None:
 
     delegator = PipelineDelegator(
         query_pipeline_builders={"events": events_pipeline, "errors": errors_pipeline},
-        selector_func=lambda query: ("events", ["errors"]),
+        selector_func=lambda query, referrer: ("events", ["errors"]),
         callback_func=mock_callback,
     )
 


### PR DESCRIPTION
We plan to gradually roll out the new events storage referrer by
referrer. This change passes the referrer string to the selector function,
so it can be used to determine the storage chosen.