### PR TITLE
feat: Turn on column splitter for errors and discover storages

### DIFF
--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -20,7 +20,7 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
 )
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.web.split import TimeSplitQueryStrategy
+from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 columns = ColumnSet(
     [
@@ -79,5 +79,12 @@ storage = ReadableTableStorage(
         ArrayJoinKeyValueOptimizer("tags"),
         PrewhereProcessor(),
     ],
-    query_splitters=[TimeSplitQueryStrategy(timestamp_col="timestamp")],
+    query_splitters=[
+        ColumnSplitQueryStrategy(
+            id_column="event_id",
+            project_column="project_id",
+            timestamp_column="timestamp",
+        ),
+        TimeSplitQueryStrategy(timestamp_col="timestamp"),
+    ],
 )

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -25,7 +25,7 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.web.split import TimeSplitQueryStrategy
+from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 required_columns = [
     "event_id",
@@ -148,5 +148,8 @@ query_processors = [
 ]
 
 query_splitters = [
+    ColumnSplitQueryStrategy(
+        id_column="event_id", project_column="project_id", timestamp_column="timestamp",
+    ),
     TimeSplitQueryStrategy(timestamp_col="timestamp"),
 ]


### PR DESCRIPTION
This matches the split behavior on errors and discover to what we have on
the original events table. The only notable difference is that the
event ID column processor will kick in on the first query since those
columns are now stored as UUIDs.