### PR TITLE
fix(tests) Add a compare test to the API tests

### DIFF
--- a/snuba/query/organization_extension.py
+++ b/snuba/query/organization_extension.py
@@ -29,7 +29,7 @@ class OrganizationExtensionProcessor(ExtensionQueryProcessor):
         query.add_condition_to_ast(
             binary_condition(
                 ConditionFunctions.EQ,
-                Column(None, None, "org_id"),
+                Column("_snuba_org_id", None, "org_id"),
                 Literal(None, organization_id),
             )
         )

--- a/snuba/query/project_extension.py
+++ b/snuba/query/project_extension.py
@@ -75,7 +75,9 @@ class ProjectExtensionProcessor(ExtensionQueryProcessor):
         if project_ids:
             query.add_condition_to_ast(
                 in_condition(
-                    Column(None, None, self.__project_column),
+                    Column(
+                        f"_snuba_{self.__project_column}", None, self.__project_column
+                    ),
                     [Literal(None, p) for p in project_ids],
                 )
             )

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import replace
 from typing import (
     Any,
@@ -12,8 +13,10 @@ from typing import (
     Union,
 )
 
+from parsimonious.exceptions import IncompleteParseError
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -88,6 +91,8 @@ from snuba.query.snql.joins import (
 )
 from snuba.util import parse_datetime
 
+logger = logging.getLogger("snuba.snql.parser")
+
 snql_grammar = Grammar(
     r"""
     query_exp             = match_clause select_clause group_by_clause? where_clause? having_clause? order_by_clause? limit_by_clause? limit_clause? offset_clause? granularity_clause? totals_clause? space*
@@ -118,7 +123,7 @@ snql_grammar = Grammar(
     or_tuple              = space+ "OR" and_expression
 
     condition             = main_condition / parenthesized_cdn
-    main_condition        = low_pri_arithmetic space* condition_op space* (function_call / column_name / quoted_literal / numeric_literal)
+    main_condition        = low_pri_arithmetic space* condition_op space* (function_call / simple_term)
     condition_op          = "!=" / ">=" / ">" / "<=" / "<" / "=" / "NOT IN" / "NOT LIKE" / "IN" / "LIKE"
     parenthesized_cdn     = space* open_paren or_expression close_paren
 
@@ -136,7 +141,7 @@ snql_grammar = Grammar(
     low_pri_tuple         = low_pri_op space* high_pri_arithmetic
     high_pri_tuple        = high_pri_op space* arithmetic_term
 
-    arithmetic_term       = space* (function_call / numeric_literal / subscriptable / column_name / parenthesized_arithm)
+    arithmetic_term       = space* (function_call / subscriptable / simple_term / parenthesized_arithm)
     parenthesized_arithm  = open_paren low_pri_arithmetic close_paren
 
     low_pri_op            = "+" / "-"
@@ -145,8 +150,7 @@ snql_grammar = Grammar(
     parameters_list       = parameter* (param_expression)
     parameter             = param_expression space* comma space*
     function_call         = function_name open_paren parameters_list? close_paren (open_paren parameters_list? close_paren)? (space* "AS" space* string_literal)?
-    simple_term           = quoted_literal / numeric_literal / column_name
-    literal               = ~r"[a-zA-Z0-9_\.:-]+"
+    simple_term           = quoted_literal / numeric_literal / null_literal / boolean_literal / column_name
     quoted_literal        = ~r"((?<!\\)')((?!(?<!\\)').)*.?'"
     string_literal        = ~r"[a-zA-Z0-9_\.\+\*\/:\-]*"
     numeric_literal       = ~r"-?[0-9]+(\.[0-9]+)?(e[\+\-][0-9]+)?"
@@ -154,6 +158,7 @@ snql_grammar = Grammar(
     boolean_literal       = true_literal / false_literal
     true_literal          = ~r"TRUE"i
     false_literal         = ~r"FALSE"i
+    null_literal          = ~r"NULL"i
     subscriptable         = column_name open_square column_name close_square
     column_name           = ~r"[a-zA-Z_][a-zA-Z0-9_\.]*"
     function_name         = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
@@ -213,10 +218,17 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
             if isinstance(args[k], Node):
                 del args[k]
 
+        if "limit" not in args:
+            args["limit"] = 1000
+        if "offset" not in args:
+            args["offset"] = 0
+
         if "groupby" in args:
             if "selected_columns" not in args:
-                args["selected_columns"] = []
-            args["selected_columns"] += args["groupby"]
+                args["selected_columns"] = args["groupby"]
+            else:
+                args["selected_columns"] = args["groupby"] + args["selected_columns"]
+
             args["groupby"] = map(lambda gb: gb.expression, args["groupby"])
 
         if isinstance(data_source, (CompositeQuery, LogicalQuery, JoinClause)):
@@ -334,7 +346,7 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
         data = lhs_entity.get_join_relationship(relationship)
         if data is None:
             raise ParsingException(
-                f"{lhs.data_source.key.value} does not have a join relationship {relationship}"
+                f"{lhs.data_source.key.value} does not have a join relationship -[{relationship}]->"
             )
         elif data.rhs_entity != rhs.data_source.key:
             raise ParsingException(
@@ -443,6 +455,11 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
             return Literal(None, True)
 
         return Literal(None, False)
+
+    def visit_null_literal(
+        self, node: Node, visited_children: Iterable[Any]
+    ) -> Literal:
+        return Literal(None, None)
 
     def visit_quoted_literal(
         self, node: Node, visited_children: Tuple[Node]
@@ -728,8 +745,23 @@ def parse_snql_query_initial(
     account the initial query body. Extensions are parsed by extension
     processors and are supposed to update the AST.
     """
-    exp_tree = snql_grammar.parse(body)
-    parsed = SnQLVisitor().visit(exp_tree)
+    try:
+        exp_tree = snql_grammar.parse(body)
+        parsed = SnQLVisitor().visit(exp_tree)
+    except ParsingException as e:
+        logger.warning(f"Invalid SnQL query ({e}): {body}")
+        raise e
+    except IncompleteParseError as e:
+        idx = e.column()
+        prefix = body[max(0, idx - 1) : idx]
+        suffix = body[idx : (idx + 10)]
+        raise ParsingException(f"Parsing error at '{prefix}{suffix}'")
+    except Exception as e:
+        message = str(e)
+        if "\n" in message:
+            message, _ = message.split("\n", 1)
+        raise ParsingException(message)
+
     assert isinstance(parsed, (CompositeQuery, LogicalQuery))  # mypy
     return parsed
 

--- a/snuba/query/timeseries_extension.py
+++ b/snuba/query/timeseries_extension.py
@@ -90,12 +90,20 @@ class TimeSeriesExtensionProcessor(ExtensionQueryProcessor):
                 BooleanFunctions.AND,
                 binary_condition(
                     ConditionFunctions.GTE,
-                    Column(None, None, self.__timestamp_column),
+                    Column(
+                        f"_snuba_{self.__timestamp_column}",
+                        None,
+                        self.__timestamp_column,
+                    ),
                     Literal(None, from_date),
                 ),
                 binary_condition(
                     ConditionFunctions.LT,
-                    Column(None, None, self.__timestamp_column),
+                    Column(
+                        f"_snuba_{self.__timestamp_column}",
+                        None,
+                        self.__timestamp_column,
+                    ),
                     Literal(None, to_date),
                 ),
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,7 @@
-from typing import Any, Callable, Iterator, List, Union
-
 import json
-import pytest
+from typing import Any, Callable, Iterator, List, Tuple, Union
 
+import pytest
 from snuba import settings
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings
@@ -72,7 +71,7 @@ def run_migrations() -> Iterator[None]:
 
 
 @pytest.fixture
-def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
+def convert_legacy_to_snql() -> Callable[[str, str], str]:
     def convert(data: str, entity: str) -> str:
         legacy = json.loads(data)
 
@@ -104,8 +103,16 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
         sample_clause = f"SAMPLE {sample}" if sample else ""
         match_clause = f"MATCH ({entity} {sample_clause})"
 
-        selected = ", ".join(map(func, legacy.get("selected_columns", [])))
-        select_clause = f"SELECT {selected}" if selected else ""
+        aggregations = []
+        for a in legacy.get("aggregations", []):
+            if a[0].endswith(")") and not a[1]:
+                aggregations.append(f"{a[0]} AS {a[2]}")
+            else:
+                agg = func(a)
+                aggregations.append(agg)
+
+        expressions = aggregations + list(map(func, legacy.get("selected_columns", [])))
+        select_clause = f"SELECT {', '.join(expressions)}" if expressions else ""
 
         arrayjoin = legacy.get("arrayjoin")
         if arrayjoin:
@@ -118,48 +125,19 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                 else f"{select_clause}, {array_join_clause}"
             )
 
-        aggregations = []
-        for a in legacy.get("aggregations", []):
-            if a[0].endswith(")") and not a[1]:
-                aggregations.append(f"{a[0]} AS {a[2]}")
-            else:
-                agg = func(a)
-                aggregations.append(agg)
-
-        aggregations_str = ", ".join(aggregations)
-        joined = ", " if select_clause else "SELECT "
-        aggregation_clause = f"{joined}{aggregations_str}" if aggregations_str else ""
-
         groupby = legacy.get("groupby", [])
         if groupby and not isinstance(groupby, list):
             groupby = [groupby]
 
+        phrase = "BY" if select_clause else "SELECT"
         groupby = ", ".join(map(func, groupby))
-        groupby_clause = f"BY {groupby}" if groupby else ""
+        groupby_clause = f"{phrase} {groupby}" if groupby else ""
 
         word_ops = ("NOT IN", "IN", "LIKE", "NOT LIKE")
         conditions = []
-        for cond in legacy.get("conditions", []):
-            if len(cond) != 3 or not isinstance(cond[1], str):
-                or_condition = []
-                for or_cond in cond:
-                    op = f" {or_cond[1]} " if or_cond[1] in word_ops else or_cond[1]
-                    or_condition.append(
-                        f"{func(or_cond[0])}{op}{literal(or_cond[2])}".join(or_cond)
-                    )
-                or_condition_str = " OR ".join(or_condition)
-                conditions.append(f"{or_condition_str}")
-            else:
-                op = f" {cond[1]} " if cond[1] in word_ops else cond[1]
-                conditions.append(f"{func(cond[0])}{op}{literal(cond[2])}")
 
-        project = legacy.get("project")
-        if isinstance(project, int):
-            conditions.append(f"project_id={project}")
-        elif isinstance(project, list):
-            project = ",".join(map(str, project))
-            conditions.append(f"project_id IN tuple({project})")
-
+        # These conditions are ordered to match how the legacy parser would
+        # add these conditions so we can compare SQL queries directly.
         organization = legacy.get("organization")
         if isinstance(organization, int):
             conditions.append(f"org_id={organization}")
@@ -177,6 +155,27 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                     conditions.append(
                         f"{main_entity._required_time_column} {op} toDateTime('{date_val}')"
                     )
+
+        project = legacy.get("project")
+        if isinstance(project, int):
+            conditions.append(f"project_id IN tuple({project})")
+        elif isinstance(project, list):
+            project = ",".join(map(str, project))
+            conditions.append(f"project_id IN tuple({project})")
+
+        for cond in legacy.get("conditions", []):
+            if len(cond) != 3 or not isinstance(cond[1], str):
+                or_condition = []
+                for or_cond in cond:
+                    op = f" {or_cond[1]} " if or_cond[1] in word_ops else or_cond[1]
+                    or_condition.append(
+                        f"{func(or_cond[0])}{op}{literal(or_cond[2])}".join(or_cond)
+                    )
+                or_condition_str = " OR ".join(or_condition)
+                conditions.append(f"{or_condition_str}")
+            else:
+                op = f" {cond[1]} " if cond[1] in word_ops else cond[1]
+                conditions.append(f"{func(cond[0])}{op}{literal(cond[2])}")
 
         conditions_str = " AND ".join(conditions)
         where_clause = f"WHERE {conditions_str}" if conditions_str else ""
@@ -232,9 +231,52 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                 extra_exps.append(f"{extra.upper()} {legacy.get(extra)}")
         extras_clause = " ".join(extra_exps)
 
-        query = f"{match_clause} {select_clause} {aggregation_clause} {groupby_clause} {where_clause} {having_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
+        query = f"{match_clause} {select_clause} {groupby_clause} {where_clause} {having_clause} {order_by_clause} {limit_by_clause} {extras_clause}"
         body = {"query": query}
 
         return json.dumps(body)
 
-    yield convert
+    return convert
+
+
+@pytest.fixture(params=["legacy", "snql", "compare"])
+def _build_snql_post_methods(
+    request: Any,
+    test_entity: Union[str, Tuple[str, str]],
+    test_app: Any,
+    convert_legacy_to_snql: Callable[[str, str], str],
+) -> Callable[[str, str], Any]:
+    dataset = entity = ""
+    if isinstance(test_entity, tuple):
+        entity, dataset = test_entity
+    else:
+        dataset = entity = test_entity
+
+    if request.param == "legacy" or request.param == "snql":
+        endpoint = "/query" if request.param == "legacy" else f"/{dataset}/snql"
+
+        def simple_post(data: str, entity: str = entity) -> Any:
+            if request.param == "snql":
+                data = convert_legacy_to_snql(data, entity)
+            return test_app.post(endpoint, data=data, headers={"referer": "test"})
+
+        return simple_post
+
+    def compare_post(data: str, entity: str = entity) -> Any:
+        # Run legacy and snql and compare the outputs
+        legacy_resp = test_app.post("/query", data=data, headers={"referer": "test"})
+        snql_resp = test_app.post(
+            f"/{dataset}/snql",
+            data=convert_legacy_to_snql(data, entity),
+            headers={"referer": "test"},
+        )
+
+        legacy_data = json.loads(legacy_resp.data)
+        snql_data = json.loads(snql_resp.data)
+        assert (
+            legacy_data["sql"] == snql_data["sql"]
+        ), f"LEGACY:\n{legacy_data['sql']}\n\nSNQL:\n{snql_data['sql']}\n"
+
+        return snql_resp
+
+    return compare_post

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,7 +245,7 @@ def _build_snql_post_methods(
     test_entity: Union[str, Tuple[str, str]],
     test_app: Any,
     convert_legacy_to_snql: Callable[[str, str], str],
-) -> Callable[[str, str], Any]:
+) -> Callable[..., Any]:
     dataset = entity = ""
     if isinstance(test_entity, tuple):
         entity, dataset = test_entity

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -1,15 +1,13 @@
-import pytest
 import re
-from parsimonious.exceptions import IncompleteParseError, VisitationError
+from typing import Optional
+
+import pytest
 
 from snuba import state
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
-from snuba.query.data_source.join import (
-    JoinType,
-    JoinRelationship,
-)
+from snuba.query.data_source.join import JoinRelationship, JoinType
 from snuba.query.parser.exceptions import ParsingException
 from snuba.query.snql.parser import parse_snql_query
 
@@ -18,33 +16,33 @@ test_cases = [
     # i.e. the entire string is not consumed
     pytest.param(
         "MATCH (events) SELECT 4-5,3*g(c),c BY d,2+7 WHEREa<3 ORDERBY f DESC",
-        IncompleteParseError,
-        "The non-matching portion of the text begins with 'WHERE",
+        ParsingException,
+        "Parsing error at 'WHEREa<3 OR'",
         id="ORDER BY is two words",
     ),
     pytest.param(
         "MATCH (events) SELECT 4-5, 3*g(c), c BY d,2+7 WHERE a<3  ORDER BY fDESC",
-        IncompleteParseError,
-        "The non-matching portion of the text begins with 'ORDER BY",
+        ParsingException,
+        "Parsing error at 'ORDER BY fD'",
         id="Expression before ASC / DESC needs to be separated from ASC / DESC keyword by space",
     ),
     pytest.param(
         "MATCH (events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3  ORDER BY f DESC",
-        IncompleteParseError,
-        "The non-matching portion of the text begins with 'BY",
+        ParsingException,
+        "Parsing error at 'BY d, ,2+7 '",
         id="In a list, columns are separated by exactly one comma",
     ),
     pytest.param(
-        "MATCH (events) SELECT 4-5, 3*g(c), c BY d, ,2+7 WHERE a<3ORb>2  ORDER BY f DESC",
-        IncompleteParseError,
-        "The non-matching portion of the text begins with 'BY",
+        "MATCH (events) SELECT 4-5, 3*g(c), c BY d, 2+7 WHERE a<3ORb>2  ORDER BY f DESC",
+        ParsingException,
+        "Parsing error at 'ORb>2  ORDE'",
         id="mandatory spacing",
     ),
     pytest.param(
         """MATCH (e: events) -[nonsense]-> (t: transactions) SELECT 4-5, e.c
         WHERE e.project_id = 1 AND e.timestamp > toDateTime('2021-01-01') AND t.project_id = 1 AND t.finish_ts > toDateTime('2021-01-01')""",
-        VisitationError,
-        "KeyError: 'nonsense'",
+        ParsingException,
+        "ParsingException: events does not have a join relationship -[nonsense]->",
         id="invalid relationship name",
     ),
     pytest.param(
@@ -105,7 +103,9 @@ def test_failures(query_body: str, exception: Exception, message: str) -> None:
         "activity": (EntityKey.SESSIONS, "org_id"),
     }
 
-    def events_mock(relationship: str) -> JoinRelationship:
+    def events_mock(relationship: str) -> Optional[JoinRelationship]:
+        if relationship not in mapping:
+            return None
         entity_key, rhs_column = mapping[relationship]
         return JoinRelationship(
             rhs_entity=entity_key,

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -58,6 +58,8 @@ test_cases = [
             ],
             granularity=60,
             condition=required_condition,
+            limit=1000,
+            offset=0,
         ),
         id="granularity on whole query",
     ),
@@ -76,6 +78,8 @@ test_cases = [
             ],
             condition=required_condition,
             totals=True,
+            limit=1000,
+            offset=0,
         ),
         id="totals on whole query",
     ),
@@ -94,6 +98,8 @@ test_cases = [
             ],
             condition=required_condition,
             sample=0.5,
+            limit=1000,
+            offset=0,
         ),
         id="sample on entity",
     ),
@@ -112,6 +118,8 @@ test_cases = [
             ],
             condition=required_condition,
             limitby=LimitBy(5, Column("_snuba_c", None, "c")),
+            limit=1000,
+            offset=0,
         ),
         id="limit by column",
     ),
@@ -155,6 +163,8 @@ test_cases = [
             ],
             condition=required_condition,
             totals=True,
+            limit=1000,
+            offset=0,
         ),
         id="Array join",
     ),
@@ -185,6 +195,8 @@ test_cases = [
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
             condition=required_condition,
+            limit=1000,
+            offset=0,
         ),
         id="Basic query with no spaces and no ambiguous clause content",
     ),
@@ -195,9 +207,6 @@ test_cases = [
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
-                SelectedExpression(
-                    "count", FunctionCall("_snuba_count", "count", tuple()),
-                ),
                 SelectedExpression(
                     "tags[key]",
                     SubscriptableReference(
@@ -213,6 +222,9 @@ test_cases = [
                         Column("_snuba_measurements", None, "measurements"),
                         Literal(None, "lcp.elementSize"),
                     ),
+                ),
+                SelectedExpression(
+                    "count", FunctionCall("_snuba_count", "count", tuple()),
                 ),
             ],
             groupby=[
@@ -240,6 +252,8 @@ test_cases = [
                 ),
                 required_condition,
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Basic query with subscriptables",
     ),
@@ -250,6 +264,11 @@ test_cases = [
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
+                SelectedExpression("d", Column("_snuba_d", None, "d")),
+                SelectedExpression(
+                    "2+7",
+                    FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
+                ),
                 SelectedExpression(
                     "(2*(4-5)+3)",
                     FunctionCall(
@@ -277,11 +296,6 @@ test_cases = [
                     FunctionCall("_snuba_goo", "g", (Column("_snuba_c", None, "c"),)),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
-                SelectedExpression("d", Column("_snuba_d", None, "d")),
-                SelectedExpression(
-                    "2+7",
-                    FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
-                ),
             ],
             condition=required_condition,
             groupby=[
@@ -289,6 +303,8 @@ test_cases = [
                 FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
             ],
             order_by=[OrderBy(OrderByDirection.DESC, Column("_snuba_f", None, "f"))],
+            limit=1000,
+            offset=0,
         ),
         id="Simple complete query with example of parenthesized arithmetic expression in SELECT",
     ),
@@ -299,6 +315,11 @@ test_cases = [
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
+                SelectedExpression("d", Column("_snuba_d", None, "d")),
+                SelectedExpression(
+                    "2+7",
+                    FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
+                ),
                 SelectedExpression(
                     "(2*(4-5)+3)",
                     FunctionCall(
@@ -328,11 +349,6 @@ test_cases = [
                     ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
-                SelectedExpression("d", Column("_snuba_d", None, "d")),
-                SelectedExpression(
-                    "2+7",
-                    FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
-                ),
             ],
             condition=required_condition,
             groupby=[
@@ -340,6 +356,8 @@ test_cases = [
                 FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
             ],
             order_by=[OrderBy(OrderByDirection.DESC, Column("_snuba_f", None, "f"))],
+            limit=1000,
+            offset=0,
         ),
         id="Simple complete query with aliased function in SELECT",
     ),
@@ -350,6 +368,9 @@ test_cases = [
                 EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
             ),
             selected_columns=[
+                SelectedExpression(
+                    "now", Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
+                ),
                 SelectedExpression(
                     "now", Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
                 ),
@@ -366,12 +387,11 @@ test_cases = [
                         ),
                     ),
                 ),
-                SelectedExpression(
-                    "now", Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
-                ),
             ],
             groupby=[Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0))],
             condition=required_condition,
+            limit=1000,
+            offset=0,
         ),
         id="Basic query with date literals",
     ),
@@ -413,6 +433,8 @@ test_cases = [
                     ),
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Query with multiple conditions joined by AND",
     ),
@@ -448,6 +470,8 @@ test_cases = [
                 ),
                 required_condition,
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Query with multiple conditions joined by OR / parenthesized OR",
     ),
@@ -499,6 +523,8 @@ test_cases = [
                 ),
                 required_condition,
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Query with multiple / complex conditions joined by parenthesized / regular AND / OR",
     ),
@@ -532,6 +558,8 @@ test_cases = [
                     Literal(None, datetime.datetime(2021, 1, 1, 0, 0)),
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Query with IN condition",
     ),
@@ -564,6 +592,8 @@ test_cases = [
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
             condition=required_condition,
+            limit=1000,
+            offset=0,
         ),
         id="Basic query with new lines and no ambiguous clause content",
     ),
@@ -675,6 +705,8 @@ test_cases = [
                 ),
                 required_condition,
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Special array join functions",
     ),
@@ -740,6 +772,8 @@ test_cases = [
                     ),
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Basic join match",
     ),
@@ -806,6 +840,8 @@ test_cases = [
                     ),
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Basic join match with sample",
     ),
@@ -891,6 +927,8 @@ test_cases = [
                     ),
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Multi join match",
     ),
@@ -1044,6 +1082,8 @@ test_cases = [
                     ),
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Multi multi join match",
     ),
@@ -1055,13 +1095,15 @@ test_cases = [
                     EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
                 ),
                 selected_columns=[
+                    SelectedExpression("title", Column("_snuba_title", None, "title")),
                     SelectedExpression(
                         "count", FunctionCall("_snuba_count", "count", tuple())
                     ),
-                    SelectedExpression("title", Column("_snuba_title", None, "title")),
                 ],
                 groupby=[Column("_snuba_title", None, "title")],
                 condition=required_condition,
+                limit=1000,
+                offset=0,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -1073,6 +1115,8 @@ test_cases = [
                     ),
                 ),
             ],
+            limit=1000,
+            offset=0,
         ),
         id="sub query match",
     ),
@@ -1086,14 +1130,16 @@ test_cases = [
                     ),
                     selected_columns=[
                         SelectedExpression(
-                            "count", FunctionCall("_snuba_count", "count", tuple())
+                            "title", Column("_snuba_title", None, "title")
                         ),
                         SelectedExpression(
-                            "title", Column("_snuba_title", None, "title")
+                            "count", FunctionCall("_snuba_count", "count", tuple())
                         ),
                     ],
                     groupby=[Column("_snuba_title", None, "title")],
                     condition=required_condition,
+                    limit=1000,
+                    offset=0,
                 ),
                 selected_columns=[
                     SelectedExpression(
@@ -1105,6 +1151,8 @@ test_cases = [
                         ),
                     ),
                 ],
+                limit=1000,
+                offset=0,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -1116,6 +1164,8 @@ test_cases = [
                     ),
                 ),
             ],
+            limit=1000,
+            offset=0,
         ),
         id="sub query of sub query match",
     ),
@@ -1162,6 +1212,8 @@ test_cases = [
                     required_condition,
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Basic query with crazy characters and escaping",
     ),
@@ -1177,10 +1229,10 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "count", FunctionCall("_snuba_count", "count", tuple()),
+                    "tags_key", Column("_snuba_tags_key", None, "tags_key"),
                 ),
                 SelectedExpression(
-                    "tags_key", Column("_snuba_tags_key", None, "tags_key"),
+                    "count", FunctionCall("_snuba_count", "count", tuple()),
                 ),
             ],
             groupby=[Column("_snuba_tags_key", None, "tags_key")],
@@ -1237,6 +1289,7 @@ test_cases = [
                 ),
                 required_condition,
             ),
+            offset=0,
         ),
         id="Query with nested boolean conditions with multiple empty quoted literals",
     ),

--- a/tests/query/test_organization_extension.py
+++ b/tests/query/test_organization_extension.py
@@ -22,7 +22,7 @@ def test_organization_extension_query_processing_happy_path() -> None:
 
     extension.get_processor().process_query(query, valid_data, request_settings)
     assert query.get_condition_from_ast() == binary_condition(
-        ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 2)
+        ConditionFunctions.EQ, Column("_snuba_org_id", None, "org_id"), Literal(None, 2)
     )
 
 

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -19,7 +19,7 @@ def build_in(project_column: str, projects: Sequence[int]) -> Expression:
         None,
         "in",
         (
-            Column(None, None, project_column),
+            Column(f"_snuba_{project_column}", None, project_column),
             FunctionCall(None, "tuple", tuple([Literal(None, p) for p in projects])),
         ),
     )

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -25,12 +25,12 @@ def build_time_condition(
         BooleanFunctions.AND,
         binary_condition(
             ConditionFunctions.GTE,
-            Column(None, None, time_columns),
+            Column(f"_snuba_{time_columns}", None, time_columns),
             Literal(None, from_date),
         ),
         binary_condition(
             ConditionFunctions.LT,
-            Column(None, None, time_columns),
+            Column(f"_snuba_{time_columns}", None, time_columns),
             Literal(None, to_date),
         ),
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -837,7 +837,7 @@ class TestApi(BaseApiTest):
             ).data
         )
         assert (
-            "PREWHERE notEquals(positionCaseInsensitive((message AS _snuba_message), 'abc'), 0) AND in(project_id, tuple(1))"
+            "PREWHERE notEquals(positionCaseInsensitive((message AS _snuba_message), 'abc'), 0) AND in((project_id AS _snuba_project_id), tuple(1))"
             in result["sql"]
         )
 
@@ -859,8 +859,12 @@ class TestApi(BaseApiTest):
         )
 
         # make sure the conditions is in PREWHERE and nowhere else
-        assert "PREWHERE in(project_id, tuple(1))" in result["sql"]
-        assert result["sql"].count("in(project_id, tuple(1))") == 1
+        assert (
+            "PREWHERE in((project_id AS _snuba_project_id), tuple(1))" in result["sql"]
+        )
+        assert (
+            result["sql"].count("in((project_id AS _snuba_project_id), tuple(1))") == 1
+        )
 
     def test_aggregate(self):
         result = json.loads(

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -26,10 +26,10 @@ class TestDiscoverApi(BaseApiTest):
         return self.app
 
     @pytest.fixture(autouse=True)
-    def setup_post(self, _build_snql_post_methods: Callable[[Any], Any]) -> None:
+    def setup_post(self, _build_snql_post_methods: Callable[..., Any]) -> None:
         self.post = _build_snql_post_methods
 
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: Any) -> None:
         super().setup_method(test_method)
         self.trace_id = uuid.UUID("7400045b-25c4-43b8-8591-4600aa83ad04")
         self.event = get_raw_event()
@@ -45,7 +45,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_raw_data(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -69,8 +69,7 @@ class TestDiscoverApi(BaseApiTest):
         }
 
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -90,6 +89,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200
@@ -106,7 +106,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_aggregations(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -132,8 +132,7 @@ class TestDiscoverApi(BaseApiTest):
         ]
 
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -146,6 +145,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
 
@@ -161,8 +161,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_handles_columns_from_other_dataset(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -182,6 +181,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
 
@@ -196,7 +196,7 @@ class TestDiscoverApi(BaseApiTest):
         ]
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -221,7 +221,7 @@ class TestDiscoverApi(BaseApiTest):
         write_unprocessed_events(get_writable_storage(StorageKey.EVENTS), [event])
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -247,8 +247,7 @@ class TestDiscoverApi(BaseApiTest):
         )
 
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -265,6 +264,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
 
         assert response.status_code == 200
@@ -273,8 +273,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_geo_column_condition(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -288,6 +287,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
 
@@ -295,8 +295,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"] == [{"count": 0}]
 
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -312,6 +311,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
 
@@ -320,7 +320,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_exception_stack_column_boolean_condition_arrayjoin_function(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -370,7 +370,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_tags_key_boolean_condition(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "turbo": False,
@@ -416,8 +416,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_os_fields_condition(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -432,6 +431,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         assert response.status_code == 200
         data = json.loads(response.data)
@@ -439,8 +439,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_http_fields(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -452,6 +451,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         assert response.status_code == 200
         data = json.loads(response.data)
@@ -465,7 +465,7 @@ class TestDiscoverApi(BaseApiTest):
         ]
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -491,8 +491,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_device_fields_condition(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -507,6 +506,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
 
         assert response.status_code == 200
@@ -514,7 +514,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"][0]["count"] == 1
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -537,8 +537,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_device_boolean_fields_context_vs_promoted_column(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -551,6 +550,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         assert response.status_code == 200
         data = json.loads(response.data)
@@ -558,7 +558,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"][0]["count"] == 1
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -579,7 +579,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_is_handled(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -602,7 +602,7 @@ class TestDiscoverApi(BaseApiTest):
     def test_having(self) -> None:
         result = json.loads(
             self.post(
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -621,7 +621,7 @@ class TestDiscoverApi(BaseApiTest):
     def test_time(self) -> None:
         result = json.loads(
             self.post(
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -638,8 +638,7 @@ class TestDiscoverApi(BaseApiTest):
 
         result = json.loads(
             self.post(
-                entity="discover_transactions",
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -650,6 +649,7 @@ class TestDiscoverApi(BaseApiTest):
                         "to_date": (self.base_time + self.skew).isoformat(),
                     }
                 ),
+                entity="discover_transactions",
             ).data
         )
         assert len(result["data"]) == 1
@@ -657,8 +657,7 @@ class TestDiscoverApi(BaseApiTest):
     def test_transaction_group_ids(self) -> None:
         result = json.loads(
             self.post(
-                entity="discover_transactions",
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -671,14 +670,14 @@ class TestDiscoverApi(BaseApiTest):
                         "to_date": (self.base_time + self.skew).isoformat(),
                     }
                 ),
+                entity="discover_transactions",
             ).data
         )
         assert result["data"][0]["group_id"] == 0
 
         result = json.loads(
             self.post(
-                entity="discover_transactions",
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -692,6 +691,7 @@ class TestDiscoverApi(BaseApiTest):
                         "to_date": (self.base_time + self.skew).isoformat(),
                     }
                 ),
+                entity="discover_transactions",
             ).data
         )
 
@@ -700,7 +700,7 @@ class TestDiscoverApi(BaseApiTest):
     def test_contexts(self) -> None:
         result = json.loads(
             self.post(
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -716,8 +716,7 @@ class TestDiscoverApi(BaseApiTest):
 
         result = json.loads(
             self.post(
-                entity="discover_transactions",
-                data=json.dumps(
+                json.dumps(
                     {
                         "dataset": "discover",
                         "project": self.project_id,
@@ -727,14 +726,14 @@ class TestDiscoverApi(BaseApiTest):
                         "to_date": (self.base_time + self.skew).isoformat(),
                     }
                 ),
+                entity="discover_transactions",
             ).data
         )
         assert result["data"] == [{"contexts[device.online]": "True"}]
 
     def test_ast_impossible_queries(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -749,6 +748,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
 
@@ -763,7 +763,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_count_null_user_consistency(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -786,8 +786,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"][0]["uniq_user"] == 0
 
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -803,6 +802,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200
@@ -812,8 +812,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_individual_measurement(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -828,6 +827,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
@@ -838,8 +838,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"][0]["measurements[asd]"] is None
 
         response = self.post(
-            entity="discover",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -849,6 +848,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover",
         )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
@@ -858,7 +858,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_functions_called_on_null(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -878,7 +878,7 @@ class TestDiscoverApi(BaseApiTest):
         assert data["data"][0]["sum_transaction_duration"] is None
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -905,8 +905,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_web_vitals_histogram_function(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -982,6 +981,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
@@ -989,7 +989,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_max_timestamp_by_timestamp(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "project": self.project_id,
@@ -1010,8 +1010,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_invalid_event_id_condition(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "discover",
                     "aggregations": [
@@ -1031,6 +1030,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
@@ -1038,8 +1038,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_null_processor_with_if_function(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "consistent": False,
                     "having": [],
@@ -1094,6 +1093,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
@@ -1107,8 +1107,7 @@ class TestDiscoverApi(BaseApiTest):
 
     def test_zero_literal_caching(self) -> None:
         response = self.post(
-            entity="discover_transactions",
-            data=json.dumps(
+            json.dumps(
                 {
                     "selected_columns": [],
                     "having": [["count_unique_user", ">", 0.0]],
@@ -1134,6 +1133,7 @@ class TestDiscoverApi(BaseApiTest):
                     "to_date": (self.base_time + self.skew).isoformat(),
                 }
             ),
+            entity="discover_transactions",
         )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
@@ -1178,7 +1178,7 @@ class TestArrayJoinDiscoverAPI(BaseApiTest):
         data = json.loads(response.data)
         assert data["data"] == [{"count": 1}]
 
-    def test_exception_stack_column_boolean_condition(self, request) -> None:
+    def test_exception_stack_column_boolean_condition(self) -> None:
         response = self.app.post(
             "/query",
             headers={"referer": "test"},

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -1,9 +1,9 @@
 import calendar
-import pytest
 import uuid
 from datetime import datetime, timedelta
-from functools import partial
+from typing import Any, Callable, Tuple, Union
 
+import pytest
 import pytz
 import simplejson as json
 
@@ -16,24 +16,20 @@ from tests.helpers import write_processed_messages
 
 
 class TestTransactionsApi(BaseApiTest):
-    @pytest.fixture(
-        autouse=True, params=["/query", "/transactions/snql"], ids=["legacy", "snql"]
-    )
-    def _set_endpoint(self, request, convert_legacy_to_snql) -> None:
-        self.endpoint = request.param
-        if request.param == "/transactions/snql":
-            old_post = self.app.post
+    @pytest.fixture
+    def test_entity(self) -> Union[str, Tuple[str, str]]:
+        return "transactions"
 
-            def new_post(endpoint, data=None):
-                return old_post(
-                    endpoint, data=convert_legacy_to_snql(data, "transactions")
-                )
+    @pytest.fixture
+    def test_app(self) -> Any:
+        return self.app
 
-            self.app.post = new_post
+    @pytest.fixture(autouse=True)
+    def setup_post(self, _build_snql_post_methods: Callable[[Any], Any]) -> None:
+        self.post = _build_snql_post_methods
 
     def setup_method(self, test_method) -> None:
         super().setup_method(test_method)
-        self.app.post = partial(self.app.post, headers={"referer": "test"})
 
         # values for test data
         self.project_ids = [1, 2]  # 2 projects
@@ -163,8 +159,7 @@ class TestTransactionsApi(BaseApiTest):
         write_processed_messages(self.storage, events)
 
     def test_read_ip(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -182,8 +177,7 @@ class TestTransactionsApi(BaseApiTest):
         assert "ip_address" in data["data"][0]
 
     def test_read_lowcard(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -202,8 +196,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][0]["transaction_op"] == "http"
 
     def test_start_ts_microsecond_truncation(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -239,8 +232,7 @@ class TestTransactionsApi(BaseApiTest):
         assert "transaction_name" in data["data"][0]
 
     def test_split_query(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -262,8 +254,7 @@ class TestTransactionsApi(BaseApiTest):
         assert len(data["data"]) > 1, data
 
     def test_column_formatting(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -283,8 +274,7 @@ class TestTransactionsApi(BaseApiTest):
         assert len(first_event_id) == 32
         assert data["data"][0]["ip_address"] == "8.8.8.8"
 
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -303,8 +293,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][0]["event_id"] == first_event_id
 
     def test_trace_column_formatting(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -324,8 +313,7 @@ class TestTransactionsApi(BaseApiTest):
         assert len(first_trace_id) == 36
         assert data["data"][0]["ip_address"] == "8.8.8.8"
 
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -344,8 +332,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][0]["trace_id"] == first_trace_id
 
     def test_apdex_function(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -372,8 +359,7 @@ class TestTransactionsApi(BaseApiTest):
         }
 
     def test_failure_rate_function(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -399,8 +385,7 @@ class TestTransactionsApi(BaseApiTest):
         }
 
     def test_individual_measurement(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -424,8 +409,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][0]["measurements[asd]"] is None
 
     def test_arrayjoin_measurements(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",
@@ -455,8 +439,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][3]["value"] == 4242
 
     def test_escaping_strings(self) -> None:
-        response = self.app.post(
-            self.endpoint,
+        response = self.post(
             data=json.dumps(
                 {
                     "dataset": "transactions",

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -25,10 +25,10 @@ class TestTransactionsApi(BaseApiTest):
         return self.app
 
     @pytest.fixture(autouse=True)
-    def setup_post(self, _build_snql_post_methods: Callable[[Any], Any]) -> None:
+    def setup_post(self, _build_snql_post_methods: Callable[[str], Any]) -> None:
         self.post = _build_snql_post_methods
 
-    def setup_method(self, test_method) -> None:
+    def setup_method(self, test_method: Any) -> None:
         super().setup_method(test_method)
 
         # values for test data
@@ -46,7 +46,7 @@ class TestTransactionsApi(BaseApiTest):
         self.storage = get_writable_storage(StorageKey.TRANSACTIONS)
         self.generate_fizzbuzz_events()
 
-    def teardown_method(self, test_method) -> None:
+    def teardown_method(self, test_method: Any) -> None:
         # Reset rate limits
         state.delete_config("global_concurrent_limit")
         state.delete_config("global_per_second_limit")
@@ -155,12 +155,13 @@ class TestTransactionsApi(BaseApiTest):
                             KafkaMessageMetadata(0, 0, self.base_time),
                         )
                     )
-                    events.append(processed)
+                    if processed:
+                        events.append(processed)
         write_processed_messages(self.storage, events)
 
     def test_read_ip(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -178,7 +179,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_read_lowcard(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -197,7 +198,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_start_ts_microsecond_truncation(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -233,7 +234,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_split_query(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -255,7 +256,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_column_formatting(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -275,7 +276,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][0]["ip_address"] == "8.8.8.8"
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -294,7 +295,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_trace_column_formatting(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -314,7 +315,7 @@ class TestTransactionsApi(BaseApiTest):
         assert data["data"][0]["ip_address"] == "8.8.8.8"
 
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -333,7 +334,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_apdex_function(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -360,7 +361,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_failure_rate_function(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -386,7 +387,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_individual_measurement(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -410,7 +411,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_arrayjoin_measurements(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,
@@ -440,7 +441,7 @@ class TestTransactionsApi(BaseApiTest):
 
     def test_escaping_strings(self) -> None:
         response = self.post(
-            data=json.dumps(
+            json.dumps(
                 {
                     "dataset": "transactions",
                     "project": 1,


### PR DESCRIPTION
Refactored the current SnQL test fixtures to add a 'compare' param that runs
both the SnQL and legacy query and compares the sql output. Added to most API
tests (test_api.py will be a separate PR because it's huge).