### PR TITLE
fix(discover): Fix bug in Snuplicator storage selection

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -445,10 +445,10 @@ class DiscoverEntity(Entity):
                 return "events", []
 
             if referrer in settings.ERRORS_ROLLOUT_BY_REFERRER:
-                return "errors", []
+                return "discover", []
 
             if settings.ERRORS_ROLLOUT_ALL:
-                return "errors", []
+                return "discover", []
 
             config = state.get_config("discover_query_percentage", 0)
             assert isinstance(config, (float, int, str))


### PR DESCRIPTION
Fixes a bug where an invalid pipeline ID was being referenced
in the Discover entity. Fortunately this didn't have an
impact in production since these settings weren't used yet.