### PR TITLE
test: Rewrite Discover API tests to pass with both events and errors storage

### DIFF
--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -242,10 +242,10 @@ class TestDiscoverApi(BaseApiTest):
 
         response = self.app.post(
             self.endpoint,
-            "discover",
+            "discover_events",
             data=json.dumps(
                 {
-                    "dataset": "discover_events",
+                    "dataset": "discover",
                     "project": self.project_id,
                     "selected_columns": ["geo_city"],
                     "aggregations": [["count()", "", "count"]],


### PR DESCRIPTION
Discover API tests now pass for both old and new events storage - i.e. when the
settings ERRORS_ROLLOUT_ALL and ERRORS_ROLLOUT_WRITABLE_STORAGE are flipped to True.