### PR TITLE
test: Refactor events and errors replacer tests

### DIFF
--- a/snuba/datasets/errors.py
+++ b/snuba/datasets/errors.py
@@ -1,7 +1,0 @@
-from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities import EntityKey
-
-
-class ErrorsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.ERRORS)

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -11,7 +11,6 @@ DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
 DATASET_NAMES: Set[str] = {
     "discover",
     "events",
-    "events_migration",
     "groupassignee",
     "groupedmessage",
     "outcomes",

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -41,7 +41,7 @@ def get_dataset(name: str) -> Dataset:
     from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
     from snuba.datasets.discover import DiscoverDataset
     from snuba.datasets.events import EventsDataset
-    from snuba.datasets.errors import ErrorsDataset
+
     from snuba.datasets.outcomes import OutcomesDataset
     from snuba.datasets.outcomes_raw import OutcomesRawDataset
     from snuba.datasets.sessions import SessionsDataset
@@ -50,7 +50,6 @@ def get_dataset(name: str) -> Dataset:
     dataset_factories: MutableMapping[str, Callable[[], Dataset]] = {
         "discover": DiscoverDataset,
         "events": EventsDataset,
-        "events_migration": ErrorsDataset,
         "groupassignee": GroupAssigneeDataset,
         "groupedmessage": GroupedMessageDataset,
         "outcomes": OutcomesDataset,

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -1,10 +1,11 @@
+import importlib
 import pytz
 import re
 from datetime import datetime
 from functools import partial
 import simplejson as json
 
-from snuba import replacer
+from snuba import replacer, settings
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.datasets.errors_replacer import ReplacerState
 from snuba.datasets import errors_replacer
@@ -34,6 +35,11 @@ class TestReplacer:
 
         self.project_id = 1
         self.event = get_raw_event()
+        settings.ERRORS_ROLLOUT_ALL = False
+        settings.ERRORS_ROLLOUT_WRITABLE_STORAGE = False
+
+    def teardown_method(self):
+        importlib.reload(settings)
 
     def _wrap(self, msg: str) -> Message[KafkaPayload]:
         return Message(


### PR DESCRIPTION
Refactor the events and errors replacer tests so they will still
pass when ERRORS_ROLLOUT_ALL and ERRORS_ROLLOUT_WRITABLE_STORAGE
are flipped. Also removes the "events_migration" (aka Errors)
dataset, which is never used and only existed for the purposes
of this test.