### PR TITLE
fix(snql) Add unary conditions to parser

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -3,9 +3,9 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    List,
     MutableMapping,
     NamedTuple,
-    List,
     Optional,
     Sequence,
     Tuple,
@@ -14,21 +14,18 @@ from typing import (
 
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import Node, NodeVisitor
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.query import (
-    LimitBy,
-    OrderBy,
-    OrderByDirection,
-    SelectedExpression,
-)
+from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,
     binary_condition,
     combine_and_conditions,
     combine_or_conditions,
+    unary_condition,
 )
 from snuba.query.data_source.join import IndividualNode, JoinClause
 from snuba.query.data_source.simple import Entity as QueryEntity
@@ -41,18 +38,14 @@ from snuba.query.expressions import (
     Lambda,
     Literal,
 )
-from snuba.query.matchers import (
-    Any as AnyMatch,
-    AnyExpression,
-    AnyOptionalString,
-    Column as ColumnMatch,
-    FunctionCall as FunctionCallMatch,
-    Literal as LiteralMatch,
-    Param,
-    Or,
-    String as StringMatch,
-)
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.matchers import Any as AnyMatch
+from snuba.query.matchers import AnyExpression, AnyOptionalString
+from snuba.query.matchers import Column as ColumnMatch
+from snuba.query.matchers import FunctionCall as FunctionCallMatch
+from snuba.query.matchers import Literal as LiteralMatch
+from snuba.query.matchers import Or, Param
+from snuba.query.matchers import String as StringMatch
 from snuba.query.parser import (
     _apply_column_aliases,
     _expand_aliases,
@@ -82,10 +75,7 @@ from snuba.query.snql.expression_visitor import (
     visit_parameters_list,
     visit_quoted_literal,
 )
-from snuba.query.snql.joins import (
-    RelationshipTuple,
-    build_join_clause,
-)
+from snuba.query.snql.joins import RelationshipTuple, build_join_clause
 from snuba.util import parse_datetime
 
 snql_grammar = Grammar(
@@ -117,9 +107,11 @@ snql_grammar = Grammar(
     and_tuple             = space+ "AND" condition
     or_tuple              = space+ "OR" and_expression
 
-    condition             = main_condition / parenthesized_cdn
+    condition             = unary_condition / main_condition / parenthesized_cdn
+    unary_condition       = low_pri_arithmetic space+ unary_op
     main_condition        = low_pri_arithmetic space* condition_op space* (function_call / column_name / quoted_literal / numeric_literal)
     condition_op          = "!=" / ">=" / ">" / "<=" / "<" / "=" / "NOT IN" / "NOT LIKE" / "IN" / "LIKE"
+    unary_op              = "IS NULL" / "IS NOT NULL"
     parenthesized_cdn     = space* open_paren or_expression close_paren
 
     select_list          = select_columns* (selected_expression)
@@ -501,6 +493,15 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
                 elif isinstance(elem, (AndTuple, OrTuple)):
                     args.append(elem.exp)
         return combine_or_conditions(args)
+
+    def visit_unary_condition(
+        self, node: Node, visited_children: Tuple[Expression, Any, str]
+    ) -> Expression:
+        exp, _, op = visited_children
+        return unary_condition(op, exp)
+
+    def visit_unary_op(self, node: Node, visited_children: Iterable[Any]) -> str:
+        return OPERATOR_TO_FUNCTION[node.text]
 
     def visit_main_condition(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,7 +158,7 @@ def convert_legacy_to_snql() -> Callable[[str, str], str]:
 
         project = legacy.get("project")
         if isinstance(project, int):
-            conditions.append(f"project_id={project}")
+            conditions.append(f"project_id IN tuple({project})")
         elif isinstance(project, list):
             project = ",".join(map(str, project))
             conditions.append(f"project_id IN tuple({project})")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
         groupby = ", ".join(map(func, groupby))
         groupby_clause = f"BY {groupby}" if groupby else ""
 
-        word_ops = ("NOT IN", "IN", "LIKE", "NOT LIKE")
+        word_ops = ("NOT IN", "IN", "LIKE", "NOT LIKE", "IS NULL", "IS NOT NULL")
         conditions = []
         for cond in legacy.get("conditions", []):
             if len(cond) != 3 or not isinstance(cond[1], str):
@@ -150,8 +150,12 @@ def convert_legacy_to_snql() -> Iterator[Callable[[str, str], str]]:
                 or_condition_str = " OR ".join(or_condition)
                 conditions.append(f"{or_condition_str}")
             else:
+                rhs = ""
+                if cond[1] not in ["IS NULL", "IS NOT NULL"]:
+                    rhs = literal(cond[2])
+
                 op = f" {cond[1]} " if cond[1] in word_ops else cond[1]
-                conditions.append(f"{func(cond[0])}{op}{literal(cond[2])}")
+                conditions.append(f"{func(cond[0])}{op}{rhs}")
 
         project = legacy.get("project")
         if isinstance(project, int):

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -5,7 +5,7 @@ from snuba import state
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
-from snuba.query.conditions import binary_condition
+from snuba.query.conditions import binary_condition, unary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.data_source.join import (
     IndividualNode,
@@ -187,6 +187,55 @@ test_cases = [
             condition=required_condition,
         ),
         id="Basic query with no spaces and no ambiguous clause content",
+    ),
+    pytest.param(
+        """MATCH (events)
+        SELECT 4-5,3*foo(c) AS foo,c
+        WHERE platform NOT IN tuple('x', 'y') AND message IS NULL
+        AND project_id = 1 AND timestamp > toDateTime('2021-01-01')""",
+        LogicalQuery(
+            QueryEntity(
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
+            ),
+            selected_columns=[
+                SelectedExpression(
+                    "4-5",
+                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                ),
+                SelectedExpression(
+                    "3*foo(c) AS foo",
+                    FunctionCall(
+                        None,
+                        "multiply",
+                        (
+                            Literal(None, 3),
+                            FunctionCall(
+                                "_snuba_foo", "foo", (Column("_snuba_c", None, "c"),)
+                            ),
+                        ),
+                    ),
+                ),
+                SelectedExpression("c", Column("_snuba_c", None, "c")),
+            ],
+            condition=binary_condition(
+                "and",
+                binary_condition(
+                    "notIn",
+                    Column("_snuba_platform", None, "platform"),
+                    FunctionCall(
+                        None, "tuple", (Literal(None, "x"), Literal(None, "y"))
+                    ),
+                ),
+                binary_condition(
+                    "and",
+                    unary_condition(
+                        "isNull", Column("_snuba_message", None, "message")
+                    ),
+                    required_condition,
+                ),
+            ),
+        ),
+        id="Basic query with word condition ops",
     ),
     pytest.param(
         "MATCH (events) SELECT count() AS count BY tags[key], measurements[lcp.elementSize] WHERE measurements[lcp.elementSize] > 1 AND project_id = 1 AND timestamp > toDateTime('2021-01-01')",

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -246,6 +246,8 @@ test_cases = [
                     required_condition,
                 ),
             ),
+            limit=1000,
+            offset=0,
         ),
         id="Basic query with word condition ops",
     ),


### PR DESCRIPTION
SnQL wasn't handling when IS NULL or IS NOT NULL were sent as the condition op.