### PR TITLE
test: Refactor tests so they still pass with errors storage

### DIFF
--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -4,9 +4,9 @@ import uuid
 
 from snuba import settings
 from snuba.datasets.factory import get_dataset
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.events_processor_base import InsertEvent
-from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_writable_storage
 from tests.helpers import write_unprocessed_events
 
 
@@ -21,8 +21,10 @@ class BaseSubscriptionTest:
             minute=0, second=0, microsecond=0
         ) - timedelta(minutes=self.minutes)
 
+        events_storage = get_entity(EntityKey.EVENTS).get_writable_storage()
+
         write_unprocessed_events(
-            get_writable_storage(StorageKey.EVENTS),
+            events_storage,
             [
                 InsertEvent(
                     {

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -5,6 +5,8 @@ from functools import partial
 
 import simplejson as json
 
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
 from tests.base import BaseApiTest
@@ -24,7 +26,8 @@ class TestSnQLApi(BaseApiTest):
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0, tzinfo=pytz.utc
         ) - timedelta(minutes=180)
-        write_unprocessed_events(get_writable_storage(StorageKey.EVENTS), [self.event])
+        events_storage = get_entity(EntityKey.EVENTS).get_writable_storage()
+        write_unprocessed_events(events_storage, [self.event])
         write_unprocessed_events(
             get_writable_storage(StorageKey.TRANSACTIONS), [get_raw_transaction()],
         )


### PR DESCRIPTION
Tests still pass when ERRORS_ROLLOUT_ALL and
ERRORS_ROLLOUT_WRITABLE_STORAGE are set to True. We'll flip
these values in settings_test.py as part of the SaaS rollout.