### PR TITLE
feat(errors): Default replacement and commit log topic names match events

### DIFF
--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -36,7 +36,8 @@ storage = WritableTableStorage(
         StorageKey.ERRORS,
         processor=ErrorsProcessor(promoted_tag_columns),
         default_topic_name="events",
-        replacement_topic_name="errors-replacements",
+        replacement_topic_name="event-replacements",
+        commit_log_topic_name="snuba-commit-log",
     ),
     replacer_processor=ErrorsReplacer(
         schema=schema,


### PR DESCRIPTION
Update the default replacement and commit log topic names to match those
of the events storage. This allows us to safely swap the events consumer
and replacer for the errors consumer and replacer, for environments
like dev and onpremise where the multistorage consumer isn't being used
as part of the rollout strategy and these defaults are relied on.