### PR TITLE
feat(devserver): Devserver can switch between events and errors storage

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -10,6 +10,12 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
     import sys
     from subprocess import list2cmdline, call
     from honcho.manager import Manager
+    from snuba import settings
+
+    if settings.ERRORS_ROLLOUT_WRITABLE_STORAGE:
+        events_storage = "errors"
+    else:
+        events_storage = "events"
 
     os.environ["PYTHONUNBUFFERED"] = "1"
 
@@ -73,7 +79,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "consumer",
                 "--auto-offset-reset=latest",
                 "--log-level=debug",
-                "--storage=events",
+                f"--storage={events_storage}",
             ],
         ),
         (
@@ -83,7 +89,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "replacer",
                 "--auto-offset-reset=latest",
                 "--log-level=debug",
-                "--storage=events",
+                f"--storage={events_storage}",
             ],
         ),
         (


### PR DESCRIPTION
Devserver switches to the errors storage instead of events if
settings.ERRORS_ROLLOUT_WRITABLE_STORAGE is set to True.