### PR TITLE
feat(errors): Assign discrepancies in Snuplicator results to a category

### DIFF
--- a/snuba/datasets/entities/assign_reason.py
+++ b/snuba/datasets/entities/assign_reason.py
@@ -1,0 +1,65 @@
+from typing import Any, Mapping, Optional, Sequence
+
+
+def assign_reason_category(
+    data: Sequence[Mapping[str, Any]],
+    expected_data: Sequence[Mapping[str, Any]],
+    referrer: str,
+) -> str:
+    """
+    Attempt to categorize the reason for the discrepancy.
+    Mostly based on the type of query we expect for each referrer.
+    """
+
+    try:
+        if referrer.startswith("tsdb-modelid:"):
+            agg = check_aggregate(data, expected_data, "aggregate")
+            if agg is not None:
+                return agg
+
+        if referrer == "tagstore.get_groups_user_counts":
+            agg = check_aggregate(data, expected_data, "count")
+            if agg is not None:
+                return agg
+
+        if referrer == "api.serializer.projects.get_stats":
+            agg = check_aggregate(data, expected_data, "count")
+            if agg is not None:
+                return agg
+
+        if referrer == "tagstore.__get_tag_key_and_top_values":
+            agg = check_aggregate(data, expected_data, "count")
+            if agg is not None:
+                return agg
+
+        return "UNKNOWN"
+
+    except Exception:
+        return "UNKNOWN"
+
+
+def check_aggregate(
+    data: Sequence[Mapping[str, Any]],
+    expected_data: Sequence[Mapping[str, Any]],
+    aggregate_key: str,
+) -> Optional[str]:
+    """
+    Returns AGGREGATE_TOO_HIGH or AGGREGATE_TOO_LOW if the result is the same
+    except for the aggregate value. Could be an indication of differences in how
+    parts are merged between the two tables, timing differences or something else.
+    """
+    if len(data) == len(expected_data):
+        for idx in range(len(data)):
+            if data[idx] != expected_data[idx]:
+                non_matching_keys = set()
+                for key in data[idx]:
+                    if data[idx][key] != expected_data[idx][key]:
+                        non_matching_keys.add(key)
+
+                if non_matching_keys == {aggregate_key}:
+                    if data[idx][aggregate_key] > expected_data[idx][aggregate_key]:
+                        return "AGGREGATE_TOO_HIGH"
+                    else:
+                        return "AGGREGATE_TOO_LOW"
+
+    return None

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -14,6 +14,7 @@ from snuba.clickhouse.translators.snuba.mappers import (
 )
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entity import Entity
+from snuba.datasets.entities.assign_reason import assign_reason_category
 from snuba.datasets.plans.single_storage import SelectedStorageQueryPlanBuilder
 from snuba.datasets.storage import (
     QueryStorageSelector,
@@ -131,9 +132,16 @@ def callback_func(
                 tags={"storage": storage, "match": "true", "referrer": referrer},
             )
         else:
+            reason = assign_reason_category(result_data, primary_result_data, referrer)
+
             metrics.increment(
                 "query_result",
-                tags={"storage": storage, "match": "false", "referrer": referrer},
+                tags={
+                    "storage": storage,
+                    "match": "false",
+                    "referrer": referrer,
+                    "reason": reason,
+                },
             )
 
             if len(result_data) != len(primary_result_data):
@@ -145,6 +153,7 @@ def callback_func(
                         "query": format_query(query),
                         "primary_result": len(primary_result_data),
                         "other_result": len(result_data),
+                        "reason": reason,
                     },
                 )
 
@@ -161,6 +170,7 @@ def callback_func(
                             "query": format_query(query),
                             "primary_result": primary_result_data[idx],
                             "other_result": result_data[idx],
+                            "reason": reason,
                         },
                     )
 

--- a/tests/datasets/entities/test_assign_reason.py
+++ b/tests/datasets/entities/test_assign_reason.py
@@ -1,0 +1,39 @@
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from datetime import datetime
+
+from snuba.datasets.entities.assign_reason import assign_reason_category
+
+
+now = datetime.now()
+
+
+test_data = [
+    pytest.param(
+        [{"group_id": 1, "time": now, "aggregate": 2}],
+        [{"group_id": 1, "time": now, "aggregate": 3}],
+        "tsdb-modelid:4",
+        "AGGREGATE_TOO_LOW",
+        id="tsdb",
+    ),
+    pytest.param(
+        [{"count": 4, "group_id": 2}, {"count": 4, "group_id": 4}],
+        [{"count": 1, "group_id": 2}, {"count": 4, "group_id": 4}],
+        "tagstore.get_groups_user_counts",
+        "AGGREGATE_TOO_HIGH",
+        id="tagstore.get_groups_user_counts",
+    ),
+    pytest.param([{"count": 1}], [{"count": 1}], "unknown", "UNKNOWN", id="default"),
+]
+
+
+@pytest.mark.parametrize("data, primary_data, referrer, expected_reason", test_data)
+def test_assign_reason_category(
+    data: Sequence[Mapping[str, Any]],
+    primary_data: Sequence[Mapping[str, Any]],
+    referrer: str,
+    expected_reason: str,
+) -> None:
+    assert assign_reason_category(data, primary_data, referrer) == expected_reason


### PR DESCRIPTION
This is an attempt to categorize the discrepancies observed between the events
and errors storage, and quantify the impact of each category.

This implementation is primarily based on the premise that each "referrer"
sent from Sentry tends to be associated with a specific type or shape of query,
and knowing this context about the kind of query we are dealing with and where
it comes from can give us some better insights into what might have gone wrong.

This initial implementation of the "assign_reason_category()" function looks for
one main class of mismatch - mismatched aggregate values when everything else
remains the same. I picked this first because I suspect it accounts for the
lion's share of the discrepancies that we are currently observing. Later, we
should try to add more expected scenarios here though.

The "reason" is tagged in both our Sentry warnings and Snuplicator metrics so
we can break down our data by this additional dimension.