### PR TITLE
fix(snql) Don't apply defaults to inner queries

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -209,11 +209,6 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
             if isinstance(args[k], Node):
                 del args[k]
 
-        if "limit" not in args:
-            args["limit"] = 1000
-        if "offset" not in args:
-            args["offset"] = 0
-
         if "groupby" in args:
             if "selected_columns" not in args:
                 args["selected_columns"] = args["groupby"]
@@ -763,6 +758,13 @@ def parse_snql_query_initial(
         raise ParsingException(message)
 
     assert isinstance(parsed, (CompositeQuery, LogicalQuery))  # mypy
+
+    # Add these defaults here to avoid them getting applied to subqueries
+    if parsed.get_limit() is None:
+        parsed.set_limit(1000)
+    if parsed.get_offset() is None:
+        parsed.set_offset(0)
+
     return parsed
 
 

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -1153,8 +1153,6 @@ test_cases = [
                 ],
                 groupby=[Column("_snuba_title", None, "title")],
                 condition=required_condition,
-                limit=1000,
-                offset=0,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -1189,8 +1187,6 @@ test_cases = [
                     ],
                     groupby=[Column("_snuba_title", None, "title")],
                     condition=required_condition,
-                    limit=1000,
-                    offset=0,
                 ),
                 selected_columns=[
                     SelectedExpression(
@@ -1202,8 +1198,6 @@ test_cases = [
                         ),
                     ),
                 ],
-                limit=1000,
-                offset=0,
             ),
             selected_columns=[
                 SelectedExpression(


### PR DESCRIPTION
The limit and offset defaults were being applied to subqueries which could lead
to incorrect results. Instead apply the defaults only to the top level query.