### PR TITLE
feat(snuplicator): Improve reason assignment

### DIFF
--- a/snuba/datasets/entities/assign_reason.py
+++ b/snuba/datasets/entities/assign_reason.py
@@ -10,9 +10,16 @@ def assign_reason_category(
     Attempt to categorize the reason for the discrepancy.
     Mostly based on the type of query we expect for each referrer.
     """
-
     try:
         if referrer.startswith("tsdb-modelid:"):
+            missing_data = check_missing_data(data, expected_data)
+            if missing_data is not None:
+                return missing_data
+
+            out_of_order = check_result_out_of_order(data, expected_data)
+            if out_of_order is not None:
+                return out_of_order
+
             agg = check_aggregate(data, expected_data, "aggregate")
             if agg is not None:
                 return agg
@@ -29,6 +36,21 @@ def assign_reason_category(
 
         if referrer == "tagstore.__get_tag_key_and_top_values":
             agg = check_aggregate(data, expected_data, "count")
+            if agg is not None:
+                return agg
+
+        if referrer == "api.organization-events-meta":
+            agg = check_aggregate(data, expected_data, "count")
+            if agg is not None:
+                return agg
+
+        if referrer == "api.organization-event-stats.find-topn":
+            agg = check_aggregate(data, expected_data, "count")
+            if agg is not None:
+                return agg
+
+        if referrer == "serializers.GroupSerializerSnuba._execute_seen_stats_query":
+            agg = check_aggregate(data, expected_data, "times_seen")
             if agg is not None:
                 return agg
 
@@ -61,5 +83,37 @@ def check_aggregate(
                         return "AGGREGATE_TOO_HIGH"
                     else:
                         return "AGGREGATE_TOO_LOW"
+
+    return None
+
+
+def check_missing_data(
+    data: Sequence[Mapping[str, Any]], expected_data: Sequence[Mapping[str, Any]]
+) -> Optional[str]:
+    """
+    Returns FOUND_EXTRA_DATA if extra rows as found, returns FOUND_MISSING_DATA if
+    rows are missing.
+    """
+    if len(data) > len(expected_data):
+        if all(row in data for row in expected_data):
+            return "FOUND_EXTRA_DATA"
+    if len(data) < len(expected_data):
+        if all(row in expected_data for row in data):
+            return "FOUND_MISSING_DATA"
+
+    return None
+
+
+def check_result_out_of_order(
+    data: Sequence[Mapping[str, Any]], expected_data: Sequence[Mapping[str, Any]],
+) -> Optional[str]:
+    """
+    Returns RESULT_OUT_OF_ORDER if the entries are the same but they are present
+    in a different order. Could be an indication of a missing order by term in the query
+    or a column with a different type in both tables causing different ordering.
+    """
+    if len(data) == len(expected_data):
+        if all(row in data for row in expected_data):
+            return "RESULT_OUT_OF_ORDER"
 
     return None

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -148,12 +148,11 @@ def callback_func(
                 sentry_sdk.capture_message(
                     f"Non matching {storage} result - different length",
                     level="warning",
-                    tags={"referrer": referrer, "storage": storage},
+                    tags={"referrer": referrer, "storage": storage, "reason": reason},
                     extras={
                         "query": format_query(query),
                         "primary_result": len(primary_result_data),
                         "other_result": len(result_data),
-                        "reason": reason,
                     },
                 )
 
@@ -165,12 +164,15 @@ def callback_func(
                     sentry_sdk.capture_message(
                         "Non matching result - different result",
                         level="warning",
-                        tags={"referrer": referrer, "storage": storage},
+                        tags={
+                            "referrer": referrer,
+                            "storage": storage,
+                            "reason": reason,
+                        },
                         extras={
                             "query": format_query(query),
                             "primary_result": primary_result_data[idx],
                             "other_result": result_data[idx],
-                            "reason": reason,
                         },
                     )
 

--- a/tests/datasets/entities/test_assign_reason.py
+++ b/tests/datasets/entities/test_assign_reason.py
@@ -25,7 +25,35 @@ test_data = [
         "AGGREGATE_TOO_HIGH",
         id="tagstore.get_groups_user_counts",
     ),
-    pytest.param([{"count": 1}], [{"count": 1}], "unknown", "UNKNOWN", id="default"),
+    pytest.param(
+        [{"count": 1}], [{"count": 2}], "tsdb:modelid:4", "UNKNOWN", id="default"
+    ),
+    pytest.param(
+        [
+            {"group_id": 1, "count": 1},
+            {"group_id": 2, "count": 1},
+            {"group_id": 3, "count": 1},
+        ],
+        [{"group_id": 1, "count": 1}, {"group_id": 2, "count": 1}],
+        "tsdb-modelid:4",
+        "FOUND_EXTRA_DATA",
+        id="extra_data",
+    ),
+    pytest.param(
+        [
+            {"group_id": 1, "count": 1},
+            {"group_id": 2, "count": 1},
+            {"group_id": 3, "count": 1},
+        ],
+        [
+            {"group_id": 1, "count": 1},
+            {"group_id": 3, "count": 1},
+            {"group_id": 2, "count": 1},
+        ],
+        "tsdb-modelid:4",
+        "RESULT_OUT_OF_ORDER",
+        id="out_of_order",
+    ),
 ]
 
 


### PR DESCRIPTION
This changeset includes 3 improvements to reason assignment:

1. "reason" is sent as part of Sentry's "tag" data, rather than "extra",
enabling us to filter on this dimension in Sentry.

2. TSDB queries are checked for misisng/extra rows and out of order results.

3. Add aggregate checks from a number of other expected referrers.