### PR TITLE
Add a project rate limiter as a query processor

### DIFF
--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from typing import Optional, Sequence, Set, Tuple, cast
 
-from snuba.clickhouse.query import Query
-from snuba.query import ProcessableQuery
+from snuba.query import ProcessableQuery, TSimpleDataSource
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,
     BooleanFunctions,
@@ -27,7 +26,7 @@ from snuba.query.matchers import (
 
 
 def get_project_ids_in_query_ast(
-    query: Query, project_column: str
+    query: ProcessableQuery[TSimpleDataSource], project_column: str
 ) -> Optional[Set[int]]:
     """
     Finds the project ids this query is filtering according to the AST

--- a/snuba/datasets/cdc/groupassignee_entity.py
+++ b/snuba/datasets/cdc/groupassignee_entity.py
@@ -10,6 +10,7 @@ from snuba.query.data_source.join import JoinRelationship, JoinType
 from snuba.query.extensions import QueryExtension
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 
 
 class GroupAssigneeEntity(Entity):
@@ -47,6 +48,7 @@ class GroupAssigneeEntity(Entity):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             BasicFunctionsProcessor(),
+            ProjectRateLimiterProcessor("project_id"),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/cdc/groupedmessage_entity.py
+++ b/snuba/datasets/cdc/groupedmessage_entity.py
@@ -10,6 +10,7 @@ from snuba.query.data_source.join import JoinRelationship, JoinType
 from snuba.query.extensions import QueryExtension
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 
 
 class GroupedMessageEntity(Entity):
@@ -47,6 +48,7 @@ class GroupedMessageEntity(Entity):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             BasicFunctionsProcessor(),
+            ProjectRateLimiterProcessor("project_id"),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -62,6 +62,7 @@ from snuba.query.matchers import Or
 from snuba.query.matchers import String as StringMatch
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
@@ -488,6 +489,7 @@ class DiscoverEntity(Entity):
             TimeSeriesProcessor({"time": "timestamp"}, ("timestamp",)),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
+            ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/entities/errors.py
+++ b/snuba/datasets/entities/errors.py
@@ -11,6 +11,7 @@ from snuba.query.extensions import QueryExtension
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.handled_functions import HandledFunctionsProcessor
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
@@ -76,4 +77,5 @@ class ErrorsEntity(Entity):
             HandledFunctionsProcessor(
                 "exception_stacks.mechanism_handled", self.get_data_model()
             ),
+            ProjectRateLimiterProcessor(project_column="project_id"),
         ]

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -34,6 +34,7 @@ from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.handled_functions import HandledFunctionsProcessor
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
@@ -333,6 +334,7 @@ class BaseEventsEntity(Entity, ABC):
             HandledFunctionsProcessor(
                 "exception_stacks.mechanism_handled", self.get_data_model()
             ),
+            ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 
 

--- a/snuba/datasets/entities/sessions.py
+++ b/snuba/datasets/entities/sessions.py
@@ -16,6 +16,7 @@ from snuba.query.extensions import QueryExtension
 from snuba.query.organization_extension import OrganizationExtension
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
 from snuba.query.timeseries_extension import TimeSeriesExtension
@@ -120,4 +121,5 @@ class SessionsEntity(Entity):
             TimeSeriesProcessor(
                 {"bucketed_started": "started"}, ("started", "received")
             ),
+            ProjectRateLimiterProcessor(project_column="project_id"),
         ]

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -25,6 +25,7 @@ from snuba.query.processors.performance_expressions import (
     apdex_processor,
     failure_rate_processor,
 )
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.project_extension import ProjectExtension
@@ -136,6 +137,7 @@ class BaseTransactionsEntity(Entity, ABC):
             BasicFunctionsProcessor(),
             apdex_processor(self.get_data_model()),
             failure_rate_processor(self.get_data_model()),
+            ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 
 

--- a/snuba/query/processors/project_rate_limiter.py
+++ b/snuba/query/processors/project_rate_limiter.py
@@ -27,6 +27,7 @@ class ProjectRateLimiterProcessor(QueryProcessor):
         if not project_ids:
             return
 
+        # TODO: Use all the projects, not just one
         project_id = project_ids.pop()
 
         prl, pcl = get_configs(

--- a/snuba/query/processors/project_rate_limiter.py
+++ b/snuba/query/processors/project_rate_limiter.py
@@ -1,0 +1,104 @@
+from snuba.query.processors import QueryProcessor
+from snuba.query.logical import Query
+from snuba.query.conditions import (
+    ConditionFunctions,
+    get_first_level_and_conditions,
+)
+from snuba.query.expressions import FunctionCall, Literal
+from snuba.query.matchers import Any as AnyMatch
+from snuba.query.matchers import Column as ColumnMatch
+from snuba.query.matchers import FunctionCall as FunctionCallMatch
+from snuba.query.matchers import Literal as LiteralMatch
+from snuba.query.matchers import String as StringMatch
+from snuba.query.matchers import Or, Param
+from snuba.request.request_settings import RequestSettings
+from snuba.state import get_configs
+from snuba.state.rate_limit import PROJECT_RATE_LIMIT_NAME, RateLimitParameters
+
+
+class ProjectRateLimiterProcessor(QueryProcessor):
+    """
+    If there isn't already a rate limiter on a project, search the top level conditions
+    for project IDs using the given project column name and add a rate limiter for them.
+    """
+
+    def __init__(self, project_column: str) -> None:
+        self.project_column = project_column
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        # If the settings don't already have a project rate limit, add one
+        existing = request_settings.get_rate_limit_params()
+        for ex in existing:
+            if ex.rate_limit_name == PROJECT_RATE_LIMIT_NAME:
+                return
+
+        condition = query.get_condition_from_ast()
+        if not condition:
+            return
+
+        top_level = get_first_level_and_conditions(condition)
+        column_match = ColumnMatch(None, StringMatch(self.project_column))
+        match = Or(
+            [
+                FunctionCallMatch(
+                    StringMatch(ConditionFunctions.EQ),
+                    (column_match, Param("single", LiteralMatch(AnyMatch(int)))),
+                ),
+                FunctionCallMatch(
+                    StringMatch(ConditionFunctions.IN),
+                    (
+                        column_match,
+                        Param(
+                            "multiple",
+                            FunctionCallMatch(
+                                Or([StringMatch("array"), StringMatch("tuple")]),
+                                all_parameters=LiteralMatch(AnyMatch(int)),
+                            ),
+                        ),
+                    ),
+                ),
+            ]
+        )
+
+        project_id = 0  # TODO rate limit on every project in the list?
+        for cond in top_level:
+            result = match.match(cond)
+            if result is not None:
+                if result.contains("single"):
+                    exp = result.expression("single")
+                    if isinstance(exp, Literal) and isinstance(exp.value, int):
+                        project_id = exp.value
+                        break
+                elif result.contains("multiple"):
+                    exp = result.expression("multiple")
+                    assert isinstance(exp, FunctionCall)
+                    found = False
+                    for p in exp.parameters:
+                        if isinstance(p, Literal) and isinstance(p.value, int):
+                            project_id = p.value
+                            found = True
+                            break
+
+                    if found:
+                        break
+
+        prl, pcl = get_configs(
+            [("project_per_second_limit", 1000), ("project_concurrent_limit", 1000)]
+        )
+
+        # Specific projects can have their rate limits overridden
+        (per_second, concurr) = get_configs(
+            [
+                ("project_per_second_limit_{}".format(project_id), prl),
+                ("project_concurrent_limit_{}".format(project_id), pcl),
+            ]
+        )
+
+        rate_limit = RateLimitParameters(
+            rate_limit_name=PROJECT_RATE_LIMIT_NAME,
+            bucket=str(project_id),
+            per_second_limit=per_second,
+            concurrent_limit=concurr,
+        )
+
+        request_settings.add_rate_limit(rate_limit)

--- a/snuba/query/processors/project_rate_limiter.py
+++ b/snuba/query/processors/project_rate_limiter.py
@@ -18,8 +18,9 @@ from snuba.state.rate_limit import PROJECT_RATE_LIMIT_NAME, RateLimitParameters
 
 class ProjectRateLimiterProcessor(QueryProcessor):
     """
-    If there isn't already a rate limiter on a project, search the top level conditions
-    for project IDs using the given project column name and add a rate limiter for them.
+    If there isn't already a rate limiter on a project, search the top level
+    conditions for project IDs using the given project column name and add a
+    rate limiter for them.
     """
 
     def __init__(self, project_column: str) -> None:

--- a/tests/query/processors/test_project_rate_limiter.py
+++ b/tests/query/processors/test_project_rate_limiter.py
@@ -1,0 +1,93 @@
+import pytest
+
+from snuba import state
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.entities import EntityKey
+from snuba.query import SelectedExpression
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state.rate_limit import PROJECT_RATE_LIMIT_NAME
+
+tests = [
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column("_snuba_project_id", None, "project_id"),
+            Literal(None, 1),
+        ),
+        1,
+        id="simple project column",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column("_snuba_project_id", None, "project_id"),
+            FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 2))),
+        ),
+        2,
+        id="multiple project column",
+    ),
+    pytest.param(
+        binary_condition(
+            "and",
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 3),
+            ),
+            binary_condition(
+                ConditionFunctions.IN,
+                Column("_snuba_project_id", None, "project_id"),
+                FunctionCall(None, "array", (Literal(None, 4), Literal(None, 5))),
+            ),
+        ),
+        3,
+        id="all sorts of projects",
+    ),
+]
+
+
+@pytest.mark.parametrize("unprocessed, project_id", tests)
+def test_project_rate_limit_processor(unprocessed: Expression, project_id: int) -> None:
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=unprocessed,
+    )
+    settings = HTTPRequestSettings()
+
+    num_before = len(settings.get_rate_limit_params())
+    ProjectRateLimiterProcessor("project_id").process_query(query, settings)
+    assert len(settings.get_rate_limit_params()) == num_before + 1
+    rate_limiter = settings.get_rate_limit_params()[-1]
+    assert rate_limiter.rate_limit_name == PROJECT_RATE_LIMIT_NAME
+    assert rate_limiter.bucket == str(project_id)
+    assert rate_limiter.per_second_limit == 1000
+    assert rate_limiter.concurrent_limit == 1000
+
+
+@pytest.mark.parametrize("unprocessed, project_id", tests)
+def test_project_rate_limit_processor_overridden(
+    unprocessed: Expression, project_id: int
+) -> None:
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=unprocessed,
+    )
+    settings = HTTPRequestSettings()
+    state.set_config(f"project_per_second_limit_{project_id}", 5)
+    state.set_config(f"project_concurrent_limit_{project_id}", 10)
+
+    num_before = len(settings.get_rate_limit_params())
+    ProjectRateLimiterProcessor("project_id").process_query(query, settings)
+    assert len(settings.get_rate_limit_params()) == num_before + 1
+    rate_limiter = settings.get_rate_limit_params()[-1]
+    assert rate_limiter.rate_limit_name == PROJECT_RATE_LIMIT_NAME
+    assert rate_limiter.bucket == str(project_id)
+    assert rate_limiter.per_second_limit == 5
+    assert rate_limiter.concurrent_limit == 10


### PR DESCRIPTION
This is meant for use with SnQL, which is getting rid of query extensions.
Moving this logic to a query processor separates it from the entity logic and
makes it more portable and easier to understand.