### PR TITLE
fix(typing) Add None return to tests

### DIFF
--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -82,7 +82,7 @@ class TestReplacer:
 
         return data[0]["group_id"]
 
-    def test_delete_groups_process(self):
+    def test_delete_groups_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -117,7 +117,7 @@ class TestReplacer:
             [1, 2, 3],
         )
 
-    def test_tombstone_events_process(self):
+    def test_tombstone_events_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -147,7 +147,7 @@ class TestReplacer:
         }
         assert replacement.query_time_flags == (None, self.project_id,)
 
-    def test_replace_group_process(self):
+    def test_replace_group_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -179,7 +179,7 @@ class TestReplacer:
         }
         assert replacement.query_time_flags == (None, self.project_id,)
 
-    def test_merge_process(self):
+    def test_merge_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -215,7 +215,7 @@ class TestReplacer:
             [1, 2],
         )
 
-    def test_unmerge_process(self):
+    def test_unmerge_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -253,7 +253,7 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_promoted_tag_process(self):
+    def test_delete_promoted_tag_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -288,7 +288,7 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_unpromoted_tag_process(self):
+    def test_delete_unpromoted_tag_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -324,7 +324,7 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_groups_insert(self):
+    def test_delete_groups_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         write_unprocessed_events(self.storage, [self.event])
@@ -361,7 +361,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == []
 
-    def test_reprocessing_flow_insert(self):
+    def test_reprocessing_flow_insert(self) -> None:
         # We have a group that contains two events, 1 and 2.
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
@@ -432,7 +432,7 @@ class TestReplacer:
         assert self._get_group_id(project_id, event_id2) == 2
         assert not self._get_group_id(project_id, event_id)
 
-    def test_merge_insert(self):
+    def test_merge_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         write_unprocessed_events(self.storage, [self.event])
@@ -470,7 +470,7 @@ class TestReplacer:
 
         assert self._issue_count(1) == [{"count": 1, "group_id": 2}]
 
-    def test_unmerge_insert(self):
+    def test_unmerge_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -71,7 +71,7 @@ class TestEventsProcessor:
         assert isinstance(processed, InsertBatch)
         assert processed.rows[0]["primary_hash"] == "a52ccc1a61c2258e918b43b5aff50db1"
 
-    def test_extract_required(self):
+    def test_extract_required(self) -> None:
         now = datetime.utcnow()
         event = {
             "event_id": "1" * 32,
@@ -94,7 +94,7 @@ class TestEventsProcessor:
             "retention_days": settings.DEFAULT_RETENTION_DAYS,
         }
 
-    def test_extract_common(self):
+    def test_extract_common(self) -> None:
         now = datetime.utcnow().replace(microsecond=0)
         event = {
             "primary_hash": "a" * 32,
@@ -122,70 +122,70 @@ class TestEventsProcessor:
             "location": "bar.py",
         }
 
-    def test_v2_invalid_type(self):
+    def test_v2_invalid_type(self) -> None:
         with pytest.raises(InvalidMessageType):
             assert (
                 self.processor.process_message((2, "__invalid__", {}), self.metadata)
                 == 1
             )
 
-    def test_v2_start_delete_groups(self):
+    def test_v2_start_delete_groups(self) -> None:
         project_id = 1
         message = (2, "start_delete_groups", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_end_delete_groups(self):
+    def test_v2_end_delete_groups(self) -> None:
         project_id = 1
         message = (2, "end_delete_groups", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_start_merge(self):
+    def test_v2_start_merge(self) -> None:
         project_id = 1
         message = (2, "start_merge", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_end_merge(self):
+    def test_v2_end_merge(self) -> None:
         project_id = 1
         message = (2, "end_merge", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_start_unmerge(self):
+    def test_v2_start_unmerge(self) -> None:
         project_id = 1
         message = (2, "start_unmerge", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_end_unmerge(self):
+    def test_v2_end_unmerge(self) -> None:
         project_id = 1
         message = (2, "end_unmerge", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_start_delete_tag(self):
+    def test_v2_start_delete_tag(self) -> None:
         project_id = 1
         message = (2, "start_delete_tag", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_v2_end_delete_tag(self):
+    def test_v2_end_delete_tag(self) -> None:
         project_id = 1
         message = (2, "end_delete_tag", {"project_id": project_id})
         assert self.processor.process_message(
             message, self.metadata
         ) == ReplacementBatch(str(project_id), [message])
 
-    def test_extract_sdk(self):
+    def test_extract_sdk(self) -> None:
         sdk = {
             "integrations": ["logback"],
             "name": "sentry-java",
@@ -201,7 +201,7 @@ class TestEventsProcessor:
             "sdk_integrations": [u"logback"],
         }
 
-    def test_extract_tags(self):
+    def test_extract_tags(self) -> None:
         orig_tags = {
             "sentry:user": "the_user",
             "level": "the_level",
@@ -244,7 +244,7 @@ class TestEventsProcessor:
             "tags.value": [v for k, v in valid_items],
         }
 
-    def test_extract_tags_empty_string(self):
+    def test_extract_tags_empty_string(self) -> None:
         # verify our text field extraction doesn't coerce '' to None
         tags = {
             "environment": "",
@@ -255,7 +255,7 @@ class TestEventsProcessor:
 
         assert output["environment"] == u""
 
-    def test_extract_contexts(self):
+    def test_extract_contexts(self) -> None:
         contexts = {
             "app": {"device_app_hash": "the_app_device_uuid"},
             "os": {
@@ -366,7 +366,7 @@ class TestEventsProcessor:
             "contexts.value": [u"0", u"1.3", u"string", u"invalid utf-8 surrogate"],
         }
 
-    def test_extract_user(self):
+    def test_extract_user(self) -> None:
         user = {
             "id": "user_id",
             "email": "user_email",
@@ -384,7 +384,7 @@ class TestEventsProcessor:
             "username": u"user_username",
         }
 
-    def test_extract_geo(self):
+    def test_extract_geo(self) -> None:
         geo = {
             "country_code": "US",
             "city": "San Francisco",
@@ -400,7 +400,7 @@ class TestEventsProcessor:
             "geo_region": "CA",
         }
 
-    def test_extract_http(self):
+    def test_extract_http(self) -> None:
         request = {
             "method": "GET",
             "headers": [
@@ -419,7 +419,7 @@ class TestEventsProcessor:
             "http_url": "the_url",
         }
 
-    def test_extract_stacktraces(self):
+    def test_extract_stacktraces(self) -> None:
         stacks = [
             {
                 "module": "java.lang",

--- a/tests/datasets/test_fast_bulk_load.py
+++ b/tests/datasets/test_fast_bulk_load.py
@@ -5,7 +5,7 @@ from snuba.datasets.cdc.groupedmessage_processor import GroupedMessageRow
 
 
 class TestFastGroupedMessageLoad:
-    def test_supported_date_format(self):
+    def test_supported_date_format(self) -> None:
         """
         This test is to ensure the compatibility between
         the clickhouse datetime format and the hardcoded
@@ -15,7 +15,7 @@ class TestFastGroupedMessageLoad:
         """
         assert DATETIME_FORMAT == "%Y-%m-%d %H:%M:%S"
 
-    def test_basic_date(self):
+    def test_basic_date(self) -> None:
         message = GroupedMessageRow.from_bulk(
             {
                 "project_id": "2",
@@ -43,7 +43,7 @@ class TestFastGroupedMessageLoad:
             "first_release_id": 0,
         }
 
-    def test_failure(self):
+    def test_failure(self) -> None:
         with pytest.raises(AssertionError):
             GroupedMessageRow.from_bulk(
                 {

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -6,7 +6,7 @@ from snuba.processor import InsertBatch
 
 
 class TestSessionProcessor:
-    def test_ingest_session_event_max_sample_rate(self):
+    def test_ingest_session_event_max_sample_rate(self) -> None:
         timestamp = datetime.now(timezone.utc)
         started = timestamp - timedelta(hours=1)
 
@@ -53,7 +53,7 @@ class TestSessionProcessor:
             ]
         )
 
-    def test_ingest_session_event_abnormal(self):
+    def test_ingest_session_event_abnormal(self) -> None:
         timestamp = datetime.now(timezone.utc)
         started = timestamp - timedelta(hours=1)
 
@@ -101,7 +101,7 @@ class TestSessionProcessor:
             ]
         )
 
-    def test_ingest_session_event_crashed(self):
+    def test_ingest_session_event_crashed(self) -> None:
         timestamp = datetime.now(timezone.utc)
         started = timestamp - timedelta(hours=1)
 

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -222,7 +222,7 @@ class TestTransactionsProcessor:
         start_timestamp = timestamp - timedelta(seconds=5)
         return (start_timestamp.timestamp(), timestamp.timestamp())
 
-    def test_skip_non_transactions(self):
+    def test_skip_non_transactions(self) -> None:
         start, finish = self.__get_timestamps()
         message = TransactionEvent(
             event_id="e5e062bf2e1d4afd96fd2f90b6770431",
@@ -258,7 +258,7 @@ class TestTransactionsProcessor:
         processor = TransactionsMessageProcessor()
         assert processor.process_message(payload, meta) is None
 
-    def test_missing_trace_context(self):
+    def test_missing_trace_context(self) -> None:
         start, finish = self.__get_timestamps()
         message = TransactionEvent(
             event_id="e5e062bf2e1d4afd96fd2f90b6770431",
@@ -294,7 +294,7 @@ class TestTransactionsProcessor:
         processor = TransactionsMessageProcessor()
         assert processor.process_message(payload, meta) is None
 
-    def test_base_process(self):
+    def test_base_process(self) -> None:
         start, finish = self.__get_timestamps()
         message = TransactionEvent(
             event_id="e5e062bf2e1d4afd96fd2f90b6770431",

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -14,7 +14,7 @@ from snuba.state.rate_limit import (
 
 
 class TestRateLimit:
-    def test_concurrent_limit(self):
+    def test_concurrent_limit(self) -> None:
         # No concurrent limit should not raise
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)
         with rate_limit(rate_limit_params) as stats:
@@ -52,7 +52,7 @@ class TestRateLimit:
             with RateLimitAggregator([rate_limit_params2]):
                 pass
 
-    def test_per_second_limit(self):
+    def test_per_second_limit(self) -> None:
         bucket = uuid.uuid4()
         rate_limit_params = RateLimitParameters("foo", bucket, 1, None)
         # Create 30 queries at time 0, should all be allowed
@@ -84,7 +84,7 @@ class TestRateLimit:
             with rate_limit(rate_limit_params) as stats:
                 assert stats is not None
 
-    def test_aggregator(self):
+    def test_aggregator(self) -> None:
         # do not raise with multiple valid rate limits
         rate_limit_params_outer = RateLimitParameters("foo", "bar", None, 5)
         rate_limit_params_inner = RateLimitParameters("foo", "bar", None, 5)
@@ -112,7 +112,7 @@ class TestRateLimit:
             ):
                 pass
 
-    def test_rate_limit_container(self):
+    def test_rate_limit_container(self) -> None:
         rate_limit_container = RateLimitStatsContainer()
         rate_limit_stats = RateLimitStats(rate=0.5, concurrent=2)
 
@@ -123,7 +123,7 @@ class TestRateLimit:
 
         assert rate_limit_container.to_dict() == {"foo_rate": 0.5, "foo_concurrent": 2}
 
-    def test_bypass_rate_limit(self):
+    def test_bypass_rate_limit(self) -> None:
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)
         state.set_config("bypass_rate_limit", 1)
 

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -15,7 +15,7 @@ class TestState:
         self.app = application.test_client()
         self.app.post = partial(self.app.post, headers={"referer": "test"})
 
-    def test_config(self):
+    def test_config(self) -> None:
         state.set_config("foo", 1)
         state.set_configs({"bar": 2, "baz": 3})
         assert state.get_config("foo") == 1
@@ -33,7 +33,7 @@ class TestState:
             all_configs[k] == v for k, v in [("foo", 1), ("bar", "quux"), ("baz", 3)]
         )
 
-    def test_memoize(self):
+    def test_memoize(self) -> None:
         @state.memoize(0.1)
         def rand() -> float:
             return random.random()
@@ -44,7 +44,7 @@ class TestState:
         time.sleep(0.1)
         assert rand1 != rand()
 
-    def test_abtest(self):
+    def test_abtest(self) -> None:
         assert state.abtest("1000:1/2000:1") in (1000, 2000)
         assert state.abtest("1000/2000") in (1000, 2000)
         assert state.abtest("1000/2000:5") in (1000, 2000)

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -29,12 +29,12 @@ class TestSubscriptionCodec:
             resolution=timedelta(minutes=1),
         )
 
-    def test_basic(self):
+    def test_basic(self) -> None:
         data = self.build_subscription_data()
         codec = SubscriptionDataCodec()
         assert codec.decode(codec.encode(data)) == data
 
-    def test_encode(self):
+    def test_encode(self) -> None:
         codec = SubscriptionDataCodec()
         subscription = self.build_subscription_data()
 
@@ -46,7 +46,7 @@ class TestSubscriptionCodec:
         assert data["time_window"] == int(subscription.time_window.total_seconds())
         assert data["resolution"] == int(subscription.resolution.total_seconds())
 
-    def test_decode(self):
+    def test_decode(self) -> None:
         codec = SubscriptionDataCodec()
         subscription = self.build_subscription_data()
         data = {

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -7,7 +7,7 @@ from tests.subscriptions import BaseSubscriptionTest
 
 
 class TestBuildRequest(BaseSubscriptionTest):
-    def test_conditions(self):
+    def test_conditions(self) -> None:
         subscription = SubscriptionData(
             project_id=self.project_id,
             conditions=[["platform", "IN", ["a"]]],

--- a/tests/subscriptions/test_store.py
+++ b/tests/subscriptions/test_store.py
@@ -21,13 +21,13 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
     def build_store(self, key="1") -> RedisSubscriptionDataStore:
         return RedisSubscriptionDataStore(redis_client, self.dataset, key)
 
-    def test_create(self):
+    def test_create(self) -> None:
         store = self.build_store()
         subscription_id = uuid1()
         store.create(subscription_id, self.subscription)
         assert store.all() == [(subscription_id, self.subscription)]
 
-    def test_delete(self):
+    def test_delete(self) -> None:
         store = self.build_store()
         subscription_id = uuid1()
         store.create(subscription_id, self.subscription)
@@ -35,7 +35,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
         store.delete(subscription_id)
         assert store.all() == []
 
-    def test_all(self):
+    def test_all(self) -> None:
         store = self.build_store()
         assert store.all() == []
         subscription_id = uuid1()
@@ -55,7 +55,7 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
             (new_subscription_id, new_subscription),
         ]
 
-    def test_partitions(self):
+    def test_partitions(self) -> None:
         store_1 = self.build_store("1")
         store_2 = self.build_store("2")
         subscription_id = uuid1()

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -29,7 +29,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             redis_client, self.dataset, identifier.partition,
         ).all()[0][1] == subscription
 
-    def test_invalid_condition_column(self):
+    def test_invalid_condition_column(self) -> None:
         creator = SubscriptionCreator(self.dataset)
         with raises(QueryException):
             creator.create(
@@ -43,7 +43,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
                 self.timer,
             )
 
-    def test_invalid_aggregation(self):
+    def test_invalid_aggregation(self) -> None:
         creator = SubscriptionCreator(self.dataset)
         with raises(QueryException):
             creator.create(
@@ -57,7 +57,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
                 self.timer,
             )
 
-    def test_invalid_time_window(self):
+    def test_invalid_time_window(self) -> None:
         creator = SubscriptionCreator(self.dataset)
         with raises(InvalidSubscriptionError):
             creator.create(
@@ -83,7 +83,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
                 self.timer,
             )
 
-    def test_invalid_resolution(self):
+    def test_invalid_resolution(self) -> None:
         creator = SubscriptionCreator(self.dataset)
         with raises(InvalidSubscriptionError):
             creator.create(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,7 +154,7 @@ class TestApi(BaseApiTest):
         else:
             return dbsize
 
-    def test_invalid_queries(self):
+    def test_invalid_queries(self) -> None:
         result = self.app.post(
             "/query",
             data=json.dumps(
@@ -178,7 +178,7 @@ class TestApi(BaseApiTest):
         payload = json.loads(result.data)
         assert payload["error"]["type"] == "invalid_query"
 
-    def test_count(self):
+    def test_count(self) -> None:
         """
         Test total counts are correct in the hourly time buckets for each project
         """
@@ -220,7 +220,7 @@ class TestApi(BaseApiTest):
                 )
                 assert result["data"][b]["aggregate"] == float(rollup_mins) / p
 
-    def test_rollups(self):
+    def test_rollups(self) -> None:
         for rollup_mins in (1, 2, 15, 30, 60):
             # Note for buckets bigger than 1 hour, the results may not line up
             # with self.base_time as base_time is not necessarily on a bucket boundary
@@ -254,7 +254,7 @@ class TestApi(BaseApiTest):
                     result["data"][b]["aggregate"] == rollup_mins
                 )  # project 1 has 1 event per minute
 
-    def test_time_alignment(self):
+    def test_time_alignment(self) -> None:
         # Adding a half hour skew to the time.
         skew = timedelta(minutes=30)
         result = json.loads(
@@ -302,7 +302,7 @@ class TestApi(BaseApiTest):
         bucket_time = parse_datetime(result["data"][0]["time"]).replace(tzinfo=None)
         assert bucket_time == self.base_time
 
-    def test_no_issues(self):
+    def test_no_issues(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -345,7 +345,7 @@ class TestApi(BaseApiTest):
         assert "error" not in result
         assert result["data"] == []
 
-    def test_offset_limit(self):
+    def test_offset_limit(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -379,7 +379,7 @@ class TestApi(BaseApiTest):
         )
         assert result.status_code == 400
 
-    def test_totals(self):
+    def test_totals(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -455,7 +455,7 @@ class TestApi(BaseApiTest):
         )  # totals row is zero or empty for non-aggregate cols
         assert result["totals"]["count"] == 180 + 90 + 60
 
-    def test_conditions(self):
+    def test_conditions(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -638,7 +638,7 @@ class TestApi(BaseApiTest):
         )
         assert result["data"][0]["null_group_id"] == 1
 
-    def test_null_array_conditions(self):
+    def test_null_array_conditions(self) -> None:
         events = []
         for value in (None, False, True):
             events.append(
@@ -712,7 +712,7 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 1
         assert result["data"][0]["message"] == "handled False"
 
-    def test_escaping(self):
+    def test_escaping(self) -> None:
         # Escape single quotes so we don't get Bobby Tables'd
         result = json.loads(
             self.app.post(
@@ -760,7 +760,7 @@ class TestApi(BaseApiTest):
         )
         assert "error" not in result
 
-    def test_prewhere_conditions(self):
+    def test_prewhere_conditions(self) -> None:
         settings.MAX_PREWHERE_CONDITIONS = 1
         prewhere_keys = [
             "event_id",
@@ -843,7 +843,7 @@ class TestApi(BaseApiTest):
             in result["sql"]
         )
 
-    def test_prewhere_conditions_dont_show_up_in_where_conditions(self):
+    def test_prewhere_conditions_dont_show_up_in_where_conditions(self) -> None:
         settings.MAX_PREWHERE_CONDITIONS = 1
         result = json.loads(
             self.app.post(
@@ -868,7 +868,7 @@ class TestApi(BaseApiTest):
             result["sql"].count("in((project_id AS _snuba_project_id), tuple(1))") == 1
         )
 
-    def test_aggregate(self):
+    def test_aggregate(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -941,7 +941,7 @@ class TestApi(BaseApiTest):
             assert len(data[idx]["top_platforms"]) == 1
             assert data[idx]["top_platforms"][0] in self.platforms
 
-    def test_aggregate_with_multiple_arguments(self):
+    def test_aggregate_with_multiple_arguments(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -960,7 +960,7 @@ class TestApi(BaseApiTest):
         assert "latest_event" in result["data"][0]
         assert "project_id" in result["data"][0]
 
-    def test_having_conditions(self):
+    def test_having_conditions(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -1006,7 +1006,7 @@ class TestApi(BaseApiTest):
         )
         assert result["error"]
 
-    def test_tag_expansion(self):
+    def test_tag_expansion(self) -> None:
         # A promoted tag
         result = json.loads(
             self.app.post(
@@ -1084,7 +1084,7 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 1
         assert result["data"][0]["aggregate"] == 90
 
-    def test_column_expansion(self):
+    def test_column_expansion(self) -> None:
         # If there is a condition on an already SELECTed column, then use the
         # column alias instead of the full column expression again.
         response = json.loads(
@@ -1104,7 +1104,7 @@ class TestApi(BaseApiTest):
         assert "equals(_snuba_group_id, 0)" in response["sql"]
         assert "equals(_snuba_group_id, 1)" in response["sql"]
 
-    def test_sampling_expansion(self):
+    def test_sampling_expansion(self) -> None:
         response = json.loads(
             self.app.post(
                 "/query", data=json.dumps({"project": 2, "sample": 1000})
@@ -1117,7 +1117,7 @@ class TestApi(BaseApiTest):
         )
         assert "SAMPLE 0.1" in response["sql"]
 
-    def test_promoted_expansion(self):
+    def test_promoted_expansion(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -1171,7 +1171,7 @@ class TestApi(BaseApiTest):
         assert len(result_map["environment"]["top"]) == 2
         assert all(r in self.environments for r in result_map["environment"]["top"])
 
-    def test_tag_translation(self):
+    def test_tag_translation(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -1187,7 +1187,7 @@ class TestApi(BaseApiTest):
 
         assert "os.rooted" in result["data"][0]["top"]
 
-    def test_unicode_condition(self):
+    def test_unicode_condition(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -1204,7 +1204,7 @@ class TestApi(BaseApiTest):
         )
         assert result["data"][0] == {"environment": "prød", "count": 90}
 
-    def test_query_timing(self):
+    def test_query_timing(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -1217,12 +1217,12 @@ class TestApi(BaseApiTest):
         assert "timing" in result
         assert "timestamp" in result["timing"]
 
-    def test_global_rate_limiting(self):
+    def test_global_rate_limiting(self) -> None:
         state.set_config("global_concurrent_limit", 0)
         response = self.app.post("/query", data=json.dumps({"project": 1}))
         assert response.status_code == 429
 
-    def test_project_rate_limiting(self):
+    def test_project_rate_limiting(self) -> None:
         # All projects except project 1 are allowed
         state.set_config("project_concurrent_limit", 1)
         state.set_config("project_concurrent_limit_1", 0)
@@ -1237,7 +1237,7 @@ class TestApi(BaseApiTest):
         )
         assert response.status_code == 429
 
-    def test_doesnt_select_deletions(self):
+    def test_doesnt_select_deletions(self) -> None:
         query = {
             "project": 1,
             "groupby": "project_id",
@@ -1270,7 +1270,7 @@ class TestApi(BaseApiTest):
         result2 = json.loads(self.app.post("/query", data=json.dumps(query)).data)
         assert result1["data"] == result2["data"]
 
-    def test_selected_columns(self):
+    def test_selected_columns(self) -> None:
         query = {
             "project": 1,
             "selected_columns": ["platform", "message"],
@@ -1281,7 +1281,7 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 180
         assert result["data"][0] == {"message": "a message", "platform": "a"}
 
-    def test_complex_selected_columns(self):
+    def test_complex_selected_columns(self) -> None:
         query = {
             "project": 1,
             "selected_columns": ["platform", ["notEmpty", ["exception_stacks.type"]]],
@@ -1306,7 +1306,7 @@ class TestApi(BaseApiTest):
         assert "type_not_empty" in result["data"][0]
         assert result["data"][0]["type_not_empty"] == 1
 
-    def test_complex_order(self):
+    def test_complex_order(self) -> None:
         # sort by a complex sort key with an expression, and a regular column,
         # and both ASC and DESC sorts.
         result = json.loads(
@@ -1332,7 +1332,7 @@ class TestApi(BaseApiTest):
         test_timestamps = [d["time"] for d in result["data"][:90]]
         assert sorted(test_timestamps) == test_timestamps
 
-    def test_nullable_datetime_columns(self):
+    def test_nullable_datetime_columns(self) -> None:
         # Test that requesting a Nullable(DateTime) column does not throw
         query = {
             "project": 1,
@@ -1340,7 +1340,7 @@ class TestApi(BaseApiTest):
         }
         json.loads(self.app.post("/query", data=json.dumps(query)).data)
 
-    def test_duplicate_column(self):
+    def test_duplicate_column(self) -> None:
         query = {
             "selected_columns": ["timestamp", "timestamp"],
             "limit": 3,
@@ -1352,7 +1352,7 @@ class TestApi(BaseApiTest):
         result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
         assert result["meta"] == [{"name": "timestamp", "type": "DateTime"}]
 
-    def test_test_endpoints(self):
+    def test_test_endpoints(self) -> None:
         project_id = 73
         group_id = 74
         event = (
@@ -1423,7 +1423,7 @@ class TestApi(BaseApiTest):
         assert len(clickhouse.execute(f"SELECT * FROM {self.table}")) == 0
 
     @pytest.mark.xfail
-    def test_row_stats(self):
+    def test_row_stats(self) -> None:
         query = {
             "project": 1,
             "selected_columns": ["platform"],
@@ -1434,12 +1434,12 @@ class TestApi(BaseApiTest):
         assert "bytes_read" in result["stats"]
         assert result["stats"]["bytes_read"] > 0
 
-    def test_static_page_renders(self):
+    def test_static_page_renders(self) -> None:
         response = self.app.get("/config")
         assert response.status_code == 200
         assert len(response.data) > 100
 
-    def test_exception_captured_by_sentry(self):
+    def test_exception_captured_by_sentry(self) -> None:
         events = []
         with Hub(Client(transport=events.append)):
             # This endpoint should return 500 as it internally raises an exception
@@ -1449,7 +1449,7 @@ class TestApi(BaseApiTest):
             assert len(events) == 1
             assert events[0]["exception"]["values"][0]["type"] == "ZeroDivisionError"
 
-    def test_split_query(self):
+    def test_split_query(self) -> None:
         state.set_config("use_split", 1)
         state.set_config("split_step", 3600)  # first batch will be 1 hour
         try:
@@ -1744,7 +1744,7 @@ class TestApi(BaseApiTest):
         finally:
             state.set_config("use_split", 0)
 
-    def test_consistent(self):
+    def test_consistent(self) -> None:
         response = json.loads(
             self.app.post(
                 "/query",
@@ -1760,7 +1760,7 @@ class TestApi(BaseApiTest):
         )
         assert response["stats"]["consistent"]
 
-    def test_gracefully_handle_multiple_conditions_on_same_column(self):
+    def test_gracefully_handle_multiple_conditions_on_same_column(self) -> None:
         response = self.app.post(
             "/query",
             data=json.dumps(
@@ -1778,7 +1778,7 @@ class TestApi(BaseApiTest):
 
         assert response.status_code == 200
 
-    def test_mandatory_conditions(self):
+    def test_mandatory_conditions(self) -> None:
         result = json.loads(
             self.app.post(
                 "/query",
@@ -1849,7 +1849,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
             "subscription_id": f"0/{expected_uuid.hex}",
         }
 
-    def test_time_error(self):
+    def test_time_error(self) -> None:
         resp = self.app.post(
             "{}/subscriptions".format(self.dataset_name),
             data=json.dumps(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import time
 
 
 class TestCli(object):
-    def test_consumer_cli(self):
+    def test_consumer_cli(self) -> None:
         """
         Check that the consumer daemon runs until it is killed
         """

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -61,7 +61,7 @@ class TestReplacer:
 
         return json.loads(self.app.post("/query", data=json.dumps(args)).data)["data"]
 
-    def test_delete_groups_process(self):
+    def test_delete_groups_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -96,7 +96,7 @@ class TestReplacer:
             [1, 2, 3],
         )
 
-    def test_merge_process(self):
+    def test_merge_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -132,7 +132,7 @@ class TestReplacer:
             [1, 2],
         )
 
-    def test_unmerge_process(self):
+    def test_unmerge_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -169,7 +169,7 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_promoted_tag_process(self):
+    def test_delete_promoted_tag_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -204,7 +204,7 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_unpromoted_tag_process(self):
+    def test_delete_unpromoted_tag_process(self) -> None:
         timestamp = datetime.now(tz=pytz.utc)
         message = (
             2,
@@ -240,7 +240,7 @@ class TestReplacer:
             self.project_id,
         )
 
-    def test_delete_groups_insert(self):
+    def test_delete_groups_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         write_unprocessed_events(self.storage, [self.event])
@@ -277,7 +277,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == []
 
-    def test_merge_insert(self):
+    def test_merge_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         write_unprocessed_events(self.storage, [self.event])
@@ -315,7 +315,7 @@ class TestReplacer:
 
         assert self._issue_count(1) == [{"count": 1, "group_id": 2}]
 
-    def test_unmerge_insert(self):
+    def test_unmerge_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["primary_hash"] = "a" * 32
@@ -355,7 +355,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 2}]
 
-    def test_delete_tag_promoted_insert(self):
+    def test_delete_tag_promoted_insert(self) -> None:
         self.event["project_id"] = self.project_id
         self.event["group_id"] = 1
         self.event["data"]["tags"].append(["browser.name", "foo"])
@@ -413,7 +413,7 @@ class TestReplacer:
         assert _issue_count() == []
         assert _issue_count(total=True) == [{"count": 1, "group_id": 1}]
 
-    def test_query_time_flags(self):
+    def test_query_time_flags(self) -> None:
         project_ids = [1, 2]
 
         assert errors_replacer.get_projects_query_flags(


### PR DESCRIPTION
A quick and dirty change to capture one one of the low hanging fruits when type
hinting the tests.