### PR TITLE
feat(migrations): Support global Python migrations

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -68,8 +68,7 @@ class CodeMigration(Migration, ABC):
 
         migration_id, logger, update_status = context
         logger.info(f"Running migration: {migration_id}")
-        if not self.is_first_migration():
-            update_status(Status.IN_PROGRESS)
+        update_status(Status.IN_PROGRESS)
 
         for op in self.forwards_global():
             op.execute()
@@ -91,10 +90,7 @@ class CodeMigration(Migration, ABC):
             op.execute()
         logger.info(f"Finished reversing: {migration_id}")
 
-        # The migrations table will be destroyed if the first
-        # migration is reversed; do not attempt to update status
-        if not self.is_first_migration():
-            update_status(Status.NOT_STARTED)
+        update_status(Status.NOT_STARTED)
 
 
 class ClickhouseNodeMigration(Migration, ABC):

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -11,7 +11,7 @@ class Migration(ABC):
     """
     A Migration should implement the forwards and backwards methods. Migrations should
     not use this class directly, rather they should extend either the ClickHouseNodeMigration
-    (for SQL migrations to be run on ClickHouse) or GlobalMigration (for Python migrations).
+    (for SQL migrations to be run on ClickHouse) or CodeMigration (for Python migrations).
 
     Migrations that cannot be completed immediately, such as those that contain
     a data migration, must be marked with blocking = True.
@@ -46,9 +46,9 @@ class Migration(ABC):
         raise NotImplementedError
 
 
-class GlobalMigration(Migration, ABC):
+class CodeMigration(Migration, ABC):
     """
-    Consists of one or more Python functions executed once globally.
+    Consists of one or more Python functions executed in sequence.
     """
 
     @abstractmethod

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -61,7 +61,9 @@ class GlobalMigration(Migration, ABC):
 
     def forwards(self, context: Context, dry_run: bool) -> None:
         if dry_run:
-            print("Non SQL operation")
+            for op in self.forwards_global():
+                desc = op.description() or "No description provided"
+                print(f"Non SQL operation - {desc}")
             return
 
         migration_id, logger, update_status = context
@@ -77,7 +79,9 @@ class GlobalMigration(Migration, ABC):
 
     def backwards(self, context: Context, dry_run: bool) -> None:
         if dry_run:
-            print("Non SQL operation")
+            for op in self.backwards_global():
+                desc = op.description() or "No description provided"
+                print(f"Non SQL operation - {desc}")
             return
 
         migration_id, logger, update_status = context

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -11,17 +11,7 @@ from snuba.migrations.columns import MigrationModifiers
 from snuba.migrations.table_engines import TableEngine
 
 
-class Operation(ABC):
-    """
-    Executed on all the nodes of the cluster.
-    """
-
-    @abstractmethod
-    def execute(self, local: bool) -> None:
-        raise NotImplementedError
-
-
-class SqlOperation(Operation, ABC):
+class SqlOperation(ABC):
     def __init__(self, storage_set: StorageSetKey):
         self._storage_set = storage_set
 
@@ -298,9 +288,15 @@ class InsertIntoSelect(SqlOperation):
         return f"INSERT INTO {self.__dest_table_name} ({dest_columns}) SELECT {src_columns} FROM {self.__src_table_name}{prewhere_clause}{where_clause};"
 
 
-class RunPython(Operation):
-    def __init__(self, func: Callable[[], None]) -> None:
+class RunPython:
+    def __init__(
+        self, func: Callable[[], None], description: Optional[str] = None
+    ) -> None:
         self.__func = func
+        self.__description = description
 
-    def execute(self, local: bool) -> None:
+    def execute(self) -> None:
         self.__func()
+
+    def description(self) -> Optional[str]:
+        return self.__description

--- a/snuba/migrations/snuba_migrations/discover/0001_discover_merge_table.py
+++ b/snuba/migrations/snuba_migrations/discover/0001_discover_merge_table.py
@@ -42,10 +42,10 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.DISCOVER,
@@ -57,14 +57,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.DISCOVER, table_name="discover_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.DISCOVER,
@@ -76,7 +76,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.DISCOVER, table_name="discover_dist"

--- a/snuba/migrations/snuba_migrations/discover/0002_discover_add_deleted_tags_hash_map.py
+++ b/snuba/migrations/snuba_migrations/discover/0002_discover_add_deleted_tags_hash_map.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the _tags_hash_map and deleted columns to the merge table so we can use
     the tags optimization, and ensure deleted rows are omitted from queries.
@@ -13,7 +13,9 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -29,7 +31,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -43,14 +47,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backward_migrations("discover_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backward_migrations("discover_dist")

--- a/snuba/migrations/snuba_migrations/discover/0003_discover_fix_user_column.py
+++ b/snuba/migrations/snuba_migrations/discover/0003_discover_fix_user_column.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     The user column should not be low cardinality - it's not in the underlying errors
     or transactions tables.
@@ -14,7 +14,9 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -23,7 +25,9 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -32,14 +36,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("discover_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("discover_dist")

--- a/snuba/migrations/snuba_migrations/discover/0004_discover_fix_title_and_message.py
+++ b/snuba/migrations/snuba_migrations/discover/0004_discover_fix_title_and_message.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     The title and message column should not be nullable, since they are not in errors
     or transactions.
@@ -14,7 +14,9 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -28,7 +30,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -42,14 +46,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("discover_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("discover_dist")

--- a/snuba/migrations/snuba_migrations/discover/0005_discover_fix_transaction_name.py
+++ b/snuba/migrations/snuba_migrations/discover/0005_discover_fix_transaction_name.py
@@ -6,14 +6,16 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     The transaction_name column should not be nullable; it is not in either errors or transacions
     """
 
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -24,7 +26,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
@@ -36,14 +40,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("discover_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("discover_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("discover_dist")

--- a/snuba/migrations/snuba_migrations/events/0001_events_initial.py
+++ b/snuba/migrations/snuba_migrations/events/0001_events_initial.py
@@ -113,10 +113,10 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         sample_expr = "cityHash64(toString(event_id))"
 
         return [
@@ -134,14 +134,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="sentry_local"
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -163,7 +163,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="sentry_dist"

--- a/snuba/migrations/snuba_migrations/events/0002_events_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0002_events_onpremise_compatibility.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     This is a one-off migration to support on premise users who are upgrading from
     any older version of Snuba that used the old migration system. Since their sentry_local
@@ -17,7 +17,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -80,11 +80,11 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []

--- a/snuba/migrations/snuba_migrations/events/0003_errors.py
+++ b/snuba/migrations/snuba_migrations/events/0003_errors.py
@@ -101,10 +101,10 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -122,14 +122,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="errors_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -141,7 +141,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="errors_dist"

--- a/snuba/migrations/snuba_migrations/events/0004_errors_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0004_errors_onpremise_compatibility.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Syncs the errors_local table for onpremise users migration from Snuba versions
     prior to the new migration system being introduced.
@@ -13,7 +13,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -23,11 +23,11 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []

--- a/snuba/migrations/snuba_migrations/events/0005_events_tags_hash_map.py
+++ b/snuba/migrations/snuba_migrations/events/0005_events_tags_hash_map.py
@@ -7,7 +7,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the tags hash map column defined as Array(Int64) Materialized with
     arrayMap((k, v) -> cityHash64(
@@ -20,7 +20,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = True
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -33,14 +33,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.EVENTS, "sentry_local", "_tags_hash_map"
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -50,7 +50,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(StorageSetKey.EVENTS, "sentry_dist", "_tags_hash_map")
         ]

--- a/snuba/migrations/snuba_migrations/events/0006_errors_tags_hash_map.py
+++ b/snuba/migrations/snuba_migrations/events/0006_errors_tags_hash_map.py
@@ -7,7 +7,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the tags hash map column defined as Array(Int64) Materialized with
     arrayMap((k, v) -> cityHash64(
@@ -20,7 +20,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = True
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -33,14 +33,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.EVENTS, "errors_local", "_tags_hash_map"
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -50,7 +50,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(StorageSetKey.EVENTS, "errors_dist", "_tags_hash_map")
         ]

--- a/snuba/migrations/snuba_migrations/events/0007_groupedmessages.py
+++ b/snuba/migrations/snuba_migrations/events/0007_groupedmessages.py
@@ -24,10 +24,10 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -43,14 +43,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="groupedmessage_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -62,7 +62,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="groupedmessage_dist",

--- a/snuba/migrations/snuba_migrations/events/0008_groupassignees.py
+++ b/snuba/migrations/snuba_migrations/events/0008_groupassignees.py
@@ -18,10 +18,10 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -36,14 +36,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="groupassignee_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -55,7 +55,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="groupassignee_dist",

--- a/snuba/migrations/snuba_migrations/events/0009_errors_add_http_fields.py
+++ b/snuba/migrations/snuba_migrations/events/0009_errors_add_http_fields.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the http columns defined, with the method and referer coming from the request interface
     and url materialized from the tags.
@@ -14,7 +14,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -33,13 +33,13 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(StorageSetKey.EVENTS, "errors_local", "http_method"),
             operations.DropColumn(StorageSetKey.EVENTS, "errors_local", "http_referer"),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -58,7 +58,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(StorageSetKey.EVENTS, "errors_dist", "http_method"),
             operations.DropColumn(StorageSetKey.EVENTS, "errors_dist", "http_referer"),

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -89,7 +89,7 @@ def ensure_drop_temporary_tables() -> None:
     )
 
 
-class Migration(migration.GlobalMigration):
+class Migration(migration.CodeMigration):
     """
     An earlier version of the groupedmessage table (pre September 2019) did not
     include the project ID. This migration adds the column and rebuilds that table

--- a/snuba/migrations/snuba_migrations/events/0011_rebuild_errors.py
+++ b/snuba/migrations/snuba_migrations/events/0011_rebuild_errors.py
@@ -93,7 +93,7 @@ columns: Sequence[Column[Modifiers]] = [
 sample_expr = "cityHash64(event_id)"
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     This migration rebuilds the errors table, with the following changes:
 
@@ -114,7 +114,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -150,14 +150,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="errors_local_new"
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -191,7 +191,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.EVENTS, table_name="errors_dist_new"

--- a/snuba/migrations/snuba_migrations/events/0012_errors_make_level_nullable.py
+++ b/snuba/migrations/snuba_migrations/events/0012_errors_make_level_nullable.py
@@ -6,10 +6,12 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -20,7 +22,9 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.EVENTS,
@@ -29,14 +33,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("errors_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("errors_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("errors_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("errors_dist")

--- a/snuba/migrations/snuba_migrations/outcomes/0001_outcomes.py
+++ b/snuba/migrations/snuba_migrations/outcomes/0001_outcomes.py
@@ -36,10 +36,10 @@ materialized_view_columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.OUTCOMES,
@@ -83,7 +83,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.OUTCOMES,
@@ -97,7 +97,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.OUTCOMES,
@@ -117,7 +117,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.OUTCOMES, table_name="outcomes_hourly_local"

--- a/snuba/migrations/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
+++ b/snuba/migrations/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
@@ -3,7 +3,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     We added the size and bytes_received columns on 15 Dec 2019 and reverted the next
     day. This migration ensures the column is dropped for all users on the off chance
@@ -12,7 +12,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(StorageSetKey.OUTCOMES, "outcomes_raw_local", "size"),
             operations.DropColumn(
@@ -20,11 +20,11 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -51,10 +51,10 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.QUERYLOG,
@@ -69,14 +69,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.QUERYLOG, table_name="querylog_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.QUERYLOG,
@@ -88,7 +88,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.QUERYLOG, table_name="querylog_dist",

--- a/snuba/migrations/snuba_migrations/querylog/0002_status_type_change.py
+++ b/snuba/migrations/snuba_migrations/querylog/0002_status_type_change.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Drops the status enum and replaces it with a LowCardinality string
     now that the support for low cardinality strings is better.
@@ -14,7 +14,9 @@ class Migration(migration.MultiStepMigration):
 
     blocking = True
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 StorageSetKey.QUERYLOG,
@@ -31,7 +33,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         status_type = Enum[Modifiers](
             [("success", 0), ("error", 1), ("rate-limited", 2)]
         )
@@ -46,14 +50,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("querylog_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("querylog_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("querylog_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("querylog_dist")

--- a/snuba/migrations/snuba_migrations/querylog/0003_add_profile_fields.py
+++ b/snuba/migrations/snuba_migrations/querylog/0003_add_profile_fields.py
@@ -6,14 +6,16 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds fields for query profile.
     """
 
     blocking = True
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.QUERYLOG,
@@ -101,7 +103,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.QUERYLOG, table_name, "clickhouse_queries.all_columns"
@@ -127,14 +131,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("querylog_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("querylog_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("querylog_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("querylog_dist")

--- a/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
+++ b/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
@@ -30,10 +30,10 @@ raw_columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.SESSIONS,
@@ -60,7 +60,7 @@ class Migration(migration.MultiStepMigration):
             create_matview_v1,
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.SESSIONS,
@@ -74,7 +74,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.SESSIONS,
@@ -94,7 +94,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.SESSIONS, table_name="sessions_hourly_dist",

--- a/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
+++ b/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
@@ -54,7 +54,7 @@ new_dest_columns: Sequence[Tuple[Column[Modifiers], str]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     This migration adds new columns to both the raw and aggregated sessions.
     The new `X_preaggr` columns in the aggregated dataset will be used later on
@@ -63,7 +63,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.SESSIONS,
@@ -82,7 +82,7 @@ class Migration(migration.MultiStepMigration):
             for [column, after] in new_dest_columns
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.SESSIONS, "sessions_raw_local", column.name
@@ -95,7 +95,7 @@ class Migration(migration.MultiStepMigration):
             for [column, after] in new_dest_columns
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.SESSIONS,
@@ -114,7 +114,7 @@ class Migration(migration.MultiStepMigration):
             for [column, after] in new_dest_columns
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.SESSIONS, "sessions_raw_dist", column.name

--- a/snuba/migrations/snuba_migrations/sessions/0003_sessions_matview.py
+++ b/snuba/migrations/snuba_migrations/sessions/0003_sessions_matview.py
@@ -93,7 +93,7 @@ GROUP BY
 """
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     This migration re-creates the materialized view that aggregates sessions.
     It is now using the new `X_preaggr` columns based on the `quantity`.
@@ -101,7 +101,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.SESSIONS,
@@ -116,7 +116,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.SESSIONS,
@@ -125,8 +125,8 @@ class Migration(migration.MultiStepMigration):
             create_matview_v1,
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []

--- a/snuba/migrations/snuba_migrations/spans_experimental/0001_spans_experimental.py
+++ b/snuba/migrations/snuba_migrations/spans_experimental/0001_spans_experimental.py
@@ -31,10 +31,10 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -65,7 +65,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -73,7 +73,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -95,7 +95,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.TRANSACTIONS,

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -15,9 +15,9 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
-    This migration extends Migration instead of MultiStepMigration since it is
+    This migration is the only one that sets is_first_migration = True since it is
     responsible for bootstrapping the migration system itself. It skips setting
     the in progress status in the forwards method and the not started status in
     the backwards method. Since the migration table doesn't exist yet, we can't
@@ -29,7 +29,7 @@ class Migration(migration.MultiStepMigration):
     def is_first_migration(self) -> bool:
         return True
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -43,14 +43,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.MIGRATIONS,
@@ -62,7 +62,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_dist"

--- a/snuba/migrations/snuba_migrations/transactions/0001_transactions.py
+++ b/snuba/migrations/snuba_migrations/transactions/0001_transactions.py
@@ -61,10 +61,10 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -82,14 +82,14 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.TRANSACTIONS, table_name="transactions_local",
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         # We removed the materialized for the dist table DDL.
         def strip_materialized(columns: Sequence[Column[Modifiers]]) -> None:
             for col in columns:
@@ -115,7 +115,7 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.TRANSACTIONS, table_name="transactions_dist",

--- a/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
+++ b/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
@@ -152,7 +152,7 @@ def backwards() -> None:
         clickhouse.execute(f"DROP TABLE {TABLE_NAME_OLD};")
 
 
-class Migration(migration.GlobalMigration):
+class Migration(migration.CodeMigration):
     """
     The first of two migrations that syncs the transactions_local table for onpremise
     users migrating from versions of Snuba prior to the migration system.

--- a/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
+++ b/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
@@ -152,7 +152,7 @@ def backwards() -> None:
         clickhouse.execute(f"DROP TABLE {TABLE_NAME_OLD};")
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.GlobalMigration):
     """
     The first of two migrations that syncs the transactions_local table for onpremise
     users migrating from versions of Snuba prior to the migration system.
@@ -166,16 +166,13 @@ class Migration(migration.MultiStepMigration):
 
     blocking = True  # This migration may take some time if there is data to migrate
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_global(self) -> Sequence[operations.RunPython]:
         return [
-            operations.RunPython(func=forwards),
+            operations.RunPython(
+                func=forwards,
+                description="Sync sample, partition and primary key for onpremise",
+            ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_global(self) -> Sequence[operations.RunPython]:
         return [operations.RunPython(func=backwards)]
-
-    def forwards_dist(self) -> Sequence[operations.Operation]:
-        return []
-
-    def backwards_dist(self) -> Sequence[operations.Operation]:
-        return []

--- a/snuba/migrations/snuba_migrations/transactions/0003_transactions_onpremise_fix_columns.py
+++ b/snuba/migrations/snuba_migrations/transactions/0003_transactions_onpremise_fix_columns.py
@@ -8,7 +8,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 UNKNOWN_SPAN_STATUS = 2
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     The second of two migrations that syncs the transactions_local table for onpremise
     users migrating from versions of Snuba prior to the migration system.
@@ -18,7 +18,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = True  # Just to be safe since we are changing some column types
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -132,11 +132,11 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []

--- a/snuba/migrations/snuba_migrations/transactions/0004_transactions_add_tags_hash_map.py
+++ b/snuba/migrations/snuba_migrations/transactions/0004_transactions_add_tags_hash_map.py
@@ -7,7 +7,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the tags hash map column defined as Array(Int64) Materialized with
     arrayMap((k, v) -> cityHash64(
@@ -20,7 +20,7 @@ class Migration(migration.MultiStepMigration):
 
     blocking = True
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -33,14 +33,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_local", "_tags_hash_map"
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -50,7 +50,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_dist", "_tags_hash_map"

--- a/snuba/migrations/snuba_migrations/transactions/0005_transactions_add_measurements.py
+++ b/snuba/migrations/snuba_migrations/transactions/0005_transactions_add_measurements.py
@@ -6,14 +6,14 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the measurements nested column
     """
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -31,14 +31,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_local", "measurements"
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -56,7 +56,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_dist", "measurements"

--- a/snuba/migrations/snuba_migrations/transactions/0006_transactions_add_http_fields.py
+++ b/snuba/migrations/snuba_migrations/transactions/0006_transactions_add_http_fields.py
@@ -6,14 +6,14 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Adds the http columns populated from the Request interface that is missing from transactions.
     """
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -32,7 +32,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_local", "http_method"
@@ -42,7 +42,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -61,7 +61,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_dist", "http_method"

--- a/snuba/migrations/snuba_migrations/transactions/0007_transactions_add_discover_cols.py
+++ b/snuba/migrations/snuba_migrations/transactions/0007_transactions_add_discover_cols.py
@@ -10,14 +10,16 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Add the materialized columns required for the Discover merge table.
     """
 
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -62,7 +64,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backwards_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(StorageSetKey.TRANSACTIONS, table_name, "type"),
             operations.DropColumn(StorageSetKey.TRANSACTIONS, table_name, "message"),
@@ -70,14 +74,14 @@ class Migration(migration.MultiStepMigration):
             operations.DropColumn(StorageSetKey.TRANSACTIONS, table_name, "timestamp"),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("transactions_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("transactions_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("transactions_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backwards_migrations("transactions_dist")

--- a/snuba/migrations/snuba_migrations/transactions/0008_transactions_add_timestamp_index.py
+++ b/snuba/migrations/snuba_migrations/transactions/0008_transactions_add_timestamp_index.py
@@ -4,10 +4,10 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.AddIndex(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -19,7 +19,7 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropIndex(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -28,8 +28,8 @@ class Migration(migration.MultiStepMigration):
             )
         ]
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []

--- a/snuba/migrations/snuba_migrations/transactions/0009_transactions_fix_title_and_message.py
+++ b/snuba/migrations/snuba_migrations/transactions/0009_transactions_fix_title_and_message.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.MultiStepMigration):
+class Migration(migration.ClickhouseNodeMigration):
     """
     Removes the low cardinality modifier on the title and message fields. These column
     types need to match the corresponding fields in the errors table for Discover.
@@ -14,7 +14,9 @@ class Migration(migration.MultiStepMigration):
 
     blocking = False
 
-    def __forward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -32,7 +34,9 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def __backward_migrations(self, table_name: str) -> Sequence[operations.Operation]:
+    def __backward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
         return [
             operations.ModifyColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
@@ -56,14 +60,14 @@ class Migration(migration.MultiStepMigration):
             ),
         ]
 
-    def forwards_local(self) -> Sequence[operations.Operation]:
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("transactions_local")
 
-    def backwards_local(self) -> Sequence[operations.Operation]:
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return self.__backward_migrations("transactions_local")
 
-    def forwards_dist(self) -> Sequence[operations.Operation]:
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__forward_migrations("transactions_dist")
 
-    def backwards_dist(self) -> Sequence[operations.Operation]:
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return self.__backward_migrations("transactions_dist")


### PR DESCRIPTION
The purpose of this change is to support more complex migrations that cannot
solely be defined as a series of SQL statements. It is required in order to
support the upcoming migration that will backfill the new errors table from the
events table.

This change splits the generic MultiStepMigration class into two separate
migration classes which serve distinct purposes.

1. The ClickhouseNodeMigration should be used for "standard" ClickHouse schema migrations.
When writing a migration of this type, the list of local and dist operations must be provided,
and the migration runner orchestrates executing these on the correct set of ClickHouse nodes.
This is pretty much the same as how today's MultiStepMigration behaves, however it's now
restricted to SQL operations only. This is the one to be used in most standard cases of
schema migrations.

2. The CodeMigration should be used for most data migrations, or anything that is more
complex than plain SQL. Only Python operations can be provided in a code migration.
The operations are simply executed once globally (not once per ClickHouse node). If any
ClickHouse connections are required in the course of the migration, the migration operation 
is responsible for establishing those itself.