### PR TITLE
fix(migrations): Allow dry run on blocking migrations without force

### DIFF
--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -202,7 +202,7 @@ class Runner:
         )
         migration = get_group_loader(migration_key.group).load_migration(migration_id)
 
-        if migration.blocking and not force:
+        if migration.blocking and not dry_run and not force:
             raise MigrationError("Blocking migrations must be run with force")
 
         migration.forwards(context, dry_run)


### PR DESCRIPTION
A dry run of a blocking migration shouldn't require force, since it doesn't
really do anything except print a preview of the migration.