### PR TITLE
feat(cache): Record stats for readthrough cache in querylog

### DIFF
--- a/snuba/state/cache/abstract.py
+++ b/snuba/state/cache/abstract.py
@@ -35,6 +35,7 @@ class Cache(Generic[TValue], ABC):
         self,
         key: str,
         function: Callable[[], TValue],
+        record_cache_hit_type: Callable[[int], None],
         timeout: int,
         timer: Optional[Timer] = None,
     ) -> TValue:

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -74,6 +74,7 @@ class RedisCache(Cache[TValue]):
         self,
         key: str,
         function: Callable[[], TValue],
+        record_cache_hit_type: Callable[[int], None],
         timeout: int,
         timer: Optional[Timer] = None,
     ) -> TValue:
@@ -130,6 +131,9 @@ class RedisCache(Cache[TValue]):
 
         if timer is not None:
             timer.mark("cache_get")
+
+        # This updates the stats object and querylog
+        record_cache_hit_type(result[0])
 
         if result[0] == RESULT_VALUE:
             # If we got a cache hit, this is easy -- we just return it.

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -337,7 +337,6 @@ def execute_query_with_readthrough_caching(
     query_settings["query_id"] = query_id
 
     def record_cache_hit_type(hit_type: int) -> None:
-        print("RECORDING HIT TYPE", hit_type)
         if hit_type == RESULT_VALUE:
             stats["cache_hit"] = 1
         elif hit_type == RESULT_WAIT:


### PR DESCRIPTION
There are 3 possible scenarios:
- If we get an immediate cache hit, "cache_hit" for that query is set to True
- If we get a duplicate query (a same query that will populate the cache is
ahead in the queue but we have to wait for it), "is_duplicate" is set to True
- If none of the above, neither "cache_hit" nor "is_duplicate" is set