### PR TITLE
feat(snql) Use SnQL in all API tests

### DIFF
--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -250,6 +250,11 @@ def _parse_query_impl(body: MutableMapping[str, Any], entity: Entity) -> Query:
             parse_expression(limitby_expr, entity.get_data_model(), set()),
         )
 
+    sample = body.get("sample")
+    if sample is not None:
+        assert isinstance(sample, (int, float))
+        sample = float(sample)
+
     return Query(
         None,
         selected_columns=select_clause,
@@ -259,7 +264,7 @@ def _parse_query_impl(body: MutableMapping[str, Any], entity: Entity) -> Query:
         having=having_expr,
         order_by=orderby_exprs,
         limitby=limitby_clause,
-        sample=body.get("sample"),
+        sample=sample,
         limit=body.get("limit", None),
         offset=body.get("offset", 0),
         totals=body.get("totals", False),

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -151,7 +151,7 @@ snql_grammar = Grammar(
     false_literal         = ~r"FALSE"i
     null_literal          = ~r"NULL"i
     subscriptable         = column_name open_square column_name close_square
-    column_name           = ~r"[a-zA-Z_][a-zA-Z0-9_\.]*"
+    column_name           = ~r"[a-zA-Z_][a-zA-Z0-9_\.:]*"
     function_name         = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
     entity_alias          = ~r"[a-zA-Z_][a-zA-Z0-9_]*"
     entity_name           = ~r"[a-zA-Z_]+"
@@ -760,8 +760,12 @@ def parse_snql_query_initial(
     assert isinstance(parsed, (CompositeQuery, LogicalQuery))  # mypy
 
     # Add these defaults here to avoid them getting applied to subqueries
-    if parsed.get_limit() is None:
+    limit = parsed.get_limit()
+    if limit is None:
         parsed.set_limit(1000)
+    elif limit > 10000:
+        raise ParsingException("queries cannot have a limit higher than 10000")
+
     if parsed.get_offset() is None:
         parsed.set_offset(0)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,8 @@
+from typing import Any, Callable
+
+
 class BaseApiTest:
-    def setup_method(self, test_method):
+    def setup_method(self, test_method: Callable[..., Any]) -> None:
         from snuba.web.views import application
 
         assert application.testing is True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,14 @@
 import calendar
-import time
-import uuid
-from datetime import datetime, timedelta
-from functools import partial
-from unittest.mock import patch
-
 import pytest
 import pytz
+import time
+import uuid
 import simplejson as json
+from datetime import datetime, timedelta
 from dateutil.parser import parse as parse_datetime
+from typing import Any, Callable, List, Sequence, Tuple, Union
+from unittest.mock import MagicMock, patch
+
 from sentry_sdk import Client, Hub
 
 from snuba import settings, state
@@ -19,7 +19,7 @@ from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.processor import InsertBatch
 from snuba.redis import redis_client
 from snuba.subscriptions.store import RedisSubscriptionDataStore
@@ -28,9 +28,20 @@ from tests.helpers import write_processed_messages
 
 
 class TestApi(BaseApiTest):
-    def setup_method(self, test_method):
+    @pytest.fixture  # type: ignore
+    def test_entity(self) -> Union[str, Tuple[str, str]]:
+        return "events"
+
+    @pytest.fixture  # type: ignore
+    def test_app(self) -> Any:
+        return self.app
+
+    @pytest.fixture(autouse=True)  # type: ignore
+    def setup_post(self, _build_snql_post_methods: Callable[..., Any]) -> None:
+        self.post = _build_snql_post_methods
+
+    def setup_method(self, test_method: Callable[..., Any]) -> None:
         super().setup_method(test_method)
-        self.app.post = partial(self.app.post, headers={"referer": "test"})
 
         # values for test data
         self.project_ids = [1, 2, 3]  # 3 projects
@@ -43,11 +54,13 @@ class TestApi(BaseApiTest):
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0
         ) - timedelta(minutes=self.minutes)
-        self.storage = get_entity(EntityKey.EVENTS).get_writable_storage()
+        storage = get_entity(EntityKey.EVENTS).get_writable_storage()
+        assert storage is not None
+        self.storage = storage
         self.table = self.storage.get_table_writer().get_schema().get_table_name()
         self.generate_fizzbuzz_events()
 
-    def teardown_method(self, test_method):
+    def teardown_method(self, test_method: Callable[..., Any]) -> None:
         # Reset rate limits
         state.delete_config("global_concurrent_limit")
         state.delete_config("global_per_second_limit")
@@ -56,7 +69,7 @@ class TestApi(BaseApiTest):
         state.delete_config("project_per_second_limit")
         state.delete_config("date_align_seconds")
 
-    def write_events(self, events):
+    def write_events(self, events: Sequence[InsertEvent]) -> None:
         processor = self.storage.get_table_writer().get_stream_loader().get_processor()
 
         processed_messages = []
@@ -145,7 +158,7 @@ class TestApi(BaseApiTest):
                     )
         self.write_events(events)
 
-    def redis_db_size(self):
+    def redis_db_size(self) -> int:
         # dbsize could be an integer for a single node cluster or a dictionary
         # with one key value pair per node for a multi node cluster
         dbsize = redis_client.dbsize()
@@ -153,30 +166,6 @@ class TestApi(BaseApiTest):
             return sum(dbsize.values())
         else:
             return dbsize
-
-    def test_invalid_queries(self) -> None:
-        result = self.app.post(
-            "/query",
-            data=json.dumps(
-                {"project": [], "aggregations": [["count()", "", "times_seen"]]}
-            ),
-        )
-        assert result.status_code == 400
-        payload = json.loads(result.data)
-        assert payload["error"]["type"] == "schema"
-
-        result = self.app.post(
-            "/query",
-            data=json.dumps(
-                {
-                    "project": [2],
-                    "aggregations": [["parenth((eses(arehard)", "", "times_seen"]],
-                }
-            ),
-        )
-        assert result.status_code == 400
-        payload = json.loads(result.data)
-        assert payload["error"]["type"] == "invalid_query"
 
     def test_count(self) -> None:
         """
@@ -193,9 +182,8 @@ class TestApi(BaseApiTest):
         rollup_mins = 60
         for p in self.project_ids:
             result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
+                self.post(
+                    json.dumps(
                         {
                             "project": p,
                             "granularity": rollup_mins * 60,
@@ -225,9 +213,8 @@ class TestApi(BaseApiTest):
             # Note for buckets bigger than 1 hour, the results may not line up
             # with self.base_time as base_time is not necessarily on a bucket boundary
             result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
+                self.post(
+                    json.dumps(
                         {
                             "project": 1,
                             "granularity": rollup_mins * 60,
@@ -258,12 +245,12 @@ class TestApi(BaseApiTest):
         # Adding a half hour skew to the time.
         skew = timedelta(minutes=30)
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 60,
+                        "selected_columns": ["time"],
                         "groupby": "time",
                         "from_date": (self.base_time + skew)
                         .replace(tzinfo=pytz.utc)
@@ -283,12 +270,12 @@ class TestApi(BaseApiTest):
         # the 1hr boundary.
         state.set_config("date_align_seconds", 3600)
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 60,
+                        "selected_columns": ["time"],
                         "groupby": "time",
                         "from_date": (self.base_time + skew).isoformat(),
                         "to_date": (
@@ -304,24 +291,36 @@ class TestApi(BaseApiTest):
 
     def test_no_issues(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {"project": 1, "granularity": 3600, "groupby": "group_id"}
+            self.post(
+                json.dumps(
+                    {
+                        "project": 1,
+                        "granularity": 3600,
+                        "selected_columns": ["group_id"],
+                        "groupby": "group_id",
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
                 ),
             ).data
         )
         assert "error" not in result
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
+                        "selected_columns": ["group_id"],
                         "groupby": "group_id",
                         "conditions": [["group_id", "=", 100]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -330,14 +329,18 @@ class TestApi(BaseApiTest):
         assert result["data"] == []
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
+                        "selected_columns": ["group_id"],
                         "groupby": "group_id",
                         "conditions": [["group_id", "IN", [100, 200]]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -347,9 +350,8 @@ class TestApi(BaseApiTest):
 
     def test_offset_limit(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": self.project_ids,
                         "groupby": ["project_id"],
@@ -357,6 +359,10 @@ class TestApi(BaseApiTest):
                         "orderby": "-count",
                         "offset": 1,
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -364,26 +370,10 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 1
         assert result["data"][0]["project_id"] == 2
 
-        # limit over max-limit is invalid
-        result = self.app.post(
-            "/query",
-            data=json.dumps(
-                {
-                    "project": self.project_ids,
-                    "groupby": ["project_id"],
-                    "aggregations": [["count()", "", "count"]],
-                    "orderby": "-count",
-                    "limit": 1000000,
-                }
-            ),
-        )
-        assert result.status_code == 400
-
     def test_totals(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": self.project_ids,
                         "groupby": ["project_id"],
@@ -391,6 +381,10 @@ class TestApi(BaseApiTest):
                         "aggregations": [["count()", "", "count"]],
                         "orderby": "-count",
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -409,9 +403,8 @@ class TestApi(BaseApiTest):
 
         # LIMIT BY
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": self.project_ids,
                         "aggregations": [["count()", "", "count"]],
@@ -419,6 +412,10 @@ class TestApi(BaseApiTest):
                         "groupby": "environment",
                         "limitby": [100, "environment"],
                         "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -427,9 +424,8 @@ class TestApi(BaseApiTest):
 
         # Stress nullable totals column, making sure we get results as expected
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": self.project_ids,
                         "groupby": [
@@ -440,6 +436,10 @@ class TestApi(BaseApiTest):
                         "aggregations": [["count()", "", "count"]],
                         "orderby": "-count",
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -457,24 +457,8 @@ class TestApi(BaseApiTest):
 
     def test_conditions(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {
-                        "project": 2,
-                        "granularity": 3600,
-                        "groupby": "group_id",
-                        "conditions": [[], ["group_id", "IN", self.group_ids[:5]]],
-                    }
-                ),
-            ).data
-        )
-        assert set([d["group_id"] for d in result["data"]]) == set([self.group_ids[4]])
-
-        result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
@@ -483,6 +467,10 @@ class TestApi(BaseApiTest):
                         "conditions": [
                             ["platform", "NOT IN", ["b", "c", "d", "e", "f"]]
                         ],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -491,15 +479,18 @@ class TestApi(BaseApiTest):
         assert result["data"][0]["platform"] == "a"
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
                         "conditions": [["message", "LIKE", "a mess%"]],
                         "orderby": "event_id",
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -507,15 +498,18 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 1
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
                         "conditions": [["message", "NOT LIKE", "a mess%"]],
                         "orderby": "event_id",
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -523,15 +517,18 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 0
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
                         "conditions": [["tags[environment]", "LIKE", "%es%"]],
                         "orderby": "event_id",
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -539,72 +536,28 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 1
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id", "received"],
                         "conditions": [["received", "=", str(self.base_time)]],
                         "orderby": "event_id",
                         "limit": 1,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
         )
         assert len(result["data"]) == 1
-
-        # Test that a scalar condition on an array column expands to an all() type
-        # iterator
-        result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {
-                        "project": [1, 2, 3],
-                        "selected_columns": ["project_id"],
-                        "groupby": "project_id",
-                        "conditions": [
-                            # only project 1 should have an event with lineno 5
-                            ["exception_frames.lineno", "=", 5],
-                            ["exception_frames.filename", "LIKE", "%bar%"],
-                            # TODO these conditions are both separately true for the event,
-                            # but they are not both true for a single exception_frame (i.e.
-                            # there is no frame with filename:bar and lineno:5). We need to
-                            # fix this so that we have one iterator that tests both
-                            # conditions, instead of 2 iterators testing 1 condition each.
-                        ],
-                    }
-                ),
-            ).data
-        )
-        assert len(result["data"]) == 1
-        assert result["data"][0]["project_id"] == 1
-
-        # Test that a negative scalar condition on an array column expands to an
-        # all() type iterator. Looking for stack traces that do not contain foo.py
-        # at all ie. all(filename != 'foo.py')
-        result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {
-                        "project": [1, 2, 3],
-                        "selected_columns": ["project_id"],
-                        "groupby": "project_id",
-                        "debug": True,
-                        "conditions": [["exception_frames.filename", "!=", "foo.py"]],
-                    }
-                ),
-            ).data
-        )
-        assert len(result["data"]) == 0
 
         # Test null group_id
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": [1, 2, 3],
                         "selected_columns": ["group_id"],
@@ -612,6 +565,10 @@ class TestApi(BaseApiTest):
                         "aggregations": [["count()", "", "count"]],
                         "debug": True,
                         "conditions": [["group_id", "IS NULL", None]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -622,9 +579,8 @@ class TestApi(BaseApiTest):
         assert res["count"] > 0
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "dataset": "events",
                         "project": [1, 2, 3],
@@ -632,6 +588,10 @@ class TestApi(BaseApiTest):
                         "groupby": ["group_id"],
                         "debug": True,
                         "conditions": [["group_id", "IS NULL", None]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -680,14 +640,17 @@ class TestApi(BaseApiTest):
         self.write_events(events)
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 4,
                         "selected_columns": ["message"],
                         "conditions": [[["isHandled", []], "=", 1]],
                         "orderby": ["message"],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -697,14 +660,17 @@ class TestApi(BaseApiTest):
         assert result["data"][1]["message"] == "handled True"
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 4,
                         "selected_columns": ["message"],
                         "conditions": [[["notHandled", []], "=", 1]],
                         "orderby": ["message"],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -715,9 +681,8 @@ class TestApi(BaseApiTest):
     def test_escaping(self) -> None:
         # Escape single quotes so we don't get Bobby Tables'd
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
@@ -726,6 +691,10 @@ class TestApi(BaseApiTest):
                         "conditions": [
                             ["platform", "=", r"production'; DROP TABLE test; --"]
                         ],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -733,10 +702,16 @@ class TestApi(BaseApiTest):
 
         # Make sure we still got our table
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {"project": 1, "aggregations": [["count()", "", "count"]]}
+            self.post(
+                json.dumps(
+                    {
+                        "project": 1,
+                        "aggregations": [["count()", "", "count"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
                 ),
             ).data
         )
@@ -745,15 +720,18 @@ class TestApi(BaseApiTest):
         # Need to escape backslash as well otherwise the unescped
         # backslash would nullify the escaping on the quote.
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
                         "aggregations": [["count()", "", "count"]],
                         "groupby": "platform",
                         "conditions": [["platform", "=", r"\'"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -774,9 +752,8 @@ class TestApi(BaseApiTest):
         # Before we run our test, make sure the column exists in our prewhere keys
         assert "message" in prewhere_keys
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
@@ -785,6 +762,10 @@ class TestApi(BaseApiTest):
                         ],
                         "limit": 1,
                         "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -800,9 +781,8 @@ class TestApi(BaseApiTest):
         # Before we run our test, make sure that we have our priorities in the test right.
         assert prewhere_keys.index("message") < prewhere_keys.index("project_id")
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
@@ -811,6 +791,10 @@ class TestApi(BaseApiTest):
                         ],
                         "limit": 1,
                         "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -823,9 +807,8 @@ class TestApi(BaseApiTest):
         # Allow 2 conditions in prewhere clause
         settings.MAX_PREWHERE_CONDITIONS = 2
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
@@ -834,6 +817,10 @@ class TestApi(BaseApiTest):
                         ],
                         "limit": 1,
                         "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -846,15 +833,18 @@ class TestApi(BaseApiTest):
     def test_prewhere_conditions_dont_show_up_in_where_conditions(self) -> None:
         settings.MAX_PREWHERE_CONDITIONS = 1
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["event_id"],
                         "conditions": [["http_method", "=", "GET"]],
                         "limit": 1,
                         "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -870,13 +860,16 @@ class TestApi(BaseApiTest):
 
     def test_aggregate(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 3,
                         "groupby": "project_id",
                         "aggregations": [["topK(4)", "group_id", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -888,13 +881,16 @@ class TestApi(BaseApiTest):
         ]
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 3,
                         "groupby": "project_id",
                         "aggregations": [["uniq", "group_id", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -902,13 +898,16 @@ class TestApi(BaseApiTest):
         assert result["data"][0]["aggregate"] == 3
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 3,
                         "groupby": ["project_id", "time"],
                         "aggregations": [["uniq", "group_id", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -917,9 +916,8 @@ class TestApi(BaseApiTest):
         assert all(d["aggregate"] == 3 for d in result["data"])
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": self.project_ids,
                         "groupby": ["project_id"],
@@ -928,11 +926,15 @@ class TestApi(BaseApiTest):
                             ["uniq", "platform", "uniq_platforms"],
                             ["topK(1)", "platform", "top_platforms"],
                         ],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
         )
-        data = sorted(result["data"], key=lambda r: r["project_id"])
+        data = sorted(result["data"], key=lambda r: int(r["project_id"]))
 
         for idx, pid in enumerate(self.project_ids):
             assert data[idx]["project_id"] == pid
@@ -943,15 +945,18 @@ class TestApi(BaseApiTest):
 
     def test_aggregate_with_multiple_arguments(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 3,
                         "groupby": "project_id",
                         "aggregations": [
                             ["argMax", ["event_id", "timestamp"], "latest_event"]
                         ],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -962,14 +967,17 @@ class TestApi(BaseApiTest):
 
     def test_having_conditions(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "groupby": "primary_hash",
                         "having": [["times_seen", ">", 1]],
                         "aggregations": [["count()", "", "times_seen"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -977,14 +985,17 @@ class TestApi(BaseApiTest):
         assert len(result["data"]) == 3
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "groupby": "primary_hash",
                         "having": [["times_seen", ">", 100]],
                         "aggregations": [["count()", "", "times_seen"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -993,13 +1004,17 @@ class TestApi(BaseApiTest):
 
         # unknown field times_seen
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "having": [["times_seen", ">", 1]],
+                        "selected_columns": ["group_id"],
                         "groupby": "time",
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1009,15 +1024,18 @@ class TestApi(BaseApiTest):
     def test_tag_expansion(self) -> None:
         # A promoted tag
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "granularity": 3600,
                         "groupby": "project_id",
                         "conditions": [["tags[sentry:dist]", "IN", ["dist1", "dist2"]]],
                         "aggregations": [["count()", "", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1027,9 +1045,8 @@ class TestApi(BaseApiTest):
 
         # A non promoted tag
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "granularity": 3600,
@@ -1039,6 +1056,10 @@ class TestApi(BaseApiTest):
                             ["tags[foo.bar]", "=", "qux"],
                         ],
                         "aggregations": [["count()", "", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1048,9 +1069,8 @@ class TestApi(BaseApiTest):
 
         # A combination of promoted and nested
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "granularity": 3600,
@@ -1060,6 +1080,10 @@ class TestApi(BaseApiTest):
                             ["tags[foo.bar]", "=", "qux"],
                         ],
                         "aggregations": [["count()", "", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1068,15 +1092,18 @@ class TestApi(BaseApiTest):
         assert result["data"][0]["aggregate"] == 90
 
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "granularity": 3600,
                         "groupby": "project_id",
                         "conditions": [["tags[os.rooted]", "=", "1"]],
                         "aggregations": [["count()", "", "aggregate"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1088,14 +1115,18 @@ class TestApi(BaseApiTest):
         # If there is a condition on an already SELECTed column, then use the
         # column alias instead of the full column expression again.
         response = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 2,
                         "granularity": 3600,
+                        "selected_columns": ["group_id"],
                         "groupby": "group_id",
                         "conditions": [["group_id", "=", 0], ["group_id", "=", 1]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1106,22 +1137,43 @@ class TestApi(BaseApiTest):
 
     def test_sampling_expansion(self) -> None:
         response = json.loads(
-            self.app.post(
-                "/query", data=json.dumps({"project": 2, "sample": 1000})
+            self.post(
+                json.dumps(
+                    {
+                        "project": 2,
+                        "sample": 1000,
+                        "selected_columns": ["project_id"],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                )
             ).data
         )
         assert "SAMPLE 1000" in response["sql"]
 
         response = json.loads(
-            self.app.post("/query", data=json.dumps({"project": 2, "sample": 0.1})).data
+            self.post(
+                json.dumps(
+                    {
+                        "project": 2,
+                        "sample": 0.1,
+                        "selected_columns": ["project_id"],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                )
+            ).data
         )
         assert "SAMPLE 0.1" in response["sql"]
 
     def test_promoted_expansion(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
@@ -1132,6 +1184,10 @@ class TestApi(BaseApiTest):
                             ["topK(3)", "tags_value", "top"],
                         ],
                         "conditions": [["tags_value", "IS NOT NULL", None]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1173,13 +1229,16 @@ class TestApi(BaseApiTest):
 
     def test_tag_translation(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
                         "aggregations": [["topK(100)", "tags_key", "top"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1189,15 +1248,18 @@ class TestApi(BaseApiTest):
 
     def test_unicode_condition(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "granularity": 3600,
                         "groupby": ["environment"],
                         "aggregations": [["count()", "", "count"]],
                         "conditions": [["environment", "IN", ["prød"]]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1206,10 +1268,18 @@ class TestApi(BaseApiTest):
 
     def test_query_timing(self) -> None:
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
-                    {"project": 1, "granularity": 3600, "groupby": "group_id"}
+            self.post(
+                json.dumps(
+                    {
+                        "project": 1,
+                        "granularity": 3600,
+                        "selected_columns": ["group_id"],
+                        "groupby": "group_id",
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
                 ),
             ).data
         )
@@ -1219,7 +1289,18 @@ class TestApi(BaseApiTest):
 
     def test_global_rate_limiting(self) -> None:
         state.set_config("global_concurrent_limit", 0)
-        response = self.app.post("/query", data=json.dumps({"project": 1}))
+        response = self.post(
+            json.dumps(
+                {
+                    "project": 1,
+                    "from_date": self.base_time.isoformat(),
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                    "selected_columns": ["project"],
+                }
+            )
+        )
         assert response.status_code == 429
 
     def test_project_rate_limiting(self) -> None:
@@ -1227,13 +1308,31 @@ class TestApi(BaseApiTest):
         state.set_config("project_concurrent_limit", 1)
         state.set_config("project_concurrent_limit_1", 0)
 
-        response = self.app.post(
-            "/query", data=json.dumps({"project": 2, "selected_columns": ["platform"]})
+        response = self.post(
+            json.dumps(
+                {
+                    "project": 2,
+                    "selected_columns": ["platform"],
+                    "from_date": self.base_time.isoformat(),
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                }
+            )
         )
         assert response.status_code == 200
 
-        response = self.app.post(
-            "/query", data=json.dumps({"project": 1, "selected_columns": ["platform"]})
+        response = self.post(
+            json.dumps(
+                {
+                    "project": 1,
+                    "selected_columns": ["platform"],
+                    "from_date": self.base_time.isoformat(),
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                }
+            )
         )
         assert response.status_code == 429
 
@@ -1242,8 +1341,10 @@ class TestApi(BaseApiTest):
             "project": 1,
             "groupby": "project_id",
             "aggregations": [["count()", "", "count"]],
+            "from_date": self.base_time.isoformat(),
+            "to_date": (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
         }
-        result1 = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        result1 = json.loads(self.post(json.dumps(query)).data)
 
         event_id = "9" * 32
         if self.storage.get_storage_key() == StorageKey.ERRORS:
@@ -1267,7 +1368,7 @@ class TestApi(BaseApiTest):
             ],
         )
 
-        result2 = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        result2 = json.loads(self.post(json.dumps(query)).data)
         assert result1["data"] == result2["data"]
 
     def test_selected_columns(self) -> None:
@@ -1275,8 +1376,10 @@ class TestApi(BaseApiTest):
             "project": 1,
             "selected_columns": ["platform", "message"],
             "orderby": "platform",
+            "from_date": self.base_time.isoformat(),
+            "to_date": (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
         }
-        result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        result = json.loads(self.post(json.dumps(query)).data)
 
         assert len(result["data"]) == 180
         assert result["data"][0] == {"message": "a message", "platform": "a"}
@@ -1285,8 +1388,10 @@ class TestApi(BaseApiTest):
         query = {
             "project": 1,
             "selected_columns": ["platform", ["notEmpty", ["exception_stacks.type"]]],
+            "from_date": self.base_time.isoformat(),
+            "to_date": (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
         }
-        result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        result = json.loads(self.post(json.dumps(query)).data)
         assert len(result["data"]) == 180
         assert "platform" in result["data"][0]
         assert "notEmpty(exception_stacks.type)" in result["data"][0]
@@ -1299,8 +1404,10 @@ class TestApi(BaseApiTest):
                 "platform",
                 ["notEmpty", ["exception_stacks.type"], "type_not_empty"],
             ],
+            "from_date": self.base_time.isoformat(),
+            "to_date": (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
         }
-        result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        result = json.loads(self.post(json.dumps(query)).data)
         assert len(result["data"]) == 180
         assert "platform" in result["data"][0]
         assert "type_not_empty" in result["data"][0]
@@ -1310,14 +1417,17 @@ class TestApi(BaseApiTest):
         # sort by a complex sort key with an expression, and a regular column,
         # and both ASC and DESC sorts.
         result = json.loads(
-            self.app.post(
-                "/query",
-                data=json.dumps(
+            self.post(
+                json.dumps(
                     {
                         "project": 1,
                         "selected_columns": ["environment", "time"],
                         "orderby": [["-substringUTF8", ["environment", 1, 3]], "time"],
                         "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
@@ -1337,8 +1447,10 @@ class TestApi(BaseApiTest):
         query = {
             "project": 1,
             "selected_columns": ["received"],
+            "from_date": self.base_time.isoformat(),
+            "to_date": (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
         }
-        json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        json.loads(self.post(json.dumps(query)).data)
 
     def test_duplicate_column(self) -> None:
         query = {
@@ -1349,8 +1461,623 @@ class TestApi(BaseApiTest):
             "to_date": "2019-11-26T01:00:36",
             "granularity": 3600,
         }
-        result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
+        result = json.loads(self.post(json.dumps(query)).data)
         assert result["meta"] == [{"name": "timestamp", "type": "DateTime"}]
+
+    @pytest.mark.xfail  # type: ignore
+    def test_row_stats(self) -> None:
+        query = {
+            "project": 1,
+            "selected_columns": ["platform"],
+        }
+        result = json.loads(self.post(json.dumps(query)).data)
+
+        assert "rows_read" in result["stats"]
+        assert "bytes_read" in result["stats"]
+        assert result["stats"]["bytes_read"] > 0
+
+    def test_static_page_renders(self) -> None:
+        response = self.app.get("/config")
+        assert response.status_code == 200
+        assert len(response.data) > 100
+
+    def test_exception_captured_by_sentry(self) -> None:
+        events: List[Any] = []
+        with Hub(Client(transport=events.append)):
+            # This endpoint should return 500 as it internally raises an exception
+            response = self.app.get("/tests/error")
+
+            assert response.status_code == 500
+            assert len(events) == 1
+            assert events[0]["exception"]["values"][0]["type"] == "ZeroDivisionError"
+
+    def test_split_query(self) -> None:
+        state.set_config("use_split", 1)
+        state.set_config("split_step", 3600)  # first batch will be 1 hour
+        try:
+
+            # Test getting the last 150 events, should happen in 2 batches
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "limit": 150,
+                        }
+                    ),
+                ).data
+            )
+            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
+                map(str, reversed(range(30, 180)))
+            )
+
+            # Test getting the last 150 events, offset by 10
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "limit": 150,
+                            "offset": 10,
+                        }
+                    ),
+                ).data
+            )
+            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
+                map(str, reversed(range(20, 170)))
+            )
+
+            # Test asking for more events than there are
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "limit": 200,
+                        }
+                    ),
+                ).data
+            )
+            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
+                map(str, reversed(range(0, 180)))
+            )
+
+            # Test offset by more events than there are
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "limit": 10,
+                            "offset": 180,
+                        }
+                    ),
+                ).data
+            )
+            assert result["data"] == []
+
+            # Test offset that spans batches
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "limit": 10,
+                            "offset": 55,
+                        }
+                    ),
+                ).data
+            )
+            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
+                map(str, reversed(range(115, 125)))
+            )
+
+            # Test offset by the size of the first batch retrieved. (the first batch will be discarded/trimmed)
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "limit": 10,
+                            "offset": 60,
+                        }
+                    ),
+                ).data
+            )
+            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
+                map(str, reversed(range(110, 120)))
+            )
+
+            # Test condition that means 0 events will be returned
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": ["tags[sentry:release]", "timestamp"],
+                            "conditions": [["message", "=", "doesnt exist"]],
+                            "limit": 10,
+                            "offset": 55,
+                        }
+                    ),
+                ).data
+            )
+            assert result["data"] == []
+
+            # Test splitting query by columns - non timestamp sort
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=59)
+                            ).isoformat(),
+                            "orderby": "tags[sentry:release]",
+                            "selected_columns": [
+                                "event_id",
+                                "timestamp",
+                                "tags[sentry:release]",
+                                "tags[one]",
+                                "tags[two]",
+                                "tags[three]",
+                                "tags[four]",
+                                "tags[five]",
+                            ],
+                            "limit": 5,
+                        }
+                    ),
+                ).data
+            )
+            # Alphabetical sort
+            assert [d["tags[sentry:release]"] for d in result["data"]] == [
+                "0",
+                "1",
+                "10",
+                "11",
+                "12",
+            ]
+
+            # Test splitting query by columns - timestamp sort
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=59)
+                            ).isoformat(),
+                            "orderby": "timestamp",
+                            "selected_columns": [
+                                "event_id",
+                                "timestamp",
+                                "tags[sentry:release]",
+                                "tags[one]",
+                                "tags[two]",
+                                "tags[three]",
+                                "tags[four]",
+                                "tags[five]",
+                            ],
+                            "limit": 5,
+                        }
+                    ),
+                ).data
+            )
+            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
+                map(str, range(0, 5))
+            )
+
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": (
+                                self.base_time - timedelta(days=100)
+                            ).isoformat(),
+                            "to_date": (
+                                self.base_time - timedelta(days=99)
+                            ).isoformat(),
+                            "orderby": "timestamp",
+                            "selected_columns": [
+                                "event_id",
+                                "timestamp",
+                                "tags[sentry:release]",
+                                "tags[one]",
+                                "tags[two]",
+                                "tags[three]",
+                                "tags[four]",
+                                "tags[five]",
+                            ],
+                            "limit": 5,
+                        }
+                    ),
+                ).data
+            )
+            assert len(result["data"]) == 0
+
+            # Test offset
+            result = json.loads(
+                self.post(
+                    json.dumps(
+                        {
+                            "project": 1,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
+                            "orderby": "-timestamp",
+                            "selected_columns": [
+                                "event_id",
+                                "timestamp",
+                                "tags[sentry:release]",
+                                "tags[one]",
+                                "tags[two]",
+                                "tags[three]",
+                                "tags[four]",
+                                "tags[five]",
+                            ],
+                            "offset": 170,
+                            "limit": 170,
+                        }
+                    ),
+                ).data
+            )
+
+            assert len(result["data"]) == 10
+            assert [e["tags[sentry:release]"] for e in result["data"]] == list(
+                map(str, reversed(range(0, 10)))
+            )
+
+        finally:
+            state.set_config("use_split", 0)
+
+    def test_consistent(self, disable_query_cache: Callable[..., Any]) -> None:
+        response = json.loads(
+            self.post(
+                json.dumps(
+                    {
+                        "project": 2,
+                        "aggregations": [["count()", "", "aggregate"]],
+                        "consistent": True,
+                        "debug": True,
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                ),
+            ).data
+        )
+        assert response["stats"]["consistent"]
+
+    def test_gracefully_handle_multiple_conditions_on_same_column(self) -> None:
+        response = self.post(
+            json.dumps(
+                {
+                    "project": [2],
+                    "selected_columns": ["timestamp"],
+                    "conditions": [
+                        ["group_id", "IN", [2, 1]],
+                        [["isNull", ["group_id"]], "=", 1],
+                    ],
+                    "debug": True,
+                    "from_date": self.base_time.isoformat(),
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                }
+            ),
+        )
+
+        assert response.status_code == 200
+
+    def test_mandatory_conditions(self) -> None:
+        result = json.loads(
+            self.post(
+                json.dumps(
+                    {
+                        "project": 1,
+                        "granularity": 3600,
+                        "selected_columns": ["group_id"],
+                        "groupby": "group_id",
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                ),
+            ).data
+        )
+        assert "deleted = 0" in result["sql"] or "equals(deleted, 0)" in result["sql"]
+
+
+class TestCreateSubscriptionApi(BaseApiTest):
+    dataset_name = "events"
+
+    def test(self) -> None:
+        expected_uuid = uuid.uuid1()
+
+        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
+            uuid4.return_value = expected_uuid
+            resp = self.app.post(
+                "{}/subscriptions".format(self.dataset_name),
+                data=json.dumps(
+                    {
+                        "project_id": 1,
+                        "conditions": [["platform", "IN", ["a"]]],
+                        "aggregations": [["count()", "", "count"]],
+                        "time_window": int(timedelta(minutes=10).total_seconds()),
+                        "resolution": int(timedelta(minutes=1).total_seconds()),
+                    }
+                ).encode("utf-8"),
+            )
+
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        assert data == {
+            "subscription_id": f"0/{expected_uuid.hex}",
+        }
+
+    def test_time_error(self) -> None:
+        resp = self.app.post(
+            "{}/subscriptions".format(self.dataset_name),
+            data=json.dumps(
+                {
+                    "project_id": 1,
+                    "conditions": [["platform", "IN", ["a"]]],
+                    "aggregations": [["count()", "", "count"]],
+                    "time_window": 0,
+                    "resolution": 1,
+                }
+            ),
+        )
+
+        assert resp.status_code == 400
+        data = json.loads(resp.data)
+        assert data == {
+            "error": {
+                "message": "Time window must be greater than or equal to 1 minute",
+                "type": "subscription",
+            }
+        }
+
+
+class TestDeleteSubscriptionApi(BaseApiTest):
+    dataset_name = "events"
+    dataset = get_dataset(dataset_name)
+
+    def test(self) -> None:
+        resp = self.app.post(
+            "{}/subscriptions".format(self.dataset_name),
+            data=json.dumps(
+                {
+                    "project_id": 1,
+                    "conditions": [],
+                    "aggregations": [["count()", "", "count"]],
+                    "time_window": int(timedelta(minutes=10).total_seconds()),
+                    "resolution": int(timedelta(minutes=1).total_seconds()),
+                }
+            ).encode("utf-8"),
+        )
+
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        subscription_id = data["subscription_id"]
+        partition = subscription_id.split("/", 1)[0]
+        assert (
+            len(
+                RedisSubscriptionDataStore(redis_client, self.dataset, partition,).all()  # type: ignore
+            )
+            == 1
+        )
+
+        resp = self.app.delete(
+            f"{self.dataset_name}/subscriptions/{data['subscription_id']}"
+        )
+        assert resp.status_code == 202, resp
+        assert (
+            RedisSubscriptionDataStore(redis_client, self.dataset, partition,).all()
+            == []
+        )
+
+
+class TestExtraAPI(BaseApiTest):
+    """ These are tests for features that are not supported in SnQL. """
+
+    def setup_method(self, test_method: Callable[..., Any]) -> None:
+        super().setup_method(test_method)
+
+        # values for test data
+        self.project_ids = [1, 2, 3]  # 3 projects
+        self.environments = ["prød", "test"]  # 2 environments
+        self.platforms = ["a", "b", "c", "d", "e", "f"]  # 6 platforms
+        self.hashes = [x * 32 for x in "0123456789ab"]  # 12 hashes
+        self.group_ids = [int(hsh[:16], 16) for hsh in self.hashes]
+        self.minutes = 180
+
+        self.base_time = datetime.utcnow().replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(minutes=self.minutes)
+        storage = get_entity(EntityKey.EVENTS).get_writable_storage()
+        assert storage is not None
+        self.storage = storage
+        self.table = self.storage.get_table_writer().get_schema().get_table_name()
+        self.generate_fizzbuzz_events()
+
+    def teardown_method(self, test_method: Callable[..., Any]) -> None:
+        # Reset rate limits
+        state.delete_config("global_concurrent_limit")
+        state.delete_config("global_per_second_limit")
+        state.delete_config("project_concurrent_limit")
+        state.delete_config("project_concurrent_limit_1")
+        state.delete_config("project_per_second_limit")
+        state.delete_config("date_align_seconds")
+
+    def write_events(self, events: Sequence[InsertEvent]) -> None:
+        processor = self.storage.get_table_writer().get_stream_loader().get_processor()
+
+        processed_messages = []
+        for i, event in enumerate(events):
+            processed_message = processor.process_message(
+                (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
+            )
+            assert processed_message is not None
+            processed_messages.append(processed_message)
+
+        write_processed_messages(self.storage, processed_messages)
+
+    def generate_fizzbuzz_events(self) -> None:
+        """
+        Generate a deterministic set of events across a time range.
+        """
+
+        events = []
+        for tick in range(self.minutes):
+            tock = tick + 1
+            for p in self.project_ids:
+                # project N sends an event every Nth minute
+                if tock % p == 0:
+                    events.append(
+                        InsertEvent(
+                            {
+                                "organization_id": 1,
+                                "project_id": p,
+                                "event_id": uuid.uuid4().hex,
+                                "datetime": (
+                                    self.base_time + timedelta(minutes=tick)
+                                ).strftime(settings.PAYLOAD_DATETIME_FORMAT),
+                                "message": "a message",
+                                "platform": self.platforms[
+                                    (tock * p) % len(self.platforms)
+                                ],
+                                "primary_hash": self.hashes[
+                                    (tock * p) % len(self.hashes)
+                                ],
+                                "group_id": self.group_ids[
+                                    (tock * p) % len(self.hashes)
+                                ],
+                                "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                                "data": {
+                                    # Project N sends every Nth (mod len(hashes)) hash (and platform)
+                                    "received": calendar.timegm(
+                                        (
+                                            self.base_time + timedelta(minutes=tick)
+                                        ).timetuple()
+                                    ),
+                                    "tags": {
+                                        # Sentry
+                                        "environment": self.environments[
+                                            (tock * p) % len(self.environments)
+                                        ],
+                                        "sentry:release": str(tick),
+                                        "sentry:dist": "dist1",
+                                        "os.name": "windows",
+                                        "os.rooted": 1,
+                                        # User
+                                        "foo": "baz",
+                                        "foo.bar": "qux",
+                                        "os_name": "linux",
+                                    },
+                                    "exception": {
+                                        "values": [
+                                            {
+                                                "stacktrace": {
+                                                    "frames": [
+                                                        {
+                                                            "filename": "foo.py",
+                                                            "lineno": tock,
+                                                        },
+                                                        {
+                                                            "filename": "bar.py",
+                                                            "lineno": tock * 2,
+                                                        },
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                },
+                            }
+                        )
+                    )
+        self.write_events(events)
+
+    def redis_db_size(self) -> int:
+        # dbsize could be an integer for a single node cluster or a dictionary
+        # with one key value pair per node for a multi node cluster
+        dbsize = redis_client.dbsize()
+        if isinstance(dbsize, dict):
+            return sum(dbsize.values())
+        else:
+            return dbsize
+
+    def test_invalid_queries(self) -> None:
+        result = self.app.post(
+            "/query",
+            data=json.dumps(
+                {"project": [], "aggregations": [["count()", "", "times_seen"]]}
+            ),
+        )
+        assert result.status_code == 400
+        payload = json.loads(result.data)
+        assert payload["error"]["type"] == "schema"
+
+        result = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "project": [2],
+                    "aggregations": [["parenth((eses(arehard)", "", "times_seen"]],
+                }
+            ),
+        )
+        assert result.status_code == 400
+        payload = json.loads(result.data)
+        assert payload["error"]["type"] == "invalid_query"
 
     def test_test_endpoints(self) -> None:
         project_id = 73
@@ -1404,7 +2131,7 @@ class TestApi(BaseApiTest):
         # make sure redis has _something_ before we go about dropping all the keys in it
         assert self.redis_db_size() > 0
 
-        storage = get_storage(StorageKey.EVENTS)
+        storage = get_writable_storage(StorageKey.EVENTS)
         clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.QUERY
         )
@@ -1422,376 +2149,161 @@ class TestApi(BaseApiTest):
         # No data in events table
         assert len(clickhouse.execute(f"SELECT * FROM {self.table}")) == 0
 
-    @pytest.mark.xfail
-    def test_row_stats(self) -> None:
-        query = {
-            "project": 1,
-            "selected_columns": ["platform"],
-        }
-        result = json.loads(self.app.post("/query", data=json.dumps(query)).data)
-
-        assert "rows_read" in result["stats"]
-        assert "bytes_read" in result["stats"]
-        assert result["stats"]["bytes_read"] > 0
-
-    def test_static_page_renders(self) -> None:
-        response = self.app.get("/config")
-        assert response.status_code == 200
-        assert len(response.data) > 100
-
-    def test_exception_captured_by_sentry(self) -> None:
-        events = []
-        with Hub(Client(transport=events.append)):
-            # This endpoint should return 500 as it internally raises an exception
-            response = self.app.get("/tests/error")
-
-            assert response.status_code == 500
-            assert len(events) == 1
-            assert events[0]["exception"]["values"][0]["type"] == "ZeroDivisionError"
-
-    def test_split_query(self) -> None:
-        state.set_config("use_split", 1)
-        state.set_config("split_step", 3600)  # first batch will be 1 hour
-        try:
-
-            # Test getting the last 150 events, should happen in 2 batches
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "limit": 150,
-                        }
-                    ),
-                ).data
-            )
-            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
-                map(str, reversed(range(30, 180)))
-            )
-
-            # Test getting the last 150 events, offset by 10
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "limit": 150,
-                            "offset": 10,
-                        }
-                    ),
-                ).data
-            )
-            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
-                map(str, reversed(range(20, 170)))
-            )
-
-            # Test asking for more events than there are
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "limit": 200,
-                        }
-                    ),
-                ).data
-            )
-            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
-                map(str, reversed(range(0, 180)))
-            )
-
-            # Test offset by more events than there are
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "limit": 10,
-                            "offset": 180,
-                        }
-                    ),
-                ).data
-            )
-            assert result["data"] == []
-
-            # Test offset that spans batches
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "limit": 10,
-                            "offset": 55,
-                        }
-                    ),
-                ).data
-            )
-            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
-                map(str, reversed(range(115, 125)))
-            )
-
-            # Test offset by the size of the first batch retrieved. (the first batch will be discarded/trimmed)
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "limit": 10,
-                            "offset": 60,
-                        }
-                    ),
-                ).data
-            )
-            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
-                map(str, reversed(range(110, 120)))
-            )
-
-            # Test condition that means 0 events will be returned
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": ["tags[sentry:release]", "timestamp"],
-                            "conditions": [["message", "=", "doesnt exist"]],
-                            "limit": 10,
-                            "offset": 55,
-                        }
-                    ),
-                ).data
-            )
-            assert result["data"] == []
-
-            # Test splitting query by columns - non timestamp sort
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=59)
-                            ).isoformat(),
-                            "orderby": "tags[sentry:release]",
-                            "selected_columns": [
-                                "event_id",
-                                "timestamp",
-                                "tags[sentry:release]",
-                                "tags[one]",
-                                "tags[two]",
-                                "tags[three]",
-                                "tags[four]",
-                                "tags[five]",
-                            ],
-                            "limit": 5,
-                        }
-                    ),
-                ).data
-            )
-            # Alphabetical sort
-            assert [d["tags[sentry:release]"] for d in result["data"]] == [
-                "0",
-                "1",
-                "10",
-                "11",
-                "12",
-            ]
-
-            # Test splitting query by columns - timestamp sort
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=59)
-                            ).isoformat(),
-                            "orderby": "timestamp",
-                            "selected_columns": [
-                                "event_id",
-                                "timestamp",
-                                "tags[sentry:release]",
-                                "tags[one]",
-                                "tags[two]",
-                                "tags[three]",
-                                "tags[four]",
-                                "tags[five]",
-                            ],
-                            "limit": 5,
-                        }
-                    ),
-                ).data
-            )
-            assert [d["tags[sentry:release]"] for d in result["data"]] == list(
-                map(str, range(0, 5))
-            )
-
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": (
-                                self.base_time - timedelta(days=100)
-                            ).isoformat(),
-                            "to_date": (
-                                self.base_time - timedelta(days=99)
-                            ).isoformat(),
-                            "orderby": "timestamp",
-                            "selected_columns": [
-                                "event_id",
-                                "timestamp",
-                                "tags[sentry:release]",
-                                "tags[one]",
-                                "tags[two]",
-                                "tags[three]",
-                                "tags[four]",
-                                "tags[five]",
-                            ],
-                            "limit": 5,
-                        }
-                    ),
-                ).data
-            )
-            assert len(result["data"]) == 0
-
-            # Test offset
-            result = json.loads(
-                self.app.post(
-                    "/query",
-                    data=json.dumps(
-                        {
-                            "project": 1,
-                            "from_date": self.base_time.isoformat(),
-                            "to_date": (
-                                self.base_time + timedelta(minutes=self.minutes)
-                            ).isoformat(),
-                            "orderby": "-timestamp",
-                            "selected_columns": [
-                                "event_id",
-                                "timestamp",
-                                "tags[sentry:release]",
-                                "tags[one]",
-                                "tags[two]",
-                                "tags[three]",
-                                "tags[four]",
-                                "tags[five]",
-                            ],
-                            "offset": 170,
-                            "limit": 170,
-                        }
-                    ),
-                ).data
-            )
-
-            assert len(result["data"]) == 10
-            assert [e["tags[sentry:release]"] for e in result["data"]] == list(
-                map(str, reversed(range(0, 10)))
-            )
-
-        finally:
-            state.set_config("use_split", 0)
-
-    def test_consistent(self) -> None:
-        response = json.loads(
+    def test_conditions(self) -> None:
+        result = json.loads(
             self.app.post(
                 "/query",
                 data=json.dumps(
                     {
                         "project": 2,
-                        "aggregations": [["count()", "", "aggregate"]],
-                        "consistent": True,
-                        "debug": True,
+                        "granularity": 3600,
+                        "groupby": "group_id",
+                        "conditions": [[], ["group_id", "IN", self.group_ids[:5]]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
                     }
                 ),
             ).data
         )
-        assert response["stats"]["consistent"]
+        assert set([d["group_id"] for d in result["data"]]) == set([self.group_ids[4]])
 
-    def test_gracefully_handle_multiple_conditions_on_same_column(self) -> None:
-        response = self.app.post(
-            "/query",
-            data=json.dumps(
-                {
-                    "project": [2],
-                    "selected_columns": ["timestamp"],
-                    "conditions": [
-                        ["group_id", "IN", [2, 1]],
-                        [["isNull", ["group_id"]], "=", 1],
-                    ],
-                    "debug": True,
-                }
-            ),
-        )
-
-        assert response.status_code == 200
-
-    def test_mandatory_conditions(self) -> None:
+        # Test that a scalar condition on an array column expands to an all() type
+        # iterator
         result = json.loads(
             self.app.post(
                 "/query",
                 data=json.dumps(
-                    {"project": 1, "granularity": 3600, "groupby": "group_id"}
+                    {
+                        "project": [1, 2, 3],
+                        "selected_columns": ["project_id"],
+                        "groupby": "project_id",
+                        "conditions": [
+                            # only project 1 should have an event with lineno 5
+                            ["exception_frames.lineno", "=", 5],
+                            ["exception_frames.filename", "LIKE", "%bar%"],
+                            # TODO these conditions are both separately true for the event,
+                            # but they are not both true for a single exception_frame (i.e.
+                            # there is no frame with filename:bar and lineno:5). We need to
+                            # fix this so that we have one iterator that tests both
+                            # conditions, instead of 2 iterators testing 1 condition each.
+                        ],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
                 ),
             ).data
         )
-        assert "deleted = 0" in result["sql"] or "equals(deleted, 0)" in result["sql"]
+        assert len(result["data"]) == 1
+        assert result["data"][0]["project_id"] == 1
+
+        # Test that a negative scalar condition on an array column expands to an
+        # all() type iterator. Looking for stack traces that do not contain foo.py
+        # at all ie. all(filename != 'foo.py')
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "project": [1, 2, 3],
+                        "selected_columns": ["project_id"],
+                        "groupby": "project_id",
+                        "debug": True,
+                        "conditions": [["exception_frames.filename", "!=", "foo.py"]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                ),
+            ).data
+        )
+        assert len(result["data"]) == 0
+
+    def test_no_issues(self) -> None:
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "project": 1,
+                        "granularity": 3600,
+                        "groupby": "group_id",
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                ),
+            ).data
+        )
+        assert "error" not in result
+
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "project": 1,
+                        "granularity": 3600,
+                        "groupby": "group_id",
+                        "conditions": [["group_id", "=", 100]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                ),
+            ).data
+        )
+        assert "error" not in result
+        assert result["data"] == []
+
+        result = json.loads(
+            self.app.post(
+                "/query",
+                data=json.dumps(
+                    {
+                        "project": 1,
+                        "granularity": 3600,
+                        "groupby": "group_id",
+                        "conditions": [["group_id", "IN", [100, 200]]],
+                        "from_date": self.base_time.isoformat(),
+                        "to_date": (
+                            self.base_time + timedelta(minutes=self.minutes)
+                        ).isoformat(),
+                    }
+                ),
+            ).data
+        )
+        assert "error" not in result
+        assert result["data"] == []
+
+    def test_max_limit(self) -> None:
+        result = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "project": self.project_ids,
+                    "groupby": ["project_id"],
+                    "aggregations": [["count()", "", "count"]],
+                    "orderby": "-count",
+                    "limit": 1000000,
+                    "from_date": self.base_time.isoformat(),
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                }
+            ),
+        )
+        assert result.status_code == 400
 
     @patch("snuba.settings.RECORD_QUERIES", True)
     @patch("snuba.state.record_query")
-    def test_record_queries(self, record_query_mock):
+    def test_record_queries(self, record_query_mock: MagicMock) -> None:
         for use_split, expected_query_count in [(0, 1), (1, 2)]:
             state.set_config("use_split", use_split)
             record_query_mock.reset_mock()
@@ -1809,8 +2321,13 @@ class TestApi(BaseApiTest):
                                 "tags[b]",
                             ],
                             "limit": 5,
+                            "from_date": self.base_time.isoformat(),
+                            "to_date": (
+                                self.base_time + timedelta(minutes=self.minutes)
+                            ).isoformat(),
                         }
                     ),
+                    headers={"referer": "test"},
                 ).data
             )
 
@@ -1820,93 +2337,3 @@ class TestApi(BaseApiTest):
             assert metadata["dataset"] == "events"
             assert metadata["request"]["referrer"] == "test"
             assert len(metadata["query_list"]) == expected_query_count
-
-
-class TestCreateSubscriptionApi(BaseApiTest):
-    dataset_name = "events"
-
-    def test(self):
-        expected_uuid = uuid.uuid1()
-
-        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
-            uuid4.return_value = expected_uuid
-            resp = self.app.post(
-                "{}/subscriptions".format(self.dataset_name),
-                data=json.dumps(
-                    {
-                        "project_id": 1,
-                        "conditions": [["platform", "IN", ["a"]]],
-                        "aggregations": [["count()", "", "count"]],
-                        "time_window": int(timedelta(minutes=10).total_seconds()),
-                        "resolution": int(timedelta(minutes=1).total_seconds()),
-                    }
-                ).encode("utf-8"),
-            )
-
-        assert resp.status_code == 202
-        data = json.loads(resp.data)
-        assert data == {
-            "subscription_id": f"0/{expected_uuid.hex}",
-        }
-
-    def test_time_error(self) -> None:
-        resp = self.app.post(
-            "{}/subscriptions".format(self.dataset_name),
-            data=json.dumps(
-                {
-                    "project_id": 1,
-                    "conditions": [["platform", "IN", ["a"]]],
-                    "aggregations": [["count()", "", "count"]],
-                    "time_window": 0,
-                    "resolution": 1,
-                }
-            ),
-        )
-
-        assert resp.status_code == 400
-        data = json.loads(resp.data)
-        assert data == {
-            "error": {
-                "message": "Time window must be greater than or equal to 1 minute",
-                "type": "subscription",
-            }
-        }
-
-
-class TestDeleteSubscriptionApi(BaseApiTest):
-    dataset_name = "events"
-    dataset = get_dataset(dataset_name)
-
-    def test(self):
-        resp = self.app.post(
-            "{}/subscriptions".format(self.dataset_name),
-            data=json.dumps(
-                {
-                    "project_id": 1,
-                    "conditions": [],
-                    "aggregations": [["count()", "", "count"]],
-                    "time_window": int(timedelta(minutes=10).total_seconds()),
-                    "resolution": int(timedelta(minutes=1).total_seconds()),
-                }
-            ).encode("utf-8"),
-        )
-
-        assert resp.status_code == 202
-        data = json.loads(resp.data)
-        subscription_id = data["subscription_id"]
-        partition = subscription_id.split("/", 1)[0]
-        assert (
-            len(
-                RedisSubscriptionDataStore(redis_client, self.dataset, partition,).all()
-            )
-            == 1
-        )
-
-        resp = self.app.delete(
-            f"{self.dataset_name}/subscriptions/{data['subscription_id']}"
-        )
-        assert resp.status_code == 202, resp
-        assert (
-            RedisSubscriptionDataStore(redis_client, self.dataset, partition,).all()
-            == []
-        )


### PR DESCRIPTION
Now all API tests are running a legacy version, a SnQL version and a compare
version that asserts the generated SQL is the same between the two versions.