### PR TITLE
ref: Log "consistent" for Snuplicator queries

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -120,6 +120,8 @@ def callback_func(
     ):
         is_duplicate = True
 
+    consistent = request_settings.get_consistent()
+
     if not results:
         metrics.increment(
             "query_result",
@@ -140,6 +142,7 @@ def callback_func(
                 "referrer": referrer,
                 "cache_hit": str(cache_hit),
                 "is_duplicate": str(is_duplicate),
+                "consistent": str(consistent),
             },
         )
 
@@ -156,6 +159,7 @@ def callback_func(
                     "referrer": referrer,
                     "cache_hit": str(cache_hit),
                     "is_duplicate": str(is_duplicate),
+                    "consistent": str(consistent),
                 },
             )
         else:
@@ -170,6 +174,7 @@ def callback_func(
                     "reason": reason,
                     "cache_hit": str(cache_hit),
                     "is_duplicate": str(is_duplicate),
+                    "consistent": str(consistent),
                 },
             )
 
@@ -183,6 +188,7 @@ def callback_func(
                         "reason": reason,
                         "cache_hit": str(cache_hit),
                         "is_duplicate": str(is_duplicate),
+                        "consistent": str(consistent),
                     },
                     extras={
                         "query": format_query(query),
@@ -205,6 +211,7 @@ def callback_func(
                             "reason": reason,
                             "cache_hit": str(cache_hit),
                             "is_duplicate": str(is_duplicate),
+                            "consistent": str(consistent),
                         },
                         extras={
                             "query": format_query(query),


### PR DESCRIPTION
Allows us to test a hypothesis about whether "consistent" has any
impact on differences seen when running a same query on both the
events and errors storages.