### PR TITLE
ref: Schemas should not contain columns not present in database

### DIFF
--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -177,9 +177,6 @@ all_columns = (
         ("culprit", String(Modifiers(nullable=True))),
         ("sdk_integrations", Array(String())),
         ("modules", Nested([("name", String()), ("version", String())])),
-        ("release", String(Modifiers(nullable=True, readonly=True))),
-        ("dist", String(Modifiers(nullable=True, readonly=True))),
-        ("user", String(Modifiers(nullable=True, readonly=True))),
     ]
 )
 


### PR DESCRIPTION
The "user", "release" and "dist" columns were incorrectly added to the
events schema in https://github.com/getsentry/snuba/commit/481571a16fbb2e592c30a4460c407455c5d65528.

These columns do not actually exist; rather they are mapped to sentry:user,
sentry:release and sentry:dist respectively.