### PR TITLE
feat(prewhere): Add prewhere processor for the grouped message storage

### DIFF
--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -13,6 +13,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.expressions import Column, Literal
+from snuba.query.processors.prewhere import PrewhereProcessor
 
 columns = ColumnSet(
     [
@@ -56,7 +57,7 @@ storage = CdcStorage(
     storage_key=StorageKey.GROUPEDMESSAGES,
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
-    query_processors=[],
+    query_processors=[PrewhereProcessor()],
     stream_loader=build_kafka_stream_loader_from_settings(
         StorageKey.GROUPEDMESSAGES,
         processor=GroupedMessageProcessor(POSTGRES_TABLE),


### PR DESCRIPTION
I'm not sure why the prewhere processor is not being run on the grouped message
storage. I assume it is an oversight since the corresponding schema has got
defined prewhere candidates.