### PR TITLE
fix(errors) Add a 500 error handler

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ import time
 import uuid
 from datetime import datetime, timedelta
 from functools import partial
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
@@ -1820,6 +1820,41 @@ class TestApi(BaseApiTest):
             assert metadata["dataset"] == "events"
             assert metadata["request"]["referrer"] == "test"
             assert len(metadata["query_list"]) == expected_query_count
+
+    @patch("snuba.web.query._run_query_pipeline")
+    def test_error_handler(self, pipeline_mock: MagicMock) -> None:
+        from rediscluster.utils import ClusterDownError
+
+        pipeline_mock.side_effect = ClusterDownError("stuff")
+        response = self.app.post(
+            "/query",
+            data=json.dumps(
+                {
+                    "conditions": [
+                        ["project_id", "IN", [1]],
+                        ["group_id", "IN", [self.group_ids[0]]],
+                    ],
+                    "from_date": self.base_time.isoformat(),
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                    "limit": 1,
+                    "offset": 0,
+                    "orderby": ["-timestamp", "-event_id"],
+                    "project": [1],
+                    "selected_columns": [
+                        "event_id",
+                        "group_id",
+                        "project_id",
+                        "timestamp",
+                    ],
+                }
+            ),
+        )
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert data["error"]["type"] == "internal_server_error"
+        assert data["error"]["message"] == "stuff"
 
 
 class TestCreateSubscriptionApi(BaseApiTest):


### PR DESCRIPTION
If we get unexpected errors (redis errors for example) we return an HTML 500
response. Add a handler that will return JSON so at least Sentry doesn't also
throw exceptions.