### PR TITLE
feat(prewhere): Modified prewhere candidates for final queries

### DIFF
--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -80,7 +80,6 @@ def get_query_data_source(
         final=final,
         sampling_rate=sampling_rate,
         mandatory_conditions=relational_source.get_mandatory_conditions(),
-        prewhere_candidates=relational_source.get_prewhere_candidates(),
     )
 
 

--- a/snuba/datasets/schemas/__init__.py
+++ b/snuba/datasets/schemas/__init__.py
@@ -32,18 +32,6 @@ class RelationalSource(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
-    def get_prewhere_candidates(self) -> Sequence[str]:
-        """
-        Returns the list of keys that can be promoted to PREWHERE conditions
-        if found in the conditions field of the query.
-        pre where keys depend on the actual table used to run the query, so,
-        since the query processors can change the datasource of the query, the
-        list of candidates must be associated to the data source itself and not
-        to the dataset.
-        """
-        raise NotImplementedError
-
 
 class Schema(ABC):
     """

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -21,12 +21,10 @@ class TableSource(RelationalSource):
         table_name: str,
         columns: ColumnSet,
         mandatory_conditions: Optional[Sequence[FunctionCall]] = None,
-        prewhere_candidates: Optional[Sequence[str]] = None,
     ) -> None:
         self.__table_name = table_name
         self.__columns = columns
         self.__mandatory_conditions = mandatory_conditions or []
-        self.__prewhere_candidates = prewhere_candidates or []
 
     def get_table_name(self) -> str:
         return self.__table_name
@@ -36,9 +34,6 @@ class TableSource(RelationalSource):
 
     def get_mandatory_conditions(self) -> Sequence[FunctionCall]:
         return self.__mandatory_conditions
-
-    def get_prewhere_candidates(self) -> Sequence[str]:
-        return self.__prewhere_candidates
 
 
 class TableSchema(Schema):
@@ -55,7 +50,6 @@ class TableSchema(Schema):
         dist_table_name: str,
         storage_set_key: StorageSetKey,
         mandatory_conditions: Optional[Sequence[FunctionCall]] = None,
-        prewhere_candidates: Optional[Sequence[str]] = None,
         part_format: Optional[Sequence[util.PartSegment]] = None,
     ):
         self.__local_table_name = local_table_name
@@ -65,7 +59,7 @@ class TableSchema(Schema):
             else dist_table_name
         )
         self.__table_source = TableSource(
-            self.get_table_name(), columns, mandatory_conditions, prewhere_candidates,
+            self.get_table_name(), columns, mandatory_conditions
         )
         self.__part_format = part_format
 

--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -59,14 +59,6 @@ schema = TableSchema(
     dist_table_name="discover_dist",
     storage_set_key=StorageSetKey.DISCOVER,
     mandatory_conditions=mandatory_conditions,
-    prewhere_candidates=[
-        "event_id",
-        "release",
-        "message",
-        "transaction_name",
-        "environment",
-        "project_id",
-    ],
 )
 
 storage = ReadableTableStorage(
@@ -77,7 +69,16 @@ storage = ReadableTableStorage(
         MappingOptimizer("tags", "_tags_hash_map", "tags_hash_map_enabled"),
         EventIdColumnProcessor(),
         ArrayJoinKeyValueOptimizer("tags"),
-        PrewhereProcessor(),
+        PrewhereProcessor(
+            [
+                "event_id",
+                "release",
+                "message",
+                "transaction_name",
+                "environment",
+                "project_id",
+            ]
+        ),
     ],
     query_splitters=[
         ColumnSplitQueryStrategy(

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -8,7 +8,6 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors_common import (
     all_columns,
     mandatory_conditions,
-    prewhere_candidates,
     promoted_tag_columns,
     query_processors,
     query_splitters,
@@ -22,7 +21,6 @@ schema = WritableTableSchema(
     dist_table_name="errors_dist",
     storage_set_key=StorageSetKey.EVENTS,
     mandatory_conditions=mandatory_conditions,
-    prewhere_candidates=prewhere_candidates,
     part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -144,7 +144,7 @@ query_processors = [
     GroupIdColumnProcessor(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),
-    PrewhereProcessor(),
+    PrewhereProcessor(prewhere_candidates, omit_if_final=["environment"]),
 ]
 
 query_splitters = [

--- a/snuba/datasets/storages/errors_ro.py
+++ b/snuba/datasets/storages/errors_ro.py
@@ -6,7 +6,6 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors_common import (
     all_columns,
     mandatory_conditions,
-    prewhere_candidates,
     query_processors,
     query_splitters,
 )
@@ -18,7 +17,6 @@ schema = TableSchema(
     dist_table_name="errors_dist_ro",
     storage_set_key=StorageSetKey.EVENTS_RO,
     mandatory_conditions=mandatory_conditions,
-    prewhere_candidates=prewhere_candidates,
 )
 
 storage = ReadableTableStorage(

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -10,7 +10,6 @@ from snuba.datasets.storages.events_common import (
     get_promoted_tags,
     get_tag_column_map,
     mandatory_conditions,
-    prewhere_candidates,
     promoted_tag_columns,
     query_processors,
     query_splitters,
@@ -25,7 +24,6 @@ schema = WritableTableSchema(
     dist_table_name="sentry_dist",
     storage_set_key=StorageSetKey.EVENTS,
     mandatory_conditions=mandatory_conditions,
-    prewhere_candidates=prewhere_candidates,
     part_format=[util.PartSegment.DATE, util.PartSegment.RETENTION_DAYS],
 )
 

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -294,7 +294,7 @@ query_processors = [
     EventsBooleanContextsProcessor(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),
-    PrewhereProcessor(),
+    PrewhereProcessor(prewhere_candidates),
 ]
 
 

--- a/snuba/datasets/storages/events_ro.py
+++ b/snuba/datasets/storages/events_ro.py
@@ -6,7 +6,6 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.events_common import (
     all_columns,
     mandatory_conditions,
-    prewhere_candidates,
     query_processors,
     query_splitters,
 )
@@ -18,7 +17,6 @@ schema = TableSchema(
     dist_table_name="sentry_dist_ro",
     storage_set_key=StorageSetKey.EVENTS_RO,
     mandatory_conditions=mandatory_conditions,
-    prewhere_candidates=prewhere_candidates,
 )
 
 storage = ReadableTableStorage(

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -41,7 +41,7 @@ storage = CdcStorage(
     storage_key=StorageKey.GROUPASSIGNEES,
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
-    query_processors=[PrewhereProcessor()],
+    query_processors=[PrewhereProcessor(["project_id"])],
     stream_loader=build_kafka_stream_loader_from_settings(
         StorageKey.GROUPASSIGNEES,
         processor=GroupAssigneeProcessor(POSTGRES_TABLE),

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -47,7 +47,6 @@ schema = WritableTableSchema(
             Literal(None, 0),
         ),
     ],
-    prewhere_candidates=["project_id", "id"],
 )
 
 POSTGRES_TABLE = "sentry_groupedmessage"

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -56,7 +56,7 @@ storage = CdcStorage(
     storage_key=StorageKey.GROUPEDMESSAGES,
     storage_set_key=StorageSetKey.EVENTS,
     schema=schema,
-    query_processors=[PrewhereProcessor()],
+    query_processors=[PrewhereProcessor(["project_id", "id"])],
     stream_loader=build_kafka_stream_loader_from_settings(
         StorageKey.GROUPEDMESSAGES,
         processor=GroupedMessageProcessor(POSTGRES_TABLE),

--- a/snuba/datasets/storages/outcomes.py
+++ b/snuba/datasets/storages/outcomes.py
@@ -69,7 +69,6 @@ materialized_view_schema = TableSchema(
     local_table_name="outcomes_mv_hourly_local",
     dist_table_name="outcomes_mv_hourly_dist",
     storage_set_key=StorageSetKey.OUTCOMES,
-    prewhere_candidates=["project_id", "org_id"],
     columns=materialized_view_columns,
 )
 
@@ -89,5 +88,5 @@ materialized_storage = ReadableTableStorage(
     storage_key=StorageKey.OUTCOMES_HOURLY,
     storage_set_key=StorageSetKey.OUTCOMES,
     schema=read_schema,
-    query_processors=[PrewhereProcessor()],
+    query_processors=[PrewhereProcessor(["project_id", "org_id"])],
 )

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -90,13 +90,11 @@ read_schema = TableSchema(
     local_table_name=READ_LOCAL_TABLE_NAME,
     dist_table_name=READ_DIST_TABLE_NAME,
     storage_set_key=StorageSetKey.SESSIONS,
-    prewhere_candidates=["project_id", "org_id"],
 )
 materialized_view_schema = TableSchema(
     local_table_name=READ_LOCAL_MV_NAME,
     dist_table_name=READ_DIST_MV_NAME,
     storage_set_key=StorageSetKey.SESSIONS,
-    prewhere_candidates=["project_id", "org_id"],
     columns=read_columns,
 )
 
@@ -118,5 +116,5 @@ materialized_storage = ReadableTableStorage(
     storage_key=StorageKey.SESSIONS_HOURLY,
     storage_set_key=StorageSetKey.SESSIONS,
     schema=read_schema,
-    query_processors=[PrewhereProcessor()],
+    query_processors=[PrewhereProcessor(["project_id", "org_id"])],
 )

--- a/snuba/datasets/storages/spans.py
+++ b/snuba/datasets/storages/spans.py
@@ -7,7 +7,6 @@ from snuba.datasets.spans_processor import SpansMessageProcessor
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
-from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.web.split import TimeSplitQueryStrategy
 
 columns = ColumnSet(
@@ -45,7 +44,7 @@ storage = WritableTableStorage(
     storage_key=StorageKey.SPANS,
     storage_set_key=StorageSetKey.TRANSACTIONS,
     schema=schema,
-    query_processors=[PrewhereProcessor()],
+    query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
         StorageKey.SPANS,
         processor=SpansMessageProcessor(),

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -80,7 +80,6 @@ schema = WritableTableSchema(
     dist_table_name="transactions_dist",
     storage_set_key=StorageSetKey.TRANSACTIONS,
     mandatory_conditions=[],
-    prewhere_candidates=["event_id", "transaction_name", "transaction", "title"],
     part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
@@ -95,7 +94,7 @@ storage = WritableTableStorage(
         ArrayJoinKeyValueOptimizer("tags"),
         ArrayJoinKeyValueOptimizer("measurements"),
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
-        PrewhereProcessor(),
+        PrewhereProcessor(["event_id", "transaction_name", "transaction", "title"]),
     ],
     stream_loader=build_kafka_stream_loader_from_settings(
         StorageKey.TRANSACTIONS,

--- a/snuba/query/data_source/simple.py
+++ b/snuba/query/data_source/simple.py
@@ -47,11 +47,10 @@ class Table(SimpleDataSource):
     schema: ColumnSet
     final: bool = False
     sampling_rate: Optional[float] = None
-    # TODO: Move mandatory connditions ad prewhere candidates out of
+    # TODO: Move mandatory connditions out of
     # here as they are structural property of a storage. This requires
     # the processors that consume these fields to access the storage.
     mandatory_conditions: Sequence[FunctionCall] = field(default_factory=list)
-    prewhere_candidates: Sequence[str] = field(default_factory=list)
 
     def get_columns(self) -> ColumnSet:
         return self.schema

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -51,9 +51,6 @@ events_table = Table(
     mandatory_conditions=events_storage.get_schema()
     .get_data_source()
     .get_mandatory_conditions(),
-    prewhere_candidates=events_storage.get_schema()
-    .get_data_source()
-    .get_prewhere_candidates(),
 )
 
 groups_ent = Entity(
@@ -68,9 +65,6 @@ groups_table = Table(
     mandatory_conditions=groups_storage.get_schema()
     .get_data_source()
     .get_mandatory_conditions(),
-    prewhere_candidates=groups_storage.get_schema()
-    .get_data_source()
-    .get_prewhere_candidates(),
 )
 
 TEST_CASES = [

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -55,7 +55,6 @@ def test_mand_conditions(table: str, mand_conditions: List[FunctionCall]) -> Non
             final=False,
             sampling_rate=None,
             mandatory_conditions=mand_conditions,
-            prewhere_candidates=["c1"],
         ),
         None,
         None,

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -2,9 +2,9 @@ from typing import Any, MutableMapping, Optional, Sequence
 
 import pytest
 from snuba import settings
-from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.translator.query import identity_translate
+from snuba.datasets.storages.errors_common import all_columns
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,
     BooleanFunctions,
@@ -15,6 +15,7 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.parser import parse_query
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.request.request_settings import HTTPRequestSettings
+
 
 test_data = [
     (
@@ -27,6 +28,7 @@ test_data = [
             "environment",
             "project_id",
         ],
+        [],
         None,
         FunctionCall(
             None,
@@ -40,6 +42,7 @@ test_data = [
                 Literal(None, 0),
             ),
         ),
+        False,
     ),
     (
         # Add pre-where condition in the expected order
@@ -51,6 +54,7 @@ test_data = [
             ],
         },
         ["a", "b", "c"],
+        [],
         FunctionCall(
             None,
             BooleanFunctions.AND,
@@ -83,11 +87,13 @@ test_data = [
                 ),
             ),
         ),
+        False,
     ),
     (
         # Do not add conditions that are parts of an OR
         {"conditions": [[["a", "=", "1"], ["b", "=", "2"]], ["c", "=", "3"]]},
         ["a", "b", "c"],
+        [],
         FunctionCall(
             None,
             BooleanFunctions.OR,
@@ -109,12 +115,14 @@ test_data = [
             OPERATOR_TO_FUNCTION["="],
             (Column("_snuba_c", None, "c"), Literal(None, "3")),
         ),
+        False,
     ),
     (
         # Exclude NOT IN condition from the prewhere as they are generally not excluding
         # most of the dataset.
         {"conditions": [["a", "NOT IN", [1, 2, 3]], ["b", "=", "2"], ["c", "=", "3"]]},
         ["a", "b"],
+        [],
         FunctionCall(
             None,
             BooleanFunctions.AND,
@@ -135,26 +143,54 @@ test_data = [
             OPERATOR_TO_FUNCTION["="],
             (Column("_snuba_b", None, "b"), Literal(None, "2")),
         ),
+        False,
+    ),
+    # Does not promote omit_if_final columns
+    (
+        {"conditions": [["environment", "=", "abc"], ["project_id", "=", 1]]},
+        [
+            "event_id",
+            "group_id",
+            "tags[sentry:release]",
+            "message",
+            "environment",
+            "project_id",
+        ],
+        ["environment"],
+        FunctionCall(
+            None,
+            OPERATOR_TO_FUNCTION["="],
+            (Column("_snuba_environment", None, "environment"), Literal(None, "abc"),),
+        ),
+        FunctionCall(
+            None,
+            OPERATOR_TO_FUNCTION["="],
+            (Column("_snuba_project_id", None, "project_id"), Literal(None, 1),),
+        ),
+        True,
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    "query_body, keys, new_ast_condition, new_prewhere_ast_condition", test_data,
+    "query_body, keys, omit_if_final_keys, new_ast_condition, new_prewhere_ast_condition, final",
+    test_data,
 )
 def test_prewhere(
     query_body: MutableMapping[str, Any],
     keys: Sequence[str],
+    omit_if_final_keys: Sequence[str],
     new_ast_condition: Optional[Expression],
     new_prewhere_ast_condition: Optional[Expression],
+    final: bool,
 ) -> None:
     settings.MAX_PREWHERE_CONDITIONS = 2
     events = get_dataset("events")
     query = identity_translate(parse_query(query_body, events))
-    query.set_from_clause(Table("my_table", ColumnSet([]), prewhere_candidates=keys))
+    query.set_from_clause(Table("my_table", all_columns, final=final))
 
     request_settings = HTTPRequestSettings()
-    processor = PrewhereProcessor()
+    processor = PrewhereProcessor(keys, omit_if_final=omit_if_final_keys)
     processor.process_query(query, request_settings)
 
     assert query.get_condition_from_ast() == new_ast_condition


### PR DESCRIPTION
Adds a mechanism to prevent specified columns from being included in the prewhere
clause if a query runs with final.

This helps us avoid a fairly obscure ClickHouse bug that causes an error when
a query contains a prewhere on a low cardinality, nullable column and that
query is run with final.

Since the new errors storage uses this column type more often than the events
table that it replaces, this may start to come up more often. It would also allow
us to safely add the `release` column to the list of prewhere candidates as long
as final is not used.

Fixes SNUBA-26G