### PR TITLE
fix(metrics) Fix the latency metrics on multi storage consumer 

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -541,7 +541,11 @@ class MultistorageConsumerProcessingStrategyFactory(
                     self.__metrics,
                     {"load_balancing": "in_order", "insert_distributed_sync": 1},
                 ),
-                self.__metrics,
+                MetricsWrapper(
+                    self.__metrics,
+                    "insertions",
+                    {"storage": storage.get_storage_key().value},
+                ),
             ),
             replacement_batch_writer,
         )


### PR DESCRIPTION
The standard consumer records latency as 
`consumer.insertion.latency_ms` with tags `storage:.....`
The multistorage consumer instead records latency as 
`consumer.latency_ms` without tags.

This makes the multistorage consumer behave like the standard consumer and fixes our metrics and alerts which are based on consumer.insertion.latency_ms.