### PR TITLE
feat(cdc) Collect some end to end latency metrics for cdc

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import logging
 import time
+from datetime import datetime
 from pickle import PickleBuffer
 from typing import (
     Any,
@@ -18,17 +19,12 @@ from typing import (
 
 import rapidjson
 from confluent_kafka import Producer as ConfluentKafkaProducer
-
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.message_filters import StreamMessageFilter
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.processor import (
-    InsertBatch,
-    MessageProcessor,
-    ReplacementBatch,
-)
+from snuba.processor import InsertBatch, MessageProcessor, ReplacementBatch
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams import Message, Partition, Topic
@@ -36,13 +32,11 @@ from snuba.utils.streams.backends.kafka import (
     KafkaPayload,
     build_kafka_producer_configuration,
 )
-from snuba.utils.streams.processing.strategies import (
-    ProcessingStrategy,
-    ProcessingStrategyFactory,
-)
+from snuba.utils.streams.processing.strategies import ProcessingStrategy
 from snuba.utils.streams.processing.strategies import (
     ProcessingStrategy as ProcessingStep,
 )
+from snuba.utils.streams.processing.strategies import ProcessingStrategyFactory
 from snuba.utils.streams.processing.strategies.streaming import (
     CollectStep,
     FilterStep,
@@ -51,18 +45,23 @@ from snuba.utils.streams.processing.strategies.streaming import (
 )
 from snuba.writer import BatchWriter
 
-
 logger = logging.getLogger("snuba.consumer")
 
 
 class JSONRowInsertBatch(NamedTuple):
     rows: Sequence[JSONRow]
+    origin_timestamp: Optional[datetime]
 
-    def __reduce_ex__(self, protocol: int) -> Tuple[Any, Tuple[Sequence[Any]]]:
+    def __reduce_ex__(
+        self, protocol: int
+    ) -> Tuple[Any, Tuple[Sequence[Any], Optional[datetime]]]:
         if protocol >= 5:
-            return (type(self), ([PickleBuffer(row) for row in self.rows],))
+            return (
+                type(self),
+                ([PickleBuffer(row) for row in self.rows], self.origin_timestamp),
+            )
         else:
-            return type(self), (self.rows,)
+            return type(self), (self.rows, self.origin_timestamp)
 
 
 class InsertBatchWriter(ProcessingStep[JSONRowInsertBatch]):
@@ -99,6 +98,12 @@ class InsertBatchWriter(ProcessingStep[JSONRowInsertBatch]):
             self.__metrics.timing(
                 "latency_ms", (write_finish - message.timestamp.timestamp()) * 1000
             )
+            if message.payload.origin_timestamp is not None:
+                self.__metrics.timing(
+                    "end_to_end_latency_ms",
+                    (write_finish - message.payload.origin_timestamp.timestamp())
+                    * 1000,
+                )
 
         logger.debug(
             "Waited %0.4f seconds for %r rows to be written to %r.",
@@ -255,7 +260,10 @@ def process_message(
     )
 
     if isinstance(result, InsertBatch):
-        return JSONRowInsertBatch([json_row_encoder.encode(row) for row in result.rows])
+        return JSONRowInsertBatch(
+            [json_row_encoder.encode(row) for row in result.rows],
+            result.origin_timestamp,
+        )
     else:
         return result
 
@@ -462,7 +470,8 @@ def process_message_multistorage(
                 (
                     storage_key,
                     JSONRowInsertBatch(
-                        [json_row_encoder.encode(row) for row in result.rows]
+                        [json_row_encoder.encode(row) for row in result.rows],
+                        result.origin_timestamp,
                     ),
                 )
             )

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -118,11 +118,14 @@ class CdcProcessor(MessageProcessor):
 
         offset = metadata.offset
         event = value["event"]
+        timestamp: Optional[datetime] = None
         if event == "begin":
             messages = self._process_begin(offset)
         elif event == "commit":
             messages = self._process_commit(offset)
         elif event == "change":
+            if "timestamp" in value:
+                timestamp = parse_postgres_datetime(value["timestamp"])
             table_name = value["table"]
             if table_name != self.pg_table:
                 return None
@@ -153,4 +156,4 @@ class CdcProcessor(MessageProcessor):
         if not messages:
             return None
 
-        return InsertBatch(messages)
+        return InsertBatch(messages, timestamp)

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -161,7 +161,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
             if row is None:  # the processor cannot/does not handle this input
                 return None
 
-            return InsertBatch([row])
+            return InsertBatch([row], None)
         elif type_ in REPLACEMENT_EVENT_TYPES:
             # pass raw events along to republish
             return ReplacementBatch(str(event["project_id"]), [message])

--- a/snuba/datasets/outcomes_processor.py
+++ b/snuba/datasets/outcomes_processor.py
@@ -41,4 +41,4 @@ class OutcomesProcessor(MessageProcessor):
             "event_id": str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
         }
 
-        return InsertBatch([message])
+        return InsertBatch([message], None)

--- a/snuba/datasets/querylog_processor.py
+++ b/snuba/datasets/querylog_processor.py
@@ -126,4 +126,4 @@ class QuerylogProcessor(MessageProcessor):
             **self.__extract_query_list(message["query_list"]),
         }
 
-        return InsertBatch([processed])
+        return InsertBatch([processed], None)

--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -76,4 +76,4 @@ class SessionsProcessor(MessageProcessor):
             "release": message["release"],
             "environment": message.get("environment") or "",
         }
-        return InsertBatch([processed])
+        return InsertBatch([processed], None)

--- a/snuba/datasets/spans_processor.py
+++ b/snuba/datasets/spans_processor.py
@@ -156,6 +156,6 @@ class SpansMessageProcessor(MessageProcessor):
             ret.append(processed)
 
         if ret:
-            return InsertBatch(ret)
+            return InsertBatch(ret, None)
         else:
             return None

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -202,4 +202,4 @@ class TransactionsMessageProcessor(MessageProcessor):
         if processed["sdk_version"] == "":
             metrics.increment("missing_sdk_version")
 
-        return InsertBatch([processed])
+        return InsertBatch([processed], None)

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -31,6 +31,7 @@ NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
 class InsertBatch(NamedTuple):
     rows: Sequence[WriterTableRow]
+    origin_timestamp: Optional[datetime]
 
 
 class ReplacementBatch(NamedTuple):

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -164,7 +164,9 @@ class TestGroupassignee:
         )
 
         ret = processor.process_message(self.INSERT_MSG, metadata)
-        assert ret == InsertBatch([self.PROCESSED])
+        assert ret == InsertBatch(
+            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 55, 32443, tzinfo=pytz.UTC)
+        )
         write_processed_messages(self.storage, [ret])
         ret = (
             self.storage.get_cluster()
@@ -182,15 +184,22 @@ class TestGroupassignee:
         )
 
         ret = processor.process_message(self.UPDATE_MSG_NO_KEY_CHANGE, metadata)
-        assert ret == InsertBatch([self.PROCESSED])
+        assert ret == InsertBatch(
+            [self.PROCESSED], datetime(2019, 9, 19, 0, 6, 56, 376853, tzinfo=pytz.UTC)
+        )
 
         # Tests an update with key change which becomes a two inserts:
         # one deletion and the insertion of the new row.
         ret = processor.process_message(self.UPDATE_MSG_WITH_KEY_CHANGE, metadata)
-        assert ret == InsertBatch([self.DELETED, self.PROCESSED_UPDATE])
+        assert ret == InsertBatch(
+            [self.DELETED, self.PROCESSED_UPDATE],
+            datetime(2019, 9, 19, 0, 6, 56, 376853, tzinfo=pytz.UTC),
+        )
 
         ret = processor.process_message(self.DELETE_MSG, metadata)
-        assert ret == InsertBatch([self.DELETED])
+        assert ret == InsertBatch(
+            [self.DELETED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        )
 
     def test_bulk_load(self) -> None:
         row = GroupAssigneeRow.from_bulk(
@@ -202,7 +211,9 @@ class TestGroupassignee:
                 "team_id": "",
             }
         )
-        write_processed_messages(self.storage, [InsertBatch([row.to_clickhouse()])])
+        write_processed_messages(
+            self.storage, [InsertBatch([row.to_clickhouse()], None)]
+        )
         ret = (
             self.storage.get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -230,7 +230,9 @@ class TestGroupedMessage:
         )
 
         ret = processor.process_message(self.INSERT_MSG, metadata)
-        assert ret == InsertBatch([self.PROCESSED])
+        assert ret == InsertBatch(
+            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        )
         write_processed_messages(self.storage, [ret])
         ret = (
             get_cluster(StorageSetKey.EVENTS)
@@ -250,10 +252,14 @@ class TestGroupedMessage:
         )
 
         ret = processor.process_message(self.UPDATE_MSG, metadata)
-        assert ret == InsertBatch([self.PROCESSED])
+        assert ret == InsertBatch(
+            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        )
 
         ret = processor.process_message(self.DELETE_MSG, metadata)
-        assert ret == InsertBatch([self.DELETED])
+        assert ret == InsertBatch(
+            [self.DELETED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        )
 
     def test_bulk_load(self) -> None:
         row = GroupedMessageRow.from_bulk(
@@ -267,7 +273,9 @@ class TestGroupedMessage:
                 "first_release_id": "26",
             }
         )
-        write_processed_messages(self.storage, [InsertBatch([row.to_clickhouse()])])
+        write_processed_messages(
+            self.storage, [InsertBatch([row.to_clickhouse()], None)]
+        )
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -324,4 +324,6 @@ def test_error_processor() -> None:
         }
     )
 
-    assert processor.process_message(error, meta) == InsertBatch([expected_result])
+    assert processor.process_message(error, meta) == InsertBatch(
+        [expected_result], None
+    )

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -110,4 +110,5 @@ def test_simple() -> None:
                 "clickhouse_queries.array_join_columns": [[]],
             }
         ],
+        None,
     )

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -50,7 +50,8 @@ class TestSessionProcessor:
                     "status": 1,
                     "received": timestamp.replace(tzinfo=None),
                 }
-            ]
+            ],
+            None,
         )
 
     def test_ingest_session_event_abnormal(self) -> None:
@@ -98,7 +99,8 @@ class TestSessionProcessor:
                     "status": 3,
                     "received": timestamp.replace(tzinfo=None),
                 }
-            ]
+            ],
+            None,
         )
 
     def test_ingest_session_event_crashed(self) -> None:
@@ -146,5 +148,6 @@ class TestSessionProcessor:
                     "status": 2,
                     "received": timestamp.replace(tzinfo=None),
                 }
-            ]
+            ],
+            None,
         )

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -325,4 +325,4 @@ class TestTransactionsProcessor:
         )
         assert TransactionsMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)])
+        ) == InsertBatch([message.build_result(meta)], None)

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -111,8 +111,8 @@ test_data = [
     (90, None),
     (100, None),
     (110, None),
-    (120, InsertBatch([PROCESSED])),
-    (210, InsertBatch([PROCESSED])),
+    (120, InsertBatch([PROCESSED], None)),
+    (210, InsertBatch([PROCESSED], None)),
 ]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1262,7 +1262,8 @@ class TestApi(BaseApiTest):
                             "deleted": 1,
                             "retention_days": settings.DEFAULT_RETENTION_DAYS,
                         }
-                    ]
+                    ],
+                    None,
                 )
             ],
         )

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -24,7 +24,8 @@ test_data = [
                     "timestamp": dt,
                     "retention_days": retention or settings.DEFAULT_RETENTION_DAYS,
                 }
-            ]
+            ],
+            None,
         ),
         id="events",
     ),
@@ -40,7 +41,8 @@ test_data = [
                     "timestamp": dt,
                     "retention_days": retention or settings.DEFAULT_RETENTION_DAYS,
                 }
-            ]
+            ],
+            None,
         ),
         id="errors",
     ),
@@ -55,7 +57,8 @@ test_data = [
                     "finish_ts": dt,
                     "retention_days": retention or settings.DEFAULT_RETENTION_DAYS,
                 }
-            ]
+            ],
+            None,
         ),
         id="transactions",
     ),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -39,7 +39,7 @@ def test_streaming_consumer_strategy() -> None:
     processor = Mock()
     processor.process_message.side_effect = [
         None,
-        InsertBatch([{}]),
+        InsertBatch([{}], None),
         ReplacementBatch("key", [{}]),
     ]
 
@@ -97,12 +97,12 @@ def test_streaming_consumer_strategy() -> None:
 
 
 def test_json_row_batch_pickle_simple() -> None:
-    batch = JSONRowInsertBatch([b"foo", b"bar", b"baz"])
+    batch = JSONRowInsertBatch([b"foo", b"bar", b"baz"], datetime(2021, 1, 1, 11, 0, 1))
     assert pickle.loads(pickle.dumps(batch)) == batch
 
 
 def test_json_row_batch_pickle_out_of_band() -> None:
-    batch = JSONRowInsertBatch([b"foo", b"bar", b"baz"])
+    batch = JSONRowInsertBatch([b"foo", b"bar", b"baz"], datetime(2021, 1, 1, 11, 0, 1))
 
     buffers: MutableSequence[PickleBuffer] = []
     data = pickle.dumps(batch, protocol=5, buffer_callback=buffers.append)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -25,7 +25,8 @@ test_data = [
                     "timestamp": dt,
                     "retention_days": settings.DEFAULT_RETENTION_DAYS,
                 }
-            ]
+            ],
+            None,
         ),
         id="events",
     ),
@@ -41,7 +42,8 @@ test_data = [
                     "timestamp": dt,
                     "retention_days": settings.DEFAULT_RETENTION_DAYS,
                 }
-            ]
+            ],
+            None,
         ),
         id="errors",
     ),
@@ -56,7 +58,8 @@ test_data = [
                     "finish_ts": dt,
                     "retention_days": settings.DEFAULT_RETENTION_DAYS,
                 }
-            ]
+            ],
+            None,
         ),
         id="transactions",
     ),


### PR DESCRIPTION
This is a very approximate end to end metric: postgres commit timestamp - clickhosue write timestamp to understand the order of magnitude of the latency we are going to expect and to understand how stable this latency is over time.

It allows each consumer to provide an origin timestamp (which is produced from the parsed message body, so it cannot be extracted by the consumer infrastructure) in the InsertBatch the processor produces for each Kafka message.
Then this is propagated till the BatchWriter that collects the metrics.