### PR TITLE
feat(snuplicator): Assign reason for non deterministic queries

### DIFF
--- a/tests/datasets/entities/test_assign_reason.py
+++ b/tests/datasets/entities/test_assign_reason.py
@@ -54,10 +54,25 @@ test_data = [
         "RESULT_OUT_OF_ORDER",
         id="out_of_order",
     ),
+    pytest.param(
+        [
+            {"group_id": 1, "count": 1},
+            {"group_id": 2, "count": 1},
+            {"group_id": 3, "count": 1},
+        ],
+        [
+            {"group_id": 3, "count": 1},
+            {"group_id": 2, "count": 1},
+            {"group_id": 1, "count": 1},
+        ],
+        "tagstore.get_groups_user_counts",
+        "NONDETERMINISTIC_QUERY",
+        id="nondeterministic_query",
+    ),
 ]
 
 
-@pytest.mark.parametrize("data, primary_data, referrer, expected_reason", test_data)
+@pytest.mark.parametrize("data, primary_data, referrer, expected_reason", test_data)  # type: ignore
 def test_assign_reason_category(
     data: Sequence[Mapping[str, Any]],
     primary_data: Sequence[Mapping[str, Any]],


### PR DESCRIPTION
If a result differs between events and errors due to a missing or
non unique order by term, assign "NONDETERMINISTIC_QUERY" as the reason.