### PR TITLE
feat(query) Add commutative condition matcher

### DIFF
--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -94,7 +94,7 @@ set_condition_pattern = {
 
 
 def __is_set_condition(exp: Expression, operator: str) -> bool:
-    if is_binary_condition(exp, operator):
+    if is_any_binary_condition(exp, operator):
         if operator in set_condition_pattern:
             if set_condition_pattern[operator].match(exp) is not None:
                 assert isinstance(exp, FunctionCall)  # mypy
@@ -141,7 +141,7 @@ binary_condition_patterns = {
 }
 
 
-def is_binary_condition(exp: Expression, operator: str) -> bool:
+def is_any_binary_condition(exp: Expression, operator: str) -> bool:
     if operator in binary_condition_patterns:
         return binary_condition_patterns[operator].match(exp) is not None
 

--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -7,7 +7,7 @@ from snuba.query.conditions import (
     ConditionFunctions,
     get_first_level_and_conditions,
     in_condition,
-    is_binary_condition,
+    is_any_binary_condition,
     is_in_condition_pattern,
 )
 from snuba.query.dsl import arrayJoin, tupleElement
@@ -57,7 +57,7 @@ def _get_mapping_keys_in_condition(
 
     conditions = get_first_level_and_conditions(condition)
     for c in conditions:
-        if is_binary_condition(c, BooleanFunctions.OR):
+        if is_any_binary_condition(c, BooleanFunctions.OR):
             return None
 
         match = FunctionCall(

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -11,11 +11,13 @@ from snuba.query.conditions import (
     is_not_in_condition,
     is_not_in_condition_pattern,
     is_unary_condition,
+    match_condition,
     unary_condition,
 )
 from snuba.query.dsl import literals_tuple
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.matchers import Column as ColumnPattern
+from snuba.query.matchers import Literal as LiteralPattern
 from snuba.query.matchers import String
 
 
@@ -247,3 +249,17 @@ def test_first_level_conditions() -> None:
         c1,
         binary_condition(BooleanFunctions.AND, c2, c3),
     ]
+
+
+def test_binary_match() -> None:
+    c1 = binary_condition(
+        ConditionFunctions.EQ, Column(None, "table1", "column1"), Literal(None, "test"),
+    )
+
+    lhs = ColumnPattern(String("table1"), String("column1"))
+    rhs = LiteralPattern(String("test"))
+
+    assert match_condition(c1, {ConditionFunctions.EQ}, lhs, rhs, True) is not None
+    assert match_condition(c1, {ConditionFunctions.EQ}, lhs, rhs, False) is not None
+    assert match_condition(c1, {ConditionFunctions.EQ}, rhs, lhs, True) is not None
+    assert match_condition(c1, {ConditionFunctions.EQ}, rhs, lhs, False) is None

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -4,7 +4,7 @@ from snuba.query.conditions import (
     binary_condition,
     get_first_level_and_conditions,
     get_first_level_or_conditions,
-    is_binary_condition,
+    is_any_binary_condition,
     is_condition,
     is_in_condition,
     is_in_condition_pattern,
@@ -187,8 +187,8 @@ def test_is_x_condition_functions() -> None:
     eq_condition = binary_condition(
         ConditionFunctions.EQ, Column(None, None, "test"), Literal(None, "1")
     )
-    assert is_binary_condition(eq_condition, ConditionFunctions.EQ)
-    assert not is_binary_condition(eq_condition, ConditionFunctions.NEQ)
+    assert is_any_binary_condition(eq_condition, ConditionFunctions.EQ)
+    assert not is_any_binary_condition(eq_condition, ConditionFunctions.NEQ)
 
     un_condition = unary_condition(
         ConditionFunctions.IS_NOT_NULL, Column(None, None, "test")


### PR DESCRIPTION
We have to match conditions often that could have literal on either side of the expression. This is specifically true with SnQL that does not impose the literal to be on the right hand side.

This adds a helper function to generate a proper pattern to match conditions in a commutative way. It will be useful for promoting the trace_id and span_id contexts.