### PR TITLE
perf(trace_id) Add trace_id and span_id to the prewhere clause

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -107,7 +107,16 @@ storage = WritableTableStorage(
         ArrayJoinKeyValueOptimizer("tags"),
         ArrayJoinKeyValueOptimizer("measurements"),
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
-        PrewhereProcessor(["event_id", "transaction_name", "transaction", "title"]),
+        PrewhereProcessor(
+            [
+                "event_id",
+                "trace_id",
+                "span_id",
+                "transaction_name",
+                "transaction",
+                "title",
+            ]
+        ),
     ],
     stream_loader=build_kafka_stream_loader_from_settings(
         StorageKey.TRANSACTIONS,

--- a/snuba/query/processors/typed_context_promoter.py
+++ b/snuba/query/processors/typed_context_promoter.py
@@ -21,7 +21,6 @@ from snuba.query.expressions import Column
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.matchers import Any, Literal, MatchResult, Param, Pattern
 from snuba.request.request_settings import RequestSettings
-from snuba.state import get_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "typed_context")
@@ -103,9 +102,6 @@ class TypedContextPromoter(QueryProcessor):
         self.__specs = {spec.context_name: spec for spec in specs}
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
-        if not get_config("typed_context_promoter_enabled", 0):
-            return
-
         def apply_pattern(
             exp: Expression,
             pattern: Pattern[Expression],

--- a/tests/query/processors/test_typed_context_promoter.py
+++ b/tests/query/processors/test_typed_context_promoter.py
@@ -13,7 +13,6 @@ from snuba.query.processors.typed_context_promoter import (
     UUIDContextType,
 )
 from snuba.request.request_settings import HTTPRequestSettings
-from snuba.state import set_config
 from tests.query.processors.query_builders import (
     build_query,
     column,
@@ -163,7 +162,6 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("query, expected_query", TEST_CASES)
 def test_tags_hash_map(query: ClickhouseQuery, expected_query: ClickhouseQuery) -> None:
-    set_config("typed_context_promoter_enabled", 1)
     TypedContextPromoter(
         "contexts",
         {


### PR DESCRIPTION
Now that we are using the trace_id and span_id columns on discover queries, we can improve the performance of those queries further by adding them to the prewhere clause as they are extremely high selectivity columns.