### PR TITLE
feat: Drop the group_id processor from errors

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -12,7 +12,6 @@ from snuba.clickhouse.columns import (
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.datasets.errors_replacer import ReplacerState
 from snuba.datasets.storages.event_id_column_processor import EventIdColumnProcessor
-from snuba.datasets.storages.group_id_column_processor import GroupIdColumnProcessor
 from snuba.datasets.storages.user_column_processor import UserColumnProcessor
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
@@ -143,7 +142,6 @@ query_processors = [
     MappingColumnPromoter(mapping_specs={"tags": promoted_tag_columns}),
     UserColumnProcessor(),
     EventIdColumnProcessor(),
-    GroupIdColumnProcessor(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),
     PrewhereProcessor(prewhere_candidates, omit_if_final=["environment", "release"]),


### PR DESCRIPTION
We never have group IDs that are 0 in the errors table, so do not convert
to nullIf(group_id, 0)