### PR TITLE
ref: Send less data to Sentry

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -169,10 +169,6 @@ def callback_func(
 
             reason = assign_reason_category(result_data, primary_result_data, referrer)
 
-            # Avoid noise in Sentry
-            if reason == "NONDETERMINISTIC_QUERY":
-                continue
-
             metrics.increment(
                 "query_result",
                 tags={
@@ -185,6 +181,10 @@ def callback_func(
                     "consistent": str(consistent),
                 },
             )
+
+            # Avoid noise in Sentry
+            if reason == "NONDETERMINISTIC_QUERY":
+                continue
 
             if len(result_data) != len(primary_result_data):
                 sentry_sdk.capture_message(

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -163,10 +163,6 @@ def callback_func(
                 },
             )
         else:
-            # Do not log cache hits to Sentry as it creates too much noise
-            if cache_hit:
-                continue
-
             reason = assign_reason_category(result_data, primary_result_data, referrer)
 
             metrics.increment(
@@ -183,7 +179,7 @@ def callback_func(
             )
 
             # Avoid noise in Sentry
-            if reason == "NONDETERMINISTIC_QUERY":
+            if cache_hit or reason == "NONDETERMINISTIC_QUERY":
                 continue
 
             if len(result_data) != len(primary_result_data):

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -169,6 +169,10 @@ def callback_func(
 
             reason = assign_reason_category(result_data, primary_result_data, referrer)
 
+            # Avoid noise in Sentry
+            if reason == "NONDETERMINISTIC_QUERY":
+                continue
+
             metrics.increment(
                 "query_result",
                 tags={


### PR DESCRIPTION
Don't log the Snuplicator results of nondeterministic queries to Sentry
as this creates too much noise and there's not a lot we can do to change
this.