### PR TITLE
feat(errors): Add type optimization for errors storage

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -13,6 +13,7 @@ from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.datasets.errors_replacer import ReplacerState
 from snuba.datasets.storages.event_id_column_processor import EventIdColumnProcessor
 from snuba.datasets.storages.user_column_processor import UserColumnProcessor
+from snuba.datasets.storages.type_condition_optimizer import TypeConditionOptimizer
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
 )
@@ -143,6 +144,7 @@ query_processors = [
     MappingColumnPromoter(mapping_specs={"tags": promoted_tag_columns}),
     UserColumnProcessor(),
     EventIdColumnProcessor(),
+    TypeConditionOptimizer(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),
     PrewhereProcessor(prewhere_candidates, omit_if_final=["environment", "release"]),

--- a/snuba/datasets/storages/type_condition_optimizer.py
+++ b/snuba/datasets/storages/type_condition_optimizer.py
@@ -1,0 +1,36 @@
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+
+from snuba.query.expressions import Expression
+from snuba.query.expressions import Literal as LiteralExpr
+from snuba.query.matchers import (
+    Column,
+    FunctionCall,
+    Literal,
+    String,
+)
+
+from snuba.request.request_settings import RequestSettings
+
+
+class TypeConditionOptimizer(QueryProcessor):
+    """
+    Temporary processor that optimizes the type condition by stripping
+    any condition matching type != transaction on the errrors storage.
+    This condition will eventually be removed from all queries but is
+    required for compatibility with the events storage.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def replace_exp(exp: Expression) -> Expression:
+            matcher = FunctionCall(
+                String("notEquals"),
+                (Column(None, String("type")), Literal(String("transaction"))),
+            )
+
+            if matcher.match(exp):
+                return LiteralExpr(None, 1)
+
+            return exp
+
+        query.transform_expressions(replace_exp)

--- a/tests/query/processors/test_type_condition_optimizer.py
+++ b/tests/query/processors/test_type_condition_optimizer.py
@@ -1,0 +1,45 @@
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.query.conditions import (
+    ConditionFunctions,
+    binary_condition,
+    BooleanFunctions,
+)
+from snuba.query.data_source.simple import Table
+from snuba.datasets.storages.type_condition_optimizer import TypeConditionOptimizer
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.expressions import Column, Literal
+from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+
+
+def test_type_condition_optimizer() -> None:
+    cond1 = binary_condition(
+        ConditionFunctions.EQ, Column(None, None, "col1"), Literal(None, "val1")
+    )
+
+    unprocessed_query = Query(
+        Table("errors", ColumnSet([])),
+        condition=binary_condition(
+            BooleanFunctions.AND,
+            binary_condition(
+                ConditionFunctions.NEQ,
+                Column(None, None, "type"),
+                Literal(None, "transaction"),
+            ),
+            cond1,
+        ),
+    )
+    expected_query = Query(
+        Table("errors", ColumnSet([])),
+        condition=binary_condition(BooleanFunctions.AND, Literal(None, 1), cond1),
+    )
+    TypeConditionOptimizer().process_query(unprocessed_query, HTTPRequestSettings())
+
+    assert (
+        expected_query.get_condition_from_ast()
+        == unprocessed_query.get_condition_from_ast()
+    )
+    condition = unprocessed_query.get_condition_from_ast()
+    assert condition is not None
+    ret = condition.accept(ClickhouseExpressionFormatter())
+    assert ret == "1 AND equals(col1, 'val1')"


### PR DESCRIPTION
The expression `type != transaction` is frequently included in events entity queries
in order to filter rows because the events table includes transaction events.
Since the errors table never includes these events to begin with, this condition
will always be met. This optimizer rewrites `type != transaction` to `1` if it is
present when running the errors storage, so that the ClickHouse query does not need
to unnecessarily access the `type` column.

Once the errors storage is fully rolled out, Sentry queries will no longer include this
condition and this optimizer can be removed.