### PR TITLE
ref: Fix naming of query methods

### DIFF
--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -100,19 +100,13 @@ def _format_query_content(query: FormattableQuery) -> Sequence[FormattedNode]:
         for v in [
             _format_select(query, formatter),
             PaddingNode("FROM", DataSourceFormatter().visit(query.get_from_clause())),
-            _build_optional_string_node(
-                "ARRAY JOIN", query.get_arrayjoin_from_ast(), formatter
-            ),
+            _build_optional_string_node("ARRAY JOIN", query.get_arrayjoin(), formatter),
             _build_optional_string_node("PREWHERE", query.get_prewhere_ast(), formatter)
             if isinstance(query, Query)
             else None,
-            _build_optional_string_node(
-                "WHERE", query.get_condition_from_ast(), formatter
-            ),
+            _build_optional_string_node("WHERE", query.get_condition(), formatter),
             _format_groupby(query, formatter),
-            _build_optional_string_node(
-                "HAVING", query.get_having_from_ast(), formatter
-            ),
+            _build_optional_string_node("HAVING", query.get_having(), formatter),
             _format_orderby(query, formatter),
             _format_limitby(query, formatter),
             _format_limit(query, formatter),
@@ -125,7 +119,7 @@ def _format_select(
     query: AbstractQuery, formatter: ClickhouseExpressionFormatter
 ) -> StringNode:
     selected_cols = [
-        e.expression.accept(formatter) for e in query.get_selected_columns_from_ast()
+        e.expression.accept(formatter) for e in query.get_selected_columns()
     ]
     return StringNode(f"SELECT {', '.join(selected_cols)}")
 
@@ -146,7 +140,7 @@ def _format_groupby(
     query: AbstractQuery, formatter: ClickhouseExpressionFormatter
 ) -> Optional[StringNode]:
     group_clause: Optional[StringNode] = None
-    ast_groupby = query.get_groupby_from_ast()
+    ast_groupby = query.get_groupby()
     if ast_groupby:
         groupby_expressions = [e.accept(formatter) for e in ast_groupby]
         group_clause_str = f"{', '.join(groupby_expressions)}"
@@ -159,7 +153,7 @@ def _format_groupby(
 def _format_orderby(
     query: AbstractQuery, formatter: ClickhouseExpressionFormatter
 ) -> Optional[StringNode]:
-    ast_orderby = query.get_orderby_from_ast()
+    ast_orderby = query.get_orderby()
     if ast_orderby:
         orderby = [
             f"{e.expression.accept(formatter)} {e.direction.value}" for e in ast_orderby

--- a/snuba/clickhouse/query_dsl/accessors.py
+++ b/snuba/clickhouse/query_dsl/accessors.py
@@ -87,7 +87,7 @@ def get_project_ids_in_query_ast(
 
         return None
 
-    condition = query.get_condition_from_ast()
+    condition = query.get_condition()
     return get_project_ids_in_condition(condition) if condition is not None else None
 
 
@@ -144,7 +144,7 @@ def get_time_range(
     say anything on how that compares to the other timestamp conditions.
     """
 
-    condition_clause = query.get_condition_from_ast()
+    condition_clause = query.get_condition()
     if not condition_clause:
         return (None, None)
 

--- a/snuba/clickhouse/query_inspector.py
+++ b/snuba/clickhouse/query_inspector.py
@@ -24,7 +24,7 @@ def _get_date_range(query: ProcessableQuery[Table]) -> Optional[int]:
         (Column(None, Param("col_name", Any(str))), Literal(Any(datetime))),
     )
 
-    condition = query.get_condition_from_ast()
+    condition = query.get_condition()
     if condition is None:
         return None
     for exp in condition:
@@ -85,7 +85,7 @@ class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
         return self.__all_array_joins
 
     def __find_complex_conditions(self, query: ProcessableQuery[Table]) -> bool:
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         if condition is None:
             return False
         for c in condition:
@@ -107,7 +107,7 @@ class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
 
     def _list_array_join(self, query: ProcessableQuery[Table]) -> Set[Expression]:
         ret = set()
-        query_arrayjoin = query.get_arrayjoin_from_ast()
+        query_arrayjoin = query.get_arrayjoin()
         if query_arrayjoin is not None:
             ret.add(query_arrayjoin)
 
@@ -133,11 +133,11 @@ class TablesCollector(DataSourceVisitor[None, Table], JoinVisitor[None, Table]):
             c for c in data_source.get_all_ast_referenced_columns()
         }
 
-        condition = data_source.get_condition_from_ast()
+        condition = data_source.get_condition()
         if condition is not None:
             self.__all_conditions[table_name] = condition
 
-        self.__all_groupby[table_name] = set(data_source.get_groupby_from_ast())
+        self.__all_groupby[table_name] = set(data_source.get_groupby())
 
         self.__all_array_joins[table_name] = self._list_array_join(data_source)
 

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -66,7 +66,7 @@ def match_query_to_entity(
     query: Query, events_only_columns: ColumnSet, transactions_only_columns: ColumnSet,
 ) -> EntityKey:
     # First check for a top level condition on the event type
-    condition = query.get_condition_from_ast()
+    condition = query.get_condition()
     event_types = set()
     if condition:
         top_level_condition = get_first_level_and_conditions(condition)

--- a/snuba/datasets/entity.py
+++ b/snuba/datasets/entity.py
@@ -100,7 +100,7 @@ class Entity(ABC):
         if not self._required_filter_columns and not self._required_time_column:
             return None
 
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         top_level = get_first_level_and_conditions(condition) if condition else []
         alias_match = AnyOptionalString() if alias is None else StringMatch(alias)
 
@@ -196,7 +196,7 @@ class Entity(ABC):
 
             return exp
 
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         top_level = get_first_level_and_conditions(condition) if condition else []
         new_top_level = list(map(replace_cond, top_level))
         query.set_ast_condition(combine_and_conditions(new_top_level))

--- a/snuba/datasets/plans/translator/query.py
+++ b/snuba/datasets/plans/translator/query.py
@@ -15,12 +15,12 @@ def identity_translate(query: LogicalQuery) -> ClickhouseQuery:
     """
     return ClickhouseQuery(
         from_clause=None,
-        selected_columns=query.get_selected_columns_from_ast(),
-        array_join=query.get_arrayjoin_from_ast(),
-        condition=query.get_condition_from_ast(),
-        groupby=query.get_groupby_from_ast(),
-        having=query.get_having_from_ast(),
-        order_by=query.get_orderby_from_ast(),
+        selected_columns=query.get_selected_columns(),
+        array_join=query.get_arrayjoin(),
+        condition=query.get_condition(),
+        groupby=query.get_groupby(),
+        having=query.get_having(),
+        order_by=query.get_orderby(),
         limitby=query.get_limitby(),
         limit=query.get_limit(),
         offset=query.get_offset(),

--- a/snuba/pipeline/composite.py
+++ b/snuba/pipeline/composite.py
@@ -90,12 +90,12 @@ def _plan_composite_query(
         # have to restructure the query plan.
         query=CompositeQuery(
             from_clause=planned_data_source.translated_source,
-            selected_columns=query.get_selected_columns_from_ast(),
-            array_join=query.get_arrayjoin_from_ast(),
-            condition=query.get_condition_from_ast(),
-            groupby=query.get_groupby_from_ast(),
-            having=query.get_having_from_ast(),
-            order_by=query.get_orderby_from_ast(),
+            selected_columns=query.get_selected_columns(),
+            array_join=query.get_arrayjoin(),
+            condition=query.get_condition(),
+            groupby=query.get_groupby(),
+            having=query.get_having(),
+            order_by=query.get_orderby(),
             limitby=query.get_limitby(),
             limit=query.get_limit(),
             offset=query.get_offset(),

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -140,7 +140,7 @@ class Query(DataSource, ABC):
 
     # TODO: Run a codemod to remove the "from_ast" from all these
     # methods.
-    def get_selected_columns_from_ast(self) -> Sequence[SelectedExpression]:
+    def get_selected_columns(self) -> Sequence[SelectedExpression]:
         return self.__selected_columns
 
     def set_ast_selected_columns(
@@ -148,13 +148,13 @@ class Query(DataSource, ABC):
     ) -> None:
         self.__selected_columns = selected_columns
 
-    def get_groupby_from_ast(self) -> Sequence[Expression]:
+    def get_groupby(self) -> Sequence[Expression]:
         return self.__groupby
 
     def set_ast_groupby(self, groupby: Sequence[Expression]) -> None:
         self.__groupby = groupby
 
-    def get_condition_from_ast(self) -> Optional[Expression]:
+    def get_condition(self) -> Optional[Expression]:
         return self.__condition
 
     def set_ast_condition(self, condition: Optional[Expression]) -> None:
@@ -168,19 +168,19 @@ class Query(DataSource, ABC):
                 BooleanFunctions.AND, condition, self.__condition
             )
 
-    def get_arrayjoin_from_ast(self) -> Optional[Expression]:
+    def get_arrayjoin(self) -> Optional[Expression]:
         return self.__array_join
 
     def set_arrayjoin(self, arrayjoin: Optional[Expression]) -> None:
         self.__array_join = arrayjoin
 
-    def get_having_from_ast(self) -> Optional[Expression]:
+    def get_having(self) -> Optional[Expression]:
         return self.__having
 
     def set_ast_having(self, condition: Optional[Expression]) -> None:
         self.__having = condition
 
-    def get_orderby_from_ast(self) -> Sequence[OrderBy]:
+    def get_orderby(self) -> Sequence[OrderBy]:
         return self.__order_by
 
     def set_ast_orderby(self, orderby: Sequence[OrderBy]) -> None:
@@ -408,12 +408,12 @@ class Query(DataSource, ABC):
 
     def _eq_functions(self) -> Sequence[str]:
         return (
-            "get_selected_columns_from_ast",
-            "get_groupby_from_ast",
-            "get_condition_from_ast",
-            "get_arrayjoin_from_ast",
-            "get_having_from_ast",
-            "get_orderby_from_ast",
+            "get_selected_columns",
+            "get_groupby",
+            "get_condition",
+            "get_arrayjoin",
+            "get_having",
+            "get_orderby",
             "get_limitby",
             "get_limit",
             "get_offset",

--- a/snuba/query/formatters/tracing.py
+++ b/snuba/query/formatters/tracing.py
@@ -137,23 +137,21 @@ def _format_query_body(query: Query) -> Mapping[str, Any]:
     formatted = {
         "SELECT": [
             [e.name, e.expression.accept(expression_formatter)]
-            for e in query.get_selected_columns_from_ast()
+            for e in query.get_selected_columns()
         ],
-        "GROUPBY": [
-            e.accept(expression_formatter) for e in query.get_groupby_from_ast()
-        ],
+        "GROUPBY": [e.accept(expression_formatter) for e in query.get_groupby()],
         "ORDERBY": [
             [e.expression.accept(expression_formatter), e.direction]
-            for e in query.get_orderby_from_ast()
+            for e in query.get_orderby()
         ],
     }
-    array_join = query.get_arrayjoin_from_ast()
+    array_join = query.get_arrayjoin()
     if array_join:
         formatted["ARRAYJOIN"] = array_join.accept(expression_formatter)
-    condition = query.get_condition_from_ast()
+    condition = query.get_condition()
     if condition:
         formatted["WHERE"] = condition.accept(expression_formatter)
-    having = query.get_having_from_ast()
+    having = query.get_having()
     if having:
         formatted["HAVING"] = having.accept(expression_formatter)
     limitby = query.get_limitby()

--- a/snuba/query/joins/equivalence_adder.py
+++ b/snuba/query/joins/equivalence_adder.py
@@ -56,7 +56,7 @@ def add_equivalent_conditions(query: CompositeQuery[Entity]) -> None:
         entity_to_alias.setdefault(entity, set()).add(alias)
 
     column_equivalence = get_equivalent_columns(from_clause)
-    condition = query.get_condition_from_ast()
+    condition = query.get_condition()
     if condition is None:
         return
 

--- a/snuba/query/joins/subquery_generator.py
+++ b/snuba/query/joins/subquery_generator.py
@@ -239,15 +239,15 @@ def generate_subqueries(query: CompositeQuery[Entity]) -> None:
                 name=s.name,
                 expression=_process_root(s.expression, subqueries, alias_generator),
             )
-            for s in query.get_selected_columns_from_ast()
+            for s in query.get_selected_columns()
         ]
     )
 
-    array_join = query.get_arrayjoin_from_ast()
+    array_join = query.get_arrayjoin()
     if array_join is not None:
         query.set_arrayjoin(_process_root(array_join, subqueries, alias_generator))
 
-    ast_condition = query.get_condition_from_ast()
+    ast_condition = query.get_condition()
     if ast_condition is not None:
         main_conditions = []
         for c in get_first_level_and_conditions(ast_condition):
@@ -277,13 +277,10 @@ def generate_subqueries(query: CompositeQuery[Entity]) -> None:
 
     # TODO: push down the group by when it is the same as the join key.
     query.set_ast_groupby(
-        [
-            _process_root(e, subqueries, alias_generator)
-            for e in query.get_groupby_from_ast()
-        ]
+        [_process_root(e, subqueries, alias_generator) for e in query.get_groupby()]
     )
 
-    having = query.get_having_from_ast()
+    having = query.get_having()
     if having is not None:
         query.set_ast_having(
             combine_and_conditions(
@@ -302,7 +299,7 @@ def generate_subqueries(query: CompositeQuery[Entity]) -> None:
                     orderby.expression, subqueries, alias_generator
                 ),
             )
-            for orderby in query.get_orderby_from_ast()
+            for orderby in query.get_orderby()
         ]
     )
 

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -406,7 +406,7 @@ def _mangle_aliases(query: Union[CompositeQuery[QueryEntity], Query]) -> None:
 
     # HACK: This reverts the mangle of arrayjoin since we cannot reference aliases
     # there
-    arrayjoin = query.get_arrayjoin_from_ast()
+    arrayjoin = query.get_arrayjoin()
 
     def transform_arrayjoin(expr: Expression) -> Expression:
         if isinstance(expr, Column):
@@ -420,7 +420,7 @@ def _mangle_aliases(query: Union[CompositeQuery[QueryEntity], Query]) -> None:
 def _validate_arrayjoin(query: Union[CompositeQuery[QueryEntity], Query]) -> None:
     # TODO: Actually validate arrayjoin. For now log how it is used.
     body_arrayjoin = ""
-    arrayjoin = query.get_arrayjoin_from_ast()
+    arrayjoin = query.get_arrayjoin()
     if arrayjoin is not None:
         if isinstance(arrayjoin, Column):
             body_arrayjoin = arrayjoin.column_name
@@ -467,10 +467,7 @@ def _deescape_aliases(query: Union[CompositeQuery[QueryEntity], Query]) -> None:
     query.transform_expressions(lambda expr: replace(expr, alias=deescape(expr.alias)))
 
     query.set_ast_selected_columns(
-        [
-            replace(s, name=deescape(s.name))
-            for s in query.get_selected_columns_from_ast() or []
-        ]
+        [replace(s, name=deescape(s.name)) for s in query.get_selected_columns() or []]
     )
 
 

--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -90,14 +90,14 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> Set[str]:
     """
     array_join_found = any(
         array_join_pattern(column_name).match(f) is not None
-        for selected in query.get_selected_columns_from_ast() or []
+        for selected in query.get_selected_columns() or []
         for f in selected.expression
     )
 
     if not array_join_found:
         return set()
 
-    ast_condition = query.get_condition_from_ast()
+    ast_condition = query.get_condition()
     cond_keys = (
         _get_mapping_keys_in_condition(ast_condition, column_name)
         if ast_condition is not None
@@ -108,7 +108,7 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> Set[str]:
         # be cases where this condition is still optimizable.
         return set()
 
-    ast_having = query.get_having_from_ast()
+    ast_having = query.get_having()
     having_keys = (
         _get_mapping_keys_in_condition(ast_having, column_name)
         if ast_having is not None

--- a/snuba/query/processors/mapping_optimizer.py
+++ b/snuba/query/processors/mapping_optimizer.py
@@ -164,14 +164,14 @@ class MappingOptimizer(QueryProcessor):
             return
 
         cond_class = ConditionClass.IRRELEVANT
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         if condition is not None:
             cond_class = self.__classify_combined_conditions(condition)
             if cond_class == ConditionClass.NOT_OPTIMIZABLE:
                 return
 
         having_cond_class = ConditionClass.IRRELEVANT
-        having_cond = query.get_having_from_ast()
+        having_cond = query.get_having()
         if having_cond is not None:
             having_cond_class = self.__classify_combined_conditions(having_cond)
             if having_cond_class == ConditionClass.NOT_OPTIMIZABLE:

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -66,7 +66,7 @@ class PrewhereProcessor(QueryProcessor):
         if not prewhere_keys:
             return
 
-        ast_condition = query.get_condition_from_ast()
+        ast_condition = query.get_condition()
         if ast_condition is None:
             return
 

--- a/snuba/query/processors/timeseries_processor.py
+++ b/snuba/query/processors/timeseries_processor.py
@@ -182,7 +182,7 @@ class TimeSeriesProcessor(QueryProcessor):
 
         # Now that all the column names are correct, search the conditions for time based
         # conditions and make sure the comparison is with a datetime
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         if condition:
             query.set_ast_condition(condition.transform(self.__process_condition))
 
@@ -199,7 +199,7 @@ def extract_granularity_from_query(query: Query, column: str) -> Optional[int]:
     This extracts the `granularity` from the `groupby` statement of the query.
     The matches are essentially the reverse of `TimeSeriesProcessor.__group_time_function`.
     """
-    groupby = query.get_groupby_from_ast()
+    groupby = query.get_groupby()
 
     column_match = ColumnMatch(None, String(column))
     fn_match = FunctionCallMatch(

--- a/snuba/query/processors/typed_context_promoter.py
+++ b/snuba/query/processors/typed_context_promoter.py
@@ -148,7 +148,7 @@ class TypedContextPromoter(QueryProcessor):
 
             return exp
 
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         if condition is None:
             return
 

--- a/snuba/query/processors/uuid_column_processor.py
+++ b/snuba/query/processors/uuid_column_processor.py
@@ -150,7 +150,7 @@ class UUIDColumnProcessor(QueryProcessor):
         return exp
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
-        condition = query.get_condition_from_ast()
+        condition = query.get_condition()
         if condition:
             query.set_ast_condition(condition.transform(self.process_condition))
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -141,7 +141,7 @@ def _run_and_apply_column_names(
     )
 
     alias_name_mapping: MutableMapping[str, str] = {}
-    for select_col in clickhouse_query.get_selected_columns_from_ast():
+    for select_col in clickhouse_query.get_selected_columns():
         alias = select_col.expression.alias
         name = select_col.name
         if alias is None or name is None:

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -58,7 +58,7 @@ def _replace_ast_condition(
             )
         )
 
-    condition = query.get_condition_from_ast()
+    condition = query.get_condition()
     if condition is not None:
         query.set_ast_condition(
             combine_and_conditions(
@@ -94,13 +94,13 @@ class TimeSplitQueryStrategy(QuerySplitStrategy):
         avoid querying the entire range.
         """
         limit = query.get_limit()
-        if limit is None or query.get_groupby_from_ast():
+        if limit is None or query.get_groupby():
             return None
 
         if query.get_offset() >= 1000:
             return None
 
-        orderby = query.get_orderby_from_ast()
+        orderby = query.get_orderby()
         if (
             not orderby
             or orderby[0].direction != OrderByDirection.DESC
@@ -211,8 +211,8 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
         if (
             limit is None
             or limit == 0
-            or query.get_groupby_from_ast()
-            or not query.get_selected_columns_from_ast()
+            or query.get_groupby()
+            or not query.get_selected_columns()
         ):
             return None
 
@@ -226,7 +226,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             (Column(None, String(self.__id_column)), AnyExpression(),),
         )
 
-        for expr in query.get_condition_from_ast() or []:
+        for expr in query.get_condition() or []:
             match = id_column_matcher.match(expr)
 
             if match:

--- a/tests/datasets/plans/translator/test_mapping.py
+++ b/tests/datasets/plans/translator/test_mapping.py
@@ -198,12 +198,9 @@ def test_translation(
 
     # TODO: consider providing an __eq__ method to the Query class. Or turn it into
     # a dataclass.
-    assert (
-        expected.get_selected_columns_from_ast()
-        == translated.get_selected_columns_from_ast()
-    )
-    assert expected.get_groupby_from_ast() == translated.get_groupby_from_ast()
-    assert expected.get_condition_from_ast() == translated.get_condition_from_ast()
-    assert expected.get_arrayjoin_from_ast() == translated.get_arrayjoin_from_ast()
-    assert expected.get_having_from_ast() == translated.get_having_from_ast()
-    assert expected.get_orderby_from_ast() == translated.get_orderby_from_ast()
+    assert expected.get_selected_columns() == translated.get_selected_columns()
+    assert expected.get_groupby() == translated.get_groupby()
+    assert expected.get_condition() == translated.get_condition()
+    assert expected.get_arrayjoin() == translated.get_arrayjoin()
+    assert expected.get_having() == translated.get_having()
+    assert expected.get_orderby() == translated.get_orderby()

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -46,7 +46,7 @@ def test_with_turbo(query: ClickhouseQuery) -> None:
         query, HTTPRequestSettings(turbo=True)
     )
 
-    assert query.get_condition_from_ast() == build_in("project_id", [2])
+    assert query.get_condition() == build_in("project_id", [2])
 
 
 def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> None:
@@ -56,7 +56,7 @@ def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> No
         "project_id", ReplacerState.EVENTS
     ).process_query(query, HTTPRequestSettings())
 
-    assert query.get_condition_from_ast() == build_in("project_id", [2])
+    assert query.get_condition() == build_in("project_id", [2])
     assert query.get_from_clause().final
 
 
@@ -65,7 +65,7 @@ def test_without_turbo_without_projects_needing_final(query: ClickhouseQuery) ->
         query, HTTPRequestSettings()
     )
 
-    assert query.get_condition_from_ast() == build_in("project_id", [2])
+    assert query.get_condition() == build_in("project_id", [2])
     assert not query.get_from_clause().final
 
 
@@ -77,7 +77,7 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
         "project_id", ReplacerState.EVENTS
     ).process_query(query, HTTPRequestSettings())
 
-    assert query.get_condition_from_ast() == FunctionCall(
+    assert query.get_condition() == FunctionCall(
         None,
         BooleanFunctions.AND,
         (
@@ -109,5 +109,5 @@ def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
         "project_id", ReplacerState.EVENTS
     ).process_query(query, HTTPRequestSettings())
 
-    assert query.get_condition_from_ast() == build_in("project_id", [2])
+    assert query.get_condition() == build_in("project_id", [2])
     assert query.get_from_clause().final

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -29,7 +29,7 @@ def test_events_processing() -> None:
         else:
             transaction_col_name = "transaction_name"
 
-        assert query.get_selected_columns_from_ast() == [
+        assert query.get_selected_columns() == [
             SelectedExpression(
                 "tags[transaction]",
                 Column("_snuba_tags[transaction]", None, transaction_col_name),

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -26,7 +26,7 @@ def test_sessions_processing() -> None:
         quantiles = tuple(
             Literal(None, quant) for quant in [0.5, 0.75, 0.9, 0.95, 0.99, 1]
         )
-        assert query.get_selected_columns_from_ast() == [
+        assert query.get_selected_columns() == [
             SelectedExpression(
                 "duration_quantiles",
                 CurriedFunctionCall(

--- a/tests/query/joins/test_equivalence_adder.py
+++ b/tests/query/joins/test_equivalence_adder.py
@@ -271,6 +271,6 @@ def test_add_equivalent_condition(
         condition=initial_condition,
     )
     add_equivalent_conditions(query)
-    assert query.get_condition_from_ast() == expected_expr
+    assert query.get_condition() == expected_expr
 
     ENTITY_IMPL.clear()

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -80,12 +80,9 @@ def test_apdex_format_expressions() -> None:
     )
 
     apdex_processor(ColumnSet([])).process_query(unprocessed, HTTPRequestSettings())
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
-    ret = unprocessed.get_selected_columns_from_ast()[1].expression.accept(
+    ret = unprocessed.get_selected_columns()[1].expression.accept(
         ClickhouseExpressionFormatter()
     )
     assert ret == (

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -353,12 +353,9 @@ def test_tags_processor(
     Tests the whole processing in some notable cases.
     """
     processed = parse_and_process(query_body)
-    assert (
-        processed.get_selected_columns_from_ast()
-        == expected_query.get_selected_columns_from_ast()
-    )
-    assert processed.get_condition_from_ast() == expected_query.get_condition_from_ast()
-    assert processed.get_having_from_ast() == expected_query.get_having_from_ast()
+    assert processed.get_selected_columns() == expected_query.get_selected_columns()
+    assert processed.get_condition() == expected_query.get_condition()
+    assert processed.get_having() == expected_query.get_having()
 
 
 def test_formatting() -> None:

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -87,7 +87,4 @@ def test_events_boolean_context() -> None:
     ).process_query(query, settings)
     EventsBooleanContextsProcessor().process_query(query, settings)
 
-    assert (
-        query.get_selected_columns_from_ast()
-        == expected.get_selected_columns_from_ast()
-    )
+    assert query.get_selected_columns() == expected.get_selected_columns()

--- a/tests/query/processors/test_custom_function.py
+++ b/tests/query/processors/test_custom_function.py
@@ -146,15 +146,12 @@ def test_format_expressions(query: Query, expected_query: Query) -> None:
     # We cannot just run == on the query objects. The content of the two
     # objects is different, being one the AST and the ont the AST + raw body
     processor.process_query(query, HTTPRequestSettings())
-    assert (
-        query.get_selected_columns_from_ast()
-        == expected_query.get_selected_columns_from_ast()
-    )
-    assert query.get_groupby_from_ast() == expected_query.get_groupby_from_ast()
-    assert query.get_condition_from_ast() == expected_query.get_condition_from_ast()
-    assert query.get_arrayjoin_from_ast() == expected_query.get_arrayjoin_from_ast()
-    assert query.get_having_from_ast() == expected_query.get_having_from_ast()
-    assert query.get_orderby_from_ast() == expected_query.get_orderby_from_ast()
+    assert query.get_selected_columns() == expected_query.get_selected_columns()
+    assert query.get_groupby() == expected_query.get_groupby()
+    assert query.get_condition() == expected_query.get_condition()
+    assert query.get_arrayjoin() == expected_query.get_arrayjoin()
+    assert query.get_having() == expected_query.get_having()
+    assert query.get_orderby() == expected_query.get_orderby()
 
 
 INVALID_QUERIES = [

--- a/tests/query/processors/test_events_column_processor.py
+++ b/tests/query/processors/test_events_column_processor.py
@@ -36,16 +36,13 @@ def test_events_column_format_expressions() -> None:
     )
 
     GroupIdColumnProcessor().process_query(unprocessed, HTTPRequestSettings())
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
     expected = (
         "(nullIf(group_id, 0) AS the_group_id)",
         "(message AS the_message)",
     )
 
-    for idx, column in enumerate(unprocessed.get_selected_columns_from_ast()[1:]):
+    for idx, column in enumerate(unprocessed.get_selected_columns()[1:]):
         formatted = column.expression.accept(ClickhouseExpressionFormatter())
         assert expected[idx] == formatted

--- a/tests/query/processors/test_failure_rate.py
+++ b/tests/query/processors/test_failure_rate.py
@@ -56,12 +56,9 @@ def test_failure_rate_format_expressions() -> None:
     failure_rate_processor(ColumnSet([])).process_query(
         unprocessed, HTTPRequestSettings()
     )
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
-    ret = unprocessed.get_selected_columns_from_ast()[1].expression.accept(
+    ret = unprocessed.get_selected_columns()[1].expression.accept(
         ClickhouseExpressionFormatter()
     )
     assert ret == (

--- a/tests/query/processors/test_functions_processor.py
+++ b/tests/query/processors/test_functions_processor.py
@@ -174,9 +174,6 @@ test_data = [
 def test_format_expressions(pre_format: Query, expected_query: Query) -> None:
     copy = deepcopy(pre_format)
     BasicFunctionsProcessor().process_query(copy, HTTPRequestSettings())
-    assert (
-        copy.get_selected_columns_from_ast()
-        == expected_query.get_selected_columns_from_ast()
-    )
-    assert copy.get_groupby_from_ast() == expected_query.get_groupby_from_ast()
-    assert copy.get_condition_from_ast() == expected_query.get_condition_from_ast()
+    assert copy.get_selected_columns() == expected_query.get_selected_columns()
+    assert copy.get_groupby() == expected_query.get_groupby()
+    assert copy.get_condition() == expected_query.get_condition()

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -64,12 +64,9 @@ def test_handled_processor() -> None:
     )
     processor.process_query(unprocessed, HTTPRequestSettings())
 
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
-    ret = unprocessed.get_selected_columns_from_ast()[1].expression.accept(
+    ret = unprocessed.get_selected_columns()[1].expression.accept(
         ClickhouseExpressionFormatter()
     )
     assert ret == (
@@ -143,12 +140,9 @@ def test_not_handled_processor() -> None:
     )
     processor.process_query(unprocessed, HTTPRequestSettings())
 
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
-    ret = unprocessed.get_selected_columns_from_ast()[1].expression.accept(
+    ret = unprocessed.get_selected_columns()[1].expression.accept(
         ClickhouseExpressionFormatter()
     )
     assert ret == (

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -77,4 +77,4 @@ def test_mand_conditions(table: str, mand_conditions: List[FunctionCall]) -> Non
 
     query_ast_copy.add_condition_to_ast(combine_and_conditions(mand_conditions))
 
-    assert query.get_condition_from_ast() == query_ast_copy.get_condition_from_ast()
+    assert query.get_condition() == query_ast_copy.get_condition()

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -196,4 +196,4 @@ def test_tags_hash_map(query: ClickhouseQuery, expected_condition: Expression,) 
         killswitch="tags_hash_map_enabled",
     ).process_query(query, HTTPRequestSettings())
 
-    assert query.get_condition_from_ast() == expected_condition
+    assert query.get_condition() == expected_condition

--- a/tests/query/processors/test_mapping_promoter.py
+++ b/tests/query/processors/test_mapping_promoter.py
@@ -110,7 +110,4 @@ def test_format_expressions(
         query, HTTPRequestSettings()
     )
 
-    assert (
-        query.get_selected_columns_from_ast()
-        == expected_query.get_selected_columns_from_ast()
-    )
+    assert query.get_selected_columns() == expected_query.get_selected_columns()

--- a/tests/query/processors/test_pattern_replacer.py
+++ b/tests/query/processors/test_pattern_replacer.py
@@ -80,7 +80,4 @@ def test_pattern_replacer_format_expressions(
     PatternReplacer(
         Param("column", ColumnMatch(None, StringMatch("column1"))), transform,
     ).process_query(unprocessed, HTTPRequestSettings())
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -193,5 +193,5 @@ def test_prewhere(
     processor = PrewhereProcessor(keys, omit_if_final=omit_if_final_keys)
     processor.process_query(query, request_settings)
 
-    assert query.get_condition_from_ast() == new_ast_condition
+    assert query.get_condition() == new_ast_condition
     assert query.get_prewhere_ast() == new_prewhere_ast_condition

--- a/tests/query/processors/test_tags_expander.py
+++ b/tests/query/processors/test_tags_expander.py
@@ -28,7 +28,7 @@ def test_tags_expander() -> None:
     request_settings = HTTPRequestSettings()
     processor.process_query(query, request_settings)
 
-    assert query.get_selected_columns_from_ast() == [
+    assert query.get_selected_columns() == [
         SelectedExpression(
             "platforms",
             FunctionCall(
@@ -70,13 +70,13 @@ def test_tags_expander() -> None:
         SelectedExpression("f2_alias", FunctionCall("_snuba_f2_alias", "f2", tuple())),
     ]
 
-    assert query.get_condition_from_ast() == binary_condition(
+    assert query.get_condition() == binary_condition(
         OPERATOR_TO_FUNCTION["="],
         FunctionCall("_snuba_tags_key", "arrayJoin", (Column(None, None, "tags.key"),)),
         Literal(None, "tags_key"),
     )
 
-    assert query.get_having_from_ast() == in_condition(
+    assert query.get_having() == in_condition(
         FunctionCall(
             "_snuba_tags_value", "arrayJoin", (Column(None, None, "tags.value"),)
         ),

--- a/tests/query/processors/test_timeseries_processor.py
+++ b/tests/query/processors/test_timeseries_processor.py
@@ -175,20 +175,15 @@ def test_timeseries_format_expressions(
         if isinstance(processor, TimeSeriesProcessor):
             processor.process_query(unprocessed, HTTPRequestSettings())
 
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
-    assert expected.get_condition_from_ast() == unprocessed.get_condition_from_ast()
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
+    assert expected.get_condition() == unprocessed.get_condition()
 
-    ret = unprocessed.get_selected_columns_from_ast()[1].expression.accept(
+    ret = unprocessed.get_selected_columns()[1].expression.accept(
         ClickhouseExpressionFormatter()
     )
     assert ret == formatted_column
     if condition:
-        ret = unprocessed.get_condition_from_ast().accept(
-            ClickhouseExpressionFormatter()
-        )
+        ret = unprocessed.get_condition().accept(ClickhouseExpressionFormatter())
         assert formatted_condition == ret
 
     assert extract_granularity_from_query(unprocessed, "finish_ts") == granularity

--- a/tests/query/processors/test_transaction_column_processor.py
+++ b/tests/query/processors/test_transaction_column_processor.py
@@ -44,12 +44,9 @@ def test_event_id_column_format_expressions() -> None:
     )
 
     EventIdColumnProcessor().process_query(unprocessed, HTTPRequestSettings())
-    assert (
-        expected.get_selected_columns_from_ast()
-        == unprocessed.get_selected_columns_from_ast()
-    )
+    assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
-    formatted = unprocessed.get_selected_columns_from_ast()[1].expression.accept(
+    formatted = unprocessed.get_selected_columns()[1].expression.accept(
         ClickhouseExpressionFormatter()
     )
     assert formatted == "(replaceAll(toString(event_id), '-', '') AS the_event_id)"

--- a/tests/query/processors/test_type_condition_optimizer.py
+++ b/tests/query/processors/test_type_condition_optimizer.py
@@ -35,11 +35,8 @@ def test_type_condition_optimizer() -> None:
     )
     TypeConditionOptimizer().process_query(unprocessed_query, HTTPRequestSettings())
 
-    assert (
-        expected_query.get_condition_from_ast()
-        == unprocessed_query.get_condition_from_ast()
-    )
-    condition = unprocessed_query.get_condition_from_ast()
+    assert expected_query.get_condition() == unprocessed_query.get_condition()
+    condition = unprocessed_query.get_condition()
     assert condition is not None
     ret = condition.accept(ClickhouseExpressionFormatter())
     assert ret == "1 AND equals(col1, 'val1')"

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -284,11 +284,8 @@ def test_uuid_column_processor(
     UUIDColumnProcessor(set(["column1", "column2"])).process_query(
         unprocessed_query, HTTPRequestSettings()
     )
-    assert (
-        expected_query.get_condition_from_ast()
-        == unprocessed_query.get_condition_from_ast()
-    )
-    condition = unprocessed_query.get_condition_from_ast()
+    assert expected_query.get_condition() == unprocessed_query.get_condition()
+    condition = unprocessed_query.get_condition()
     assert condition is not None
     ret = condition.accept(ClickhouseExpressionFormatter())
     assert ret == formatted_value

--- a/tests/query/test_organization_extension.py
+++ b/tests/query/test_organization_extension.py
@@ -21,7 +21,7 @@ def test_organization_extension_query_processing_happy_path() -> None:
     request_settings = HTTPRequestSettings()
 
     extension.get_processor().process_query(query, valid_data, request_settings)
-    assert query.get_condition_from_ast() == binary_condition(
+    assert query.get_condition() == binary_condition(
         ConditionFunctions.EQ, Column("_snuba_org_id", None, "org_id"), Literal(None, 2)
     )
 

--- a/tests/query/test_project_extension.py
+++ b/tests/query/test_project_extension.py
@@ -50,7 +50,7 @@ def test_project_extension_query_processing(
     request_settings = HTTPRequestSettings()
 
     extension.get_processor().process_query(query, valid_data, request_settings)
-    assert query.get_condition_from_ast() == expected_ast_conditions
+    assert query.get_condition() == expected_ast_conditions
 
 
 def test_project_extension_query_adds_rate_limits() -> None:

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -127,14 +127,11 @@ def test_replace_expression() -> None:
         order_by=[orderby],
     )
 
-    assert (
-        query.get_selected_columns_from_ast()
-        == expected_query.get_selected_columns_from_ast()
-    )
-    assert query.get_condition_from_ast() == expected_query.get_condition_from_ast()
-    assert query.get_groupby_from_ast() == expected_query.get_groupby_from_ast()
-    assert query.get_having_from_ast() == expected_query.get_having_from_ast()
-    assert query.get_orderby_from_ast() == expected_query.get_orderby_from_ast()
+    assert query.get_selected_columns() == expected_query.get_selected_columns()
+    assert query.get_condition() == expected_query.get_condition()
+    assert query.get_groupby() == expected_query.get_groupby()
+    assert query.get_having() == expected_query.get_having()
+    assert query.get_orderby() == expected_query.get_orderby()
 
     assert list(query.get_all_expressions()) == list(
         expected_query.get_all_expressions()

--- a/tests/query/test_timeseries_extension.py
+++ b/tests/query/test_timeseries_extension.py
@@ -94,5 +94,5 @@ def test_query_extension_processing(
     request_settings = HTTPRequestSettings()
 
     extension.get_processor().process_query(query, valid_data, request_settings)
-    assert query.get_condition_from_ast() == expected_ast_condition
+    assert query.get_condition() == expected_ast_condition
     assert query.get_granularity() == expected_granularity

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -117,7 +117,7 @@ def test_col_split(
     ) -> QueryResult:
         selected_col_names = [
             c.expression.column_name
-            for c in query.get_selected_columns_from_ast() or []
+            for c in query.get_selected_columns() or []
             if isinstance(c.expression, Column)
         ]
         if selected_col_names == list(first_query_data[0].keys()):


### PR DESCRIPTION
Drop the `_from_ast` suffixes that are present on some of the query methods
as these are unnescessary and inconsistent with the rest of the methods that
do not have this suffix.