### PR TITLE
test: Fix the composite planner test so it also works on errors storage

### DIFF
--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -342,7 +342,9 @@ TEST_CASES = [
                                         Column(None, None, "group_id"),
                                         Literal(None, 0),
                                     ),
-                                ),
+                                )
+                                if events_storage.get_storage_key() == StorageKey.EVENTS
+                                else Column("_snuba_group_id", None, "group_id"),
                             ),
                             SelectedExpression(
                                 "f_release",


### PR DESCRIPTION
The errors storage doesn't apply the group ID processor so the generated
query after processing is slightly different.