### PR TITLE
feat: Improve UUID processing so it can be extended to other columns

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -10,7 +10,6 @@ from snuba.clickhouse.columns import (
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
 from snuba.datasets.errors_replacer import ReplacerState
-from snuba.datasets.storages.event_id_column_processor import EventIdColumnProcessor
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
 )
@@ -24,7 +23,7 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.processors.uuid_column_processor import UUIDColumnProcessor
+from snuba.query.processors.uuid_column_processor import BetterUUIDColumnProcessor
 from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 required_columns = [
@@ -143,11 +142,10 @@ query_processors = [
     ),
     MappingColumnPromoter(mapping_specs={"tags": promoted_tag_columns}),
     UserColumnProcessor(),
-    EventIdColumnProcessor(),
+    BetterUUIDColumnProcessor({"event_id"}),
     TypeConditionOptimizer(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),
-    UUIDColumnProcessor(set(["event_id"])),
     PrewhereProcessor(prewhere_candidates, omit_if_final=["environment", "release"]),
 ]
 

--- a/snuba/query/processors/uuid_column_processor.py
+++ b/snuba/query/processors/uuid_column_processor.py
@@ -39,7 +39,7 @@ class BetterUUIDColumnProcessor(QueryProcessor):
 
     def __init__(self, uuid_columns: Set[str]) -> None:
         self.__uuid_columns = uuid_columns
-        self.__uuid_column_match = Or([String(col) for col in uuid_columns])
+        uuid_column_match = Or([String(col) for col in uuid_columns])
 
         operator = Param(
             "operator",
@@ -62,7 +62,7 @@ class BetterUUIDColumnProcessor(QueryProcessor):
             (
                 FunctionCallMatch(
                     String("toString"),
-                    (Param("col", ColumnMatch(None, self.__uuid_column_match)),),
+                    (Param("col", ColumnMatch(None, uuid_column_match)),),
                 ),
             ),
             with_optionals=True,

--- a/snuba/query/processors/uuid_column_processor.py
+++ b/snuba/query/processors/uuid_column_processor.py
@@ -15,6 +15,7 @@ from snuba.query.matchers import (
     Param,
     String,
 )
+from snuba.query.matchers import Any as AnyMatch
 from snuba.query.matchers import Column as ColumnMatch
 from snuba.query.matchers import FunctionCall as FunctionCallMatch
 from snuba.query.matchers import Literal as LiteralMatch
@@ -24,6 +25,141 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 
 
 metrics = MetricsWrapper(environment.metrics, "api.query.uuid_processor")
+
+
+class UUIDTranslationError(Exception):
+    pass
+
+
+class BetterUUIDColumnProcessor(QueryProcessor):
+    """
+    Processor that handles columns which are stored as UUID in ClickHouse but
+    are represented externally as a non hyphenated hex string.
+    """
+
+    def __init__(self, uuid_columns: Set[str]) -> None:
+        self.__uuid_columns = uuid_columns
+        self.__uuid_column_match = Or([String(col) for col in uuid_columns])
+
+        operator = Param(
+            "operator",
+            Or(
+                [
+                    String(op)
+                    for op in FUNCTION_TO_OPERATOR
+                    if op not in (ConditionFunctions.IN, ConditionFunctions.NOT_IN)
+                ]
+            ),
+        )
+
+        in_operators = Param(
+            "operator",
+            Or((String(ConditionFunctions.IN), String(ConditionFunctions.NOT_IN))),
+        )
+
+        col_func = FunctionCallMatch(
+            String("replaceAll"),
+            (
+                FunctionCallMatch(
+                    String("toString"),
+                    (Param("col", ColumnMatch(None, self.__uuid_column_match)),),
+                ),
+            ),
+            with_optionals=True,
+        )
+
+        literal = Param("literal", LiteralMatch(AnyMatch(str)))
+
+        self.__condition_matcher = Or(
+            [
+                FunctionCallMatch(operator, (literal, col_func)),
+                FunctionCallMatch(operator, (col_func, literal)),
+            ]
+        )
+
+        self.__in_condition_matcher = FunctionCallMatch(
+            in_operators,
+            (col_func, Param("tuple", FunctionCallMatch(String("tuple"), None)),),
+        )
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def translate_uuid_literal(exp: Expression) -> Expression:
+            try:
+                assert isinstance(exp, Literal)
+                new_val = str(uuid.UUID(str(exp.value)))
+                return Literal(alias=exp.alias, value=new_val)
+            except (AssertionError, ValueError):
+                raise UUIDTranslationError("Not a valid UUID string")
+
+        def process_condition(exp: Expression) -> Expression:
+            match = self.__condition_matcher.match(exp)
+
+            if match:
+                try:
+                    return FunctionCall(
+                        exp.alias,
+                        match.string("operator"),
+                        (
+                            match.expression("col"),
+                            translate_uuid_literal(match.expression("literal")),
+                        ),
+                    )
+                except UUIDTranslationError:
+                    # We probably won't get to this point since we should have validations earlier
+                    # in the pipeline, but just in case return 0 otherwise the query is going to
+                    # cause a type mismatch on ClickHouse
+                    return Literal(exp.alias, 0)
+
+            in_condition_match = self.__in_condition_matcher.match(exp)
+
+            if in_condition_match:
+                try:
+                    tuple_func = in_condition_match.expression("tuple")
+                    assert isinstance(tuple_func, FunctionCall)
+                    new_tuple_func = FunctionCall(
+                        tuple_func.alias,
+                        tuple_func.function_name,
+                        parameters=tuple(
+                            [
+                                translate_uuid_literal(lit)
+                                for lit in tuple_func.parameters
+                            ]
+                        ),
+                    )
+                    return FunctionCall(
+                        exp.alias,
+                        in_condition_match.string("operator"),
+                        (in_condition_match.expression("col"), new_tuple_func,),
+                    )
+                except UUIDTranslationError:
+                    return Literal(exp.alias, 0)
+
+            return exp
+
+        def process_all(exp: Expression) -> Expression:
+            if isinstance(exp, Column):
+                if exp.column_name in self.__uuid_columns:
+                    return FunctionCall(
+                        exp.alias,
+                        "replaceAll",
+                        (
+                            FunctionCall(
+                                None,
+                                "toString",
+                                (Column(None, None, exp.column_name),),
+                            ),
+                            Literal(None, "-"),
+                            Literal(None, ""),
+                        ),
+                    )
+
+            return exp
+
+        query.transform_expressions(process_all)
+
+        condition = query.get_condition()
+        if condition:
+            query.set_ast_condition(condition.transform(process_condition))
 
 
 class UUIDColumnProcessor(QueryProcessor):

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -12,7 +12,10 @@ from snuba.query.conditions import (
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.clickhouse.query import Query
-from snuba.query.processors.uuid_column_processor import UUIDColumnProcessor
+from snuba.query.processors.uuid_column_processor import (
+    UUIDColumnProcessor,
+    BetterUUIDColumnProcessor,
+)
 from snuba.request.request_settings import HTTPRequestSettings
 
 
@@ -284,6 +287,192 @@ def test_uuid_column_processor(
     UUIDColumnProcessor(set(["column1", "column2"])).process_query(
         unprocessed_query, HTTPRequestSettings()
     )
+    assert expected_query.get_condition() == unprocessed_query.get_condition()
+    condition = unprocessed_query.get_condition()
+    assert condition is not None
+    ret = condition.accept(ClickhouseExpressionFormatter())
+    assert ret == formatted_value
+
+
+tests_new_processor = [
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+        ),
+        "equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "notauuid"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "notauuid"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        "equals(notauuid, 'a7d67cf796774551a95be6543cacd459')",
+        id="notauuid, 'a7d67cf796774551a95be6543cacd459')",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+            Column(None, None, "column1"),
+        ),
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+        ),
+        "equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "tuple",
+                (
+                    Literal(None, "a7d67cf796774551a95be6543cacd459"),
+                    Literal(None, "a7d67cf796774551a95be6543cacd45a"),
+                ),
+            ),
+        ),
+        binary_condition(
+            ConditionFunctions.IN,
+            Column(None, None, "column1"),
+            FunctionCall(
+                None,
+                "tuple",
+                (
+                    Literal(
+                        None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))
+                    ),
+                    Literal(
+                        None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd45a"))
+                    ),
+                ),
+            ),
+        ),
+        "in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
+        id="in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+        ),
+        "equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "notauuid"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "notauuid"),
+            Literal(None, "a7d67cf796774551a95be6543cacd459"),
+        ),
+        "equals(notauuid, 'a7d67cf796774551a95be6543cacd459')",
+        id="equals(notauuid, 'a7d67cf796774551a95be6543cacd459')",
+    ),
+    pytest.param(
+        binary_condition(
+            BooleanFunctions.AND,
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, None, "column2"),
+                Literal(None, "a7d67cf796774551a95be6543cacd460"),
+            ),
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, None, "column1"),
+                Literal(None, "a7d67cf796774551a95be6543cacd459"),
+            ),
+        ),
+        binary_condition(
+            BooleanFunctions.AND,
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, None, "column2"),
+                Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd460"))),
+            ),
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column(None, None, "column1"),
+                Literal(None, str(uuid.UUID("a7d67cf7-9677-4551-a95b-e6543cacd459"))),
+            ),
+        ),
+        "equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AND equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+        id="equals(column2, 'a7d67cf7-9677-4551-a95b-e6543cacd460') AND equals(column1, 'a7d67cf7-9677-4551-a95b-e6543cacd459')",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column(None, None, "column1"),
+            Literal(None, "deadbeefabad"),
+        ),
+        Literal(None, 0),
+        "0",
+        id="0",
+    ),
+]
+
+
+@pytest.mark.parametrize("unprocessed, expected, formatted_value", tests_new_processor)
+def test_better_uuid_column_processor(
+    unprocessed: Expression, expected: Expression, formatted_value: str,
+) -> None:
+    unprocessed_query = Query(
+        Table("transactions", ColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=unprocessed,
+    )
+    expected_query = Query(
+        Table("transactions", ColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=expected,
+    )
+
+    BetterUUIDColumnProcessor(set(["column1", "column2"])).process_query(
+        unprocessed_query, HTTPRequestSettings()
+    )
+    assert unprocessed_query.get_selected_columns() == [
+        SelectedExpression(
+            "column2",
+            FunctionCall(
+                None,
+                "replaceAll",
+                (
+                    FunctionCall(None, "toString", (Column(None, None, "column2"),),),
+                    Literal(None, "-"),
+                    Literal(None, ""),
+                ),
+            ),
+        )
+    ]
+
     assert expected_query.get_condition() == unprocessed_query.get_condition()
     condition = unprocessed_query.get_condition()
     assert condition is not None

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -435,7 +435,17 @@ tests_new_processor = [
         ),
         Literal(None, 0),
         "0",
-        id="0",
+        id="invalid uuid",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column(None, None, "column1"),
+            FunctionCall(None, "tuple", (Literal(None, "deadbeefabad"),)),
+        ),
+        Literal(None, 0),
+        "0",
+        id="invalid uuid - IN condition",
     ),
 ]
 


### PR DESCRIPTION
This processor combines the functionality of what is currently split across the
EventIdColumnProcessor and the UUIDColumnProcessor. It gives us the ability to
easily add support and optimizations for UUID columns without having a specific
processor for each column. It also makes it impossible to accidentally apply one
of the processors but not the other one, or apply them in the wrong order which
will result in broken behavior. Now you can no longer apply a UUID processor
without the optimization for conditions as well.

The new processor is only applied to the errors storage to begin with.