### PR TITLE
fix(cdc_snapshot) Fix the logic that loads the snapshot descriptor

### DIFF
--- a/snuba/snapshots/__init__.py
+++ b/snuba/snapshots/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-
 from contextlib import contextmanager
-from typing import Any, Mapping, NewType, Generator, Iterable, Optional, Sequence
 from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Generator, Iterable, Mapping, NewType, Optional, Sequence
 
 SnapshotId = NewType("SnapshotId", str)
 SnapshotTableRow = Mapping[str, Any]
@@ -17,7 +17,60 @@ class TableConfig:
     """
 
     table: str
-    columns: Optional[Sequence[str]]
+    zip: bool
+    columns: Optional[Sequence[ColumnConfig]]
+
+    @classmethod
+    def from_dict(cls, content: Mapping[str, Any]) -> TableConfig:
+        columns = []
+        for column in content["columns"]:
+            # This has already been validated by the jsonschema validator
+            assert isinstance(column, Mapping)
+            if column.get("formatter") is not None:
+                formatter: Optional[FormatterConfig] = FormatterConfig.from_dict(
+                    column["formatter"]
+                )
+            else:
+                formatter = None
+            columns.append(ColumnConfig(name=column["name"], formatter=formatter))
+        return TableConfig(content["table"], content["zip"], columns)
+
+
+class FormatterConfig(ABC):
+    """
+    Parent class to all the the formatter configs.
+    """
+
+    @classmethod
+    def from_dict(cls, content: Mapping[str, str]) -> FormatterConfig:
+        if content["type"] == "datetime":
+            return DateTimeFormatterConfig.from_dict(content)
+        else:
+            raise ValueError("Unknown config for column formatter")
+
+
+class DateFormatPrecision(Enum):
+    SECOND = "second"
+    # Add more if/when needed
+
+
+@dataclass(frozen=True)
+class DateTimeFormatterConfig(FormatterConfig):
+    precision: DateFormatPrecision
+
+    @classmethod
+    def from_dict(cls, content: Mapping[str, str]) -> DateTimeFormatterConfig:
+        return DateTimeFormatterConfig(DateFormatPrecision(content["precision"]))
+
+
+@dataclass(frozen=True)
+class ColumnConfig:
+    """
+    Represents a column in the snapshot configuration.
+    """
+
+    name: str
+    formatter: Optional[FormatterConfig] = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
We recently changed the format of the cdc snapshot meta data including a formatter.
This was not yet reflected in the Snuba code base which was still assuming the list of columns to be alist of strings.

This fixes it by adding the details of the missing details in the schema.