### PR TITLE
feat(breakdowns): Schema change for span op breakdowns

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -67,6 +67,7 @@ columns = ColumnSet(
         ("contexts", Nested([("key", String()), ("value", String())])),
         ("_contexts_flattened", String()),
         ("measurements", Nested([("key", String()), ("value", Float(64))]),),
+        ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))]),),
         ("partition", UInt(16)),
         ("offset", UInt(64)),
         ("message_timestamp", DateTime()),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -120,6 +120,7 @@ class TransactionsLoader(DirectoryLoader):
             "0008_transactions_add_timestamp_index",
             "0009_transactions_fix_title_and_message",
             "0010_transactions_nullable_trace_id",
+            "0011_transactions_add_span_op_breakdowns",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/transactions/0011_transactions_add_span_op_breakdowns.py
+++ b/snuba/migrations/snuba_migrations/transactions/0011_transactions_add_span_op_breakdowns.py
@@ -1,0 +1,64 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, Float, Nested, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds the span_op_breakdowns nested column
+    """
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                column=Column(
+                    "span_op_breakdowns",
+                    Nested(
+                        [
+                            ("key", String(Modifiers(low_cardinality=True))),
+                            ("value", Float(64)),
+                        ]
+                    ),
+                ),
+                after="measurements",
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, "transactions_local", "span_op_breakdowns"
+            ),
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_dist",
+                column=Column(
+                    "span_op_breakdowns",
+                    Nested(
+                        [
+                            ("key", String(Modifiers(low_cardinality=True))),
+                            ("value", Float(64)),
+                        ]
+                    ),
+                ),
+                after="measurements",
+            ),
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, "transactions_dist", "span_op_breakdowns"
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/transactions/0011_transactions_add_span_op_breakdowns.py
+++ b/snuba/migrations/snuba_migrations/transactions/0011_transactions_add_span_op_breakdowns.py
@@ -27,7 +27,7 @@ class Migration(migration.ClickhouseNodeMigration):
                         ]
                     ),
                 ),
-                after="measurements",
+                after="measurements.value",
             ),
         ]
 
@@ -52,7 +52,7 @@ class Migration(migration.ClickhouseNodeMigration):
                         ]
                     ),
                 ),
-                after="measurements",
+                after="measurements.value",
             ),
         ]
 


### PR DESCRIPTION
Based on https://github.com/getsentry/snuba/pull/1233

Associated change in Relay: https://github.com/getsentry/relay/pull/934

Add span op breakdowns column to the transactions dataset that has identical schema to the `measurements` column.