### PR TITLE
feat(breakdowns): Populate the span op breakdowns field

### DIFF
--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -107,6 +107,13 @@ class TransactionEvent:
                         "invalid": None,
                         "invalid2": {},
                     },
+                    "breakdowns": {
+                        "span_ops": {
+                            "ops.db": {"value": 62.512},
+                            "ops.http": {"value": 109.774},
+                            "total.time": {"value": 172.286},
+                        }
+                    },
                     "contexts": {
                         "trace": {
                             "sampled": True,
@@ -207,6 +214,8 @@ class TransactionEvent:
             "retention_days": 90,
             "measurements.key": ["lcp", "lcp.elementSize"],
             "measurements.value": [32.129, 4242.0],
+            "span_op_breakdowns.key": ["ops.db", "ops.http", "total.time"],
+            "span_op_breakdowns.value": [62.512, 109.774, 172.286],
         }
 
         if self.ipv4:


### PR DESCRIPTION
Depends on https://github.com/getsentry/snuba/pull/1761

Associated change in Relay: https://github.com/getsentry/relay/pull/934

Ingested transaction events in Relay (https://github.com/getsentry/relay/pull/934) will emit span op breakdowns into the event as in the following example (values are in milliseconds):

```
{
    "breakdowns": {
        "span_ops": {
            "ops.http": {"value": 2000000.0},
            "ops.resource": {"value": 100001.003},
            "total.time": {"value": 2200001.003},
        }
    }
}
```

The keys and values will be read from `breakdowns.span_ops` and populate the `span_op_breakdowns` columns of the transactions table.