### PR TITLE
feat: Restrict minute-resolution sessions to a 7h time window

### DIFF
--- a/snuba/datasets/entities/sessions.py
+++ b/snuba/datasets/entities/sessions.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from typing import Mapping, Sequence
 
-from snuba import environment, state
+from snuba import environment
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToCurriedFunction,
     ColumnToFunction,
@@ -217,10 +217,6 @@ class SessionsQueryStorageSelector(QueryStorageSelector):
                 else "raw",
             },
         )
-
-        allow_subhour_sessions = state.get_config("allow_subhour_sessions", 0)
-        if not allow_subhour_sessions:
-            use_materialized_storage = True
 
         if use_materialized_storage:
             return StorageAndMappers(

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -84,8 +84,6 @@ selector_tests = [
             "selected_columns": ["sessions", "bucketed_started"],
             "groupby": ["bucketed_started"],
             "granularity": 60,
-            # XXX: using `conditions` here, as `from_date`/`to_date` is not being
-            # correctly translated in the test code?
             "conditions": [
                 ("started", ">=", "2019-09-19T10:00:00"),
                 ("started", "<", "2019-09-19T12:00:00"),
@@ -104,13 +102,8 @@ def test_select_storage(
     query_body: MutableMapping[str, Any], expected_table: str
 ) -> None:
     sessions = get_dataset("sessions")
-    sessions_entity = sessions.get_default_entity()
-    settings = HTTPRequestSettings()
-
     query = parse_query(query_body, sessions)
-    for processor in sessions_entity.get_query_processors():
-        processor.process_query(query, settings)
-    request = Request("", query_body, query, settings, "")
+    request = Request("", query_body, query, HTTPRequestSettings(), "")
 
     def query_runner(
         query: Query, settings: RequestSettings, reader: Reader
@@ -118,6 +111,6 @@ def test_select_storage(
         assert query.get_from_clause().table_name == expected_table
         return QueryResult({}, {})
 
-    sessions_entity.get_query_pipeline_builder().build_execution_pipeline(
+    sessions.get_default_entity().get_query_pipeline_builder().build_execution_pipeline(
         request, query_runner
     ).execute()

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -1,7 +1,6 @@
 import pytest
 from typing import MutableMapping, Any
 
-from snuba import state
 from snuba.clickhouse.query import Query
 from snuba.datasets.factory import get_dataset
 from snuba.query import SelectedExpression
@@ -98,7 +97,6 @@ selector_tests = [
 def test_select_storage(
     query_body: MutableMapping[str, Any], expected_table: str
 ) -> None:
-    state.set_config("allow_subhour_sessions", 1)
     sessions = get_dataset("sessions")
     query = parse_query(query_body, sessions)
     request = Request("", query_body, query, HTTPRequestSettings(), "")


### PR DESCRIPTION
This also removes the config switch, always enabling minute-resolution sessions unconditionally.