### PR TITLE
feat: Add a type condition enforcer

### DIFF
--- a/snuba/clickhouse/query.py
+++ b/snuba/clickhouse/query.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence, Set
 
 from snuba.query import LimitBy, OrderBy
 from snuba.query import ProcessableQuery as AbstractQuery
@@ -29,6 +29,7 @@ class Query(AbstractQuery[Table]):
         offset: int = 0,
         totals: bool = False,
         granularity: Optional[int] = None,
+        hints: Optional[Set[str]] = None,
     ) -> None:
         self.__prewhere = prewhere
 
@@ -45,6 +46,7 @@ class Query(AbstractQuery[Table]):
             offset=offset,
             totals=totals,
             granularity=granularity,
+            hints=hints,
         )
 
     def _get_expressions_impl(self) -> Iterable[Expression]:

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -55,6 +55,7 @@ from snuba.query.expressions import (
 )
 from snuba.query.extensions import QueryExtension
 from snuba.query.logical import Query
+from snuba.query.mark_discover_query import MarkDiscoverQuery
 from snuba.query.matchers import FunctionCall as FunctionCallMatch
 from snuba.query.matchers import Literal as LiteralMatch
 from snuba.query.matchers import Or
@@ -477,6 +478,7 @@ class DiscoverEntity(Entity):
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
+            MarkDiscoverQuery(),  # temporary
             TimeSeriesProcessor({"time": "timestamp"}, ("timestamp",)),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),

--- a/snuba/datasets/plans/translator/query.py
+++ b/snuba/datasets/plans/translator/query.py
@@ -26,6 +26,7 @@ def identity_translate(query: LogicalQuery) -> ClickhouseQuery:
         offset=query.get_offset(),
         totals=query.has_totals(),
         granularity=query.get_granularity(),
+        hints=query.get_hints(),
     )
 
 

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -16,6 +16,7 @@ from snuba.datasets.storages.group_id_column_processor import GroupIdColumnProce
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
 )
+from snuba.datasets.storages.type_condition_enforcer import TypeConditionEnforcer
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.expressions import Column, Literal
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
@@ -272,6 +273,7 @@ query_processors = [
         # into in redis are stored with "EVENTS" in the name, we can change this.
         replacer_state_name=None,
     ),
+    TypeConditionEnforcer(),
     GroupIdColumnProcessor(),
     MappingColumnPromoter(
         mapping_specs={

--- a/snuba/datasets/storages/type_condition_enforcer.py
+++ b/snuba/datasets/storages/type_condition_enforcer.py
@@ -18,7 +18,9 @@ class TypeConditionEnforcer(QueryProcessor):
             col.column_name for col in query.get_columns_referenced_in_conditions_ast()
         }
 
-        if "group_id" not in cols:
+        discover_query = "discover" in query.get_hints()
+
+        if not discover_query and "group_id" not in cols:
             query.add_condition_to_ast(
                 binary_condition(
                     ConditionFunctions.NEQ,

--- a/snuba/datasets/storages/type_condition_enforcer.py
+++ b/snuba/datasets/storages/type_condition_enforcer.py
@@ -1,0 +1,30 @@
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.conditions import binary_condition, ConditionFunctions
+from snuba.query.expressions import Column, Literal
+from snuba.request.request_settings import RequestSettings
+
+
+class TypeConditionEnforcer(QueryProcessor):
+    """
+    Enforces that transactions are never returned from the events entity.
+    This condition is required for the events storage only, transactions are never
+    present in errors storage. If the query contains any other (likely more restrictive)
+    condition on type or group ID, do not apply the additional condition.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        type_cols = {"type", "group_id"}
+
+        cols = {
+            col.column_name for col in query.get_columns_referenced_in_conditions_ast()
+        }
+
+        if not cols.intersection(type_cols):
+            query.add_condition_to_ast(
+                binary_condition(
+                    ConditionFunctions.NEQ,
+                    Column("_snuba_type", None, "type"),
+                    Literal(None, "transaction"),
+                )
+            )

--- a/snuba/datasets/storages/type_condition_enforcer.py
+++ b/snuba/datasets/storages/type_condition_enforcer.py
@@ -9,18 +9,16 @@ class TypeConditionEnforcer(QueryProcessor):
     """
     Enforces that transactions are never returned from the events entity.
     This condition is required for the events storage only, transactions are never
-    present in errors storage. If the query contains any other (likely more restrictive)
-    condition on type or group ID, do not apply the additional condition.
+    present in errors storage. If the query contains a (likely more restrictive)
+    condition on group ID, do not apply the additional condition.
     """
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
-        type_cols = {"type", "group_id"}
-
         cols = {
             col.column_name for col in query.get_columns_referenced_in_conditions_ast()
         }
 
-        if not cols.intersection(type_cols):
+        if "group_id" not in cols:
             query.add_condition_to_ast(
                 binary_condition(
                     ConditionFunctions.NEQ,

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -465,6 +465,7 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
         offset: int = 0,
         totals: bool = False,
         granularity: Optional[int] = None,
+        hints: Optional[Set[str]] = None,
     ):
         super().__init__(
             selected_columns=selected_columns,
@@ -480,6 +481,7 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
             granularity=granularity,
         )
         self.__from_clause = from_clause
+        self.__hints = hints or set()
 
     def get_from_clause(self) -> TSimpleDataSource:
         assert self.__from_clause is not None, "Data source has not been provided yet."
@@ -490,3 +492,9 @@ class ProcessableQuery(Query, ABC, Generic[TSimpleDataSource]):
 
     def _eq_functions(self) -> Sequence[str]:
         return tuple(super()._eq_functions()) + ("get_from_clause",)
+
+    def set_hint(self, hint: str) -> None:
+        self.__hints.add(hint)
+
+    def get_hints(self,) -> Set[str]:
+        return self.__hints

--- a/snuba/query/mark_discover_query.py
+++ b/snuba/query/mark_discover_query.py
@@ -1,0 +1,12 @@
+from snuba.query.logical import Query
+from snuba.query.processors import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+
+
+class MarkDiscoverQuery(QueryProcessor):
+    """
+    Temporary query processor to support accessing transactions through the events storage.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        query.set_hint("discover")

--- a/tests/query/processors/test_type_condition_enforcer.py
+++ b/tests/query/processors/test_type_condition_enforcer.py
@@ -1,0 +1,70 @@
+import pytest
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.query.conditions import (
+    ConditionFunctions,
+    binary_condition,
+    BooleanFunctions,
+)
+from snuba.query.expressions import FunctionCall
+from snuba.query.data_source.simple import Table
+from snuba.datasets.storages.type_condition_enforcer import TypeConditionEnforcer
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.expressions import Column, Literal
+from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+
+
+cond1 = binary_condition(
+    ConditionFunctions.EQ, Column(None, None, "col1"), Literal(None, "val1")
+)
+
+
+test_data = [
+    pytest.param(
+        Query(
+            Table("events", ColumnSet([])),
+            condition=binary_condition(
+                BooleanFunctions.AND,
+                binary_condition(
+                    ConditionFunctions.NEQ,
+                    Column(None, None, "type"),
+                    Literal(None, "transaction"),
+                ),
+                cond1,
+            ),
+        ),
+        "notEquals(type, 'transaction') AND equals(col1, 'val1')",
+        id="has_type_condition",
+    ),
+    pytest.param(
+        Query(
+            Table("events", ColumnSet([])),
+            condition=binary_condition(
+                BooleanFunctions.AND,
+                binary_condition(
+                    ConditionFunctions.IN,
+                    Column(None, None, "group_id"),
+                    FunctionCall(None, "tuple", (Literal(None, 1), Literal(None, 2))),
+                ),
+                cond1,
+            ),
+        ),
+        "in(group_id, tuple(1, 2)) AND equals(col1, 'val1')",
+        id="has_groupid_condition",
+    ),
+    pytest.param(
+        Query(Table("events", ColumnSet([])), condition=cond1,),
+        "notEquals((type AS _snuba_type), 'transaction') AND equals(col1, 'val1')",
+        id="no_type_or_group_condition",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, formatted", test_data)
+def test_type_condition_optimizer(query: Query, formatted: str) -> None:
+    TypeConditionEnforcer().process_query(query, HTTPRequestSettings())
+    condition = query.get_condition()
+    assert condition is not None
+    ret = condition.accept(ClickhouseExpressionFormatter())
+    assert ret == formatted

--- a/tests/query/processors/test_type_condition_enforcer.py
+++ b/tests/query/processors/test_type_condition_enforcer.py
@@ -27,22 +27,6 @@ test_data = [
             condition=binary_condition(
                 BooleanFunctions.AND,
                 binary_condition(
-                    ConditionFunctions.NEQ,
-                    Column(None, None, "type"),
-                    Literal(None, "transaction"),
-                ),
-                cond1,
-            ),
-        ),
-        "notEquals(type, 'transaction') AND equals(col1, 'val1')",
-        id="has_type_condition",
-    ),
-    pytest.param(
-        Query(
-            Table("events", ColumnSet([])),
-            condition=binary_condition(
-                BooleanFunctions.AND,
-                binary_condition(
                     ConditionFunctions.IN,
                     Column(None, None, "group_id"),
                     FunctionCall(None, "tuple", (Literal(None, 1), Literal(None, 2))),
@@ -56,7 +40,7 @@ test_data = [
     pytest.param(
         Query(Table("events", ColumnSet([])), condition=cond1,),
         "notEquals((type AS _snuba_type), 'transaction') AND equals(col1, 'val1')",
-        id="no_type_or_group_condition",
+        id="no_groupid_condition",
     ),
 ]
 

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -38,6 +38,7 @@ class BaseSubscriptionTest:
                             settings.PAYLOAD_DATETIME_FORMAT
                         ),
                         "data": {
+                            "type": "error",
                             "received": calendar.timegm(
                                 (self.base_time + timedelta(minutes=tick)).timetuple()
                             ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,6 +102,7 @@ class SimpleAPITest(BaseApiTest):
                                 ],
                                 "retention_days": settings.DEFAULT_RETENTION_DAYS,
                                 "data": {
+                                    "type": "error",
                                     # Project N sends every Nth (mod len(hashes)) hash (and platform)
                                     "received": calendar.timegm(
                                         (
@@ -597,6 +598,7 @@ class TestApi(SimpleAPITest):
                         "primary_hash": self.hashes[0],
                         "retention_days": settings.DEFAULT_RETENTION_DAYS,
                         "data": {
+                            "type": "error",
                             "received": calendar.timegm(self.base_time.timetuple()),
                             "tags": {},
                             "exception": {

--- a/tests/web/test_transform_names.py
+++ b/tests/web/test_transform_names.py
@@ -8,6 +8,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
+from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
@@ -31,6 +32,8 @@ def test_transform_column_names() -> None:
     """
     events_storage = get_entity(EntityKey.EVENTS).get_writable_storage()
 
+    assert isinstance(events_storage, WritableTableStorage)
+
     event_id = uuid.uuid4().hex
 
     event_date = datetime.utcnow()
@@ -46,7 +49,7 @@ def test_transform_column_names() -> None:
                     "message": "a message",
                     "platform": "python",
                     "datetime": event_date.strftime(settings.PAYLOAD_DATETIME_FORMAT),
-                    "data": {"received": time.time()},
+                    "data": {"received": time.time(), "type": "error"},
                     "organization_id": 1,
                     "retention_days": settings.DEFAULT_RETENTION_DAYS,
                 }


### PR DESCRIPTION
The type condition enforcer ensures that transactions are never
returned from the events entity. This is an issue when the events
entity is picked together with the legacy events storage, and Sentry works
around this by including the `type != transaction` condition on
most queries to events.

This change will allow us to stop sending that condition on all queries from
Sentry, as Snuba will automatically apply if it is required. It also allows us
to remove the TypeConditionOptimizer that operates on the errors storage in order
to optimize that unncessary condition away.

TODO:
- [ ] Run / fix Sentry tests