### PR TITLE
ref: Don't ignore all type errors in tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     rev: 'v0.800'
     hooks:
     -   id: mypy
+        files: snuba
         args: [--config-file, mypy.ini, --ignore-missing-imports, --strict, --warn-unreachable]
 default_language_version:
   python: python3.8

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,9 +1,6 @@
 [mypy]
 ignore_missing_imports = False
 
-[mypy-tests.*]
-ignore_errors = True
-
 [mypy-_strptime]
 ignore_missing_imports = True
 
@@ -65,6 +62,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-sentry_sdk]
+ignore_missing_imports = True
 no_implicit_reexport = False
 
 [mypy-setuptools]


### PR DESCRIPTION
We should not ignore all type errors in tests as these will be completely
silenced in development and we will never be aware of these issues. For now, we
still allow CI to pass if there are type errors in tests, only `snuba` is required
for CI.