### PR TITLE
fix(replacer) Add the toString back and remove the hash from errors

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -413,14 +413,18 @@ def process_tombstone_events(
             ]
         )
     else:
-        event_id_lhs = "cityHash64(event_id)"
-        event_id_list = ", ".join(
-            "cityHash64(toUUID('%s'))" % uuid.UUID(eid) for eid in event_ids
+        event_id_lhs = "event_id"
+        event_id_list = ", ".join("'%s'" % uuid.UUID(eid) for eid in event_ids)
+
+    if old_primary_hash:
+        old_primary_hash_condition = (
+            " AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s)"
         )
+    else:
+        old_primary_hash_condition = ""
 
     where = f"""\
-        PREWHERE {event_id_lhs} IN (%(event_ids)s)
-        AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s)
+        PREWHERE {event_id_lhs} IN (%(event_ids)s){old_primary_hash_condition}
         WHERE project_id = %(project_id)s {from_condition} {to_condition}
         AND NOT deleted
     """

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -417,9 +417,7 @@ def process_tombstone_events(
         event_id_list = ", ".join("'%s'" % uuid.UUID(eid) for eid in event_ids)
 
     if old_primary_hash:
-        old_primary_hash_condition = (
-            " AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s)"
-        )
+        old_primary_hash_condition = " AND primary_hash = %(old_primary_hash)s"
     else:
         old_primary_hash_condition = ""
 

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -405,7 +405,7 @@ def process_tombstone_events(
     to_condition = get_timestamp_condition("to_timestamp", "<=")
 
     if state_name == ReplacerState.EVENTS:
-        event_id_lhs = "cityHash64(event_id)"
+        event_id_lhs = "cityHash64(toString(event_id))"
         event_id_list = ", ".join(
             [
                 f"cityHash64('{str(uuid.UUID(event_id)).replace('-', '')}')"

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -145,16 +145,22 @@ class TestReplacer:
 
         replacement = self.replacer.process_message(self._wrap(message))
 
+        old_primary_condition = (
+            " AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s)"
+            if old_primary_hash
+            else ""
+        )
+
         assert (
             re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s){old_primary_condition} WHERE project_id = %(project_id)s AND NOT deleted"
         )
         assert (
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s){old_primary_condition} WHERE project_id = %(project_id)s AND NOT deleted"
         )
         assert replacement.query_args == {
-            "event_ids": "cityHash64(toUUID('00e24a15-0d7f-4ee4-b142-b61b4d893b6d'))",
+            "event_ids": "'00e24a15-0d7f-4ee4-b142-b61b4d893b6d'",
             "project_id": self.project_id,
             "required_columns": "event_id, primary_hash, project_id, group_id, timestamp, deleted, retention_days",
             "select_columns": "event_id, primary_hash, project_id, group_id, timestamp, 1, retention_days",
@@ -182,14 +188,14 @@ class TestReplacer:
 
         assert (
             re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
+            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
         )
         assert (
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
+            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE event_id IN (%(event_ids)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
         )
         assert replacement.query_args == {
-            "event_ids": "cityHash64(toUUID('00e24a15-0d7f-4ee4-b142-b61b4d893b6d'))",
+            "event_ids": "'00e24a15-0d7f-4ee4-b142-b61b4d893b6d'",
             "project_id": self.project_id,
             "required_columns": "event_id, primary_hash, project_id, group_id, timestamp, deleted, retention_days",
             "select_columns": "event_id, primary_hash, project_id, group_id, timestamp, 1, retention_days",

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -146,9 +146,7 @@ class TestReplacer:
         replacement = self.replacer.process_message(self._wrap(message))
 
         old_primary_condition = (
-            " AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s)"
-            if old_primary_hash
-            else ""
+            " AND primary_hash = %(old_primary_hash)s" if old_primary_hash else ""
         )
 
         assert (

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -494,11 +494,11 @@ class TestReplacer:
 
         assert (
             re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            == "SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
         )
         assert (
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
         )
 
         assert replacement.query_args == {
@@ -531,11 +531,11 @@ class TestReplacer:
 
         assert (
             re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
+            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
         )
         assert (
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(event_id) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
+            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
         )
 
         assert replacement.query_args == {

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -494,11 +494,11 @@ class TestReplacer:
 
         assert (
             re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            == "SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted"
         )
         assert (
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND NOT deleted"
+            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted"
         )
 
         assert replacement.query_args == {
@@ -531,11 +531,11 @@ class TestReplacer:
 
         assert (
             re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
+            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
         )
         assert (
             re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) AND (%(old_primary_hash)s IS NULL OR primary_hash = %(old_primary_hash)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
+            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}') AND NOT deleted"
         )
 
         assert replacement.query_args == {


### PR DESCRIPTION
This seems to make clickhouse scan fewer rows.
Also removes a useless condition from the PREWHERE when there is no old primary hash and removes the cityHash from the errors replacer