### PR TITLE
ref: Remove redundant condition in boolean context processor

### DIFF
--- a/snuba/datasets/storages/events_bool_contexts.py
+++ b/snuba/datasets/storages/events_bool_contexts.py
@@ -54,12 +54,8 @@ class EventsBooleanContextsProcessor(QueryProcessor):
                 inner = replace(exp, alias=None)
                 return FunctionCallExpr(
                     exp.alias,
-                    "multiIf",
+                    "if",
                     (
-                        binary_condition(
-                            ConditionFunctions.EQ, inner, Literal(None, "")
-                        ),
-                        Literal(None, ""),
                         binary_condition(
                             ConditionFunctions.IN,
                             inner,

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -50,18 +50,8 @@ def test_events_boolean_context() -> None:
                 "contexts[device.charging]",
                 FunctionCall(
                     "contexts[device.charging]",
-                    "multiIf",
+                    "if",
                     (
-                        binary_condition(
-                            ConditionFunctions.EQ,
-                            FunctionCall(
-                                None,
-                                "toString",
-                                (Column(None, None, "device_charging"),),
-                            ),
-                            Literal(None, ""),
-                        ),
-                        Literal(None, ""),
                         binary_condition(
                             ConditionFunctions.IN,
                             FunctionCall(


### PR DESCRIPTION
These fields are all nullable UInt8. Since this first condition will
never be met remove it from the ClickHouse query.