### PR TITLE
feat: Port boolean context processing to all storages

### DIFF
--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -14,6 +14,7 @@ from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors_common import mandatory_conditions
+from snuba.datasets.storages.events_bool_contexts import EventsBooleanContextsProcessor
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
 )
@@ -82,6 +83,7 @@ storage = ReadableTableStorage(
         MappingOptimizer("tags", "_tags_hash_map", "tags_hash_map_enabled"),
         ArrayJoinKeyValueOptimizer("tags"),
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
+        EventsBooleanContextsProcessor(),
         PrewhereProcessor(
             [
                 "event_id",

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -10,6 +10,7 @@ from snuba.clickhouse.columns import (
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
 from snuba.datasets.errors_replacer import ReplacerState
+from snuba.datasets.storages.events_bool_contexts import EventsBooleanContextsProcessor
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
 )
@@ -151,6 +152,7 @@ query_processors = [
     ),
     UserColumnProcessor(),
     UUIDColumnProcessor({"event_id", "trace_id"}),
+    EventsBooleanContextsProcessor(),
     TypeConditionOptimizer(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),

--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -11,7 +11,9 @@ from snuba.clickhouse.columns import (
 )
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
-from snuba.datasets.storages.events_bool_contexts import EventsBooleanContextsProcessor
+from snuba.datasets.storages.events_bool_contexts import (
+    EventsPromotedBooleanContextsProcessor,
+)
 from snuba.datasets.storages.group_id_column_processor import GroupIdColumnProcessor
 from snuba.datasets.storages.processors.replaced_groups import (
     PostReplacementConsistencyEnforcer,
@@ -289,7 +291,7 @@ query_processors = [
     # tags/contexts. Once the errors dataset is in use, we will not have
     # boolean promoted tags/contexts so this constraint will be easy
     # to enforce.
-    EventsBooleanContextsProcessor(),
+    EventsPromotedBooleanContextsProcessor(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),
     ArrayJoinKeyValueOptimizer("tags"),
     PrewhereProcessor(prewhere_candidates),

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -20,6 +20,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.events_bool_contexts import EventsBooleanContextsProcessor
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
@@ -106,6 +107,7 @@ storage = WritableTableStorage(
             }
         ),
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
+        EventsBooleanContextsProcessor(),
         MappingOptimizer("tags", "_tags_hash_map", "tags_hash_map_enabled"),
         TypedContextPromoter(
             "contexts",

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -147,7 +147,6 @@ def test_events_boolean_context() -> None:
                                     ),
                                 ),
                             ),
-                            # Column(None, None, "device_charging"),
                             literals_tuple(
                                 None, [Literal(None, "1"), Literal(None, "True")]
                             ),

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -2,7 +2,10 @@ from snuba.clickhouse.columns import ColumnSet, Nested
 from snuba.clickhouse.columns import SchemaModifiers as Modifier
 from snuba.clickhouse.columns import String, UInt
 from snuba.clickhouse.query import Query as ClickhouseQuery
-from snuba.datasets.storages.events_bool_contexts import EventsBooleanContextsProcessor
+from snuba.datasets.storages.events_bool_contexts import (
+    EventsBooleanContextsProcessor,
+    EventsPromotedBooleanContextsProcessor,
+)
 from snuba.query import SelectedExpression
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Table
@@ -12,7 +15,7 @@ from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.request.request_settings import HTTPRequestSettings
 
 
-def test_events_boolean_context() -> None:
+def test_events_promoted_boolean_context() -> None:
     columns = ColumnSet(
         [
             ("device_charging", UInt(8, Modifier(nullable=True))),
@@ -85,6 +88,79 @@ def test_events_boolean_context() -> None:
     MappingColumnPromoter(
         {"contexts": {"device.charging": "device_charging"}}
     ).process_query(query, settings)
+    EventsPromotedBooleanContextsProcessor().process_query(query, settings)
+
+    assert query.get_selected_columns() == expected.get_selected_columns()
+
+
+def test_events_boolean_context() -> None:
+    columns = ColumnSet(
+        [("contexts", Nested([("key", String()), ("value", String())]))]
+    )
+    query = ClickhouseQuery(
+        Table("errors", columns),
+        selected_columns=[
+            SelectedExpression(
+                "contexts[device.charging]",
+                FunctionCall(
+                    "contexts[device.charging]",
+                    "arrayElement",
+                    (
+                        Column(None, None, "contexts.value"),
+                        FunctionCall(
+                            None,
+                            "indexOf",
+                            (
+                                Column(None, None, "contexts.key"),
+                                Literal(None, "device.charging"),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        ],
+    )
+
+    expected = ClickhouseQuery(
+        Table("errors", columns),
+        selected_columns=[
+            SelectedExpression(
+                "contexts[device.charging]",
+                FunctionCall(
+                    "contexts[device.charging]",
+                    "if",
+                    (
+                        binary_condition(
+                            ConditionFunctions.IN,
+                            FunctionCall(
+                                None,
+                                "arrayElement",
+                                (
+                                    Column(None, None, "contexts.value"),
+                                    FunctionCall(
+                                        None,
+                                        "indexOf",
+                                        (
+                                            Column(None, None, "contexts.key"),
+                                            Literal(None, "device.charging"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                            # Column(None, None, "device_charging"),
+                            literals_tuple(
+                                None, [Literal(None, "1"), Literal(None, "True")]
+                            ),
+                        ),
+                        Literal(None, "True"),
+                        Literal(None, "False"),
+                    ),
+                ),
+            )
+        ],
+    )
+
+    settings = HTTPRequestSettings()
     EventsBooleanContextsProcessor().process_query(query, settings)
 
     assert query.get_selected_columns() == expected.get_selected_columns()


### PR DESCRIPTION
Add equivalent processing for the 3 boolean contexts - device.online,
device.simulator and device.charging - to the errors, transactions and
discover storages. The results are now equivalent to those from the
events storage.