### PR TITLE
feat: Mapping column promoter does not cast to string by default

### DIFF
--- a/snuba/datasets/storages/events_common.py
+++ b/snuba/datasets/storages/events_common.py
@@ -283,6 +283,7 @@ query_processors = [
             ),
             "contexts": get_promoted_context_col_mapping(),
         },
+        cast_to_string=True,
     ),
     # This processor must not be ported to the errors dataset. We should
     # not support promoting tags/contexts with boolean values. There is

--- a/snuba/query/processors/mapping_promoter.py
+++ b/snuba/query/processors/mapping_promoter.py
@@ -78,12 +78,17 @@ class MappingColumnPromoter(QueryProcessor):
     that maps to the myTag tag.
     """
 
-    def __init__(self, mapping_specs: Mapping[str, Mapping[str, str]]) -> None:
+    def __init__(
+        self,
+        mapping_specs: Mapping[str, Mapping[str, str]],
+        cast_to_string: bool = False,  # TODO: remove once events storage is gone
+    ) -> None:
         # The configuration for this processor. The key of the
         # mapping is the name of the nested column. The value is
         # a mapping between key in the mapping column and promoted
         # column name.
         self.__specs = mapping_specs
+        self.__cast_to_string = cast_to_string
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         def transform_nested_column(exp: Expression) -> Expression:
@@ -107,7 +112,7 @@ class MappingColumnPromoter(QueryProcessor):
                     # function when the promoted column is not a string since the
                     # supported values of mapping columns are strings and the clients
                     # expect such.
-                    if (
+                    if not self.__cast_to_string or (
                         col_type_name
                         and "String" in col_type_name
                         and "FixedString" not in col_type_name

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -76,7 +76,7 @@ def test_events_promoted_boolean_context() -> None:
 
     settings = HTTPRequestSettings()
     MappingColumnPromoter(
-        {"contexts": {"device.charging": "device_charging"}}
+        {"contexts": {"device.charging": "device_charging"}}, cast_to_string=True
     ).process_query(query, settings)
     EventsPromotedBooleanContextsProcessor().process_query(query, settings)
 

--- a/tests/query/processors/test_mapping_promoter.py
+++ b/tests/query/processors/test_mapping_promoter.py
@@ -90,11 +90,7 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "tags[promoted_tag]",
-                    FunctionCall(
-                        "tags[promoted_tag]",
-                        "toString",
-                        (Column(None, "table", "promoted"),),
-                    ),
+                    Column("tags[promoted_tag]", "table", "promoted"),
                 )
             ],
         ),


### PR DESCRIPTION
The mapping column promoter now only promotes a column and does not
attempt to fix it's type by simply casting to string. We need to keep
the old behavior around temporarily as it's used in the legacy events
table - once that is gone the option to cast the type will no longer
be required here.

The previous behavior caused issues with the UUIDColumnProcessor as the
expected query no longer matched what the processor expected if a column
was a promoted one due to the insertion of the extra toString() function.