### PR TITLE
fix: Fix formatting of primary hash

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -151,7 +151,7 @@ query_processors = [
         }
     ),
     UserColumnProcessor(),
-    UUIDColumnProcessor({"event_id", "trace_id"}),
+    UUIDColumnProcessor({"event_id", "primary_hash", "trace_id"}),
     EventsBooleanContextsProcessor(),
     TypeConditionOptimizer(),
     MappingOptimizer("tags", "_tags_hash_map", "events_tags_hash_map_enabled"),


### PR DESCRIPTION
This change ensures that the primary hash column in the errors storage
is always formatted in the same way as it was on the events storage (non
hyphenated 32 byte string).