### PR TITLE
fix(cloudbuild): Add images section so freight can find the builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -93,6 +93,8 @@ steps:
         docker push $$DOCKER_REPO:$COMMIT_SHA
         docker tag $$SNUBA_IMAGE $$DOCKER_REPO:nightly
         docker push $$DOCKER_REPO:nightly
+# This is needed for Freight to find matching builds
+images: ['us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
 timeout: 2640s
 options:
   # We need more memory for Webpack builds & e2e onpremise tests


### PR DESCRIPTION
In Freight, our deployment app, we use Cloudbuild list API to search for build for particular commit using filter query e.g.

```
{'filter': 'images="us.gcr.io/sentryio/snuba:4234a46aead05c8acf6744420995509de11543d3"'}
```

Without the `images` section Freight is unable to find a matching build a thus will not allow deployment.