### PR TITLE
fix(errors-migration): Avoid migrating unnecessary extra partition

### DIFF
--- a/snuba/migrations/snuba_migrations/events/0014_backfill_errors.py
+++ b/snuba/migrations/snuba_migrations/events/0014_backfill_errors.py
@@ -181,7 +181,7 @@ def backfill_errors() -> None:
 
         timestamp -= WINDOW
 
-        if timestamp < BEGINNING_OF_TIME:
+        if timestamp <= BEGINNING_OF_TIME:
             print("Done. Optimizing.")
             break
 


### PR DESCRIPTION
We only need to migrate up to 90 days of data (our retention window).
The previous implementation incorrectly migrated an extra partition that
is not required.