### PR TITLE
fix(hexint-processor): Return 400 error if invalid hexint value

### DIFF
--- a/snuba/query/processors/type_converters/hexint_column_processor.py
+++ b/snuba/query/processors/type_converters/hexint_column_processor.py
@@ -7,7 +7,7 @@ class HexIntColumnProcessor(BaseTypeConverter):
         try:
             assert isinstance(exp.value, str)
             return Literal(alias=exp.alias, value=int(exp.value, 16))
-        except AssertionError:
+        except (AssertionError, ValueError):
             raise ColumnTypeError("Invalid hexint")
 
     def _process_expressions(self, exp: Expression) -> Expression:


### PR DESCRIPTION
Ensure that we return 400 instead of 500 if a string is not a valid hexint value