### PR TITLE
fix: Prevent all conditions from being dropped from a query

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -130,6 +130,13 @@ class DefaultIfNullFunctionMapper(FunctionCallMapper):
         expression: FunctionCall,
         children_translator: SnubaClickhouseStrictTranslator,
     ) -> Optional[FunctionCall]:
+
+        # HACK: Quick fix to avoid this function dropping important conditions from the query
+        logical_functions = {"and", "or", "not", "xor"}
+
+        if expression.function_name in logical_functions:
+            return None
+
         parameters = tuple(p.accept(children_translator) for p in expression.parameters)
         for param in parameters:
             # All impossible columns will have been converted to the identity function.

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -778,6 +778,34 @@ class TestDiscoverApi(BaseApiTest):
             }
         ]
 
+        response = self.post(
+            json.dumps(
+                {
+                    "dataset": "discover",
+                    "project": self.project_id,
+                    "aggregations": [
+                        ["count()", None, "count"],
+                        [
+                            "countIf(not(has(array(0,1,2), transaction_status)))",
+                            None,
+                            "failure_count",
+                        ],
+                    ],
+                    "groupby": ["project_id", "tags[foo]"],
+                    "conditions": [["server_name", "=", "TypeError"]],
+                    "orderby": "count",
+                    "limit": 1000,
+                    "from_date": (self.base_time - self.skew).isoformat(),
+                    "to_date": (self.base_time + self.skew).isoformat(),
+                }
+            ),
+            entity="discover",
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == []
+
     def test_count_null_user_consistency(self) -> None:
         response = self.post(
             json.dumps(


### PR DESCRIPTION
This is a quick fix to prevent the entire condition expression
from being mapped to null by the DefaultIfNullFunctionMapper. It
ensures that mapping of and/or/not/xor expressions is skipped
even if a match for the identity(...) expression is found.

We sbould probably follow up with a more optimal solution that does
not replace any expression that contains identity(...) with
identity(NULL).