### PR TITLE
fix(snql) Keep tags in consistent order in arrayjoin optimizer

### DIFF
--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence, Set
+from typing import Optional, Sequence, Set
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
@@ -80,7 +80,7 @@ def _get_mapping_keys_in_condition(
     return keys_found
 
 
-def get_filtered_mapping_keys(query: Query, column_name: str) -> List[str]:
+def get_filtered_mapping_keys(query: Query, column_name: str) -> Sequence[str]:
     """
     Identifies the conditions we can apply the arrayFilter optimization
     on.
@@ -106,7 +106,7 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> List[str]:
     if cond_keys is None:
         # This means we found an OR. Cowardly we give up even though there could
         # be cases where this condition is still optimizable.
-        return list()
+        return []
 
     ast_having = query.get_having()
     having_keys = (
@@ -116,7 +116,7 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> List[str]:
     )
     if having_keys is None:
         # Same as above
-        return list()
+        return []
 
     keys = cond_keys | having_keys
     return sorted(list(keys))

--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Set
+from typing import List, Optional, Sequence, Set
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
@@ -80,7 +80,7 @@ def _get_mapping_keys_in_condition(
     return keys_found
 
 
-def get_filtered_mapping_keys(query: Query, column_name: str) -> Set[str]:
+def get_filtered_mapping_keys(query: Query, column_name: str) -> List[str]:
     """
     Identifies the conditions we can apply the arrayFilter optimization
     on.
@@ -95,7 +95,7 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> Set[str]:
     )
 
     if not array_join_found:
-        return set()
+        return list()
 
     ast_condition = query.get_condition()
     cond_keys = (
@@ -106,7 +106,7 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> Set[str]:
     if cond_keys is None:
         # This means we found an OR. Cowardly we give up even though there could
         # be cases where this condition is still optimizable.
-        return set()
+        return list()
 
     ast_having = query.get_having()
     having_keys = (
@@ -116,9 +116,10 @@ def get_filtered_mapping_keys(query: Query, column_name: str) -> Set[str]:
     )
     if having_keys is None:
         # Same as above
-        return set()
+        return list()
 
-    return cond_keys | having_keys
+    keys = cond_keys | having_keys
+    return sorted(list(keys))
 
 
 class ArrayJoinKeyValueOptimizer(QueryProcessor):

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -54,7 +54,7 @@ tags_filter_tests = [
                 ),
             ],
         ),
-        set(),
+        [],
         id="no tag filter",
     ),
     pytest.param(
@@ -72,7 +72,7 @@ tags_filter_tests = [
                 Literal(None, "tag"),
             ),
         ),
-        {"tag"},
+        ["tag"],
         id="simple equality",
     ),
     pytest.param(
@@ -89,7 +89,7 @@ tags_filter_tests = [
                 [Literal(None, "tag1"), Literal(None, "tag2")],
             ),
         ),
-        {"tag1", "tag2"},
+        ["tag1", "tag2"],
         id="tag IN condition",
     ),
     pytest.param(
@@ -114,7 +114,7 @@ tags_filter_tests = [
                 Literal(None, "tag2"),
             ),
         ),
-        {"tag", "tag2"},
+        ["tag", "tag2"],
         id="conditions and having",
     ),
     pytest.param(
@@ -144,7 +144,7 @@ tags_filter_tests = [
                 Literal(None, "tag"),
             ),
         ),
-        set(),
+        [],
         id="tag OR condition",
     ),
 ]


### PR DESCRIPTION
In order for the SQL comparison between Legacy and SnQL to consistently pass,
the tag keys need to be in a consistent order.