### PR TITLE
test: Remove references to events storage in tests

### DIFF
--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -1,6 +1,5 @@
 from snuba.clickhouse.query import Query
 from snuba.datasets.factory import get_dataset
-from snuba.datasets.storages import StorageKey
 from snuba.query import SelectedExpression
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.parser import parse_query
@@ -15,7 +14,6 @@ def test_events_processing() -> None:
 
     events_dataset = get_dataset("events")
     events_entity = events_dataset.get_default_entity()
-    events_storage = events_entity.get_writable_storage()
 
     query = parse_query(query_body, events_dataset)
     request = Request("", query_body, query, HTTPRequestSettings(), "")
@@ -23,16 +21,10 @@ def test_events_processing() -> None:
     def query_runner(
         query: Query, settings: RequestSettings, reader: Reader
     ) -> QueryResult:
-
-        if events_storage.get_storage_key() == StorageKey.EVENTS:
-            transaction_col_name = "transaction"
-        else:
-            transaction_col_name = "transaction_name"
-
         assert query.get_selected_columns() == [
             SelectedExpression(
                 "tags[transaction]",
-                Column("_snuba_tags[transaction]", None, transaction_col_name),
+                Column("_snuba_tags[transaction]", None, "transaction_name"),
             ),
             SelectedExpression(
                 "contexts[browser.name]",

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -30,7 +30,7 @@ def test_simple() -> None:
         "project": 1,
     }
 
-    query = Query(get_storage(StorageKey.EVENTS).get_schema().get_data_source())
+    query = Query(get_storage(StorageKey.ERRORS).get_schema().get_data_source())
 
     request = Request(
         uuid.UUID("a" * 32).hex, request_body, query, HTTPRequestSettings(), "search",
@@ -125,7 +125,7 @@ def test_missing_fields() -> None:
         "project": 1,
     }
 
-    query = Query(get_storage(StorageKey.EVENTS).get_schema().get_data_source())
+    query = Query(get_storage(StorageKey.ERRORS).get_schema().get_data_source())
 
     request = Request(
         uuid.UUID("a" * 32).hex, request_body, query, HTTPRequestSettings(), "search",

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -41,6 +41,7 @@ from snuba.web import QueryResult
 
 events_ent = Entity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model())
 events_storage = get_entity(EntityKey.EVENTS).get_writable_storage()
+assert events_storage is not None
 events_table_name = events_storage.get_table_writer().get_schema().get_table_name()
 
 events_table = Table(
@@ -335,32 +336,14 @@ TEST_CASES = [
                         selected_columns=[
                             SelectedExpression(
                                 "_snuba_group_id",
-                                FunctionCall(
-                                    "_snuba_group_id",
-                                    function_name="nullIf",
-                                    parameters=(
-                                        Column(None, None, "group_id"),
-                                        Literal(None, 0),
-                                    ),
-                                )
-                                if events_storage.get_storage_key() == StorageKey.EVENTS
-                                else Column("_snuba_group_id", None, "group_id"),
+                                Column("_snuba_group_id", None, "group_id"),
                             ),
                             SelectedExpression(
                                 "f_release",
                                 FunctionCall(
                                     "f_release",
                                     function_name="f",
-                                    parameters=(
-                                        Column(
-                                            None,
-                                            None,
-                                            "sentry:release"
-                                            if events_storage.get_storage_key()
-                                            == StorageKey.EVENTS
-                                            else "release",
-                                        ),
-                                    ),
+                                    parameters=(Column(None, None, "release"),),
                                 ),
                             ),
                         ],

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -33,21 +33,24 @@ def test() -> None:
     events = get_dataset("events")
     query = parse_query(query_body, events)
 
-    events_pipeline = SimplePipelineBuilder(
-        query_plan_builder=SingleStorageQueryPlanBuilder(
-            storage=get_storage(StorageKey.EVENTS)
-        ),
-    )
-
     errors_pipeline = SimplePipelineBuilder(
         query_plan_builder=SingleStorageQueryPlanBuilder(
             storage=get_storage(StorageKey.ERRORS)
         ),
     )
 
+    errors_ro_pipeline = SimplePipelineBuilder(
+        query_plan_builder=SingleStorageQueryPlanBuilder(
+            storage=get_storage(StorageKey.ERRORS_RO)
+        ),
+    )
+
     delegator = PipelineDelegator(
-        query_pipeline_builders={"events": events_pipeline, "errors": errors_pipeline},
-        selector_func=lambda query, referrer: ("events", ["errors"]),
+        query_pipeline_builders={
+            "errors": errors_pipeline,
+            "errors_ro": errors_ro_pipeline,
+        },
+        selector_func=lambda query, referrer: ("errors", ["errors_ro"]),
         callback_func=mock_callback,
     )
 
@@ -64,5 +67,5 @@ def test() -> None:
         query,
         request_settings,
         "ref",
-        [Result("events", query_result, ANY), Result("errors", query_result, ANY)],
+        [Result("errors", query_result, ANY), Result("errors_ro", query_result, ANY)],
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,7 +174,7 @@ class TestApi(SimpleAPITest):
         Test total counts are correct in the hourly time buckets for each project
         """
         clickhouse = (
-            get_storage(StorageKey.EVENTS)
+            get_storage(StorageKey.ERRORS)
             .get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)
         )
@@ -1371,9 +1371,7 @@ class TestApi(SimpleAPITest):
         }
         result1 = json.loads(self.post(json.dumps(query)).data)
 
-        event_id = "9" * 32
-        if self.storage.get_storage_key() == StorageKey.ERRORS:
-            event_id = str(uuid.UUID(event_id))
+        event_id = str(uuid.UUID("9" * 32))
 
         write_processed_messages(
             self.storage,
@@ -2076,7 +2074,7 @@ class TestLegacyAPI(SimpleAPITest):
         # make sure redis has _something_ before we go about dropping all the keys in it
         assert self.redis_db_size() > 0
 
-        storage = get_writable_storage(StorageKey.EVENTS)
+        storage = get_writable_storage(StorageKey.ERRORS)
         clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.QUERY
         )

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1345,16 +1345,8 @@ class TestDiscoverApi(BaseApiTest):
         data = json.loads(response.data)
         assert len(data["data"]) == 0
 
-        # TODO: This can be simplified once errors rollout is complete
-        # and we no longer need to support tests passing on both storages.
-        release_column = (
-            "`sentry:release`"
-            if self.events_storage == get_writable_storage(StorageKey.EVENTS)
-            else "release"
-        )
-
         assert data["sql"].startswith(
-            f"SELECT (type AS _snuba_type), (arrayElement(tags.value, indexOf(tags.key, 'custom_tag')) AS `_snuba_tags[custom_tag]`), ({release_column} AS _snuba_release)"
+            "SELECT (type AS _snuba_type), (arrayElement(tags.value, indexOf(tags.key, 'custom_tag')) AS `_snuba_tags[custom_tag]`), (release AS _snuba_release)"
         )
 
     def test_exception_stack_column_boolean_condition_with_arrayjoin(self) -> None:

--- a/tests/web/test_transform_names.py
+++ b/tests/web/test_transform_names.py
@@ -8,7 +8,6 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
-from snuba.datasets.storages import StorageKey
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, FunctionCall, Literal
@@ -104,12 +103,7 @@ def test_transform_column_names() -> None:
     assert data == [{"event_id": event_id, "message": "a message"}]
     meta = result.result["meta"]
 
-    if events_storage.get_storage_key() == StorageKey.EVENTS:
-        events_meta_type = "FixedString(32)"
-    else:
-        events_meta_type = "String"
-
     assert meta == [
-        MetaColumn(name="event_id", type=events_meta_type),
+        MetaColumn(name="event_id", type="String"),
         MetaColumn(name="message", type="String"),
     ]


### PR DESCRIPTION
We no longer require our tests to pass when run on the events storage.
This change removes references to these in tests so the storage can be
easily removed later.