### PR TITLE
feat: Remove deprecated DEFAULT_BROKERS setting

### DIFF
--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -71,8 +71,6 @@ BULK_CLICKHOUSE_BUFFER = 10000
 BULK_BINARY_LOAD_CHUNK = 2 ** 22  # 4 MB
 
 # Processor/Writer Options
-# DEPRECATED, please use BROKER_CONFIG instead
-DEFAULT_BROKERS: Sequence[str] = []
 # DEPRECATED, please use STORAGE_BROKER_CONFIG instead
 DEFAULT_STORAGE_BROKERS: Mapping[str, Sequence[str]] = {}
 

--- a/snuba/utils/streams/backends/kafka.py
+++ b/snuba/utils/streams/backends/kafka.py
@@ -409,9 +409,7 @@ class KafkaConsumer(Consumer[KafkaPayload]):
             Partition(Topic(message.topic()), message.partition()),
             message.offset(),
             KafkaPayload(
-                message.key(),
-                message.value(),
-                headers if headers is not None else [],
+                message.key(), message.value(), headers if headers is not None else [],
             ),
             datetime.utcfromtimestamp(message.timestamp()[1] / 1000.0),
         )
@@ -669,19 +667,12 @@ def get_default_kafka_configuration(
             default_bootstrap_servers = ",".join(
                 settings.DEFAULT_STORAGE_BROKERS[storage_name]
             )
-        elif settings.DEFAULT_BROKERS:
-            default_config = {}
-            default_bootstrap_servers = ",".join(settings.DEFAULT_BROKERS)
         else:
             default_config = settings.STORAGE_BROKER_CONFIG.get(
                 storage_name, settings.BROKER_CONFIG
             )
     else:
-        if settings.DEFAULT_BROKERS:
-            default_config = {}
-            default_bootstrap_servers = ",".join(settings.DEFAULT_BROKERS)
-        else:
-            default_config = settings.BROKER_CONFIG
+        default_config = settings.BROKER_CONFIG
     broker_config = copy.deepcopy(default_config)
     assert isinstance(broker_config, dict)
     bootstrap_servers = (
@@ -851,9 +842,7 @@ class KafkaProducer(Producer[KafkaPayload]):
                 future.set_exception(error)
 
     def produce(
-        self,
-        destination: Union[Topic, Partition],
-        payload: KafkaPayload,
+        self, destination: Union[Topic, Partition], payload: KafkaPayload,
     ) -> Future[Message[KafkaPayload]]:
         if self.__shutdown_requested.is_set():
             raise RuntimeError("producer has been closed")

--- a/tests/utils/streams/backends/test_kafka_config.py
+++ b/tests/utils/streams/backends/test_kafka_config.py
@@ -28,18 +28,6 @@ def test_default_config_cli_bootstrap_servers():
     assert broker_config["bootstrap.servers"] == "cli.server:9092,cli2.server:9092"
 
 
-def test_default_config_legacy_override_default_servers():
-    default_broker = "my.broker:9092"
-    settings.DEFAULT_BROKERS = [default_broker]
-    broker_config = get_default_kafka_configuration()
-    assert broker_config["bootstrap.servers"] == default_broker
-
-    default_brokers = ["my.broker:9092", "my.second.broker:9092"]
-    settings.DEFAULT_BROKERS = default_brokers
-    broker_config = get_default_kafka_configuration()
-    assert broker_config["bootstrap.servers"] == ",".join(default_brokers)
-
-
 def test_default_config_legacy_override_storage_servers():
     storage_name = StorageKey.EVENTS.value
     storage_key = StorageKey(storage_name)
@@ -57,7 +45,7 @@ def test_default_config_legacy_override_storage_servers():
 def test_default_config_legacy_override_storage_servers_fallback():
     default_broker = "my.other.broker:9092"
     default_brokers = ["my.broker:9092", "my.second.broker:9092"]
-    settings.DEFAULT_BROKERS = [default_broker]
+    settings.BROKER_CONFIG = {"bootstrap.servers": default_broker}
     settings.DEFAULT_STORAGE_BROKERS = {
         StorageKey.EVENTS.value: default_brokers,
     }
@@ -101,7 +89,7 @@ def test_default_config_new_fallback_old():
     default_broker_config = {
         "bootstrap.servers": default_broker,
     }
-    settings.DEFAULT_BROKERS = [old_default_broker]
+    settings.BROKER_CONFIG = {"bootstrap.servers": old_default_broker}
     settings.STORAGE_BROKER_CONFIG = {
         StorageKey.EVENTS.value: default_broker_config,
     }
@@ -117,7 +105,6 @@ def test_default_config_new_fallback_old_storage():
     }
     settings.BROKER_CONFIG = default_broker_config
     settings.STORAGE_BROKER_CONFIG = {}
-    settings.DEFAULT_BROKERS = []
     settings.DEFAULT_STORAGE_BROKERS = {
         StorageKey.ERRORS.value: [old_default_broker],
     }


### PR DESCRIPTION
DEFAULT_BROKERS has been deprecated for some time; BROKER_CONFIG should be used
instead. This removes support for the DEFAULT_BROKERS setting.