### PR TITLE
fix(splitter) Skip the splitter if the order by is a function

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1228,6 +1228,59 @@ class TestApi(SimpleAPITest):
 
         assert "os.rooted" in result["data"][0]["top"]
 
+    def test_timestamp_functions(self) -> None:
+        response = self.post(
+            json.dumps(
+                {
+                    "aggregations": [],
+                    "conditions": [
+                        [
+                            ["coalesce", ["email", "username", "ip_address"]],
+                            "=",
+                            "42.200.228.8",
+                        ],
+                        ["project_id", "IN", [1]],
+                        ["group_id", "IN", [self.group_ids[0]]],
+                    ],
+                    "from_date": self.base_time.isoformat(),
+                    "granularity": 3600,
+                    "groupby": [],
+                    "having": [],
+                    "limit": 51,
+                    "offset": 0,
+                    "orderby": ["-timestamp.to_hour"],
+                    "project": [1],
+                    "selected_columns": [
+                        [
+                            "coalesce",
+                            ["email", "username", "ip_address"],
+                            "user.display",
+                        ],
+                        "release",
+                        ["toStartOfHour", ["timestamp"], "timestamp.to_hour"],
+                        "event_id",
+                        "project_id",
+                        [
+                            "transform",
+                            [
+                                ["toString", ["project_id"]],
+                                ["array", ["'1'"]],
+                                ["array", ["'stuff'"]],
+                                "''",
+                            ],
+                            "project.name",
+                        ],
+                    ],
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                    "totals": False,
+                }
+            ),
+        )
+
+        assert response.status_code == 200
+
     def test_tag_key_query(self) -> None:
         tags = [
             "browser",

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1193,6 +1193,48 @@ class TestDiscoverApi(BaseApiTest):
         assert len(data["data"]) == 1, data
         assert data["data"][0]["last_seen"] is not None
 
+    def test_timestamp_functions(self) -> None:
+        response = self.post(
+            json.dumps(
+                {
+                    "dataset": "discover",
+                    "aggregations": [],
+                    "conditions": [
+                        ["project_id", "IN", [self.project_id]],
+                        ["group_id", "IN", [2]],
+                    ],
+                    "granularity": 3600,
+                    "groupby": [],
+                    "having": [],
+                    "limit": 51,
+                    "offset": 0,
+                    "orderby": ["-timestamp.to_day"],
+                    "project": [1],
+                    "selected_columns": [
+                        "tags[url]",
+                        ["toStartOfDay", ["timestamp"], "timestamp.to_day"],
+                        "event_id",
+                        "project_id",
+                        [
+                            "transform",
+                            [
+                                ["toString", ["project_id"]],
+                                ["array", [f"'{self.project_id}'"]],
+                                ["array", ["'things'"]],
+                                "''",
+                            ],
+                            "project.name",
+                        ],
+                    ],
+                    "from_date": (self.base_time - self.skew).isoformat(),
+                    "to_date": (self.base_time + self.skew).isoformat(),
+                    "totals": False,
+                }
+            ),
+            entity="discover_events",
+        )
+        assert response.status_code == 200, response.data
+
     def test_invalid_event_id_condition(self) -> None:
         response = self.post(
             json.dumps(


### PR DESCRIPTION
It's possible for the minimal query to break if the orderby is a function on a
column instead of a bare column. Clickhouse throws an exception along the lines
of `Not found column f(x) in block` if f(x) is not in the select clause. Since
the minimal query replaces the select clause, this failure happens. Skip the
splitter entirely in this case.