### PR TITLE
feat: Remove the ability to run the events storage in dev and test

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -10,12 +10,6 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
     import sys
     from subprocess import list2cmdline, call
     from honcho.manager import Manager
-    from snuba import settings
-
-    if settings.ERRORS_ROLLOUT_WRITABLE_STORAGE:
-        events_storage = "errors"
-    else:
-        events_storage = "events"
 
     os.environ["PYTHONUNBUFFERED"] = "1"
 
@@ -79,7 +73,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "consumer",
                 "--auto-offset-reset=latest",
                 "--log-level=debug",
-                f"--storage={events_storage}",
+                "--storage=errors",
             ],
         ),
         (
@@ -89,7 +83,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "replacer",
                 "--auto-offset-reset=latest",
                 "--log-level=debug",
-                f"--storage={events_storage}",
+                "--storage=errors",
             ],
         ),
         (

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -16,7 +16,6 @@ from snuba.datasets.plans.single_storage import SelectedStorageQueryPlanBuilder
 from snuba.datasets.storage import (
     QueryStorageSelector,
     StorageAndMappers,
-    WritableTableStorage,
 )
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
@@ -173,12 +172,6 @@ class BaseEventsEntity(Entity, ABC):
 
             return "events", []
 
-        def writable_storage() -> WritableTableStorage:
-            if settings.ERRORS_ROLLOUT_WRITABLE_STORAGE:
-                return get_writable_storage(StorageKey.ERRORS)
-            else:
-                return get_writable_storage(StorageKey.EVENTS)
-
         super().__init__(
             storages=[events_storage, errors_storage],
             query_pipeline_builder=PipelineDelegator(
@@ -204,7 +197,7 @@ class BaseEventsEntity(Entity, ABC):
                     equivalences=[],
                 ),
             },
-            writable_storage=writable_storage(),
+            writable_storage=errors_storage,
             required_filter_columns=["project_id"],
             required_time_column="timestamp",
         )

--- a/snuba/settings.py
+++ b/snuba/settings.py
@@ -116,7 +116,6 @@ PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 
 ERRORS_ROLLOUT_ALL: bool = True
-ERRORS_ROLLOUT_WRITABLE_STORAGE: bool = True
 
 COLUMN_SPLIT_MIN_COLS = 6
 COLUMN_SPLIT_MAX_LIMIT = 1000

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -42,7 +42,6 @@ class TestReplacer:
         self.project_id = 1
         self.event = get_raw_event()
         settings.ERRORS_ROLLOUT_ALL = True
-        settings.ERRORS_ROLLOUT_WRITABLE_STORAGE = True
 
     def teardown_method(self):
         importlib.reload(settings)

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -40,7 +40,6 @@ class TestReplacer:
         self.project_id = 1
         self.event = get_raw_event()
         settings.ERRORS_ROLLOUT_ALL = False
-        settings.ERRORS_ROLLOUT_WRITABLE_STORAGE = False
 
     def teardown_method(self):
         importlib.reload(settings)


### PR DESCRIPTION
Removes support for the ERRORS_ROLLOUT_WRITABLE_STORAGE flag which
previously allowed switching between the events and errors storage in
dev and test environments. Only errors can be used now.