### PR TITLE
fix(snql) Allow duplicate conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .venv
 htmlcov/
 snuba.egg-info/
+.DS_Store

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import Any, Callable, Optional, Sequence, Set, TypeVar
 
 from snuba.clickhouse.columns import ColumnSet
@@ -54,25 +53,21 @@ def parse_conditions(
         return None
 
     if depth == 0:
-        # dedupe conditions at top level, but keep them in order
-        sub = OrderedDict(
-            (
-                parse_conditions(
-                    operand_builder,
-                    and_builder,
-                    or_builder,
-                    unpack_array_condition_builder,
-                    simple_condition_builder,
-                    entity,
-                    cond,
-                    arrayjoin_cols,
-                    depth + 1,
-                ),
-                None,
+        parsed = [
+            parse_conditions(
+                operand_builder,
+                and_builder,
+                or_builder,
+                unpack_array_condition_builder,
+                simple_condition_builder,
+                entity,
+                cond,
+                arrayjoin_cols,
+                depth + 1,
             )
             for cond in conditions
-        )
-        return and_builder([s for s in sub.keys() if s])
+        ]
+        return and_builder([c for c in parsed if c])
     elif is_condition(conditions):
         try:
             lhs, op, lit = conditions

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -17,7 +17,6 @@ from snuba.query.conditions import (
     BooleanFunctions,
 )
 from snuba.query.parser.conditions import parse_conditions_to_expr
-from snuba.util import tuplify
 
 test_conditions = [
     ([], None,),
@@ -471,23 +470,6 @@ test_conditions = [
             (Column(None, None, "tags.key"), Literal(None, "key")),
         ),
     ),  # Array columns not expanded because in arrayjoin
-    (
-        tuplify(
-            [["platform", "IN", ["a", "b", "c"]], ["platform", "IN", ["c", "b", "a"]]]
-        ),
-        FunctionCall(
-            None,
-            ConditionFunctions.IN,
-            (
-                Column(None, None, "platform"),
-                FunctionCall(
-                    None,
-                    "tuple",
-                    (Literal(None, "a"), Literal(None, "b"), Literal(None, "c")),
-                ),
-            ),
-        ),
-    ),  # Test that a duplicate IN condition is de-duplicated even if the lists are in different orders.
     (
         [["group_id", "IS NULL", None]],
         FunctionCall(


### PR DESCRIPTION
The legacy code strips duplicate top level conditions. I could add this to the
SnQL parser as well, but most SnQL queries have duplicate project conditions,
which the legacy parser preserves (since the extension conditions are added
after the deduping happens). So either I handle the single case of duplicate
project conditions, which requires rewriting the extension, the snql parser
and the SDK, or I remove this check from the legacy parser.

Since there's no Clickhouse impact to having duplicate conditions, I figured
this was the cleaner solution.