### PR TITLE
fix: Fixes a bug when using settings.STORAGE_TOPICS

### DIFF
--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -127,7 +127,6 @@ def build_kafka_stream_loader_from_settings(
         replacement_topic_spec = KafkaTopicSpec(
             replacement_topic, storage_topics.get("replacements"),
         )
-
     elif "replacements" in storage_topics:
         raise ValueError(
             f"invalid topic configuration for {storage_key!r}: replacements unsupported"
@@ -146,11 +145,6 @@ def build_kafka_stream_loader_from_settings(
         )
     else:
         commit_log_topic_spec = None
-
-    if storage_topics.keys():
-        raise ValueError(
-            f"invalid topic configuration for {storage_key!r}: unknown keys {[*storage_topics.keys()]!r}"
-        )
 
     return KafkaStreamLoader(
         processor,


### PR DESCRIPTION
This fixes a bug in the settings validation when the STORAGE_TOPICS
setting is being used. This check is no longer valid since we are no
longer mutating the storage_topics dict.