### PR TITLE
fix: Legacy events replacements should be on a separate topic

### DIFF
--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -38,7 +38,7 @@ storage = WritableTableStorage(
         StorageKey.EVENTS,
         processor=EventsProcessor(promoted_tag_columns),
         default_topic=Topic.EVENTS,
-        replacement_topic=Topic.EVENT_REPLACEMENTS,
+        replacement_topic=Topic.EVENT_REPLACEMENTS_LEGACY,
         commit_log_topic=Topic.COMMIT_LOG,
     ),
     query_splitters=query_splitters,

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -5,6 +5,7 @@ from typing import Mapping
 class Topic(Enum):
     EVENTS = "events"
     EVENT_REPLACEMENTS = "event-replacements"
+    EVENT_REPLACEMENTS_LEGACY = "event-replacements-legacy"
     COMMIT_LOG = "snuba-commit-log"
     CDC = "cdc"
     OUTCOMES = "outcomes"


### PR DESCRIPTION
Replacements for events and errors need to be on separate topics.
This is required to support environments (like Sentry prod) where the
multistorage consumer is used to run both events and errors consumers
at the same time. In that case replacements need to be on different topics.