### PR TITLE
Revert "feat: Remove unused datasets (#1843)"

### DIFF
--- a/snuba/cli/confirm_load.py
+++ b/snuba/cli/confirm_load.py
@@ -7,7 +7,7 @@ from confluent_kafka import KafkaError, Message, Producer
 
 from snuba import settings
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import CDC_STORAGES, get_cdc_storage
+from snuba.datasets.storages.factory import get_cdc_storage, CDC_STORAGES
 from snuba.environment import setup_logging, setup_sentry
 from snuba.snapshots.postgres_snapshot import PostgresSnapshot
 from snuba.stateful_consumer.control_protocol import SnapshotLoaded, TransactionData

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -19,7 +19,6 @@ from typing import (
 
 import rapidjson
 from confluent_kafka import Producer as ConfluentKafkaProducer
-
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.message_filters import StreamMessageFilter

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -19,8 +19,8 @@ from snuba.utils.streams.backends.kafka import (
     KafkaPayload,
     TransportError,
     build_kafka_consumer_configuration,
-    build_kafka_producer_configuration,
     get_default_kafka_configuration,
+    build_kafka_producer_configuration,
 )
 from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.streams.processing.strategies import ProcessingStrategyFactory
@@ -141,7 +141,6 @@ class ConsumerBuilder:
     def __build_consumer(
         self, strategy_factory: ProcessingStrategyFactory[KafkaPayload]
     ) -> StreamProcessor[KafkaPayload]:
-
         configuration = build_kafka_consumer_configuration(
             self.storage.get_table_writer()
             .get_stream_loader()

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,0 +1,15 @@
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+
+
+class GroupAssigneeDataset(Dataset):
+    """
+    This is a clone of sentry_groupasignee table in postgres.
+
+    REMARK: the name in Clickhouse fixes the typo we have in postgres.
+    Since the table does not correspond 1:1 to the postgres one anyway
+    there is no issue in fixing the name.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(default_entity=EntityKey.GROUPASSIGNEE)

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,0 +1,7 @@
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+
+
+class GroupedMessageDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(default_entity=EntityKey.GROUPEDMESSAGES)

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -11,6 +11,8 @@ DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
 DATASET_NAMES: Set[str] = {
     "discover",
     "events",
+    "groupassignee",
+    "groupedmessage",
     "outcomes",
     "outcomes_raw",
     "sessions",
@@ -32,6 +34,8 @@ def get_dataset(name: str) -> Dataset:
             f"dataset {name!r} is not available in this environment"
         )
 
+    from snuba.datasets.cdc.groupassignee import GroupAssigneeDataset
+    from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
     from snuba.datasets.discover import DiscoverDataset
     from snuba.datasets.events import EventsDataset
 
@@ -43,6 +47,8 @@ def get_dataset(name: str) -> Dataset:
     dataset_factories: MutableMapping[str, Callable[[], Dataset]] = {
         "discover": DiscoverDataset,
         "events": EventsDataset,
+        "groupassignee": GroupAssigneeDataset,
+        "groupedmessage": GroupedMessageDataset,
         "outcomes": OutcomesDataset,
         "outcomes_raw": OutcomesRawDataset,
         "sessions": SessionsDataset,

--- a/snuba/utils/streams/backends/kafka.py
+++ b/snuba/utils/streams/backends/kafka.py
@@ -48,8 +48,8 @@ from snuba.utils.streams.backends.abstract import (
     OffsetOutOfRange,
     Producer,
 )
-from snuba.utils.streams.topics import Topic as KafkaTopic
 from snuba.utils.streams.types import Message, Partition, Topic
+from snuba.utils.streams.topics import Topic as KafkaTopic
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,23 +3,23 @@ from typing import Optional
 
 import pytest
 import rapidjson
-
 from snuba.clickhouse.errors import ClickhouseWriterError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
-from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.factory import enforce_table_writer, get_dataset
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 
 
 class TestHTTPBatchWriter:
-    storage = get_writable_storage(StorageKey.ERRORS)
+    dataset = get_dataset("events")
     metrics = DummyMetricsBackend(strict=True)
 
     def test_empty_batch(self) -> None:
-        self.storage.get_table_writer().get_batch_writer(metrics=self.metrics).write([])
+        enforce_table_writer(self.dataset).get_batch_writer(metrics=self.metrics).write(
+            []
+        )
 
     def test_error_handling(self) -> None:
-        table_writer = self.storage.get_table_writer()
+        table_writer = enforce_table_writer(self.dataset)
 
         with pytest.raises(ClickhouseWriterError) as error:
             table_writer.get_batch_writer(
@@ -51,9 +51,9 @@ class FakeQuery(FormattedQuery):
 def test_gzip_load() -> None:
     content = gzip.compress(DATA.encode("utf-8"))
 
-    storage = get_writable_storage(StorageKey.GROUPEDMESSAGES)
+    dataset = get_dataset("groupedmessage")
     metrics = DummyMetricsBackend(strict=True)
-    writer = storage.get_table_writer().get_bulk_writer(
+    writer = enforce_table_writer(dataset).get_bulk_writer(
         metrics,
         "gzip",
         [
@@ -71,7 +71,8 @@ def test_gzip_load() -> None:
 
     writer.write([content])
 
-    reader = storage.get_cluster().get_reader()
+    cluster = dataset.get_default_entity().get_all_storages()[0].get_cluster()
+    reader = cluster.get_reader()
 
     ret = reader.execute(FakeQuery([]))
     assert ret["data"][0] == {"count()": 2}

--- a/tests/utils/streams/backends/test_kafka_config.py
+++ b/tests/utils/streams/backends/test_kafka_config.py
@@ -1,6 +1,6 @@
 import importlib
-
 from snuba import settings
+
 from snuba.utils.streams.backends.kafka import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
 


### PR DESCRIPTION
This reverts commit adb07d8bf71c93974466b1e3f8161260379e3a8b.

These datasets are still referenced in Sentry tests, we should remove that first.