### PR TITLE
feat: Subscription result Kafka topic can be configured via settings

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -8,7 +8,8 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
     "Starts all Snuba processes for local development."
     import os
     import sys
-    from subprocess import list2cmdline, call
+    from subprocess import call, list2cmdline
+
     from honcho.manager import Manager
 
     os.environ["PYTHONUNBUFFERED"] = "1"
@@ -95,8 +96,6 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--log-level=debug",
                 "--max-batch-size=1",
                 "--consumer-group=snuba-events-subscriptions-consumers",
-                "--topic=events",
-                "--result-topic=events-subscription-results",
                 "--dataset=events",
                 "--commit-log-topic=snuba-commit-log",
                 "--commit-log-group=snuba-consumers",
@@ -114,8 +113,6 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--log-level=debug",
                 "--max-batch-size=1",
                 "--consumer-group=snuba-transactions-subscriptions-consumers",
-                "--topic=events",
-                "--result-topic=transactions-subscription-results",
                 "--dataset=transactions",
                 "--commit-log-topic=snuba-commit-log",
                 "--commit-log-group=transactions_group",

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -111,8 +111,6 @@ def subscriptions(
 ) -> None:
     """Evaluates subscribed queries for a dataset."""
 
-    assert result_topic is not None
-
     setup_logging(log_level)
     setup_sentry()
 
@@ -126,6 +124,9 @@ def subscriptions(
     loader = enforce_table_writer(dataset).get_stream_loader()
     commit_log_topic_spec = loader.get_commit_log_topic_spec()
     assert commit_log_topic_spec is not None
+
+    result_topic_spec = loader.get_subscription_result_topic_spec()
+    assert result_topic_spec is not None
 
     metrics = MetricsWrapper(
         environment.metrics,
@@ -211,7 +212,9 @@ def subscriptions(
                         )
                     },
                     producer,
-                    Topic(result_topic),
+                    Topic(result_topic)
+                    if result_topic is not None
+                    else Topic(result_topic_spec.topic_name),
                     metrics,
                 ),
                 max_batch_size,

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -38,6 +38,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,
+        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),
     replacer_processor=ErrorsReplacer(
         schema=schema,

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -39,6 +39,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS_LEGACY,
         commit_log_topic=Topic.COMMIT_LOG,
+        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),
     query_splitters=query_splitters,
     mandatory_condition_checkers=[ProjectIdEnforcer()],

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -131,6 +131,7 @@ storage = WritableTableStorage(
         processor=TransactionsMessageProcessor(),
         default_topic=Topic.EVENTS,
         commit_log_topic=Topic.COMMIT_LOG,
+        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_TRANSACTIONS,
     ),
     query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
     mandatory_condition_checkers=[ProjectIdEnforcer()],

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -65,11 +65,13 @@ class KafkaStreamLoader:
         pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
         replacement_topic_spec: Optional[KafkaTopicSpec] = None,
         commit_log_topic_spec: Optional[KafkaTopicSpec] = None,
+        subscription_result_topic_spec: Optional[KafkaTopicSpec] = None,
     ) -> None:
         self.__processor = processor
         self.__default_topic_spec = default_topic_spec
         self.__replacement_topic_spec = replacement_topic_spec
         self.__commit_log_topic_spec = commit_log_topic_spec
+        self.__subscription_result_topic_spec = subscription_result_topic_spec
         self.__pre_filter = pre_filter
 
     def get_processor(self) -> MessageProcessor:
@@ -91,13 +93,8 @@ class KafkaStreamLoader:
     def get_commit_log_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__commit_log_topic_spec
 
-    def get_all_topic_specs(self) -> Sequence[KafkaTopicSpec]:
-        ret = [self.__default_topic_spec]
-        if self.__replacement_topic_spec is not None:
-            ret.append(self.__replacement_topic_spec)
-        if self.__commit_log_topic_spec is not None:
-            ret.append(self.__commit_log_topic_spec)
-        return ret
+    def get_subscription_result_topic_spec(self) -> Optional[KafkaTopicSpec]:
+        return self.__subscription_result_topic_spec
 
 
 def build_kafka_stream_loader_from_settings(
@@ -106,6 +103,7 @@ def build_kafka_stream_loader_from_settings(
     pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
     replacement_topic: Optional[Topic] = None,
     commit_log_topic: Optional[Topic] = None,
+    subscription_result_topic: Optional[Topic] = None,
 ) -> KafkaStreamLoader:
     default_topic_spec = KafkaTopicSpec(default_topic)
 
@@ -122,12 +120,19 @@ def build_kafka_stream_loader_from_settings(
     else:
         commit_log_topic_spec = None
 
+    subscription_result_topic_spec: Optional[KafkaTopicSpec]
+    if subscription_result_topic is not None:
+        subscription_result_topic_spec = KafkaTopicSpec(subscription_result_topic)
+    else:
+        subscription_result_topic_spec = None
+
     return KafkaStreamLoader(
         processor,
         default_topic_spec,
         pre_filter,
         replacement_topic_spec,
         commit_log_topic_spec,
+        subscription_result_topic_spec=subscription_result_topic_spec,
     )
 
 

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -27,6 +27,8 @@ def _validate_settings(locals: Mapping[str, Any]) -> None:
         "outcomes",
         "ingest-sessions",
         "snuba-queries",
+        "events-subscription-results",
+        "transactions-subscription-results",
     }
 
     for key in locals["KAFKA_TOPIC_MAP"].keys():

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -11,6 +11,8 @@ class Topic(Enum):
     CDC = "cdc"
     OUTCOMES = "outcomes"
     SESSIONS = "ingest-sessions"
+    SUBSCRIPTION_RESULTS_EVENTS = "events-subscription-results"
+    SUBSCRIPTION_RESULTS_TRANSACTIONS = "transactions-subscription-results"
     QUERYLOG = "snuba-queries"
 
 


### PR DESCRIPTION
This is an attempt to align the way subscription result topics are configured
with the rest of the Kafka topics.

Previously any storage could be subscribed to (though it may not work properly).
Now a storage defines whether it can be subscribed to or not via
`stream_loader.subscription_result_topic`. It is no longer necessary to pass the
--result-topic into the subscriptions consumer, the topic name will come from
the default or settings configuration like all other Kafka topics.

The result topics will also now get created when `snuba bootstrap` is run.