### PR TITLE
feat(cdc) Make destination table optional on bulk_load

### DIFF
--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import click
 import progressbar
+
 from snuba import environment, settings
 from snuba.clickhouse.http import JSONRowEncoder
 from snuba.datasets.storages import StorageKey
@@ -25,7 +26,10 @@ from snuba.writer import BufferedWriterWrapper
     "--source",
     help="Source of the dump. Depending on the storage it may have different meaning.",
 )
-@click.option("--dest-table", help="Clickhouse destination table.")
+@click.option(
+    "--dest-table",
+    help="Clickhouse destination table, if different from storage write table",
+)
 @click.option(
     "--ignore-existing-data",
     default=False,
@@ -45,7 +49,7 @@ from snuba.writer import BufferedWriterWrapper
 def bulk_load(
     *,
     storage_name: str,
-    dest_table: str,
+    dest_table: Optional[str],
     source: str,
     ignore_existing_data: bool,
     pre_processed: bool,
@@ -71,8 +75,8 @@ def bulk_load(
     loader = table_writer.get_bulk_loader(
         snapshot_source,
         storage.get_postgres_table(),
-        dest_table,
         storage.get_row_processor(),
+        dest_table,
     )
     # TODO: see whether we need to pass options to the writer
 

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -210,17 +210,18 @@ class TableWriter:
         self,
         source: BulkLoadSource,
         source_table: str,
-        dest_table: str,
         row_processor: RowProcessor,
+        table_name: Optional[str] = None,
     ) -> BulkLoader:
         """
         Returns the instance of the bulk loader to populate the dataset from an
         external source when present.
         """
+        table_name = table_name or self.__table_schema.get_table_name()
         return SingleTableBulkLoader(
             source=source,
             source_table=source_table,
-            dest_table=dest_table,
+            dest_table=table_name,
             row_processor=row_processor,
             clickhouse=self.__cluster.get_query_connection(
                 ClickhouseClientSettings.QUERY


### PR DESCRIPTION
We never need to set this parameter in dev. Or in any environment other than specific production tests. 
Defaulting to the storage table is the right option most of the times. This way we can avoid exposing the clickhouse table names outside of this script.