### PR TITLE
ref: Move Snuba specific code out of `snuba.utils.streams.backends`

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -9,7 +9,7 @@ from snuba.environment import setup_logging
 from snuba.migrations.connect import check_clickhouse_connections
 from snuba.migrations.runner import Runner
 from snuba.utils.logging import pylog_to_syslog_level
-from snuba.utils.streams.backends.kafka import get_default_kafka_configuration
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
 
 

--- a/snuba/cli/confirm_load.py
+++ b/snuba/cli/confirm_load.py
@@ -7,11 +7,11 @@ from confluent_kafka import KafkaError, Message, Producer
 
 from snuba import settings
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_cdc_storage, CDC_STORAGES
+from snuba.datasets.storages.factory import CDC_STORAGES, get_cdc_storage
 from snuba.environment import setup_logging, setup_sentry
 from snuba.snapshots.postgres_snapshot import PostgresSnapshot
 from snuba.stateful_consumer.control_protocol import SnapshotLoaded, TransactionData
-from snuba.utils.streams.backends.kafka import build_kafka_producer_configuration
+from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 
 
 @click.command()

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -11,9 +11,8 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import WRITABLE_STORAGES, get_writable_storage
 from snuba.environment import setup_logging, setup_sentry
 from snuba.utils.metrics.wrapper import MetricsWrapper
-from snuba.utils.streams.backends.kafka import (
-    KafkaConsumer,
-    KafkaConsumerWithCommitLog,
+from snuba.utils.streams.backends.kafka import KafkaConsumer, KafkaConsumerWithCommitLog
+from snuba.utils.streams.configuration_builder import (
     build_kafka_consumer_configuration,
     build_kafka_producer_configuration,
 )

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -76,9 +76,8 @@ def replacer(
 
     from snuba.replacer import ReplacerWorker
     from snuba.utils.streams import Topic
-    from snuba.utils.streams.backends.kafka import (
-        KafkaConsumer,
-        TransportError,
+    from snuba.utils.streams.backends.kafka import KafkaConsumer, TransportError
+    from snuba.utils.streams.configuration_builder import (
         build_kafka_consumer_configuration,
     )
     from snuba.utils.streams.processing import StreamProcessor

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -20,9 +20,8 @@ from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.worker import SubscriptionWorker
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams import Topic
-from snuba.utils.streams.backends.kafka import (
-    KafkaConsumer,
-    KafkaProducer,
+from snuba.utils.streams.backends.kafka import KafkaConsumer, KafkaProducer
+from snuba.utils.streams.configuration_builder import (
     build_kafka_consumer_configuration,
     build_kafka_producer_configuration,
 )

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -19,6 +19,7 @@ from typing import (
 
 import rapidjson
 from confluent_kafka import Producer as ConfluentKafkaProducer
+
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.message_filters import StreamMessageFilter
@@ -28,10 +29,8 @@ from snuba.processor import InsertBatch, MessageProcessor, ReplacementBatch
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams import Message, Partition, Topic
-from snuba.utils.streams.backends.kafka import (
-    KafkaPayload,
-    build_kafka_producer_configuration,
-)
+from snuba.utils.streams.backends.kafka import KafkaPayload
+from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.processing.strategies import ProcessingStrategy
 from snuba.utils.streams.processing.strategies import (
     ProcessingStrategy as ProcessingStep,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -18,9 +18,11 @@ from snuba.utils.streams.backends.kafka import (
     KafkaConsumerWithCommitLog,
     KafkaPayload,
     TransportError,
+)
+from snuba.utils.streams.configuration_builder import (
     build_kafka_consumer_configuration,
-    get_default_kafka_configuration,
     build_kafka_producer_configuration,
+    get_default_kafka_configuration,
 )
 from snuba.utils.streams.processing import StreamProcessor
 from snuba.utils.streams.processing.strategies import ProcessingStrategyFactory

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -1,10 +1,10 @@
-from confluent_kafka import Consumer, KafkaError, Message, TopicPartition
+import logging
 from enum import Enum
 from typing import Callable, MutableMapping, Optional, Sequence, Tuple
 
-import logging
+from confluent_kafka import Consumer, KafkaError, Message, TopicPartition
 
-from snuba.utils.streams.backends.kafka import KafkaBrokerConfig
+from snuba.utils.streams.backends.configuration import KafkaBrokerConfig
 
 logger = logging.getLogger("snuba.kafka-consumer")
 

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -25,7 +25,7 @@ from confluent_kafka import Producer
 from snuba import environment, settings
 from snuba.redis import redis_client
 from snuba.utils.metrics.wrapper import MetricsWrapper
-from snuba.utils.streams.backends.kafka import (
+from snuba.utils.streams.configuration_builder import (
     build_default_kafka_producer_configuration,
 )
 from snuba.utils.streams.topics import Topic

--- a/snuba/stateful_consumer/states/bootstrap.py
+++ b/snuba/stateful_consumer/states/bootstrap.py
@@ -1,23 +1,23 @@
 import json
 import logging
-
 from typing import Optional, Set, Tuple
+
 from confluent_kafka import Message
 
 from snuba import settings
 from snuba.consumers.strict_consumer import CommitDecision, StrictConsumer
 from snuba.datasets.cdc import CdcStorage
-from snuba.stateful_consumer import ConsumerStateData, ConsumerStateCompletionEvent
 from snuba.snapshots import SnapshotId
+from snuba.stateful_consumer import ConsumerStateCompletionEvent, ConsumerStateData
 from snuba.stateful_consumer.control_protocol import (
-    parse_control_message,
-    SnapshotInit,
     SnapshotAbort,
+    SnapshotInit,
     SnapshotLoaded,
     TransactionData,
+    parse_control_message,
 )
 from snuba.utils.state_machine import State
-from snuba.utils.streams.backends.kafka import KafkaBrokerConfig
+from snuba.utils.streams.backends.configuration import KafkaBrokerConfig
 
 logger = logging.getLogger("snuba.snapshot-load")
 

--- a/snuba/utils/streams/backends/configuration.py
+++ b/snuba/utils/streams/backends/configuration.py
@@ -1,0 +1,95 @@
+import copy
+import logging
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+from snuba.utils.logging import pylog_to_syslog_level
+
+logger = logging.getLogger(__name__)
+
+KafkaBrokerConfig = Dict[str, Any]
+
+
+DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
+DEFAULT_QUEUED_MIN_MESSAGES = 10000
+DEFAULT_PARTITIONER = "consistent"
+DEFAULT_MAX_MESSAGE_BYTES = 50000000  # 50MB, default is 1MB
+SUPPORTED_KAFKA_CONFIGURATION = (
+    # Check https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+    # for the full list of available options
+    "bootstrap.servers",
+    "sasl.mechanism",
+    "sasl.username",
+    "sasl.password",
+    "security.protocol",
+    "ssl.ca.location",
+    "ssl.ca.certificate.stores",
+    "ssl.certificate.location",
+    "ssl.certificate.pem",
+    "ssl.cipher.suites",
+    "ssl.crl.location",
+    "ssl.curves.list",
+    "ssl.endpoint.identification.algorithm",
+    "ssl.key.location",
+    "ssl.key.password",
+    "ssl.key.pem",
+    "ssl.keystore.location",
+    "ssl.keystore.password",
+    "ssl.sigalgs.list",
+)
+
+
+def build_kafka_configuration_with_overrides(
+    default_config: Mapping[str, Any],
+    bootstrap_servers: Optional[Sequence[str]] = None,
+    override_params: Optional[Mapping[str, Any]] = None,
+) -> KafkaBrokerConfig:
+    default_bootstrap_servers = None
+    broker_config = copy.deepcopy(default_config)
+    assert isinstance(broker_config, dict)
+    bootstrap_servers = (
+        ",".join(bootstrap_servers) if bootstrap_servers else default_bootstrap_servers
+    )
+    if bootstrap_servers:
+        broker_config["bootstrap.servers"] = bootstrap_servers
+    broker_config = {k: v for k, v in broker_config.items() if v is not None}
+    for configuration_key in broker_config:
+        if configuration_key not in SUPPORTED_KAFKA_CONFIGURATION:
+            raise ValueError(
+                f"The `{configuration_key}` configuration key is not supported."
+            )
+
+    broker_config["log_level"] = pylog_to_syslog_level(logger.getEffectiveLevel())
+
+    if override_params:
+        broker_config.update(override_params)
+
+    return broker_config
+
+
+def build_kafka_consumer_configuration_with_overrides(
+    default_config: Mapping[str, Any],
+    group_id: str,
+    auto_offset_reset: str = "error",
+    queued_max_messages_kbytes: int = DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
+    queued_min_messages: int = DEFAULT_QUEUED_MIN_MESSAGES,
+    bootstrap_servers: Optional[Sequence[str]] = None,
+    override_params: Optional[Mapping[str, Any]] = None,
+) -> KafkaBrokerConfig:
+
+    broker_config = build_kafka_configuration_with_overrides(
+        default_config, bootstrap_servers, override_params
+    )
+
+    broker_config.update(
+        {
+            "enable.auto.commit": False,
+            "enable.auto.offset.store": False,
+            "group.id": group_id,
+            "auto.offset.reset": auto_offset_reset,
+            # overridden to reduce memory usage when there's a large backlog
+            "queued.max.messages.kbytes": queued_max_messages_kbytes,
+            "queued.min.messages": queued_min_messages,
+            "enable.partition.eof": False,
+        }
+    )
+    return broker_config

--- a/snuba/utils/streams/backends/kafka.py
+++ b/snuba/utils/streams/backends/kafka.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import logging
 from concurrent.futures import Future
 from datetime import datetime
@@ -11,7 +10,6 @@ from threading import Event
 from typing import (
     Any,
     Callable,
-    Dict,
     Mapping,
     MutableMapping,
     MutableSequence,
@@ -37,9 +35,7 @@ from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentProducer
 from confluent_kafka import TopicPartition as ConfluentTopicPartition
 
-from snuba import settings
 from snuba.utils.concurrent import execute
-from snuba.utils.logging import pylog_to_syslog_level
 from snuba.utils.retries import NoRetryPolicy, RetryPolicy
 from snuba.utils.streams.backends.abstract import (
     Consumer,
@@ -49,7 +45,6 @@ from snuba.utils.streams.backends.abstract import (
     Producer,
 )
 from snuba.utils.streams.types import Message, Partition, Topic
-from snuba.utils.streams.topics import Topic as KafkaTopic
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +56,6 @@ class TransportError(ConsumerError):
 KafkaConsumerState = Enum(
     "KafkaConsumerState", ["CONSUMING", "ERROR", "CLOSED", "ASSIGNING", "REVOKING"]
 )
-
-KafkaBrokerConfig = Dict[str, Any]
 
 
 class InvalidState(RuntimeError):
@@ -618,115 +611,6 @@ class KafkaConsumer(Consumer[KafkaPayload]):
     @property
     def closed(self) -> bool:
         return self.__state is KafkaConsumerState.CLOSED
-
-
-DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
-DEFAULT_QUEUED_MIN_MESSAGES = 10000
-DEFAULT_PARTITIONER = "consistent"
-DEFAULT_MAX_MESSAGE_BYTES = 50000000  # 50MB, default is 1MB
-SUPPORTED_KAFKA_CONFIGURATION = (
-    # Check https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
-    # for the full list of available options
-    "bootstrap.servers",
-    "sasl.mechanism",
-    "sasl.username",
-    "sasl.password",
-    "security.protocol",
-    "ssl.ca.location",
-    "ssl.ca.certificate.stores",
-    "ssl.certificate.location",
-    "ssl.certificate.pem",
-    "ssl.cipher.suites",
-    "ssl.crl.location",
-    "ssl.curves.list",
-    "ssl.endpoint.identification.algorithm",
-    "ssl.key.location",
-    "ssl.key.password",
-    "ssl.key.pem",
-    "ssl.keystore.location",
-    "ssl.keystore.password",
-    "ssl.sigalgs.list",
-)
-
-
-def get_default_kafka_configuration(
-    topic: Optional[KafkaTopic] = None,
-    bootstrap_servers: Optional[Sequence[str]] = None,
-    override_params: Optional[Mapping[str, Any]] = None,
-) -> KafkaBrokerConfig:
-    default_bootstrap_servers = None
-    default_config: Mapping[str, Any]
-
-    if topic is not None:
-        default_config = settings.KAFKA_BROKER_CONFIG.get(
-            topic.value, settings.BROKER_CONFIG
-        )
-    else:
-        default_config = settings.BROKER_CONFIG
-    broker_config = copy.deepcopy(default_config)
-    assert isinstance(broker_config, dict)
-    bootstrap_servers = (
-        ",".join(bootstrap_servers) if bootstrap_servers else default_bootstrap_servers
-    )
-    if bootstrap_servers:
-        broker_config["bootstrap.servers"] = bootstrap_servers
-    broker_config = {k: v for k, v in broker_config.items() if v is not None}
-    for configuration_key in broker_config:
-        if configuration_key not in SUPPORTED_KAFKA_CONFIGURATION:
-            raise ValueError(
-                f"The `{configuration_key}` configuration key is not supported."
-            )
-
-    broker_config["log_level"] = pylog_to_syslog_level(logger.getEffectiveLevel())
-
-    if override_params:
-        broker_config.update(override_params)
-
-    return broker_config
-
-
-def build_kafka_consumer_configuration(
-    topic: Optional[KafkaTopic],
-    group_id: str,
-    auto_offset_reset: str = "error",
-    queued_max_messages_kbytes: int = DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
-    queued_min_messages: int = DEFAULT_QUEUED_MIN_MESSAGES,
-    bootstrap_servers: Optional[Sequence[str]] = None,
-    override_params: Optional[Mapping[str, Any]] = None,
-) -> KafkaBrokerConfig:
-    broker_config = get_default_kafka_configuration(
-        topic, bootstrap_servers=bootstrap_servers, override_params=override_params,
-    )
-    broker_config.update(
-        {
-            "enable.auto.commit": False,
-            "enable.auto.offset.store": False,
-            "group.id": group_id,
-            "auto.offset.reset": auto_offset_reset,
-            # overridden to reduce memory usage when there's a large backlog
-            "queued.max.messages.kbytes": queued_max_messages_kbytes,
-            "queued.min.messages": queued_min_messages,
-            "enable.partition.eof": False,
-        }
-    )
-    return broker_config
-
-
-def build_kafka_producer_configuration(
-    topic: Optional[KafkaTopic],
-    bootstrap_servers: Optional[Sequence[str]] = None,
-    override_params: Optional[Mapping[str, Any]] = None,
-) -> KafkaBrokerConfig:
-    broker_config = get_default_kafka_configuration(
-        topic=topic,
-        bootstrap_servers=bootstrap_servers,
-        override_params=override_params,
-    )
-    return broker_config
-
-
-def build_default_kafka_producer_configuration() -> KafkaBrokerConfig:
-    return build_kafka_producer_configuration(None, None)
 
 
 # XXX: This must be imported after `KafkaPayload` to avoid a circular import.

--- a/snuba/utils/streams/configuration_builder.py
+++ b/snuba/utils/streams/configuration_builder.py
@@ -1,0 +1,73 @@
+import logging
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+from snuba import settings
+from snuba.utils.streams.backends.configuration import (
+    DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
+    DEFAULT_QUEUED_MIN_MESSAGES,
+    build_kafka_configuration_with_overrides,
+    build_kafka_consumer_configuration_with_overrides,
+)
+from snuba.utils.streams.topics import Topic
+
+logger = logging.getLogger(__name__)
+
+KafkaBrokerConfig = Dict[str, Any]
+
+
+def _get_default_topic_configuration(topic: Optional[Topic]) -> Mapping[str, Any]:
+    if topic is not None:
+        return settings.KAFKA_BROKER_CONFIG.get(topic.value, settings.BROKER_CONFIG)
+    else:
+        return settings.BROKER_CONFIG
+
+
+def get_default_kafka_configuration(
+    topic: Optional[Topic] = None,
+    bootstrap_servers: Optional[Sequence[str]] = None,
+    override_params: Optional[Mapping[str, Any]] = None,
+) -> KafkaBrokerConfig:
+    default_topic_config = _get_default_topic_configuration(topic)
+
+    return build_kafka_configuration_with_overrides(
+        default_topic_config, bootstrap_servers, override_params
+    )
+
+
+def build_kafka_consumer_configuration(
+    topic: Optional[Topic],
+    group_id: str,
+    auto_offset_reset: str = "error",
+    queued_max_messages_kbytes: int = DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
+    queued_min_messages: int = DEFAULT_QUEUED_MIN_MESSAGES,
+    bootstrap_servers: Optional[Sequence[str]] = None,
+    override_params: Optional[Mapping[str, Any]] = None,
+) -> KafkaBrokerConfig:
+    default_topic_config = _get_default_topic_configuration(topic)
+
+    return build_kafka_consumer_configuration_with_overrides(
+        default_topic_config,
+        group_id,
+        auto_offset_reset,
+        queued_max_messages_kbytes,
+        queued_min_messages,
+        bootstrap_servers,
+        override_params,
+    )
+
+
+def build_kafka_producer_configuration(
+    topic: Optional[Topic],
+    bootstrap_servers: Optional[Sequence[str]] = None,
+    override_params: Optional[Mapping[str, Any]] = None,
+) -> KafkaBrokerConfig:
+    broker_config = get_default_kafka_configuration(
+        topic=topic,
+        bootstrap_servers=bootstrap_servers,
+        override_params=override_params,
+    )
+    return broker_config
+
+
+def build_default_kafka_producer_configuration() -> KafkaBrokerConfig:
+    return build_kafka_producer_configuration(None, None)

--- a/tests/consumers/test_strict_consumer.py
+++ b/tests/consumers/test_strict_consumer.py
@@ -1,15 +1,14 @@
-import pytest
+from unittest.mock import MagicMock, patch
 
+import pytest
 from confluent_kafka import KafkaError
-from unittest.mock import patch
-from unittest.mock import MagicMock
 
 from snuba.consumers.strict_consumer import (
     CommitDecision,
     NoPartitionAssigned,
     StrictConsumer,
 )
-from snuba.utils.streams.backends.kafka import get_default_kafka_configuration
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from tests.backends.confluent_kafka import (
     FakeConfluentKafkaConsumer,
     build_confluent_kafka_message,

--- a/tests/stateful_consumer/test_bootstrap_state.py
+++ b/tests/stateful_consumer/test_bootstrap_state.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch
 
+from snuba.consumers.strict_consumer import StrictConsumer
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_cdc_storage
 from snuba.stateful_consumer import ConsumerStateCompletionEvent
-from snuba.consumers.strict_consumer import StrictConsumer
 from snuba.stateful_consumer.states.bootstrap import BootstrapState
-from snuba.utils.streams.backends.kafka import get_default_kafka_configuration
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from tests.backends.confluent_kafka import (
     FakeConfluentKafkaConsumer,
     build_confluent_kafka_message,

--- a/tests/utils/streams/backends/test_kafka.py
+++ b/tests/utils/streams/backends/test_kafka.py
@@ -17,8 +17,8 @@ from snuba.utils.streams.backends.kafka import (
     KafkaPayload,
     KafkaProducer,
     as_kafka_configuration_bool,
-    get_default_kafka_configuration,
 )
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.synchronized import Commit, commit_codec
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer

--- a/tests/utils/streams/backends/test_kafka_config.py
+++ b/tests/utils/streams/backends/test_kafka_config.py
@@ -1,7 +1,7 @@
 import importlib
-from snuba import settings
 
-from snuba.utils.streams.backends.kafka import get_default_kafka_configuration
+from snuba import settings
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
 
 


### PR DESCRIPTION
This is an attempt to separate the Snuba specific parts of Kafka configuration
(specifically the part that depends on Snuba's settings formats and topics)
from the parts that are generic and can be eventually shared with other codebases
such as Sentry.