### PR TITLE
fix(gauge): Fix decrement() to use value passed

### DIFF
--- a/snuba/utils/metrics/gauge.py
+++ b/snuba/utils/metrics/gauge.py
@@ -36,7 +36,7 @@ class Gauge:
         self.__report()
 
     def decrement(self, value: float = 1.0) -> None:
-        self.__value -= 1
+        self.__value -= value
         self.__report()
 
 


### PR DESCRIPTION
Not sure why this was hardcoded to 1 previously, I assume it's meant to
decrement by the value passed to the function.