### PR TITLE
ref(typing): Simplify typing assertion helpers

### DIFF
--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,18 +1,18 @@
 import operator
 from contextlib import contextmanager
-from typing import Callable, Iterator, TypeVar
+from typing import Any, Callable, Iterator, TypeVar, cast
 
 T = TypeVar("T")
 
 
 @contextmanager
 def assert_changes(
-    callable: Callable[[], T],
+    callable: Callable[[], Any],
     before: T,
     after: T,
     operator: Callable[[T, T], bool] = operator.eq,
 ) -> Iterator[None]:
-    actual = callable()
+    actual = cast(T, callable())
     assert operator(
         actual, before
     ), f"precondition ({operator}) on {callable} failed: expected: {before!r}, actual: {actual!r}"
@@ -27,9 +27,11 @@ def assert_changes(
 
 @contextmanager
 def assert_does_not_change(
-    callable: Callable[[], T], value: T, operator: Callable[[T, T], bool] = operator.eq,
+    callable: Callable[[], Any],
+    value: T,
+    operator: Callable[[T, T], bool] = operator.eq,
 ) -> Iterator[None]:
-    actual = callable()
+    actual = cast(T, callable())
     assert operator(
         actual, value
     ), f"precondition ({operator}) on {callable} failed: expected: {value!r}, actual: {actual!r}"


### PR DESCRIPTION
Do not enforce the return type of callable passed to assert_changes and
assert_does_not_change to return any type. The goal of this change is
to make these functions easier to use.