### PR TITLE
ref: Redefine Replacement as ABC [minimal]

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -274,7 +274,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
                     set_project_needs_final(project_id, None)
                 set_project_needs_final(project_id, self.__state_name)
 
-            if isinstance(query_time_flags, ExcludeGroups):
+            elif isinstance(query_time_flags, ExcludeGroups):
                 if compatibility_double_write:
                     set_project_exclude_groups(
                         project_id, query_time_flags.group_ids, None

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -1,30 +1,35 @@
 import logging
 import time
 import uuid
-
+from abc import abstractmethod
 from collections import deque
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Deque, Mapping, Optional, Sequence, Tuple, MutableMapping, List
+from typing import (
+    Any,
+    Deque,
+    Dict,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 from snuba import settings
 from snuba.clickhouse import DATETIME_FORMAT
-from snuba.clickhouse.columns import FlattenedColumn, ReadOnly, Nullable
+from snuba.clickhouse.columns import FlattenedColumn, Nullable, ReadOnly
 from snuba.clickhouse.escaping import escape_identifier, escape_string
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.processor import InvalidMessageType, _hashify
 from snuba.redis import redis_client
-from snuba.replacers.replacer_processor import (
-    Replacement,
-    ReplacementMessage,
-    ReplacerProcessor,
-)
-
+from snuba.replacers.replacer_processor import Replacement as ReplacementBase
+from snuba.replacers.replacer_processor import ReplacementMessage, ReplacerProcessor
 
 logger = logging.getLogger(__name__)
-
-EXCLUDE_GROUPS = object()
-NEEDS_FINAL = object()
 
 """
 Disambiguate the dataset/storage when there are multiple tables representing errors
@@ -36,6 +41,63 @@ In theory this will be needed only during the events to errors migration.
 class ReplacerState(Enum):
     EVENTS = "events"
     ERRORS = "errors"
+
+
+class Replacement(ReplacementBase):
+    @abstractmethod
+    def get_excluded_groups(self) -> Sequence[int]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_needs_final(self) -> bool:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_project_id(self) -> int:
+        raise NotImplementedError()
+
+
+EXCLUDE_GROUPS = object()
+NEEDS_FINAL = object()
+QueryTimeFlags = Union[Tuple[object, int], Tuple[object, int, Any]]
+
+
+@dataclass(frozen=True)
+class LegacyReplacement(Replacement):
+    # XXX: For the group_exclude message we need to be able to run a
+    # replacement without running any query.
+    count_query_template: Optional[str]
+    insert_query_template: Optional[str]
+    query_args: Mapping[str, Any]
+    query_time_flags: QueryTimeFlags
+
+    def get_project_id(self) -> int:
+        return self.query_time_flags[1]
+
+    def get_needs_final(self) -> bool:
+        return self.query_time_flags[0] == NEEDS_FINAL
+
+    def get_excluded_groups(self) -> Sequence[int]:
+        if self.query_time_flags[0] == EXCLUDE_GROUPS:
+            return self.query_time_flags[2]  # type: ignore
+
+        return []
+
+    def get_insert_query(self, table_name: str) -> Optional[str]:
+        if self.insert_query_template is None:
+            return None
+
+        args: Dict[str, Any] = dict(self.query_args or ())
+        args["table_name"] = table_name
+        return self.insert_query_template % args
+
+    def get_count_query(self, table_name: str) -> Optional[str]:
+        if self.count_query_template is None:
+            return None
+
+        args: Dict[str, Any] = dict(self.query_args or ())
+        args["table_name"] = table_name
+        return self.count_query_template % args
 
 
 def get_project_exclude_groups_key(
@@ -123,7 +185,7 @@ def get_projects_query_flags(
     return (needs_final, exclude_groups)
 
 
-class ErrorsReplacer(ReplacerProcessor):
+class ErrorsReplacer(ReplacerProcessor[Replacement]):
     def __init__(
         self,
         schema: WritableTableSchema,
@@ -187,8 +249,6 @@ class ErrorsReplacer(ReplacerProcessor):
         return processed
 
     def pre_replacement(self, replacement: Replacement, matching_records: int) -> bool:
-        # query_time_flags == (type, project_id, [...data...])
-        flag_type, project_id = replacement.query_time_flags[:2]
         if self.__state_name == ReplacerState.EVENTS:
             # Backward compatibility with the old keys already in Redis, we will let double write
             # the old key structure and the new one for a while then we can get rid of the old one.
@@ -196,17 +256,24 @@ class ErrorsReplacer(ReplacerProcessor):
         else:
             compatibility_double_write = False
 
+        needs_final = replacement.get_needs_final()
+        group_ids_to_exclude = replacement.get_excluded_groups()
+        project_id = replacement.get_project_id()
+
         if not settings.REPLACER_IMMEDIATE_OPTIMIZE:
-            if flag_type == NEEDS_FINAL:
+            if needs_final:
                 if compatibility_double_write:
                     set_project_needs_final(project_id, None)
                 set_project_needs_final(project_id, self.__state_name)
-            elif flag_type == EXCLUDE_GROUPS:
-                group_ids = replacement.query_time_flags[2]
+
+            if group_ids_to_exclude:
                 if compatibility_double_write:
-                    set_project_exclude_groups(project_id, group_ids, None)
-                set_project_exclude_groups(project_id, group_ids, self.__state_name)
-        elif flag_type in {NEEDS_FINAL, EXCLUDE_GROUPS}:
+                    set_project_exclude_groups(project_id, group_ids_to_exclude, None)
+                set_project_exclude_groups(
+                    project_id, group_ids_to_exclude, self.__state_name
+                )
+
+        elif needs_final or group_ids_to_exclude:
             return True
 
         return False
@@ -217,7 +284,7 @@ def _build_event_tombstone_replacement(
     required_columns: Sequence[str],
     where: str,
     query_args: Mapping[str, str],
-    query_time_flags: Tuple[Any, ...],
+    query_time_flags: QueryTimeFlags,
 ) -> Replacement:
     select_columns = map(lambda i: i if i != "deleted" else "1", required_columns)
     count_query_template = (
@@ -244,7 +311,7 @@ def _build_event_tombstone_replacement(
     }
     final_query_args.update(query_args)
 
-    return Replacement(
+    return LegacyReplacement(
         count_query_template, insert_query_template, final_query_args, query_time_flags
     )
 
@@ -255,7 +322,7 @@ def _build_group_replacement(
     new_group_id: str,
     where: str,
     query_args: Mapping[str, str],
-    query_time_flags: Tuple[Any, ...],
+    query_time_flags: QueryTimeFlags,
     all_columns: Sequence[FlattenedColumn],
 ) -> Optional[Replacement]:
     # HACK: We were sending duplicates of the `end_merge` message from Sentry,
@@ -295,7 +362,7 @@ def _build_group_replacement(
     }
     final_query_args.update(query_args)
 
-    return Replacement(
+    return LegacyReplacement(
         count_query_template, insert_query_template, final_query_args, query_time_flags
     )
 
@@ -482,7 +549,7 @@ def process_exclude_groups(message: Mapping[str, Any]) -> Optional[Replacement]:
         return None
 
     query_time_flags = (EXCLUDE_GROUPS, message["project_id"], group_ids)
-    return Replacement(None, None, {}, query_time_flags)
+    return LegacyReplacement(None, None, {}, query_time_flags)
 
 
 SEEN_MERGE_TXN_CACHE: Deque[str] = deque(maxlen=100)
@@ -597,7 +664,7 @@ def process_unmerge(
 
     query_time_flags = (NEEDS_FINAL, message["project_id"])
 
-    return Replacement(
+    return LegacyReplacement(
         count_query_template, insert_query_template, query_args, query_time_flags
     )
 
@@ -687,6 +754,6 @@ def process_delete_tag(
 
     query_time_flags = (NEEDS_FINAL, message["project_id"])
 
-    return Replacement(
+    return LegacyReplacement(
         count_query_template, insert_query_template, query_args, query_time_flags
     )

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -96,16 +96,20 @@ class LegacyReplacement(Replacement):
         if self.insert_query_template is None:
             return None
 
-        args: Dict[str, Any] = dict(self.query_args or ())
-        args["table_name"] = table_name
+        args = {
+            **self.query_args,
+            "table_name": table_name
+        }
         return self.insert_query_template % args
 
     def get_count_query(self, table_name: str) -> Optional[str]:
         if self.count_query_template is None:
             return None
 
-        args: Dict[str, Any] = dict(self.query_args or ())
-        args["table_name"] = table_name
+        args = {
+            **self.query_args,
+            "table_name": table_name
+        }
         return self.count_query_template % args
 
 

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import NamedTuple, Optional, Sequence
+from typing import Any, NamedTuple, Optional, Sequence
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
@@ -167,7 +167,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         stream_loader: KafkaStreamLoader,
         query_splitters: Optional[Sequence[QuerySplitStrategy]] = None,
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
-        replacer_processor: Optional[ReplacerProcessor] = None,
+        replacer_processor: Optional[ReplacerProcessor[Any]] = None,
         writer_options: ClickhouseWriterOptions = None,
     ) -> None:
         super().__init__(

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -157,7 +157,7 @@ class TableWriter:
         storage_set: StorageSetKey,
         write_schema: WritableTableSchema,
         stream_loader: KafkaStreamLoader,
-        replacer_processor: Optional[ReplacerProcessor] = None,
+        replacer_processor: Optional[ReplacerProcessor[Any]] = None,
         writer_options: ClickhouseWriterOptions = None,
     ) -> None:
         self.__storage_set = storage_set
@@ -237,7 +237,7 @@ class TableWriter:
     def get_stream_loader(self) -> KafkaStreamLoader:
         return self.__stream_loader
 
-    def get_replacer_processor(self) -> Optional[ReplacerProcessor]:
+    def get_replacer_processor(self) -> Optional[ReplacerProcessor[Any]]:
         """
         Returns a replacement processor if this table writer knows how to do
         replacements on the table it manages.

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -1,9 +1,9 @@
 import logging
 import time
-import simplejson as json
-
 from datetime import datetime
 from typing import Optional, Sequence
+
+import simplejson as json
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storage import WritableTableStorage
@@ -13,7 +13,6 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams import Message
 from snuba.utils.streams.backends.kafka import KafkaPayload
 from snuba.utils.streams.processing.strategies.batching import AbstractBatchWorker
-
 
 logger = logging.getLogger("snuba.replacer")
 
@@ -50,15 +49,11 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
     def flush_batch(self, batch: Sequence[Replacement]) -> None:
         need_optimize = False
         for replacement in batch:
-            query_args = {
-                **replacement.query_args,
-                "table_name": self.__replacer_processor.get_schema().get_table_name(),
-            }
+            table_name = self.__replacer_processor.get_schema().get_table_name()
+            count_query = replacement.get_count_query(table_name)
 
-            if replacement.count_query_template is not None:
-                count = self.clickhouse.execute_robust(
-                    replacement.count_query_template % query_args
-                )[0][0]
+            if count_query is not None:
+                count = self.clickhouse.execute_robust(count_query)[0][0]
                 if count == 0:
                     continue
             else:
@@ -69,11 +64,12 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
                 or need_optimize
             )
 
-            if replacement.insert_query_template is not None:
+            insert_query = replacement.get_insert_query(table_name)
+
+            if insert_query is not None:
                 t = time.time()
-                query = replacement.insert_query_template % query_args
-                logger.debug("Executing replace query: %s" % query)
-                self.clickhouse.execute_robust(query)
+                logger.debug("Executing replace query: %s" % insert_query)
+                self.clickhouse.execute_robust(insert_query)
                 duration = int((time.time() - t) * 1000)
 
                 logger.info("Replacing %s rows took %sms" % (count, duration))

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Any, Mapping, NamedTuple, Optional
+from typing import Any, Generic, Mapping, NamedTuple, Optional, TypeVar
 
 from snuba.datasets.schemas.tables import WritableTableSchema
 
@@ -16,17 +15,20 @@ class ReplacementMessage(NamedTuple):
     data: Mapping[str, Any]
 
 
-@dataclass(frozen=True)
-class Replacement:
-    # XXX: For the group_exclude message we need to be able to run a
-    # replacement without running any query.
-    count_query_template: Optional[str]
-    insert_query_template: Optional[str]
-    query_args: Mapping[str, Any]
-    query_time_flags: Any
+class Replacement(ABC):
+    @abstractmethod
+    def get_insert_query(self, table_name: str) -> Optional[str]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_count_query(self, table_name: str) -> Optional[str]:
+        raise NotImplementedError()
 
 
-class ReplacerProcessor(ABC):
+R = TypeVar("R", bound=Replacement)
+
+
+class ReplacerProcessor(ABC, Generic[R]):
     """
     Processes one message from the replacer topic into a data structure that contains
     the query to apply the replacement.
@@ -38,7 +40,7 @@ class ReplacerProcessor(ABC):
         self.__schema = schema
 
     @abstractmethod
-    def process_message(self, message: ReplacementMessage) -> Optional[Replacement]:
+    def process_message(self, message: ReplacementMessage) -> Optional[R]:
         """
         Processes one message from the topic.
         """
@@ -47,7 +49,7 @@ class ReplacerProcessor(ABC):
     def get_schema(self) -> WritableTableSchema:
         return self.__schema
 
-    def pre_replacement(self, replacement: Replacement, matching_records: int) -> bool:
+    def pre_replacement(self, replacement: R, matching_records: int) -> bool:
         """
         Custom actions to run before the replacements when we already know how
         many rows will be impacted.
@@ -55,7 +57,7 @@ class ReplacerProcessor(ABC):
         return False
 
     def post_replacement(
-        self, replacement: Replacement, duration: int, matching_records: int
+        self, replacement: R, duration: int, matching_records: int
     ) -> None:
         """
         Custom actions to run after the replacement was executed.


### PR DESCRIPTION
Split out the replacement type refactor from https://github.com/getsentry/snuba/pull/1861 without rewriting any replacements at all. In future PRs we can port the replacements one-by-one (like done in #1861) and then remove LegacyReplacement.