### PR TITLE
ref(typing): Fix typing in the processor tests

### DIFF
--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Mapping, MutableSequence, Optional, Set
+from typing import Any, Dict, Mapping, MutableSequence, Optional, Set
 
 from snuba.request import Request
 from snuba.utils.metrics.timer import Timer
@@ -91,7 +91,7 @@ class SnubaQueryMetadata:
     timer: Timer
     query_list: MutableSequence[ClickhouseQueryMetadata]
 
-    def to_dict(self) -> Mapping[str, Any]:
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "request": {
                 "id": self.request.id,

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -3,8 +3,10 @@ from uuid import UUID
 
 import pytz
 
+from snuba import settings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.errors_processor import ErrorsProcessor
+from snuba.datasets.events_processor_base import InsertEvent
 from snuba.processor import InsertBatch
 from snuba.settings import PAYLOAD_DATETIME_FORMAT
 
@@ -16,204 +18,209 @@ def test_error_processor() -> None:
     error = (
         2,
         "insert",
-        {
-            "event_id": "dcb9d002cac548c795d1c9adbfc68040",
-            "group_id": 100,
-            "project_id": 300688,
-            "release": None,
-            "dist": None,
-            "platform": "python",
-            "message": "",
-            "datetime": error_timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-            "primary_hash": "04233d08ac90cf6fc015b1be5932e7e2",
-            "data": {
+        InsertEvent(
+            {
+                "organization_id": 1,
+                "retention_days": settings.DEFAULT_RETENTION_DAYS,
                 "event_id": "dcb9d002cac548c795d1c9adbfc68040",
+                "group_id": 100,
                 "project_id": 300688,
-                "release": None,
-                "dist": None,
                 "platform": "python",
                 "message": "",
                 "datetime": error_timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                "tags": [
-                    ["handled", "no"],
-                    ["level", "error"],
-                    ["mechanism", "excepthook"],
-                    ["runtime", "CPython 3.7.6"],
-                    ["runtime.name", "CPython"],
-                    ["server_name", "snuba"],
-                    ["environment", "dev"],
-                    ["sentry:user", "this_is_me"],
-                    ["sentry:release", "4d23338017cdee67daf25f2c"],
-                ],
-                "user": {
-                    "username": "me",
-                    "ip_address": "127.0.0.1",
-                    "id": "still_me",
-                    "email": "me@myself.org",
-                    "geo": {
-                        "country_code": "XY",
-                        "region": "fake_region",
-                        "city": "fake_city",
+                "primary_hash": "04233d08ac90cf6fc015b1be5932e7e2",
+                "data": {
+                    "event_id": "dcb9d002cac548c795d1c9adbfc68040",
+                    "project_id": 300688,
+                    "release": None,
+                    "dist": None,
+                    "platform": "python",
+                    "message": "",
+                    "datetime": error_timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
+                    "tags": [
+                        ["handled", "no"],
+                        ["level", "error"],
+                        ["mechanism", "excepthook"],
+                        ["runtime", "CPython 3.7.6"],
+                        ["runtime.name", "CPython"],
+                        ["server_name", "snuba"],
+                        ["environment", "dev"],
+                        ["sentry:user", "this_is_me"],
+                        ["sentry:release", "4d23338017cdee67daf25f2c"],
+                    ],
+                    "user": {
+                        "username": "me",
+                        "ip_address": "127.0.0.1",
+                        "id": "still_me",
+                        "email": "me@myself.org",
+                        "geo": {
+                            "country_code": "XY",
+                            "region": "fake_region",
+                            "city": "fake_city",
+                        },
                     },
-                },
-                "request": {
-                    "url": "http://127.0.0.1:/query",
-                    "headers": [
-                        ["Accept-Encoding", "identity"],
-                        ["Content-Length", "398"],
-                        ["Host", "127.0.0.1:"],
-                        ["Referer", "tagstore.something"],
-                        ["Trace", "8fa73032d-1"],
-                    ],
-                    "data": "",
-                    "method": "POST",
-                    "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
-                },
-                "_relay_processed": True,
-                "breadcrumbs": {
-                    "values": [
-                        {
-                            "category": "snuba.utils.streams.batching",
-                            "level": "info",
-                            "timestamp": error_timestamp.timestamp(),
-                            "data": {
-                                "asctime": error_timestamp.strftime(
-                                    PAYLOAD_DATETIME_FORMAT
-                                )
+                    "request": {
+                        "url": "http://127.0.0.1:/query",
+                        "headers": [
+                            ["Accept-Encoding", "identity"],
+                            ["Content-Length", "398"],
+                            ["Host", "127.0.0.1:"],
+                            ["Referer", "tagstore.something"],
+                            ["Trace", "8fa73032d-1"],
+                        ],
+                        "data": "",
+                        "method": "POST",
+                        "env": {"SERVER_PORT": "1010", "SERVER_NAME": "snuba"},
+                    },
+                    "_relay_processed": True,
+                    "breadcrumbs": {
+                        "values": [
+                            {
+                                "category": "snuba.utils.streams.batching",
+                                "level": "info",
+                                "timestamp": error_timestamp.timestamp(),
+                                "data": {
+                                    "asctime": error_timestamp.strftime(
+                                        PAYLOAD_DATETIME_FORMAT
+                                    )
+                                },
+                                "message": "New partitions assigned: {}",
+                                "type": "default",
                             },
-                            "message": "New partitions assigned: {}",
-                            "type": "default",
-                        },
-                        {
-                            "category": "snuba.utils.streams.batching",
-                            "level": "info",
-                            "timestamp": error_timestamp.timestamp(),
-                            "data": {
-                                "asctime": error_timestamp.strftime(
-                                    PAYLOAD_DATETIME_FORMAT
-                                )
+                            {
+                                "category": "snuba.utils.streams.batching",
+                                "level": "info",
+                                "timestamp": error_timestamp.timestamp(),
+                                "data": {
+                                    "asctime": error_timestamp.strftime(
+                                        PAYLOAD_DATETIME_FORMAT
+                                    )
+                                },
+                                "message": "Flushing ",
+                                "type": "default",
                             },
-                            "message": "Flushing ",
-                            "type": "default",
-                        },
-                        {
-                            "category": "httplib",
-                            "timestamp": error_timestamp.timestamp(),
-                            "type": "http",
-                            "data": {
-                                "url": "http://127.0.0.1:8123/",
-                                "status_code": 500,
-                                "reason": "Internal Server Error",
-                                "method": "POST",
+                            {
+                                "category": "httplib",
+                                "timestamp": error_timestamp.timestamp(),
+                                "type": "http",
+                                "data": {
+                                    "url": "http://127.0.0.1:8123/",
+                                    "status_code": 500,
+                                    "reason": "Internal Server Error",
+                                    "method": "POST",
+                                },
+                                "level": "info",
                             },
-                            "level": "info",
-                        },
-                    ]
-                },
-                "contexts": {
-                    "runtime": {
-                        "version": "3.7.6",
-                        "type": "runtime",
-                        "name": "CPython",
-                        "build": "3.7.6",
-                    }
-                },
-                "culprit": "snuba.clickhouse.http in write",
-                "exception": {
-                    "values": [
-                        {
-                            "stacktrace": {
-                                "frames": [
-                                    {
-                                        "function": "<module>",
-                                        "abs_path": "/usr/local/bin/snuba",
-                                        "pre_context": [
-                                            "from pkg_resources import load_entry_point",
-                                            "",
-                                            "if __name__ == '__main__':",
-                                            "    sys.argv[0] = re.sub(r'(-script\\.pyw?|\\.exe)?$', '', sys.argv[0])",
-                                            "    sys.exit(",
-                                        ],
-                                        "post_context": ["    )"],
-                                        "vars": {
-                                            "__spec__": "None",
-                                            "__builtins__": "<module 'builtins' (built-in)>",
-                                            "__annotations__": {},
-                                            "__file__": "'/usr/local/bin/snuba'",
-                                            "__loader__": "<_frozen_importlib_external.SourceFileLoader object at 0x7fbbc3a36ed0>",
-                                            "__requires__": "'snuba'",
-                                            "__cached__": "None",
-                                            "__name__": "'__main__'",
-                                            "__package__": "None",
-                                            "__doc__": "None",
-                                        },
-                                        "module": "__main__",
-                                        "filename": "snuba",
-                                        "lineno": 11,
-                                        "in_app": False,
-                                        "data": {"orig_in_app": 1},
-                                        "context_line": "        load_entry_point('snuba', 'console_scripts', 'snuba')()",
-                                    },
-                                ]
-                            },
-                            "type": "ClickHouseError",
-                            "module": "snuba.clickhouse.http",
-                            "value": "[171] DB::Exception: Block structure mismatch",
-                            "mechanism": {"type": "excepthook", "handled": False},
+                        ]
+                    },
+                    "contexts": {
+                        "runtime": {
+                            "version": "3.7.6",
+                            "type": "runtime",
+                            "name": "CPython",
+                            "build": "3.7.6",
                         }
-                    ]
-                },
-                "extra": {
-                    "sys.argv": [
-                        "/usr/local/bin/snuba",
-                        "consumer",
-                        "--dataset",
-                        "transactions",
-                    ]
-                },
-                "fingerprint": ["{{ default }}"],
-                "hashes": ["c8b21c571231e989060b9110a2ade7d3"],
-                "hierarchical_hashes": [
-                    "04233d08ac90cf6fc015b1be5932e7e3",
-                    "04233d08ac90cf6fc015b1be5932e7e4",
-                ],
-                "key_id": "537125",
-                "level": "error",
-                "location": "snuba/clickhouse/http.py",
-                "logger": "",
-                "metadata": {
-                    "function": "write",
-                    "type": "ClickHouseError",
-                    "value": "[171] DB::Exception: Block structure mismatch",
-                    "filename": "snuba/something.py",
-                },
-                "modules": {
-                    "cffi": "1.13.2",
-                    "ipython-genutils": "0.2.0",
-                    "isodate": "0.6.0",
-                },
-                "received": received_timestamp.timestamp(),
-                "sdk": {
-                    "version": "0.0.0.0.1",
-                    "name": "sentry.python",
-                    "packages": [{"version": "0.0.0.0.1", "name": "pypi:sentry-sdk"}],
-                    "integrations": [
-                        "argv",
-                        "atexit",
-                        "dedupe",
-                        "excepthook",
-                        "logging",
-                        "modules",
-                        "stdlib",
-                        "threading",
+                    },
+                    "culprit": "snuba.clickhouse.http in write",
+                    "exception": {
+                        "values": [
+                            {
+                                "stacktrace": {
+                                    "frames": [
+                                        {
+                                            "function": "<module>",
+                                            "abs_path": "/usr/local/bin/snuba",
+                                            "pre_context": [
+                                                "from pkg_resources import load_entry_point",
+                                                "",
+                                                "if __name__ == '__main__':",
+                                                "    sys.argv[0] = re.sub(r'(-script\\.pyw?|\\.exe)?$', '', sys.argv[0])",
+                                                "    sys.exit(",
+                                            ],
+                                            "post_context": ["    )"],
+                                            "vars": {
+                                                "__spec__": "None",
+                                                "__builtins__": "<module 'builtins' (built-in)>",
+                                                "__annotations__": {},
+                                                "__file__": "'/usr/local/bin/snuba'",
+                                                "__loader__": "<_frozen_importlib_external.SourceFileLoader object at 0x7fbbc3a36ed0>",
+                                                "__requires__": "'snuba'",
+                                                "__cached__": "None",
+                                                "__name__": "'__main__'",
+                                                "__package__": "None",
+                                                "__doc__": "None",
+                                            },
+                                            "module": "__main__",
+                                            "filename": "snuba",
+                                            "lineno": 11,
+                                            "in_app": False,
+                                            "data": {"orig_in_app": 1},
+                                            "context_line": "        load_entry_point('snuba', 'console_scripts', 'snuba')()",
+                                        },
+                                    ]
+                                },
+                                "type": "ClickHouseError",
+                                "module": "snuba.clickhouse.http",
+                                "value": "[171] DB::Exception: Block structure mismatch",
+                                "mechanism": {"type": "excepthook", "handled": False},
+                            }
+                        ]
+                    },
+                    "extra": {
+                        "sys.argv": [
+                            "/usr/local/bin/snuba",
+                            "consumer",
+                            "--dataset",
+                            "transactions",
+                        ]
+                    },
+                    "fingerprint": ["{{ default }}"],
+                    "hashes": ["c8b21c571231e989060b9110a2ade7d3"],
+                    "hierarchical_hashes": [
+                        "04233d08ac90cf6fc015b1be5932e7e3",
+                        "04233d08ac90cf6fc015b1be5932e7e4",
                     ],
+                    "key_id": "537125",
+                    "level": "error",
+                    "location": "snuba/clickhouse/http.py",
+                    "logger": "",
+                    "metadata": {
+                        "function": "write",
+                        "type": "ClickHouseError",
+                        "value": "[171] DB::Exception: Block structure mismatch",
+                        "filename": "snuba/something.py",
+                    },
+                    "modules": {
+                        "cffi": "1.13.2",
+                        "ipython-genutils": "0.2.0",
+                        "isodate": "0.6.0",
+                    },
+                    "received": received_timestamp.timestamp(),
+                    "sdk": {
+                        "version": "0.0.0.0.1",
+                        "name": "sentry.python",
+                        "packages": [
+                            {"version": "0.0.0.0.1", "name": "pypi:sentry-sdk"}
+                        ],
+                        "integrations": [
+                            "argv",
+                            "atexit",
+                            "dedupe",
+                            "excepthook",
+                            "logging",
+                            "modules",
+                            "stdlib",
+                            "threading",
+                        ],
+                    },
+                    "timestamp": error_timestamp.timestamp(),
+                    "title": "ClickHouseError: [171] DB::Exception: Block structure mismatch",
+                    "type": "error",
+                    "version": "7",
                 },
-                "timestamp": error_timestamp.timestamp(),
-                "title": "ClickHouseError: [171] DB::Exception: Block structure mismatch",
-                "type": "error",
-                "version": "7",
-            },
-        },
+            }
+        ),
+        None,
     )
 
     expected_result = {

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -3,9 +3,12 @@ from copy import deepcopy
 from datetime import datetime
 
 from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_storage, get_writable_storage
+from snuba.datasets.storages.factory import get_writable_storage
 from snuba.processor import InsertBatch
+from snuba.query.data_source.simple import Entity
 from snuba.query.logical import Query
 from snuba.querylog.query_metadata import (
     ClickhouseQueryMetadata,
@@ -30,7 +33,9 @@ def test_simple() -> None:
         "project": 1,
     }
 
-    query = Query(get_storage(StorageKey.ERRORS).get_schema().get_data_source())
+    query = Query(
+        Entity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model())
+    )
 
     request = Request(
         uuid.UUID("a" * 32).hex, request_body, query, HTTPRequestSettings(), "search",
@@ -125,7 +130,9 @@ def test_missing_fields() -> None:
         "project": 1,
     }
 
-    query = Query(get_storage(StorageKey.ERRORS).get_schema().get_data_source())
+    query = Query(
+        Entity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model())
+    )
 
     request = Request(
         uuid.UUID("a" * 32).hex, request_body, query, HTTPRequestSettings(), "search",

--- a/tests/datasets/test_spans_processor.py
+++ b/tests/datasets/test_spans_processor.py
@@ -13,8 +13,8 @@ class SpanData(NamedTuple):
     span_id: str
     parent_span_id: str
     op: str
-    start_timestamp: datetime
-    timestamp: datetime
+    start_timestamp: float
+    timestamp: float
 
     def serialize(self) -> Mapping[str, Any]:
         return {

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -33,7 +33,7 @@ class TransactionEvent:
     geo: Mapping[str, str]
     status: str
 
-    def serialize(self) -> Mapping[str, Any]:
+    def serialize(self) -> Tuple[int, str, Mapping[str, Any]]:
         return (
             2,
             "insert",

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,6 +1,8 @@
+from typing import cast
+
 from snuba.processor import _unicodify
 
 
-def test_unicodify():
+def test_unicodify() -> None:
     # invalid utf-8 surrogate should be replaced with escape sequence
-    assert _unicodify("\ud83c").encode("utf8") == b"\\ud83c"
+    assert cast(str, _unicodify("\ud83c")).encode("utf8") == b"\\ud83c"


### PR DESCRIPTION
Tackles the type issues in all of the message processor tests except for
`test_events_processor`, as that should be deleted soon.