### PR TITLE
ref: Pass topic as string instead of Topic instance to stream API

### DIFF
--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -21,7 +21,6 @@ from snuba.utils.streams.kafka_consumer_with_commit_log import (
 )
 from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 from snuba.utils.streams.processing import StreamProcessor
-from snuba.utils.streams.types import Topic
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +116,7 @@ def multistorage_consumer(
     # XXX: The ``StreamProcessor`` only supports a single topic at this time,
     # but is easily modified. The topic routing in the processing strategy is a
     # bit trickier (but also shouldn't be too bad.)
-    topic = Topic(topics.pop())
+    topic = topics.pop()
     if topics:
         raise ValueError("only one topic is supported")
 
@@ -133,9 +132,9 @@ def multistorage_consumer(
         if spec is not None
     }
 
-    commit_log_topic: Optional[Topic]
+    commit_log_topic: Optional[str]
     if commit_log_topics:
-        commit_log_topic = Topic(commit_log_topics.pop())
+        commit_log_topic = commit_log_topics.pop()
     else:
         commit_log_topic = None
 

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -76,7 +76,6 @@ def replacer(
 ) -> None:
 
     from snuba.replacer import ReplacerWorker
-    from snuba.utils.streams import Topic
     from snuba.utils.streams.backends.kafka import KafkaConsumer, TransportError
     from snuba.utils.streams.configuration_builder import (
         build_kafka_consumer_configuration,
@@ -113,7 +112,7 @@ def replacer(
                 queued_min_messages=queued_min_messages,
             ),
         ),
-        Topic(replacements_topic),
+        replacements_topic,
         BatchProcessingStrategyFactory(
             worker=ReplacerWorker(storage, metrics=metrics),
             max_batch_size=max_batch_size,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -12,7 +12,6 @@ from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.retries import BasicRetryPolicy, RetryPolicy, constant_delay
-from snuba.utils.streams import Topic
 from snuba.utils.streams.backends.kafka import (
     KafkaConsumer,
     KafkaPayload,
@@ -81,29 +80,25 @@ class ConsumerBuilder:
 
         stream_loader = self.storage.get_table_writer().get_stream_loader()
 
-        self.raw_topic: Topic
-        if raw_topic is not None:
-            self.raw_topic = Topic(raw_topic)
-        else:
-            self.raw_topic = Topic(stream_loader.get_default_topic_spec().topic_name)
+        self.raw_topic = raw_topic or stream_loader.get_default_topic_spec().topic_name
 
-        self.replacements_topic: Optional[Topic]
+        self.replacements_topic: Optional[str]
         if replacements_topic is not None:
-            self.replacements_topic = Topic(replacements_topic)
+            self.replacements_topic = replacements_topic
         else:
             replacement_topic_spec = stream_loader.get_replacement_topic_spec()
             if replacement_topic_spec is not None:
-                self.replacements_topic = Topic(replacement_topic_spec.topic_name)
+                self.replacements_topic = replacement_topic_spec.topic_name
             else:
                 self.replacements_topic = None
 
-        self.commit_log_topic: Optional[Topic]
+        self.commit_log_topic: Optional[str]
         if commit_log_topic is not None:
-            self.commit_log_topic = Topic(commit_log_topic)
+            self.commit_log_topic = commit_log_topic
         else:
             commit_log_topic_spec = stream_loader.get_commit_log_topic_spec()
             if commit_log_topic_spec is not None:
-                self.commit_log_topic = Topic(commit_log_topic_spec.topic_name)
+                self.commit_log_topic = commit_log_topic_spec.topic_name
             else:
                 self.commit_log_topic = None
 

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -1,9 +1,9 @@
 import logging
 import time
-import simplejson as json
-
 from datetime import datetime
 from typing import Optional, Sequence
+
+import simplejson as json
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storage import WritableTableStorage
@@ -13,7 +13,6 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams import Message
 from snuba.utils.streams.backends.kafka import KafkaPayload
 from snuba.utils.streams.processing.strategies.batching import AbstractBatchWorker
-
 
 logger = logging.getLogger("snuba.replacer")
 
@@ -32,9 +31,6 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
         ), f"This storage writer does not support replacements {storage.get_storage_key().value}"
         self.__replacer_processor = processor
         self.__database_name = storage.get_cluster().get_database()
-        self.__table_name = (
-            storage.get_table_writer().get_schema().get_local_table_name()
-        )
 
     def process_message(self, message: Message[KafkaPayload]) -> Optional[Replacement]:
         seq_message = json.loads(message.payload.value)

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -15,7 +15,7 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.scheduler import ScheduledTask, Scheduler
-from snuba.utils.streams import Producer, Message, Topic
+from snuba.utils.streams import Message, Producer, Topic
 from snuba.utils.streams.processing.strategies.batching import AbstractBatchWorker
 from snuba.web.query import parse_and_run_query
 
@@ -39,14 +39,14 @@ class SubscriptionWorker(
         executor: ThreadPoolExecutor,
         schedulers: Mapping[int, Scheduler[Subscription]],
         producer: Producer[SubscriptionTaskResult],
-        topic: Topic,
+        topic: str,
         metrics: MetricsBackend,
     ) -> None:
         self.__dataset = dataset
         self.__executor = executor
         self.__schedulers = schedulers
         self.__producer = producer
-        self.__topic = topic
+        self.__topic = Topic(topic)
         self.__metrics = metrics
 
         self.__concurrent_gauge: Gauge = ThreadSafeGauge(

--- a/snuba/utils/streams/kafka_consumer_with_commit_log.py
+++ b/snuba/utils/streams/kafka_consumer_with_commit_log.py
@@ -16,12 +16,12 @@ class KafkaConsumerWithCommitLog(KafkaConsumer):
         configuration: Mapping[str, Any],
         *,
         producer: ConfluentProducer,
-        commit_log_topic: Topic,
+        commit_log_topic: str,
         commit_retry_policy: Optional[RetryPolicy] = None,
     ) -> None:
         super().__init__(configuration, commit_retry_policy=commit_retry_policy)
         self.__producer = producer
-        self.__commit_log_topic = commit_log_topic
+        self.__commit_log_topic = Topic(commit_log_topic)
         self.__group_id = configuration["group.id"]
 
     def poll(self, timeout: Optional[float] = None) -> Optional[Message[KafkaPayload]]:

--- a/snuba/utils/streams/processing/processor.py
+++ b/snuba/utils/streams/processing/processor.py
@@ -33,7 +33,8 @@ class StreamProcessor(Generic[TPayload]):
     def __init__(
         self,
         consumer: Consumer[TPayload],
-        topic: Topic,
+        topic: str,
+        # topic: Topic,
         processor_factory: ProcessingStrategyFactory[TPayload],
         metrics: Metrics = DummyMetricsBackend,
         recoverable_errors: Optional[Sequence[Type[ConsumerError]]] = None,
@@ -94,7 +95,9 @@ class StreamProcessor(Generic[TPayload]):
             self.__message = None  # avoid leaking buffered messages across assignments
 
         self.__consumer.subscribe(
-            [topic], on_assign=on_partitions_assigned, on_revoke=on_partitions_revoked
+            [Topic(topic)],
+            on_assign=on_partitions_assigned,
+            on_revoke=on_partitions_revoked,
         )
 
     def __commit(self, offsets: Mapping[Partition, int]) -> None:

--- a/snuba/utils/streams/synchronized.py
+++ b/snuba/utils/streams/synchronized.py
@@ -13,7 +13,6 @@ from snuba.utils.streams.backends.abstract import (
 from snuba.utils.streams.backends.kafka import KafkaPayload
 from snuba.utils.streams.types import Message, Partition, Topic, TPayload
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -81,13 +80,13 @@ class SynchronizedConsumer(Consumer[TPayload]):
         self,
         consumer: Consumer[TPayload],
         commit_log_consumer: Consumer[KafkaPayload],
-        commit_log_topic: Topic,
+        commit_log_topic: str,
         commit_log_groups: Set[str],
     ) -> None:
         self.__consumer = consumer
 
         self.__commit_log_consumer = commit_log_consumer
-        self.__commit_log_topic = commit_log_topic
+        self.__commit_log_topic = Topic(commit_log_topic)
         self.__commit_log_groups = commit_log_groups
 
         self.__remote_offsets: Synchronized[

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -39,7 +39,8 @@ class DummySubscriptionDataStore(SubscriptionDataStore):
 
 
 def test_subscription_worker(broker: Broker[SubscriptionTaskResult],) -> None:
-    result_topic = Topic("subscription-results")
+    result_topic_name = "subscription-results"
+    result_topic = Topic(result_topic_name)
 
     broker.create_topic(result_topic, partitions=1)
 
@@ -68,7 +69,7 @@ def test_subscription_worker(broker: Broker[SubscriptionTaskResult],) -> None:
         ThreadPoolExecutor(),
         {0: SubscriptionScheduler(store, PartitionId(0), timedelta(), metrics)},
         broker.get_producer(),
-        result_topic,
+        result_topic_name,
         metrics,
     )
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -7,6 +7,7 @@ from typing import MutableSequence, Optional
 from unittest.mock import Mock, call
 
 import pytest
+
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.consumer import (
     JSONRowInsertBatch,
@@ -17,7 +18,6 @@ from snuba.datasets.storage import Storage
 from snuba.processor import InsertBatch, ReplacementBatch
 from snuba.utils.streams import Message, Partition, Topic
 from snuba.utils.streams.backends.kafka import KafkaPayload
-
 from tests.assertions import assert_changes
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 from tests.backends.metrics import TestingMetricsBackend, Timing
@@ -58,7 +58,7 @@ def test_streaming_consumer_strategy() -> None:
         input_block_size=None,
         output_block_size=None,
         replacements_producer=replacements_producer,
-        replacements_topic=Topic("replacements"),
+        replacements_topic="replacements",
     )
 
     commit_function = Mock()
@@ -132,7 +132,6 @@ def test_multistorage_strategy(
     output_block_size: Optional[int],
 ) -> None:
     from snuba.datasets.storages import groupassignees, groupedmessages
-
     from tests.datasets.cdc.test_groupassignee import TestGroupassignee
     from tests.datasets.cdc.test_groupedmessage import TestGroupedMessage
 

--- a/tests/utils/streams/backends/test_kafka.py
+++ b/tests/utils/streams/backends/test_kafka.py
@@ -153,7 +153,7 @@ class KafkaStreamsTestCase(StreamsTestMixin[KafkaPayload], TestCase):
                 "session.timeout.ms": 10000,
             },
             producer=commit_log_producer,
-            commit_log_topic=Topic("commit-log"),
+            commit_log_topic="commit-log",
         )
 
         with self.get_topic() as topic, closing(consumer) as consumer:

--- a/tests/utils/streams/processing/strategies/test_batching.py
+++ b/tests/utils/streams/processing/strategies/test_batching.py
@@ -30,7 +30,8 @@ class FakeWorker(AbstractBatchWorker[int, int]):
 
 class TestConsumer(object):
     def test_batch_size(self, broker: Broker[int]) -> None:
-        topic = Topic("topic")
+        topic_name = "topic"
+        topic = Topic(topic_name)
         broker.create_topic(topic, partitions=1)
         producer = broker.get_producer()
         for i in [1, 2, 3]:
@@ -43,7 +44,7 @@ class TestConsumer(object):
         metrics = DummyMetricsBackend(strict=True)
         batching_consumer = StreamProcessor(
             consumer,
-            topic,
+            topic_name,
             BatchProcessingStrategyFactory(
                 worker=worker, max_batch_size=2, max_batch_time=100, metrics=metrics,
             ),
@@ -62,7 +63,8 @@ class TestConsumer(object):
 
     @patch("time.time")
     def test_batch_time(self, mock_time: Any, broker: Broker[int]) -> None:
-        topic = Topic("topic")
+        topic_name = "topic"
+        topic = Topic(topic_name)
         broker.create_topic(topic, partitions=1)
         producer = broker.get_producer()
         consumer = broker.get_consumer("group")
@@ -72,7 +74,7 @@ class TestConsumer(object):
         metrics = DummyMetricsBackend(strict=True)
         batching_consumer = StreamProcessor(
             consumer,
-            topic,
+            topic_name,
             BatchProcessingStrategyFactory(
                 worker=worker, max_batch_size=100, max_batch_time=2000, metrics=metrics,
             ),

--- a/tests/utils/streams/processing/test_processor.py
+++ b/tests/utils/streams/processing/test_processor.py
@@ -12,7 +12,8 @@ from tests.backends.metrics import TestingMetricsBackend, Timing
 
 
 def test_stream_processor_lifecycle() -> None:
-    topic = Topic("topic")
+    topic_name = "topic"
+    topic = Topic(topic_name)
 
     consumer = mock.Mock()
     strategy = mock.Mock()
@@ -23,7 +24,7 @@ def test_stream_processor_lifecycle() -> None:
 
     with assert_changes(lambda: int(consumer.subscribe.call_count), 0, 1):
         processor: StreamProcessor[int] = StreamProcessor(
-            consumer, topic, factory, StreamMetricsAdapter(metrics)
+            consumer, topic_name, factory, StreamMetricsAdapter(metrics)
         )
 
     # The processor should accept heartbeat messages without an assignment or
@@ -111,7 +112,8 @@ def test_stream_processor_lifecycle() -> None:
 
 
 def test_stream_processor_termination_on_error() -> None:
-    topic = Topic("test")
+    topic_name = "test"
+    topic = Topic(topic_name)
 
     consumer = mock.Mock()
     consumer.poll.return_value = Message(Partition(topic, 0), 0, 0, datetime.now())
@@ -125,7 +127,7 @@ def test_stream_processor_termination_on_error() -> None:
     factory.create.return_value = strategy
 
     processor: StreamProcessor[int] = StreamProcessor(
-        consumer, topic, factory, StreamMetricsAdapter(TestingMetricsBackend())
+        consumer, topic_name, factory, StreamMetricsAdapter(TestingMetricsBackend())
     )
 
     assignment_callback = consumer.subscribe.call_args.kwargs["on_assign"]

--- a/tests/utils/streams/test_synchronized.py
+++ b/tests/utils/streams/test_synchronized.py
@@ -7,8 +7,8 @@ import pytest
 
 from snuba.utils.streams.backends.abstract import Consumer
 from snuba.utils.streams.backends.kafka import KafkaPayload
-from snuba.utils.streams.backends.local.backend import LocalConsumer
 from snuba.utils.streams.backends.local.backend import LocalBroker as Broker
+from snuba.utils.streams.backends.local.backend import LocalConsumer
 from snuba.utils.streams.synchronized import Commit, SynchronizedConsumer, commit_codec
 from snuba.utils.streams.types import Message, Partition, Topic
 from tests.assertions import assert_changes, assert_does_not_change
@@ -16,7 +16,9 @@ from tests.assertions import assert_changes, assert_does_not_change
 T = TypeVar("T")
 
 
-def wait_for_consumer(consumer: Consumer[T], message: Message[T], attempts: int = 10):
+def wait_for_consumer(
+    consumer: Consumer[T], message: Message[T], attempts: int = 10
+) -> None:
     """Block until the provided consumer has received the provided message."""
     for i in range(attempts):
         part = consumer.tell().get(message.partition)
@@ -31,8 +33,10 @@ def wait_for_consumer(consumer: Consumer[T], message: Message[T], attempts: int 
 
 
 def test_synchronized_consumer(broker: Broker[KafkaPayload]) -> None:
-    topic = Topic("topic")
-    commit_log_topic = Topic("commit-log")
+    topic_name = "topic"
+    topic = Topic(topic_name)
+    commit_log_topic_name = "commit-log"
+    commit_log_topic = Topic(commit_log_topic_name)
 
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
@@ -51,7 +55,7 @@ def test_synchronized_consumer(broker: Broker[KafkaPayload]) -> None:
     synchronized_consumer: Consumer[KafkaPayload] = SynchronizedConsumer(
         consumer,
         commit_log_consumer,
-        commit_log_topic=commit_log_topic,
+        commit_log_topic=commit_log_topic_name,
         commit_log_groups={"leader-a", "leader-b"},
     )
 
@@ -183,7 +187,8 @@ def test_synchronized_consumer(broker: Broker[KafkaPayload]) -> None:
 
 def test_synchronized_consumer_pause_resume(broker: Broker[KafkaPayload]) -> None:
     topic = Topic("topic")
-    commit_log_topic = Topic("commit-log")
+    commit_log_topic_name = "commit-log"
+    commit_log_topic = Topic(commit_log_topic_name)
 
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
@@ -202,7 +207,7 @@ def test_synchronized_consumer_pause_resume(broker: Broker[KafkaPayload]) -> Non
     synchronized_consumer: Consumer[KafkaPayload] = SynchronizedConsumer(
         consumer,
         commit_log_consumer,
-        commit_log_topic=commit_log_topic,
+        commit_log_topic=commit_log_topic_name,
         commit_log_groups={"leader"},
     )
 
@@ -268,7 +273,8 @@ def test_synchronized_consumer_handles_end_of_partition(
     broker: Broker[KafkaPayload],
 ) -> None:
     topic = Topic("topic")
-    commit_log_topic = Topic("commit-log")
+    commit_log_topic_name = "commit-log"
+    commit_log_topic = Topic(commit_log_topic_name)
 
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
@@ -287,7 +293,7 @@ def test_synchronized_consumer_handles_end_of_partition(
     synchronized_consumer: Consumer[KafkaPayload] = SynchronizedConsumer(
         consumer,
         commit_log_consumer,
-        commit_log_topic=commit_log_topic,
+        commit_log_topic=commit_log_topic_name,
         commit_log_groups={"leader"},
     )
 
@@ -325,7 +331,8 @@ def test_synchronized_consumer_worker_crash_before_assignment(
     broker: Broker[KafkaPayload],
 ) -> None:
     topic = Topic("topic")
-    commit_log_topic = Topic("commit-log")
+    commit_logt_topic_name = "commit-log"
+    commit_log_topic = Topic(commit_logt_topic_name)
 
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
@@ -350,10 +357,10 @@ def test_synchronized_consumer_worker_crash_before_assignment(
     )
 
     with pytest.raises(BrokenConsumerException):
-        Consumer[KafkaPayload] = SynchronizedConsumer(
+        SynchronizedConsumer(
             consumer,
             commit_log_consumer,
-            commit_log_topic=commit_log_topic,
+            commit_log_topic=commit_logt_topic_name,
             commit_log_groups={"leader"},
         )
 
@@ -362,7 +369,8 @@ def test_synchronized_consumer_worker_crash_after_assignment(
     broker: Broker[KafkaPayload],
 ) -> None:
     topic = Topic("topic")
-    commit_log_topic = Topic("commit-log")
+    commit_log_topic_name = "commit-log"
+    commit_log_topic = Topic(commit_log_topic_name)
 
     broker.create_topic(topic, partitions=1)
     broker.create_topic(commit_log_topic, partitions=1)
@@ -392,7 +400,7 @@ def test_synchronized_consumer_worker_crash_after_assignment(
     synchronized_consumer: Consumer[KafkaPayload] = SynchronizedConsumer(
         consumer,
         commit_log_consumer,
-        commit_log_topic=commit_log_topic,
+        commit_log_topic=commit_log_topic_name,
         commit_log_groups={"leader"},
     )
 


### PR DESCRIPTION
The `Topic` (as well as `Partition` and `Message` classes will move
to the streaming consumer library, and will need to be imported
from there to be used in Snuba. We should avoid unnecessarily using
this class in cases a simple string will do instead.