### PR TITLE
feat: Insert batch encoding is done by message processors

### DIFF
--- a/snuba/consumers/snapshot_worker.py
+++ b/snuba/consumers/snapshot_worker.py
@@ -7,7 +7,6 @@ from snuba.processor import MessageProcessor, ProcessedMessage
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
 
-
 logger = logging.getLogger("snuba.snapshot-consumer")
 
 

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -6,9 +6,8 @@ from datetime import datetime
 from typing import Any, List, Mapping, Optional, Sequence, Type
 
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.processor import InsertBatch, MessageProcessor, ProcessedMessage
+from snuba.processor import InsertBatch, ProcessedStreamMessage, StreamMessageProcessor
 from snuba.writer import WriterTableRow
-
 
 POSTGRES_DATE_FORMAT_WITH_NS = "%Y-%m-%d %H:%M:%S.%f%z"
 POSTGRES_DATE_FORMAT_WITHOUT_NS = "%Y-%m-%d %H:%M:%S%z"
@@ -65,7 +64,7 @@ class CdcMessageRow(ABC):
         raise NotImplementedError
 
 
-class CdcProcessor(MessageProcessor):
+class CdcProcessor(StreamMessageProcessor):
     def __init__(self, pg_table: str, message_row_class: Type[CdcMessageRow]):
         self.pg_table = pg_table
         self._message_row_class = message_row_class
@@ -111,9 +110,9 @@ class CdcProcessor(MessageProcessor):
     ) -> Sequence[WriterTableRow]:
         return []
 
-    def process_message(
+    def process_stream_message(
         self, value: Mapping[str, Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         assert isinstance(value, dict)
 
         offset = metadata.offset

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -16,9 +16,9 @@ from snuba.processor import (
     InsertBatch,
     InvalidMessageType,
     InvalidMessageVersion,
-    MessageProcessor,
-    ProcessedMessage,
+    ProcessedStreamMessage,
     ReplacementBatch,
+    StreamMessageProcessor,
     _as_dict_safe,
     _boolify,
     _collapse_uint32,
@@ -59,7 +59,7 @@ class InsertEvent(TypedDict):
     retention_days: int
 
 
-class EventsProcessorBase(MessageProcessor, ABC):
+class EventsProcessorBase(StreamMessageProcessor, ABC):
     """
     Base class for events and errors processors.
     """
@@ -135,11 +135,11 @@ class EventsProcessorBase(MessageProcessor, ABC):
                 sdk_integrations.append(i)
         output["sdk_integrations"] = sdk_integrations
 
-    def process_message(
+    def process_stream_message(
         self,
         message: Tuple[int, str, InsertEvent, Any],
         metadata: KafkaMessageMetadata,
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         """\
         Process a raw message into an insertion or replacement batch. Returns
         `None` if the event is too old to be written.

--- a/snuba/datasets/metrics_processor.py
+++ b/snuba/datasets/metrics_processor.py
@@ -4,16 +4,16 @@ from typing import Any, Mapping, Optional
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.processor import (
     InsertBatch,
-    MessageProcessor,
-    ProcessedMessage,
+    ProcessedStreamMessage,
+    StreamMessageProcessor,
     _ensure_valid_date,
 )
 
 
-class MetricsProcessor(MessageProcessor):
-    def process_message(
+class MetricsProcessor(StreamMessageProcessor):
+    def process_stream_message(
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         # TODO: Support messages with multiple buckets
 
         if message["type"] != "s":

--- a/snuba/datasets/outcomes_processor.py
+++ b/snuba/datasets/outcomes_processor.py
@@ -2,27 +2,26 @@ import uuid
 from datetime import datetime
 from typing import Any, Mapping, Optional
 
-from snuba.consumers.types import KafkaMessageMetadata
 from sentry_relay import DataCategory
 
-from snuba import settings, environment
+from snuba import environment, settings
+from snuba.consumers.types import KafkaMessageMetadata
 from snuba.processor import (
     InsertBatch,
-    MessageProcessor,
-    ProcessedMessage,
+    ProcessedStreamMessage,
+    StreamMessageProcessor,
     _ensure_valid_date,
     _unicodify,
 )
-
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "outcomes.processor")
 
 
-class OutcomesProcessor(MessageProcessor):
-    def process_message(
+class OutcomesProcessor(StreamMessageProcessor):
+    def process_stream_message(
         self, value: Mapping[str, Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         assert isinstance(value, dict)
         v_uuid = value.get("event_id")
 

--- a/snuba/datasets/querylog_processor.py
+++ b/snuba/datasets/querylog_processor.py
@@ -5,14 +5,13 @@ import simplejson as json
 
 from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.processor import InsertBatch, MessageProcessor, ProcessedMessage
+from snuba.processor import InsertBatch, ProcessedStreamMessage, StreamMessageProcessor
 from snuba.utils.metrics.wrapper import MetricsWrapper
-
 
 metrics = MetricsWrapper(environment.metrics, "snuba.querylog")
 
 
-class QuerylogProcessor(MessageProcessor):
+class QuerylogProcessor(StreamMessageProcessor):
     def __to_json_string(self, map: Mapping[str, Any]) -> str:
         return json.dumps({k: v for k, v in sorted(map.items())})
 
@@ -109,9 +108,9 @@ class QuerylogProcessor(MessageProcessor):
             "clickhouse_queries.array_join_columns": array_join_columns,
         }
 
-    def process_message(
+    def process_stream_message(
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         projects = message["request"]["body"].get("project", [])
         if not isinstance(projects, (list, tuple)):
             projects = [projects]

--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Any, Optional, Mapping
+from typing import Any, Mapping, Optional
 
 from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
@@ -8,8 +8,8 @@ from snuba.processor import (
     MAX_UINT32,
     NIL_UUID,
     InsertBatch,
-    MessageProcessor,
-    ProcessedMessage,
+    ProcessedStreamMessage,
+    StreamMessageProcessor,
     _collapse_uint16,
     _collapse_uint32,
     _ensure_valid_date,
@@ -27,10 +27,10 @@ STATUS_MAPPING = {
 metrics = MetricsWrapper(environment.metrics, "sessions.processor")
 
 
-class SessionsProcessor(MessageProcessor):
-    def process_message(
+class SessionsProcessor(StreamMessageProcessor):
+    def process_stream_message(
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         # some old relays accidentally emit rows without release
         if message["release"] is None:
             return None

--- a/snuba/datasets/spans_processor.py
+++ b/snuba/datasets/spans_processor.py
@@ -9,8 +9,8 @@ from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.events_format import enforce_retention, extract_extra_tags
 from snuba.processor import (
     InsertBatch,
-    MessageProcessor,
-    ProcessedMessage,
+    ProcessedStreamMessage,
+    StreamMessageProcessor,
     _as_dict_safe,
     _ensure_valid_date,
     _unicodify,
@@ -22,7 +22,7 @@ UNKNOWN_SPAN_STATUS = 2
 metrics = MetricsWrapper(environment.metrics, "spans.processor")
 
 
-class SpansMessageProcessor(MessageProcessor):
+class SpansMessageProcessor(StreamMessageProcessor):
     def __extract_timestamp(self, field: float) -> Tuple[datetime, int]:
         timestamp = _ensure_valid_date(datetime.utcfromtimestamp(field))
         if timestamp is None:
@@ -91,9 +91,9 @@ class SpansMessageProcessor(MessageProcessor):
             metrics.increment("missing_field", tags={"field": field})
         return None
 
-    def process_message(
+    def process_stream_message(
         self, message: Sequence[Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         if not (isinstance(message, (list, tuple)) and len(message) >= 2):
             return None
         version = message[0]

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -10,7 +10,7 @@ from snuba.clusters.cluster import (
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.message_filters import StreamMessageFilter
 from snuba.datasets.schemas.tables import WritableTableSchema
-from snuba.processor import MessageProcessor
+from snuba.processor import MessageProcessor, StreamMessageProcessor
 from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.snapshots import BulkLoadSource
 from snuba.snapshots.loaders import BulkLoader
@@ -99,7 +99,7 @@ class KafkaStreamLoader:
 
 
 def build_kafka_stream_loader_from_settings(
-    processor: MessageProcessor,
+    processor: StreamMessageProcessor,
     default_topic: Topic,
     pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
     replacement_topic: Optional[Topic] = None,

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -20,8 +20,8 @@ from snuba.datasets.events_format import (
 )
 from snuba.processor import (
     InsertBatch,
-    MessageProcessor,
-    ProcessedMessage,
+    ProcessedStreamMessage,
+    StreamMessageProcessor,
     _as_dict_safe,
     _ensure_valid_date,
     _ensure_valid_ip,
@@ -37,7 +37,7 @@ metrics = MetricsWrapper(environment.metrics, "transactions.processor")
 UNKNOWN_SPAN_STATUS = 2
 
 
-class TransactionsMessageProcessor(MessageProcessor):
+class TransactionsMessageProcessor(StreamMessageProcessor):
     PROMOTED_TAGS = {
         "environment",
         "sentry:release",
@@ -54,9 +54,9 @@ class TransactionsMessageProcessor(MessageProcessor):
         milliseconds = int(timestamp.microsecond / 1000)
         return (timestamp, milliseconds)
 
-    def process_message(
+    def process_stream_message(
         self, message: Tuple[int, str, Any], metadata: KafkaMessageMetadata
-    ) -> Optional[ProcessedMessage]:
+    ) -> Optional[ProcessedStreamMessage]:
         processed: MutableMapping[str, Any] = {"deleted": 0}
         if not (isinstance(message, (list, tuple)) and len(message) >= 2):
             return None

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -20,17 +20,6 @@ class BatchWriter(ABC, Generic[T]):
         raise NotImplementedError
 
 
-class BatchWriterEncoderWrapper(BatchWriter[TDecoded]):
-    def __init__(
-        self, writer: BatchWriter[TEncoded], encoder: Encoder[TEncoded, TDecoded]
-    ) -> None:
-        self.__writer = writer
-        self.__encoder = encoder
-
-    def write(self, values: Iterable[TDecoded]) -> None:
-        return self.__writer.write(map(self.__encoder.encode, values))
-
-
 class BufferedWriterWrapper(Generic[TEncoded, TDecoded]):
     """
     This is a wrapper that adds a buffer around a BatchWriter.

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -12,7 +12,7 @@ from snuba.datasets.cdc.groupedmessage_processor import (
 from snuba.datasets.cdc.types import DeleteEvent, InsertEvent, UpdateEvent
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.processor import InsertBatch
+from snuba.processor import InsertBatch, json_encode_insert_batch
 from tests.helpers import write_processed_messages
 
 
@@ -230,8 +230,11 @@ class TestGroupedMessage:
         )
 
         ret = processor.process_message(self.INSERT_MSG, metadata)
-        assert ret == InsertBatch(
-            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        assert ret == json_encode_insert_batch(
+            InsertBatch(
+                [self.PROCESSED],
+                datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC),
+            )
         )
         write_processed_messages(self.storage, [ret])
         ret = (
@@ -252,13 +255,19 @@ class TestGroupedMessage:
         )
 
         ret = processor.process_message(self.UPDATE_MSG, metadata)
-        assert ret == InsertBatch(
-            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        assert ret == json_encode_insert_batch(
+            InsertBatch(
+                [self.PROCESSED],
+                datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC),
+            )
         )
 
         ret = processor.process_message(self.DELETE_MSG, metadata)
-        assert ret == InsertBatch(
-            [self.DELETED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+        assert ret == json_encode_insert_batch(
+            InsertBatch(
+                [self.DELETED],
+                datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC),
+            )
         )
 
     def test_bulk_load(self) -> None:
@@ -274,7 +283,8 @@ class TestGroupedMessage:
             }
         )
         write_processed_messages(
-            self.storage, [InsertBatch([row.to_clickhouse()], None)]
+            self.storage,
+            [json_encode_insert_batch(InsertBatch([row.to_clickhouse()], None))],
         )
         ret = (
             get_cluster(StorageSetKey.EVENTS)

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -6,7 +6,7 @@ import pytest
 from snuba import settings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.metrics_processor import MetricsProcessor
-from snuba.processor import InsertBatch
+from snuba.processor import InsertBatch, json_encode_insert_batch
 
 TEST_CASES = [
     pytest.param(
@@ -63,6 +63,10 @@ def test_metrics_processor(
 
     meta = KafkaMessageMetadata(offset=100, partition=1, timestamp=datetime(1970, 1, 1))
 
-    expected_result = InsertBatch(expected, None) if expected is not None else None
+    expected_result = (
+        json_encode_insert_batch(InsertBatch(expected, None))
+        if expected is not None
+        else None
+    )
 
     assert MetricsProcessor().process_message(message, meta) == expected_result

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -7,7 +7,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.processor import InsertBatch
+from snuba.processor import InsertBatch, json_encode_insert_batch
 from snuba.query.data_source.simple import Entity
 from snuba.query.logical import Query
 from snuba.querylog.query_metadata import (
@@ -80,43 +80,45 @@ def test_simple() -> None:
 
     assert processor.process_message(
         message, KafkaMessageMetadata(0, 0, datetime.now())
-    ) == InsertBatch(
-        [
-            {
-                "request_id": str(uuid.UUID("a" * 32)),
-                "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
-                "referrer": "search",
-                "dataset": "events",
-                "projects": [1],
-                "organization": None,
-                "timestamp": timer.for_json()["timestamp"],
-                "duration_ms": 10,
-                "status": "success",
-                "clickhouse_queries.sql": [
-                    "select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100"
-                ],
-                "clickhouse_queries.status": ["success"],
-                "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
-                "clickhouse_queries.duration_ms": [0],
-                "clickhouse_queries.stats": ['{"sample": 10}'],
-                "clickhouse_queries.final": [0],
-                "clickhouse_queries.cache_hit": [0],
-                "clickhouse_queries.sample": [10.0],
-                "clickhouse_queries.max_threads": [0],
-                "clickhouse_queries.num_days": [10],
-                "clickhouse_queries.clickhouse_table": [""],
-                "clickhouse_queries.query_id": [""],
-                "clickhouse_queries.is_duplicate": [0],
-                "clickhouse_queries.consistent": [0],
-                "clickhouse_queries.all_columns": [["tags", "timestamp"]],
-                "clickhouse_queries.or_conditions": [False],
-                "clickhouse_queries.where_columns": [["timestamp"]],
-                "clickhouse_queries.where_mapping_columns": [["tags"]],
-                "clickhouse_queries.groupby_columns": [[]],
-                "clickhouse_queries.array_join_columns": [[]],
-            }
-        ],
-        None,
+    ) == json_encode_insert_batch(
+        InsertBatch(
+            [
+                {
+                    "request_id": str(uuid.UUID("a" * 32)),
+                    "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
+                    "referrer": "search",
+                    "dataset": "events",
+                    "projects": [1],
+                    "organization": None,
+                    "clickhouse_queries.sql": [
+                        "select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100"
+                    ],
+                    "clickhouse_queries.status": ["success"],
+                    "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
+                    "clickhouse_queries.duration_ms": [0],
+                    "clickhouse_queries.stats": ['{"sample": 10}'],
+                    "clickhouse_queries.final": [0],
+                    "clickhouse_queries.cache_hit": [0],
+                    "clickhouse_queries.sample": [10.0],
+                    "clickhouse_queries.max_threads": [0],
+                    "clickhouse_queries.num_days": [10],
+                    "clickhouse_queries.clickhouse_table": [""],
+                    "clickhouse_queries.query_id": [""],
+                    "clickhouse_queries.is_duplicate": [0],
+                    "clickhouse_queries.consistent": [0],
+                    "clickhouse_queries.all_columns": [["tags", "timestamp"]],
+                    "clickhouse_queries.or_conditions": [False],
+                    "clickhouse_queries.where_columns": [["timestamp"]],
+                    "clickhouse_queries.where_mapping_columns": [["tags"]],
+                    "clickhouse_queries.groupby_columns": [[]],
+                    "clickhouse_queries.array_join_columns": [[]],
+                    "timestamp": timer.for_json()["timestamp"],
+                    "duration_ms": 10,
+                    "status": "success",
+                }
+            ],
+            None,
+        )
     )
 
 
@@ -188,38 +190,40 @@ def test_missing_fields() -> None:
 
         assert processor.process_message(
             message, KafkaMessageMetadata(0, 0, datetime.now())
-        ) == InsertBatch(
-            [
-                {
-                    "request_id": str(uuid.UUID("a" * 32)),
-                    "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
-                    "referrer": "search",
-                    "dataset": "events",
-                    "projects": [1],
-                    "organization": None,
-                    "clickhouse_queries.sql": [
-                        "select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100"
-                    ],
-                    "clickhouse_queries.status": ["success"],
-                    "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
-                    "clickhouse_queries.duration_ms": [0],
-                    "clickhouse_queries.stats": ['{"sample": 10}'],
-                    "clickhouse_queries.final": [0],
-                    "clickhouse_queries.cache_hit": [0],
-                    "clickhouse_queries.sample": [10.0],
-                    "clickhouse_queries.max_threads": [0],
-                    "clickhouse_queries.num_days": [10],
-                    "clickhouse_queries.clickhouse_table": [""],
-                    "clickhouse_queries.query_id": [""],
-                    "clickhouse_queries.is_duplicate": [0],
-                    "clickhouse_queries.consistent": [0],
-                    "clickhouse_queries.all_columns": [["tags", "timestamp"]],
-                    "clickhouse_queries.or_conditions": [False],
-                    "clickhouse_queries.where_columns": [["timestamp"]],
-                    "clickhouse_queries.where_mapping_columns": [["tags"]],
-                    "clickhouse_queries.groupby_columns": [[]],
-                    "clickhouse_queries.array_join_columns": [[]],
-                }
-            ],
-            None,
+        ) == json_encode_insert_batch(
+            InsertBatch(
+                [
+                    {
+                        "request_id": str(uuid.UUID("a" * 32)),
+                        "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
+                        "referrer": "search",
+                        "dataset": "events",
+                        "projects": [1],
+                        "organization": None,
+                        "clickhouse_queries.sql": [
+                            "select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100"
+                        ],
+                        "clickhouse_queries.status": ["success"],
+                        "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
+                        "clickhouse_queries.duration_ms": [0],
+                        "clickhouse_queries.stats": ['{"sample": 10}'],
+                        "clickhouse_queries.final": [0],
+                        "clickhouse_queries.cache_hit": [0],
+                        "clickhouse_queries.sample": [10.0],
+                        "clickhouse_queries.max_threads": [0],
+                        "clickhouse_queries.num_days": [10],
+                        "clickhouse_queries.clickhouse_table": [""],
+                        "clickhouse_queries.query_id": [""],
+                        "clickhouse_queries.is_duplicate": [0],
+                        "clickhouse_queries.consistent": [0],
+                        "clickhouse_queries.all_columns": [["tags", "timestamp"]],
+                        "clickhouse_queries.or_conditions": [False],
+                        "clickhouse_queries.where_columns": [["timestamp"]],
+                        "clickhouse_queries.where_mapping_columns": [["tags"]],
+                        "clickhouse_queries.groupby_columns": [[]],
+                        "clickhouse_queries.array_join_columns": [[]],
+                    }
+                ],
+                None,
+            )
         )

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
 
-from snuba.datasets.sessions_processor import SessionsProcessor
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.processor import InsertBatch
+from snuba.datasets.sessions_processor import SessionsProcessor
+from snuba.processor import InsertBatch, json_encode_insert_batch
 
 
 class TestSessionProcessor:
@@ -32,26 +32,30 @@ class TestSessionProcessor:
         meta = KafkaMessageMetadata(
             offset=1, partition=2, timestamp=datetime(1970, 1, 1)
         )
-        assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
-            [
-                {
-                    "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
-                    "quantity": 1,
-                    "duration": 1947490,
-                    "environment": "production",
-                    "org_id": 1,
-                    "project_id": 42,
-                    "release": "sentry-test@1.0.0",
-                    "retention_days": 90,
-                    "seq": 42,
-                    "errors": 0,
-                    "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
-                    "started": started.replace(tzinfo=None),
-                    "status": 1,
-                    "received": timestamp.replace(tzinfo=None),
-                }
-            ],
-            None,
+        assert SessionsProcessor().process_message(
+            payload, meta
+        ) == json_encode_insert_batch(
+            InsertBatch(
+                [
+                    {
+                        "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+                        "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                        "quantity": 1,
+                        "seq": 42,
+                        "org_id": 1,
+                        "project_id": 42,
+                        "retention_days": 90,
+                        "duration": 1947490,
+                        "status": 1,
+                        "errors": 0,
+                        "received": timestamp.replace(tzinfo=None),
+                        "started": started.replace(tzinfo=None),
+                        "release": "sentry-test@1.0.0",
+                        "environment": "production",
+                    }
+                ],
+                None,
+            )
         )
 
     def test_ingest_session_event_abnormal(self) -> None:
@@ -80,27 +84,31 @@ class TestSessionProcessor:
         meta = KafkaMessageMetadata(
             offset=1, partition=2, timestamp=datetime(1970, 1, 1)
         )
-        assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
-            [
-                {
-                    "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
-                    "quantity": 1,
-                    "duration": 1947490,
-                    "environment": "production",
-                    "org_id": 1,
-                    "project_id": 42,
-                    "release": "sentry-test@1.0.0",
-                    "retention_days": 90,
-                    "seq": 42,
-                    # abnormal counts as at least one error
-                    "errors": 1,
-                    "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
-                    "started": started.replace(tzinfo=None),
-                    "status": 3,
-                    "received": timestamp.replace(tzinfo=None),
-                }
-            ],
-            None,
+        assert SessionsProcessor().process_message(
+            payload, meta
+        ) == json_encode_insert_batch(
+            InsertBatch(
+                [
+                    {
+                        "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+                        "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                        "quantity": 1,
+                        "seq": 42,
+                        "org_id": 1,
+                        "project_id": 42,
+                        "retention_days": 90,
+                        "duration": 1947490,
+                        "status": 3,
+                        # abnormal counts as at least one error
+                        "errors": 1,
+                        "received": timestamp.replace(tzinfo=None),
+                        "started": started.replace(tzinfo=None),
+                        "release": "sentry-test@1.0.0",
+                        "environment": "production",
+                    }
+                ],
+                None,
+            )
         )
 
     def test_ingest_session_event_crashed(self) -> None:
@@ -129,25 +137,29 @@ class TestSessionProcessor:
         meta = KafkaMessageMetadata(
             offset=1, partition=2, timestamp=datetime(1970, 1, 1)
         )
-        assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
-            [
-                {
-                    "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
-                    "quantity": 1,
-                    "duration": 1947490,
-                    "environment": "production",
-                    "org_id": 1,
-                    "project_id": 42,
-                    "release": "sentry-test@1.0.0",
-                    "retention_days": 90,
-                    "seq": 42,
-                    # abnormal counts as at least one error
-                    "errors": 1,
-                    "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
-                    "started": started.replace(tzinfo=None),
-                    "status": 2,
-                    "received": timestamp.replace(tzinfo=None),
-                }
-            ],
-            None,
+        assert SessionsProcessor().process_message(
+            payload, meta
+        ) == json_encode_insert_batch(
+            InsertBatch(
+                [
+                    {
+                        "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+                        "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                        "quantity": 1,
+                        "seq": 42,
+                        "org_id": 1,
+                        "project_id": 42,
+                        "retention_days": 90,
+                        "duration": 1947490,
+                        "status": 2,
+                        # abnormal counts as at least one error
+                        "errors": 1,
+                        "received": timestamp.replace(tzinfo=None),
+                        "started": started.replace(tzinfo=None),
+                        "release": "sentry-test@1.0.0",
+                        "environment": "production",
+                    }
+                ],
+                None,
+            )
         )

--- a/tests/snapshots/test_snapshot_worker.py
+++ b/tests/snapshots/test_snapshot_worker.py
@@ -5,12 +5,12 @@ from uuid import uuid1
 import pytest
 import pytz
 
-from snuba.consumers.types import KafkaMessageMetadata
 from snuba.consumers.snapshot_worker import SnapshotProcessor
+from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.cdc.types import InsertEvent
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.processor import InsertBatch, ProcessedMessage
+from snuba.processor import InsertBatch, ProcessedMessage, json_encode_insert_batch
 from snuba.snapshots import SnapshotId
 from snuba.snapshots.postgres_snapshot import Xid
 from snuba.stateful_consumer.control_protocol import TransactionData
@@ -111,8 +111,8 @@ test_data = [
     (90, None),
     (100, None),
     (110, None),
-    (120, InsertBatch([PROCESSED], None)),
-    (210, InsertBatch([PROCESSED], None)),
+    (120, json_encode_insert_batch(InsertBatch([PROCESSED], None))),
+    (210, json_encode_insert_batch(InsertBatch([PROCESSED], None))),
 ]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,7 +20,7 @@ from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
-from snuba.processor import InsertBatch
+from snuba.processor import InsertBatch, json_encode_insert_batch
 from snuba.redis import redis_client
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from tests.base import BaseApiTest
@@ -1429,18 +1429,20 @@ class TestApi(SimpleAPITest):
         write_processed_messages(
             self.storage,
             [
-                InsertBatch(
-                    [
-                        {
-                            "event_id": event_id,
-                            "project_id": 1,
-                            "group_id": 1,
-                            "timestamp": self.base_time,
-                            "deleted": 1,
-                            "retention_days": settings.DEFAULT_RETENTION_DAYS,
-                        }
-                    ],
-                    None,
+                json_encode_insert_batch(
+                    InsertBatch(
+                        [
+                            {
+                                "event_id": event_id,
+                                "project_id": 1,
+                                "group_id": 1,
+                                "timestamp": self.base_time,
+                                "deleted": 1,
+                                "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                            }
+                        ],
+                        None,
+                    )
                 )
             ],
         )


### PR DESCRIPTION
JSON encoding of insert batches should not be done by the streaming
consumer strategy factory, as this code should eventually become generic
and agnostic of encoding formats so that it can be used outside of Snuba.

Now it's the job of the message processor to do the encoding and convert
an InsertBatch into a JSONRowInsertBatch.