### PR TITLE
feat(metrics) Support tags with integer keys

### DIFF
--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -8,20 +8,46 @@ from snuba.clickhouse.columns import (
     Nested,
     UInt,
 )
-from snuba.clickhouse.translators.snuba.mappers import ColumnToFunction
+from snuba.clickhouse.translators.snuba.mappers import (
+    ColumnToFunction,
+    SubscriptableMapper,
+)
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entity import Entity
 from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
+from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Column as ColumnExpr
+from snuba.query.expressions import Expression, Literal, SubscriptableReference
 from snuba.query.extensions import QueryExtension
+from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.project_rate_limiter import ProjectRateLimiterProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
+from snuba.request.request_settings import RequestSettings
+
+
+class TagsTypeTransformer(QueryProcessor):
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def transform_expression(exp: Expression) -> Expression:
+            if not isinstance(exp, SubscriptableReference):
+                return exp
+
+            key = exp.key
+            if not isinstance(key.value, str) or not key.value.isdigit():
+                raise InvalidExpressionException(
+                    exp, "Expected a string key in subscriptable"
+                )
+
+            return SubscriptableReference(
+                exp.alias, exp.column, Literal(None, int(key.value))
+            )
+
+        query.transform_expressions(transform_expression)
 
 
 class MetricsSetsEntity(Entity):
@@ -43,6 +69,9 @@ class MetricsSetsEntity(Entity):
                                 "uniqCombined64Merge",
                                 (ColumnExpr(None, None, "value"),),
                             ),
+                        ],
+                        subscriptables=[
+                            SubscriptableMapper(None, "tags", None, "tags"),
                         ],
                     ),
                 )
@@ -73,4 +102,5 @@ class MetricsSetsEntity(Entity):
             BasicFunctionsProcessor(),
             TimeSeriesProcessor({"bucketed_time": "timestamp"}, ("timestamp",)),
             ProjectRateLimiterProcessor(project_column="project_id"),
+            TagsTypeTransformer(),
         ]

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -40,7 +40,7 @@ class TagsTypeTransformer(QueryProcessor):
             key = exp.key
             if not isinstance(key.value, str) or not key.value.isdigit():
                 raise InvalidExpressionException(
-                    exp, "Expected a string key in subscriptable"
+                    exp, "Expected a string key containing an integer in subscriptable."
                 )
 
             return SubscriptableReference(

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -15,6 +15,9 @@ from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
 from snuba.datasets.storage import ReadableTableStorage, WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
+from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
+    ArrayJoinKeyValueOptimizer,
+)
 from snuba.utils.streams.topics import Topic
 
 buckets_columns = ColumnSet(
@@ -71,5 +74,5 @@ sets_storage = ReadableTableStorage(
         storage_set_key=StorageSetKey.METRICS,
         columns=sets_columns,
     ),
-    query_processors=[],
+    query_processors=[ArrayJoinKeyValueOptimizer("tags")],
 )

--- a/tests/datasets/entities/test_tags_transformer.py
+++ b/tests/datasets/entities/test_tags_transformer.py
@@ -1,0 +1,38 @@
+import pytest
+
+from snuba.datasets.entities.metrics import TagsTypeTransformer
+from snuba.query import SelectedExpression
+from snuba.query.exceptions import InvalidExpressionException
+from snuba.query.expressions import Column, Literal, SubscriptableReference
+from snuba.query.logical import Query
+from snuba.request.request_settings import HTTPRequestSettings
+
+
+def build_query(tag_key: Literal) -> Query:
+    return Query(
+        from_clause=None,
+        selected_columns=[
+            SelectedExpression(
+                "tags[10]",
+                SubscriptableReference(
+                    "_snuba_tags[10]", Column(None, None, "tags"), tag_key
+                ),
+            )
+        ],
+    )
+
+
+def test_transformer() -> None:
+    query = build_query(Literal(None, "10"))
+    TagsTypeTransformer().process_query(query, HTTPRequestSettings())
+
+    assert query.get_selected_columns()[0].expression == SubscriptableReference(
+        "_snuba_tags[10]", Column(None, None, "tags"), Literal(None, 10)
+    )
+
+
+def test_broken_query() -> None:
+    with pytest.raises(InvalidExpressionException):
+        TagsTypeTransformer().process_query(
+            build_query(Literal(None, "asdasd")), HTTPRequestSettings()
+        )

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -1,0 +1,80 @@
+import importlib
+
+from snuba import settings
+from snuba.clickhouse.query import Query
+from snuba.datasets import factory
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.factory import get_dataset
+from snuba.datasets.storages import factory as storage_factory
+from snuba.query import SelectedExpression
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.snql.parser import parse_snql_query
+from snuba.reader import Reader
+from snuba.request import Request
+from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
+from snuba.web import QueryResult
+
+
+def test_metrics_processing() -> None:
+    settings.ENABLE_DEV_FEATURES = True
+    settings.DISABLED_DATASETS = set()
+
+    importlib.reload(factory)
+    importlib.reload(storage_factory)
+
+    query_body = {
+        "query": (
+            "MATCH (metrics_sets) "
+            "SELECT value BY org_id, project_id, tags[10] "
+            "WHERE "
+            "timestamp >= toDateTime('2021-05-17 19:42:01') AND "
+            "timestamp < toDateTime('2021-05-17 23:42:01') AND "
+            "org_id = 1 AND "
+            "project_id = 1"
+        ),
+    }
+
+    metrics_dataset = get_dataset("metrics")
+    query = parse_snql_query(query_body["query"], metrics_dataset)
+
+    request = Request("", query_body, query, HTTPRequestSettings(), "")
+
+    def query_runner(
+        query: Query, settings: RequestSettings, reader: Reader
+    ) -> QueryResult:
+        assert query.get_selected_columns() == [
+            SelectedExpression("org_id", Column("_snuba_org_id", None, "org_id"),),
+            SelectedExpression(
+                "project_id", Column("_snuba_project_id", None, "project_id"),
+            ),
+            SelectedExpression(
+                "tags[10]",
+                FunctionCall(
+                    "_snuba_tags[10]",
+                    "arrayElement",
+                    (
+                        Column(None, None, "tags.value"),
+                        FunctionCall(
+                            None,
+                            "indexOf",
+                            (Column(None, None, "tags.key"), Literal(None, 10),),
+                        ),
+                    ),
+                ),
+            ),
+            SelectedExpression(
+                "value",
+                FunctionCall(
+                    "_snuba_value",
+                    "uniqCombined64Merge",
+                    (Column(None, None, "value"),),
+                ),
+            ),
+        ]
+        return QueryResult({}, {})
+
+    entity = get_entity(EntityKey.METRICS_SETS)
+    entity.get_query_pipeline_builder().build_execution_pipeline(
+        request, query_runner
+    ).execute()

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -36,7 +36,7 @@ def test_metrics_processing() -> None:
     }
 
     metrics_dataset = get_dataset("metrics")
-    query = parse_snql_query(query_body["query"], metrics_dataset)
+    query = parse_snql_query(query_body["query"], [], metrics_dataset)
 
     request = Request("", query_body, query, HTTPRequestSettings(), "")
 


### PR DESCRIPTION
`tags[10]` is today parsed as `SubscriptableReference(None, Column(None, None, "tags"), Literal(None, "10"))` as we assume the key is a string.
This has been true for all datasets except for metrics where the tag key is an integer.

I don't think we should change the parser for making it know about specific types of subscriptables, as the valid subscriptables are defined by the dataset and the parser is generic.
Since this is a specific behavior of one dataset, I added this processing as an entity query processor instead of adding this specific logic to the common subscriptable translator (also this kind of change is easier to do in a processor that has a lot more context than a translator or the translator would have to make changes to its children, which can be dangerous). 

I doubt we would need this outside metrics for a very long time, so I put the processor in the metrics entity module itself.