### PR TITLE
fix(replacer) Bad tombstone message causes replacements to stop

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -9,7 +9,6 @@ from enum import Enum
 from typing import (
     Any,
     Deque,
-    Dict,
     List,
     Mapping,
     MutableMapping,
@@ -96,20 +95,14 @@ class LegacyReplacement(Replacement):
         if self.insert_query_template is None:
             return None
 
-        args = {
-            **self.query_args,
-            "table_name": table_name
-        }
+        args = {**self.query_args, "table_name": table_name}
         return self.insert_query_template % args
 
     def get_count_query(self, table_name: str) -> Optional[str]:
         if self.count_query_template is None:
             return None
 
-        args = {
-            **self.query_args,
-            "table_name": table_name
-        }
+        args = {**self.query_args, "table_name": table_name}
         return self.count_query_template % args
 
 
@@ -524,11 +517,13 @@ def process_tombstone_events(
     prewhere, where, query_args = event_set_filter
 
     if old_primary_hash:
-        query_args["old_primary_hash"] = (
-            ("'%s'" % (str(uuid.UUID(old_primary_hash)),))
-            if old_primary_hash
-            else "NULL"
-        )
+        try:
+            parsed_hash = uuid.UUID(old_primary_hash)
+        except Exception as err:
+            logger.error("Invalid old primary hash %s", old_primary_hash, exc_info=err)
+            return None
+
+        query_args["old_primary_hash"] = f"'{str(parsed_hash)}'"
 
         prewhere.append("primary_hash = %(old_primary_hash)s")
 


### PR DESCRIPTION
We received this message 
```
{
event_ids: [
'e66bad96c1614dcaa927bdb2b29efe08'
], 
from_timestamp: '2021-05-20T17:04:38.000000Z', 
old_primary_hash: 'AF733E6D20256FEE784E39332EC17A27E0DF3C5A', 
project_id: 5448233, 
to_timestamp: '2021-05-20T17:04:38.000000Z'
}
```

old_primary_hash is not a valid UUID.