### PR TITLE
feat(metrics) Add Counters entity

### DIFF
--- a/snuba/datasets/entities/__init__.py
+++ b/snuba/datasets/entities/__init__.py
@@ -14,6 +14,7 @@ class EntityKey(Enum):
     # TODO: This has an S on the end in solidarity with storages, but it's got to go
     GROUPEDMESSAGES = "groupedmessage"
     METRICS_SETS = "metrics_sets"
+    METRICS_COUNTERS = "metrics_counters"
     OUTCOMES = "outcomes"
     OUTCOMES_RAW = "outcomes_raw"
     SESSIONS = "sessions"

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -27,7 +27,7 @@ def get_entity(name: EntityKey) -> Entity:
         DiscoverTransactionsEntity,
     )
     from snuba.datasets.entities.events import EventsEntity
-    from snuba.datasets.entities.metrics import MetricsSetsEntity
+    from snuba.datasets.entities.metrics import MetricsCountersEntity, MetricsSetsEntity
     from snuba.datasets.entities.outcomes import OutcomesEntity
     from snuba.datasets.entities.outcomes_raw import OutcomesRawEntity
     from snuba.datasets.entities.sessions import SessionsEntity
@@ -36,6 +36,7 @@ def get_entity(name: EntityKey) -> Entity:
 
     dev_entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {
         EntityKey.METRICS_SETS: MetricsSetsEntity,
+        EntityKey.METRICS_COUNTERS: MetricsCountersEntity,
     }
 
     entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -1,7 +1,9 @@
 import importlib
 
+import pytest
+
 from snuba import settings
-from snuba.clickhouse.query import Query
+from snuba.clickhouse.query import Expression, Query
 from snuba.datasets import factory
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -15,8 +17,28 @@ from snuba.request import Request
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
+TEST_CASES = [
+    pytest.param(
+        "metrics_sets",
+        EntityKey.METRICS_SETS,
+        FunctionCall(
+            "_snuba_value", "uniqCombined64Merge", (Column(None, None, "value"),),
+        ),
+        id="Test sets entity",
+    ),
+    pytest.param(
+        "metrics_counters",
+        EntityKey.METRICS_COUNTERS,
+        FunctionCall("_snuba_value", "sumMerge", (Column(None, None, "value"),),),
+        id="Test counters entity",
+    ),
+]
 
-def test_metrics_processing() -> None:
+
+@pytest.mark.parametrize("entity_name, entity_key, translated_value", TEST_CASES)
+def test_metrics_processing(
+    entity_name: str, entity_key: EntityKey, translated_value: Expression
+) -> None:
     settings.ENABLE_DEV_FEATURES = True
     settings.DISABLED_DATASETS = set()
 
@@ -25,7 +47,7 @@ def test_metrics_processing() -> None:
 
     query_body = {
         "query": (
-            "MATCH (metrics_sets) "
+            f"MATCH ({entity_name}) "
             "SELECT value BY org_id, project_id, tags[10] "
             "WHERE "
             "timestamp >= toDateTime('2021-05-17 19:42:01') AND "
@@ -63,18 +85,11 @@ def test_metrics_processing() -> None:
                     ),
                 ),
             ),
-            SelectedExpression(
-                "value",
-                FunctionCall(
-                    "_snuba_value",
-                    "uniqCombined64Merge",
-                    (Column(None, None, "value"),),
-                ),
-            ),
+            SelectedExpression("value", translated_value,),
         ]
         return QueryResult({}, {})
 
-    entity = get_entity(EntityKey.METRICS_SETS)
+    entity = get_entity(entity_key)
     entity.get_query_pipeline_builder().build_execution_pipeline(
         request, query_runner
     ).execute()

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -29,7 +29,7 @@ TEST_CASES = [
     pytest.param(
         "metrics_counters",
         EntityKey.METRICS_COUNTERS,
-        FunctionCall("_snuba_value", "sumMerge", (Column(None, None, "value"),),),
+        FunctionCall("_snuba_value", "sumMerge", (Column(None, None, "value"),)),
         id="Test counters entity",
     ),
 ]

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -80,7 +80,7 @@ def test_metrics_processing(
                         FunctionCall(
                             None,
                             "indexOf",
-                            (Column(None, None, "tags.key"), Literal(None, 10),),
+                            (Column(None, None, "tags.key"), Literal(None, 10)),
                         ),
                     ),
                 ),


### PR DESCRIPTION
Adds an entity for the storages added in #1907

It can be queried this way:
```
MATCH (metrics_counters) 
SELECT value BY org_id, project_id, tags[10] 
WHERE 
   timestamp >= toDateTime('2021-05-17 19:42:01') AND 
   timestamp < toDateTime('2021-05-30 23:42:01') AND 
   org_id = 1 AND 
   project_id = 1
```