### PR TITLE
ci(docs): Add github action to verify docs on PR's

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,0 +1,20 @@
+name: Snuba Docs on PR's
+
+on:
+  pull_request:
+
+jobs:
+  docs:
+    name: Sphinx
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Build docs
+        run: |
+          pip install virtualenv
+          make snubadocs


### PR DESCRIPTION
Added a new github action file docs-pr.yml which runs only on pull requests. It runs make snubadocs and ensures no failures are found when running that command.