### PR TITLE
ref: Move concurrent to the streaming_kafka_consumer package

### DIFF
--- a/streaming_kafka_consumer/backends/kafka/__init__.py
+++ b/streaming_kafka_consumer/backends/kafka/__init__.py
@@ -41,10 +41,9 @@ from streaming_kafka_consumer.backends.abstract import (
     OffsetOutOfRange,
     Producer,
 )
+from streaming_kafka_consumer.concurrent import execute
 from streaming_kafka_consumer.retries import NoRetryPolicy, RetryPolicy
 from streaming_kafka_consumer.types import Message, Partition, Topic
-
-from snuba.utils.concurrent import execute
 
 logger = logging.getLogger(__name__)
 

--- a/streaming_kafka_consumer/concurrent.py
+++ b/streaming_kafka_consumer/concurrent.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from threading import Lock, Thread
 from typing import Callable, Generic, Iterator, Optional, TypeVar
 
-
 T = TypeVar("T")
 
 

--- a/streaming_kafka_consumer/synchronized.py
+++ b/streaming_kafka_consumer/synchronized.py
@@ -9,10 +9,10 @@ from streaming_kafka_consumer.backends.abstract import (
     EndOfPartition,
 )
 from streaming_kafka_consumer.backends.kafka import KafkaPayload
+from streaming_kafka_consumer.concurrent import Synchronized, execute
 from streaming_kafka_consumer.types import Message, Partition, Topic, TPayload
 
 from snuba.utils.codecs import Codec
-from snuba.utils.concurrent import Synchronized, execute
 
 logger = logging.getLogger(__name__)
 

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -6,12 +6,12 @@ from typing import Iterator
 from unittest import mock
 
 import pytest
+from streaming_kafka_consumer.concurrent import execute
 
 from snuba.redis import redis_client
 from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import PassthroughCodec
-from snuba.utils.concurrent import execute
 from tests.assertions import assert_changes, assert_does_not_change
 
 

--- a/tests/utils/metrics/test_gauge.py
+++ b/tests/utils/metrics/test_gauge.py
@@ -3,8 +3,8 @@ from threading import Barrier
 from typing import Callable
 
 import pytest
+from streaming_kafka_consumer.concurrent import execute
 
-from snuba.utils.concurrent import execute
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
 from snuba.utils.metrics.types import Tags

--- a/tests/utils/test_concurrent.py
+++ b/tests/utils/test_concurrent.py
@@ -1,10 +1,9 @@
 import threading
 import time
-
-import pytest
 from concurrent.futures import TimeoutError
 
-from snuba.utils.concurrent import Synchronized, execute
+import pytest
+from streaming_kafka_consumer.concurrent import Synchronized, execute
 
 
 def test_execute() -> None:


### PR DESCRIPTION
The `concurrent` module is primarily used by the streaming_kafka_consumer package.