### PR TITLE
ref: Move logging utility to streaming_kafka_consumer

### DIFF
--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -1,4 +1,5 @@
 import logging
+from syslog import LOG_CRIT
 from typing import Optional, Sequence
 
 import click
@@ -8,7 +9,6 @@ from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.environment import setup_logging
 from snuba.migrations.connect import check_clickhouse_connections
 from snuba.migrations.runner import Runner
-from snuba.utils.logging import pylog_to_syslog_level
 from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
 
@@ -54,7 +54,7 @@ def bootstrap(
             # Override rdkafka loglevel to be critical unless we are
             # debugging as we expect failures when trying to connect
             # (Kafka may not be up yet)
-            override_params["log_level"] = pylog_to_syslog_level(logging.CRITICAL)
+            override_params["log_level"] = LOG_CRIT
 
         attempts = 0
         while True:

--- a/streaming_kafka_consumer/backends/kafka/configuration.py
+++ b/streaming_kafka_consumer/backends/kafka/configuration.py
@@ -2,7 +2,7 @@ import copy
 import logging
 from typing import Any, Dict, Mapping, Optional, Sequence
 
-from snuba.utils.logging import pylog_to_syslog_level
+from streaming_kafka_consumer.logging import pylog_to_syslog_level
 
 logger = logging.getLogger(__name__)
 

--- a/streaming_kafka_consumer/logging.py
+++ b/streaming_kafka_consumer/logging.py
@@ -1,5 +1,4 @@
-from logging import NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL
-
+from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARNING
 
 PYTHON_TO_SYSLOG_MAP = {
     NOTSET: 7,


### PR DESCRIPTION
The `pylog_to_syslog` method is now only being used by the streaming kafka consumer package