### PR TITLE
ref: Streaming kafka consumer does not depend on snuba.utils.codecs

### DIFF
--- a/streaming_kafka_consumer/backends/local/storages/file.py
+++ b/streaming_kafka_consumer/backends/local/storages/file.py
@@ -23,9 +23,8 @@ from streaming_kafka_consumer.backends.local.storages.abstract import (
     TopicDoesNotExist,
     TopicExists,
 )
+from streaming_kafka_consumer.codecs import Codec
 from streaming_kafka_consumer.types import Message, Partition, Topic, TPayload
-
-from snuba.utils.codecs import Codec
 
 
 class PickleCodec(Codec[bytes, Tuple[TPayload, datetime]]):

--- a/streaming_kafka_consumer/codecs.py
+++ b/streaming_kafka_consumer/codecs.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+TEncoded = TypeVar("TEncoded")
+
+TDecoded = TypeVar("TDecoded")
+
+
+class Encoder(Generic[TEncoded, TDecoded], ABC):
+    @abstractmethod
+    def encode(self, value: TDecoded) -> TEncoded:
+        raise NotImplementedError
+
+
+class Decoder(Generic[TEncoded, TDecoded], ABC):
+    @abstractmethod
+    def decode(self, value: TEncoded) -> TDecoded:
+        raise NotImplementedError
+
+
+class Codec(
+    Encoder[TEncoded, TDecoded], Decoder[TEncoded, TDecoded],
+):
+    pass

--- a/streaming_kafka_consumer/synchronized.py
+++ b/streaming_kafka_consumer/synchronized.py
@@ -9,10 +9,9 @@ from streaming_kafka_consumer.backends.abstract import (
     EndOfPartition,
 )
 from streaming_kafka_consumer.backends.kafka import KafkaPayload
+from streaming_kafka_consumer.codecs import Codec
 from streaming_kafka_consumer.concurrent import Synchronized, execute
 from streaming_kafka_consumer.types import Message, Partition, Topic, TPayload
-
-from snuba.utils.codecs import Codec
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This copies the Codec class to the streaming kafka consumer package
so that we do not depend on the snuba implementation there.