### PR TITLE
test: Add test for streaming kafka consumer's gauge implementation

### DIFF
--- a/streaming_kafka_consumer/tests/test_metrics.py
+++ b/streaming_kafka_consumer/tests/test_metrics.py
@@ -1,0 +1,20 @@
+from streaming_kafka_consumer.metrics import Gauge
+from streaming_kafka_consumer.tests.metrics import Gauge as GaugeCall
+from streaming_kafka_consumer.tests.metrics import TestingMetricsBackend
+
+
+def test_gauge_simple() -> None:
+    backend = TestingMetricsBackend()
+
+    name = "name"
+    tags = {"tag": "value"}
+    gauge = Gauge(backend, name, tags)
+
+    with gauge:
+        pass
+
+    assert backend.calls == [
+        GaugeCall(name, 0.0, tags),
+        GaugeCall(name, 1.0, tags),
+        GaugeCall(name, 0.0, tags),
+    ]


### PR DESCRIPTION
This is based on a similar test for Snuba's gauge implementation