### PR TITLE
test: Refactor cache and gauge tests

### DIFF
--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -1,18 +1,36 @@
+from __future__ import annotations
+
 import random
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from functools import partial
-from typing import Iterator
+from threading import Thread
+from typing import Any, Callable, Iterator
 from unittest import mock
 
 import pytest
-from streaming_kafka_consumer.concurrent import execute
 
 from snuba.redis import redis_client
 from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import PassthroughCodec
 from tests.assertions import assert_changes, assert_does_not_change
+
+
+def execute(function: Callable[[], Any]) -> Future[Any]:
+    future: Future[Any] = Future()
+
+    def run() -> None:
+        try:
+            result = function()
+        except Exception as e:
+            future.set_exception(e)
+        else:
+            future.set_result(result)
+
+    Thread(target=run).start()
+
+    return future
 
 
 @pytest.fixture

--- a/tests/utils/metrics/test_gauge.py
+++ b/tests/utils/metrics/test_gauge.py
@@ -1,15 +1,27 @@
-from concurrent.futures import wait
-from threading import Barrier
-from typing import Callable
+from __future__ import annotations
+
+from concurrent.futures import Future, wait
+from threading import Barrier, Thread
+from typing import Any, Callable
 
 import pytest
-from streaming_kafka_consumer.concurrent import execute
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
 from snuba.utils.metrics.types import Tags
 from tests.backends.metrics import Gauge as GaugeCall
 from tests.backends.metrics import TestingMetricsBackend
+
+
+def execute(function: Callable[[], Any]) -> Future[Any]:
+    future: Future[Any] = Future()
+
+    def run() -> None:
+        future.set_result(function())
+
+    Thread(target=run).start()
+
+    return future
 
 
 @pytest.mark.parametrize("factory", [Gauge, ThreadSafeGauge])


### PR DESCRIPTION
Snuba's cache and gauge have not nothing to do with the streaming
consumer. We should not rely on methods imported from there for these tests.