### PR TITLE
fix(perf) Add span data to track query execution

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -1,12 +1,13 @@
+import concurrent.futures
 import logging
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import Callable, Optional
 
-import concurrent.futures
-from concurrent.futures import ThreadPoolExecutor
 from pkg_resources import resource_string
-from redis.exceptions import ResponseError
+from sentry_sdk import Hub
 
+from redis.exceptions import ResponseError
 from snuba.redis import RedisClientType
 from snuba.state import get_config
 from snuba.state.cache.abstract import (
@@ -17,7 +18,6 @@ from snuba.state.cache.abstract import (
 )
 from snuba.utils.codecs import Codec
 from snuba.utils.metrics.timer import Timer
-
 
 logger = logging.getLogger(__name__)
 
@@ -135,9 +135,12 @@ class RedisCache(Cache[TValue]):
         # This updates the stats object and querylog
         record_cache_hit_type(result[0])
 
+        span = Hub.current.scope.span
         if result[0] == RESULT_VALUE:
             # If we got a cache hit, this is easy -- we just return it.
             logger.debug("Immediately returning result from cache hit.")
+            if span:
+                span.set_data("backend", "cache")
             return self.__codec.decode(result[1])
         elif result[0] == RESULT_EXECUTE:
             # If we were the first in line, we need to execute the function.
@@ -152,6 +155,8 @@ class RedisCache(Cache[TValue]):
                 task_ident,
                 task_timeout,
             )
+            if span:
+                span.set_data("backend", "db")
 
             argv = [task_ident, 60]
             try:
@@ -202,6 +207,8 @@ class RedisCache(Cache[TValue]):
                 task_ident,
                 effective_timeout,
             )
+            if span:
+                span.set_data("backend", "cache_wait")
 
             notification_received = (
                 self.__client.blpop(

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -350,16 +350,17 @@ def execute_query_with_readthrough_caching(
     span = Hub.current.scope.span
 
     def record_cache_hit_type(hit_type: int) -> None:
-        span_tag = "db"
+        span_tag = "cache_miss"
         if hit_type == RESULT_VALUE:
             stats["cache_hit"] = 1
-            span_tag = "cache"
+            span_tag = "cache_hit"
         elif hit_type == RESULT_WAIT:
             stats["is_duplicate"] = 1
             span_tag = "cache_wait"
 
+        sentry_sdk.set_tag("cache_status", span_tag)
         if span:
-            span.set_data("backend", span_tag)
+            span.set_data("cache_status", span_tag)
 
     return cache.get_readthrough(
         query_id,


### PR DESCRIPTION
Add data to the span in the cache to track whether a query was actually executed
or was cached or queued for a cached result.