### PR TITLE
ref(metrics): Give multistorage consumer metrics a different name

### DIFF
--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -205,7 +205,7 @@ def multistorage_consumer(
             commit_log_topic=commit_log_topic,
         )
 
-    metrics = MetricsWrapper(environment.metrics, "consumer")
+    metrics = MetricsWrapper(environment.metrics, "multistorage-consumer")
     processor = StreamProcessor(
         consumer,
         topic,


### PR DESCRIPTION
Currently both consumer and multistorage consumer metrics have the
same names. I'm not sure if this was intentional; it seems useful
to me to be able to easily distinguish between them.