### PR TITLE
fix(requirements) Update sentry-relay requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==0.9.1
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-relay>=0.5.11,<0.6.0
+sentry-relay==0.8.7
 sentry-sdk==1.1.0
 simplejson==3.15.0
 urllib3==1.26.5


### PR DESCRIPTION
The current version of sentry-relay dependency does not compile with rust versions 1.49.0 and above. Bumping up the sentry-relay requirement to the latest 0.8.7

Found the following open issue in relay project https://github.com/getsentry/relay/issues/915. I have version 1.52.1 installed and hence its failing for me.