### PR TITLE
ref(debug) Add query_id to transaction and span

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -348,7 +348,6 @@ def execute_query_with_readthrough_caching(
     query_settings["query_id"] = query_id
 
     span = Hub.current.scope.span
-    sentry_sdk.set_tag("query_id", query_id)
     if span:
         span.set_data("query_id", query_id)
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -348,6 +348,9 @@ def execute_query_with_readthrough_caching(
     query_settings["query_id"] = query_id
 
     span = Hub.current.scope.span
+    sentry_sdk.set_tag("query_id", query_id)
+    if span:
+        span.set_data("query_id", query_id)
 
     def record_cache_hit_type(hit_type: int) -> None:
         span_tag = "cache_miss"


### PR DESCRIPTION
Add the query id which is saved in the clickhouse querylog to the
transaction tags and the span to correlate slow transactions with
the corresponding query