### PR TITLE
fix(tests) Attempt fix for flaky cache test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==0.9.1
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-relay>=0.5.11,<0.6.0
+sentry-relay==0.8.7
 sentry-sdk==1.1.0
 simplejson==3.15.0
 urllib3==1.26.5

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -124,6 +124,7 @@ def test_get_readthrough_set_wait_error(backend: Cache[bytes]) -> None:
         return backend.get_readthrough(key, function, noop, 10)
 
     setter = execute(worker)
+    time.sleep(0.5)
     waiter = execute(worker)
 
     with pytest.raises(CustomException):

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -138,15 +138,17 @@ def test_get_readthrough_set_wait_timeout(backend: Cache[bytes]) -> None:
     key = "key"
     value = b"value"
 
-    def function() -> bytes:
+    def function(id: int) -> bytes:
         time.sleep(2.5)
-        return value
+        return value + f"{id}".encode()
 
     def worker(timeout: int) -> bytes:
-        return backend.get_readthrough(key, function, noop, timeout)
+        return backend.get_readthrough(key, partial(function, timeout), noop, timeout)
 
     setter = execute(partial(worker, 2))
+    time.sleep(0.1)
     waiter_fast = execute(partial(worker, 1))
+    time.sleep(0.1)
     waiter_slow = execute(partial(worker, 3))
 
     with pytest.raises(TimeoutError):


### PR DESCRIPTION
I think this test would fail because the `waiter` might get run before the
`setter` since they were delayed equal amounts of time. I added the small sleep
to help ensure that they run in parallel but the waiter won't finish until after
the `setter`.