### PR TITLE
ref: Remove default storage from CLI

### DIFF
--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -24,9 +24,9 @@ from snuba.environment import setup_logging
 @click.option(
     "--storage",
     "storage_name",
-    default="events",
     type=click.Choice(["events", "errors", "transactions"]),
     help="The storage to target",
+    required=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 def cleanup(
@@ -43,7 +43,7 @@ def cleanup(
 
     setup_logging(log_level)
 
-    from snuba.cleanup import run_cleanup, logger
+    from snuba.cleanup import logger, run_cleanup
     from snuba.clickhouse.native import ClickhousePool
 
     storage = get_writable_storage(StorageKey(storage_name))
@@ -64,9 +64,7 @@ def cleanup(
     elif not cluster.is_single_node():
         raise click.ClickException("Provide ClickHouse host and port for cleanup")
     else:
-        connection = cluster.get_query_connection(
-            ClickhouseClientSettings.CLEANUP
-        )
+        connection = cluster.get_query_connection(ClickhouseClientSettings.CLEANUP)
 
     num_dropped = run_cleanup(connection, storage, database, dry_run=dry_run)
     logger.info("Dropped %s partitions on %s" % (num_dropped, cluster))

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -35,9 +35,9 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--storage",
     "storage_name",
-    default="events",
     type=click.Choice([storage_key.value for storage_key in WRITABLE_STORAGES.keys()]),
     help="The storage to target",
+    required=True,
 )
 @click.option(
     "--max-batch-size",

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -30,9 +30,9 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--storage",
     "storage_names",
-    default=["events"],
     type=click.Choice([storage_key.value for storage_key in WRITABLE_STORAGES.keys()]),
     multiple=True,
+    required=True,
 )
 @click.option(
     "--consumer-group", default="snuba-consumers",

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -19,9 +19,9 @@ from snuba.environment import setup_logging
 @click.option(
     "--storage",
     "storage_name",
-    default="events",
     type=click.Choice(["events", "errors", "transactions"]),
     help="The storage to target",
+    required=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 def optimize(
@@ -32,8 +32,9 @@ def optimize(
     log_level: Optional[str] = None,
 ) -> None:
     from datetime import datetime
+
     from snuba.clickhouse.native import ClickhousePool
-    from snuba.optimize import run_optimize, logger
+    from snuba.optimize import logger, run_optimize
 
     setup_logging(log_level)
 

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -26,9 +26,9 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--storage",
     "storage_name",
-    default="events",
     type=click.Choice(["events", "errors"]),
     help="The storage to consume/run replacements for (currently only events supported)",
+    required=True,
 )
 @click.option(
     "--max-batch-size",


### PR DESCRIPTION
The consumer, multistorage consumer, replacer, optimize and cleanup
commands previously defaulted to the events storage (which is now
deprecated and should be removed). This change removes the default
completely and requires the user to always provide the storage name.