### PR TITLE
perf(subscriptions) Test possible message processing improvement by sampling metrics

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -41,4 +41,6 @@ def setup_sentry() -> None:
     )
 
 
-metrics = create_metrics("snuba")
+metrics = create_metrics(
+    "snuba", tags=None, sample_rates=settings.DOGSTATSD_SAMPLING_RATES,
+)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -46,6 +46,10 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
 # Dogstatsd Options
 DOGSTATSD_HOST = "localhost"
 DOGSTATSD_PORT = 8125
+DOGSTATSD_SAMPLING_RATES = {
+    "subscriptions.receive_latency": 0.1,
+    "subscriptions.process_message": 0.1,
+}
 
 # Redis Options
 USE_REDIS_CLUSTER = os.environ.get("USE_REDIS_CLUSTER", "0") != "0"

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     List,
+    Mapping,
     MutableMapping,
     NamedTuple,
     Optional,
@@ -215,7 +216,11 @@ def force_bytes(s: Union[bytes, str]) -> bytes:
         raise TypeError(f"cannot convert {type(s).__name__} to bytes")
 
 
-def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
+def create_metrics(
+    prefix: str,
+    tags: Optional[Tags] = None,
+    sample_rates: Optional[Mapping[str, float]] = None,
+) -> MetricsBackend:
     """Create a DogStatsd object if DOGSTATSD_HOST and DOGSTATSD_PORT are defined,
     with the specified prefix and tags. Return a DummyMetricsBackend otherwise.
     Prefixes must start with `snuba.<category>`, for example: `snuba.processor`.
@@ -246,6 +251,7 @@ def create_metrics(prefix: str, tags: Optional[Tags] = None) -> MetricsBackend:
             if tags is not None
             else None,
         ),
+        sample_rates,
     )
 
 


### PR DESCRIPTION
We are logging `subscriptions.receive_latency` and `subscriptions.process_message` at every tick of the TickConsumer (which is per message).
This happens in the main consuming thread.

This is a test to measure the impact of these metrics on the consumption time.
In the past we saw there was a visible impact in throughput for a consumer due to these metrics logged for each message. 

Probably the gain won't be similar to the one we had on the cdc consumer as the logic is not fully serial in the consumer. Query processing are in separate threads which can use the core while we send the UDP metric to datadog. This is meant to measure that.