### PR TITLE
ref: Upgrade mypy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install mypy==0.800
+          pip install mypy==0.812
           pip install pytest==6.1.2
       - name: Run mypy
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: flake8
         language_version: python3.8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.800'
+    rev: 'v0.812'
     hooks:
     -   id: mypy
         files: snuba

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Markdown==2.6.11
 MarkupSafe==1.1.1
 mywsgi==1.0.3
 more-itertools==4.2.0
-mypy>=0.800
+mypy>=0.812
 packaging==17.1
 parsimonious==0.8.1
 py==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ Markdown==2.6.11
 MarkupSafe==1.1.1
 mywsgi==1.0.3
 more-itertools==4.2.0
-mypy>=0.812
+mypy>=0.812,<0.900
 packaging==17.1
 parsimonious==0.8.1
 py==1.10.0


### PR DESCRIPTION
Upgrade mypy from 0.800 to 0.812. This now matches the version of
mypy used in Arroyo - this may be required to get mypy in precommit
working properly.