### PR TITLE
feat: Enable stdlib integration in Sentry sdk

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 from sentry_sdk.integrations.gnu_backtrace import GnuBacktraceIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.stdlib import StdlibIntegration
 
 from snuba import settings
 from snuba.util import create_metrics
@@ -35,6 +36,7 @@ def setup_sentry() -> None:
             GnuBacktraceIntegration(),
             LoggingIntegration(event_level=logging.WARNING),
             RedisIntegration(),
+            StdlibIntegration(),
         ],
         release=os.getenv("SNUBA_RELEASE"),
         traces_sampler=traces_sampler,


### PR DESCRIPTION
The stdlib integration is required in order to have spawned subprocesses
send logging and other data to Sentry.