### PR TITLE
perf(subscriptions) Log the referrer with the marks in the query timer.

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -35,7 +35,7 @@ def record_query(
                 "referrer": referrer,
                 "final": final,
             },
-            mark_tags={"final": final},
+            mark_tags={"final": final, "referrer": referrer},
         )
 
         _add_tags(timer, request)


### PR DESCRIPTION
This would be useful have the breakdown by phase during the query for individual referrers.