### PR TITLE
feat: Run subscription worker with execute_robust

### DIFF
--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -1,7 +1,7 @@
-from snuba.query.processors.conditions_enforcer import MandatoryConditionEnforcer
 from typing import Optional, Sequence
 
 import sentry_sdk
+
 from snuba import state
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
@@ -20,6 +20,7 @@ from snuba.datasets.schemas.tables import TableSource
 from snuba.datasets.storage import QueryStorageSelector, ReadableStorage
 from snuba.query.data_source.simple import Table
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.processors.conditions_enforcer import MandatoryConditionEnforcer
 from snuba.query.processors.mandatory_condition_applier import MandatoryConditionApplier
 from snuba.request.request_settings import RequestSettings
 
@@ -44,7 +45,7 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy[Query]):
 
     @with_span()
     def execute(
-        self, query: Query, request_settings: RequestSettings, runner: QueryRunner
+        self, query: Query, request_settings: RequestSettings, runner: QueryRunner,
     ) -> QueryResult:
         def process_and_run_query(
             query: Query, request_settings: RequestSettings

--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -117,6 +117,7 @@ class Reader(ABC):
         query: FormattedQuery,
         settings: Optional[Mapping[str, str]] = None,
         with_totals: bool = False,
+        robust: bool = False,
     ) -> Result:
         """Execute a query."""
         raise NotImplementedError

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -114,7 +114,7 @@ class SubscriptionWorker(
             return (
                 request,
                 parse_and_run_query(
-                    self.__dataset, copy.deepcopy(request), timer
+                    self.__dataset, copy.deepcopy(request), timer, robust=True
                 ).result,
             )
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -192,6 +192,7 @@ def execute_query(
     timer: Timer,
     stats: MutableMapping[str, Any],
     query_settings: MutableMapping[str, Any],
+    robust: bool,
 ) -> Result:
     """
     Execute a query and return a result.
@@ -235,6 +236,7 @@ def execute_query_with_rate_limits(
     timer: Timer,
     stats: MutableMapping[str, Any],
     query_settings: MutableMapping[str, Any],
+    robust: bool,
 ) -> Result:
     # XXX: We should consider moving this that it applies to the logical query,
     # not the physical query.
@@ -276,6 +278,7 @@ def execute_query_with_rate_limits(
             timer,
             stats,
             query_settings,
+            robust=robust,
         )
 
 
@@ -292,6 +295,7 @@ def execute_query_with_caching(
     timer: Timer,
     stats: MutableMapping[str, Any],
     query_settings: MutableMapping[str, Any],
+    robust: bool,
 ) -> Result:
     # XXX: ``uncompressed_cache_max_cols`` is used to control both the result
     # cache, as well as the uncompressed cache. These should be independent.
@@ -314,6 +318,7 @@ def execute_query_with_caching(
         timer,
         stats,
         query_settings,
+        robust=robust,
     )
 
     with sentry_sdk.start_span(description="execute", op="db") as span:
@@ -344,6 +349,7 @@ def execute_query_with_readthrough_caching(
     timer: Timer,
     stats: MutableMapping[str, Any],
     query_settings: MutableMapping[str, Any],
+    robust: bool,
 ) -> Result:
     query_id = get_query_cache_key(formatted_query)
     query_settings["query_id"] = query_id
@@ -376,6 +382,7 @@ def execute_query_with_readthrough_caching(
             timer,
             stats,
             query_settings,
+            robust,
         ),
         record_cache_hit_type=record_cache_hit_type,
         timeout=query_settings.get("max_execution_time", 30),
@@ -396,6 +403,7 @@ def raw_query(
     query_metadata: SnubaQueryMetadata,
     stats: MutableMapping[str, Any],
     trace_id: Optional[str] = None,
+    robust: bool = False,
 ) -> QueryResult:
     """
     Submits a raw SQL query to the DB and does some post-processing on it to
@@ -440,6 +448,7 @@ def raw_query(
             timer,
             stats,
             query_settings,
+            robust=robust,
         )
     except Exception as cause:
         if isinstance(cause, RateLimitExceeded):

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -216,7 +216,10 @@ def execute_query(
         query_settings["max_threads"] = 1
 
     result = reader.execute(
-        formatted_query, query_settings, with_totals=clickhouse_query.has_totals(),
+        formatted_query,
+        query_settings,
+        with_totals=clickhouse_query.has_totals(),
+        robust=robust,
     )
 
     timer.mark("execute")


### PR DESCRIPTION
This change runs subscription worker with the robust ClickHouse execution
strategy. This means that (like replacers) connection issues are retried 3
times and too many concurrent queries will be retried forever with a 1
second delay.

The main motivation for this change is to prevent subscription workers
unnecessarily crashing and restarting when ClickHouse is overloaded.

An alternative strategy would be to have the subscription worker define
it's own retry logic rather than use the default execute_robust behavior.
This may be preferable if we want to be able to define and tweak subscription
specific retry behavior. However this would require the original ClickHouse
error code to be stored on the QueryException so that the subscription worker
can detect which type of error occurred. Since this information isn't present
there currently I picked the seemingly simpler strategy here instead.