### PR TITLE
test: Remove flaky assertion

### DIFF
--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -1,5 +1,5 @@
 import importlib
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -52,7 +52,6 @@ def test_get_status() -> None:
     )
     assert status[0] == Status.COMPLETED
     assert isinstance(status[1], datetime)
-    assert status[1] > datetime.now() - timedelta(seconds=1)
 
 
 def test_show_all() -> None:


### PR DESCRIPTION
This assertion seems to occasionally fail on Google cloud builder (likely
since more than 1 second has elapsed since the status was retreived from
ClickHouse earlier in the test). I don't think it adds that much value so
let's just remove it.