### PR TITLE
fix(consistent) Have a killswitch we can use in case the amount of consistent queries is too high for clickhouse

### DIFF
--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -94,11 +94,14 @@ class SubscriptionRequestSettings(RequestSettings):
     parameters and skips all rate limiting.
     """
 
+    def __init__(self, consistent: bool = True) -> None:
+        self.__consistent = consistent
+
     def get_turbo(self) -> bool:
         return False
 
     def get_consistent(self) -> bool:
-        return True
+        return self.__consistent
 
     def get_debug(self) -> bool:
         return False

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -1,8 +1,10 @@
+import random
 import uuid
 from typing import Any, Callable, ChainMap, MutableMapping, Sequence, Type, Union
 
 import sentry_sdk
 
+from snuba import state
 from snuba.datasets.dataset import Dataset
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Entity
@@ -43,6 +45,19 @@ def parse_legacy_query(
     return query
 
 
+def _consistent_override(original_setting: bool, referrer: str) -> bool:
+    consistent_config = state.get_config("consistent_override", None)
+    if isinstance(consistent_config, str):
+        referrers_override = consistent_config.split(";")
+        for config in referrers_override:
+            referrer_config, percentage = config.split("=")
+            if referrer_config == referrer:
+                if random.random() > float(percentage):
+                    return False
+
+    return original_setting
+
+
 def build_request(
     body: MutableMapping[str, Any],
     parser: Parser,
@@ -56,11 +71,19 @@ def build_request(
         try:
             request_parts = schema.validate(body)
             if isinstance(settings_class, type(HTTPRequestSettings)):
+                settings = {
+                    **request_parts.settings,
+                    "consistent": _consistent_override(
+                        request_parts.settings.get("consistent", False), referrer
+                    ),
+                }
                 settings_obj: Union[
                     HTTPRequestSettings, SubscriptionRequestSettings
-                ] = settings_class(**request_parts.settings)
+                ] = settings_class(**settings)
             elif isinstance(settings_class, type(SubscriptionRequestSettings)):
-                settings_obj = settings_class()
+                settings_obj = settings_class(
+                    consistent=_consistent_override(True, referrer)
+                )
 
             query = parser(request_parts, settings_obj, dataset)
 


### PR DESCRIPTION
This is the quickest safeguard in case we still go beyond the max concurrent queries in clickhouse on the nodes that take consistent queries. 

This allows compromises consistency (for the percentage of queries configured) by sending to any node. 
Hopefully we will not have to use it. But it is better to have it  just in case.

The consistent flag means that the query will go to to the same node we write onto so avoiding the replication lag (and use one thread only). Replication lag tends to by tiny: below 10ms), so in case of incident it is probably better being capable to compromise that than to fail large amount of queries.