### PR TITLE
feat: Initialize Sentry SDK in spawned subprocesses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: mypy
         files: snuba
         args: [--config-file, mypy.ini, --ignore-missing-imports, --strict, --warn-unreachable]
-        additional_dependencies: ['sentry-arroyo==0.0.1']
+        additional_dependencies: ['sentry-arroyo==0.0.2']
   - repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==0.9.1
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-arroyo==0.0.1
+sentry-arroyo==0.0.2
 sentry-relay==0.8.7
 sentry-sdk==1.1.0
 simplejson==3.15.0

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -35,6 +35,7 @@ from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import TableWriter
+from snuba.environment import setup_sentry
 from snuba.processor import InsertBatch, MessageProcessor, ReplacementBatch
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.wrapper import MetricsWrapper
@@ -542,6 +543,7 @@ class MultistorageConsumerProcessingStrategyFactory(
                 self.__max_batch_time,
                 self.__input_block_size,
                 self.__output_block_size,
+                initializer=setup_sentry,
             )
 
         return TransformStep(

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -14,6 +14,7 @@ from snuba.consumers.consumer import build_batch_writer, process_message
 from snuba.consumers.snapshot_worker import SnapshotProcessor
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
+from snuba.environment import setup_sentry
 from snuba.processor import MessageProcessor
 from snuba.snapshots import SnapshotId
 from snuba.stateful_consumer.control_protocol import TransactionData
@@ -196,6 +197,7 @@ class ConsumerBuilder:
             processes=self.processes,
             input_block_size=self.input_block_size,
             output_block_size=self.output_block_size,
+            initialize_parallel_transform=setup_sentry,
         )
 
         if self.__profile_path is not None:


### PR DESCRIPTION
This change initializes the Sentry SDK in the subprocesses
spawned by Snuba consumers. Non-fatal errors and warnings
emitted from these subprocesses should now be sent to our
Sentry instance.

It's possible that Sentry will become a bit more noisy as
a result - we may want to follow up later with tweaks to
optimize what we are actually sending Sentry.