### PR TITLE
fix(query settings) Create the right instance of query settings

### DIFF
--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from typing import Any, Callable, ChainMap, MutableMapping, Sequence, Type, Union, cast
+from typing import Any, Callable, ChainMap, MutableMapping, Sequence, Type, Union
 
 import sentry_sdk
 
@@ -61,7 +61,7 @@ def _consistent_override(original_setting: bool, referrer: str) -> bool:
 def build_request(
     body: MutableMapping[str, Any],
     parser: Parser,
-    settings_class: Type[RequestSettings],
+    settings_class: Union[Type[HTTPRequestSettings], Type[SubscriptionRequestSettings]],
     schema: RequestSchema,
     dataset: Dataset,
     timer: Timer,
@@ -79,9 +79,9 @@ def build_request(
                 }
                 settings_obj: Union[
                     HTTPRequestSettings, SubscriptionRequestSettings
-                ] = cast(Type[HTTPRequestSettings], settings_class)(**settings)
+                ] = settings_class(**settings)
             elif settings_class == SubscriptionRequestSettings:
-                settings_obj = cast(Type[SubscriptionRequestSettings], settings_class)(
+                settings_obj = settings_class(
                     consistent=_consistent_override(True, referrer)
                 )
 

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -1,6 +1,6 @@
 import random
 import uuid
-from typing import Any, Callable, ChainMap, MutableMapping, Sequence, Type, Union
+from typing import Any, Callable, ChainMap, MutableMapping, Sequence, Type, Union, cast
 
 import sentry_sdk
 
@@ -70,7 +70,7 @@ def build_request(
     with sentry_sdk.start_span(description="build_request", op="validate") as span:
         try:
             request_parts = schema.validate(body)
-            if isinstance(settings_class, type(HTTPRequestSettings)):
+            if settings_class == HTTPRequestSettings:
                 settings = {
                     **request_parts.settings,
                     "consistent": _consistent_override(
@@ -79,9 +79,9 @@ def build_request(
                 }
                 settings_obj: Union[
                     HTTPRequestSettings, SubscriptionRequestSettings
-                ] = settings_class(**settings)
-            elif isinstance(settings_class, type(SubscriptionRequestSettings)):
-                settings_obj = settings_class(
+                ] = cast(Type[HTTPRequestSettings], settings_class)(**settings)
+            elif settings_class == SubscriptionRequestSettings:
+                settings_obj = cast(Type[SubscriptionRequestSettings], settings_class)(
                     consistent=_consistent_override(True, referrer)
                 )
 


### PR DESCRIPTION
We have been creating HTTPRequestSettings instances for subscriptions instead of SubscriptionRequestSettings for quite some time. This is a bug. 
IT had no consequence until I added a bypass to reduce the concurrent queries, as the parameters used in the HTTPRequestSettings were the same. I noticed the issue since the bypass generates wrong results removing consistent too often.

This fixes the bug.