### PR TITLE
perf(subscriptions) Add a jitter to the subscriptions scheduler to distribute queries in the evaluation window

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -133,6 +133,8 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 # Migrations in skipped groups will not be run
 SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics", "querylog", "spans_experimental"}
 
+MAX_RESOLUTION_FOR_JITTER = 60
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -10,10 +10,10 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.scheduler import ScheduledTask, Scheduler
 from snuba.utils.types import Interval
 
-TTask = TypeVar("TTask")
+TSubscription = TypeVar("TSubscription")
 
 
-class TaskBuilder(ABC, Generic[TTask]):
+class TaskBuilder(ABC, Generic[TSubscription]):
     """
     Takes a Subscription and a timestamp, decides whether we should
     schedule that task at the current timestamp and provides the
@@ -23,7 +23,7 @@ class TaskBuilder(ABC, Generic[TTask]):
     @abstractmethod
     def get_task(
         self, subscription: Subscription, timestamp: int
-    ) -> Optional[ScheduledTask[TTask]]:
+    ) -> Optional[ScheduledTask[TSubscription]]:
         raise NotImplementedError
 
     @abstractmethod
@@ -75,7 +75,7 @@ class JitteredTaskBuilder(TaskBuilder[Subscription]):
     def __init__(self) -> None:
         self.__count = 0
 
-    def filter(
+    def get_task(
         self, subscription: Subscription, timestamp: int
     ) -> Optional[ScheduledTask[Subscription]]:
         max_resolution = settings.MAX_RESOLUTION_FOR_JITTER

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -70,6 +70,11 @@ class JitteredTaskBuilder(TaskBuilder[Subscription]):
     This would spread the subscription evenly.
 
     There is a setting to define the maximum resolution the jitter applies.
+
+    The time range of the query does not include the jitter. So if the
+    jitter for a 60 seconds resolution query is 4 seconds. The query is
+    scheduled 4 seconds after the beginning of the minute, but the time
+    range of the query is still aligned with the minute.
     """
 
     def __init__(self) -> None:

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -201,6 +201,18 @@ class DelegateTaskBuilder(TaskBuilder[Subscription]):
     A delegate capable of switching back and forth between the
     immediate and jittered task builders according to runtime
     settings.
+
+    It relies on TaskBuilderModeState to decide which task builder
+    to use. The reason for this is that we cannot simply switch
+    from one mode to another at any point in time. We need to wait
+    for the end of the resolution time interval, or we risk to
+    skip some queries.
+
+    Example: if we transitioned from jittered to immediate at the
+    second 30 of a minute. A query scheduled with a jitter = 40
+    would not be scheduled at all during that minute because,
+    with the immediate task builder, that would be scheduled at
+    second 0.
     """
 
     def __init__(self) -> None:

--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -1,12 +1,32 @@
 import math
+from abc import ABC
 from datetime import datetime, timedelta
 from typing import Iterator, List, Optional
 
 from snuba.subscriptions.data import PartitionId, Subscription, SubscriptionIdentifier
 from snuba.subscriptions.store import SubscriptionDataStore
 from snuba.utils.metrics import MetricsBackend
-from snuba.utils.scheduler import Scheduler, ScheduledTask
+from snuba.utils.scheduler import ScheduledTask, Scheduler
 from snuba.utils.types import Interval
+
+
+class SubscriptionFilter(ABC):
+    """
+    Decides when to run a subscription or when to defer it.
+    """
+
+    def filter(self, subscription: Subscription, timestamp: int) -> bool:
+        raise NotImplementedError
+
+
+class ImmediateSubscriptionFilter(SubscriptionFilter):
+    """
+    Schedules a subscription as soon as possible
+    """
+
+    def filter(self, subscription: Subscription, timestamp: int) -> bool:
+        resolution = int(subscription.data.resolution.total_seconds())
+        return timestamp % resolution == 0
 
 
 class SubscriptionScheduler(Scheduler[Subscription]):
@@ -24,6 +44,7 @@ class SubscriptionScheduler(Scheduler[Subscription]):
 
         self.__subscriptions: List[Subscription] = []
         self.__last_refresh: Optional[datetime] = None
+        self.__filter = ImmediateSubscriptionFilter()
 
     def __get_subscriptions(self) -> List[Subscription]:
         current_time = datetime.now()
@@ -56,11 +77,15 @@ class SubscriptionScheduler(Scheduler[Subscription]):
     ) -> Iterator[ScheduledTask[Subscription]]:
         subscriptions = self.__get_subscriptions()
 
+        count = 0
         for timestamp in range(
             math.ceil(interval.lower.timestamp()),
             math.ceil(interval.upper.timestamp()),
         ):
             for subscription in subscriptions:
-                resolution = int(subscription.data.resolution.total_seconds())
-                if timestamp % resolution == 0:
+                if self.__filter.filter(subscription, timestamp):
+                    count += 1
                     yield ScheduledTask(datetime.fromtimestamp(timestamp), subscription)
+
+        if count:
+            self.__metrics.increment("metrics_scheduled", count)

--- a/tests/subscriptions/subscriptions_utils.py
+++ b/tests/subscriptions/subscriptions_utils.py
@@ -1,0 +1,26 @@
+from datetime import timedelta
+from uuid import UUID
+
+from snuba.subscriptions.data import (
+    PartitionId,
+    SnQLSubscriptionData,
+    Subscription,
+    SubscriptionIdentifier,
+)
+
+UUIDS = [
+    UUID("fac82541-049f-4435-982d-819082761a53"),
+    UUID("49215ec6-939e-41e9-a209-f09b5514e884"),
+]
+
+
+def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
+    return Subscription(
+        SubscriptionIdentifier(PartitionId(1), UUIDS[sequence]),
+        SnQLSubscriptionData(
+            project_id=1,
+            time_window=timedelta(minutes=5),
+            resolution=resolution,
+            query="MATCH events SELECT count()",
+        ),
+    )

--- a/tests/subscriptions/test_builder_mode_state.py
+++ b/tests/subscriptions/test_builder_mode_state.py
@@ -96,6 +96,7 @@ def test_state_changes(
     subscriptions: Sequence[Tuple[Subscription, int]],
     expected_modes: Sequence[TaskBuilderMode],
 ) -> None:
+    prev_threshold = settings.MAX_RESOLUTION_FOR_JITTER
     settings.MAX_RESOLUTION_FOR_JITTER = 300
     state.set_config("subscription_primary_task_builder", general_mode)
     mode_state = TaskBuilderModeState()
@@ -104,3 +105,4 @@ def test_state_changes(
         for subscription, timestamp in subscriptions
     ]
     assert modes == expected_modes
+    settings.MAX_RESOLUTION_FOR_JITTER = prev_threshold

--- a/tests/subscriptions/test_builder_mode_state.py
+++ b/tests/subscriptions/test_builder_mode_state.py
@@ -1,35 +1,12 @@
 from datetime import timedelta
 from typing import Sequence, Tuple
-from uuid import UUID
 
 import pytest
 
 from snuba import settings, state
-from snuba.subscriptions.data import (
-    PartitionId,
-    SnQLSubscriptionData,
-    Subscription,
-    SubscriptionIdentifier,
-)
+from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.scheduler import TaskBuilderMode, TaskBuilderModeState
-
-UUIDS = [
-    UUID("fac82541-049f-4435-982d-819082761a53"),
-    UUID("49215ec6-939e-41e9-a209-f09b5514e884"),
-]
-
-
-def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
-    return Subscription(
-        SubscriptionIdentifier(PartitionId(1), UUIDS[sequence]),
-        SnQLSubscriptionData(
-            project_id=1,
-            time_window=timedelta(minutes=5),
-            resolution=resolution,
-            query="MATCH events SELECT count()",
-        ),
-    )
-
+from tests.subscriptions.subscriptions_utils import build_subscription
 
 ALIGNED_TIMESTAMP = 1625527800  # Aligned to start of a minute
 

--- a/tests/subscriptions/test_builder_mode_state.py
+++ b/tests/subscriptions/test_builder_mode_state.py
@@ -1,0 +1,129 @@
+from datetime import timedelta
+from typing import Sequence, Tuple
+from uuid import UUID
+
+import pytest
+
+from snuba import settings, state
+from snuba.subscriptions.data import (
+    PartitionId,
+    SnQLSubscriptionData,
+    Subscription,
+    SubscriptionIdentifier,
+)
+from snuba.subscriptions.scheduler import TaskBuilderMode, TaskBuilderModeState
+
+UUIDS = [
+    UUID("fac82541-049f-4435-982d-819082761a53"),
+    UUID("49215ec6-939e-41e9-a209-f09b5514e884"),
+]
+
+
+def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
+    return Subscription(
+        SubscriptionIdentifier(PartitionId(1), UUIDS[sequence]),
+        SnQLSubscriptionData(
+            project_id=1,
+            time_window=timedelta(minutes=5),
+            resolution=resolution,
+            query="MATCH events SELECT count()",
+        ),
+    )
+
+
+ALIGNED_TIMESTAMP = 1625527800  # Aligned to start of a minute
+
+TEST_CASES = [
+    pytest.param(
+        "immediate",
+        [(build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP)],
+        [TaskBuilderMode.IMMEDIATE],
+        id="Immediate general mode",
+    ),
+    pytest.param(
+        "jittered",
+        [(build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP)],
+        [TaskBuilderMode.JITTERED],
+        id="Jittered general mode",
+    ),
+    pytest.param(
+        "transition_jitter",
+        [
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 30),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 45),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 60),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 65),
+        ],
+        [
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.JITTERED,
+        ],
+        id="Transition of one subscription to jittered",
+    ),
+    pytest.param(
+        "transition_immediate",
+        [
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 30),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 45),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 60),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 65),
+        ],
+        [
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.IMMEDIATE,
+        ],
+        id="Transition of one subscription to immediate",
+    ),
+    pytest.param(
+        "transition_jitter",
+        [
+            (build_subscription(timedelta(minutes=5), 0), ALIGNED_TIMESTAMP + 45),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 45),
+            (build_subscription(timedelta(minutes=5), 0), ALIGNED_TIMESTAMP + 60),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 60),
+            (build_subscription(timedelta(minutes=5), 0), ALIGNED_TIMESTAMP + 65),
+            (build_subscription(timedelta(minutes=5), 0), ALIGNED_TIMESTAMP + 300),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 300),
+            (build_subscription(timedelta(minutes=5), 0), ALIGNED_TIMESTAMP + 305),
+            (build_subscription(timedelta(minutes=1), 0), ALIGNED_TIMESTAMP + 305),
+        ],
+        [
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.IMMEDIATE,
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.JITTERED,
+            TaskBuilderMode.JITTERED,
+        ],
+        id="Transitions with multiple different resolutions",
+    ),
+    pytest.param(
+        "transition_jitter",
+        [(build_subscription(timedelta(minutes=1800), 0), ALIGNED_TIMESTAMP + 1)],
+        [TaskBuilderMode.JITTERED],
+        id="Resolution beyond maximum. Perform transition",
+    ),
+]
+
+
+@pytest.mark.parametrize("general_mode, subscriptions, expected_modes", TEST_CASES)
+def test_state_changes(
+    general_mode: str,
+    subscriptions: Sequence[Tuple[Subscription, int]],
+    expected_modes: Sequence[TaskBuilderMode],
+) -> None:
+    settings.MAX_RESOLUTION_FOR_JITTER = 300
+    state.set_config("subscription_primary_task_builder", general_mode)
+    mode_state = TaskBuilderModeState()
+    modes = [
+        mode_state.get_current_mode(subscription, timestamp)
+        for subscription, timestamp in subscriptions
+    ]
+    assert modes == expected_modes

--- a/tests/subscriptions/test_task_builder.py
+++ b/tests/subscriptions/test_task_builder.py
@@ -1,16 +1,10 @@
 from datetime import datetime, timedelta
 from typing import Sequence, Tuple
-from uuid import UUID
 
 import pytest
 
 from snuba import state
-from snuba.subscriptions.data import (
-    PartitionId,
-    SnQLSubscriptionData,
-    Subscription,
-    SubscriptionIdentifier,
-)
+from snuba.subscriptions.data import Subscription
 from snuba.subscriptions.scheduler import (
     DelegateTaskBuilder,
     ImmediateTaskBuilder,
@@ -19,24 +13,7 @@ from snuba.subscriptions.scheduler import (
     TaskBuilder,
 )
 from snuba.utils.scheduler import ScheduledTask
-
-UUIDS = [
-    UUID("fac82541-049f-4435-982d-819082761a53"),
-    UUID("49215ec6-939e-41e9-a209-f09b5514e884"),
-]
-
-
-def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
-    return Subscription(
-        SubscriptionIdentifier(PartitionId(1), UUIDS[sequence]),
-        SnQLSubscriptionData(
-            project_id=1,
-            time_window=timedelta(minutes=5),
-            resolution=resolution,
-            query="MATCH events SELECT count()",
-        ),
-    )
-
+from tests.subscriptions.subscriptions_utils import UUIDS, build_subscription
 
 ALIGNED_TIMESTAMP = 1625518080  # Aligned to start of a minute
 

--- a/tests/subscriptions/test_task_builder.py
+++ b/tests/subscriptions/test_task_builder.py
@@ -52,14 +52,14 @@ TEST_CASES = [
                 ),
             )
         ],
-        {"tasks.built": 1},
+        [("tasks.built", 1, {})],
         id="One subscription immediately scheduled",
     ),
     pytest.param(
         ImmediateTaskBuilder(),
         [(ALIGNED_TIMESTAMP + 1, build_subscription(timedelta(minutes=1), 0))],
         [],
-        {"tasks.built": 0},
+        [("tasks.built", 0, {})],
         id="One subscription not aligned with resolution",
     ),
     pytest.param(
@@ -87,7 +87,7 @@ TEST_CASES = [
                 ),
             )
         ],
-        {"tasks.built": 1, "tasks.above.resolution": 0},
+        [("tasks.built", 1, {}), ("tasks.above.resolution", 0, {})],
         id="One subscription scheduled with jitter. Happens at 43rd second",
     ),
     pytest.param(
@@ -121,7 +121,7 @@ TEST_CASES = [
                 ),
             )
         ],
-        {"tasks.built": 1, "tasks.above.resolution": 0},
+        [("tasks.built", 1, {}), ("tasks.above.resolution", 0, {})],
         id="Ensures different ids generate different jitters",
     ),
     pytest.param(
@@ -136,7 +136,7 @@ TEST_CASES = [
                 ),
             )
         ],
-        {"tasks.built": 1, "tasks.above.resolution": 1},
+        [("tasks.built", 1, {}), ("tasks.above.resolution", 1, {})],
         id="Do not apply jitter if resolution is above threshold",
     ),
     pytest.param(
@@ -157,11 +157,11 @@ TEST_CASES = [
                 ),
             )
         ],
-        {
-            "tasks.built.immediate": 1,
-            "tasks.built.jittered": 1,
-            "tasks.above.resolution.jittered": 0,
-        },
+        [
+            ("tasks.built", 1, {"type": "immediate"}),
+            ("tasks.built", 1, {"type": "jittered"}),
+            ("tasks.above.resolution", 0, {"type": "jittered"}),
+        ],
         id="Delegate returns the jittered one.",
     ),
 ]

--- a/tests/subscriptions/test_task_builder.py
+++ b/tests/subscriptions/test_task_builder.py
@@ -1,0 +1,155 @@
+from datetime import datetime, timedelta
+from typing import Sequence, Tuple
+from uuid import UUID
+
+import pytest
+
+from snuba.subscriptions.data import (
+    PartitionId,
+    SnQLSubscriptionData,
+    Subscription,
+    SubscriptionIdentifier,
+)
+from snuba.subscriptions.scheduler import (
+    ImmediateTaskBuilder,
+    JitteredTaskBuilder,
+    TaskBuilder,
+)
+from snuba.utils.scheduler import ScheduledTask
+
+UUIDS = [
+    UUID("fac82541-049f-4435-982d-819082761a53"),
+    UUID("49215ec6-939e-41e9-a209-f09b5514e884"),
+]
+
+
+def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
+    return Subscription(
+        SubscriptionIdentifier(PartitionId(1), UUIDS[sequence]),
+        SnQLSubscriptionData(
+            project_id=1,
+            time_window=timedelta(minutes=5),
+            resolution=resolution,
+            query="MATCH events SELECT count()",
+        ),
+    )
+
+
+ALIGNED_TIMESTAMP = 1625518080  # Aligned to start of a minute
+
+TEST_CASES = [
+    pytest.param(
+        ImmediateTaskBuilder(),
+        [(ALIGNED_TIMESTAMP, build_subscription(timedelta(minutes=1), 0))],
+        [
+            (
+                ALIGNED_TIMESTAMP,
+                ScheduledTask(
+                    datetime.fromtimestamp(ALIGNED_TIMESTAMP),
+                    build_subscription(timedelta(minutes=1), 0),
+                ),
+            )
+        ],
+        id="One subscription immediately scheduled",
+    ),
+    pytest.param(
+        ImmediateTaskBuilder(),
+        [(ALIGNED_TIMESTAMP + 1, build_subscription(timedelta(minutes=1), 0))],
+        [],
+        id="One subscription not aligned with resolution",
+    ),
+    pytest.param(
+        JitteredTaskBuilder(),
+        [
+            (ALIGNED_TIMESTAMP, build_subscription(timedelta(minutes=1), 0)),
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
+                build_subscription(timedelta(minutes=1), 0),
+            ),
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60 + 1,
+                build_subscription(timedelta(minutes=1), 0),
+            ),
+        ],
+        [
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
+                ScheduledTask(
+                    # Notice the timestamp of the task is the one without
+                    # jitter so that the query time range is still aligned
+                    # to the minute without jitter.
+                    datetime.fromtimestamp(ALIGNED_TIMESTAMP),
+                    build_subscription(timedelta(minutes=1), 0),
+                ),
+            )
+        ],
+        id="One subscription scheduled with jitter. Happens at 43rd second",
+    ),
+    pytest.param(
+        JitteredTaskBuilder(),
+        [
+            (ALIGNED_TIMESTAMP, build_subscription(timedelta(minutes=1), 0)),
+            (ALIGNED_TIMESTAMP, build_subscription(timedelta(minutes=1), 1)),
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
+                build_subscription(timedelta(minutes=1), 0),
+            ),
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
+                build_subscription(timedelta(minutes=1), 1),
+            ),
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60 + 1,
+                build_subscription(timedelta(minutes=1), 0),
+            ),
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60 + 1,
+                build_subscription(timedelta(minutes=1), 1),
+            ),
+        ],
+        [
+            (
+                ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
+                ScheduledTask(
+                    datetime.fromtimestamp(ALIGNED_TIMESTAMP),
+                    build_subscription(timedelta(minutes=1), 0),
+                ),
+            )
+        ],
+        id="Ensures different ids generate different jitters",
+    ),
+    pytest.param(
+        JitteredTaskBuilder(),
+        [(ALIGNED_TIMESTAMP, build_subscription(timedelta(minutes=2), 0))],
+        [
+            (
+                ALIGNED_TIMESTAMP,
+                ScheduledTask(
+                    datetime.fromtimestamp(ALIGNED_TIMESTAMP),
+                    build_subscription(timedelta(minutes=2), 0),
+                ),
+            )
+        ],
+        id="Do not apply jitter if resolution is above threshold",
+    ),
+]
+
+
+@pytest.mark.parametrize("builder, sequence_in, task_sequence", TEST_CASES)
+def test_sequences(
+    builder: TaskBuilder[Subscription],
+    sequence_in: Sequence[Tuple[int, Subscription]],
+    task_sequence: Sequence[Tuple[int, ScheduledTask[Subscription]]],
+) -> None:
+    """
+    Tries to execute the task builder on several sequences of
+    subscriptions and validate the proper jitter is applied.
+    """
+
+    output = []
+    for timestamp, subscription in sequence_in:
+        ret = builder.get_task(subscription, timestamp)
+        if ret:
+            output.append((timestamp, ret))
+
+    assert output == task_sequence


### PR DESCRIPTION
In the current subscription scheduler implementations, queries are scheduled as soon as possible. This causes a thundering herd of queries at the beginning of each minute as hundreds of queries can be scheduled together.

This has a negative impact on clikchouse as too many ocncurrent queries are executed and the response time of each query gets longer. This also causes additional delay in consumption and backlog.

This PR addresses this problem by spreading queries along the time range corresponding to the subscription resolution.
Example: if the resolution is 60 seconds (which it is), each subscription gets executed every 60 seconds.
Now, instead of executing all the queries at the beginning, each query gets a jitter assigned that is stable and calculated based on the subscription id. 
The subscription gets scheduled when the timestamp is `beginning of time range + jitter` instead of `beginning of time range`.

This behavior can be configured by runtime settings. When the setting is changed, the scheduler waits the end of the time range to switch so that no query is missed or duplicated during the transition.