### PR TITLE
perf: Support comparing subscription queries with and without consistent

### DIFF
--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -24,10 +24,6 @@ class RequestSettings(ABC):
         pass
 
     @abstractmethod
-    def set_consistent(self, consistent: bool) -> None:
-        pass
-
-    @abstractmethod
     def get_debug(self) -> bool:
         pass
 
@@ -76,9 +72,6 @@ class HTTPRequestSettings(RequestSettings):
     def get_consistent(self) -> bool:
         return self.__consistent
 
-    def set_consistent(self, consistent: bool) -> None:
-        self.__consistent = consistent
-
     def get_debug(self) -> bool:
         return self.__debug
 
@@ -109,9 +102,6 @@ class SubscriptionRequestSettings(RequestSettings):
 
     def get_consistent(self) -> bool:
         return self.__consistent
-
-    def set_consistent(self, consistent: bool) -> None:
-        self.__consistent = consistent
 
     def get_debug(self) -> bool:
         return False

--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -24,6 +24,10 @@ class RequestSettings(ABC):
         pass
 
     @abstractmethod
+    def set_consistent(self, consistent: bool) -> None:
+        pass
+
+    @abstractmethod
     def get_debug(self) -> bool:
         pass
 
@@ -72,6 +76,9 @@ class HTTPRequestSettings(RequestSettings):
     def get_consistent(self) -> bool:
         return self.__consistent
 
+    def set_consistent(self, consistent: bool) -> None:
+        self.__consistent = consistent
+
     def get_debug(self) -> bool:
         return self.__debug
 
@@ -102,6 +109,9 @@ class SubscriptionRequestSettings(RequestSettings):
 
     def get_consistent(self) -> bool:
         return self.__consistent
+
+    def set_consistent(self, consistent: bool) -> None:
+        self.__consistent = consistent
 
     def get_debug(self) -> bool:
         return False

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import copy
 import itertools
 import logging
+import random
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from typing import Mapping, NamedTuple, Optional, Sequence, Tuple
+from typing import List, Mapping, NamedTuple, Optional, Sequence, Tuple
 
 from arroyo import Message, Topic
 from arroyo.backends.abstract import Producer
 from arroyo.processing.strategies.batching import AbstractBatchWorker
 
+from snuba import state
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.factory import get_dataset_name
 from snuba.reader import Result
 from snuba.request import Request
 from snuba.subscriptions.consumer import Tick
@@ -20,6 +23,10 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.scheduler import ScheduledTask, Scheduler
+from snuba.utils.threaded_function_delegator import (
+    Result as ThreadedFunctionDelegatorResult,
+)
+from snuba.utils.threaded_function_delegator import ThreadedFunctionDelegator
 from snuba.web.query import parse_and_run_query
 
 logger = logging.getLogger("snuba.subscriptions")
@@ -48,6 +55,7 @@ class SubscriptionWorker(
         metrics: MetricsBackend,
     ) -> None:
         self.__dataset = dataset
+        self.__dataset_name = get_dataset_name(self.__dataset)
         self.__executor = executor
         self.__schedulers = schedulers
         self.__producer = producer
@@ -109,22 +117,79 @@ class SubscriptionWorker(
 
     def __execute_query(self, request: Request, timer: Timer) -> Tuple[Request, Result]:
         with self.__concurrent_gauge:
-            # XXX: The ``extra`` is discarded from ``QueryResult`` since it is
-            # not particularly useful in this context and duplicates data that
-            # is already being published to the query log.
-            # XXX: The ``request`` instance is copied when passed to
-            # ``parse_and_run_query`` since it can/will be mutated during
-            # processing.
-            return (
-                request,
-                parse_and_run_query(
+            is_consistent_query = request.settings.get_consistent()
+
+            def run_consistent() -> Result:
+                request_copy = copy.deepcopy(request)
+                request_copy.settings.set_consistent(True)
+
+                return parse_and_run_query(
+                    self.__dataset,
+                    request_copy,
+                    timer,
+                    robust=True,
+                    concurrent_queries_gauge=self.__concurrent_clickhouse_gauge,
+                ).result
+
+            def run_non_consistent() -> Result:
+                request_copy = copy.deepcopy(request)
+                request_copy.settings.set_consistent(False)
+
+                return parse_and_run_query(
                     self.__dataset,
                     copy.deepcopy(request),
                     timer,
                     robust=True,
                     concurrent_queries_gauge=self.__concurrent_clickhouse_gauge,
-                ).result,
+                ).result
+
+            def selector_func(run_snuplicator: bool) -> Tuple[str, List[str]]:
+                primary = "consistent" if is_consistent_query else "non_consistent"
+                other = "non_consistent" if is_consistent_query else "consistent"
+
+                return (primary, [other] if run_snuplicator else [])
+
+            def callback_func(
+                data: List[ThreadedFunctionDelegatorResult[Result]],
+            ) -> None:
+                primary_result = data.pop(0).result
+
+                for result in data:
+                    match = result.result == primary_result
+                    self.__metrics.increment(
+                        "consistent",
+                        tags={
+                            "dataset": self.__dataset_name,
+                            "consistent": str(is_consistent_query),
+                            "match": str(match),
+                        },
+                    )
+
+            if self.__dataset_name == "events":
+                sample_rate = state.get_config(
+                    "event_subscription_non_consistent_sample_rate", 0
+                )
+            elif self.__dataset_name == "transactions":
+                sample_rate = state.get_config(
+                    "transaction_subscription_non_consistent_sample_rate", 0
+                )
+            else:
+                sample_rate = 0
+
+            assert sample_rate is not None
+
+            run_snuplicator = random.random() < float(sample_rate)
+
+            executor = ThreadedFunctionDelegator[bool, Result](
+                callables={
+                    "consistent": run_consistent,
+                    "non_consistent": run_non_consistent,
+                },
+                selector_func=selector_func,
+                callback_func=callback_func,
             )
+
+            return (request, executor.execute(run_snuplicator))
 
     def process_message(
         self, message: Message[Tick]

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -128,7 +128,9 @@ class SubscriptionWorker(
                     request_copy,
                     timer,
                     robust=True,
-                    concurrent_queries_gauge=self.__concurrent_clickhouse_gauge,
+                    concurrent_queries_gauge=self.__concurrent_clickhouse_gauge
+                    if is_consistent_query
+                    else None,
                 ).result
 
             def run_non_consistent() -> Result:
@@ -137,10 +139,12 @@ class SubscriptionWorker(
 
                 return parse_and_run_query(
                     self.__dataset,
-                    copy.deepcopy(request),
+                    request_copy,
                     timer,
                     robust=True,
-                    concurrent_queries_gauge=self.__concurrent_clickhouse_gauge,
+                    concurrent_queries_gauge=self.__concurrent_clickhouse_gauge
+                    if not is_consistent_query
+                    else None,
                 ).result
 
             def selector_func(run_snuplicator: bool) -> Tuple[str, List[str]]:

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -1,3 +1,4 @@
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -36,6 +37,7 @@ from snuba.subscriptions.store import SubscriptionDataStore
 from snuba.subscriptions.worker import SubscriptionTaskResult, SubscriptionWorker
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.types import Interval
+from tests.backends.metrics import Increment, TestingMetricsBackend
 
 
 class DummySubscriptionDataStore(SubscriptionDataStore):
@@ -198,3 +200,64 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
             "meta": [{"name": "count", "type": "UInt64"}],
             "data": [{"count": 0}],
         }
+
+
+def test_subscription_worker_consistent(subscription_data: SubscriptionData) -> None:
+    state.set_config("event_subscription_non_consistent_sample_rate", 1)
+    broker: Broker[SubscriptionTaskResult] = Broker(
+        MemoryMessageStorage(), TestingClock()
+    )
+
+    result_topic = Topic("subscription-results")
+
+    broker.create_topic(result_topic, partitions=1)
+
+    frequency = timedelta(minutes=1)
+    evaluations = 1
+
+    subscription = Subscription(
+        SubscriptionIdentifier(PartitionId(0), uuid1()), subscription_data,
+    )
+
+    store = DummySubscriptionDataStore()
+    store.create(subscription.identifier.uuid, subscription.data)
+
+    metrics = TestingMetricsBackend()
+
+    dataset = get_dataset("events")
+    worker = SubscriptionWorker(
+        dataset,
+        ThreadPoolExecutor(),
+        {
+            0: SubscriptionScheduler(
+                store, PartitionId(0), timedelta(), DummyMetricsBackend(strict=True)
+            )
+        },
+        broker.get_producer(),
+        result_topic,
+        metrics,
+    )
+
+    now = datetime(2000, 1, 1)
+
+    tick = Tick(
+        offsets=Interval(0, 1),
+        timestamps=Interval(now - (frequency * evaluations), now),
+    )
+
+    worker.process_message(Message(Partition(Topic("events"), 0), 0, tick, now))
+
+    time.sleep(0.1)
+
+    assert (
+        len(
+            [
+                m
+                for m in metrics.calls
+                if isinstance(m, Increment) and m.name == "consistent"
+            ]
+        )
+        == 1
+    )
+
+    state.delete_config("event_subscription_non_consistent_sample_rate")

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -259,5 +259,3 @@ def test_subscription_worker_consistent(subscription_data: SubscriptionData) -> 
         )
         == 1
     )
-
-    state.delete_config("event_subscription_non_consistent_sample_rate")


### PR DESCRIPTION
This change adds a way to run and compare the results of subscription queries
without the "consistent" setting to those that currently run in production
with "consistent" set to true. If results turn out not to be significantly
different, it may be worthwhile to turn off consistent for subscriptions
allowing their queries to be spread over all replicas instead of just the
first one.

This can be set for events and transactions subscriptions via the
"event_subscription_non_consistent_sample_rate", and
"transaction_subscription_non_consistent_sample_rate" configuration keys.
Both of these configurations should be set to a value between 0 and 1 where
0 means don't snuplicate any queries (the default) and 1 means run 100% of
queries with both settings and record metrics.

The actual result being returned is unchanged, the secondary query is
only used for recording metrics.