### PR TITLE
ref(snql) Remove project rollout flag and default to 100%

### DIFF
--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -15,7 +15,11 @@ from snuba.datasets.dataset import Dataset
 from snuba.reader import Result
 from snuba.request import Request
 from snuba.subscriptions.consumer import Tick
-from snuba.subscriptions.data import DelegateSubscriptionData, Subscription
+from snuba.subscriptions.data import (
+    DelegateSubscriptionData,
+    SnQLSubscriptionData,
+    Subscription,
+)
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
 from snuba.utils.metrics.timer import Timer
@@ -75,6 +79,14 @@ class SubscriptionWorker(
         # performance metrics are reported to the same spot, regardless of
         # execution environment.
         timer = Timer("query")
+
+        data_type = "legacy"
+        if isinstance(task.task.data, DelegateSubscriptionData):
+            data_type = "delegate"
+        elif isinstance(task.task.data, SnQLSubscriptionData):
+            data_type = "snql"
+
+        self.__metrics.increment("incoming.task", tags={"type": data_type})
 
         if isinstance(task.task.data, DelegateSubscriptionData):
             try:

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -96,10 +96,8 @@ class TestBuildRequest(BaseSubscriptionTest):
     @pytest.fixture(autouse=True)
     def subscription_rollout(self) -> Generator[None, None, None]:
         state.set_config("snql_subscription_rollout_pct", 1.0)
-        state.set_config("snql_subscription_rollout_projects", "1")
         yield
         state.set_config("snql_subscription_rollout", 0.0)
-        state.set_config("snql_subscription_rollout_projects", "")
 
     @pytest.mark.parametrize("subscription, exception", TESTS)  # type: ignore
     def test_conditions(

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -114,10 +114,8 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
     @pytest.fixture(autouse=True)
     def subscription_rollout(self) -> Generator[None, None, None]:
         state.set_config("snql_subscription_rollout_pct", 1.0)
-        state.set_config("snql_subscription_rollout_projects", "123")
         yield
         state.set_config("snql_subscription_rollout", 0.0)
-        state.set_config("snql_subscription_rollout_projects", "")
 
     @pytest.mark.parametrize("subscription", TESTS_CREATE)
     def test(self, subscription: SubscriptionData) -> None:

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -101,10 +101,8 @@ def subscription_data(request: Any) -> SubscriptionData:
 @pytest.fixture
 def subscription_rollout() -> Generator[None, None, None]:
     state.set_config("snql_subscription_rollout_pct", 1.0)
-    state.set_config("snql_subscription_rollout_projects", "1")
     yield
     state.set_config("snql_subscription_rollout", 0.0)
-    state.set_config("snql_subscription_rollout_projects", "")
 
 
 def test_subscription_worker(subscription_data: SubscriptionData) -> None:


### PR DESCRIPTION
Also add a metric to track if any subscriptions are still using legacy. This
metric should always be zero.