### PR TITLE
feat: Log a small percentage of non matching queries to Sentry

### DIFF
--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -180,8 +180,8 @@ class SubscriptionWorker(
                         },
                     )
 
-                    # Only log 1 in 1000 mistmatches to sentry
-                    if random.random() < 0.001:
+                    # Only log 1 in 100 mistmatches to sentry
+                    if match is False and random.random() < 0.01:
                         logger.warning(
                             "Non matching result with consistent and non-consistent subscription query",
                             extra={
@@ -189,6 +189,7 @@ class SubscriptionWorker(
                                 "consistent": str(is_consistent_query),
                                 "primary": primary_result,
                                 "other": result.result,
+                                "query": request.query,
                             },
                         )
 

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -180,6 +180,18 @@ class SubscriptionWorker(
                         },
                     )
 
+                    # Only log 1 in 1000 mistmatches to sentry
+                    if random.random() < 0.001:
+                        logger.warning(
+                            "Non matching result with consistent and non-consistent subscription query",
+                            extra={
+                                "dataset": self.__dataset_name,
+                                "consistent": str(is_consistent_query),
+                                "primary": primary_result,
+                                "other": result.result,
+                            },
+                        )
+
             if self.__dataset_name == "events":
                 sample_rate = state.get_config(
                     "event_subscription_non_consistent_sample_rate", 0


### PR DESCRIPTION
Log 1 in 100 subscription queries that do not match with consistent
vs non-consistent to Sentry