### PR TITLE
ref(replacer): Log metrics for type of replacement

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -245,7 +245,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
         event = message.data
 
         if type_ in REPLACEMENT_EVENT_TYPES:
-            metrics.increment(type_, 1)
+            metrics.increment("process", 1, tags={"type": type_})
 
         if type_ in (
             "start_delete_groups",


### PR DESCRIPTION
Add a mechanism to find out what is the type of the replacement
message the replacer is receiving. This would help narrow down the
cause of spikes in clickhouse queries due to replacements.