### PR TITLE
fix: version option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ def get_requirements() -> Sequence[str]:
 
 setup(
     name="snuba",
+    version=VERSION,
     packages=find_packages(exclude=["tests"]),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Before
```
$ docker run -d --name=snuba --rm --entrypoint=tail -it getsentry/snuba:21.6.3 -f /dev/null
9cdbe2fc10e288e00b514ccb90b3be79657d655ff5ce56f11e6de15cefaad62d
$ docker exec -it snuba /bin/bash
root@9cdbe2fc10e2:/usr/src/snuba# snuba --version
snuba, version 0.0.0
```

After
```
$ docker exec -it snuba /bin/bash
root@9ed21f508eb3:/usr/src/snuba# snuba --version
snuba, version 21.7.0.dev0
```