### PR TITLE
feat: Log all consistent discrepancies to Sentry

### DIFF
--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -183,8 +183,7 @@ class SubscriptionWorker(
                         },
                     )
 
-                    # Only log 1 in 100 mistmatches to sentry
-                    if match is False and random.random() < 0.01:
+                    if match is False:
                         logger.warning(
                             "Non matching result with consistent and non-consistent subscription query",
                             extra={


### PR DESCRIPTION
Now that discrepancies between the consistent vs non-consistent subscription
queries are extremely rare, let's log them all to Sentry to figure out what's
going on.