### PR TITLE
fix(snql) Use the same metrics path for SnQL queries

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -372,7 +372,7 @@ def dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response, str
 
 
 @application.route("/<dataset:dataset>/snql", methods=["GET", "POST"])
-@util.time_request("snql")
+@util.time_request("query")
 def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response, str]:
     if http_request.method == "GET":
         schema = RequestSchema.build_with_extensions(


### PR DESCRIPTION
I originally had SnQL queries using a separate metrics tag so I could track the
performance separately. Now that all traffic is shifting to SnQL it's better to
put all of it in one place so we don't have to change any of our current SLOs
and alerts etc.