### PR TITLE
perf(transactions) Allows us to configure specific contexts not to be stored

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -136,6 +136,8 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics", "querylog", "spans_experimental
 MAX_RESOLUTION_FOR_JITTER = 60
 
 # These contexts will not be stored in the transactions table
+# Example: {123: {"context1", "context2"}}
+# where 123 is the project id.
 TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -135,6 +135,9 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics", "querylog", "spans_experimental
 
 MAX_RESOLUTION_FOR_JITTER = 60
 
+# These contexts will not be stored in the transactions table
+TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment


### PR DESCRIPTION
Today we are storing in Snuba all contexts the client is sending.
This includes custom contexts, which cannot be searched nor aggregated anyway.
So far this has not been a problem, but custom contexts started being the vast majority of the contexts stored for some projects.
This bloats the size of the contexts column for no reasonas these do not need to be in Snuba at all.

This is the quickest fix to reduce the impact on the queries that look for standard contexts (like trace and geo), then, after we find a way to ensure Snuba always have an up to date list of standard contexts, we should ensure we only store searchable contexts.