### PR TITLE
fix(tests) No need to run the compare version of SnQL tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,20 +96,3 @@ def disable_query_cache() -> Generator[None, None, None]:
     state.set_configs({"use_cache": 0, "use_readthrough_query_cache": 0})
     yield
     state.set_configs({"use_cache": cache, "use_readthrough_query_cache": readthrough})
-
-
-@pytest.fixture
-def set_state() -> Generator[Callable[[str, Any], None], None, None]:
-    modified_keys = {}
-
-    def _change_state(key: str, value: Any) -> None:
-        old_value = state.get_config(key)
-        if old_value not in modified_keys:
-            modified_keys[key] = old_value
-
-        state.set_config(key, value)
-
-    yield _change_state
-
-    for key, old in modified_keys.items():
-        state.set_config(key, old)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def convert_legacy_to_snql() -> Callable[[str, str], str]:
     return convert
 
 
-@pytest.fixture(params=["legacy", "snql", "compare"])
+@pytest.fixture(params=["legacy", "snql"])
 def _build_snql_post_methods(
     request: Any,
     test_entity: Union[str, Tuple[str, str]],
@@ -78,39 +78,14 @@ def _build_snql_post_methods(
     else:
         dataset = entity = test_entity
 
-    if request.param == "legacy" or request.param == "snql":
-        endpoint = "/query" if request.param == "legacy" else f"/{dataset}/snql"
+    endpoint = "/query" if request.param == "legacy" else f"/{dataset}/snql"
 
-        def simple_post(data: str, entity: str = entity) -> Any:
-            if request.param == "snql":
-                data = convert_legacy_to_snql(data, entity)
-            return test_app.post(endpoint, data=data, headers={"referer": "test"})
+    def simple_post(data: str, entity: str = entity, referrer: str = "test") -> Any:
+        if request.param == "snql":
+            data = convert_legacy_to_snql(data, entity)
+        return test_app.post(endpoint, data=data, headers={"referer": referrer})
 
-        return simple_post
-
-    def compare_post(data: str, entity: str = entity) -> Any:
-        # Run legacy and snql and compare the outputs
-        legacy_resp = test_app.post("/query", data=data, headers={"referer": "test"})
-        snql_resp = test_app.post(
-            f"/{dataset}/snql",
-            data=convert_legacy_to_snql(data, entity),
-            headers={"referer": "test"},
-        )
-
-        legacy_data = json.loads(legacy_resp.data)
-        snql_data = json.loads(snql_resp.data)
-
-        if legacy_data.get("sql"):
-            assert (
-                legacy_data["sql"] == snql_data["sql"]
-            ), f"LEGACY:\n{legacy_data['sql']}\n\nSNQL:\n{snql_data['sql']}\n"
-        else:
-            # There was a validation error, the response should be identical
-            assert legacy_data == snql_data
-
-        return snql_resp
-
-    return compare_post
+    return simple_post
 
 
 @pytest.fixture
@@ -121,3 +96,20 @@ def disable_query_cache() -> Generator[None, None, None]:
     state.set_configs({"use_cache": 0, "use_readthrough_query_cache": 0})
     yield
     state.set_configs({"use_cache": cache, "use_readthrough_query_cache": readthrough})
+
+
+@pytest.fixture
+def set_state() -> Generator[Callable[[str, Any], None], None, None]:
+    modified_keys = {}
+
+    def _change_state(key: str, value: Any) -> None:
+        old_value = state.get_config(key)
+        if old_value not in modified_keys:
+            modified_keys[key] = old_value
+
+        state.set_config(key, value)
+
+    yield _change_state
+
+    for key, old in modified_keys.items():
+        state.set_config(key, old)


### PR DESCRIPTION
It's not necessary to compare the SnQL and legacy outputs anymore, since that
was originally just to ensure that SnQL was returning the correct results. I am
going to leave the legacy tests since there might be customers using the old
endpoint.