### PR TITLE
Add pyenv install script and clean up env setup docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 pyenv-setup:
 	@./scripts/pyenv_setup.sh
-	pip install --upgrade pip==21.1.3
 
 develop: install-python-dependencies setup-git
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 pyenv-setup:
 	@./scripts/pyenv_setup.sh
-	pip install --upgrage pip==21.1.3
+	pip install --upgrade pip==21.1.3
 
 develop: install-python-dependencies setup-git
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: develop setup-git test install-python-dependencies
 
+pyenv-setup:
+	@./scripts/pyenv_setup.sh
+	pip install --upgrage pip==21.1.3
+
 develop: install-python-dependencies setup-git
 
 setup-git:

--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -36,8 +36,6 @@ data from Kafka::
 
     snuba devserver
 
-To verify that
-
 Running tests
 -------------
 

--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -25,6 +25,7 @@ These commands set up the Python virtual environment::
     make pyenv-setup
     python -m venv .venv
     source .venv/bin/activate
+	pip install --upgrage pip==21.1.3
     make develop
 
 These commands start the Snuba api, which is capable of processing queries::

--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -25,7 +25,7 @@ These commands set up the Python virtual environment::
     make pyenv-setup
     python -m venv .venv
     source .venv/bin/activate
-	pip install --upgrage pip==21.1.3
+    pip install --upgrage pip==21.1.3
     make develop
 
 These commands start the Snuba api, which is capable of processing queries::

--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -7,15 +7,25 @@ environment.
 
 In order to set up Clickhouse and Redis, please refer to :doc:`/getstarted`.
 
+Prerequisites
+-------------
+`pyenv <https://github.com/pyenv/pyenv#installation>`_ must be installed on your system.
+It is also assumed that you have completed the steps to set up the `sentry dev environment <https://develop.sentry.dev/environment/>`_.
+
 Install / Run
 -------------
 
+clone this repo into your workspace::
+
+    git@github.com:getsentry/snuba.git
+
 These commands set up the Python virtual environment::
 
-    mkvirtualenv snuba --python=python3.8
-    workon snuba
-    make install-python-dependencies
-    make setup-git
+    cd snuba
+    make pyenv-setup
+    python -m venv .venv
+    source .venv/bin/activate
+    make develop
 
 These commands start the Snuba api, which is capable of processing queries::
 
@@ -26,23 +36,28 @@ data from Kafka::
 
     snuba devserver
 
+To verify that
+
 Running tests
 -------------
 
 This command runs unit and integration tests::
 
-    pip install -e .
+    make develop (if you have not run it already)
     make test
+
+Running sentry tests against snuba
+++++++++++++++++++++++++++++++++++
 
 This section instead runs Sentry tests against a running Snuba installation::
 
-    workon snuba
     git checkout your-snuba-branch
+    source .venv/bin/activate
     snuba api
 
 and, in another terminal::
 
-    workon sentry
+    cd ../sentry
     git checkout master
     git pull
     sentry devservices up --exclude=snuba
@@ -55,4 +70,4 @@ You will want to run the following Sentry tests::
     make test-snuba
     make test-python
 
-These tests do not use Kafka.
+These tests do not use Kafka due to performance reasons. The snuba test suite does test the kafka functionality

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Module containing code shared across various shell scripts
+# Execute functions from this module via the script do.sh
+
+# Check if a command is available
+require() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+configure-sentry-cli() {
+    if [ -n "${SENTRY_DSN+x}" ] && [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
+        if ! require sentry-cli; then
+            curl -sL https://sentry.io/get-cli/ | bash
+        fi
+        eval "$(sentry-cli bash-hook)"
+    fi
+}
+
+query_big_sur() {
+    if require sw_vers && sw_vers -productVersion | grep -E "11\." >/dev/null; then
+        return 0
+    fi
+    return 1
+}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -7,15 +7,6 @@ require() {
     command -v "$1" >/dev/null 2>&1
 }
 
-configure-sentry-cli() {
-    if [ -n "${SENTRY_DSN+x}" ] && [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
-        if ! require sentry-cli; then
-            curl -sL https://sentry.io/get-cli/ | bash
-        fi
-        eval "$(sentry-cli bash-hook)"
-    fi
-}
-
 query_big_sur() {
     if require sw_vers && sw_vers -productVersion | grep -E "11\." >/dev/null; then
         return 0

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# This script correctly sets up pyenv
+#
+# Assumptions:
+# - This script assumes you're calling from the top directory of the repository
+set -eu
+
+HERE="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  pwd -P
+)"
+# shellcheck disable=SC1090
+source "${HERE}/lib.sh"
+
+get_shell_startup_script() {
+  local _startup_script=''
+  if [[ -n "$SHELL" ]]; then
+    case "$SHELL" in
+    */bash)
+      _startup_script="${HOME}/.bash_profile"
+      ;;
+    */zsh)
+      _startup_script="${HOME}/.zprofile"
+      ;;
+    */fish)
+      _startup_script="${HOME}/.config/fish/config.fish"
+      ;;
+    *)
+      echo "$SHELL is currently not supported."
+      exit 1
+      ;;
+    esac
+  else
+    echo "The environment variable \$SHELL needs to be defined."
+    exit 1
+  fi
+  echo "$_startup_script"
+}
+
+# The first \n is important on Github workers since it was being appended to
+# the last line rather than on a new line. I never figured out why
+_append_to_startup_script() {
+  if [[ -n "$SHELL" ]]; then
+    case "$SHELL" in
+    */bash)
+      # shellcheck disable=SC2016
+      echo "Visit https://github.com/pyenv/pyenv#installation on how to fully set up your Bash shell.";;
+    */zsh)
+      # shellcheck disable=SC2016
+      echo -e '# It is assumed that pyenv is installed via Brew, so this is all we need to do.\n' \
+        'eval "$(pyenv init --path)"' >>"${1}"
+      ;;
+    */fish)
+      # shellcheck disable=SC2016
+      echo -e '\n# pyenv init\nstatus is-login; and pyenv init --path | source' >> "${1}"
+      ;;
+    esac
+
+    echo "--> Tail of ${1}"
+    tail -n 3 "${1}"
+  fi
+}
+
+append_to_config() {
+  if [[ -n "$1" ]]; then
+    if grep -qF "(pyenv init -)" "${1}"; then
+      echo >&2 "!!! Please remove the old-style pyenv initialization and try again:"
+      echo "sed -i.bak 's/(pyenv init -)/(pyenv init --path)/' ${1}"
+      exit 1
+    fi
+    if ! grep -qF "pyenv init --path" "${1}"; then
+      echo "Adding pyenv init --path to ${1}..."
+      # pyenv init --path is needed to include the pyenv shims in your PATH
+      _append_to_startup_script "${1}"
+    fi
+  fi
+}
+
+install_pyenv() {
+  if require pyenv; then
+    echo "Installing Python (if missing) via pyenv"
+    local pyenv_version
+    pyenv_version=$(pyenv -v | awk '{print $2}')
+    python_version=$(xargs -n1 <.python-version)
+    # NOTE: We're dropping support for older pyenv versions
+    if [[ "$pyenv_version" < 2.0.0 ]]; then
+      echo >&2 "!!! We've dropped support for pyenv v1." \
+        "Run the following (this is slow) and try again."
+      # brew upgrade does not quite do the right thing
+      # > ~/.pyenv/shims/python: line 8: /usr/local/Cellar/pyenv/1.2.26/libexec/pyenv: No such file or directory
+      echo >&2 "brew update && brew uninstall pyenv && brew install pyenv"
+      exit 1
+    fi
+
+    # We need to patch the source code on Big Sur before building Python
+    # We can remove this once we upgrade to newer versions of Python
+    if query_big_sur; then
+      # cat is used since pyenv would finish to soon when the Python version is already installed
+      curl -sSL https://github.com/python/cpython/commit/8ea6353.patch | cat |
+        pyenv install --skip-existing --patch "$python_version"
+    else
+      pyenv install --skip-existing "$python_version"
+    fi
+  else
+    echo >&2 "!!! pyenv not found, try running bootstrap script again or run \`brew bundle\` in the sentry repo"
+    exit 1
+  fi
+}
+
+# Setup pyenv of path
+setup_pyenv() {
+  configure-sentry-cli
+  install_pyenv
+  _startup_script=$(get_shell_startup_script)
+  append_to_config "$_startup_script"
+
+  # If the script is called with the "dot space right" approach (. ./scripts/pyenv_setup.sh),
+  # the effects of this will be persistent outside of this script
+  echo "Activating pyenv and validating Python version"
+  # Sets up PATH for pyenv
+  eval "$(pyenv init --path)"
+  python_version=$(python -V | sed s/Python\ //g)
+  [[ $python_version == $(cat .python-version) ]] ||
+    (echo "Wrong Python version: $python_version. Please report in #discuss-dev-tooling" && exit 1)
+}
+
+setup_pyenv

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -109,7 +109,6 @@ install_pyenv() {
 
 # Setup pyenv of path
 setup_pyenv() {
-  configure-sentry-cli
   install_pyenv
   _startup_script=$(get_shell_startup_script)
   append_to_config "$_startup_script"


### PR DESCRIPTION
# Problem
pyenv does not install python3.8.3 properly on big sur, making the dev env hard to set up

# Solution
* port the [script](https://github.com/getsentry/sentry/blob/master/scripts/pyenv_setup.sh) from getsentry/sentry into this repo (with its dependencies)
* update the docs to remove virtualenvwrapper requirement from the environment setup