### PR TITLE
fix(snuplicator): Handle exceptions in the primary query

### DIFF
--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -18,7 +18,9 @@ Timing = float
 QueryPipelineBuilders = Mapping[BuilderId, QueryPipelineBuilder[ClickhouseQueryPlan]]
 QueryResults = List[Result[QueryResult]]
 SelectorFunc = Callable[[LogicalQuery, str], Tuple[BuilderId, List[BuilderId]]]
-CallbackFunc = Callable[[LogicalQuery, str, QueryResults], None]
+CallbackFunc = Callable[
+    [LogicalQuery, str, Optional[Result[QueryResult]], QueryResults], None
+]
 
 
 class MultipleConcurrentPipeline(QueryExecutionPipeline):

--- a/snuba/utils/threaded_function_delegator.py
+++ b/snuba/utils/threaded_function_delegator.py
@@ -37,7 +37,7 @@ class ThreadedFunctionDelegator(Generic[TInput, TResult]):
         callables: Mapping[str, Callable[[], TResult]],
         selector_func: Callable[[TInput], Tuple[str, List[str]]],
         callback_func: Optional[
-            Callable[[Result[TResult], List[Result[TResult]]], None]
+            Callable[[Optional[Result[TResult]], List[Result[TResult]]], None]
         ],
     ) -> None:
         self.__callables = callables
@@ -67,12 +67,12 @@ class ThreadedFunctionDelegator(Generic[TInput, TResult]):
     def execute(self, input: TInput) -> TResult:
         generator = self.__execute_callables(input)
 
-        result: Optional[Result[TResult]] = None
+        primary_result: Optional[Result[TResult]] = None
         other_results: List[Result[TResult]] = []
 
         try:
-            result = next(generator)
-            return result.result
+            primary_result = next(generator)
+            return primary_result.result
 
         finally:
 
@@ -82,7 +82,7 @@ class ThreadedFunctionDelegator(Generic[TInput, TResult]):
                         other_results.append(result)
 
                     if self.__callback_func is not None:
-                        self.__callback_func(result, other_results)
+                        self.__callback_func(primary_result, other_results)
                 except Exception as error:
                     logger.exception(error)
 

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -1,5 +1,5 @@
 import threading
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from unittest.mock import ANY, Mock, call
 
 from snuba.datasets.factory import get_dataset
@@ -20,7 +20,9 @@ def test() -> None:
     query_result = QueryResult({}, {"stats": {}, "sql": ""})
     mock_query_runner = Mock(return_value=query_result)
 
-    def callback_func(args: List[Tuple[str, QueryResult]]) -> None:
+    def callback_func(
+        primary: Optional[Tuple[str, QueryResult]], other: List[Tuple[str, QueryResult]]
+    ) -> None:
         with cv:
             cv.notify()
 
@@ -71,5 +73,6 @@ def test() -> None:
         query,
         request_settings,
         "ref",
-        [Result("errors", query_result, ANY), Result("errors_ro", query_result, ANY)],
+        Result("errors", query_result, ANY),
+        [Result("errors_ro", query_result, ANY)],
     )

--- a/tests/utils/test_threaded_function_delegator.py
+++ b/tests/utils/test_threaded_function_delegator.py
@@ -1,6 +1,6 @@
 import threading
 from typing import Any, List, Tuple
-from unittest.mock import Mock, call, ANY
+from unittest.mock import ANY, Mock, call
 
 from snuba.utils.threaded_function_delegator import Result, ThreadedFunctionDelegator
 
@@ -19,7 +19,7 @@ def test() -> None:
     def selector_func(_: int) -> Tuple[str, List[str]]:
         return ("one", ["two"])
 
-    def callback_func(args: List[Tuple[str, int]]) -> None:
+    def callback_func(primary: Tuple[str, int], other: List[Tuple[str, int]]) -> None:
         assert result_received.wait(
             timeout=5
         ), "Timeout while waiting for the main thread."
@@ -47,5 +47,5 @@ def test() -> None:
     assert callables["two"].call_count == 1
     assert callables["three"].call_count == 0
     assert mock_callback.call_args == call(
-        [Result("one", 1, ANY), Result("two", 2, ANY)]
+        Result("one", 1, ANY), [Result("two", 2, ANY)]
     )


### PR DESCRIPTION
Currently the callback function receives a list with all of the query
results. If one of the queries has failed, it is ambiguous whether it is
the primary or some other query that has failed. This change passes
the primary result back separately to the rest of the results. It will
be None if the function has errored.