### PR TITLE
fix(sessions) Add a sessions storage without mandatory conditions

### DIFF
--- a/snuba/datasets/entities/sessions.py
+++ b/snuba/datasets/entities/sessions.py
@@ -274,7 +274,7 @@ class SessionsEntity(Entity):
 
 class OrgSessionsEntity(Entity):
     def __init__(self) -> None:
-        storage = get_storage(StorageKey.SESSIONS_HOURLY)
+        storage = get_storage(StorageKey.ORG_SESSIONS)
 
         super().__init__(
             storages=[storage],

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -24,5 +24,6 @@ class StorageKey(Enum):
     QUERYLOG = "querylog"
     SESSIONS_RAW = "sessions_raw"
     SESSIONS_HOURLY = "sessions_hourly"
+    ORG_SESSIONS = "org_sessions"
     SPANS = "spans"
     TRANSACTIONS = "transactions"

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -29,6 +29,9 @@ from snuba.datasets.storages.querylog import storage as querylog_storage
 from snuba.datasets.storages.sessions import (
     materialized_storage as sessions_hourly_storage,
 )
+from snuba.datasets.storages.sessions import (
+    org_materialized_storage as org_sessions_hourly_storage,
+)
 from snuba.datasets.storages.sessions import raw_storage as sessions_raw_storage
 from snuba.datasets.storages.spans import storage as spans_storage
 from snuba.datasets.storages.transactions import storage as transactions_storage
@@ -81,6 +84,7 @@ NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
             events_ro_storage,
             outcomes_hourly_storage,
             sessions_hourly_storage,
+            org_sessions_hourly_storage,
         ]
     },
     **(DEV_NON_WRITABLE_STORAGES if settings.ENABLE_DEV_FEATURES else {}),

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -132,3 +132,11 @@ materialized_storage = ReadableTableStorage(
     query_processors=[PrewhereProcessor(["project_id", "org_id"])],
     mandatory_condition_checkers=[OrgIdEnforcer(), ProjectIdEnforcer()],
 )
+
+org_materialized_storage = ReadableTableStorage(
+    storage_key=StorageKey.ORG_SESSIONS,
+    storage_set_key=StorageSetKey.SESSIONS,
+    schema=read_schema,
+    query_processors=[PrewhereProcessor(["project_id", "org_id"])],
+    mandatory_condition_checkers=[],
+)


### PR DESCRIPTION
We created a sessions entity that could be used to query aggregate numbers
across all organizations, however we didn't create a custom storage as well. The
mandatory condition checks on the old storage were failing, so I created a new
storage that is missing those checks just to be used with that one entity.