### PR TITLE
build(ci): Push a CI-only snuba image to make use of docker caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ conftest.py
 .venv
 htmlcov/
 snuba.egg-info/
+.github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   linting:
+    if: false == true
     name: 'pre-commit hooks' # (includes Python formatting + linting)
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -26,6 +27,7 @@ jobs:
           pre-commit run --files $(git diff --diff-filter=d --name-only master)
 
   typing:
+    if: false == true
     name: 'mypy typing'
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -43,7 +45,67 @@ jobs:
         run: |
           mypy --config-file mypy.ini --ignore-missing-imports --strict --warn-unreachable snuba
 
+  snuba-image:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get branch name (merge)
+        id: branch
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/} | tr / -)"
+
+      - name: Registry login
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+      - name: Build snuba docker image
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:latest || true
+
+          docker build . \
+            --build-arg PYTHON_VERSION=3.8 \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            -t ghcr.io/getsentry/snuba-ci:latest \
+            -t ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
+            -t ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:latest \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
+            --target testing
+
+      - name: Publish images for cache
+        run: |
+          docker push ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+          docker push ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+          docker push ghcr.io/getsentry/snuba-ci:${{ latest }}
+
+      - name: Start snuba
+        run: |
+          docker run -d --rm \
+            -p 127.0.0.1:1218:1218 \
+            -e PYTHONUNBUFFERED=1 \
+            -e SNUBA_SETTINGS=docker \
+            -e DEBUG=1 \
+            -e DEFAULT_BROKERS=sentry_kafka:9092 \
+            -e CLICKHOUSE_HOST=sentry_clickhouse \
+            -e CLICKHOUSE_PORT=9000 \
+            -e CLICKHOUSE_HTTP_PORT=8123 \
+            -e REDIS_HOST=sentry_redis \
+            -e REDIS_PORT=6379 \
+            -e REDIS_DB=1 \
+            --name sentry_snuba \
+            --network sentry \
+            ghcr.io/getsentry/snuba-ci:latest
+          docker exec sentry_snuba snuba migrations migrate --force
+
   tests:
+    if: false == true
     needs: linting
     name: Tests and code coverage
     runs-on: ubuntu-latest
@@ -67,6 +129,7 @@ jobs:
           bash <(curl -s https://codecov.io/bash)
 
   sentry:
+    if: false == true
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   linting:
-    if: false == true
     name: 'pre-commit hooks' # (includes Python formatting + linting)
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -49,6 +48,8 @@ jobs:
     name: Build snuba CI image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      branch: ${{ steps.branch.outputs.branch }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -57,6 +58,8 @@ jobs:
         id: branch
         run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/} | tr / -)"
 
+      # We are only using ghcr here for CI as `setup-gcloud` is a bit slow
+      # Should revisit this when we move off of google cloud build (we may want to move these to GCR)
       - name: Registry login
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
@@ -100,7 +103,7 @@ jobs:
       - name: Pull snuba CI images
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
-            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} || \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
 
       - name: Build snuba docker image for CI
@@ -108,7 +111,7 @@ jobs:
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
             --cache-from ghcr.io/getsentry/snuba-ci:latest \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --target testing
 
@@ -143,7 +146,7 @@ jobs:
       - name: Pull snuba CI images
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
-            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} || \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
 
       - name: Build snuba docker image for CI
@@ -151,7 +154,7 @@ jobs:
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
             --cache-from ghcr.io/getsentry/snuba-ci:latest \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --target testing
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           mypy --config-file mypy.ini --ignore-missing-imports --strict --warn-unreachable snuba
 
   snuba-image:
+    name: Build snuba CI image
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -60,12 +61,14 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
-      - name: Build snuba docker image
+      - name: Pull snuba CI images
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
             docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
 
+      - name: Build snuba docker image for CI
+        run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
             -t ghcr.io/getsentry/snuba-ci:latest \
@@ -83,8 +86,7 @@ jobs:
           docker push ghcr.io/getsentry/snuba-ci:latest
 
   tests:
-    if: false == true
-    needs: linting
+    needs: [linting, snuba-image]
     name: Tests and code coverage
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -94,20 +96,36 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout code
+
+      - name: Pull snuba CI images
+        run: |
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:latest || true
+
+      - name: Build snuba docker image for CI
+        run: |
+          docker build . \
+            --build-arg PYTHON_VERSION=3.8 \
+            --cache-from ghcr.io/getsentry/snuba-ci:latest \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
+            --target testing
+
       - name: Docker set up
         run: |
-          docker pull getsentry/snuba:latest || true
-          docker build --build-arg PYTHON_VERSION=3.8 -t getsentry/snuba . --cache-from getsentry/snuba:latest --target testing
           docker network create --attachable cloudbuild
+
       - name: Docker Snuba tests
         run: |
           SNUBA_IMAGE=getsentry/snuba SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker-compose -f docker-compose.gcb.yml run --rm snuba-test
+
       - name: Upload to codecov
         run: |
           bash <(curl -s https://codecov.io/bash)
 
   sentry:
-    if: false == true
+    needs: [snuba-image]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -122,13 +140,19 @@ jobs:
           repository: getsentry/sentry
           path: sentry
 
-      - name: Build snuba docker image
+      - name: Pull snuba CI images
         run: |
-          docker pull getsentry/snuba:latest || true
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
+            docker pull ghcr.io/getsentry/snuba-ci:latest || true
+
+      - name: Build snuba docker image for CI
+        run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
-            -t getsentry/snuba \
-            --cache-from getsentry/snuba:latest \
+            --cache-from ghcr.io/getsentry/snuba-ci:latest \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --target testing
 
       # setup python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,25 +85,6 @@ jobs:
           docker push ghcr.io/getsentry/snuba-ci:${{ github.sha }}
           docker push ghcr.io/getsentry/snuba-ci:latest
 
-      - name: Start snuba
-        run: |
-          docker run -d --rm \
-            -p 127.0.0.1:1218:1218 \
-            -e PYTHONUNBUFFERED=1 \
-            -e SNUBA_SETTINGS=docker \
-            -e DEBUG=1 \
-            -e DEFAULT_BROKERS=sentry_kafka:9092 \
-            -e CLICKHOUSE_HOST=sentry_clickhouse \
-            -e CLICKHOUSE_PORT=9000 \
-            -e CLICKHOUSE_HTTP_PORT=8123 \
-            -e REDIS_HOST=sentry_redis \
-            -e REDIS_PORT=6379 \
-            -e REDIS_DB=1 \
-            --name sentry_snuba \
-            --network sentry \
-            ghcr.io/getsentry/snuba-ci:latest
-          docker exec sentry_snuba snuba migrations migrate --force
-
   tests:
     if: false == true
     needs: linting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           pre-commit run --files $(git diff --diff-filter=d --name-only master)
 
   typing:
-    if: false == true
     name: 'mypy typing'
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
   sentry:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       # Checkout codebase
       - name: Checkout snuba
@@ -80,15 +80,6 @@ jobs:
         with:
           repository: getsentry/sentry
           path: sentry
-
-      - name: Build snuba docker image
-        run: |
-          docker pull getsentry/snuba:latest || true
-          docker build . \
-            --build-arg PYTHON_VERSION=3.8 \
-            -t getsentry/snuba:${{ github.sha }} \
-            --cache-from getsentry/snuba:latest \
-            --target testing
 
       # setup python
       - uses: actions/setup-python@v1
@@ -120,6 +111,17 @@ jobs:
           kafka: true
           clickhouse: true
 
+      - run: sentry devservices up clickhouse
+
+      - name: Build snuba docker image
+        run: |
+          docker pull getsentry/snuba:latest || true
+          docker build . \
+            --build-arg PYTHON_VERSION=3.8 \
+            -t getsentry/snuba:${{ github.sha }} \
+            --cache-from getsentry/snuba:latest \
+            --target testing
+
       - name: Start snuba
         run: |
           docker run -d --rm \
@@ -138,7 +140,6 @@ jobs:
             --network sentry \
             getsentry/snuba:${{ github.sha }}
           docker exec sentry_snuba snuba migrations migrate --force
-
 
       - name: Run snuba tests
         working-directory: sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
       - name: Build snuba docker image
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
             docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
@@ -70,7 +68,6 @@ jobs:
 
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
             -t ghcr.io/getsentry/snuba-ci:latest \
             -t ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             -t ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
+      # These are pulled in order to be able to use docker layer caching
       - name: Pull snuba CI images
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
@@ -109,9 +110,10 @@ jobs:
         run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
-            --cache-from ghcr.io/getsentry/snuba-ci:latest \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
+            -t snuba-test
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
+            --cache-from ghcr.io/getsentry/snuba-ci:latest \
             --target testing
 
       - name: Docker set up
@@ -120,7 +122,7 @@ jobs:
 
       - name: Docker Snuba tests
         run: |
-          SNUBA_IMAGE=getsentry/snuba SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker-compose -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker-compose -f docker-compose.gcb.yml run --rm snuba-test
 
       - name: Upload to codecov
         run: |
@@ -150,6 +152,7 @@ jobs:
         run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
+            -t snuba-test
             --cache-from ghcr.io/getsentry/snuba-ci:latest \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
@@ -209,7 +212,7 @@ jobs:
             -e REDIS_DB=1 \
             --name sentry_snuba \
             --network sentry \
-            getsentry/snuba:latest
+            snuba-test
           docker exec sentry_snuba snuba migrations migrate --force
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,13 +136,6 @@ jobs:
       - name: Checkout snuba
         uses: actions/checkout@v2
 
-      # Checkout Sentry and run integration tests against latest snuba
-      - name: Checkout sentry
-        uses: actions/checkout@v2
-        with:
-          repository: getsentry/sentry
-          path: sentry
-
       - name: Pull snuba CI images
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
@@ -157,6 +150,14 @@ jobs:
             --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --target testing
+
+      # Checkout Sentry and run integration tests against latest snuba
+      # Make sure this is after `docker build`, otherwise we'll break docker cache
+      - name: Checkout sentry
+        uses: actions/checkout@v2
+        with:
+          repository: getsentry/sentry
+          path: sentry
 
       # setup python
       - uses: actions/setup-python@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,25 +90,6 @@ jobs:
             --cache-from getsentry/snuba:latest \
             --target testing
 
-      - name: Start snuba
-        run: |
-          docker run -d --rm \
-            -p 127.0.0.1:1218:1218 \
-            -e PYTHONUNBUFFERED=1 \
-            -e SNUBA_SETTINGS=docker \
-            -e DEBUG=1 \
-            -e DEFAULT_BROKERS=sentry_kafka:9092 \
-            -e CLICKHOUSE_HOST=sentry_clickhouse \
-            -e CLICKHOUSE_PORT=9000 \
-            -e CLICKHOUSE_HTTP_PORT=8123 \
-            -e REDIS_HOST=sentry_redis \
-            -e REDIS_PORT=6379 \
-            -e REDIS_DB=1 \
-            --name sentry_snuba \
-            --network sentry \
-            getsentry/snuba:latest
-          docker exec sentry_snuba snuba migrations migrate --force
-
       # setup python
       - uses: actions/setup-python@v1
         with:
@@ -138,6 +119,26 @@ jobs:
           snuba: false
           kafka: true
           clickhouse: true
+
+      - name: Start snuba
+        run: |
+          docker run -d --rm \
+            -p 127.0.0.1:1218:1218 \
+            -e PYTHONUNBUFFERED=1 \
+            -e SNUBA_SETTINGS=docker \
+            -e DEBUG=1 \
+            -e DEFAULT_BROKERS=sentry_kafka:9092 \
+            -e CLICKHOUSE_HOST=sentry_clickhouse \
+            -e CLICKHOUSE_PORT=9000 \
+            -e CLICKHOUSE_HTTP_PORT=8123 \
+            -e REDIS_HOST=sentry_redis \
+            -e REDIS_PORT=6379 \
+            -e REDIS_DB=1 \
+            --name sentry_snuba \
+            --network sentry \
+            getsentry/snuba:latest
+          docker exec sentry_snuba snuba migrations migrate --force
+
 
       - name: Run snuba tests
         working-directory: sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           docker push ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
           docker push ghcr.io/getsentry/snuba-ci:${{ github.sha }}
-          docker push ghcr.io/getsentry/snuba-ci:${{ latest }}
+          docker push ghcr.io/getsentry/snuba-ci:latest
 
       - name: Start snuba
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,11 @@ jobs:
     needs: [snuba-image]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    strategy:
+      matrix:
+        instance: [0, 1]
+
     steps:
       # Checkout codebase
       - name: Checkout snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
-            -t snuba-test
+            -t snuba-test \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:latest \
@@ -152,7 +152,7 @@ jobs:
         run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
-            -t snuba-test
+            -t snuba-test \
             --cache-from ghcr.io/getsentry/snuba-ci:latest \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,34 @@ jobs:
           repository: getsentry/sentry
           path: sentry
 
+      - name: Build snuba docker image
+        run: |
+          docker pull getsentry/snuba:latest || true
+          docker build . \
+            --build-arg PYTHON_VERSION=3.8 \
+            -t getsentry/snuba \
+            --cache-from getsentry/snuba:latest \
+            --target testing
+
+      - name: Start snuba
+        run: |
+          docker run -d --rm \
+            -p 127.0.0.1:1218:1218 \
+            -e PYTHONUNBUFFERED=1 \
+            -e SNUBA_SETTINGS=docker \
+            -e DEBUG=1 \
+            -e DEFAULT_BROKERS=sentry_kafka:9092 \
+            -e CLICKHOUSE_HOST=sentry_clickhouse \
+            -e CLICKHOUSE_PORT=9000 \
+            -e CLICKHOUSE_HTTP_PORT=8123 \
+            -e REDIS_HOST=sentry_redis \
+            -e REDIS_PORT=6379 \
+            -e REDIS_DB=1 \
+            --name sentry_snuba \
+            --network sentry \
+            getsentry/snuba:latest
+          docker exec sentry_snuba snuba migrations migrate --force
+
       # setup python
       - uses: actions/setup-python@v1
         with:
@@ -110,36 +138,6 @@ jobs:
           snuba: false
           kafka: true
           clickhouse: true
-
-      - run: sentry devservices up clickhouse
-
-      - name: Build snuba docker image
-        run: |
-          docker pull getsentry/snuba:latest || true
-          docker build . \
-            --build-arg PYTHON_VERSION=3.8 \
-            -t getsentry/snuba:${{ github.sha }} \
-            --cache-from getsentry/snuba:latest \
-            --target testing
-
-      - name: Start snuba
-        run: |
-          docker run -d --rm \
-            -p 127.0.0.1:1218:1218 \
-            -e PYTHONUNBUFFERED=1 \
-            -e SNUBA_SETTINGS=docker \
-            -e DEBUG=1 \
-            -e DEFAULT_BROKERS=sentry_kafka:9092 \
-            -e CLICKHOUSE_HOST=sentry_clickhouse \
-            -e CLICKHOUSE_PORT=9000 \
-            -e CLICKHOUSE_HTTP_PORT=8123 \
-            -e REDIS_HOST=sentry_redis \
-            -e REDIS_PORT=6379 \
-            -e REDIS_DB=1 \
-            --name sentry_snuba \
-            --network sentry \
-            getsentry/snuba:${{ github.sha }}
-          docker exec sentry_snuba snuba migrations migrate --force
 
       - name: Run snuba tests
         working-directory: sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Get branch name (merge)
+      - name: Get branch name
         id: branch
+        # strip `refs/heads/` from $GITHUB_REF and replace `/` with `-` so that
+        # it can be used as a docker tag
         run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/} | tr / -)"
 
       # We are only using ghcr here for CI as `setup-gcloud` is a bit slow

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -417,6 +417,8 @@ def dataset_query(
     )
 
     try:
+        if referrer == "tagstore.__get_tag_key_and_top_values":
+            raise Exception("cause a failure")
         result = parse_and_run_query(dataset, request, timer)
     except QueryException as exception:
         status = 500

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -417,8 +417,6 @@ def dataset_query(
     )
 
     try:
-        if referrer == "tagstore.__get_tag_key_and_top_values":
-            raise Exception("cause a failure")
         result = parse_and_run_query(dataset, request, timer)
     except QueryException as exception:
         status = 500


### PR DESCRIPTION
Docker builds do not seem to be using cache.  Instead, we push (and pull) a CI-only image to GitHub's Container Registry that will be used to make use of docker layer caching.

Changed the test jobs to depend on a new job that builds the snuba CI image. We tag this image with `latest`, `<commit sha>`, and `<branch>`. This should mean that the `Tests and code coverage` jobs and Sentry integration test will have all layers cached when they build the snuba image.