### PR TITLE
perf(contexts) Add setting to skip contexts from storage across projects

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -188,8 +188,11 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["http_method"] = http_data["http_method"]
         processed["http_referer"] = http_data["http_referer"]
 
-        skipped_contexts = settings.TRANSACT_SKIP_CONTEXT_STORE.get(
+        project_skipped_contexts = settings.TRANSACT_SKIP_CONTEXT_STORE.get(
             processed["project_id"], set()
+        )
+        skipped_contexts = (
+            settings.TRANSACT_GLOBAL_SKIP_CONTEXT_STORE | project_skipped_contexts
         )
         for context in skipped_contexts:
             if context in contexts:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -139,6 +139,9 @@ MAX_RESOLUTION_FOR_JITTER = 60
 # Example: {123: {"context1", "context2"}}
 # where 123 is the project id.
 TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
+# This prevents contexts to be stored across projects
+# it is just a list of contexts
+TRANSACT_GLOBAL_SKIP_CONTEXT_STORE: Set[str] = set()
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -125,6 +125,7 @@ class TransactionEvent:
                             "status": self.status,
                         },
                         "experiments": {"test1": 1, "test2": 2},
+                        "organization": {"slug": "test"},
                     },
                     "tags": [
                         ["sentry:release", self.release],
@@ -308,6 +309,7 @@ class TestTransactionsProcessor:
     def test_base_process(self) -> None:
         old_skip_context = settings.TRANSACT_SKIP_CONTEXT_STORE
         settings.TRANSACT_SKIP_CONTEXT_STORE = {1: {"experiments"}}
+        settings.TRANSACT_GLOBAL_SKIP_CONTEXT_STORE = {"organization"}
 
         start, finish = self.__get_timestamps()
         message = TransactionEvent(


### PR DESCRIPTION
Same as https://github.com/getsentry/snuba/pull/2009

But it works across projects 