### PR TITLE
feat(migrations): Support passing log level in the migrations CLI

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -1,15 +1,18 @@
 import os
-from typing import Sequence
+from typing import Optional, Sequence
 
 import click
 
 from snuba.clusters.cluster import CLUSTERS, ClickhouseNodeType
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.environment import setup_logging
 from snuba.migrations.connect import check_clickhouse_connections
 from snuba.migrations.errors import MigrationError
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
+
+LOG_LEVELS = ["critical", "error", "warning", "info", "debug", "notset"]
 
 
 @click.group()
@@ -46,10 +49,14 @@ def list() -> None:
 
 @migrations.command()
 @click.option("--force", is_flag=True)
-def migrate(force: bool) -> None:
+@click.option(
+    "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
+)
+def migrate(force: bool, log_level: Optional[str] = None) -> None:
     """
     Runs all migrations. Blocking migrations will not be run unless --force is passed.
     """
+    setup_logging(log_level)
     check_clickhouse_connections()
     runner = Runner()
 
@@ -67,7 +74,17 @@ def migrate(force: bool) -> None:
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
 @click.option("--dry-run", is_flag=True)
-def run(group: str, migration_id: str, force: bool, fake: bool, dry_run: bool) -> None:
+@click.option(
+    "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
+)
+def run(
+    group: str,
+    migration_id: str,
+    force: bool,
+    fake: bool,
+    dry_run: bool,
+    log_level: Optional[str] = None,
+) -> None:
     """
     Runs a single migration.
     --force must be passed in order to run blocking migrations.
@@ -75,6 +92,7 @@ def run(group: str, migration_id: str, force: bool, fake: bool, dry_run: bool) -
 
     Migrations that are already in an in-progress or completed status will not be run.
     """
+    setup_logging(log_level)
     if not dry_run:
         check_clickhouse_connections()
 
@@ -105,8 +123,16 @@ def run(group: str, migration_id: str, force: bool, fake: bool, dry_run: bool) -
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
 @click.option("--dry-run", is_flag=True)
+@click.option(
+    "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
+)
 def reverse(
-    group: str, migration_id: str, force: bool, fake: bool, dry_run: bool
+    group: str,
+    migration_id: str,
+    force: bool,
+    fake: bool,
+    dry_run: bool,
+    log_level: Optional[str] = None,
 ) -> None:
     """
     Reverses a single migration.
@@ -114,6 +140,7 @@ def reverse(
     --force is required to reverse an already completed migration.
     --fake marks a migration as reversed without doing anything.
     """
+    setup_logging(log_level)
     if not dry_run:
         check_clickhouse_connections()
     runner = Runner()

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -71,7 +71,7 @@ class CodeMigration(Migration, ABC):
         update_status(Status.IN_PROGRESS)
 
         for op in self.forwards_global():
-            op.execute()
+            op.execute(logger)
 
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)
@@ -87,7 +87,7 @@ class CodeMigration(Migration, ABC):
         logger.info(f"Reversing migration: {migration_id}")
         update_status(Status.IN_PROGRESS)
         for op in self.backwards_global():
-            op.execute()
+            op.execute(logger)
         logger.info(f"Finished reversing: {migration_id}")
 
         update_status(Status.NOT_STARTED)

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -1,11 +1,9 @@
+import logging
 from abc import ABC, abstractmethod
 from typing import Callable, Optional, Sequence
 
 from snuba.clickhouse.columns import Column
-from snuba.clusters.cluster import (
-    ClickhouseClientSettings,
-    get_cluster,
-)
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.columns import MigrationModifiers
 from snuba.migrations.table_engines import TableEngine
@@ -297,7 +295,7 @@ class RunPython:
 
     def __init__(
         self,
-        func: Callable[[], None],
+        func: Callable[[logging.Logger], None],
         new_node_func: Optional[Callable[[Sequence[StorageSetKey]], None]] = None,
         description: Optional[str] = None,
     ) -> None:
@@ -305,8 +303,8 @@ class RunPython:
         self.__new_node_func = new_node_func
         self.__description = description
 
-    def execute(self) -> None:
-        self.__func()
+    def execute(self, logger: logging.Logger) -> None:
+        self.__func(logger)
 
     def execute_new_node(self, storage_sets: Sequence[StorageSetKey]) -> None:
         if self.__new_node_func is not None:

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -411,7 +411,7 @@ class Runner:
                     if isinstance(sql_op, SqlOperation):
                         if sql_op._storage_set in storage_sets:
                             sql = sql_op.format_sql()
-                            print(f"Executing {sql}")
+                            logger.info(f"Executing {sql}")
                             clickhouse.execute(sql)
             elif isinstance(migration, CodeMigration):
                 for python_op in migration.forwards_global():

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Sequence
 
 from snuba.clickhouse.columns import Column, UInt
@@ -5,13 +6,12 @@ from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
-
 TABLE_NAME = "groupedmessage_local"
 TABLE_NAME_NEW = "groupedmessage_local_new"
 TABLE_NAME_OLD = "groupedmessage_local_old"
 
 
-def fix_order_by() -> None:
+def fix_order_by(_logger: logging.Logger) -> None:
     cluster = get_cluster(StorageSetKey.EVENTS)
 
     if not cluster.is_single_node():
@@ -70,7 +70,7 @@ def fix_order_by() -> None:
     clickhouse.execute(f"DROP TABLE {TABLE_NAME_OLD};")
 
 
-def ensure_drop_temporary_tables() -> None:
+def ensure_drop_temporary_tables(_logger: logging.Logger) -> None:
     cluster = get_cluster(StorageSetKey.EVENTS)
 
     if not cluster.is_single_node():

--- a/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
+++ b/snuba/migrations/snuba_migrations/transactions/0002_transactions_onpremise_fix_orderby_and_partitionby.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import time
 from typing import Sequence
@@ -11,7 +12,7 @@ TABLE_NAME_NEW = "transactions_local_new"
 TABLE_NAME_OLD = "transactions_local_old"
 
 
-def forwards() -> None:
+def forwards(logger: logging.Logger) -> None:
     """
     The sample by clause for the transactions table was added in April 2020. Partition
     by has been changed twice. If the user has a table without the sample by clause,
@@ -122,7 +123,7 @@ def forwards() -> None:
     clickhouse.execute(f"DROP TABLE {TABLE_NAME_OLD};")
 
 
-def backwards() -> None:
+def backwards(logger: logging.Logger) -> None:
     """
     This method cleans up the temporary tables used by the forwards methodsa and
     returns us to the original state if the forwards method has failed somewhere
@@ -142,12 +143,12 @@ def backwards() -> None:
         raise Exception(f"Table {TABLE_NAME} is missing")
 
     if table_exists(TABLE_NAME_NEW):
-        print(f"Dropping table {TABLE_NAME_NEW}")
+        logger.info(f"Dropping table {TABLE_NAME_NEW}")
         time.sleep(1)
         clickhouse.execute(f"DROP TABLE {TABLE_NAME_NEW};")
 
     if table_exists(TABLE_NAME_OLD):
-        print(f"Dropping table {TABLE_NAME_OLD}")
+        logger.info(f"Dropping table {TABLE_NAME_OLD}")
         time.sleep(1)
         clickhouse.execute(f"DROP TABLE {TABLE_NAME_OLD};")
 


### PR DESCRIPTION
The migrate, run and reverse commands in the migrations CLI now support
passing a log level parameter. By default it will be a bit more noisy
than it used to be, making it easier to figure out what happened if something
goes wrong during migration. As we build distributed mode this will become
more important as there are more things that can go wrong. It will also silence
some of the unnecessarily noisy output during test runs.