### PR TITLE
Subscriptions scheduler now applies jitter by default

### DIFF
--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -174,7 +174,9 @@ class TaskBuilderModeState:
             )
 
         general_mode = TaskBuilderMode(
-            state.get_config("subscription_primary_task_builder", "immediate")
+            state.get_config(
+                "subscription_primary_task_builder", TaskBuilderMode.JITTERED
+            )
         )
 
         if (

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -72,6 +72,7 @@ class TestSubscriptionScheduler:
         assert result == expected
 
     def test_simple(self) -> None:
+        state.set_config("subscription_primary_task_builder", "immediate")
         subscription = self.build_subscription(timedelta(minutes=1))
         self.run_test(
             [subscription],
@@ -84,7 +85,6 @@ class TestSubscriptionScheduler:
         )
 
     def test_simple_jittered(self) -> None:
-        state.set_config("subscription_primary_task_builder", "jittered")
         subscription = self.build_subscription(timedelta(minutes=1))
         self.run_test(
             [subscription],
@@ -114,6 +114,7 @@ class TestSubscriptionScheduler:
         )
 
     def test_subscription_resolution_larger_than_tiny_interval(self) -> None:
+        state.set_config("subscription_primary_task_builder", "immediate")
         subscription = self.build_subscription(timedelta(minutes=1))
         self.run_test(
             [subscription],


### PR DESCRIPTION
Changed value for general mode to apply the jittered mode by default. Updated tests to reflect changes.