### PR TITLE
build(ci): Skip build/publish image for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
 
   snuba-image:
     name: Build snuba CI image
+    if: github.repository_owner != "getsentry"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,6 @@ jobs:
 
   snuba-image:
     name: Build snuba CI image
-    if: github.repository_owner != 'getsentry'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -68,12 +67,14 @@ jobs:
 
       # These are pulled in order to be able to use docker layer caching
       - name: Pull snuba CI images
+        if: github.repository_owner != 'getsentry'
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
             docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
 
       - name: Build snuba docker image for CI
+        if: github.repository_owner != 'getsentry'
         run: |
           docker build . \
             --build-arg PYTHON_VERSION=3.8 \
@@ -86,6 +87,7 @@ jobs:
             --target testing
 
       - name: Publish images for cache
+        if: github.repository_owner != 'getsentry'
         run: |
           docker push ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
           docker push ghcr.io/getsentry/snuba-ci:${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
   snuba-image:
     name: Build snuba CI image
-    if: github.repository_owner != "getsentry"
+    if: github.repository_owner != 'getsentry'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:


### PR DESCRIPTION
We skip the build/push step of the snuba CI image for forks as the users will not be able to push to images to `getsentry` org and if we use the forks org, they may not have Actions enabled, so it could fail as well.