### PR TITLE
fix(sampler) Only log callback metrics for allowed projects

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -300,31 +300,35 @@ class SampledSimplePipelineBuilder(SimplePipelineBuilder):
         return super().build_planner(new_query, settings)
 
 
+def is_in_experiment(query: LogicalQuery, referrer: str) -> bool:
+    if referrer != "tagstore.__get_tag_keys":
+        return False
+
+    project_ids = get_project_ids_in_query_ast(query, "project_id")
+    if not project_ids:
+        return False
+
+    test_projects_raw = state.get_config("snuplicator-sampling-projects", "")
+    test_projects = set()
+    if (
+        isinstance(test_projects_raw, str) and test_projects_raw != ""
+    ):  # should be in the form [1,2,3]
+        test_projects_raw = test_projects_raw[1:-1]
+        test_projects = set(int(p) for p in test_projects_raw.split(",") if p)
+    elif isinstance(test_projects_raw, (int, float)):
+        test_projects = {int(test_projects_raw)}
+
+    return project_ids.issubset(test_projects)
+
+
 def sampling_selector_func(query: LogicalQuery, referrer: str) -> Tuple[str, List[str]]:
-    if referrer == "tagstore.__get_tag_keys":
-        condition = query.get_condition()
-        assert condition is not None
-        project_ids = get_project_ids_in_query_ast(query, "project_id")
-        if not project_ids:
-            return "primary", []
-
-        test_projects_raw = state.get_config("snuplicator-sampling-projects", "")
-        test_projects = set()
-        if (
-            isinstance(test_projects_raw, str) and test_projects_raw != ""
-        ):  # should be in the form [1,2,3]
-            test_projects_raw = test_projects_raw[1:-1]
-            test_projects = set(int(p) for p in test_projects_raw.split(",") if p)
-        elif isinstance(test_projects_raw, (int, float)):
-            test_projects = {int(test_projects_raw)}
-
-        if project_ids.issubset(test_projects):
-            sample_query_rate = state.get_config(
-                "snuplicator-sampling-experiment-rate", 0.0
-            )
-            assert isinstance(sample_query_rate, float)
-            if random.random() < sample_query_rate:
-                return "primary", ["sampler"]
+    if is_in_experiment(query, referrer):
+        sample_query_rate = state.get_config(
+            "snuplicator-sampling-experiment-rate", 0.0
+        )
+        assert isinstance(sample_query_rate, float)
+        if random.random() < sample_query_rate:
+            return "primary", ["sampler"]
 
     return "primary", []
 
@@ -336,7 +340,7 @@ def sampling_callback_func(
     primary_result: Optional[Result[QueryResult]],
     results: List[Result[QueryResult]],
 ) -> None:
-    if referrer != "tagstore.__get_tag_keys":
+    if not is_in_experiment(query, referrer):
         return
 
     if primary_result is None and not results:


### PR DESCRIPTION
The extra metrics are throwing off the analysis, so properly exclude them.