### PR TITLE
feat: Move CDC to a separate storage set, cross storage set joins

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import FrozenSet
+from typing import FrozenSet, Tuple
 
 
 class StorageSetKey(Enum):
@@ -16,6 +16,7 @@ class StorageSetKey(Enum):
     Storage sets are assigned to clusters via configuration.
     """
 
+    CDC = "cdc"
     DISCOVER = "discover"
     EVENTS = "events"
     EVENTS_RO = "events_ro"
@@ -29,3 +30,25 @@ class StorageSetKey(Enum):
 
 # Storage sets enabled only when development features are enabled.
 DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({StorageSetKey.METRICS})
+
+# Storage sets in a group share the same query and distributed nodes but
+# do not have the same local node cluster configuration.
+# Joins can be performed across storage sets in the same group.
+STORAGE_SET_GROUPS: FrozenSet[Tuple[StorageSetKey, ...]] = frozenset(
+    {(StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC)}
+)
+
+
+def is_valid_storage_set_combination(*storage_sets: StorageSetKey) -> bool:
+    first = storage_sets[0]
+
+    for storage_set in storage_sets[1:]:
+        if storage_set == first:
+            continue
+
+        for group in STORAGE_SET_GROUPS:
+            if first in group and storage_set in group:
+                continue
+            return False
+
+    return True

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import FrozenSet, Tuple
+from typing import FrozenSet
 
 
 class StorageSetKey(Enum):
@@ -34,8 +34,8 @@ DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({StorageSetKey.METRICS})
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.
 # Joins can be performed across storage sets in the same group.
-STORAGE_SET_GROUPS: FrozenSet[Tuple[StorageSetKey, ...]] = frozenset(
-    {(StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC)}
+JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
+    {frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC})}
 )
 
 
@@ -46,7 +46,7 @@ def is_valid_storage_set_combination(*storage_sets: StorageSetKey) -> bool:
         if storage_set == first:
             continue
 
-        for group in STORAGE_SET_GROUPS:
+        for group in JOINABLE_STORAGE_SETS:
             if first in group and storage_set in group:
                 continue
             return False

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -40,15 +40,13 @@ JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
 
 
 def is_valid_storage_set_combination(*storage_sets: StorageSetKey) -> bool:
-    first = storage_sets[0]
+    all_storage_sets = set(storage_sets)
 
-    for storage_set in storage_sets[1:]:
-        if storage_set == first:
-            continue
+    if len(all_storage_sets) <= 1:
+        return True
 
-        for group in JOINABLE_STORAGE_SETS:
-            if first in group and storage_set in group:
-                continue
-            return False
+    for group in JOINABLE_STORAGE_SETS:
+        if all_storage_sets.issubset(group):
+            return True
 
-    return True
+    return False

--- a/snuba/datasets/storages/groupassignees.py
+++ b/snuba/datasets/storages/groupassignees.py
@@ -36,14 +36,14 @@ schema = WritableTableSchema(
     columns=columns,
     local_table_name="groupassignee_local",
     dist_table_name="groupassignee_dist",
-    storage_set_key=StorageSetKey.EVENTS,
+    storage_set_key=StorageSetKey.CDC,
 )
 
 POSTGRES_TABLE = "sentry_groupasignee"
 
 storage = CdcStorage(
     storage_key=StorageKey.GROUPASSIGNEES,
-    storage_set_key=StorageSetKey.EVENTS,
+    storage_set_key=StorageSetKey.CDC,
     schema=schema,
     query_processors=[
         PrewhereProcessor(["project_id"]),

--- a/snuba/datasets/storages/groupedmessages.py
+++ b/snuba/datasets/storages/groupedmessages.py
@@ -44,7 +44,7 @@ schema = WritableTableSchema(
     columns=columns,
     local_table_name="groupedmessage_local",
     dist_table_name="groupedmessage_dist",
-    storage_set_key=StorageSetKey.EVENTS,
+    storage_set_key=StorageSetKey.CDC,
     mandatory_conditions=[
         binary_condition(
             ConditionFunctions.EQ,
@@ -58,7 +58,7 @@ POSTGRES_TABLE = "sentry_groupedmessage"
 
 storage = CdcStorage(
     storage_key=StorageKey.GROUPEDMESSAGES,
-    storage_set_key=StorageSetKey.EVENTS,
+    storage_set_key=StorageSetKey.CDC,
     schema=schema,
     query_processors=[
         PrewhereProcessor(["project_id", "id"]),

--- a/snuba/migrations/snuba_migrations/events/0007_groupedmessages.py
+++ b/snuba/migrations/snuba_migrations/events/0007_groupedmessages.py
@@ -30,11 +30,11 @@ class Migration(migration.ClickhouseNodeMigration):
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.EVENTS,
+                storage_set=StorageSetKey.CDC,
                 table_name="groupedmessage_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    storage_set=StorageSetKey.EVENTS,
+                    storage_set=StorageSetKey.CDC,
                     version_column="offset",
                     order_by="(project_id, id)",
                     sample_by="id",
@@ -46,14 +46,14 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="groupedmessage_local",
+                storage_set=StorageSetKey.CDC, table_name="groupedmessage_local",
             )
         ]
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.EVENTS,
+                storage_set=StorageSetKey.CDC,
                 table_name="groupedmessage_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
@@ -65,6 +65,6 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="groupedmessage_dist",
+                storage_set=StorageSetKey.CDC, table_name="groupedmessage_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/events/0008_groupassignees.py
+++ b/snuba/migrations/snuba_migrations/events/0008_groupassignees.py
@@ -24,11 +24,11 @@ class Migration(migration.ClickhouseNodeMigration):
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.EVENTS,
+                storage_set=StorageSetKey.CDC,
                 table_name="groupassignee_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    storage_set=StorageSetKey.EVENTS,
+                    storage_set=StorageSetKey.CDC,
                     version_column="offset",
                     order_by="(project_id, group_id)",
                     unsharded=True,
@@ -39,14 +39,14 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="groupassignee_local",
+                storage_set=StorageSetKey.CDC, table_name="groupassignee_local",
             )
         ]
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.EVENTS,
+                storage_set=StorageSetKey.CDC,
                 table_name="groupassignee_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
@@ -58,6 +58,6 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="groupassignee_dist",
+                storage_set=StorageSetKey.CDC, table_name="groupassignee_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -37,7 +37,7 @@ def fix_order_by(_logger: logging.Logger) -> None:
 
     # Add the project_id column
     add_column_sql = operations.AddColumn(
-        storage_set=StorageSetKey.EVENTS,
+        storage_set=StorageSetKey.CDC,
         table_name=TABLE_NAME,
         column=Column("project_id", UInt(64)),
         after="record_deleted",
@@ -71,7 +71,7 @@ def fix_order_by(_logger: logging.Logger) -> None:
 
 
 def ensure_drop_temporary_tables(_logger: logging.Logger) -> None:
-    cluster = get_cluster(StorageSetKey.EVENTS)
+    cluster = get_cluster(StorageSetKey.CDC)
 
     if not cluster.is_single_node():
         return
@@ -79,12 +79,12 @@ def ensure_drop_temporary_tables(_logger: logging.Logger) -> None:
     clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
     clickhouse.execute(
         operations.DropTable(
-            storage_set=StorageSetKey.EVENTS, table_name=TABLE_NAME_NEW,
+            storage_set=StorageSetKey.CDC, table_name=TABLE_NAME_NEW,
         ).format_sql()
     )
     clickhouse.execute(
         operations.DropTable(
-            storage_set=StorageSetKey.EVENTS, table_name=TABLE_NAME_OLD,
+            storage_set=StorageSetKey.CDC, table_name=TABLE_NAME_OLD,
         ).format_sql()
     )
 

--- a/snuba/pipeline/plans_selector.py
+++ b/snuba/pipeline/plans_selector.py
@@ -20,10 +20,7 @@ class PlanCandidate:
         return is_valid_storage_set_combination(*plan_storage_sets)
 
     def get_rank_sum(self) -> int:
-        sum = 0
-        for pd in self.__plan_data:
-            sum += pd.rank
-        return sum
+        return sum(pd.rank for pd in self.__plan_data)
 
     def get_plans_mapping(self) -> Mapping[str, ClickhouseQueryPlan]:
         return {plan_data.alias: plan_data.plan for plan_data in self.__plan_data}

--- a/snuba/pipeline/plans_selector.py
+++ b/snuba/pipeline/plans_selector.py
@@ -1,33 +1,32 @@
-from dataclasses import dataclass, field
-from typing import Mapping, MutableMapping, Sequence, Tuple
+import itertools
+from typing import Mapping, NamedTuple, Sequence, Tuple
 
-from snuba.clusters.storage_sets import StorageSetKey
+from snuba.clusters.storage_sets import is_valid_storage_set_combination
 from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 
 
-@dataclass
-class StorageSetPlansCandidate:
-    """
-    Keeps track of the best plan encountered for a storage set and
-    keeps a total cost, which is the sum of the ranking order of
-    each plan.
-    """
+class PlanData(NamedTuple):
+    rank: int
+    alias: str
+    plan: ClickhouseQueryPlan
 
-    total_cost: int = 0
-    plans: MutableMapping[str, Tuple[ClickhouseQueryPlan, int]] = field(
-        default_factory=dict
-    )
 
-    def add_plan(self, alias: str, plan: ClickhouseQueryPlan, cost: int) -> None:
-        if alias not in self.plans or self.plans[alias][1] > cost:
-            self.plans[alias] = (plan, cost)
-            self.total_cost = sum([plan[1] for plan in self.plans.values()])
+class PlanCandidate:
+    def __init__(self, plan_data: Tuple[PlanData, ...]) -> None:
+        self.__plan_data = plan_data
 
-    def is_complete(self, expected_aliases: int) -> bool:
-        return len(self.plans) == expected_aliases
+    def is_valid(self) -> bool:
+        plan_storage_sets = [pd.plan.storage_set_key for pd in self.__plan_data]
+        return is_valid_storage_set_combination(*plan_storage_sets)
+
+    def get_rank_sum(self) -> int:
+        sum = 0
+        for pd in self.__plan_data:
+            sum += pd.rank
+        return sum
 
     def get_plans_mapping(self) -> Mapping[str, ClickhouseQueryPlan]:
-        return {alias: plan[0] for alias, plan in self.plans.items()}
+        return {plan_data.alias: plan_data.plan for plan_data in self.__plan_data}
 
 
 def select_best_plans(
@@ -42,17 +41,16 @@ def select_best_plans(
     all the selected plans are in the same storage set and that the sum
     of the ranking is minimal.
     """
+    plan_data = [
+        [PlanData(rank, alias, plan) for rank, plan in enumerate(_plans)]
+        for alias, _plans in plans.items()
+    ]
 
-    ranks: MutableMapping[StorageSetKey, StorageSetPlansCandidate] = {}
-    for alias, viable_plans in plans.items():
-        for rank, plan in enumerate(viable_plans):
-            if plan.storage_set_key not in ranks:
-                ranks[plan.storage_set_key] = StorageSetPlansCandidate()
-            ranks[plan.storage_set_key].add_plan(alias, plan, rank)
+    all = [PlanCandidate(data) for data in itertools.product(*plan_data)]
 
     candidates = sorted(
-        [r for r in ranks.values() if r.is_complete(len(plans))],
-        key=lambda candidate: candidate.total_cost,
+        [candidate for candidate in all if candidate.is_valid()],
+        key=lambda candidate: candidate.get_rank_sum(),
     )
 
     assert len(candidates) > 0, "Cannot build a valid query plan for this query."

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -28,6 +28,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
         "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
         "storage_sets": {
+            "cdc",
             "discover",
             "events",
             "events_ro",

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -9,6 +9,7 @@ CLUSTERS = [
         "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
         "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
         "storage_sets": {
+            "cdc",
             "discover",
             "events",
             "events_ro",

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -11,6 +11,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
 
 ENABLED_STORAGE_SETS = {
+    "cdc",
     "discover",
     "events",
     "events_ro",

--- a/tests/clusters/test_storage_sets.py
+++ b/tests/clusters/test_storage_sets.py
@@ -1,0 +1,18 @@
+from snuba.clusters.storage_sets import StorageSetKey, is_valid_storage_set_combination
+
+
+def test_storage_set_combination() -> None:
+    assert (
+        is_valid_storage_set_combination(StorageSetKey.EVENTS, StorageSetKey.CDC)
+        is True
+    )
+    assert (
+        is_valid_storage_set_combination(StorageSetKey.EVENTS, StorageSetKey.SESSIONS)
+        is False
+    )
+    assert (
+        is_valid_storage_set_combination(
+            StorageSetKey.EVENTS, StorageSetKey.CDC, StorageSetKey.SESSIONS
+        )
+        is False
+    )

--- a/tests/pipeline/test_selector.py
+++ b/tests/pipeline/test_selector.py
@@ -1,6 +1,7 @@
 from typing import Mapping, Sequence
 
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
 from snuba.clusters.cluster import get_cluster
@@ -27,10 +28,18 @@ TEST_CASES = [
     pytest.param(
         {
             "events": [build_plan("events_table", StorageSetKey.EVENTS)],
-            "groups": [build_plan("groups_table", StorageSetKey.EVENTS)],
+            "something": [build_plan("some_table", StorageSetKey.EVENTS)],
+        },
+        {"events": "events_table", "something": "some_table"},
+        id="All tables on the same storage sets",
+    ),
+    pytest.param(
+        {
+            "events": [build_plan("events_table", StorageSetKey.EVENTS)],
+            "groups": [build_plan("groups_table", StorageSetKey.CDC)],
         },
         {"events": "events_table", "groups": "groups_table"},
-        id="All tables on the same storage sets",
+        id="Tables on joinable storage sets",
     ),
     pytest.param(
         {
@@ -51,7 +60,7 @@ TEST_CASES = [
             ],
             "groups": [build_plan("groups_table", StorageSetKey.EVENTS)],
         },
-        {"events": "events_table", "groups": "groups_table"},
+        {"events": "events_readonly_table", "groups": "groups_table"},
         id="Highest ranking plan for events in the wrong storage set. Skip",
     ),
     pytest.param(
@@ -66,7 +75,7 @@ TEST_CASES = [
                 build_plan("groups_readonly_table", StorageSetKey.EVENTS_RO),
             ],
         },
-        {"events": "events_table", "groups": "groups_table"},
+        {"events": "events_readonly_table", "groups": "groups_table"},
         id="Two valid storage sets, pick the highest ranking one",
     ),
 ]


### PR DESCRIPTION
This change adds a new CDC storage set, which the groupedmessages
and groupassignee storages belong to.

Previously these storages were on the "events" storage set, same as
the errors table. This was wrong because it is impossible for
groupedmessages and groupassignee to share a ClickHouse cluster
and layout (by definition storages on the same storage set share
ClickHouse clusters). Specifically the issue is that errors
being a large table should be able to have more than 1 shard,
but because of the way CDC works, groupedmessages and groupassignees
will not work with more than 1 shard.

In order to solve this problem, we introduce JOINABLE_STORAGE_SETS,
predefined groups of storage sets that are allowed to be joined on.
Storage sets in a storage set group can have different local nodes but must
share query and distributed nodes. This is checked on initialization
and Snuba will not start if this constraint is not met.

Joins are only allowed between plans with the same storage sets or storage
sets in the same group.