### PR TITLE
feat(replacement) Load balance INSERT query to storage nodes to avoid overloading the first node of the replica set

### DIFF
--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -104,12 +104,14 @@ class RoundRobinConnectionPool(ShardedConnectionPool):
 
         all_nodes = self.__get_nodes()
 
-        return {
+        ret = {
             shard: wrapping_slice(
                 shard_nodes, self.__counter % len(shard_nodes), min(3, len(shard_nodes))
             )
             for shard, shard_nodes in all_nodes.items()
         }
+        self.__counter += 1
+        return ret
 
 
 class InsertExecutor(ABC):

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from functools import partial
-from typing import Callable, List, Mapping, MutableMapping, Optional, Sequence
+from typing import Callable, List, Mapping, Optional, Sequence
 
 import simplejson as json
 from arroyo import Message
@@ -28,6 +28,88 @@ logger = logging.getLogger("snuba.replacer")
 executor = ThreadPoolExecutor()
 
 NODES_REFRESH_PERIOD = 10
+
+
+class ShardedConnectionPool(ABC):
+    """
+    Provides Clickhouse connection to a sharded cluster.
+
+    This class takes care of keeping a list of valid nodes up to date
+    and to implement any sort of load balancing strategy.
+    """
+
+    @abstractmethod
+    def get_connections(self) -> Mapping[int, Sequence[ClickhouseNode]]:
+        """
+        Returns a sequence of valid connections for each shard.
+        The first connection in each sequence is the connection
+        that should be used first. The following ones, instead
+        are backup in case the first fails.
+
+        The sequences do not have to have the same number of
+        connections but that would be weird.
+        """
+        raise NotImplementedError
+
+
+class RoundRobinConnectionPool(ShardedConnectionPool):
+    """
+    Sharded connection pool that loads the valid nodes from the
+    Clickhouse system.clusters table, then provides up to three
+    connections for each shard picking them with a round robin
+    policy.
+
+    TODO: Consider moving this logic and the executor to the
+          Clickhouse native module.
+
+    The goal is to evenly distribute the queries across the
+    nodes.
+
+    The sequence of connections for each shard is a sliding
+    window over the list of available connections. This window
+    wrap around when it reaches the end of the list and moves
+    by one node each time `get_connections` is invoked.
+    """
+
+    def __init__(self, cluster: ClickhouseCluster,) -> None:
+        self.__cluster = cluster
+        self.__counter = 0
+        self.__nodes: Mapping[int, List[ClickhouseNode]] = defaultdict(list)
+        self.__nodes_refreshed_at = time.time()
+
+    def __get_nodes(self) -> Mapping[int, Sequence[ClickhouseNode]]:
+        now = time.time()
+        if not self.__nodes or now - self.__nodes_refreshed_at > NODES_REFRESH_PERIOD:
+            all_nodes = self.__cluster.get_local_nodes()
+
+            self.__nodes = defaultdict(list)
+            # We pick up to three replicas per shard. The order will be the
+            # one provided by the get_local_nodes. For the correctness the order
+            # in which these nodes are tried does not matter.
+            for n in all_nodes:
+                if n.replica is not None and n.shard is not None:
+                    self.__nodes[n.shard].append(n)
+
+            self.__nodes_refreshed_at = now
+        return self.__nodes
+
+    def get_connections(self) -> Mapping[int, Sequence[ClickhouseNode]]:
+        def wrapping_slice(
+            lst: Sequence[ClickhouseNode], offset: int, size: int
+        ) -> Sequence[ClickhouseNode]:
+            if len(lst) >= offset + size:
+                return lst[offset : offset + size]
+            else:
+                return [*lst[offset:], *lst[: offset + size - len(lst)]]
+
+        all_nodes = self.__get_nodes()
+
+        return {
+            shard: wrapping_slice(
+                shard_nodes, self.__counter % len(shard_nodes), min(3, len(shard_nodes))
+            )
+            for shard, shard_nodes in all_nodes.items()
+        }
 
 
 class InsertExecutor(ABC):
@@ -94,14 +176,14 @@ class ShardedExecutor(InsertExecutor):
         runner: RunQuery,
         thread_pool: ThreadPoolExecutor,
         cluster: ClickhouseCluster,
-        main_nodes: Mapping[int, Sequence[ClickhouseNode]],
+        main_connection_pool: ShardedConnectionPool,
         local_table_name: str,
         backup_executor: InsertExecutor,
         metrics: MetricsBackend,
     ) -> None:
         self.__thread_pool = thread_pool
         self.__cluster = cluster
-        self.__main_nodes = main_nodes
+        self.__connection_pool = main_connection_pool
         self.__local_table_name = local_table_name
         self.__backup_executor = backup_executor
         self.__metrics = metrics
@@ -141,7 +223,7 @@ class ShardedExecutor(InsertExecutor):
             if query is None:
                 return 0
             result_futures = []
-            for nodes in self.__main_nodes.values():
+            for nodes in self.__connection_pool.get_connections().values():
                 result_futures.append(
                     self.__thread_pool.submit(
                         partial(
@@ -179,8 +261,7 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
         self.__replacer_processor = processor
         self.__database_name = storage.get_cluster().get_database()
 
-        self.__nodes: Sequence[ClickhouseNode] = []
-        self.__nodes_refreshed_at = time.time()
+        self.__sharded_pool = RoundRobinConnectionPool(self.__storage.get_cluster())
 
     def __get_insert_executor(self, replacement: Replacement) -> InsertExecutor:
         """
@@ -236,26 +317,11 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
         if not write_every_node or cluster.is_single_node():
             return query_node_executor
 
-        now = time.time()
-        if not self.__nodes or now - self.__nodes_refreshed_at > NODES_REFRESH_PERIOD:
-            self.__nodes = self.__storage.get_cluster().get_local_nodes()
-            self.__nodes_refreshed_at = now
-        nodes: MutableMapping[int, List[ClickhouseNode]] = defaultdict(list)
-
-        # We pick up to three replicas per shard. The order will be the
-        # one provided by the get_local_nodes. For the correctness the order
-        # in which these nodes are tried does not matter.
-        # TODO: Consider reshuffling the nodes before building the executor.
-        for n in self.__nodes:
-            if n.replica is not None and n.shard is not None:
-                if len(nodes[n.shard]) < 3:
-                    nodes[n.shard].append(n)
-
         return ShardedExecutor(
             runner=run_query,
             cluster=cluster,
             thread_pool=executor,
-            main_nodes=nodes,
+            main_connection_pool=self.__sharded_pool,
             local_table_name=local_table_name,
             backup_executor=query_node_executor,
             metrics=self.metrics,

--- a/tests/replacer/test_load_balancer.py
+++ b/tests/replacer/test_load_balancer.py
@@ -1,0 +1,179 @@
+from typing import Mapping, MutableSequence, Sequence
+
+import pytest
+
+from snuba.clusters.cluster import ClickhouseNode
+from snuba.replacer import RoundRobinConnectionPool
+from tests.clusters.fake_cluster import FakeClickhouseCluster
+
+TEST_CASES = [
+    pytest.param(
+        [
+            ClickhouseNode("query_node", 9000, None, None),
+            ClickhouseNode("storage-0-0", 9000, 1, 1),
+            ClickhouseNode("storage-0-1", 9000, 1, 2),
+            ClickhouseNode("storage-1-0", 9000, 2, 1),
+            ClickhouseNode("storage-1-1", 9000, 2, 2),
+        ],
+        1,
+        [
+            {
+                1: [
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                ],
+                2: [
+                    ClickhouseNode("storage-1-0", 9000, 2, 1),
+                    ClickhouseNode("storage-1-1", 9000, 2, 2),
+                ],
+            }
+        ],
+        id="1 call to load balancer on 2 shards",
+    ),
+    pytest.param(
+        [
+            ClickhouseNode("query_node", 9000, None, None),
+            ClickhouseNode("storage-0-0", 9000, 1, 1),
+            ClickhouseNode("storage-0-1", 9000, 1, 2),
+            ClickhouseNode("storage-1-0", 9000, 2, 1),
+            ClickhouseNode("storage-1-1", 9000, 2, 2),
+        ],
+        2,
+        [
+            {
+                1: [
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                ],
+                2: [
+                    ClickhouseNode("storage-1-0", 9000, 2, 1),
+                    ClickhouseNode("storage-1-1", 9000, 2, 2),
+                ],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                ],
+                2: [
+                    ClickhouseNode("storage-1-1", 9000, 2, 2),
+                    ClickhouseNode("storage-1-0", 9000, 2, 1),
+                ],
+            },
+        ],
+        id="2 calls to load balancer test wrap around",
+    ),
+    pytest.param(
+        [
+            ClickhouseNode("query_node", 9000, None, None),
+            ClickhouseNode("storage-0-0", 9000, 1, 1),
+            ClickhouseNode("storage-0-1", 9000, 1, 2),
+            ClickhouseNode("storage-0-2", 9000, 1, 3),
+            ClickhouseNode("storage-1-0", 9000, 2, 1),
+        ],
+        3,
+        [
+            {
+                1: [
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                ],
+                2: [ClickhouseNode("storage-1-0", 9000, 2, 1)],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                ],
+                2: [ClickhouseNode("storage-1-0", 9000, 2, 1)],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                ],
+                2: [ClickhouseNode("storage-1-0", 9000, 2, 1)],
+            },
+        ],
+        id="Unbalanced cluster",
+    ),
+    pytest.param(
+        [
+            ClickhouseNode("query_node", 9000, None, None),
+            ClickhouseNode("storage-0-0", 9000, 1, 1),
+            ClickhouseNode("storage-0-1", 9000, 1, 2),
+            ClickhouseNode("storage-0-2", 9000, 1, 3),
+            ClickhouseNode("storage-0-3", 9000, 1, 4),
+        ],
+        5,
+        [
+            {
+                1: [
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                ],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                    ClickhouseNode("storage-0-3", 9000, 1, 4),
+                ],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                    ClickhouseNode("storage-0-3", 9000, 1, 4),
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                ],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-3", 9000, 1, 4),
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                ],
+            },
+            {
+                1: [
+                    ClickhouseNode("storage-0-0", 9000, 1, 1),
+                    ClickhouseNode("storage-0-1", 9000, 1, 2),
+                    ClickhouseNode("storage-0-2", 9000, 1, 3),
+                ],
+            },
+        ],
+        id="Full wrap around. Replicaset higher than 3",
+    ),
+]
+
+
+@pytest.mark.parametrize("cluster_nodes, iterations, expected_results", TEST_CASES)
+def test_load_balancer(
+    cluster_nodes: Sequence[ClickhouseNode],
+    iterations: int,
+    expected_results: Sequence[Mapping[int, Sequence[ClickhouseNode]]],
+) -> None:
+    cluster = FakeClickhouseCluster(
+        host="query_node",
+        port=9000,
+        user="default",
+        password="",
+        database="default",
+        http_port=8123,
+        storage_sets={"events"},
+        single_node=False,
+        cluster_name="my_cluster",
+        distributed_cluster_name="my_distributed_cluster",
+        nodes=[(node, True) for node in cluster_nodes],
+    )
+
+    load_balancer = RoundRobinConnectionPool(cluster)
+    results: MutableSequence[Mapping[int, Sequence[ClickhouseNode]]] = []
+    for i in range(iterations):
+        results.append(load_balancer.get_connections())
+
+    assert results == expected_results


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/2025 sends replacement INSERT queries to individual storage nodes to keep the data consistent after resharding. Before that INSERT queries were going to the query node and the distributed table.

That always preferred the first node of each replica set. As a consequence we are increasing the INSERT statement per second node too much when we have a spike of small replacements in the queue.

This adds a round robin load balancer to pick a different node for each INSERT to spread queries on the cluster. 
This load balancer could actually be made generic and added to the native clickhouse module.