### PR TITLE
ref(perf) Add tag for project/org id to transaction

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -15,7 +15,7 @@ from snuba.clickhouse.columns import (
 )
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
-from snuba.clickhouse.query_dsl.accessors import get_project_ids_in_query_ast
+from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.clickhouse.translators.snuba import SnubaClickhouseStrictTranslator
 from snuba.clickhouse.translators.snuba.allowed import (
     ColumnMapper,
@@ -304,7 +304,7 @@ def is_in_experiment(query: LogicalQuery, referrer: str) -> bool:
     if referrer != "tagstore.__get_tag_keys":
         return False
 
-    project_ids = get_project_ids_in_query_ast(query, "project_id")
+    project_ids = get_object_ids_in_query_ast(query, "project_id")
     if not project_ids:
         return False
 

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -5,7 +5,7 @@ from typing import Optional
 from snuba import environment, settings
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
-from snuba.clickhouse.query_dsl.accessors import get_project_ids_in_query_ast
+from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.datasets.errors_replacer import ReplacerState, get_projects_query_flags
 from snuba.query.conditions import not_in_condition
 from snuba.query.expressions import Column, FunctionCall, Literal
@@ -39,7 +39,7 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         if request_settings.get_turbo():
             return
 
-        project_ids = get_project_ids_in_query_ast(query, self.__project_column)
+        project_ids = get_object_ids_in_query_ast(query, self.__project_column)
 
         set_final = False
         if project_ids:

--- a/snuba/query/processors/project_rate_limiter.py
+++ b/snuba/query/processors/project_rate_limiter.py
@@ -1,4 +1,4 @@
-from snuba.clickhouse.query_dsl.accessors import get_project_ids_in_query_ast
+from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
 from snuba.request.request_settings import RequestSettings
@@ -23,7 +23,7 @@ class ProjectRateLimiterProcessor(QueryProcessor):
             if ex.rate_limit_name == PROJECT_RATE_LIMIT_NAME:
                 return
 
-        project_ids = get_project_ids_in_query_ast(query, self.project_column)
+        project_ids = get_object_ids_in_query_ast(query, self.project_column)
         if not project_ids:
             return
 

--- a/tests/clickhouse/query_dsl/test_project_id.py
+++ b/tests/clickhouse/query_dsl/test_project_id.py
@@ -1,7 +1,8 @@
 from typing import Any, MutableMapping, Set
 
 import pytest
-from snuba.clickhouse.query_dsl.accessors import get_project_ids_in_query_ast
+
+from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.translator.query import identity_translate
 from snuba.query.parser import parse_query
@@ -138,5 +139,5 @@ def test_find_projects(
 ) -> None:
     events = get_dataset("events")
     query = identity_translate(parse_query(query_body, events))
-    project_ids_ast = get_project_ids_in_query_ast(query, "project_id")
+    project_ids_ast = get_object_ids_in_query_ast(query, "project_id")
     assert project_ids_ast == expected_projects


### PR DESCRIPTION
If there is a single org ID and/or project ID, tag that on the query so we can
do some analysis on a per project basis. If there are multiple projects this tag
doesn't work, so leave it blank.