### PR TITLE
Track Query sizes

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -18,7 +18,6 @@ DISABLED_DATASETS: Set[str] = {"metrics"}
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
-CLICKHOUSE_MAX_QUERY_SIZE_BYTES = 256 * 1024  # 256 KiB by default
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -18,6 +18,7 @@ DISABLED_DATASETS: Set[str] = {"metrics"}
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
+CLICKHOUSE_MAX_QUERY_SIZE_BYTES = 256 * 1024  # 256 KiB by default
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -291,7 +291,6 @@ def get_query_size_group(formatted_query: str) -> str:
     All sizes are computed in Bytes.
     """
     query_size_in_bytes = _string_size_in_bytes(formatted_query)
-    query_size_group = 0
     if query_size_in_bytes > CLICKHOUSE_MAX_QUERY_SIZE_BYTES:
         query_size_group = 100
     else:

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -21,7 +21,6 @@ from snuba.querylog.query_metadata import SnubaQueryMetadata
 from snuba.reader import Reader
 from snuba.request import Request
 from snuba.request.request_settings import RequestSettings
-from snuba.settings import CLICKHOUSE_MAX_QUERY_SIZE_BYTES
 from snuba.util import with_span
 from snuba.utils.metrics.gauge import Gauge
 from snuba.utils.metrics.timer import Timer
@@ -32,6 +31,8 @@ from snuba.web.db_query import raw_query
 logger = logging.getLogger("snuba.query")
 
 metrics = MetricsWrapper(environment.metrics, "api")
+
+MAX_QUERY_SIZE_BYTES = 256 * 1024  # 256 KiB by default
 
 
 class SampleClauseFinder(DataSourceVisitor[bool, Entity], JoinVisitor[bool, Entity]):
@@ -290,11 +291,11 @@ def get_query_size_group(formatted_query: str) -> str:
     All sizes are computed in Bytes.
     """
     query_size_in_bytes = _string_size_in_bytes(formatted_query)
-    if query_size_in_bytes >= CLICKHOUSE_MAX_QUERY_SIZE_BYTES:
+    if query_size_in_bytes >= MAX_QUERY_SIZE_BYTES:
         query_size_group = 100
     else:
         query_size_group = (
-            int(floor(query_size_in_bytes / CLICKHOUSE_MAX_QUERY_SIZE_BYTES * 10)) * 10
+            int(floor(query_size_in_bytes / MAX_QUERY_SIZE_BYTES * 10)) * 10
         )
     return f">={query_size_group}%"
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -280,6 +280,16 @@ def _format_storage_query_and_run(
 
 
 def get_query_size_group(formatted_query: str) -> str:
+    """
+    Given a formatted query string (or any string technically),
+    returns a string representing the size of the query in 10%
+    grouped increments of the Maximum Query Size as defined in Snuba settings.
+
+    Eg. If the query size is 40-49% of the max query size, this function
+    returns ">40%".
+
+    All sizes are computed in Bytes.
+    """
     query_size_in_bytes = _string_size_in_bytes(formatted_query)
     query_size_group = 0
     if query_size_in_bytes > CLICKHOUSE_MAX_QUERY_SIZE_BYTES:

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -275,10 +275,11 @@ def _format_storage_query_and_run(
 
 def get_query_size_group(formatted_query: str) -> str:
     query_size_in_bytes = len(formatted_query.encode("utf-8"))
-    query_size_limit = CLICKHOUSE_MAX_QUERY_SIZE_BYTES
     query_size_group = 0
-    if query_size_in_bytes > query_size_limit:
+    if query_size_in_bytes > CLICKHOUSE_MAX_QUERY_SIZE_BYTES:
         query_size_group = 100
     else:
-        query_size_group = int(floor(query_size_in_bytes / query_size_limit * 10)) * 10
+        query_size_group = (
+            int(floor(query_size_in_bytes / CLICKHOUSE_MAX_QUERY_SIZE_BYTES * 10)) * 10
+        )
     return f">{query_size_group}%"

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -286,18 +286,18 @@ def get_query_size_group(formatted_query: str) -> str:
     grouped increments of the Maximum Query Size as defined in Snuba settings.
 
     Eg. If the query size is 40-49% of the max query size, this function
-    returns ">40%".
+    returns ">=40%".
 
     All sizes are computed in Bytes.
     """
     query_size_in_bytes = _string_size_in_bytes(formatted_query)
-    if query_size_in_bytes > CLICKHOUSE_MAX_QUERY_SIZE_BYTES:
+    if query_size_in_bytes >= CLICKHOUSE_MAX_QUERY_SIZE_BYTES:
         query_size_group = 100
     else:
         query_size_group = (
             int(floor(query_size_in_bytes / CLICKHOUSE_MAX_QUERY_SIZE_BYTES * 10)) * 10
         )
-    return f">{query_size_group}%"
+    return f">={query_size_group}%"
 
 
 def _string_size_in_bytes(s: str) -> int:

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -237,14 +237,13 @@ def _format_storage_query_and_run(
     table_names = ",".join(sorted(visitor.get_tables()))
     with sentry_sdk.start_span(description="create_query", op="db") as span:
         formatted_query = format_query(clickhouse_query, request_settings)
+        span.set_data("query", formatted_query.structured())
         span.set_data(
-            "query",
-            {
-                "Query": formatted_query.structured(),
-                "Size (Bytes)": _string_size_in_bytes(str(formatted_query)),
-            },
+            "query_size_bytes", _string_size_in_bytes(formatted_query.get_sql())
         )
-        span.set_tag("query_size_group", get_query_size_group(str(formatted_query)))
+        span.set_tag(
+            "query_size_group", get_query_size_group(formatted_query.get_sql())
+        )
         metrics.increment("execute")
 
     timer.mark("prepare_query")

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -242,7 +242,7 @@ def _format_storage_query_and_run(
         span.set_data(
             "query_size_bytes", _string_size_in_bytes(formatted_query.get_sql())
         )
-        span.set_tag(
+        sentry_sdk.set_tag(
             "query_size_group", get_query_size_group(formatted_query.get_sql())
         )
         metrics.increment("execute")

--- a/tests/web/test_query_size.py
+++ b/tests/web/test_query_size.py
@@ -7,11 +7,11 @@ TENTH_PLUS_ONE = int(CLICKHOUSE_MAX_QUERY_SIZE_BYTES / 10) + 1
 A = "A"
 
 TEST_GROUPS = [
-    pytest.param(A, ">0%", id="Under 10%"),
-    pytest.param(A * TENTH_PLUS_ONE, ">10%", id="Greater than 10%"),
-    pytest.param(A * TENTH_PLUS_ONE * 5, ">50%", id="Greater than 50%"),
-    pytest.param(A * TENTH_PLUS_ONE * 8, ">80%", id="Greater than 80%"),
-    pytest.param(A * TENTH_PLUS_ONE * 10, ">100%", id="Greater than 100%"),
+    pytest.param(A, ">=0%", id="Under 10%"),
+    pytest.param(A * TENTH_PLUS_ONE, ">=10%", id="Greater than or equal to 10%"),
+    pytest.param(A * TENTH_PLUS_ONE * 5, ">=50%", id="Greater than or equal to 50%"),
+    pytest.param(A * TENTH_PLUS_ONE * 8, ">=80%", id="Greater than or equal to 80%"),
+    pytest.param(A * TENTH_PLUS_ONE * 10, ">=100%", id="Greater than or equal to 100%"),
 ]
 
 

--- a/tests/web/test_query_size.py
+++ b/tests/web/test_query_size.py
@@ -1,0 +1,20 @@
+import pytest
+
+from snuba.settings import CLICKHOUSE_MAX_QUERY_SIZE_BYTES
+from snuba.web.query import get_query_size_group
+
+TENTH_PLUS_ONE = int(CLICKHOUSE_MAX_QUERY_SIZE_BYTES / 10) + 1
+A = "A"
+
+TEST_GROUPS = [
+    pytest.param(A, ">0%", id="Under 10%"),
+    pytest.param(A * TENTH_PLUS_ONE, ">10%", id="Greater than 10%"),
+    pytest.param(A * TENTH_PLUS_ONE * 5, ">50%", id="Greater than 50%"),
+    pytest.param(A * TENTH_PLUS_ONE * 8, ">80%", id="Greater than 80%"),
+    pytest.param(A * TENTH_PLUS_ONE * 10, ">100%", id="Greater than 100%"),
+]
+
+
+@pytest.mark.parametrize("query, group", TEST_GROUPS)
+def test_query_size_group(query: str, group: str) -> None:
+    assert get_query_size_group(query) == group

--- a/tests/web/test_query_size.py
+++ b/tests/web/test_query_size.py
@@ -1,9 +1,8 @@
 import pytest
 
-from snuba.settings import CLICKHOUSE_MAX_QUERY_SIZE_BYTES
-from snuba.web.query import get_query_size_group
+from snuba.web.query import MAX_QUERY_SIZE_BYTES, get_query_size_group
 
-TENTH_PLUS_ONE = int(CLICKHOUSE_MAX_QUERY_SIZE_BYTES / 10) + 1
+TENTH_PLUS_ONE = int(MAX_QUERY_SIZE_BYTES / 10) + 1
 A = "A"
 
 TEST_GROUPS = [


### PR DESCRIPTION
Updated the `create_query` span to include the size of the query in bytes, along with adding a tag to the transaction which groups the query into something easy to track for discovering trends in query sizes.

`create_query` span before:

`query`:
```
<query>
```

Now:
`query`:
```
<query>
```
`query_size_bytes`:
```
<size>
```

A new tag called `query_size_group` has been added to the transaction which groups the query into a 10% bracket of the maximum query size.

The value for this tag can be any one of the following depending on the query size:
```
>=0%, >=10%, >=20%, >=30%, >=40%, >=50%, >=60%, >=70%, >=80%, >=90%, >=100%
```

Clickhouse by default has a `max_query_size` of 256 KiB, which has been hardcoded as a setting in Snuba settings for this tag. It has no other use yet, but could potentially be used to override the Clickhouse setting or simply used to limit the size of a query in Snuba.