### PR TITLE
Add entity validation for clickhouse functions names

### DIFF
--- a/snuba/datasets/entity.py
+++ b/snuba/datasets/entity.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional, Sequence
+from typing import Mapping, Optional, Sequence, Set
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
@@ -7,6 +7,7 @@ from snuba.datasets.storage import Storage, WritableTableStorage
 from snuba.pipeline.query_pipeline import QueryPipelineBuilder
 from snuba.query.data_source.join import JoinRelationship
 from snuba.query.extensions import QueryExtension
+from snuba.query.functions import GLOBAL_VALID_FUNCTIONS
 from snuba.query.processors import QueryProcessor
 from snuba.query.validation import FunctionCallValidator
 from snuba.query.validation.validators import QueryValidator
@@ -91,6 +92,13 @@ class Entity(Describable, ABC):
         It is not supposed to be used during query processing.
         """
         return self.__storages
+
+    def get_valid_functions(self) -> Set[str]:
+        """
+        Returns valid functions names for an entity.
+        Defaults to set of functions that are valid for every entity.
+        """
+        return GLOBAL_VALID_FUNCTIONS
 
     def get_function_call_validators(self) -> Mapping[str, FunctionCallValidator]:
         """

--- a/snuba/query/functions.py
+++ b/snuba/query/functions.py
@@ -102,3 +102,27 @@ AGGREGATION_FUNCTIONS = {
 
 def is_aggregation_function(func_name: str) -> bool:
     return func_name in AGGREGATION_FUNCTIONS
+
+
+# Categorized based on ClickHouse docs
+# https://clickhouse.tech/docs/en/sql-reference/functions/
+REGULAR_FUNCTIONS = {
+    # arithmetic
+    "plus",
+    "minus",
+    "multiply",
+    "divide",
+    # comparison
+    "equals",
+    "notEquals",
+    "less",
+    "greater",
+    "lessOrEquals",
+    "greaterOrEquals",
+    # logical
+    "and",
+    "or",
+    "not",
+}
+
+GLOBAL_VALID_FUNCTIONS = set() | REGULAR_FUNCTIONS | AGGREGATION_FUNCTIONS


### PR DESCRIPTION
**Current Function Validation Status:**
when a snql query comes to snuba, it goes through a lot of processing that happens in [`parse_snql_query`](https://github.com/getsentry/snuba/blob/master/snuba/query/snql/parser.py#L1295). This is done as a series of calls to [`_post_process`](https://github.com/getsentry/snuba/blob/master/snuba/query/snql/parser.py#L1266), with different processors being passed as an argument - last of which are the `VALIDATORS`.
(`VALIDATORS` is a list of two functions: `validate_query` and `validate_entities_with_query`)
https://github.com/getsentry/snuba/blob/6bc208abe7b1d05023e9af1922628bed87c8a84b/snuba/query/snql/parser.py#L1318-L1319 

The `validate_query` function is what ultimately calls the `FunctionCallsValidator`. And since `_post_process` gets called recursively, this function does.
https://github.com/getsentry/snuba/blob/6bc208abe7b1d05023e9af1922628bed87c8a84b/snuba/query/parser/validation/__init__.py#L29-L39

> **what _currently_ gets validated ?**
Well in theory each entity could have its own function validators that come from [`get_function_call_validators`](https://github.com/getsentry/snuba/blob/08cd891055c736fa964bf6f1c510004048e74e9f/snuba/datasets/entity.py#L95), but afaict this always returns `{}`. So instead we are left with just two [`default_validators`](https://github.com/getsentry/snuba/blob/08cd891055c736fa964bf6f1c510004048e74e9f/snuba/datasets/entity.py#L95). However, these validators are for validating that the function is well formed. There is no validation if the function should be allowed or not.

**Problem**
Because we are not really validating any functions beyond the two specified in the `default_validators`, it's possible that any ClickHouse function could be used, which is not great for security reasons. ClickHouse has a lot of functions (categorized in 'regular' [functions](https://github.com/getsentry/snuba/blob/08cd891055c736fa964bf6f1c510004048e74e9f/snuba/datasets/entity.py#L95), [aggregate functions](https://clickhouse.tech/docs/en/sql-reference/aggregate-functions/) and [table functions](https://clickhouse.tech/docs/en/sql-reference/table-functions/)) 

**Goal for This PR**
We want to have basically an allow list of valid functions for entities that we can check against to make sure no one is using something we don't want. Easier to add incrementally to an allowed/valid list versus having to keep up with a deny list if ClickHouse introduces a new table function, for example.