### PR TITLE
fix(join) Fix case when an expression has multiple columns

### DIFF
--- a/snuba/query/joins/classifier.py
+++ b/snuba/query/joins/classifier.py
@@ -184,7 +184,9 @@ def _merge_and_cut(
         cut = v.cut_branch(alias_generator)
         parameters.append(cut.main_expression)
         for entity, branches in cut.cut_branches.items():
-            cut_branches.setdefault(entity, branches).add(*branches)
+            branch_set = cut_branches.setdefault(entity, branches)
+            branch_set |= branches
+
     return MainQueryExpression(builder(parameters), cut_branches)
 
 

--- a/tests/query/joins/test_branch_cutter.py
+++ b/tests/query/joins/test_branch_cutter.py
@@ -1,5 +1,7 @@
-import pytest
 from typing import Generator
+
+import pytest
+
 from snuba.query.expressions import (
     Column,
     CurriedFunctionCall,
@@ -506,6 +508,223 @@ TEST_CASES = [
             },
         ),
         id="Aggregation function that contains a function that is mixed",
+    ),
+    pytest.param(
+        FunctionCall(
+            "_snuba_toUInt64",
+            "toUInt64",
+            (
+                FunctionCall(
+                    "_snuba_plus",
+                    "plus",
+                    (
+                        FunctionCall(
+                            "_snuba_multiply",
+                            "multiply",
+                            (
+                                FunctionCall(
+                                    "_snuba_log",
+                                    "log",
+                                    (
+                                        FunctionCall(
+                                            "_snuba_count",
+                                            "count",
+                                            (
+                                                Column(
+                                                    "_snuba_events.group_id",
+                                                    "events",
+                                                    "group_id",
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                Literal(None, 600),
+                            ),
+                        ),
+                        FunctionCall(
+                            "_snuba_multiply",
+                            "multiply",
+                            (
+                                FunctionCall(
+                                    "_snuba_toUInt64",
+                                    "toUInt64",
+                                    (
+                                        FunctionCall(
+                                            "_snuba_toUInt64",
+                                            "toUInt64",
+                                            (
+                                                FunctionCall(
+                                                    "_snuba_max",
+                                                    "max",
+                                                    (
+                                                        Column(
+                                                            "_snuba_events.timestamp",
+                                                            "events",
+                                                            "timestamp",
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                                Literal(None, 1000),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        MainQueryExpression(
+            FunctionCall(
+                "_snuba_toUInt64",
+                "toUInt64",
+                (
+                    FunctionCall(
+                        "_snuba_plus",
+                        "plus",
+                        (
+                            FunctionCall(
+                                "_snuba_multiply",
+                                "multiply",
+                                (
+                                    FunctionCall(
+                                        "_snuba_log",
+                                        "log",
+                                        (
+                                            FunctionCall(
+                                                "_snuba_count",
+                                                "count",
+                                                (
+                                                    Column(
+                                                        "_snuba_events.group_id",
+                                                        "events",
+                                                        "_snuba_events.group_id",
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                    Literal(None, 600),
+                                ),
+                            ),
+                            FunctionCall(
+                                "_snuba_multiply",
+                                "multiply",
+                                (
+                                    FunctionCall(
+                                        "_snuba_toUInt64",
+                                        "toUInt64",
+                                        (
+                                            FunctionCall(
+                                                "_snuba_toUInt64",
+                                                "toUInt64",
+                                                (
+                                                    FunctionCall(
+                                                        "_snuba_max",
+                                                        "max",
+                                                        (
+                                                            Column(
+                                                                "_snuba_events.timestamp",
+                                                                "events",
+                                                                "_snuba_events.timestamp",
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                    Literal(None, 1000),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            {
+                "events": {
+                    Column("_snuba_events.timestamp", None, "timestamp"),
+                    Column("_snuba_events.group_id", None, "group_id"),
+                }
+            },
+        ),
+        MainQueryExpression(
+            FunctionCall(
+                "_snuba_toUInt64",
+                "toUInt64",
+                (
+                    FunctionCall(
+                        "_snuba_plus",
+                        "plus",
+                        (
+                            FunctionCall(
+                                "_snuba_multiply",
+                                "multiply",
+                                (
+                                    FunctionCall(
+                                        "_snuba_log",
+                                        "log",
+                                        (
+                                            FunctionCall(
+                                                "_snuba_count",
+                                                "count",
+                                                (
+                                                    Column(
+                                                        "_snuba_events.group_id",
+                                                        "events",
+                                                        "_snuba_events.group_id",
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                    Literal(None, 600),
+                                ),
+                            ),
+                            FunctionCall(
+                                "_snuba_multiply",
+                                "multiply",
+                                (
+                                    FunctionCall(
+                                        "_snuba_toUInt64",
+                                        "toUInt64",
+                                        (
+                                            FunctionCall(
+                                                "_snuba_toUInt64",
+                                                "toUInt64",
+                                                (
+                                                    FunctionCall(
+                                                        "_snuba_max",
+                                                        "max",
+                                                        (
+                                                            Column(
+                                                                "_snuba_events.timestamp",
+                                                                "events",
+                                                                "_snuba_events.timestamp",
+                                                            ),
+                                                        ),
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                    Literal(None, 1000),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            cut_branches={
+                "events": {
+                    Column("_snuba_events.group_id", None, "group_id",),
+                    Column("_snuba_events.timestamp", None, "timestamp",),
+                }
+            },
+        ),
+        id="Nested aggregation function that contains a function that is mixed",
     ),
 ]
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -510,3 +510,23 @@ class TestSnQLApi(BaseApiTest):
         )
 
         assert response.status_code == 200
+
+    def test_complex_table_join(self) -> None:
+        response = self.post(
+            "/events/snql",
+            data=json.dumps(
+                {
+                    "query": f"""
+                    MATCH (e: events) -[grouped]-> (g: groupedmessage)
+                    SELECT g.id, toUInt64(plus(multiply(log(count(e.group_id)), 600), multiply(toUInt64(toUInt64(max(e.timestamp))), 1000))) AS score BY g.id
+                    WHERE e.project_id IN array({self.project_id}) AND e.timestamp >= toDateTime('2021-07-04T01:09:08.188427') AND e.timestamp < toDateTime('2021-08-06T01:10:09.411889') AND g.status IN array(0)
+                    ORDER BY toUInt64(plus(multiply(log(count(e.group_id)), 600), multiply(toUInt64(toUInt64(max(e.timestamp))), 1000))) DESC LIMIT 101
+                    """,
+                    "turbo": False,
+                    "consistent": False,
+                    "debug": True,
+                }
+            ),
+        )
+
+        assert response.status_code == 200


### PR DESCRIPTION
If an expression that needed to be moved to a branch involved two different
columns it would cause an error.