### PR TITLE
fix: Handle multiple condition case in empty tag condition

### DIFF
--- a/snuba/query/processors/empty_tag_condition_processor.py
+++ b/snuba/query/processors/empty_tag_condition_processor.py
@@ -50,6 +50,12 @@ class EmptyTagConditionProcessor(QueryProcessor):
                     if exp.function_name == ConditionFunctions.EQ:
                         replacement = FunctionCall(exp.alias, "not", (replacement,))
 
+                    prev_value = query.get_experiment_value(
+                        "empty-string-tag-condition"
+                    )
+                    if prev_value is not None:
+                        return replacement if prev_value == "true" else exp
+
                     if settings.TESTING or random.random() < 0.5:
                         query.add_experiment("empty-string-tag-condition", "true")
                         return replacement


### PR DESCRIPTION
We weren't checking if a query had multiple empty tag conditions. If that happened, we would potentially only optimize some of the conditions, and randomly assign an experiment value to the partially optimized query. This ensures that we either optimize the entire query or none of it.

Since we weren't checking this, some queries might be partially optimized and then randomly attributed. That might explain some of the inconsistent results in the analysis.