### PR TITLE
feat: add anonymized clickhouse query sql to querylog

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -39,14 +39,14 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
     """
 
     def __init__(self, parsing_context: Optional[ParsingContext] = None) -> None:
-        self.__parsing_context = (
+        self._parsing_context = (
             parsing_context if parsing_context is not None else ParsingContext()
         )
 
-    def __alias(self, formatted_exp: str, alias: Optional[str]) -> str:
+    def _alias(self, formatted_exp: str, alias: Optional[str]) -> str:
         if not alias:
             return formatted_exp
-        elif self.__parsing_context.is_alias_present(alias):
+        elif self._parsing_context.is_alias_present(alias):
             ret = escape_alias(alias)
             # This is for the type checker. escape_alias can return None if
             # we pass None. But here we do not pass None so a None return value
@@ -54,27 +54,27 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             assert ret is not None
             return ret
         else:
-            self.__parsing_context.add_alias(alias)
+            self._parsing_context.add_alias(alias)
             return f"({formatted_exp} AS {escape_alias(alias)})"
 
     def visit_literal(self, exp: Literal) -> str:
         if exp.value is None:
-            return self.__alias("NULL", exp.alias)
+            return self._alias("NULL", exp.alias)
         elif exp.value is True:
-            return self.__alias("true", exp.alias)
+            return self._alias("true", exp.alias)
         elif exp.value is False:
-            return self.__alias("false", exp.alias)
+            return self._alias("false", exp.alias)
         elif isinstance(exp.value, str):
-            return self.__alias(escape_string(exp.value), exp.alias)
+            return self._alias(escape_string(exp.value), exp.alias)
         elif isinstance(exp.value, (int, float)):
-            return self.__alias(str(exp.value), exp.alias)
+            return self._alias(str(exp.value), exp.alias)
         elif isinstance(exp.value, datetime):
             value = exp.value.replace(tzinfo=None, microsecond=0)
-            return self.__alias(
+            return self._alias(
                 "toDateTime('{}', 'Universal')".format(value.isoformat()), exp.alias
             )
         elif isinstance(exp.value, date):
-            return self.__alias(
+            return self._alias(
                 "toDate('{}', 'Universal')".format(exp.value.isoformat()), exp.alias
             )
         else:
@@ -101,7 +101,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         # This happens often since we apply column aliases during
         # parsing so the names are preserved during query processing.
         if exp.alias != "".join(ret_unescaped):
-            return self.__alias("".join(ret), exp.alias)
+            return self._alias("".join(ret), exp.alias)
         else:
             return "".join(ret)
 
@@ -123,7 +123,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             # Workaround for https://github.com/ClickHouse/ClickHouse/issues/11622
             # Some distributed queries fail when arrays are passed as array(1,2,3)
             # and work when they are passed as [1, 2, 3]
-            return self.__alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
+            return self._alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
 
         elif exp.function_name == BooleanFunctions.AND:
             formatted = (c.accept(self) for c in get_first_level_and_conditions(exp))
@@ -134,12 +134,12 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             return f"({' OR '.join(formatted)})"
 
         ret = f"{escape_identifier(exp.function_name)}({self.__visit_params(exp.parameters)})"
-        return self.__alias(ret, exp.alias)
+        return self._alias(ret, exp.alias)
 
     def visit_curried_function_call(self, exp: CurriedFunctionCall) -> str:
         int_func = exp.internal_function.accept(self)
         ret = f"{int_func}({self.__visit_params(exp.parameters)})"
-        return self.__alias(ret, exp.alias)
+        return self._alias(ret, exp.alias)
 
     def __escape_identifier_enforce(self, expr: str) -> str:
         ret = escape_identifier(expr)
@@ -154,4 +154,34 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
     def visit_lambda(self, exp: Lambda) -> str:
         parameters = [self.__escape_identifier_enforce(v) for v in exp.parameters]
         ret = f"({', '.join(parameters)} -> {exp.transformation.accept(self)})"
-        return self.__alias(ret, exp.alias)
+        return self._alias(ret, exp.alias)
+
+
+class ClickHouseExpressionFormatterAnonymized(ClickhouseExpressionFormatter):
+    """
+    This Formatter strips string and integer literals and replaces them with a
+    a token representing the type of literal. All other behavior is the same.
+    """
+
+    def visit_literal(self, exp: Literal) -> str:
+        if exp.value is None:
+            return self._alias("NULL", exp.alias)
+        elif exp.value is True:
+            return self._alias("true", exp.alias)
+        elif exp.value is False:
+            return self._alias("false", exp.alias)
+        elif isinstance(exp.value, str):
+            return "$S"
+        elif isinstance(exp.value, (int, float)):
+            return "$I"
+        elif isinstance(exp.value, datetime):
+            value = exp.value.replace(tzinfo=None, microsecond=0)
+            return self._alias(
+                "toDateTime('{}', 'Universal')".format(value.isoformat()), exp.alias
+            )
+        elif isinstance(exp.value, date):
+            return self._alias(
+                "toDate('{}', 'Universal')".format(exp.value.isoformat()), exp.alias
+            )
+        else:
+            raise ValueError(f"Unexpected literal type {type(exp.value)}")

--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -218,4 +218,4 @@ class ClickHouseExpressionFormatterAnonymized(ClickhouseExpressionFormatterBase)
         return "$DT"
 
     def _format_date_literal(self, exp: Literal) -> str:
-        return "$DT"
+        return "$D"

--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from datetime import date, datetime
 from typing import Optional, Sequence, cast
 
@@ -21,7 +22,7 @@ from snuba.query.expressions import (
 from snuba.query.parsing import ParsingContext
 
 
-class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
+class ClickhouseExpressionFormatterBase(ExpressionVisitor[str], ABC):
     """
     This Visitor implementation is able to format one expression in the Snuba
     Query for Clickhouse.
@@ -31,11 +32,6 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
 
     When passing an instance of this class to the accept method of
     the visited expression, the return value is the formatted string.
-
-    This Formatter produces a properly escaped string. The result should never
-    be further escaped. This should be the only place where expression
-    escaping happens as it is done by each method that formats a specific
-    type of expression.
     """
 
     def __init__(self, parsing_context: Optional[ParsingContext] = None) -> None:
@@ -43,7 +39,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             parsing_context if parsing_context is not None else ParsingContext()
         )
 
-    def __alias(self, formatted_exp: str, alias: Optional[str]) -> str:
+    def _alias(self, formatted_exp: str, alias: Optional[str]) -> str:
         if not alias:
             return formatted_exp
         elif self.__parsing_context.is_alias_present(alias):
@@ -57,32 +53,39 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             self.__parsing_context.add_alias(alias)
             return f"({formatted_exp} AS {escape_alias(alias)})"
 
+    @abstractmethod
     def _format_string_literal(self, exp: Literal) -> str:
-        return self.__alias(escape_string(cast(str, exp.value)), exp.alias)
+        raise NotImplementedError
 
+    @abstractmethod
     def _format_number_literal(self, exp: Literal) -> str:
-        return self.__alias(str(exp.value), exp.alias)
+        raise NotImplementedError
+
+    @abstractmethod
+    def _format_boolean_literal(self, exp: Literal) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _format_datetime_literal(self, exp: Literal) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _format_date_literal(self, exp: Literal) -> str:
+        raise NotImplementedError
 
     def visit_literal(self, exp: Literal) -> str:
         if exp.value is None:
-            return self.__alias("NULL", exp.alias)
-        elif exp.value is True:
-            return self.__alias("true", exp.alias)
-        elif exp.value is False:
-            return self.__alias("false", exp.alias)
+            return self._alias("NULL", exp.alias)
+        if isinstance(exp.value, bool):
+            return self._format_boolean_literal(exp)
         elif isinstance(exp.value, str):
             return self._format_string_literal(exp)
         elif isinstance(exp.value, (int, float)):
             return self._format_number_literal(exp)
         elif isinstance(exp.value, datetime):
-            value = exp.value.replace(tzinfo=None, microsecond=0)
-            return self.__alias(
-                "toDateTime('{}', 'Universal')".format(value.isoformat()), exp.alias
-            )
+            return self._format_datetime_literal(exp)
         elif isinstance(exp.value, date):
-            return self.__alias(
-                "toDate('{}', 'Universal')".format(exp.value.isoformat()), exp.alias
-            )
+            return self._format_date_literal(exp)
         else:
             raise ValueError(f"Unexpected literal type {type(exp.value)}")
 
@@ -107,7 +110,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
         # This happens often since we apply column aliases during
         # parsing so the names are preserved during query processing.
         if exp.alias != "".join(ret_unescaped):
-            return self.__alias("".join(ret), exp.alias)
+            return self._alias("".join(ret), exp.alias)
         else:
             return "".join(ret)
 
@@ -129,7 +132,7 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             # Workaround for https://github.com/ClickHouse/ClickHouse/issues/11622
             # Some distributed queries fail when arrays are passed as array(1,2,3)
             # and work when they are passed as [1, 2, 3]
-            return self.__alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
+            return self._alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
 
         elif exp.function_name == BooleanFunctions.AND:
             formatted = (c.accept(self) for c in get_first_level_and_conditions(exp))
@@ -140,12 +143,12 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
             return f"({' OR '.join(formatted)})"
 
         ret = f"{escape_identifier(exp.function_name)}({self.__visit_params(exp.parameters)})"
-        return self.__alias(ret, exp.alias)
+        return self._alias(ret, exp.alias)
 
     def visit_curried_function_call(self, exp: CurriedFunctionCall) -> str:
         int_func = exp.internal_function.accept(self)
         ret = f"{int_func}({self.__visit_params(exp.parameters)})"
-        return self.__alias(ret, exp.alias)
+        return self._alias(ret, exp.alias)
 
     def __escape_identifier_enforce(self, expr: str) -> str:
         ret = escape_identifier(expr)
@@ -160,10 +163,43 @@ class ClickhouseExpressionFormatter(ExpressionVisitor[str]):
     def visit_lambda(self, exp: Lambda) -> str:
         parameters = [self.__escape_identifier_enforce(v) for v in exp.parameters]
         ret = f"({', '.join(parameters)} -> {exp.transformation.accept(self)})"
-        return self.__alias(ret, exp.alias)
+        return self._alias(ret, exp.alias)
 
 
-class ClickHouseExpressionFormatterAnonymized(ClickhouseExpressionFormatter):
+class ClickhouseExpressionFormatter(ClickhouseExpressionFormatterBase):
+    """
+    This Formatter produces a properly escaped string. The result should never
+    be further escaped. This should be the only place where expression
+    escaping happens as it is done by each method that formats a specific
+    type of expression.
+    """
+
+    def _format_string_literal(self, exp: Literal) -> str:
+        return self._alias(escape_string(cast(str, exp.value)), exp.alias)
+
+    def _format_number_literal(self, exp: Literal) -> str:
+        return self._alias(str(exp.value), exp.alias)
+
+    def _format_boolean_literal(self, exp: Literal) -> str:
+        if exp.value is True:
+            return self._alias("true", exp.alias)
+
+        return self._alias("false", exp.alias)
+
+    def _format_datetime_literal(self, exp: Literal) -> str:
+        value = cast(datetime, exp.value).replace(tzinfo=None, microsecond=0)
+        return self._alias(
+            "toDateTime('{}', 'Universal')".format(value.isoformat()), exp.alias
+        )
+
+    def _format_date_literal(self, exp: Literal) -> str:
+        return self._alias(
+            "toDate('{}', 'Universal')".format(cast(date, exp.value).isoformat()),
+            exp.alias,
+        )
+
+
+class ClickHouseExpressionFormatterAnonymized(ClickhouseExpressionFormatterBase):
     """
     This Formatter strips string and integer literals and replaces them with a
     a token representing the type of literal.
@@ -173,4 +209,13 @@ class ClickHouseExpressionFormatterAnonymized(ClickhouseExpressionFormatter):
         return "$S"
 
     def _format_number_literal(self, exp: Literal) -> str:
-        return "$I"
+        return "$N"
+
+    def _format_boolean_literal(self, exp: Literal) -> str:
+        return "$B"
+
+    def _format_datetime_literal(self, exp: Literal) -> str:
+        return "$DT"
+
+    def _format_date_literal(self, exp: Literal) -> str:
+        return "$DT"

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -65,6 +65,7 @@ class ClickhouseQueryProfile:
 @dataclass(frozen=True)
 class ClickhouseQueryMetadata:
     sql: str
+    sql_anonymized: str
     stats: Mapping[str, Any]
     status: QueryStatus
     profile: ClickhouseQueryProfile
@@ -73,6 +74,7 @@ class ClickhouseQueryMetadata:
     def to_dict(self) -> Mapping[str, Any]:
         return {
             "sql": self.sql,
+            "sql_anonymized": self.sql_anonymized,
             "stats": self.stats,
             "status": self.status.value,
             "trace_id": self.trace_id,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -153,7 +153,6 @@ class ReferencedColumnsCounter(
 def update_query_metadata_and_stats(
     query: Query,
     sql: str,
-    sql_anonymized: str,
     timer: Timer,
     stats: MutableMapping[str, Any],
     query_metadata: SnubaQueryMetadata,
@@ -167,6 +166,7 @@ def update_query_metadata_and_stats(
     Also updates stats with any relevant information and returns the updated dict.
     """
     stats.update(query_settings)
+    sql_anonymized = format_query_anonymized(query).get_sql()
 
     query_metadata.query_list.append(
         ClickhouseQueryMetadata(
@@ -427,13 +427,11 @@ def raw_query(
     timer.mark("get_configs")
 
     sql = formatted_query.get_sql()
-    sql_anonymized = format_query_anonymized(clickhouse_query).get_sql()
 
     update_with_status = partial(
         update_query_metadata_and_stats,
         clickhouse_query,
         sql,
-        sql_anonymized,
         timer,
         stats,
         query_metadata,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -15,6 +15,7 @@ from sentry_sdk.api import configure_scope
 from snuba import environment, settings, state
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
+from snuba.clickhouse.formatter.query import format_query_anonymized
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_profiler import generate_profile
 from snuba.query import ProcessableQuery
@@ -403,7 +404,6 @@ def raw_query(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
     request_settings: RequestSettings,
     formatted_query: FormattedQuery,
-    formatted_query_anonymized: FormattedQuery,
     reader: Reader,
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
@@ -427,7 +427,7 @@ def raw_query(
     timer.mark("get_configs")
 
     sql = formatted_query.get_sql()
-    sql_anonymized = formatted_query_anonymized.get_sql()
+    sql_anonymized = format_query_anonymized(clickhouse_query).get_sql()
 
     update_with_status = partial(
         update_query_metadata_and_stats,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -152,6 +152,7 @@ class ReferencedColumnsCounter(
 def update_query_metadata_and_stats(
     query: Query,
     sql: str,
+    sql_anonymized: str,
     timer: Timer,
     stats: MutableMapping[str, Any],
     query_metadata: SnubaQueryMetadata,
@@ -169,6 +170,7 @@ def update_query_metadata_and_stats(
     query_metadata.query_list.append(
         ClickhouseQueryMetadata(
             sql=sql,
+            sql_anonymized=sql_anonymized,
             stats=stats,
             status=status,
             profile=generate_profile(query),
@@ -401,6 +403,7 @@ def raw_query(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
     request_settings: RequestSettings,
     formatted_query: FormattedQuery,
+    formatted_query_anonymized: FormattedQuery,
     reader: Reader,
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
@@ -424,11 +427,13 @@ def raw_query(
     timer.mark("get_configs")
 
     sql = formatted_query.get_sql()
+    sql_anonymized = formatted_query_anonymized.get_sql()
 
     update_with_status = partial(
         update_query_metadata_and_stats,
         clickhouse_query,
         sql,
+        sql_anonymized,
         timer,
         stats,
         query_metadata,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import replace
 from functools import partial
 from math import floor
 from typing import MutableMapping, Optional, Union
@@ -6,7 +7,8 @@ from typing import MutableMapping, Optional, Union
 import sentry_sdk
 
 from snuba import environment
-from snuba.clickhouse.formatter.query import format_query
+from snuba import settings as snuba_settings
+from snuba.clickhouse.formatter.query import format_query, format_query_anonymized
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_inspector import TablesCollector
 from snuba.datasets.dataset import Dataset
@@ -145,7 +147,7 @@ def _dry_run_query_runner(
     reader: Reader,
 ) -> QueryResult:
     with sentry_sdk.start_span(description="dryrun_create_query", op="db") as span:
-        formatted_query = format_query(clickhouse_query, request_settings)
+        formatted_query = format_query(clickhouse_query)
         span.set_data("query", formatted_query.structured())
 
     return QueryResult(
@@ -237,7 +239,10 @@ def _format_storage_query_and_run(
     visitor.visit(from_clause)
     table_names = ",".join(sorted(visitor.get_tables()))
     with sentry_sdk.start_span(description="create_query", op="db") as span:
-        formatted_query = format_query(clickhouse_query, request_settings)
+        _apply_turbo_sampling_if_needed(clickhouse_query, request_settings)
+
+        formatted_query = format_query(clickhouse_query)
+        formatted_query_anonymized = format_query_anonymized(clickhouse_query)
         span.set_data("query", formatted_query.structured())
         span.set_data(
             "query_size_bytes", _string_size_in_bytes(formatted_query.get_sql())
@@ -264,6 +269,7 @@ def _format_storage_query_and_run(
                 clickhouse_query,
                 request_settings,
                 formatted_query,
+                formatted_query_anonymized,
                 reader,
                 timer,
                 query_metadata,
@@ -302,3 +308,20 @@ def get_query_size_group(formatted_query: str) -> str:
 
 def _string_size_in_bytes(s: str) -> int:
     return len(s.encode("utf-8"))
+
+
+def _apply_turbo_sampling_if_needed(
+    clickhouse_query: Union[Query, CompositeQuery[Table]],
+    request_settings: RequestSettings,
+) -> None:
+    if isinstance(clickhouse_query, Query):
+        if (
+            request_settings.get_turbo()
+            and not clickhouse_query.get_from_clause().sampling_rate
+        ):
+            clickhouse_query.set_from_clause(
+                replace(
+                    clickhouse_query.get_from_clause(),
+                    sampling_rate=snuba_settings.TURBO_SAMPLE_RATE,
+                )
+            )

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -8,7 +8,7 @@ import sentry_sdk
 
 from snuba import environment
 from snuba import settings as snuba_settings
-from snuba.clickhouse.formatter.query import format_query, format_query_anonymized
+from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_inspector import TablesCollector
 from snuba.datasets.dataset import Dataset
@@ -242,7 +242,6 @@ def _format_storage_query_and_run(
         _apply_turbo_sampling_if_needed(clickhouse_query, request_settings)
 
         formatted_query = format_query(clickhouse_query)
-        formatted_query_anonymized = format_query_anonymized(clickhouse_query)
         span.set_data("query", formatted_query.structured())
         span.set_data(
             "query_size_bytes", _string_size_in_bytes(formatted_query.get_sql())
@@ -269,7 +268,6 @@ def _format_storage_query_and_run(
                 clickhouse_query,
                 request_settings,
                 formatted_query,
-                formatted_query_anonymized,
                 reader,
                 timer,
                 query_metadata,
@@ -314,6 +312,10 @@ def _apply_turbo_sampling_if_needed(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
     request_settings: RequestSettings,
 ) -> None:
+    """
+    TODO: Remove this method entirely and move the sampling logic
+    into a query processor.
+    """
     if isinstance(clickhouse_query, Query):
         if (
             request_settings.get_turbo()

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -5,7 +5,6 @@ from snuba.query import LimitBy, OrderBy, OrderByDirection, SelectedExpression
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Literal
-from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_format_clickhouse_specific_query() -> None:
@@ -35,8 +34,7 @@ def test_format_clickhouse_specific_query() -> None:
     query.set_offset(50)
     query.set_limit(100)
 
-    request_settings = HTTPRequestSettings()
-    clickhouse_query = format_query(query, request_settings)
+    clickhouse_query = format_query(query)
 
     expected = [
         "SELECT column1, table1.column2",

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -53,6 +53,7 @@ def test_simple() -> None:
         query_list=[
             ClickhouseQueryMetadata(
                 sql="select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100",
+                sql_anonymized="select event_id from sentry_dist sample 0.1 prewhere project_id in ($I) limit 50, 100",
                 stats={"sample": 10},
                 status=QueryStatus.SUCCESS,
                 profile=ClickhouseQueryProfile(
@@ -150,6 +151,7 @@ def test_missing_fields() -> None:
         query_list=[
             ClickhouseQueryMetadata(
                 sql="select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100",
+                sql_anonymized="select event_id from sentry_dist sample 0.1 prewhere project_id in ($I) limit 50, 100",
                 stats={"sample": 10},
                 status=QueryStatus.SUCCESS,
                 profile=ClickhouseQueryProfile(

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -412,7 +412,7 @@ def test_aliasing() -> None:
             "conditions": [["tags_key", "IN", ["t1", "t2"]]],
         }
     )
-    sql = format_query(processed, HTTPRequestSettings()).get_sql()
+    sql = format_query(processed).get_sql()
     transactions_table_name = (
         transactions_storage.get_table_writer().get_schema().get_table_name()
     )


### PR DESCRIPTION
Hackweek: We'd like to store clickhouse queries in bigquery for analysis, but right now there is a problem of potential PII in the queries. This PR adds a new formatter that strips queries of these literals and adds the new formatted sql to the querylog.


- Adds a new Expression Formatter that removes literal strings and integers
- Adds a new field sql_anonymized to ClickHouseQueryMetadata for sending to querylog
- Moves a bit of code around to facilitate specifying the expression formatter in formatter/query.py