### PR TITLE
fix(concurrency) Add table rate limiter to partition the quota

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -28,6 +28,7 @@ from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.slice_of_map_optimizer import SliceOfMapOptimizer
+from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.query.processors.type_converters.uuid_array_column_processor import (
     UUIDArrayColumnProcessor,
 )
@@ -177,6 +178,7 @@ query_processors = [
         # merged together by the final.
         omit_if_final=["environment", "release", "group_id"],
     ),
+    TableRateLimit(),
 ]
 
 query_splitters = [

--- a/snuba/query/processors/table_rate_limit.py
+++ b/snuba/query/processors/table_rate_limit.py
@@ -1,0 +1,30 @@
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.request.request_settings import RequestSettings
+from snuba.state import get_configs
+from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitParameters
+
+
+class TableRateLimit(QueryProcessor):
+    """
+    Set a rate limiter for individual tables.
+    TODO: Do this at Cluster level instead.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        table_name = query.get_from_clause().table_name
+        (per_second, concurr) = get_configs(
+            [
+                (f"table_per_second_limit_{table_name}", 1000),
+                (f"table_concurrent_limit_{table_name}", 1000),
+            ]
+        )
+
+        rate_limit = RateLimitParameters(
+            rate_limit_name=TABLE_RATE_LIMIT_NAME,
+            bucket=table_name,
+            per_second_limit=per_second,
+            concurrent_limit=concurr,
+        )
+
+        request_settings.add_rate_limit(rate_limit)

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -15,6 +15,7 @@ logger = logging.getLogger("snuba.state.rate_limit")
 
 PROJECT_RATE_LIMIT_NAME = "project"
 GLOBAL_RATE_LIMIT_NAME = "global"
+TABLE_RATE_LIMIT_NAME = "table"
 
 
 @dataclass(frozen=True)

--- a/tests/query/processors/test_table_rate_limit.py
+++ b/tests/query/processors/test_table_rate_limit.py
@@ -1,0 +1,49 @@
+import pytest
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.query.data_source.simple import Table
+from snuba.query.processors.table_rate_limit import TableRateLimit
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state import set_config
+from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitParameters
+
+test_data = [
+    pytest.param(
+        Query(
+            Table("errors_local", ColumnSet([])), selected_columns=[], condition=None
+        ),
+        "table_concurrent_limit_transactions_local",
+        RateLimitParameters(
+            rate_limit_name=TABLE_RATE_LIMIT_NAME,
+            bucket="errors_local",
+            per_second_limit=1000,
+            concurrent_limit=1000,
+        ),
+        id="Set rate limiter on another table",
+    ),
+    pytest.param(
+        Query(
+            Table("errors_local", ColumnSet([])), selected_columns=[], condition=None
+        ),
+        "table_concurrent_limit_errors_local",
+        RateLimitParameters(
+            rate_limit_name=TABLE_RATE_LIMIT_NAME,
+            bucket="errors_local",
+            per_second_limit=1000,
+            concurrent_limit=50,
+        ),
+        id="Set rate limiter on another table",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, limit_to_set, params", test_data)
+def test_table_rate_limit(
+    query: Query, limit_to_set: str, params: RateLimitParameters
+) -> None:
+    set_config(limit_to_set, 50)
+    request_settings = HTTPRequestSettings(consistent=True)
+    TableRateLimit().process_query(query, request_settings)
+    rate_limiters = request_settings.get_rate_limit_params()
+    assert params in rate_limiters


### PR DESCRIPTION
Quick measure to limit the concurrency of the consistent queries on the errors table without impacting the rest of snuba which is fine.

This adds a rate limit config per table. It should be per cluster but that would require a larger change. The table is close enough.
So we can set a maximum concurrency per table.
It is applied to errors and errors_ro so far. If it works we can apply this to others but there does not seem to have been the need so far.
