### PR TITLE
fix(rate limiter) Add table rate limiter to every relevant table

### DIFF
--- a/snuba/datasets/storages/outcomes.py
+++ b/snuba/datasets/storages/outcomes.py
@@ -9,6 +9,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.conditions_enforcer import OrgIdEnforcer
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.utils.streams.topics import Topic
 
 WRITE_LOCAL_TABLE_NAME = "outcomes_raw_local"
@@ -84,7 +85,7 @@ raw_storage = WritableTableStorage(
     storage_key=StorageKey.OUTCOMES_RAW,
     storage_set_key=StorageSetKey.OUTCOMES,
     schema=raw_schema,
-    query_processors=[],
+    query_processors=[TableRateLimit()],
     mandatory_condition_checkers=[OrgIdEnforcer()],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=OutcomesProcessor(), default_topic=Topic.OUTCOMES,
@@ -95,6 +96,6 @@ materialized_storage = ReadableTableStorage(
     storage_key=StorageKey.OUTCOMES_HOURLY,
     storage_set_key=StorageSetKey.OUTCOMES,
     schema=read_schema,
-    query_processors=[PrewhereProcessor(["project_id", "org_id"])],
+    query_processors=[PrewhereProcessor(["project_id", "org_id"]), TableRateLimit()],
     mandatory_condition_checkers=[OrgIdEnforcer()],
 )

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -20,6 +20,7 @@ from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.exceptions import ValidationException
 from snuba.query.processors.conditions_enforcer import OrgIdEnforcer, ProjectIdEnforcer
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.request.request_settings import RequestSettings
 from snuba.utils.streams.topics import Topic
 
@@ -118,7 +119,7 @@ raw_storage = WritableTableStorage(
     storage_key=StorageKey.SESSIONS_RAW,
     storage_set_key=StorageSetKey.SESSIONS,
     schema=raw_schema,
-    query_processors=[MinuteResolutionProcessor()],
+    query_processors=[MinuteResolutionProcessor(), TableRateLimit()],
     mandatory_condition_checkers=[OrgIdEnforcer(), ProjectIdEnforcer()],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=SessionsProcessor(), default_topic=Topic.SESSIONS,
@@ -129,7 +130,7 @@ materialized_storage = ReadableTableStorage(
     storage_key=StorageKey.SESSIONS_HOURLY,
     storage_set_key=StorageSetKey.SESSIONS,
     schema=read_schema,
-    query_processors=[PrewhereProcessor(["project_id", "org_id"])],
+    query_processors=[PrewhereProcessor(["project_id", "org_id"]), TableRateLimit()],
     mandatory_condition_checkers=[OrgIdEnforcer(), ProjectIdEnforcer()],
 )
 
@@ -137,6 +138,6 @@ org_materialized_storage = ReadableTableStorage(
     storage_key=StorageKey.ORG_SESSIONS,
     storage_set_key=StorageSetKey.SESSIONS,
     schema=read_schema,
-    query_processors=[PrewhereProcessor(["project_id", "org_id"])],
+    query_processors=[PrewhereProcessor(["project_id", "org_id"]), TableRateLimit()],
     mandatory_condition_checkers=[],
 )

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -28,6 +28,7 @@ from snuba.query.processors.empty_tag_condition_processor import (
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )
@@ -130,6 +131,7 @@ storage = WritableTableStorage(
                 "title",
             ]
         ),
+        TableRateLimit(),
     ],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),


### PR DESCRIPTION
This is still not ideal as it is per table but there are multiple tables per cluster. 
Though better than relying on the global rate limit. 

The next step will be to actually make it parametric so different storages can use the same cluster 