### PR TITLE
fix(querylog) Restore the project id

### DIFF
--- a/snuba/datasets/querylog_processor.py
+++ b/snuba/datasets/querylog_processor.py
@@ -111,16 +111,12 @@ class QuerylogProcessor(MessageProcessor):
     def process_message(
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
     ) -> Optional[ProcessedMessage]:
-        projects = message["request"]["body"].get("project", [])
-        if not isinstance(projects, (list, tuple)):
-            projects = [projects]
-
         processed = {
             "request_id": str(uuid.UUID(message["request"]["id"])),
             "request_body": self.__to_json_string(message["request"]["body"]),
             "referrer": message["request"]["referrer"] or "",
             "dataset": message["dataset"],
-            "projects": projects,
+            "projects": list(message.get("projects", set())),
             # TODO: This column is empty for now, we plan to use it soon as we
             # will start to write org IDs into events and allow querying by org.
             "organization": None,

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -92,6 +92,7 @@ class SnubaQueryMetadata:
     dataset: str
     timer: Timer
     query_list: MutableSequence[ClickhouseQueryMetadata]
+    projects: Set[int]
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -104,6 +105,7 @@ class SnubaQueryMetadata:
             "query_list": [q.to_dict() for q in self.query_list],
             "status": self.status.value,
             "timing": self.timer.for_json(),
+            "projects": self.projects,
         }
 
     @property

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -70,6 +70,7 @@ def test_simple() -> None:
                 trace_id="b" * 32,
             )
         ],
+        projects={2},
     ).to_dict()
 
     processor = (
@@ -88,7 +89,7 @@ def test_simple() -> None:
                 "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
                 "referrer": "search",
                 "dataset": "events",
-                "projects": [1],
+                "projects": [2],
                 "organization": None,
                 "timestamp": timer.for_json()["timestamp"],
                 "duration_ms": 10,
@@ -168,6 +169,7 @@ def test_missing_fields() -> None:
                 trace_id="b" * 32,
             )
         ],
+        projects={2},
     ).to_dict()
 
     messages = []
@@ -197,7 +199,7 @@ def test_missing_fields() -> None:
                     "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
                     "referrer": "search",
                     "dataset": "events",
-                    "projects": [1],
+                    "projects": [2],
                     "organization": None,
                     "clickhouse_queries.sql": [
                         "select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100"

--- a/tests/web/test_project_finder.py
+++ b/tests/web/test_project_finder.py
@@ -1,0 +1,58 @@
+from typing import Set, Union
+
+import pytest
+
+from snuba.clickhouse.columns import UUID, ColumnSet, UInt
+from snuba.datasets.entities import EntityKey
+from snuba.query import SelectedExpression
+from snuba.query.composite import CompositeQuery
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Entity
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.web.query import ProjectsFinder
+
+ERRORS_SCHEMA = ColumnSet(
+    [("event_id", UUID()), ("project_id", UInt(32)), ("group_id", UInt(32))]
+)
+
+
+SIMPLE_QUERY = Query(
+    Entity(EntityKey.ERRORS, ERRORS_SCHEMA),
+    selected_columns=[
+        SelectedExpression("alias", Column("_snuba_project", None, "project_id"),)
+    ],
+    array_join=None,
+    condition=binary_condition(
+        ConditionFunctions.IN,
+        Column("_snuba_project", None, "project_id"),
+        FunctionCall(None, "tuple", (Literal(None, 1), Literal(None, 2))),
+    ),
+)
+
+TEST_CASES = [
+    pytest.param(SIMPLE_QUERY, {1, 2}, id="Simple Query",),
+    pytest.param(
+        CompositeQuery(
+            from_clause=SIMPLE_QUERY,
+            selected_columns=[
+                SelectedExpression(
+                    "alias",
+                    FunctionCall("alias", "something", (Column(None, None, "alias"),)),
+                )
+            ],
+        ),
+        {1, 2},
+        id="Nested query. Project from the inner query",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "query, expected_proj", TEST_CASES,
+)
+def test_count_columns(
+    query: Union[Query, CompositeQuery[Entity]], expected_proj: Set[int],
+) -> None:
+    project_finder = ProjectsFinder()
+    assert project_finder.visit(query) == expected_proj


### PR DESCRIPTION
We lost the project id field with SnQL queries as the projects field in the request object was not there anymore.

This restores it by extracting from the query when the query metadata object is built.
The extraction is done through the `get_object_ids_in_query_ast` within a visitor to deal with nested queries.