### PR TITLE
refactor FunctionCallsValidator and FunctionCallValidator

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -198,7 +198,7 @@ class BaseEventsEntity(Entity, ABC):
             ),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
-            HandledFunctionsProcessor("exception_stacks.mechanism_handled", self),
+            HandledFunctionsProcessor("exception_stacks.mechanism_handled"),
             ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -198,9 +198,7 @@ class BaseEventsEntity(Entity, ABC):
             ),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
-            HandledFunctionsProcessor(
-                "exception_stacks.mechanism_handled", self.get_data_model()
-            ),
+            HandledFunctionsProcessor("exception_stacks.mechanism_handled", self),
             ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -141,8 +141,8 @@ class BaseTransactionsEntity(Entity, ABC):
             ),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
-            apdex_processor(self),
-            failure_rate_processor(self),
+            apdex_processor(),
+            failure_rate_processor(),
             ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -141,8 +141,8 @@ class BaseTransactionsEntity(Entity, ABC):
             ),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
-            apdex_processor(self.get_data_model()),
-            failure_rate_processor(self.get_data_model()),
+            apdex_processor(self),
+            failure_rate_processor(self),
             ProjectRateLimiterProcessor(project_column="project_id"),
         ]
 

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -93,7 +93,7 @@ class FunctionCallsValidator(ExpressionValidator):
             # TODO: Decide whether these validators should exist at the Dataset or Entity level
             validator = validators.get(exp.function_name)
             if validator is not None and entity is not None:
-                validator.validate(exp.parameters, entity)
+                validator.validate(exp.parameters, entity.get_data_model())
         except InvalidFunctionCall as exception:
             raise InvalidExpressionException(
                 exp,

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -103,12 +103,7 @@ class FunctionCallsValidator(ExpressionValidator):
 
         query_entity = QueryEntityFinder().visit(data_source)
 
-        if not query_entity:
-            return
-
         entity = get_entity(query_entity.key)
-        if not entity:
-            return
 
         entity_validators = entity.get_function_call_validators()
 

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -34,7 +34,27 @@ class QueryEntityFinder(
     DataSourceVisitor[QueryEntity, QueryEntity], JoinVisitor[QueryEntity, QueryEntity]
 ):
     """
-    Finds the QueryEntity from the data source.
+    Finds the QueryEntity from the data source. The QueryEntity is passed
+    through to each FunctionCallValidator (singular):
+
+    ```
+        validator.validate(exp.parameters, query_entity)
+    ```
+
+    within the validate function below for the FunctionCallsValidator (plural).
+
+    We don't want a FunctionCallValidator (singular) to depend on the
+    dataset Entity, because of circular dependencies. However, we _need_
+    the Entity in the FunctionCallsValidator (plural) in order to get
+    the entity specific validator instances.
+
+    ```
+        entity.get_function_call_validators()
+    ```
+
+    Hences the reason for having both the QueryEntity and the Entity. :)
+
+
     TODO(meredith): Have this return a list of the QueryEntities instead of
     a single QueryEntity.
     """

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -1,10 +1,9 @@
 import logging
 from collections import ChainMap
-from typing import Mapping, Optional
+from typing import Mapping
 
 from snuba.clickhouse.columns import Array, String
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source import DataSource
@@ -100,7 +99,7 @@ class FunctionCallsValidator(ExpressionValidator):
             return
 
         entity_validators: Mapping[str, FunctionCallValidator] = {}
-        entity: Optional[Entity] = None
+        entity = None
 
         query_entity = QueryEntityFinder().visit(data_source)
 
@@ -128,7 +127,7 @@ class FunctionCallsValidator(ExpressionValidator):
         try:
             # TODO: Decide whether these validators should exist at the Dataset or Entity level
             validator = validators.get(exp.function_name)
-            if validator is not None and entity is not None:
+            if validator is not None:
                 validator.validate(exp.parameters, query_entity)
         except InvalidFunctionCall as exception:
             raise InvalidExpressionException(

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -31,7 +31,7 @@ default_validators: Mapping[str, FunctionCallValidator] = {
 
 class QueryEntityFinder(
     DataSourceVisitor[Optional[QueryEntity], QueryEntity],
-    JoinVisitor[QueryEntity, QueryEntity],
+    JoinVisitor[Optional[QueryEntity], QueryEntity],
 ):
     """
     Finds the QueryEntity from the data source. The QueryEntity is passed
@@ -62,23 +62,29 @@ class QueryEntityFinder(
     def _visit_simple_source(self, data_source: QueryEntity) -> QueryEntity:
         return data_source
 
-    def _visit_join(self, data_source: JoinClause[QueryEntity]) -> QueryEntity:
+    def _visit_join(
+        self, data_source: JoinClause[QueryEntity]
+    ) -> Optional[QueryEntity]:
         return self.visit_join_clause(data_source)
 
     def _visit_simple_query(
         self, data_source: ProcessableQuery[QueryEntity]
-    ) -> QueryEntity:
+    ) -> Optional[QueryEntity]:
         return self.visit(data_source.get_from_clause())
 
-    def _visit_composite_query(self, data_source: CompositeQuery[QueryEntity]) -> None:
+    def _visit_composite_query(
+        self, data_source: CompositeQuery[QueryEntity]
+    ) -> Optional[QueryEntity]:
         return None
 
-    def visit_individual_node(self, node: IndividualNode[QueryEntity]) -> QueryEntity:
+    def visit_individual_node(
+        self, node: IndividualNode[QueryEntity]
+    ) -> Optional[QueryEntity]:
         return self.visit(node.data_source)
 
-    def visit_join_clause(self, node: JoinClause[QueryEntity]) -> QueryEntity:
+    def visit_join_clause(self, node: JoinClause[QueryEntity]) -> Optional[QueryEntity]:
         # Just returns one entity for now, later return both entities
-        return node.left_node.accept(self)
+        return node.right_node.accept(self)
 
 
 class FunctionCallsValidator(ExpressionValidator):

--- a/snuba/query/processors/custom_function.py
+++ b/snuba/query/processors/custom_function.py
@@ -1,7 +1,6 @@
 from dataclasses import replace
 from typing import Any, Mapping, Sequence, Tuple
 
-from snuba.datasets.entity import Entity
 from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
@@ -69,13 +68,8 @@ class CustomFunction(QueryProcessor):
     """
 
     def __init__(
-        self,
-        entity: Entity,
-        name: str,
-        signature: Sequence[Tuple[str, ParamType]],
-        body: Expression,
+        self, name: str, signature: Sequence[Tuple[str, ParamType]], body: Expression,
     ) -> None:
-        self.__entity = entity
         self.__function_name = name
         self.__param_names: Sequence[str] = []
         param_types: Sequence[ParamType] = []
@@ -91,7 +85,9 @@ class CustomFunction(QueryProcessor):
                 and expression.function_name == self.__function_name
             ):
                 try:
-                    self.__validator.validate(expression.parameters, self.__entity)
+                    self.__validator.validate(
+                        expression.parameters, query.get_from_clause().schema
+                    )
                 except InvalidFunctionCall as exception:
                     raise InvalidCustomFunctionCall(
                         expression,

--- a/snuba/query/processors/custom_function.py
+++ b/snuba/query/processors/custom_function.py
@@ -1,7 +1,7 @@
 from dataclasses import replace
 from typing import Any, Mapping, Sequence, Tuple
 
-from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.entity import Entity
 from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
@@ -70,12 +70,12 @@ class CustomFunction(QueryProcessor):
 
     def __init__(
         self,
-        dataset_schema: ColumnSet,
+        entity: Entity,
         name: str,
         signature: Sequence[Tuple[str, ParamType]],
         body: Expression,
     ) -> None:
-        self.__dataset_schema = dataset_schema
+        self.__entity = entity
         self.__function_name = name
         self.__param_names: Sequence[str] = []
         param_types: Sequence[ParamType] = []
@@ -91,9 +91,7 @@ class CustomFunction(QueryProcessor):
                 and expression.function_name == self.__function_name
             ):
                 try:
-                    self.__validator.validate(
-                        expression.parameters, self.__dataset_schema
-                    )
+                    self.__validator.validate(expression.parameters, self.__entity)
                 except InvalidFunctionCall as exception:
                     raise InvalidCustomFunctionCall(
                         expression,

--- a/snuba/query/processors/custom_function.py
+++ b/snuba/query/processors/custom_function.py
@@ -86,7 +86,7 @@ class CustomFunction(QueryProcessor):
             ):
                 try:
                     self.__validator.validate(
-                        expression.parameters, query.get_from_clause().schema
+                        expression.parameters, query.get_from_clause()
                     )
                 except InvalidFunctionCall as exception:
                     raise InvalidCustomFunctionCall(

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -1,4 +1,4 @@
-from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.entity import Entity
 from snuba.query.conditions import (
     BooleanFunctions,
     ConditionFunctions,
@@ -34,14 +34,14 @@ class HandledFunctionsProcessor(QueryProcessor):
     Both functions return 1 or 0 if a row matches.
     """
 
-    def __init__(self, column: str, columnset: ColumnSet):
+    def __init__(self, column: str, entity: Entity):
         self.__column = column
-        self.__columnset = columnset
+        self.__entity = entity
 
     def validate_parameters(self, exp: FunctionCall) -> None:
         validator = SignatureValidator([])
         try:
-            validator.validate(exp.parameters, self.__columnset)
+            validator.validate(exp.parameters, self.__entity)
         except InvalidFunctionCall as err:
             raise InvalidExpressionException(
                 exp,

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -37,10 +37,10 @@ class HandledFunctionsProcessor(QueryProcessor):
     def __init__(self, column: str):
         self.__column = column
 
-    def validate_parameters(self, exp: FunctionCall, schema: QueryEntity) -> None:
+    def validate_parameters(self, exp: FunctionCall, entity: QueryEntity) -> None:
         validator = SignatureValidator([])
         try:
-            validator.validate(exp.parameters, schema)
+            validator.validate(exp.parameters, entity)
         except InvalidFunctionCall as err:
             raise InvalidExpressionException(
                 exp,

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -1,9 +1,9 @@
-from snuba.clickhouse.columns import ColumnSet
 from snuba.query.conditions import (
     BooleanFunctions,
     ConditionFunctions,
     binary_condition,
 )
+from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import (
     Argument,
@@ -37,7 +37,7 @@ class HandledFunctionsProcessor(QueryProcessor):
     def __init__(self, column: str):
         self.__column = column
 
-    def validate_parameters(self, exp: FunctionCall, schema: ColumnSet) -> None:
+    def validate_parameters(self, exp: FunctionCall, schema: QueryEntity) -> None:
         validator = SignatureValidator([])
         try:
             validator.validate(exp.parameters, schema)
@@ -52,7 +52,7 @@ class HandledFunctionsProcessor(QueryProcessor):
         def process_functions(exp: Expression) -> Expression:
             if isinstance(exp, FunctionCall):
                 if exp.function_name == "isHandled":
-                    self.validate_parameters(exp, query.get_from_clause().schema)
+                    self.validate_parameters(exp, query.get_from_clause())
                     return FunctionCall(
                         exp.alias,
                         "arrayExists",
@@ -80,7 +80,7 @@ class HandledFunctionsProcessor(QueryProcessor):
                         ),
                     )
                 if exp.function_name == "notHandled":
-                    self.validate_parameters(exp, query.get_from_clause().schema)
+                    self.validate_parameters(exp, query.get_from_clause())
                     return FunctionCall(
                         exp.alias,
                         "arrayExists",

--- a/snuba/query/processors/performance_expressions.py
+++ b/snuba/query/processors/performance_expressions.py
@@ -1,7 +1,6 @@
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
 from snuba.clickhouse.columns import UInt
-from snuba.datasets.entity import Entity
 from snuba.query.processors.custom_function import (
     CustomFunction,
     partial_function,
@@ -11,9 +10,8 @@ from snuba.query.validation.signature import Column as ColType
 from snuba.query.validation.signature import Literal as LiteralType
 
 
-def apdex_processor(entity: Entity) -> CustomFunction:
+def apdex_processor() -> CustomFunction:
     return CustomFunction(
-        entity,
         "apdex",
         [("column", ColType({UInt})), ("satisfied", LiteralType({int}))],
         simple_function(
@@ -22,9 +20,8 @@ def apdex_processor(entity: Entity) -> CustomFunction:
     )
 
 
-def failure_rate_processor(entity: Entity) -> CustomFunction:
+def failure_rate_processor() -> CustomFunction:
     return CustomFunction(
-        entity,
         "failure_rate",
         [],
         partial_function(

--- a/snuba/query/processors/performance_expressions.py
+++ b/snuba/query/processors/performance_expressions.py
@@ -1,17 +1,19 @@
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
-from snuba.clickhouse.columns import ColumnSet, UInt
-from snuba.query.validation.signature import Column as ColType, Literal as LiteralType
+from snuba.clickhouse.columns import UInt
+from snuba.datasets.entity import Entity
 from snuba.query.processors.custom_function import (
     CustomFunction,
     partial_function,
     simple_function,
 )
+from snuba.query.validation.signature import Column as ColType
+from snuba.query.validation.signature import Literal as LiteralType
 
 
-def apdex_processor(columns: ColumnSet) -> CustomFunction:
+def apdex_processor(entity: Entity) -> CustomFunction:
     return CustomFunction(
-        columns,
+        entity,
         "apdex",
         [("column", ColType({UInt})), ("satisfied", LiteralType({int}))],
         simple_function(
@@ -20,9 +22,9 @@ def apdex_processor(columns: ColumnSet) -> CustomFunction:
     )
 
 
-def failure_rate_processor(columns: ColumnSet) -> CustomFunction:
+def failure_rate_processor(entity: Entity) -> CustomFunction:
     return CustomFunction(
-        columns,
+        entity,
         "failure_rate",
         [],
         partial_function(

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Sequence
 
-from snuba.clickhouse.columns import ColumnSet
+from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Expression
 
 
@@ -17,5 +17,5 @@ class FunctionCallValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, parameters: Sequence[Expression], schema: ColumnSet) -> None:
+    def validate(self, parameters: Sequence[Expression], schema: QueryEntity) -> None:
         raise NotImplementedError

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any, Sequence
+from typing import Sequence
 
+from snuba.clickhouse.columns import ColumnSet
 from snuba.query.expressions import Expression
 
 
@@ -16,5 +17,5 @@ class FunctionCallValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, parameters: Sequence[Expression], schema: Any) -> None:
+    def validate(self, parameters: Sequence[Expression], schema: ColumnSet) -> None:
         raise NotImplementedError

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Sequence
 
-from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.data_source import DataSource
 from snuba.query.expressions import Expression
 
 
@@ -17,5 +17,7 @@ class FunctionCallValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, parameters: Sequence[Expression], entity: QueryEntity) -> None:
+    def validate(
+        self, parameters: Sequence[Expression], data_source: DataSource
+    ) -> None:
         raise NotImplementedError

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Any, Sequence
 
-from snuba.clickhouse.columns import ColumnSet
 from snuba.query.expressions import Expression
 
 
@@ -17,5 +16,5 @@ class FunctionCallValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, parameters: Sequence[Expression], schema: ColumnSet) -> None:
+    def validate(self, parameters: Sequence[Expression], schema: Any) -> None:
         raise NotImplementedError

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -17,5 +17,5 @@ class FunctionCallValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, parameters: Sequence[Expression], schema: QueryEntity) -> None:
+    def validate(self, parameters: Sequence[Expression], entity: QueryEntity) -> None:
         raise NotImplementedError

--- a/snuba/query/validation/signature.py
+++ b/snuba/query/validation/signature.py
@@ -17,7 +17,7 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
-from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.data_source import DataSource
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralType
 from snuba.query.matchers import Any as AnyMatcher
@@ -172,9 +172,11 @@ class SignatureValidator(FunctionCallValidator):
         # exceptions.
         self.__enforce = enforce
 
-    def validate(self, parameters: Sequence[Expression], entity: QueryEntity) -> None:
+    def validate(
+        self, parameters: Sequence[Expression], data_source: DataSource
+    ) -> None:
         try:
-            self.__validate_impl(parameters, entity)
+            self.__validate_impl(parameters, data_source)
         except InvalidFunctionCall as exception:
             if self.__enforce:
                 raise exception
@@ -184,7 +186,7 @@ class SignatureValidator(FunctionCallValidator):
                 )
 
     def __validate_impl(
-        self, parameters: Sequence[Expression], entity: QueryEntity
+        self, parameters: Sequence[Expression], data_source: DataSource
     ) -> None:
         if len(parameters) < len(self.__param_types):
             raise InvalidFunctionCall(
@@ -197,4 +199,4 @@ class SignatureValidator(FunctionCallValidator):
             )
 
         for validator, param in zip(self.__param_types, parameters):
-            validator.validate(param, entity.schema)
+            validator.validate(param, data_source.get_columns())

--- a/snuba/query/validation/signature.py
+++ b/snuba/query/validation/signature.py
@@ -17,6 +17,7 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
+from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralType
 from snuba.query.matchers import Any as AnyMatcher
@@ -171,7 +172,7 @@ class SignatureValidator(FunctionCallValidator):
         # exceptions.
         self.__enforce = enforce
 
-    def validate(self, parameters: Sequence[Expression], schema: ColumnSet) -> None:
+    def validate(self, parameters: Sequence[Expression], schema: QueryEntity) -> None:
         try:
             self.__validate_impl(parameters, schema)
         except InvalidFunctionCall as exception:
@@ -183,7 +184,7 @@ class SignatureValidator(FunctionCallValidator):
                 )
 
     def __validate_impl(
-        self, parameters: Sequence[Expression], schema: ColumnSet
+        self, parameters: Sequence[Expression], schema: QueryEntity
     ) -> None:
         if len(parameters) < len(self.__param_types):
             raise InvalidFunctionCall(
@@ -196,4 +197,4 @@ class SignatureValidator(FunctionCallValidator):
             )
 
         for validator, param in zip(self.__param_types, parameters):
-            validator.validate(param, schema)
+            validator.validate(param, schema.schema)

--- a/snuba/query/validation/signature.py
+++ b/snuba/query/validation/signature.py
@@ -17,6 +17,7 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
+from snuba.datasets.entity import Entity
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralType
 from snuba.query.matchers import Any as AnyMatcher
@@ -171,7 +172,7 @@ class SignatureValidator(FunctionCallValidator):
         # exceptions.
         self.__enforce = enforce
 
-    def validate(self, parameters: Sequence[Expression], schema: ColumnSet) -> None:
+    def validate(self, parameters: Sequence[Expression], schema: Entity) -> None:
         try:
             self.__validate_impl(parameters, schema)
         except InvalidFunctionCall as exception:
@@ -182,9 +183,7 @@ class SignatureValidator(FunctionCallValidator):
                     f"Query validation exception. Validator: {self}", exc_info=True
                 )
 
-    def __validate_impl(
-        self, parameters: Sequence[Expression], schema: ColumnSet
-    ) -> None:
+    def __validate_impl(self, parameters: Sequence[Expression], schema: Entity) -> None:
         if len(parameters) < len(self.__param_types):
             raise InvalidFunctionCall(
                 f"Too few arguments. Required {[str(t) for t in self.__param_types]}"
@@ -196,4 +195,4 @@ class SignatureValidator(FunctionCallValidator):
             )
 
         for validator, param in zip(self.__param_types, parameters):
-            validator.validate(param, schema)
+            validator.validate(param, schema.get_data_model())

--- a/snuba/query/validation/signature.py
+++ b/snuba/query/validation/signature.py
@@ -172,9 +172,9 @@ class SignatureValidator(FunctionCallValidator):
         # exceptions.
         self.__enforce = enforce
 
-    def validate(self, parameters: Sequence[Expression], schema: QueryEntity) -> None:
+    def validate(self, parameters: Sequence[Expression], entity: QueryEntity) -> None:
         try:
-            self.__validate_impl(parameters, schema)
+            self.__validate_impl(parameters, entity)
         except InvalidFunctionCall as exception:
             if self.__enforce:
                 raise exception
@@ -184,7 +184,7 @@ class SignatureValidator(FunctionCallValidator):
                 )
 
     def __validate_impl(
-        self, parameters: Sequence[Expression], schema: QueryEntity
+        self, parameters: Sequence[Expression], entity: QueryEntity
     ) -> None:
         if len(parameters) < len(self.__param_types):
             raise InvalidFunctionCall(
@@ -197,4 +197,4 @@ class SignatureValidator(FunctionCallValidator):
             )
 
         for validator, param in zip(self.__param_types, parameters):
-            validator.validate(param, schema.schema)
+            validator.validate(param, entity.schema)

--- a/snuba/query/validation/signature.py
+++ b/snuba/query/validation/signature.py
@@ -17,7 +17,6 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
-from snuba.datasets.entity import Entity
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralType
 from snuba.query.matchers import Any as AnyMatcher
@@ -172,7 +171,7 @@ class SignatureValidator(FunctionCallValidator):
         # exceptions.
         self.__enforce = enforce
 
-    def validate(self, parameters: Sequence[Expression], schema: Entity) -> None:
+    def validate(self, parameters: Sequence[Expression], schema: ColumnSet) -> None:
         try:
             self.__validate_impl(parameters, schema)
         except InvalidFunctionCall as exception:
@@ -183,7 +182,9 @@ class SignatureValidator(FunctionCallValidator):
                     f"Query validation exception. Validator: {self}", exc_info=True
                 )
 
-    def __validate_impl(self, parameters: Sequence[Expression], schema: Entity) -> None:
+    def __validate_impl(
+        self, parameters: Sequence[Expression], schema: ColumnSet
+    ) -> None:
         if len(parameters) < len(self.__param_types):
             raise InvalidFunctionCall(
                 f"Too few arguments. Required {[str(t) for t in self.__param_types]}"
@@ -195,4 +196,4 @@ class SignatureValidator(FunctionCallValidator):
             )
 
         for validator, param in zip(self.__param_types, parameters):
-            validator.validate(param, schema.get_data_model())
+            validator.validate(param, schema)

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -79,7 +79,7 @@ def test_apdex_format_expressions() -> None:
         ],
     )
 
-    apdex_processor(ColumnSet([])).process_query(unprocessed, HTTPRequestSettings())
+    apdex_processor().process_query(unprocessed, HTTPRequestSettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
     ret = unprocessed.get_selected_columns()[1].expression.accept(

--- a/tests/query/processors/test_failure_rate.py
+++ b/tests/query/processors/test_failure_rate.py
@@ -53,9 +53,7 @@ def test_failure_rate_format_expressions() -> None:
         ],
     )
 
-    failure_rate_processor(ColumnSet([])).process_query(
-        unprocessed, HTTPRequestSettings()
-    )
+    failure_rate_processor().process_query(unprocessed, HTTPRequestSettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
     ret = unprocessed.get_selected_columns()[1].expression.accept(

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -61,7 +61,7 @@ def test_handled_processor() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", entity
+        "exception_stacks.mechanism_handled"
     )
     processor.process_query(unprocessed, HTTPRequestSettings())
 
@@ -76,7 +76,6 @@ def test_handled_processor() -> None:
 
 
 def test_handled_processor_invalid() -> None:
-    entity = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
     unprocessed = Query(
         QueryEntity(EntityKey.EVENTS, ColumnSet([])),
         selected_columns=[
@@ -87,7 +86,7 @@ def test_handled_processor_invalid() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", entity
+        "exception_stacks.mechanism_handled",
     )
     with pytest.raises(InvalidExpressionException):
         processor.process_query(unprocessed, HTTPRequestSettings())
@@ -137,7 +136,7 @@ def test_not_handled_processor() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", entity
+        "exception_stacks.mechanism_handled",
     )
     processor.process_query(unprocessed, HTTPRequestSettings())
 
@@ -163,7 +162,7 @@ def test_not_handled_processor_invalid() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", entity
+        "exception_stacks.mechanism_handled",
     )
     with pytest.raises(InvalidExpressionException):
         processor.process_query(unprocessed, HTTPRequestSettings())

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
 from snuba.datasets.entities import EntityKey
@@ -17,9 +18,9 @@ from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_handled_processor() -> None:
-    columnset = ColumnSet([])
+    entity = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
     unprocessed = Query(
-        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        entity,
         selected_columns=[
             SelectedExpression(name=None, expression=Column(None, None, "id")),
             SelectedExpression(
@@ -29,7 +30,7 @@ def test_handled_processor() -> None:
     )
 
     expected = Query(
-        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        entity,
         selected_columns=[
             SelectedExpression(name=None, expression=Column(None, None, "id")),
             SelectedExpression(
@@ -60,7 +61,7 @@ def test_handled_processor() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", columnset
+        "exception_stacks.mechanism_handled", entity
     )
     processor.process_query(unprocessed, HTTPRequestSettings())
 
@@ -75,7 +76,7 @@ def test_handled_processor() -> None:
 
 
 def test_handled_processor_invalid() -> None:
-    columnset = ColumnSet([])
+    entity = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
     unprocessed = Query(
         QueryEntity(EntityKey.EVENTS, ColumnSet([])),
         selected_columns=[
@@ -86,16 +87,16 @@ def test_handled_processor_invalid() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", columnset
+        "exception_stacks.mechanism_handled", entity
     )
     with pytest.raises(InvalidExpressionException):
         processor.process_query(unprocessed, HTTPRequestSettings())
 
 
 def test_not_handled_processor() -> None:
-    columnset = ColumnSet([])
+    entity = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
     unprocessed = Query(
-        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        entity,
         selected_columns=[
             SelectedExpression(name=None, expression=Column(None, None, "id")),
             SelectedExpression(
@@ -105,7 +106,7 @@ def test_not_handled_processor() -> None:
     )
 
     expected = Query(
-        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        entity,
         selected_columns=[
             SelectedExpression(name=None, expression=Column(None, None, "id")),
             SelectedExpression(
@@ -136,7 +137,7 @@ def test_not_handled_processor() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", columnset
+        "exception_stacks.mechanism_handled", entity
     )
     processor.process_query(unprocessed, HTTPRequestSettings())
 
@@ -151,9 +152,9 @@ def test_not_handled_processor() -> None:
 
 
 def test_not_handled_processor_invalid() -> None:
-    columnset = ColumnSet([])
+    entity = QueryEntity(EntityKey.EVENTS, ColumnSet([]))
     unprocessed = Query(
-        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        entity,
         selected_columns=[
             SelectedExpression(
                 "result",
@@ -162,7 +163,7 @@ def test_not_handled_processor_invalid() -> None:
         ],
     )
     processor = handled_functions.HandledFunctionsProcessor(
-        "exception_stacks.mechanism_handled", columnset
+        "exception_stacks.mechanism_handled", entity
     )
     with pytest.raises(InvalidExpressionException):
         processor.process_query(unprocessed, HTTPRequestSettings())

--- a/tests/query/validation/test_signature.py
+++ b/tests/query/validation/test_signature.py
@@ -2,9 +2,11 @@ from typing import Sequence
 
 import pytest
 
+from snuba.clickhouse.columns import ColumnSet, DateTime
+from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import get_entity
+from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column as ColumnExpr
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralExpr
@@ -120,7 +122,18 @@ def test_like_validator(
     extra_param: bool,
     should_raise: bool,
 ) -> None:
-    entity = get_entity(EntityKey.EVENTS)
+    entity = QueryEntity(
+        EntityKey.EVENTS,
+        ColumnSet(
+            [
+                ("event_id", String()),
+                ("level", String(Modifiers(nullable=True))),
+                ("str_col", String()),
+                ("timestamp", DateTime()),
+                ("received", DateTime(Modifiers(nullable=True))),
+            ]
+        ),
+    )
     validator = SignatureValidator(expected_types, extra_param)
 
     if should_raise:

--- a/tests/query/validation/test_signature.py
+++ b/tests/query/validation/test_signature.py
@@ -2,13 +2,12 @@ from typing import Sequence
 
 import pytest
 
-from snuba.clickhouse.columns import SchemaModifiers as Modifiers
-from snuba.clickhouse.columns import ColumnSet, DateTime, String
-from snuba.query.expressions import (
-    Column as ColumnExpr,
-    Expression,
-    Literal as LiteralExpr,
-)
+from snuba.clickhouse.columns import String
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.query.expressions import Column as ColumnExpr
+from snuba.query.expressions import Expression
+from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.validation import InvalidFunctionCall
 from snuba.query.validation.signature import (
     Any,
@@ -121,20 +120,11 @@ def test_like_validator(
     extra_param: bool,
     should_raise: bool,
 ) -> None:
-    schema = ColumnSet(
-        [
-            ("event_id", String()),
-            ("level", String(Modifiers(nullable=True))),
-            ("str_col", String()),
-            ("timestamp", DateTime()),
-            ("received", DateTime(Modifiers(nullable=True))),
-        ]
-    )
-
+    entity = get_entity(EntityKey.EVENTS)
     validator = SignatureValidator(expected_types, extra_param)
 
     if should_raise:
         with pytest.raises(InvalidFunctionCall):
-            validator.validate(expressions, schema)
+            validator.validate(expressions, entity)
     else:
-        validator.validate(expressions, schema)
+        validator.validate(expressions, entity)


### PR DESCRIPTION
Follow up from this comment: https://github.com/getsentry/snuba/pull/2044#discussion_r684524112. But also kind of went in a circle of what I thought this meant to what is actually in the PR at the end of the day. 

This PR refactors the following:
* Change the `FunctionCallValidator` to take a `data_source` instead of the `schema` (since the schema can just be take from the data source)
* Changes custom functions to get the data source columns from the `Query` in `process_query` instead of having it be instantiated with the `ColumnSet` 
* Introduces a `QueryEntityFinder` to get the `QueryEntity` and use it to look up any entity validators that we need
    * In the case of the CompositeQuery, we cannot reliably get an entity so we return `None`, see comment https://github.com/getsentry/snuba/pull/2057#discussion_r693215085   