### PR TITLE
fix(dockerfile) Switch from libffi6 to libffi7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex; \
     apt-get update; \
     apt-get install --no-install-recommends -y \
         libexpat1 \
-        libffi6 \
+        libffi7 \
         liblz4-1 \
         libpcre3 \
     ; \


### PR DESCRIPTION
Debian 11 (bullseye) was released on 8/14. That was picked up by the python-3.8-slim docker image yesterday.
Bullseye does not seem to contain libffi6 anymore. It contains libffi7 instead. 

Upgrading this and trying to run the full CI pipeline to see if it works 