### PR TITLE
fix(ci) Increase the timeout of master build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -76,7 +76,7 @@ steps:
           docker-compose logs;
           exit $test_return;
         fi
-    timeout: 450s
+    timeout: 600s
   - name: "gcr.io/cloud-builders/docker"
     id: docker-push
     waitFor:


### PR DESCRIPTION
The CI pipeline is broken again on master.
It keeps timing out on the e2e test step.