### PR TITLE
feat: Custom zookeeper path for replicated merge tree migrations

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -142,6 +142,9 @@ MAX_RESOLUTION_FOR_JITTER = 60
 # where 123 is the project id.
 TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 
+# Map the Zookeeper path for the replicated merge tree to something else
+CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment


### PR DESCRIPTION
CLICKHOUSE_ZOOKEEPER_OVERRIDE allows the Zookeper path for a replicated
merge tree to be customized. Normally this is generated by the migration
system and should not be changed, however under certain circumstances
this is required. Specifically, we have some tables that were created
with different paths prior to the existence of the migration system.
Changing the zookeeper path after a table exists is not easy, so we should
provide a way to override this value as adding a shard to these existing
tables via the migration system will require these paths to match.