### PR TITLE
Add more funcs to GLOBAL_VALID_FUNCTIONS

### DIFF
--- a/snuba/query/functions.py
+++ b/snuba/query/functions.py
@@ -116,12 +116,15 @@ REGULAR_FUNCTIONS = {
     "divide",
     # arrays,
     "array",
+    "arrayConcat",
     "arrayElement",
     "arrayExists",
     "arrayAll",
     "indexOf",
     "has",
     "hasAny",
+    "notEmpty",  # can apply to strings as well
+    "length",  # can apply to strings as well
     # comparison
     "equals",
     "notEquals",
@@ -139,6 +142,7 @@ REGULAR_FUNCTIONS = {
     "toInt8",
     "toUInt8",
     "toUInt64",
+    "toFloat64",
     # dates and times
     "toStartOfDay",
     "toStartOfHour",
@@ -147,6 +151,9 @@ REGULAR_FUNCTIONS = {
     # conditionals
     "if",
     "multiIf",
+    # mathematical
+    "log",
+    "sqrt",
     # rounding functions
     "floor",
     # hash functions
@@ -159,6 +166,7 @@ REGULAR_FUNCTIONS = {
     "notLike",
     "match",
     "positionCaseInsensitive",
+    "multiSearchFirstPositionCaseInsensitive",
     # functions for nulls
     "isNull",
     "isNotNull",


### PR DESCRIPTION
The `GLOBAL_VALID_FUNCTIONS` set was introduced in https://github.com/getsentry/snuba/pull/2057. Instead of enforcing this list, we have metrics that let us know which ones we missed. https://github.com/getsentry/snuba/blob/c4bc7bb9b2ad3942066beb51054808f40c313baa/snuba/query/validation/functions.py#L31

This PR is to add in ones that we missed.

```bash
# custom functions
IsHandled 
notHandled

# clickhouse functions
cityHash64 
positionCaseInsensitive 
match
assumeNotNull 
arrayExists
transform
tupleElement 
indexOf 
floor 
arrayJoin 
arrayAll 
coalesce 
log
multiSearchFirstPositionCaseInsensitive
greatest
sqrt 
hasAny
arrayConcat
toFloat64 
length
notEmpty
```