### PR TITLE
 Add span_id to discover and promote it in discover, errors dataset

### DIFF
--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -24,6 +24,7 @@ from snuba.query.matchers import (
     String,
 )
 
+
 # This is a workaround for a mypy bug, found here: https://github.com/python/mypy/issues/5374
 @dataclass(frozen=True)
 class _ColumnToExpression:

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -61,10 +61,6 @@ class DatasetQueryPipelineBuilder:
     """
     Produces the QueryExecutionPipeline to run the query. This is supposed
     to handle both simple and composite queries.
-
-    TODO: Request still can only contain a simple query. This has to be
-    adapted depending on how the SnQL parser will produce a composite
-    query.
     """
 
     def build_execution_pipeline(

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -258,7 +258,6 @@ EVENTS_COLUMNS = ColumnSet(
 
 TRANSACTIONS_COLUMNS = ColumnSet(
     [
-        ("span_id", UInt(64, Modifiers(nullable=True))),
         ("transaction_hash", UInt(64, Modifiers(nullable=True))),
         ("transaction_op", String(Modifiers(nullable=True))),
         ("transaction_status", UInt(8, Modifiers(nullable=True))),
@@ -429,6 +428,7 @@ class DiscoverEntity(Entity):
                 ("tags", Nested([("key", String()), ("value", String())])),
                 ("contexts", Nested([("key", String()), ("value", String())])),
                 ("trace_id", String(Modifiers(nullable=True))),
+                ("span_id", UInt(64, Modifiers(nullable=True))),
             ]
         )
         self.__events_columns = EVENTS_COLUMNS

--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -24,9 +24,6 @@ from snuba.query.processors.empty_tag_condition_processor import (
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
-from snuba.query.processors.type_converters.hexint_column_processor import (
-    HexIntColumnProcessor,
-)
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
@@ -86,14 +83,13 @@ storage = ReadableTableStorage(
                     "sentry:dist": "dist",
                     "sentry:user": "user",
                 },
-                "contexts": {"trace.trace_id": "trace_id", "trace.span_id": "span_id"},
+                "contexts": {"trace.trace_id": "trace_id"},
             }
         ),
         MappingOptimizer("tags", "_tags_hash_map", "tags_hash_map_enabled"),
         EmptyTagConditionProcessor(),
         ArrayJoinKeyValueOptimizer("tags"),
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
-        HexIntColumnProcessor(set(["span_id"])),
         EventsBooleanContextsProcessor(),
         PrewhereProcessor(
             [

--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -24,6 +24,9 @@ from snuba.query.processors.empty_tag_condition_processor import (
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.type_converters.hexint_column_processor import (
+    HexIntColumnProcessor,
+)
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
@@ -90,6 +93,7 @@ storage = ReadableTableStorage(
         EmptyTagConditionProcessor(),
         ArrayJoinKeyValueOptimizer("tags"),
         UUIDColumnProcessor(set(["event_id", "trace_id"])),
+        HexIntColumnProcessor(set(["span_id"])),
         EventsBooleanContextsProcessor(),
         PrewhereProcessor(
             [

--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -57,6 +57,7 @@ columns = ColumnSet(
         ("_tags_hash_map", Array(UInt(64))),
         ("contexts", Nested([("key", String()), ("value", String())])),
         ("trace_id", UUID(Modifiers(nullable=True))),
+        ("span_id", UInt(64, Modifiers(nullable=True))),
         ("deleted", UInt(8)),
     ]
 )
@@ -82,7 +83,7 @@ storage = ReadableTableStorage(
                     "sentry:dist": "dist",
                     "sentry:user": "user",
                 },
-                "contexts": {"trace.trace_id": "trace_id"},
+                "contexts": {"trace.trace_id": "trace_id", "trace.span_id": "span_id"},
             }
         ),
         MappingOptimizer("tags", "_tags_hash_map", "tags_hash_map_enabled"),

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -131,7 +131,7 @@ promoted_tag_columns = {
     "level": "level",
 }
 
-promoted_context_columns = {"trace.trace_id": "trace_id"}
+promoted_context_columns = {"trace.trace_id": "trace_id", "trace.span_id": "span_id"}
 
 mandatory_conditions = [
     binary_condition(

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -131,7 +131,7 @@ promoted_tag_columns = {
     "level": "level",
 }
 
-promoted_context_columns = {"trace.trace_id": "trace_id", "trace.span_id": "span_id"}
+promoted_context_columns = {"trace.trace_id": "trace_id"}
 
 mandatory_conditions = [
     binary_condition(

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -135,6 +135,7 @@ class DiscoverLoader(DirectoryLoader):
             "0004_discover_fix_title_and_message",
             "0005_discover_fix_transaction_name",
             "0006_discover_add_trace_id",
+            "0007_discover_add_span_id",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/discover/0007_discover_add_span_id.py
+++ b/snuba/migrations/snuba_migrations/discover/0007_discover_add_span_id.py
@@ -1,0 +1,49 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Add trace_id to merge table
+    """
+
+    blocking = False
+
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column=Column("span_id", UInt(64, Modifiers(nullable=True))),
+                after="contexts",
+            ),
+        ]
+
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name=table_name,
+                column_name="span_id",
+            ),
+        ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("discover_local")
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("discover_local")
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("discover_dist")
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("discover_dist")

--- a/snuba/migrations/snuba_migrations/discover/0007_discover_add_span_id.py
+++ b/snuba/migrations/snuba_migrations/discover/0007_discover_add_span_id.py
@@ -8,7 +8,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 class Migration(migration.ClickhouseNodeMigration):
     """
-    Add trace_id to merge table
+    Add span_id to merge table
     """
 
     blocking = False

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -1,6 +1,7 @@
 from typing import Any, MutableMapping
 
 import pytest
+
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.factory import get_dataset
 from snuba.query.parser import parse_query
@@ -121,8 +122,8 @@ test_data = [
     ),
     # # No conditions, other referenced columns
     ({"selected_columns": ["group_id"]}, EntityKey.DISCOVER_EVENTS),
-    ({"selected_columns": ["span_id"]}, EntityKey.DISCOVER_TRANSACTIONS),
-    ({"selected_columns": ["group_id", "span_id"]}, EntityKey.DISCOVER),
+    ({"selected_columns": ["span_id"]}, EntityKey.DISCOVER),
+    ({"selected_columns": ["group_id", "span_id"]}, EntityKey.DISCOVER_EVENTS),
     (
         {"aggregations": [["max", "duration", "max_duration"]]},
         EntityKey.DISCOVER_TRANSACTIONS,

--- a/tests/query/processors/test_mapping_promoter.py
+++ b/tests/query/processors/test_mapping_promoter.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet, Nested
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt


### PR DESCRIPTION
## Problem
Discover queries by span_id where unwrapping the context column meaning we needed to store it.

DDL: 
```
ALTER TABLE discover_local ADD COLUMN IF NOT EXISTS span_id Nullable(UInt64) AFTER contexts;
```