### PR TITLE
build(ci): Fix sentry integration test due to refactored actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: getsentry/sentry
+          # XXX: temp
+          ref: build/ci/allow-skipping-upgrade-pip
           path: sentry
 
       - name: Setup steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
         run: |
           pip install --upgrade pip wheel
           # We cannot execute actions that are not placed under .github of the main repo
+          mkdir -p .github/actions
           cp sentry/.github/actions/* .github/actions
 
       - name: Setup Sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           pip install --upgrade pip wheel
           # We cannot execute actions that are not placed under .github of the main repo
           mkdir -p .github/actions
-          cp sentry/.github/actions/* .github/actions
+          cp -r sentry/.github/actions/* .github/actions
 
       - name: Setup Sentry
         id: setup-sentry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,32 +168,20 @@ jobs:
           repository: getsentry/sentry
           path: sentry
 
-      # setup python
-      - uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-
       - name: Setup steps
         id: setup
         run: |
           pip install --upgrade pip wheel
-          echo "::set-output name=pip-cache-dir::$(pip cache dir)"
           # We cannot execute actions that are not placed under .github of the main repo
-          mkdir -p .github/actions/setup-sentry/
-          cp sentry/.github/actions/setup-sentry/action.yml .github/actions/setup-sentry/action.yml
-
-      - name: Sentry's pip cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.setup.outputs.pip-cache-dir }}
-          key: sentry-deps-${{ hashFiles('sentry/requirements**.txt') }}
-          restore-keys: sentry-deps-
+          cp sentry/.github/actions/* .github/actions
 
       - name: Setup Sentry
         id: setup-sentry
         uses: ./.github/actions/setup-sentry
         with:
           workdir: sentry
+          cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
+          python-version: 3.8
           snuba: false
           kafka: true
           clickhouse: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,8 +166,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: getsentry/sentry
-          # XXX: temp
-          ref: build/ci/allow-skipping-upgrade-pip
           path: sentry
 
       - name: Setup steps


### PR DESCRIPTION
We refactored [`setup-sentry`](https://github.com/getsentry/sentry/pull/28281) to be able to compose actions better. This workflow was only copying `setup-sentry` which now includes `setup-python`.