### PR TITLE
perf(rate limiter) Move the global rate limit check after the project check

### DIFF
--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import List, Sequence
 
-from snuba.state.rate_limit import RateLimitParameters, get_global_rate_limit_params
+from snuba.state.rate_limit import RateLimitParameters
 
 
 class RequestSettings(ABC):
@@ -69,7 +69,7 @@ class HTTPRequestSettings(RequestSettings):
         self.__debug = debug
         self.__dry_run = dry_run
         self.__legacy = legacy
-        self.__rate_limit_params = [get_global_rate_limit_params()]
+        self.__rate_limit_params: List[RateLimitParameters] = []
 
     def get_turbo(self) -> bool:
         return self.__turbo

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1416,6 +1416,8 @@ class TestApi(SimpleAPITest):
             )
         )
         assert response.status_code == 429
+        data = json.loads(response.data)
+        assert data["error"]["message"] == "project concurrent of 1 exceeds limit of 0"
 
     def test_doesnt_select_deletions(self) -> None:
         query = {


### PR DESCRIPTION
If the per-project rate limit kicks in often for a specific project, and the project does not apply any exponential backoff when retrying, we see an  unexpected increase in the global concurrent count.
I suspect this is due to this:
https://github.com/getsentry/snuba/blob/master/snuba/state/rate_limit.py#L170-L185

The global rate limiter is evaluated first and passes. At this point we bumped the number of global concurrent queries.
If the project rate limiter fails, when resetting the state of the global one we go through line 185 here https://github.com/getsentry/snuba/blob/master/snuba/state/rate_limit.py#L170-L185, which is the success case. 
That does not erase the query from redis, it pushes it back in time like if the query had been performed successfully.
So the query keeps getting counted towards the global per second rate limit and it keeps being counted for the concurrent limit for an entire second.
This makes the project rate limiter basically unusable.

This is the quickest fix and moves the project rate limiter (the smallest quota) early in the sequence. So we would not borrow global quota when rejecting queries from the project rate limiter. It is anyway reasonable to evaluate quotas from the smallest to the largest.
The proper way to validate the problem is the one above would be to redesign the way the rate limiter code is organized in order to remove the global rate limit state for a query when the project rate limiter fails, though this would take too long to test and we need a way to make the project rate limiter work earlier.