### PR TITLE
feat(quota_control) Add the basic abstraction for quota enforcement step 1

### DIFF
--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -14,5 +14,6 @@ class GroupAssigneeDataset(Dataset):
 
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.GROUPASSIGNEE, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.GROUPASSIGNEE,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,5 +1,6 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class GroupAssigneeDataset(Dataset):
@@ -12,4 +13,6 @@ class GroupAssigneeDataset(Dataset):
     """
 
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.GROUPASSIGNEE)
+        super().__init__(
+            default_entity=EntityKey.GROUPASSIGNEE, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,7 +1,11 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class GroupedMessageDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.GROUPEDMESSAGES)
+        super().__init__(
+            default_entity=EntityKey.GROUPEDMESSAGES,
+            quota_control=ProjectQuotaControl(),
+        )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -7,5 +7,5 @@ class GroupedMessageDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             default_entity=EntityKey.GROUPEDMESSAGES,
-            quota_control=ProjectQuotaControl(),
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from contextlib import contextmanager
-from typing import Iterator, Sequence
+from typing import Iterator, Optional, Sequence
 
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -84,6 +84,12 @@ class DatasetQueryPipelineBuilder:
             return CompositeExecutionPipeline(request.query, request.settings, runner)
 
 
+class QuotaExceeded(Exception):
+    """
+    Exception thrown when the rate limit is exceeded
+    """
+
+
 class QuotaControlPolicy(ABC):
     """
     Enforces the request provided complies with the quota assigned to the
@@ -94,7 +100,7 @@ class QuotaControlPolicy(ABC):
     """
 
     @contextmanager
-    def acquire(self, request: Request) -> Iterator[RateLimitStats]:
+    def acquire(self, request: Request) -> Iterator[Optional[RateLimitStats]]:
         """
         If the request is within the quota assigned to the client this
         method succeeds and returns the current quota status.

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -5,6 +5,7 @@ from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.discover import EVENTS_COLUMNS, TRANSACTIONS_COLUMNS
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 from snuba.query.conditions import (
     BINARY_OPERATORS,
     ConditionFunctions,
@@ -27,7 +28,9 @@ EVENTS_AND_TRANSACTIONS = EntityKey.DISCOVER
 
 class DiscoverDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.DISCOVER)
+        super().__init__(
+            default_entity=EntityKey.DISCOVER, quota_control=ProjectQuotaControl()
+        )
 
     # XXX: This is temporary code that will eventually need to be ported to Sentry
     # since SnQL will require an entity to always be specified by the user.

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -29,7 +29,8 @@ EVENTS_AND_TRANSACTIONS = EntityKey.DISCOVER
 class DiscoverDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.DISCOVER, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.DISCOVER,
+            quota_control=ProjectQuotaControl("project_id"),
         )
 
     # XXX: This is temporary code that will eventually need to be ported to Sentry

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -6,5 +6,6 @@ from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 class EventsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.EVENTS, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.EVENTS,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,7 +1,10 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class EventsDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.EVENTS)
+        super().__init__(
+            default_entity=EntityKey.EVENTS, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -6,5 +6,6 @@ from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 class MetricsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.METRICS_SETS, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.METRICS_SETS,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -1,7 +1,10 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class MetricsDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.METRICS_SETS)
+        super().__init__(
+            default_entity=EntityKey.METRICS_SETS, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,5 +1,6 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class OutcomesDataset(Dataset):
@@ -8,4 +9,6 @@ class OutcomesDataset(Dataset):
     """
 
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.OUTCOMES)
+        super().__init__(
+            default_entity=EntityKey.OUTCOMES, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -10,5 +10,6 @@ class OutcomesDataset(Dataset):
 
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.OUTCOMES, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.OUTCOMES,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,5 +1,6 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class OutcomesRawDataset(Dataset):
@@ -8,4 +9,6 @@ class OutcomesRawDataset(Dataset):
     """
 
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.OUTCOMES_RAW)
+        super().__init__(
+            default_entity=EntityKey.OUTCOMES_RAW, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -10,5 +10,6 @@ class OutcomesRawDataset(Dataset):
 
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.OUTCOMES_RAW, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.OUTCOMES_RAW,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/quota/project_quota_control.py
+++ b/snuba/datasets/quota/project_quota_control.py
@@ -1,12 +1,56 @@
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Iterator, Optional
 
-from snuba.datasets.dataset import QuotaControlPolicy
+from snuba.clickhouse.query_dsl.accessors import ProjectsFinder
+from snuba.datasets.dataset import QuotaControlPolicy, QuotaExceeded
 from snuba.request import Request
-from snuba.state.rate_limit import RateLimitStats
+from snuba.state import get_config, get_configs
+from snuba.state.rate_limit import (
+    QUOTA_RATE_LIMIT_NAME,
+    RateLimitExceeded,
+    RateLimitParameters,
+    RateLimitStats,
+    rate_limit,
+)
+
+QUOTA_ENFORCEMENT_ENABLED = "quota_enforcement_enabled"
 
 
 class ProjectQuotaControl(QuotaControlPolicy):
+    def __init__(self, project_column: str):
+        self.__project_columns = project_column
+
     @contextmanager
-    def acquire(self, request: Request) -> Iterator[RateLimitStats]:
-        yield RateLimitStats(0.1, 1)
+    def acquire(self, request: Request) -> Iterator[Optional[RateLimitStats]]:
+        quota_enforcement_enabled = get_config(QUOTA_ENFORCEMENT_ENABLED, False)
+        project_ids = ProjectsFinder(self.__project_columns).visit(request.query)
+        if not quota_enforcement_enabled or not project_ids:
+            yield None
+        else:
+            # TODO: Use all the projects, not just one
+            project_id = project_ids.pop()
+
+            prl, pcl = get_configs(
+                [("project_per_second_limit", 1000), ("project_concurrent_limit", 1000)]
+            )
+
+            # Specific projects can have their rate limits overridden
+            (per_second, concurr) = get_configs(
+                [
+                    ("project_per_second_limit_{}".format(project_id), prl),
+                    ("project_concurrent_limit_{}".format(project_id), pcl),
+                ]
+            )
+
+            try:
+                with rate_limit(
+                    RateLimitParameters(
+                        rate_limit_name=QUOTA_RATE_LIMIT_NAME,
+                        bucket=str(project_id),
+                        per_second_limit=per_second,
+                        concurrent_limit=concurr,
+                    )
+                ) as stats:
+                    yield stats
+            except RateLimitExceeded as cause:
+                raise QuotaExceeded(str(cause)) from cause

--- a/snuba/datasets/quota/project_quota_control.py
+++ b/snuba/datasets/quota/project_quota_control.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager
+from typing import Iterator
+
+from snuba.datasets.dataset import QuotaControlPolicy
+from snuba.request import Request
+from snuba.state.rate_limit import RateLimitStats
+
+
+class ProjectQuotaControl(QuotaControlPolicy):
+    @contextmanager
+    def acquire(self, request: Request) -> Iterator[RateLimitStats]:
+        yield RateLimitStats(0.1, 1)

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -6,5 +6,6 @@ from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 class SessionsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.SESSIONS, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.SESSIONS,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,7 +1,10 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class SessionsDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.SESSIONS)
+        super().__init__(
+            default_entity=EntityKey.SESSIONS, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,7 +1,10 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 
 
 class TransactionsDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.TRANSACTIONS)
+        super().__init__(
+            default_entity=EntityKey.TRANSACTIONS, quota_control=ProjectQuotaControl()
+        )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -6,5 +6,6 @@ from snuba.datasets.quota.project_quota_control import ProjectQuotaControl
 class TransactionsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
-            default_entity=EntityKey.TRANSACTIONS, quota_control=ProjectQuotaControl()
+            default_entity=EntityKey.TRANSACTIONS,
+            quota_control=ProjectQuotaControl("project_id"),
         )

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -13,6 +13,7 @@ from snuba.redis import redis_client as rds
 
 logger = logging.getLogger("snuba.state.rate_limit")
 
+QUOTA_RATE_LIMIT_NAME = "quota"
 PROJECT_RATE_LIMIT_NAME = "project"
 GLOBAL_RATE_LIMIT_NAME = "global"
 TABLE_RATE_LIMIT_NAME = "table"

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import replace
 from functools import partial
 from math import floor
-from typing import MutableMapping, Optional, Set, Union
+from typing import MutableMapping, Optional, Union
 
 import sentry_sdk
 
@@ -10,7 +10,7 @@ from snuba import environment
 from snuba import settings as snuba_settings
 from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query
-from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
+from snuba.clickhouse.query_dsl.accessors import ProjectsFinder
 from snuba.clickhouse.query_inspector import TablesCollector
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset_name
@@ -63,34 +63,6 @@ class SampleClauseFinder(DataSourceVisitor[bool, Entity], JoinVisitor[bool, Enti
         return node.left_node.accept(self) or node.right_node.accept(self)
 
 
-class ProjectsFinder(
-    DataSourceVisitor[Set[int], Entity], JoinVisitor[Set[int], Entity]
-):
-    """
-    Traverses a query to find project_id conditions
-    """
-
-    def _visit_simple_source(self, data_source: Entity) -> Set[int]:
-        return set()
-
-    def _visit_join(self, data_source: JoinClause[Entity]) -> Set[int]:
-        return self.visit_join_clause(data_source)
-
-    def _visit_simple_query(self, data_source: ProcessableQuery[Entity]) -> Set[int]:
-        return get_object_ids_in_query_ast(data_source, "project_id") or set()
-
-    def _visit_composite_query(self, data_source: CompositeQuery[Entity]) -> Set[int]:
-        return self.visit(data_source.get_from_clause())
-
-    def visit_individual_node(self, node: IndividualNode[Entity]) -> Set[int]:
-        return self.visit(node.data_source)
-
-    def visit_join_clause(self, node: JoinClause[Entity]) -> Set[int]:
-        left = node.left_node.accept(self)
-        right = node.right_node.accept(self)
-        return left | right
-
-
 @with_span()
 def parse_and_run_query(
     dataset: Dataset,
@@ -107,7 +79,7 @@ def parse_and_run_query(
         dataset=get_dataset_name(dataset),
         timer=timer,
         query_list=[],
-        projects=ProjectsFinder().visit(request.query),
+        projects=ProjectsFinder("project_id").visit(request.query),
     )
 
     try:

--- a/tests/datasets/quota/test_project_quota_control.py
+++ b/tests/datasets/quota/test_project_quota_control.py
@@ -1,0 +1,123 @@
+from typing import Optional
+
+import pytest
+
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.dataset import QuotaExceeded
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.quota.project_quota_control import (
+    QUOTA_ENFORCEMENT_ENABLED,
+    ProjectQuotaControl,
+)
+from snuba.query import SelectedExpression
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.request import Request
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state import get_config, set_config
+from snuba.state.rate_limit import RateLimitStats
+
+tests = [
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column("_snuba_not_project", None, "not_project_id"),
+            Literal(None, 1),
+        ),
+        1,
+        5,
+        True,
+        None,
+        id="No project id condition",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column("_snuba_project_id", None, "project_id"),
+            Literal(None, 1),
+        ),
+        0,
+        5,
+        True,
+        None,
+        id="Different project id",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column("_snuba_project_id", None, "project_id"),
+            FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 3))),
+        ),
+        1,
+        5,
+        True,
+        RateLimitStats(0.0, 1),
+        id="Valid project id",
+    ),
+    pytest.param(
+        binary_condition(
+            "and",
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 2),
+            ),
+            binary_condition(
+                ConditionFunctions.IN,
+                Column("_snuba_project_id", None, "project_id"),
+                FunctionCall(None, "array", (Literal(None, 6), Literal(None, 7))),
+            ),
+        ),
+        1,
+        5,
+        True,
+        RateLimitStats(0.0, 1),
+        id="Valid project id complex condition",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column("_snuba_project_id", None, "project_id"),
+            FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 3))),
+        ),
+        1,
+        0,
+        False,
+        None,
+        id="Quota exceeded",
+    ),
+]
+
+
+@pytest.mark.parametrize("condition, enabled, quota, success, expected", tests)
+def test_project_rate_limit_processor(
+    condition: Expression,
+    enabled: bool,
+    quota: int,
+    success: bool,
+    expected: Optional[RateLimitStats],
+) -> None:
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=condition,
+    )
+    settings = HTTPRequestSettings()
+    request = Request("asdasd", {}, query, settings)
+
+    config = get_config(QUOTA_ENFORCEMENT_ENABLED)
+    set_config(QUOTA_ENFORCEMENT_ENABLED, enabled)
+    set_config("project_per_second_limit_2", 10.0)
+    set_config("project_concurrent_limit_2", quota)
+
+    if success:
+        with ProjectQuotaControl("project_id").acquire(request) as stats:
+            assert stats == expected
+    else:
+        with pytest.raises(QuotaExceeded):
+            with ProjectQuotaControl("project_id").acquire(request) as stats:
+                pass
+
+    set_config(QUOTA_ENFORCEMENT_ENABLED, config)

--- a/tests/web/test_project_finder.py
+++ b/tests/web/test_project_finder.py
@@ -3,6 +3,7 @@ from typing import Set, Union
 import pytest
 
 from snuba.clickhouse.columns import UUID, ColumnSet, UInt
+from snuba.clickhouse.query_dsl.accessors import ProjectsFinder
 from snuba.datasets.entities import EntityKey
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
@@ -10,7 +11,6 @@ from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
-from snuba.web.query import ProjectsFinder
 
 ERRORS_SCHEMA = ColumnSet(
     [("event_id", UUID()), ("project_id", UInt(32)), ("group_id", UInt(32))]
@@ -54,5 +54,5 @@ TEST_CASES = [
 def test_count_columns(
     query: Union[Query, CompositeQuery[Entity]], expected_proj: Set[int],
 ) -> None:
-    project_finder = ProjectsFinder()
+    project_finder = ProjectsFinder("project_id")
     assert project_finder.visit(query) == expected_proj


### PR DESCRIPTION
Today we have a rate limiter that can be configured per project, globally or per clickhouse table.
This is ok but it requires us to fully process a query before we decide to reject it. This is costing a massive amount of memory and CPU in Snuba when some project hammers snuba.

The idea of this PR and the following one is to move per project quota control earlier in the flow. So we can reject queries over quota earlier without using Snuba resources.

The first step (here) introduces the Quota Enforcement abstraction provided by a dataset. (See comments inline on why it is dataset specific).
The second step will be to hook this up in the query processing flow.
The third step will be to move it further before the parsing of the query, so we can reject queries before allocating the memory for the whole AST and before using the CPU for parsing. This will mean we need to identify the quota to be applied in the query payload and we cannot depend on the project id from the query.