### PR TITLE
feat(quota_control) Add the basic abstraction for quota enforcement step 2

### DIFF
--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Mapping, MutableSequence, Optional, Set
@@ -113,3 +114,13 @@ class SnubaQueryMetadata:
         # If we do not have any recorded query and we did not specifically log
         # invalid_query, we assume there was an error somewhere.
         return self.query_list[-1].status if self.query_list else QueryStatus.ERROR
+
+
+class FailedRequestMetadata(ABC, SnubaQueryMetadata):
+    pass
+
+
+class RateLimitedRequestMetadata(FailedRequestMetadata):
+    @property
+    def status(self) -> QueryStatus:
+        return QueryStatus.RATE_LIMITED


### PR DESCRIPTION
Based on https://github.com/getsentry/snuba/pull/2079

This wire the quota control in the query processing flow.
It is applied only to the api flow. The subscription flow by definition does not apply any quota, subscriptions are pre recorded, we are not supposed to have quota issues there.
