### PR TITLE
feat(consumer): Add a subscription consumer for Sessions dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 htmlcov/
 snuba.egg-info/
 .DS_Store
+.idea/

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from snuba import settings
 from snuba.clickhouse.columns import (
     UUID,
     AggregateFunction,
@@ -115,15 +116,25 @@ class MinuteResolutionProcessor(QueryProcessor):
 
 # The raw table we write onto, and that potentially we could
 # query.
+if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
+    kafka_stream_loader = build_kafka_stream_loader_from_settings(
+        processor=SessionsProcessor(),
+        default_topic=Topic.SESSIONS,
+        commit_log_topic=Topic.SESSIONS_COMMIT_LOG,
+        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_SESSIONS,
+    )
+else:
+    kafka_stream_loader = build_kafka_stream_loader_from_settings(
+        processor=SessionsProcessor(), default_topic=Topic.SESSIONS
+    )
+
 raw_storage = WritableTableStorage(
     storage_key=StorageKey.SESSIONS_RAW,
     storage_set_key=StorageSetKey.SESSIONS,
     schema=raw_schema,
     query_processors=[MinuteResolutionProcessor(), TableRateLimit()],
     mandatory_condition_checkers=[OrgIdEnforcer(), ProjectIdEnforcer()],
-    stream_loader=build_kafka_stream_loader_from_settings(
-        processor=SessionsProcessor(), default_topic=Topic.SESSIONS,
-    ),
+    stream_loader=kafka_stream_loader,
 )
 # The materialized view we query aggregate data from.
 materialized_storage = ReadableTableStorage(

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -2,10 +2,10 @@ from __future__ import absolute_import
 
 from typing import Any, Union
 
-from redis.client import StrictRedis
-from redis.exceptions import BusyLoadingError, ConnectionError
 from rediscluster import StrictRedisCluster
 
+from redis.client import StrictRedis
+from redis.exceptions import BusyLoadingError, ConnectionError
 from snuba import settings
 
 RedisClientType = Union[StrictRedis, StrictRedisCluster]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -145,6 +145,9 @@ TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 # Map the Zookeeper path for the replicated merge tree to something else
 CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
 
+# Metric Alerts Subscription Options
+ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", False)
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Mapping
 
+from snuba import settings
+
 
 # These are the default topic names, they can be changed via settings
 class Topic(Enum):
@@ -12,11 +14,15 @@ class Topic(Enum):
     METRICS = "ingest-metrics"
     OUTCOMES = "outcomes"
     SESSIONS = "ingest-sessions"
+    SESSIONS_COMMIT_LOG = "snuba-sessions-commit-log"
     SUBSCRIPTION_RESULTS_EVENTS = "events-subscription-results"
     SUBSCRIPTION_RESULTS_TRANSACTIONS = "transactions-subscription-results"
+    SUBSCRIPTION_RESULTS_SESSIONS = "sessions-subscription-results"
     QUERYLOG = "snuba-queries"
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
     config = {Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"}}
+    if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
+        config.update({Topic.SESSIONS: {"message.timestamp.type": "LogAppendTime"}})
     return config.get(topic, {})


### PR DESCRIPTION
This PR:
- Adds subscription consumer for sessions dataset that will be used specifically for Crash Rate alerts behind settings  `ENABLE_SESSIONS_SUBSCRIPTIONS`
- Adds `SESSIONS_COMMIT_LOG` and `SESSIONS_RESULTS_SESSIONS` topics 
- Convert the `ingest-sessions` topic to have a `LogAppendTime` timestamp setting for subscription to work 