### PR TITLE
ref(validation): Change ifnull -> ifNull for consistency

### DIFF
--- a/snuba/query/functions.py
+++ b/snuba/query/functions.py
@@ -171,12 +171,6 @@ REGULAR_FUNCTIONS = {
     "isNull",
     "isNotNull",
     "ifNull",
-    # TODO(meredith): certain functions are case insensitive, but an ifNull varient
-    # seems to be the only one used that isn't in documented format. Ideally have a
-    # better way to add in checking the case sensitivity for the right functions
-    "IfNull",
-    "ifnull",
-    "IFNULL",
     "assumeNotNull",
     "coalesce",
     # functions for tuples

--- a/snuba/query/functions.py
+++ b/snuba/query/functions.py
@@ -171,6 +171,12 @@ REGULAR_FUNCTIONS = {
     "isNull",
     "isNotNull",
     "ifNull",
+    # TODO(meredith): certain functions are case insensitive, but an ifNull varient
+    # seems to be the only one used that isn't in documented format. Ideally have a
+    # better way to add in checking the case sensitivity for the right functions
+    "IfNull",
+    "ifnull",
+    "IFNULL",
     "assumeNotNull",
     "coalesce",
     # functions for tuples

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -151,7 +151,7 @@ class LegacySubscriptionData(SubscriptionData):
         )
         extra_conditions: Sequence[Condition] = []
         if offset is not None:
-            extra_conditions = [[["ifnull", ["offset", 0]], "<=", offset]]
+            extra_conditions = [[["ifNull", ["offset", 0]], "<=", offset]]
         return build_request(
             {
                 "project": self.project_id,
@@ -236,7 +236,7 @@ class SnQLSubscriptionData(SubscriptionData):
                     ConditionFunctions.LTE,
                     FunctionCall(
                         None,
-                        "ifnull",
+                        "ifNull",
                         (Column(None, None, "offset"), Literal(None, 0)),
                     ),
                     Literal(None, offset),


### PR DESCRIPTION
**ifNull**
After adding in some missed functions in https://github.com/getsentry/snuba/pull/2067 there was still one function that was showing up in the datadog metics as not valid: `ifnull`. Datadog metrics tag values are always lowercased so we can't know what the original was, but it wasn't `ifNull` (otherwise it would have been found in `GLOBAL_VALID_FUNCTIONS` set.

In looking at ClickHouse docs, it looks like keywords are case-insensitive https://clickhouse.tech/docs/en/sql-reference/syntax/#syntax-keywords (but functions are often case sensitive). 

I tested out `ifnull`, `IfNull`, and `IFNULL` locally, and in the code it looks like we can confirm that https://github.com/ClickHouse/ClickHouse/blob/master/src/Functions/ifNull.cpp#L92-L95.

**other functions...?**
~It's not realistic to add all the possible variations of the case-insensitive functions so in the future we'd need a better `is_valid_global_function` check. But for now, I think this is a valid approach. If we see this happen with a couple more functions, then we could change it.~ 


**UPDATE:**
Turns out we just need to update our code to use `ifNull` instead of `ifnull`. If though either is technically acceptable for clickhouse, we want to keep our validation as simple as possible.
