### PR TITLE
feat: Commit log topics use LogAppendTime timestamp type

### DIFF
--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -18,5 +18,8 @@ class Topic(Enum):
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
-    config = {Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"}}
+    config = {
+        Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"},
+        Topic.COMMIT_LOG: {"message.timestamp.type": "LogAppendTime"},
+    }
     return config.get(topic, {})


### PR DESCRIPTION
This changes the topic configuration for snuba-commit-log from
CreateTime to LogAppendTime. The purpose of this change is to allow
the timestamp of the commit log topic to be used as the basis for
subscription scheduling (instead of the timestamp from the original
events topic). This change ensures that the message timestamps in the
commit log move monotonically.

The configuration change in thie PR only applies to newly bootstrapped
topics (i.e. new Sentry installations). We also need to ensure that
the topic configuration gets altered for all existing installations.