### PR TITLE
ref: Split up transactions processor into helper functions

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -1,7 +1,6 @@
 import logging
 import numbers
 import uuid
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Mapping, MutableMapping, Optional, Tuple
 
@@ -38,13 +37,8 @@ metrics = MetricsWrapper(environment.metrics, "transactions.processor")
 UNKNOWN_SPAN_STATUS = 2
 
 
-@dataclass(frozen=True)
-class StructuredMessage:
-    version: int
-    message_type: str
-    event: Dict[str, Any]
-    data: Dict[str, Any]
-    retention_days: int
+EventDict = Dict[str, Any]
+RetentionDays = int
 
 
 class TransactionsMessageProcessor(MessageProcessor):
@@ -66,7 +60,7 @@ class TransactionsMessageProcessor(MessageProcessor):
 
     def _structure_and_validate_message(
         self, message: Tuple[int, str, Dict[str, Any]]
-    ) -> Optional[StructuredMessage]:
+    ) -> Optional[Tuple[EventDict, RetentionDays]]:
         if not (isinstance(message, (list, tuple)) and len(message) >= 2):
             return None
 
@@ -94,25 +88,25 @@ class TransactionsMessageProcessor(MessageProcessor):
         except EventTooOld:
             return None
 
-        return StructuredMessage(version, type_, event, data, retention_days)
+        return event, retention_days
 
     def _process_base_event_values(
-        self, processed: MutableMapping[str, Any], structured_message: StructuredMessage
+        self, processed: MutableMapping[str, Any], event_dict: EventDict
     ) -> MutableMapping[str, Any]:
 
-        extract_base(processed, structured_message.event)
+        extract_base(processed, event_dict)
 
-        transaction_ctx = structured_message.data["contexts"]["trace"]
+        transaction_ctx = event_dict["data"]["contexts"]["trace"]
         trace_id = transaction_ctx["trace_id"]
         processed["event_id"] = str(uuid.UUID(processed["event_id"]))
         processed["trace_id"] = str(uuid.UUID(trace_id))
         processed["span_id"] = int(transaction_ctx["span_id"], 16)
         processed["transaction_op"] = _unicodify(transaction_ctx.get("op") or "")
         processed["transaction_name"] = _unicodify(
-            structured_message.data.get("transaction") or ""
+            event_dict["data"].get("transaction") or ""
         )
         processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
-            structured_message.data["start_timestamp"],
+            event_dict["data"]["start_timestamp"],
         )
         status = transaction_ctx.get("status", None)
         if status:
@@ -121,50 +115,40 @@ class TransactionsMessageProcessor(MessageProcessor):
             int_status = UNKNOWN_SPAN_STATUS
 
         processed["transaction_status"] = int_status
-        if (
-            structured_message.data["timestamp"]
-            - structured_message.data["start_timestamp"]
-            < 0
-        ):
+        if event_dict["data"]["timestamp"] - event_dict["data"]["start_timestamp"] < 0:
             # Seems we have some negative durations in the DB
             metrics.increment("negative_duration")
 
         processed["finish_ts"], processed["finish_ms"] = self.__extract_timestamp(
-            structured_message.data["timestamp"],
+            event_dict["data"]["timestamp"],
         )
 
         duration_secs = (processed["finish_ts"] - processed["start_ts"]).total_seconds()
         processed["duration"] = max(int(duration_secs * 1000), 0)
 
-        processed["platform"] = _unicodify(structured_message.event["platform"])
+        processed["platform"] = _unicodify(event_dict["platform"])
         return processed
 
     def _process_tags(
-        self,
-        processed: MutableMapping[str, Any],
-        structured_message: StructuredMessage,
+        self, processed: MutableMapping[str, Any], event_dict: EventDict,
     ) -> None:
 
-        tags: Mapping[str, Any] = _as_dict_safe(
-            structured_message.data.get("tags", None)
-        )
+        tags: Mapping[str, Any] = _as_dict_safe(event_dict["data"].get("tags", None))
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
         promoted_tags = {col: tags[col] for col in self.PROMOTED_TAGS if col in tags}
         processed["release"] = promoted_tags.get(
-            "sentry:release", structured_message.event.get("release"),
+            "sentry:release", event_dict.get("release"),
         )
         processed["environment"] = promoted_tags.get("environment")
         processed["user"] = promoted_tags.get("sentry:user", "")
         processed["dist"] = _unicodify(
-            promoted_tags.get("sentry:dist", structured_message.data.get("dist")),
+            promoted_tags.get("sentry:dist", event_dict["data"].get("dist")),
         )
 
     def _process_measurements(
-        self,
-        processed: MutableMapping[str, Any],
-        structured_message: StructuredMessage,
+        self, processed: MutableMapping[str, Any], event_dict: EventDict,
     ) -> None:
-        measurements = structured_message.data.get("measurements")
+        measurements = event_dict["data"].get("measurements")
         if measurements is not None:
             try:
                 (
@@ -189,11 +173,9 @@ class TransactionsMessageProcessor(MessageProcessor):
                 )
 
     def _process_breakdown(
-        self,
-        processed: MutableMapping[str, Any],
-        structured_message: StructuredMessage,
+        self, processed: MutableMapping[str, Any], event_dict: EventDict,
     ) -> None:
-        breakdowns = structured_message.data.get("breakdowns")
+        breakdowns = event_dict["data"].get("breakdowns")
         if breakdowns is not None:
             span_op_breakdowns = breakdowns.get("span_ops")
             if span_op_breakdowns is not None:
@@ -220,16 +202,14 @@ class TransactionsMessageProcessor(MessageProcessor):
                     )
 
     def _process_contexts_and_user(
-        self,
-        processed: MutableMapping[str, Any],
-        structured_message: StructuredMessage,
+        self, processed: MutableMapping[str, Any], event_dict: EventDict,
     ) -> None:
         contexts: MutableMapping[str, Any] = _as_dict_safe(
-            structured_message.data.get("contexts", None)
+            event_dict["data"].get("contexts", None)
         )
         user_dict = (
-            structured_message.data.get(
-                "user", structured_message.data.get("sentry.interfaces.User", None)
+            event_dict["data"].get(
+                "user", event_dict["data"].get("sentry.interfaces.User", None)
             )
             or {}
         )
@@ -262,13 +242,11 @@ class TransactionsMessageProcessor(MessageProcessor):
                 processed["ip_address_v6"] = str(ip_address)
 
     def _process_request_data(
-        self,
-        processed: MutableMapping[str, Any],
-        structured_message: StructuredMessage,
+        self, processed: MutableMapping[str, Any], event_dict: EventDict,
     ) -> None:
         request = (
-            structured_message.data.get(
-                "request", structured_message.data.get("sentry.interfaces.Http", None)
+            event_dict["data"].get(
+                "request", event_dict["data"].get("sentry.interfaces.Http", None)
             )
             or {}
         )
@@ -278,11 +256,9 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["http_referer"] = http_data["http_referer"]
 
     def _process_sdk_data(
-        self,
-        processed: MutableMapping[str, Any],
-        structured_message: StructuredMessage,
+        self, processed: MutableMapping[str, Any], event_dict: EventDict,
     ) -> None:
-        sdk = structured_message.data.get("sdk", None) or {}
+        sdk = event_dict["data"].get("sdk", None) or {}
         processed["sdk_name"] = _unicodify(sdk.get("name") or "")
         processed["sdk_version"] = _unicodify(sdk.get("version") or "")
 
@@ -294,24 +270,27 @@ class TransactionsMessageProcessor(MessageProcessor):
     def process_message(
         self, message: Tuple[int, str, Dict[Any, Any]], metadata: KafkaMessageMetadata
     ) -> Optional[ProcessedMessage]:
-        structured_message = self._structure_and_validate_message(message)
-        if not structured_message:
+        event_dict, retention_days = self._structure_and_validate_message(message) or (
+            None,
+            None,
+        )
+        if not event_dict:
             return None
         processed: MutableMapping[str, Any] = {
             "deleted": 0,
-            "retention_days": structured_message.retention_days,
+            "retention_days": retention_days,
         }
         # The following helper functions should be able to be applied in any order.
         # At time of writing, there are no reads of the values in the `processed`
         # dictionary to inform values in other functions.
         # Ideally we keep continue that rule
-        self._process_base_event_values(processed, structured_message)
-        self._process_tags(processed, structured_message)
-        self._process_measurements(processed, structured_message)
-        self._process_breakdown(processed, structured_message)
-        self._process_contexts_and_user(processed, structured_message)
-        self._process_request_data(processed, structured_message)
-        self._process_sdk_data(processed, structured_message)
+        self._process_base_event_values(processed, event_dict)
+        self._process_tags(processed, event_dict)
+        self._process_measurements(processed, event_dict)
+        self._process_breakdown(processed, event_dict)
+        self._process_contexts_and_user(processed, event_dict)
+        self._process_request_data(processed, event_dict)
+        self._process_sdk_data(processed, event_dict)
         processed["partition"] = metadata.partition
         processed["offset"] = metadata.offset
 


### PR DESCRIPTION
As I was trying to determine where to trim the contexts column, I decided to split this function up for the following reasons:

1. It is over 200 LOC, I have a vertical monitor and cannot fit the whole function into it
2. There are ~20 variables in the same function scope, that seems dangerous
3. There is no separation between different domains of message processing, making it hard to know where you should modify what you need.

There is no change in functionality this is only a simple refactor

Note: the github diff will look a little strange. It may be better to read the file in its entirety to get a picture of what's going on