### PR TITLE
fix(ratelimit) Decrement the count in all rate limiters if one limits

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -151,7 +151,7 @@ class LegacySubscriptionData(SubscriptionData):
         )
         extra_conditions: Sequence[Condition] = []
         if offset is not None:
-            extra_conditions = [[["ifnull", ["offset", 0]], "<=", offset]]
+            extra_conditions = [[["ifNull", ["offset", 0]], "<=", offset]]
         return build_request(
             {
                 "project": self.project_id,
@@ -236,7 +236,7 @@ class SnQLSubscriptionData(SubscriptionData):
                     ConditionFunctions.LTE,
                     FunctionCall(
                         None,
-                        "ifnull",
+                        "ifNull",
                         (Column(None, None, "offset"), Literal(None, 0)),
                     ),
                     Literal(None, offset),

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -1,15 +1,19 @@
-import pytest
-from unittest.mock import patch
+import time
 import uuid
+from typing import Tuple
+from unittest.mock import patch
+
+import pytest
 
 from snuba import state
+from snuba.redis import redis_client as rds
 from snuba.state.rate_limit import (
-    rate_limit,
     RateLimitAggregator,
     RateLimitExceeded,
     RateLimitParameters,
     RateLimitStats,
     RateLimitStatsContainer,
+    rate_limit,
 )
 
 
@@ -54,20 +58,20 @@ class TestRateLimit:
 
     def test_per_second_limit(self) -> None:
         bucket = uuid.uuid4()
-        rate_limit_params = RateLimitParameters("foo", bucket, 1, None)
+        rate_limit_params = RateLimitParameters("foo", str(bucket), 1, None)
         # Create 30 queries at time 0, should all be allowed
-        with patch.object(state.time, "time", lambda: 0):
+        with patch.object(state.time, "time", lambda: 0):  # type: ignore
             for _ in range(30):
                 with rate_limit(rate_limit_params) as stats:
                     assert stats is not None
 
         # Create another 30 queries at time 30, should also be allowed
-        with patch.object(state.time, "time", lambda: 30):
+        with patch.object(state.time, "time", lambda: 30):  # type: ignore
             for _ in range(30):
                 with rate_limit(rate_limit_params) as stats:
                     assert stats is not None
 
-        with patch.object(state.time, "time", lambda: 60):
+        with patch.object(state.time, "time", lambda: 60):  # type: ignore
             # 1 more query should be allowed at T60 because it does not make the previous
             # rate exceed 1/sec until it has finished.
             with rate_limit(rate_limit_params) as stats:
@@ -80,7 +84,7 @@ class TestRateLimit:
 
         # Another query at time 61 should be allowed because the first 30 queries
         # have fallen out of the lookback window
-        with patch.object(state.time, "time", lambda: 61):
+        with patch.object(state.time, "time", lambda: 61):  # type: ignore
             with rate_limit(rate_limit_params) as stats:
                 assert stats is not None
 
@@ -121,7 +125,10 @@ class TestRateLimit:
         assert rate_limit_container.get_stats("foo") == rate_limit_stats
         assert rate_limit_container.get_stats("bar") is None
 
-        assert rate_limit_container.to_dict() == {"foo_rate": 0.5, "foo_concurrent": 2}
+        assert dict(rate_limit_container.to_dict()) == {
+            "foo_rate": 0.5,
+            "foo_concurrent": 2,
+        }
 
     def test_bypass_rate_limit(self) -> None:
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)
@@ -129,3 +136,31 @@ class TestRateLimit:
 
         with rate_limit(rate_limit_params) as stats:
             assert stats is None
+
+
+tests = [
+    pytest.param((0, 5, 5)),
+    pytest.param((5, 0, 5)),
+    pytest.param((5, 5, 0)),
+]
+
+
+@pytest.mark.parametrize(
+    "vals", tests,
+)
+def test_rate_limit_failures(vals: Tuple[int, int, int]) -> None:
+    params = []
+    for i, v in enumerate(vals):
+        params.append(RateLimitParameters(f"foo{i}", f"bar{i}", None, v))
+
+    with pytest.raises(RateLimitExceeded):
+        with RateLimitAggregator(params):
+            pass
+
+    now = time.time()
+    for p in params:
+        bucket = "{}{}".format(state.ratelimit_prefix, p.bucket)
+        count = rds.zcount(
+            bucket, now - state.rate_lookback_s, now + state.rate_lookback_s
+        )
+        assert count == 0


### PR DESCRIPTION
Before, if one rate limit hit its limit, then RateLimitExceeded would be thrown
and crucially, the __exit__ method would not be called on RateLimitAggregator.
Now the __exit__ method is manually called, and if this happens, all the rate
limiters that passed will have the query ID removed to ensure they aren't
counting queries that actually got limited.