### PR TITLE
ref(metrics): Change metrics topic name

### DIFF
--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -24,7 +24,7 @@ def _validate_settings(locals: Mapping[str, Any]) -> None:
         "event-replacements-legacy",
         "snuba-commit-log",
         "cdc",
-        "ingest-metrics",
+        "snuba-metrics",
         "outcomes",
         "ingest-sessions",
         "snuba-queries",

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -11,7 +11,7 @@ class Topic(Enum):
     EVENT_REPLACEMENTS_LEGACY = "event-replacements-legacy"
     COMMIT_LOG = "snuba-commit-log"
     CDC = "cdc"
-    METRICS = "ingest-metrics"
+    METRICS = "snuba-metrics"
     OUTCOMES = "outcomes"
     SESSIONS = "ingest-sessions"
     SESSIONS_COMMIT_LOG = "snuba-sessions-commit-log"

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -22,7 +22,10 @@ class Topic(Enum):
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
-    config = {Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"}}
+    config = {
+        Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"},
+        Topic.METRICS: {"message.timestamp.type": "LogAppendTime"},
+    }
     if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
         config.update({Topic.SESSIONS: {"message.timestamp.type": "LogAppendTime"}})
     return config.get(topic, {})


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/28431 Adds a consumer for the `ingest-metrics` topic that then translates the raw metrics data of strings for all the metric names, tag keys and tag values to integers. The translated messages will go in the `snuba-metrics` topic so that ClickHouse can store the metrics data.