### PR TITLE
Test that trace and span id are present where they are expected by the product

### DIFF
--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -104,12 +104,13 @@ class ErrorsProcessor(EventsProcessorBase):
         tags: Mapping[str, Any],
     ) -> None:
         transaction_ctx = contexts.get("trace") or {}
-        if transaction_ctx.get("trace_id", None):
-            output["trace_id"] = str(uuid.UUID(transaction_ctx["trace_id"]))
-        if transaction_ctx.get("span_id", None):
-            output["span_id"] = int(transaction_ctx["span_id"], 16)
         # We store trace_id and span_id as promoted columns and on the query level
         # we make sure that all queries on contexts[trace.trace_id/span_id] use those promoted
         # columns instead. So we don't need to store them
-        transaction_ctx.pop("trace_id", None)
-        transaction_ctx.pop("span_id", None)
+        trace_id = transaction_ctx.pop("trace_id", None)
+        span_id = transaction_ctx.pop("span_id", None)
+
+        if trace_id:
+            output["trace_id"] = str(uuid.UUID(trace_id))
+        if span_id:
+            output["span_id"] = int(span_id, 16)

--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -104,11 +104,8 @@ class ErrorsProcessor(EventsProcessorBase):
         tags: Mapping[str, Any],
     ) -> None:
         transaction_ctx = contexts.get("trace") or {}
-        # We store trace_id and span_id as promoted columns and on the query level
-        # we make sure that all queries on contexts[trace.trace_id/span_id] use those promoted
-        # columns instead. So we don't need to store them
-        trace_id = transaction_ctx.pop("trace_id", None)
-        span_id = transaction_ctx.pop("span_id", None)
+        trace_id = transaction_ctx.get("trace_id", None)
+        span_id = transaction_ctx.get("span_id", None)
 
         if trace_id:
             output["trace_id"] = str(uuid.UUID(trace_id))

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -14,7 +15,8 @@ from snuba.settings import PAYLOAD_DATETIME_FORMAT
 def test_error_processor() -> None:
     received_timestamp = datetime.now() - timedelta(minutes=1)
     error_timestamp = received_timestamp - timedelta(minutes=1)
-
+    trace_id = str(uuid.uuid4())
+    span_id = "deadbeef"
     error = (
         2,
         "insert",
@@ -119,7 +121,8 @@ def test_error_processor() -> None:
                             "type": "runtime",
                             "name": "CPython",
                             "build": "3.7.6",
-                        }
+                        },
+                        "trace": {"trace_id": trace_id, "span_id": span_id},
                     },
                     "culprit": "snuba.clickhouse.http in write",
                     "exception": {
@@ -240,6 +243,10 @@ def test_error_processor() -> None:
         "sdk_version": "0.0.0.0.1",
         "http_method": "POST",
         "http_referer": "tagstore.something",
+        # Notice that trace_id and span_id shows up in columns but not in the contexts
+        # this is on purpose to save space
+        "trace_id": trace_id,
+        "span_id": int(span_id, 16),
         "tags.key": [
             "environment",
             "handled",
@@ -339,6 +346,8 @@ def test_error_processor() -> None:
         }
     )
 
-    assert processor.process_message(error, meta) == InsertBatch(
-        [expected_result], None
-    )
+    processed_message = processor.process_message(error, meta)
+    expected_message = InsertBatch([expected_result], None)
+    # assert on the rows first so we get a nice diff from pytest
+    assert processed_message.rows[0] == expected_message.rows[0]
+    assert processed_message == expected_message

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -243,8 +243,6 @@ def test_error_processor() -> None:
         "sdk_version": "0.0.0.0.1",
         "http_method": "POST",
         "http_referer": "tagstore.something",
-        # Notice that trace_id and span_id shows up in columns but not in the contexts
-        # this is on purpose to save space
         "trace_id": trace_id,
         "span_id": int(span_id, 16),
         "tags.key": [
@@ -273,6 +271,8 @@ def test_error_processor() -> None:
             "runtime.version",
             "runtime.name",
             "runtime.build",
+            "trace.trace_id",
+            "trace.span_id",
             "geo.country_code",
             "geo.region",
             "geo.city",
@@ -281,6 +281,8 @@ def test_error_processor() -> None:
             "3.7.6",
             "CPython",
             "3.7.6",
+            trace_id,
+            span_id,
             "XY",
             "fake_region",
             "fake_city",

--- a/tests/datasets/test_events_processor.py
+++ b/tests/datasets/test_events_processor.py
@@ -29,7 +29,7 @@ from tests.fixtures import get_raw_event
 
 
 class TestEventsProcessor:
-    def setup_method(self, test_method):
+    def setup_method(self, test_method) -> None:
         self.metadata = KafkaMessageMetadata(0, 0, datetime.now())
         self.event = get_raw_event()
 
@@ -54,6 +54,12 @@ class TestEventsProcessor:
 
     def __process_insert_event(self, event: InsertEvent) -> Optional[ProcessedMessage]:
         return self.processor.process_message((2, "insert", event, {}), self.metadata)
+
+    def test_has_trace_and_span_id(self) -> None:
+        processed_message = self.__process_insert_event(self.event)
+        assert isinstance(processed_message, InsertBatch)
+        assert "trace.trace_id" in processed_message.rows[0]["contexts.key"]
+        assert "trace.span_id" in processed_message.rows[0]["contexts.key"]
 
     def test_unexpected_obj(self) -> None:
         self.event["message"] = {"what": "why is this in the message"}

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,7 +20,7 @@ def get_raw_event() -> InsertEvent:
     event_datetime = (now - timedelta(seconds=2)).strftime(
         settings.PAYLOAD_DATETIME_FORMAT,
     )
-    trace_id = str(uuid.uuid4())
+    trace_id = str(uuid.uuid4().hex)
     span_id = "deadbeef"
 
     return {

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,6 +2,7 @@ import calendar
 import uuid
 from datetime import datetime, timedelta, timezone
 from hashlib import md5
+
 from snuba import settings
 from snuba.datasets.events_processor_base import InsertEvent
 
@@ -19,6 +20,8 @@ def get_raw_event() -> InsertEvent:
     event_datetime = (now - timedelta(seconds=2)).strftime(
         settings.PAYLOAD_DATETIME_FORMAT,
     )
+    trace_id = str(uuid.uuid4())
+    span_id = "deadbeef"
 
     return {
         "project_id": PROJECT_ID,
@@ -72,6 +75,7 @@ def get_raw_event() -> InsertEvent:
             "contexts": {
                 "device": {"online": True, "charging": True, "model_id": "Galaxy"},
                 "os": {"kernel_version": "1.1.1"},
+                "trace": {"trace_id": trace_id, "span_id": span_id},
             },
             "sentry.interfaces.Exception": {
                 "exc_omitted": None,

--- a/tests/migrations/test_runner_individual.py
+++ b/tests/migrations/test_runner_individual.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any, Dict, Optional, Sequence
 
 from snuba.clickhouse.http import JSONRowEncoder
@@ -290,6 +291,11 @@ def test_backfill_errors() -> None:
         ["contexts.key", "contexts.value"], errors_table_name, None, str(1), clickhouse
     )
 
+    class UUIDVerifier:
+        def __eq__(self, some_str):
+            uuid.UUID(some_str)
+            return True
+
     assert outcome[0] == (
         [
             "device.model_id",
@@ -297,6 +303,8 @@ def test_backfill_errors() -> None:
             "geo.country_code",
             "geo.region",
             "os.kernel_version",
+            "trace.span_id",
+            "trace.trace_id",
         ],
-        ["Galaxy", "San Francisco", "US", "CA", "1.1.1"],
+        ["Galaxy", "San Francisco", "US", "CA", "1.1.1", "deadbeef", UUIDVerifier()],
     )


### PR DESCRIPTION
# Context
We currently store trace_id and span_id in two places on the errors table:

* As columns
* As keys and values on the contexts table

The product expects both of these to be present

# Solution
Add tests to make sure that if someone removes these it's intentional