### PR TITLE
ref(latency) Add metrics to track various ingest latencies

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -50,6 +50,9 @@ DOGSTATSD_PORT = 8125
 DOGSTATSD_SAMPLING_RATES = {
     "subscriptions.receive_latency": 0.1,
     "subscriptions.process_message": 0.1,
+    "events.base.processor.process_timestamp_latency": 0.01,
+    "events.base.processor.process_received_latency": 0.01,
+    "events.base.processor.process_nodestore_insert_latency": 0.01,
 }
 
 # Redis Options


### PR DESCRIPTION
Add a metric that will track the delay between our processing and the event
timestamp, the time we received the event and the time the event was written
to nodestore. This should help debug a potential ingestion delay problem.