### PR TITLE
feat: Produce original message timestamp to commit log headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: mypy
         files: snuba
         args: [--config-file, mypy.ini, --ignore-missing-imports, --strict, --warn-unreachable]
-        additional_dependencies: ['sentry-arroyo==0.0.2']
+        additional_dependencies: ['sentry-arroyo==0.0.3']
   - repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==1.4
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-arroyo==0.0.2
+sentry-arroyo==0.0.3
 sentry-relay==0.8.7
 sentry-sdk==1.1.0
 simplejson==3.15.0

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -28,7 +28,7 @@ from arroyo.processing.strategies.streaming import (
     ParallelTransformStep,
     TransformStep,
 )
-from arroyo.types import Offset
+from arroyo.types import Position
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder
@@ -516,7 +516,7 @@ class MultistorageConsumerProcessingStrategyFactory(
         )
 
     def create(
-        self, commit: Callable[[Mapping[Partition, Offset]], None]
+        self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[KafkaPayload]:
         # 1. Identify the storages that should be used for the input message.
         # 2. Filter out any messages that do not apply to any storage.

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -28,6 +28,7 @@ from arroyo.processing.strategies.streaming import (
     ParallelTransformStep,
     TransformStep,
 )
+from arroyo.types import Offset
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder
@@ -515,7 +516,7 @@ class MultistorageConsumerProcessingStrategyFactory(
         )
 
     def create(
-        self, commit: Callable[[Mapping[Partition, int]], None]
+        self, commit: Callable[[Mapping[Partition, Offset]], None]
     ) -> ProcessingStrategy[KafkaPayload]:
         # 1. Identify the storages that should be used for the input message.
         # 2. Filter out any messages that do not apply to any storage.

--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -15,6 +15,7 @@ from typing import (
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer
 from arroyo.errors import ConsumerError
+from arroyo.types import Offset
 
 from snuba.utils.types import Interval, InvalidRangeError
 
@@ -190,10 +191,10 @@ class TickConsumer(Consumer[Tick]):
 
         return self.__consumer.seek(offsets)
 
-    def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
+    def stage_offsets(self, offsets: Mapping[Partition, Offset]) -> None:
         return self.__consumer.stage_offsets(offsets)
 
-    def commit_offsets(self) -> Mapping[Partition, int]:
+    def commit_offsets(self) -> Mapping[Partition, Offset]:
         return self.__consumer.commit_offsets()
 
     def close(self, timeout: Optional[float] = None) -> None:

--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -15,7 +15,7 @@ from typing import (
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer
 from arroyo.errors import ConsumerError
-from arroyo.types import Offset
+from arroyo.types import Position
 
 from snuba.utils.types import Interval, InvalidRangeError
 
@@ -191,11 +191,11 @@ class TickConsumer(Consumer[Tick]):
 
         return self.__consumer.seek(offsets)
 
-    def stage_offsets(self, offsets: Mapping[Partition, Offset]) -> None:
-        return self.__consumer.stage_offsets(offsets)
+    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
+        return self.__consumer.stage_positions(positions)
 
-    def commit_offsets(self) -> Mapping[Partition, Offset]:
-        return self.__consumer.commit_offsets()
+    def commit_positions(self) -> Mapping[Partition, Position]:
+        return self.__consumer.commit_positions()
 
     def close(self, timeout: Optional[float] = None) -> None:
         return self.__consumer.close(timeout)

--- a/snuba/utils/streams/kafka_consumer_with_commit_log.py
+++ b/snuba/utils/streams/kafka_consumer_with_commit_log.py
@@ -48,7 +48,7 @@ class KafkaConsumerWithCommitLog(KafkaConsumer):
                 key=payload.key,
                 value=payload.value,
                 headers={
-                    "message_ts": datetime.strftime(
+                    "orig_message_ts": datetime.strftime(
                         offset.timestamp, PAYLOAD_DATETIME_FORMAT
                     ),
                 },

--- a/tests/backends/confluent_kafka.py
+++ b/tests/backends/confluent_kafka.py
@@ -24,11 +24,6 @@ class FakeConfluentKafkaMessage(object):
         self._offset = offset
         self._value = value
         self._key = key
-        self._headers = (
-            {str(k): str(v) if v else None for k, v in headers.items()}
-            if headers
-            else None
-        )
         self._headers = headers
         self._error = error
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -11,6 +11,7 @@ import pytest
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies.streaming import KafkaConsumerStrategyFactory
+from arroyo.types import Position
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.consumer import (
@@ -178,10 +179,10 @@ def test_multistorage_strategy(
         ),
     ]
 
+    now = datetime.now()
+
     messages = [
-        Message(
-            Partition(Topic("topic"), 0), offset, payload, datetime.now(), offset + 1
-        )
+        Message(Partition(Topic("topic"), 0), offset, payload, now, offset + 1)
         for offset, payload in enumerate(payloads)
     ]
 
@@ -193,7 +194,9 @@ def test_multistorage_strategy(
             strategy.submit(message)
 
         with assert_changes(
-            lambda: commit.call_args_list, [], [call({Partition(Topic("topic"), 0): 3})]
+            lambda: commit.call_args_list,
+            [],
+            [call({Partition(Topic("topic"), 0): Position(3, now)})],
         ):
             strategy.close()
             strategy.join()


### PR DESCRIPTION
This change writes the timestamp of the original Kafka message
in the header of its commit log topic with the key `orig_message_ts`.
This timestamp is used as the basis for subscription scheduling and
having this in the commit log will enable subscriptions to no longer
need to consume the original topic in future, only the commit log.

This depends on https://github.com/getsentry/arroyo/pull/28,
https://github.com/getsentry/arroyo/pull/29 and a
new release of arroyo.