### PR TITLE
Remove trace.[trace_id/span_id] from transaction contexts

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -225,6 +225,12 @@ class TransactionsMessageProcessor(MessageProcessor):
             if context in contexts:
                 del contexts[context]
 
+        transaction_ctx = contexts.get("trace", {})
+        # We store trace_id and span_id as promoted columns and on the query level
+        # we make sure that all queries on contexts[trace.trace_id/span_id] use those promoted
+        # columns instead. So we don't need to store them in the contexts array as well
+        transaction_ctx.pop("trace_id", None)
+        transaction_ctx.pop("span_id", None)
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(
             contexts
         )

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -187,11 +187,11 @@ class TransactionEvent:
             "user_email": self.user_email,
             "tags.key": ["environment", "sentry:release", "sentry:user", "we|r=d"],
             "tags.value": [self.environment, self.release, self.user_id, "tag"],
+            # Notice that we do not store trace.trace_id or trace.span_id in contexts
+            # this is because it is redundant (as it is also stored as a promoted column)
             "contexts.key": [
                 "trace.sampled",
-                "trace.trace_id",
                 "trace.op",
-                "trace.span_id",
                 "trace.status",
                 "geo.country_code",
                 "geo.region",
@@ -199,9 +199,7 @@ class TransactionEvent:
             ],
             "contexts.value": [
                 "True",
-                self.trace_id,
                 self.op,
-                self.span_id,
                 self.status,
                 self.geo["country_code"],
                 self.geo["region"],


### PR DESCRIPTION
# Context

We currently store trace_id and span_id in two places on the transactions table:

* As columns
* As keys and values on the contexts table

This storage is redundant and also non-compressible since these ids are randomly generated.
Solution

This PR makes it so the message processor that writes to the table drops it from the contexts table. It will not be queried due to the changes in #2074

# Test Plan

Added to the test_transaction_processor test that validates trace_id and span_id being promoted to the column but not being stored in the contexts
    
# Rollout Concerns

If we start doing this, we have to make sure that we are no longer querying the contexts[trace.trace_id] column. This was verified in the querylog with the following query returning no rows:
```
SELECT COUNT (*) FROM (
	SELECT
	    request_id,
	    referrer,
	    clickhouse_queries.sql
	FROM
		querylog_local
	ARRAY JOIN
		clickhouse_queries
	WHERE
	    (
	        like(clickhouse_queries.sql, '%indexOf(contexts.key, \'trace.span_id\')%') OR
	        like(clickhouse_queries.sql, '%indexOf(contexts.key, \'trace.trace_id\')%') 
	
	    ) AND
	    timestamp >= toDateTime('2021-09-07 00:00:00', 'America/Los_Angeles')
) AS T
```
This query does return rows for the previous week (before #2074 was deployed)

