### PR TITLE
waiting until alter query to be executed on replicas

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -32,7 +32,10 @@ class ClickhouseClientSettingsType(NamedTuple):
 class ClickhouseClientSettings(Enum):
     CLEANUP = ClickhouseClientSettingsType({}, None)
     INSERT = ClickhouseClientSettingsType({}, None)
-    MIGRATE = ClickhouseClientSettingsType({"load_balancing": "in_order"}, 10000)
+    MIGRATE = ClickhouseClientSettingsType(
+        {"load_balancing": "in_order", "replication_alter_partitions_sync": 2},
+        10000
+    )
     OPTIMIZE = ClickhouseClientSettingsType({}, 10000)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
     REPLACE = ClickhouseClientSettingsType(

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -222,7 +222,7 @@ class AddIndex(SqlOperation):
 
     def format_sql(self) -> str:
         optional_after_clause = f" AFTER {self.__after}" if self.__after else ""
-        return f"ALTER TABLE {self.__table_name} ADD INDEX {self.__index_name} {self.__index_expression} TYPE {self.__index_type} GRANULARITY {self.__granularity}{optional_after_clause};"
+        return f"ALTER TABLE {self.__table_name} ADD INDEX IF NOT EXISTS {self.__index_name} {self.__index_expression} TYPE {self.__index_type} GRANULARITY {self.__granularity}{optional_after_clause};"
 
 
 class DropIndex(SqlOperation):

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -119,7 +119,7 @@ def test_add_index() -> None:
             3,
             after=None,
         ).format_sql()
-        == "ALTER TABLE test_table ADD INDEX index_1 timestamp TYPE minmax GRANULARITY 3;"
+        == "ALTER TABLE test_table ADD INDEX IF NOT EXISTS index_1 timestamp TYPE minmax GRANULARITY 3;"
     )
 
 


### PR DESCRIPTION
Hi!

In this PR I fixed 2 problems for distributed clickhouse:
1) ADD INDEX **IF NOT EXISTS** When migration runs on the second node of clickhouse I get an error that index already exists
2) **SETTINGS replication_alter_partitions_sync = 2** I tried to understand why I can't finish migrations on clickhouse cluster and got an error "Metadata on replica is not up to date with common metadata in Zookeeper. Cannot alter". My colleague from Yandex Clickhouse helped me to understand, that migration runs a lot of alter operations and they don't have time to finish. He [improved a little bit error message](https://github.com/ClickHouse/ClickHouse/pull/29009/files). For clickhouse cluster we need [wait for actions to be executed on replicas](https://clickhouse.tech/docs/en/operations/settings/settings/#replication-alter-partitions-sync), and should use replication_alter_partitions_sync = 2

Plz, take a look for PR, what do you think?