### PR TITLE
Skip bad outcome

### DIFF
--- a/snuba/datasets/outcomes_processor.py
+++ b/snuba/datasets/outcomes_processor.py
@@ -21,15 +21,17 @@ metrics = MetricsWrapper(environment.metrics, "outcomes.processor")
 OUTCOME_ABUSE = 4
 OUTCOME_CLIENT_DISCARD = 5
 
-CLIENT_DISCARD_REASONS = frozenset([
-    "queue_overflow",
-    "cache_overflow",
-    "ratelimit_backoff",
-    "network_error",
-    "before_send",
-    "event_processor",
-    "sample_rate",
-])
+CLIENT_DISCARD_REASONS = frozenset(
+    [
+        "queue_overflow",
+        "cache_overflow",
+        "ratelimit_backoff",
+        "network_error",
+        "before_send",
+        "event_processor",
+        "sample_rate",
+    ]
+)
 
 
 class OutcomesProcessor(MessageProcessor):
@@ -48,24 +50,33 @@ class OutcomesProcessor(MessageProcessor):
             if reason is not None and reason not in CLIENT_DISCARD_REASONS:
                 reason = None
 
-        if value["outcome"] != OUTCOME_ABUSE:  # we dont care about abuse outcomes for these metrics
+        if (
+            value["outcome"] != OUTCOME_ABUSE
+        ):  # we dont care about abuse outcomes for these metrics
             if "category" not in value:
                 metrics.increment("missing_category")
             if "quantity" not in value:
                 metrics.increment("missing_quantity")
 
-        message = {
-            "org_id": value.get("org_id", 0),
-            "project_id": value.get("project_id", 0),
-            "key_id": value.get("key_id"),
-            "timestamp": _ensure_valid_date(
-                datetime.strptime(value["timestamp"], settings.PAYLOAD_DATETIME_FORMAT),
-            ),
-            "outcome": value["outcome"],
-            "category": value.get("category", DataCategory.ERROR),
-            "quantity": value.get("quantity", 1),
-            "reason": _unicodify(reason),
-            "event_id": str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
-        }
+        message = None
+        try:
+            message = {
+                "org_id": value.get("org_id", 0),
+                "project_id": value.get("project_id", 0),
+                "key_id": value.get("key_id"),
+                "timestamp": _ensure_valid_date(
+                    datetime.strptime(
+                        value["timestamp"], settings.PAYLOAD_DATETIME_FORMAT
+                    ),
+                ),
+                "outcome": value["outcome"],
+                "category": value.get("category", DataCategory.ERROR),
+                "quantity": value.get("quantity", 1),
+                "reason": _unicodify(reason),
+                "event_id": str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
+            }
+        except Exception:
+            metrics.increment("bad_outcome")
+            return None
 
         return InsertBatch([message], None)


### PR DESCRIPTION
There is a bad outcome in kafka right now.
```
{
category: 1, 
key_id: 51405, 
org_id: 1, 
outcome: 5, 
project_id: 11276, 
quantity: 7, 
reason: 'sample_rate', 
remote_addr: '178.43.250.103', 
source: 'relay-internal', 
timestamp: '+53677-08-05T22:29:06.000000Z'
}
```