### PR TITLE
feat(web): Entity-specific insertion endpoint for tests

### DIFF
--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -1,7 +1,18 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class MetricsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(default_entity=EntityKey.METRICS_SETS)
+
+    def get_all_entities(self) -> Sequence[Entity]:
+        return (
+            get_entity(EntityKey.METRICS_COUNTERS),
+            get_entity(EntityKey.METRICS_DISTRIBUTIONS),
+            get_entity(EntityKey.METRICS_SETS),
+        )

--- a/snuba/web/converters.py
+++ b/snuba/web/converters.py
@@ -1,6 +1,9 @@
 from werkzeug.routing import BaseConverter
 
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
+from snuba.datasets.entity import Entity
 from snuba.datasets.factory import get_dataset, get_dataset_name
 
 
@@ -10,3 +13,11 @@ class DatasetConverter(BaseConverter):
 
     def to_url(self, value: Dataset) -> str:
         return get_dataset_name(value)
+
+
+class EntityConverter(BaseConverter):
+    def to_python(self, value: str) -> Entity:
+        return get_entity(EntityKey(value))
+
+    def to_url(self, value: Entity) -> str:
+        return ENTITY_NAME_LOOKUP[value].value

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -43,7 +43,7 @@ from snuba.datasets.factory import (
 )
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.query.composite import CompositeQuery
-from snuba.query.data_source.simple import Entity as EntityMarker
+from snuba.query.data_source.simple import Entity
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.logical import Query
 from snuba.redis import redis_client
@@ -406,7 +406,7 @@ def dataset_query(
     if language == Language.SNQL:
         parser: Callable[
             [RequestParts, RequestSettings, Dataset],
-            Union[Query, CompositeQuery[EntityMarker]],
+            Union[Query, CompositeQuery[Entity]],
         ] = partial(parse_snql_query, [])
     else:
         parser = parse_legacy_query
@@ -498,12 +498,12 @@ if application.debug or application.testing:
     # These should only be used for testing/debugging. Note that the database name
     # is checked to avoid scary production mishaps.
 
-    from snuba.datasets.entity import Entity
+    from snuba.datasets.entity import Entity as EntityType
     from snuba.web.converters import EntityConverter
 
     application.url_map.converters["entity"] = EntityConverter
 
-    def _write_to_entity(*, entity: Entity) -> RespTuple:
+    def _write_to_entity(*, entity: EntityType) -> RespTuple:
         from snuba.processor import InsertBatch
 
         rows: MutableSequence[WriterTableRow] = []
@@ -540,7 +540,7 @@ if application.debug or application.testing:
         return _write_to_entity(entity=dataset.get_default_entity())
 
     @application.route("/tests/entities/<entity:entity>/insert", methods=["POST"])
-    def write_to_entity(*, entity: Entity) -> RespTuple:
+    def write_to_entity(*, entity: EntityType) -> RespTuple:
         return _write_to_entity(entity=entity)
 
     @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])


### PR DESCRIPTION
The existing API endpoint `/tests/<dataset:dataset>/insert` allows writing data to the default entity of each dataset. In the case of metrics, this means that only `metrics_sets` can be written.

This PR introduces an additional endpoint `/tests/entities/<entity:entity>/insert`, which allows the client to define the target entity explicitly.

This is required to run tests in https://github.com/getsentry/sentry/pull/28598.