### PR TITLE
Communicate read-through cache exceptions to waiting clients

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 
 from pkg_resources import resource_string
 
@@ -63,7 +63,7 @@ class RedisCache(Cache[TValue]):
 
         return self.__codec.decode(value)
 
-    def set(self, key: str, value: Union[TValue]) -> None:
+    def set(self, key: str, value: TValue) -> None:
         self.__client.set(
             self.__build_key(key),
             self.__codec.encode(value),

--- a/snuba/state/cache/redis/scripts/get.lua
+++ b/snuba/state/cache/redis/scripts/get.lua
@@ -6,6 +6,7 @@
 
 -- Check to see if a value already exists at the result key. If one does, we
 -- don't have to do anything other than return it and exit.
+-- TODO(Vlad): assign the args to variables to make this more readable
 local value = redis.call('GET', KEYS[1])
 if value then
     return {0, value}
@@ -21,7 +22,9 @@ if waiting == 1 then
     -- We shouldn't be overwriting an existing task here, but it's safe if we
     -- do, given that the queue was empty.
     redis.call('SETEX', KEYS[3], ARGV[1], ARGV[2])
+    -- return RESULT_EXECUTE, TIMEOUT, TASK_ID
     return {1, ARGV[2], ARGV[1]}
 else
+    -- RESULT_WAIT,
     return {2, redis.call('GET', KEYS[3]), redis.call('TTL', KEYS[3])}
 end

--- a/snuba/state/cache/redis/scripts/get.lua
+++ b/snuba/state/cache/redis/scripts/get.lua
@@ -9,11 +9,15 @@ local task_id_key = KEYS[3]
 local task_timeout = ARGV[1]
 local task_id = ARGV[2]
 
+local CODE_RESULT_VALUE = 0
+local CODE_RESULT_EXECUTE = 1
+local CODE_RESULT_WAIT = 2
+
 -- Check to see if a value already exists at the result key. If one does, we
 -- don't have to do anything other than return it and exit.
 local value = redis.call('GET', value_key)
 if value then
-    return {0, value}
+    return {CODE_RESULT_VALUE, value}
 end
 
 -- Check to see if a waiting queue has already been established. If we are the
@@ -26,8 +30,7 @@ if waiting == 1 then
     -- We shouldn't be overwriting an existing task here, but it's safe if we
     -- do, given that the queue was empty.
     redis.call('SETEX', task_id_key, task_timeout, task_id)
-    return {1, task_id, task_timeout}
+    return {CODE_RESULT_EXECUTE, task_id, task_timeout}
 else
-    -- RESULT_WAIT,
-    return {2, redis.call('GET', task_id_key), redis.call('TTL', task_id_key)}
+    return {CODE_RESULT_WAIT, redis.call('GET', task_id_key), redis.call('TTL', task_id_key)}
 end

--- a/snuba/utils/codecs.py
+++ b/snuba/utils/codecs.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
+from snuba.utils.serializable_exception import SerializableException
+
 TEncoded = TypeVar("TEncoded")
 
 TDecoded = TypeVar("TDecoded")
@@ -25,6 +27,12 @@ class Codec(
 
 
 T = TypeVar("T")
+
+
+class ExceptionAwareCodec(Codec[TEncoded, TDecoded]):
+    @abstractmethod
+    def encode_exception(self, value: SerializableException) -> TEncoded:
+        raise NotImplementedError
 
 
 class PassthroughCodec(Generic[T], Codec[T, T]):

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -54,15 +54,15 @@ metrics = MetricsWrapper(environment.metrics, "db_query")
 
 
 class ResultCacheCodec(ExceptionAwareCodec[bytes, Result]):
-    def encode(self, value: Union[SerializableException, Result]) -> bytes:
+    def encode(self, value: Result) -> bytes:
         return cast(str, rapidjson.dumps(value)).encode("utf-8")
 
     def decode(self, value: bytes) -> Result:
         ret = rapidjson.loads(value)
-        if not isinstance(ret, Mapping) or "meta" not in ret or "data" not in ret:
-            raise ValueError("Invalid value type in result cache")
         if ret.get("__type__", "DNE") == "SerializableException":
             raise SerializableException.from_dict(cast(SerializableExceptionDict, ret))
+        if not isinstance(ret, Mapping) or "meta" not in ret or "data" not in ret:
+            raise ValueError("Invalid value type in result cache")
         return cast(Result, ret)
 
     def encode_exception(self, value: SerializableException) -> bytes:

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 
 from snuba.redis import redis_client
-from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
+from snuba.state.cache.abstract import Cache, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import PassthroughCodec
 from tests.assertions import assert_changes, assert_does_not_change
@@ -91,8 +91,6 @@ def test_get_readthrough_exception(backend: Cache[bytes]) -> None:
     with pytest.raises(CustomException):
         backend.get_readthrough(key, function, noop, 1)
 
-    assert backend.get(key) is None
-
 
 def test_get_readthrough_set_wait(backend: Cache[bytes]) -> None:
     key = "key"
@@ -130,8 +128,10 @@ def test_get_readthrough_set_wait_error(backend: Cache[bytes]) -> None:
     with pytest.raises(CustomException):
         setter.result()
 
-    with pytest.raises(ExecutionError):
+    with pytest.raises(Exception) as e:
         waiter.result()
+        assert e.__class__.__name__ == "CustomException"
+        assert e.args == ("error",)
 
 
 def test_get_readthrough_set_wait_timeout(backend: Cache[bytes]) -> None:

--- a/tests/web/test_result_cache_codec.py
+++ b/tests/web/test_result_cache_codec.py
@@ -1,0 +1,24 @@
+import pytest
+
+from snuba.utils.serializable_exception import SerializableException
+from snuba.web.db_query import ResultCacheCodec
+
+
+def test_encode_decode():
+    payload = {
+        "meta": [{"name": "foo", "type": "bar"}],
+        "data": [{"foo": "bar"}],
+        "totals": {"foo": 1},
+    }
+    codec = ResultCacheCodec()
+    assert codec.decode(codec.encode(payload)) == payload
+
+
+def test_encode_decode_exception():
+    class SomeException(SerializableException):
+        pass
+
+    codec = ResultCacheCodec()
+    encoded_exception = codec.encode_exception(SomeException("some message"))
+    with pytest.raises(SomeException):
+        codec.decode(encoded_exception)


### PR DESCRIPTION
### Problem
We have a lot of ExecutionErrors happening for reasons that we don't really know. This PR reports those errors back to clients waiting for results of duplicate queries

### Proposed Solution

If an exception happens serialize the exception using SerializableException and put that in redis. Deserialize it on the other side and re-raise it

### Feedback Desired

* The code has unit tests but I'm wondering if there is a larger integration test I can/should write. Are there larger tests that I can take inspiration from?