### PR TITLE
feat(subscription): relax validation on aggregations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 htmlcov/
 snuba.egg-info/
 .DS_Store
+.idea/

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -97,8 +97,13 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
 
     def validate(self, query: Query, alias: Optional[str] = None) -> None:
         selected = query.get_selected_columns()
-        if len(selected) != 1:
-            raise InvalidQueryException("only one aggregation in the select allowed")
+
+        if len(selected) > 2:
+            # In datasets like `sessions` dataset, we might also want to return the total count
+            # along with the aggregate value
+            raise InvalidQueryException(
+                "a maximum of two aggregations in the select are allowed"
+            )
 
         disallowed = ["groupby", "having", "orderby"]
         for field in disallowed:

--- a/tests/datasets/validation/test_subscription_clauses_validator.py
+++ b/tests/datasets/validation/test_subscription_clauses_validator.py
@@ -96,6 +96,28 @@ invalid_tests = [
         ),
         id="no orderby clauses",
     ),
+    pytest.param(
+        LogicalQuery(
+            QueryEntity(
+                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model()
+            ),
+            selected_columns=[
+                SelectedExpression("count", FunctionCall("_snuba_count", "count", ())),
+                SelectedExpression(
+                    "count", FunctionCall("_snuba_count_2", "count", ())
+                ),
+                SelectedExpression(
+                    "count", FunctionCall("_snuba_count_3", "count", ())
+                ),
+            ],
+            condition=binary_condition(
+                "equals",
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 1),
+            ),
+        ),
+        id="a maximum of two aggregations in the select are allowed",
+    ),
 ]
 
 

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -64,7 +64,7 @@ TESTS = [
             project_id=1,
             query=(
                 "MATCH (events) "
-                "SELECT count() AS count, avg(timestamp) AS average_t "
+                "SELECT count() AS count, max(timestamp) AS max_t, min(timestamp) AS min_t"
                 "WHERE "
                 "platform IN tuple('a') "
             ),
@@ -72,7 +72,7 @@ TESTS = [
             resolution=timedelta(minutes=1),
         ),
         InvalidQueryException,
-        id="SnQL subscription with 2 many aggregates",
+        id="SnQL subscription with 3 many aggregates",
     ),
     pytest.param(
         SnQLSubscriptionData(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2107,7 +2107,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
         data = json.loads(resp.data)
         assert data == {
             "error": {
-                "message": "only one aggregation in the select allowed",
+                "message": "invalid clause groupby in subscription query",
                 "type": "invalid_query",
             }
         }


### PR DESCRIPTION
Increases the allowed number of aggregations in the select column for `sessions` subscription queries to two since in crash rate alerts, we'd like to be able to return the total count along side the aggregate

Corresponding change in Sentry https://github.com/getsentry/sentry/pull/28675