### PR TITLE
Revert "feat: Produce original message timestamp to commit log header…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     -   id: mypy
         files: snuba
         args: [--config-file, mypy.ini, --ignore-missing-imports, --strict, --warn-unreachable]
-        additional_dependencies: ['sentry-arroyo==0.0.3']
+        additional_dependencies: ['sentry-arroyo==0.0.2']
   - repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==1.4
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-arroyo==0.0.3
+sentry-arroyo==0.0.2
 sentry-relay==0.8.7
 sentry-sdk==1.1.0
 simplejson==3.15.0

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -28,7 +28,6 @@ from arroyo.processing.strategies.streaming import (
     ParallelTransformStep,
     TransformStep,
 )
-from arroyo.types import Position
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder
@@ -516,7 +515,7 @@ class MultistorageConsumerProcessingStrategyFactory(
         )
 
     def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+        self, commit: Callable[[Mapping[Partition, int]], None]
     ) -> ProcessingStrategy[KafkaPayload]:
         # 1. Identify the storages that should be used for the input message.
         # 2. Filter out any messages that do not apply to any storage.

--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -15,7 +15,6 @@ from typing import (
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer
 from arroyo.errors import ConsumerError
-from arroyo.types import Position
 
 from snuba.utils.types import Interval, InvalidRangeError
 
@@ -191,11 +190,11 @@ class TickConsumer(Consumer[Tick]):
 
         return self.__consumer.seek(offsets)
 
-    def stage_positions(self, positions: Mapping[Partition, Position]) -> None:
-        return self.__consumer.stage_positions(positions)
+    def stage_offsets(self, offsets: Mapping[Partition, int]) -> None:
+        return self.__consumer.stage_offsets(offsets)
 
-    def commit_positions(self) -> Mapping[Partition, Position]:
-        return self.__consumer.commit_positions()
+    def commit_offsets(self) -> Mapping[Partition, int]:
+        return self.__consumer.commit_offsets()
 
     def close(self, timeout: Optional[float] = None) -> None:
         return self.__consumer.close(timeout)

--- a/snuba/utils/streams/kafka_consumer_with_commit_log.py
+++ b/snuba/utils/streams/kafka_consumer_with_commit_log.py
@@ -3,7 +3,6 @@ from typing import Any, Mapping, Optional
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.synchronized import Commit, commit_codec
-from arroyo.types import Position
 from arroyo.utils.retries import RetryPolicy
 from confluent_kafka import KafkaError
 from confluent_kafka import Message as ConfluentMessage
@@ -34,24 +33,20 @@ class KafkaConsumerWithCommitLog(KafkaConsumer):
         if error is not None:
             raise Exception(error.str())
 
-    def commit_positions(self) -> Mapping[Partition, Position]:
-        positions = super().commit_positions()
+    def commit_offsets(self) -> Mapping[Partition, int]:
+        offsets = super().commit_offsets()
 
-        for partition, position in positions.items():
-            commit = Commit(
-                self.__group_id, partition, position.offset, position.timestamp
-            )
+        for partition, offset in offsets.items():
+            commit = Commit(self.__group_id, partition, offset)
             payload = commit_codec.encode(commit)
-
             self.__producer.produce(
                 self.__commit_log_topic.name,
                 key=payload.key,
                 value=payload.value,
-                headers=payload.headers,
                 on_delivery=self.__commit_message_delivery_callback,
             )
 
-        return positions
+        return offsets
 
     def close(self, timeout: Optional[float] = None) -> None:
         super().close()

--- a/tests/backends/confluent_kafka.py
+++ b/tests/backends/confluent_kafka.py
@@ -24,6 +24,11 @@ class FakeConfluentKafkaMessage(object):
         self._offset = offset
         self._value = value
         self._key = key
+        self._headers = (
+            {str(k): str(v) if v else None for k, v in headers.items()}
+            if headers
+            else None
+        )
         self._headers = headers
         self._error = error
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -11,7 +11,6 @@ import pytest
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies.streaming import KafkaConsumerStrategyFactory
-from arroyo.types import Position
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.consumer import (
@@ -179,10 +178,10 @@ def test_multistorage_strategy(
         ),
     ]
 
-    now = datetime.now()
-
     messages = [
-        Message(Partition(Topic("topic"), 0), offset, payload, now, offset + 1)
+        Message(
+            Partition(Topic("topic"), 0), offset, payload, datetime.now(), offset + 1
+        )
         for offset, payload in enumerate(payloads)
     ]
 
@@ -194,9 +193,7 @@ def test_multistorage_strategy(
             strategy.submit(message)
 
         with assert_changes(
-            lambda: commit.call_args_list,
-            [],
-            [call({Partition(Topic("topic"), 0): Position(3, now)})],
+            lambda: commit.call_args_list, [], [call({Partition(Topic("topic"), 0): 3})]
         ):
             strategy.close()
             strategy.join()


### PR DESCRIPTION
…s (#2093)"

This reverts commit a5d9330afae55676a2f10d3a776de599e4357695.

This caused the commit log consumer to crash as we cannot attempt to decode `orig_message_ts` ( https://github.com/getsentry/arroyo/blob/37c48ee6259f81ead33007ae0b76a5ddf5c48afc/arroyo/synchronized.py#L56-L58) until all events in the pipeline actually have the header.