### PR TITLE
feat(suspect-spans): Schema changes for suspect spans

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -262,8 +262,14 @@ TRANSACTIONS_COLUMNS = ColumnSet(
         ("transaction_op", String(Modifiers(nullable=True))),
         ("transaction_status", UInt(8, Modifiers(nullable=True))),
         ("duration", UInt(32, Modifiers(nullable=True))),
-        ("measurements", Nested([("key", String()), ("value", Float(64))]),),
-        ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))]),),
+        ("measurements", Nested([("key", String()), ("value", Float(64))])),
+        ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))])),
+        (
+            "spans",
+            Nested(
+                [("op", String()), ("group", UInt(64)), ("exclusive_time", Float(64))]
+            ),
+        ),
     ]
 )
 

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -75,6 +75,12 @@ columns = ColumnSet(
         ("_contexts_flattened", String()),
         ("measurements", Nested([("key", String()), ("value", Float(64))]),),
         ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))]),),
+        (
+            "spans",
+            Nested(
+                [("op", String()), ("group", UInt(64)), ("exclusive_time", Float(64))]
+            ),
+        ),
         ("partition", UInt(16)),
         ("offset", UInt(64)),
         ("message_timestamp", DateTime()),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -116,6 +116,7 @@ class TransactionsLoader(DirectoryLoader):
             "0009_transactions_fix_title_and_message",
             "0010_transactions_nullable_trace_id",
             "0011_transactions_add_span_op_breakdowns",
+            "0012_transactions_add_spans",
         ]
 
 

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Sequence
+from typing import Callable, Optional, Sequence, Tuple
 
 from snuba.clickhouse.columns import Column
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
@@ -182,14 +182,24 @@ class ModifyColumn(SqlOperation):
         storage_set: StorageSetKey,
         table_name: str,
         column: Column[MigrationModifiers],
+        ttl_month: Optional[Tuple[str, int]],
     ):
         super().__init__(storage_set)
         self.__table_name = table_name
         self.__column = column
+        self.__ttl_month = ttl_month
 
     def format_sql(self) -> str:
         column = self.__column.for_schema()
-        return f"ALTER TABLE {self.__table_name} MODIFY COLUMN {column};"
+        return f"ALTER TABLE {self.__table_name} MODIFY COLUMN {column}{self.optional_ttl_clause};"
+
+    @property
+    def optional_ttl_clause(self) -> str:
+        if self.__ttl_month is None:
+            return ""
+
+        ttl_column, ttl_month = self.__ttl_month
+        return f" TTL {ttl_column} + INTERVAL {ttl_month} MONTH"
 
 
 class AddIndex(SqlOperation):

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -182,7 +182,7 @@ class ModifyColumn(SqlOperation):
         storage_set: StorageSetKey,
         table_name: str,
         column: Column[MigrationModifiers],
-        ttl_month: Optional[Tuple[str, int]],
+        ttl_month: Optional[Tuple[str, int]] = None,
     ):
         super().__init__(storage_set)
         self.__table_name = table_name

--- a/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
+++ b/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
@@ -50,7 +50,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.DropIndex(
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name="transactions_local",
-                index_name="bf_spans_op",
+                index_name="bf_spans_group",
             ),
             operations.DropIndex(
                 storage_set=StorageSetKey.TRANSACTIONS,

--- a/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
+++ b/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
@@ -45,8 +45,9 @@ class Migration(migration.ClickhouseNodeMigration):
                     "spans",
                     Nested(
                         [
-                            ("key", String(Modifiers(low_cardinality=True))),
-                            ("value", Float(64)),
+                            ("op", String(Modifiers(low_cardinality=True))),
+                            ("group", UInt(64)),
+                            ("exclusive_time", Float(64)),
                         ]
                     ),
                 ),

--- a/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
+++ b/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
@@ -27,10 +27,36 @@ class Migration(migration.ClickhouseNodeMigration):
                 ),
                 after="span_op_breakdowns.value",
             ),
+            operations.AddIndex(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                index_name="bf_spans_op",
+                index_expression="spans.op",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+            operations.AddIndex(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                index_name="bf_spans_group",
+                index_expression="spans.group",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
         ]
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
+            operations.DropIndex(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                index_name="bf_spans_op",
+            ),
+            operations.DropIndex(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                index_name="bf_spans_op",
+            ),
             operations.DropColumn(
                 StorageSetKey.TRANSACTIONS, "transactions_local", "spans"
             ),

--- a/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
+++ b/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
@@ -1,0 +1,62 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, Float, Nested, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                column=Column(
+                    "spans",
+                    Nested(
+                        [
+                            ("op", String(Modifiers(low_cardinality=True))),
+                            ("group", UInt(64)),
+                            ("exclusive_time", Float(64)),
+                        ]
+                    ),
+                ),
+                after="span_op_breakdowns.value",
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, "transactions_local", "spans"
+            ),
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_dist",
+                column=Column(
+                    "spans",
+                    Nested(
+                        [
+                            ("key", String(Modifiers(low_cardinality=True))),
+                            ("value", Float(64)),
+                        ]
+                    ),
+                ),
+                after="span_op_breakdowns.value",
+            ),
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, "transactions_dist", "spans"
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
+++ b/snuba/migrations/snuba_migrations/transactions/0012_transactions_add_spans.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, Float, Nested, String, UInt
+from snuba.clickhouse.columns import Array, Column, Float, Nested, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -26,6 +26,26 @@ class Migration(migration.ClickhouseNodeMigration):
                     ),
                 ),
                 after="span_op_breakdowns.value",
+            ),
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                column=Column(
+                    "spans.op", Array(String(Modifiers(low_cardinality=True)))
+                ),
+                ttl_month=("finish_ts", 1),
+            ),
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                column=Column("spans.group", Array(UInt(64))),
+                ttl_month=("finish_ts", 1),
+            ),
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                column=Column("spans.exclusive_time", Array(Float(64))),
+                ttl_month=("finish_ts", 1),
             ),
             operations.AddIndex(
                 storage_set=StorageSetKey.TRANSACTIONS,


### PR DESCRIPTION
Adds the nested columns for op, group, and exclusive span for suspect spans.

# Forwards

```SQL
Local operations:
ALTER TABLE transactions_local ADD COLUMN IF NOT EXISTS spans Nested(op LowCardinality(String), group UInt64, exclusive_time Float64) AFTER span_op_breakdowns.value;
ALTER TABLE transactions_local MODIFY COLUMN spans.op Array(LowCardinality(String)) TTL finish_ts + INTERVAL 1 MONTH;
ALTER TABLE transactions_local MODIFY COLUMN spans.group Array(UInt64) TTL finish_ts + INTERVAL 1 MONTH;
ALTER TABLE transactions_local MODIFY COLUMN spans.exclusive_time Array(Float64) TTL finish_ts + INTERVAL 1 MONTH;
ALTER TABLE transactions_local ADD INDEX IF NOT EXISTS bf_spans_op spans.op TYPE bloom_filter() GRANULARITY 1;
ALTER TABLE transactions_local ADD INDEX IF NOT EXISTS bf_spans_group spans.group TYPE bloom_filter() GRANULARITY 1;


Dist operations:
ALTER TABLE transactions_dist ADD COLUMN IF NOT EXISTS spans Nested(op LowCardinality(String), group UInt64, exclusive_time Float64) AFTER span_op_breakdowns.value;
```

# Backwards

```SQL
Local operations:
ALTER TABLE transactions_local DROP INDEX IF EXISTS bf_spans_group;
ALTER TABLE transactions_local DROP INDEX IF EXISTS bf_spans_op;
ALTER TABLE transactions_local DROP COLUMN IF EXISTS spans;


Dist operations:
ALTER TABLE transactions_dist DROP COLUMN IF EXISTS spans;
```