### PR TITLE
SnubaException: A new exception class for all your exception needs

### DIFF
--- a/snuba/clickhouse/errors.py
+++ b/snuba/clickhouse/errors.py
@@ -1,22 +1,15 @@
-from dataclasses import dataclass
-from typing import Optional
+from typing import cast
 
 from snuba.utils.snuba_exception import SnubaException
 
 
-@dataclass(frozen=True)
 class ClickhouseError(SnubaException):
-    # TODO: figure out what to do this this
-    code: int
-    message: str
-
-    def __str__(self) -> str:
-        return f"[{self.code}] {self.message}"
-
-    def __repr__(self) -> str:
-        return f"<{type(self).__name__}: {self}>"
+    @property
+    def code(self) -> int:
+        return cast(int, self.extra_data.get("code", -1))
 
 
-@dataclass(frozen=True)
 class ClickhouseWriterError(ClickhouseError):
-    row: Optional[int] = None  # indexes start at 1
+    @property
+    def row(self) -> int:
+        return cast(int, self.extra_data.get("row", -1))

--- a/snuba/clickhouse/errors.py
+++ b/snuba/clickhouse/errors.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from dataclasses import dataclass
 from typing import Optional
 

--- a/snuba/clickhouse/errors.py
+++ b/snuba/clickhouse/errors.py
@@ -1,6 +1,7 @@
-from snuba.utils.snuba_exception import SnubaException
 from dataclasses import dataclass
 from typing import Optional
+
+from snuba.utils.snuba_exception import SnubaException
 
 
 @dataclass(frozen=True)

--- a/snuba/clickhouse/errors.py
+++ b/snuba/clickhouse/errors.py
@@ -5,7 +5,8 @@ from snuba.utils.snuba_exception import SnubaException
 
 
 @dataclass(frozen=True)
-class ClickhouseError(Exception):
+class ClickhouseError(SnubaException):
+    # TODO: figure out what to do this this
     code: int
     message: str
 

--- a/snuba/clickhouse/errors.py
+++ b/snuba/clickhouse/errors.py
@@ -1,9 +1,9 @@
 from typing import cast
 
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class ClickhouseError(SnubaException):
+class ClickhouseError(SerializableException):
     @property
     def code(self) -> int:
         return cast(int, self.extra_data.get("code", -1))

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -5,7 +5,7 @@ import re
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from queue import Queue, SimpleQueue
-from typing import Any, Sequence, cast, Iterable, Iterator, Mapping, Optional, Union
+from typing import Any, Iterable, Iterator, Mapping, Optional, Sequence, Union, cast
 from urllib.parse import urlencode
 
 import rapidjson
@@ -19,7 +19,6 @@ from snuba.utils.codecs import Encoder
 from snuba.utils.iterators import chunked
 from snuba.utils.metrics import MetricsBackend
 from snuba.writer import BatchWriter, WriterTableRow
-
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +189,7 @@ class HTTPWriteBatch:
                 code = int(details["code"])
                 message = details["message"]
                 row = int(details["row"]) if details["row"] is not None else None
-                raise ClickhouseWriterError(code, message, row)
+                raise ClickhouseWriterError(message, code=code, row=row)
             else:
                 raise HTTPError(
                     f"Received unexpected {response.status} response: {content}"

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -93,7 +93,7 @@ class ClickhousePool(object):
                     conn = None
                     if attempts_remaining == 0:
                         if isinstance(e, errors.Error):
-                            raise ClickhouseError(e.code, e.message) from e
+                            raise ClickhouseError(e.message, code=e.code) from e
                         else:
                             raise e
                     else:
@@ -101,7 +101,7 @@ class ClickhousePool(object):
                         # balancer a chance to mark a bad host as down.
                         time.sleep(0.1)
                 except errors.Error as e:
-                    raise ClickhouseError(e.code, e.message) from e
+                    raise ClickhouseError(e.message, code=e.code) from e
         finally:
             self.pool.put(conn, block=False)
 
@@ -149,7 +149,7 @@ class ClickhousePool(object):
                 attempts_remaining -= 1
                 if attempts_remaining <= 0:
                     if isinstance(e, errors.Error):
-                        raise ClickhouseError(e.code, e.message) from e
+                        raise ClickhouseError(e.message, code=e.code) from e
                     else:
                         raise e
                 time.sleep(1)
@@ -166,9 +166,9 @@ class ClickhousePool(object):
                     continue
                 else:
                     # Quit immediately for other types of server errors.
-                    raise ClickhouseError(e.code, e.message) from e
+                    raise ClickhouseError(e.message, code=e.code) from e
             except errors.Error as e:
-                raise ClickhouseError(e.code, e.message) from e
+                raise ClickhouseError(e.message, code=e.code) from e
 
     def _create_conn(self) -> Client:
         return Client(

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -10,11 +10,11 @@ from snuba.utils.streams.types import KafkaBrokerConfig
 logger = logging.getLogger("snuba.kafka-consumer")
 
 
-class NoPartitionAssigned(Exception):
+class NoPartitionAssigned(SnubaException):
     pass
 
 
-class PartitionReassigned(Exception):
+class PartitionReassigned(SnubaException):
     pass
 
 

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -4,17 +4,17 @@ from typing import Callable, MutableMapping, Optional, Sequence, Tuple
 
 from confluent_kafka import Consumer, KafkaError, Message, TopicPartition
 
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 from snuba.utils.streams.types import KafkaBrokerConfig
 
 logger = logging.getLogger("snuba.kafka-consumer")
 
 
-class NoPartitionAssigned(SnubaException):
+class NoPartitionAssigned(SerializableException):
     pass
 
 
-class PartitionReassigned(SnubaException):
+class PartitionReassigned(SerializableException):
     pass
 
 

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 import logging
 from enum import Enum
 from typing import Callable, MutableMapping, Optional, Sequence, Tuple

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -1,10 +1,10 @@
-from snuba.utils.snuba_exception import SnubaException
 import logging
 from enum import Enum
 from typing import Callable, MutableMapping, Optional, Sequence, Tuple
 
 from confluent_kafka import Consumer, KafkaError, Message, TopicPartition
 
+from snuba.utils.snuba_exception import SnubaException
 from snuba.utils.streams.types import KafkaBrokerConfig
 
 logger = logging.getLogger("snuba.kafka-consumer")

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -6,7 +6,7 @@ from snuba.datasets.entity import Entity
 from snuba.utils.snuba_exception import SnubaException
 
 
-class InvalidEntityError(Exception):
+class InvalidEntityError(SnubaException):
     """Exception raised on invalid entity access."""
 
 

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -3,10 +3,10 @@ from typing import Callable, MutableMapping
 from snuba import settings
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class InvalidEntityError(SnubaException):
+class InvalidEntityError(SerializableException):
     """Exception raised on invalid entity access."""
 
 

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from typing import Callable, MutableMapping
 
 from snuba import settings

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -1,9 +1,9 @@
-from snuba.utils.snuba_exception import SnubaException
 from typing import Callable, MutableMapping
 
 from snuba import settings
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
+from snuba.utils.snuba_exception import SnubaException
 
 
 class InvalidEntityError(Exception):

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -48,8 +48,10 @@ class TagsTypeTransformer(QueryProcessor):
 
             key = exp.key
             if not isinstance(key.value, str) or not key.value.isdigit():
-                raise InvalidExpressionException(
-                    exp, "Expected a string key containing an integer in subscriptable."
+                raise InvalidExpressionException.from_args(
+                    exp,
+                    "Expected a string key containing an integer in subscriptable.",
+                    should_report=True,
                 )
 
             return SubscriptableReference(

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -51,7 +51,6 @@ class TagsTypeTransformer(QueryProcessor):
                 raise InvalidExpressionException.from_args(
                     exp,
                     "Expected a string key containing an integer in subscriptable.",
-                    should_report=True,
                 )
 
             return SubscriptableReference(

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 from datetime import datetime, timedelta
 from typing import (
     Any,
@@ -18,6 +17,7 @@ from snuba.processor import (
     _ensure_valid_ip,
     _unicodify,
 )
+from snuba.utils.snuba_exception import SnubaException
 
 
 def extract_project_id(

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -134,5 +134,5 @@ def escape_field(field: str) -> str:
     return field.translate(ESCAPE_TRANSLATION)
 
 
-class EventTooOld(Exception):
+class EventTooOld(SnubaException):
     pass

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from datetime import datetime, timedelta
 from typing import (
     Any,

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -17,7 +17,7 @@ from snuba.processor import (
     _ensure_valid_ip,
     _unicodify,
 )
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
 def extract_project_id(
@@ -134,5 +134,5 @@ def escape_field(field: str) -> str:
     return field.translate(ESCAPE_TRANSLATION)
 
 
-class EventTooOld(SnubaException):
+class EventTooOld(SerializableException):
     pass

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -4,7 +4,7 @@ from snuba import settings
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.table_storage import TableWriter
 from snuba.util import with_span
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 DATASETS_IMPL: MutableMapping[str, Dataset] = {}
 DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
@@ -24,7 +24,7 @@ DATASET_NAMES: Set[str] = {
 }
 
 
-class InvalidDatasetError(SnubaException):
+class InvalidDatasetError(SerializableException):
     """Exception raised on invalid dataset access."""
 
 

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -1,10 +1,10 @@
-from snuba.utils.snuba_exception import SnubaException
 from typing import Callable, MutableMapping, Sequence, Set
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.table_storage import TableWriter
 from snuba.util import with_span
+from snuba.utils.snuba_exception import SnubaException
 
 DATASETS_IMPL: MutableMapping[str, Dataset] = {}
 DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from typing import Callable, MutableMapping, Sequence, Set
 
 from snuba import settings

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -24,7 +24,7 @@ DATASET_NAMES: Set[str] = {
 }
 
 
-class InvalidDatasetError(Exception):
+class InvalidDatasetError(SnubaException):
     """Exception raised on invalid dataset access."""
 
 

--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -1,4 +1,6 @@
 from snuba.utils.snuba_exception import SnubaException
+
+
 class InvalidMigrationState(Exception):
     pass
 

--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -1,21 +1,21 @@
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class InvalidMigrationState(SnubaException):
+class InvalidMigrationState(SerializableException):
     pass
 
 
-class MigrationDoesNotExist(SnubaException):
+class MigrationDoesNotExist(SerializableException):
     pass
 
 
-class MigrationError(SnubaException):
+class MigrationError(SerializableException):
     pass
 
 
-class MigrationInProgress(SnubaException):
+class MigrationInProgress(SerializableException):
     pass
 
 
-class InvalidClickhouseVersion(SnubaException):
+class InvalidClickhouseVersion(SerializableException):
     pass

--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 class InvalidMigrationState(Exception):
     pass
 

--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -1,21 +1,21 @@
 from snuba.utils.snuba_exception import SnubaException
 
 
-class InvalidMigrationState(Exception):
+class InvalidMigrationState(SnubaException):
     pass
 
 
-class MigrationDoesNotExist(Exception):
+class MigrationDoesNotExist(SnubaException):
     pass
 
 
-class MigrationError(Exception):
+class MigrationError(SnubaException):
     pass
 
 
-class MigrationInProgress(Exception):
+class MigrationInProgress(SnubaException):
     pass
 
 
-class InvalidClickhouseVersion(Exception):
+class InvalidClickhouseVersion(SnubaException):
     pass

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -290,7 +290,7 @@ class Runner:
                 migration_key = MigrationKey(group, migration_id)
                 status = get_status(migration_key)
                 if status == Status.IN_PROGRESS:
-                    raise MigrationInProgress(migration_key)
+                    raise MigrationInProgress(str(migration_key))
                 if status == Status.NOT_STARTED:
                     group_migrations.append(migration_key)
                 elif status == Status.COMPLETED and len(group_migrations):

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 import ipaddress
 import re
 from abc import ABC, abstractmethod
@@ -21,6 +20,7 @@ import simplejson as json
 
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.util import force_bytes
+from snuba.utils.snuba_exception import SnubaException
 from snuba.writer import WriterTableRow
 
 HASH_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 import ipaddress
 import re
 from abc import ABC, abstractmethod

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -55,11 +55,11 @@ class MessageProcessor(ABC):
         raise NotImplementedError
 
 
-class InvalidMessageType(Exception):
+class InvalidMessageType(SnubaException):
     pass
 
 
-class InvalidMessageVersion(Exception):
+class InvalidMessageVersion(SnubaException):
     pass
 
 

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -20,7 +20,7 @@ import simplejson as json
 
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.util import force_bytes
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 from snuba.writer import WriterTableRow
 
 HASH_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
@@ -55,11 +55,11 @@ class MessageProcessor(ABC):
         raise NotImplementedError
 
 
-class InvalidMessageType(SnubaException):
+class InvalidMessageType(SerializableException):
     pass
 
 
-class InvalidMessageVersion(SnubaException):
+class InvalidMessageVersion(SerializableException):
     pass
 
 

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -16,9 +16,8 @@ class ValidationException(InvalidQueryException):
 
 
 class InvalidExpressionException(ValidationException):
-    # TODO (figure out what do do with this)
     @classmethod
     def from_args(
-        cls, expression: Expression, message: str, should_report: bool,
+        cls, expression: Expression, message: str, should_report: bool = True,
     ) -> "InvalidExpressionException":
         return cls(message, should_report=should_report, expression=repr(expression))

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from snuba.query.expressions import Expression
 
 

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -1,9 +1,8 @@
 from snuba.query.expressions import Expression
-from snuba.utils.snuba_exception import JsonSerializable, SnubaException
+from snuba.utils.snuba_exception import SnubaException
 
 
 class InvalidQueryException(SnubaException):
-    # TODO (figure out what do do with this)
     """
     Common parent class used for invalid queries during parsing
     and validation.
@@ -13,12 +12,6 @@ class InvalidQueryException(SnubaException):
         message: Message of the exception
         report: Should we report the exception to Sentry or not
     """
-
-    @classmethod
-    def from_args(
-        cls, *, message: str, report: bool = True, **kwargs: JsonSerializable
-    ) -> "InvalidQueryException":
-        return cls(message=message, report=report, **kwargs)
 
     def __str__(self) -> str:
         return f"{self.message}"
@@ -30,12 +23,8 @@ class ValidationException(InvalidQueryException):
 
 class InvalidExpressionException(ValidationException):
     # TODO (figure out what do do with this)
-    def __init__(
-        self, expression: Expression, message: str, report: bool = True
-    ) -> None:
-        self.expression = expression
-        self.message = message
-        super().__init__(message, report=report)
-
-    def __str__(self) -> str:
-        return f"Invalid Expression {self.expression}: {self.message}"
+    @classmethod
+    def from_args(
+        cls, message: str, expression: Expression, should_report: bool,
+    ) -> "InvalidExpressionException":
+        return cls(message, should_report=should_report, expression=repr(Expression))

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -8,13 +8,7 @@ class InvalidQueryException(SnubaException):
     and validation.
     This should not be used for system errors.
 
-    Attributes:
-        message: Message of the exception
-        report: Should we report the exception to Sentry or not
     """
-
-    def __str__(self) -> str:
-        return f"{self.message}"
 
 
 class ValidationException(InvalidQueryException):
@@ -25,6 +19,6 @@ class InvalidExpressionException(ValidationException):
     # TODO (figure out what do do with this)
     @classmethod
     def from_args(
-        cls, message: str, expression: Expression, should_report: bool,
+        cls, expression: Expression, message: str, should_report: bool,
     ) -> "InvalidExpressionException":
-        return cls(message, should_report=should_report, expression=repr(Expression))
+        return cls(message, should_report=should_report, expression=repr(expression))

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -1,8 +1,8 @@
 from snuba.query.expressions import Expression
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class InvalidQueryException(SnubaException):
+class InvalidQueryException(SerializableException):
     """
     Common parent class used for invalid queries during parsing
     and validation.

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -1,8 +1,9 @@
 from snuba.query.expressions import Expression
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.snuba_exception import JsonSerializable, SnubaException
 
 
-class InvalidQueryException(Exception):
+class InvalidQueryException(SnubaException):
+    # TODO (figure out what do do with this)
     """
     Common parent class used for invalid queries during parsing
     and validation.
@@ -13,10 +14,11 @@ class InvalidQueryException(Exception):
         report: Should we report the exception to Sentry or not
     """
 
-    def __init__(self, message: str, *, report: bool = True):
-        self.message = message
-        self.report = report
-        super().__init__(self.message, self.report)
+    @classmethod
+    def from_args(
+        cls, *, message: str, report: bool = True, **kwargs: JsonSerializable
+    ) -> "InvalidQueryException":
+        return cls(message=message, report=report, **kwargs)
 
     def __str__(self) -> str:
         return f"{self.message}"
@@ -27,6 +29,7 @@ class ValidationException(InvalidQueryException):
 
 
 class InvalidExpressionException(ValidationException):
+    # TODO (figure out what do do with this)
     def __init__(
         self, expression: Expression, message: str, report: bool = True
     ) -> None:

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -1,5 +1,5 @@
-from snuba.utils.snuba_exception import SnubaException
 from snuba.query.expressions import Expression
+from snuba.utils.snuba_exception import SnubaException
 
 
 class InvalidQueryException(Exception):

--- a/snuba/query/parser/__init__.py
+++ b/snuba/query/parser/__init__.py
@@ -126,7 +126,7 @@ def _parse_query_impl(body: Mapping[str, Any], entity: Entity) -> Query:
                     f"Invalid aggregation structure {aggregation}. "
                     "It must be a sequence containing expression, column and alias."
                 ),
-                report=False,
+                should_report=False,
             )
         aggregation_function = aggregation[0]
         column_expr = aggregation[1]
@@ -174,7 +174,7 @@ def _parse_query_impl(body: Mapping[str, Any], entity: Entity) -> Query:
                     if len(parameters) != 1:
                         raise ParsingException(
                             "arrayJoin(...) only accepts a single parameter.",
-                            report=False,
+                            should_report=False,
                         )
                     if isinstance(parameters[0], Column):
                         array_join_cols.add(parameters[0].column_name)
@@ -188,7 +188,7 @@ def _parse_query_impl(body: Mapping[str, Any], entity: Entity) -> Query:
                             if isinstance(e, Column):
                                 raise ParsingException(
                                     "arrayJoin(...) cannot contain columns nested in functions.",
-                                    report=False,
+                                    should_report=False,
                                 )
 
     where_expr = parse_conditions_to_expr(
@@ -208,7 +208,7 @@ def _parse_query_impl(body: Mapping[str, Any], entity: Entity) -> Query:
                         f"Invalid Order By clause {orderby}. If the Order By is a string, "
                         "it must respect the format `[-]column`"
                     ),
-                    report=False,
+                    should_report=False,
                 )
             direction, col = match.groups()
             orderby = col
@@ -220,7 +220,7 @@ def _parse_query_impl(body: Mapping[str, Any], entity: Entity) -> Query:
                         f"Invalid Order By clause {orderby}. If the Order By is an expression, "
                         "the function name must respect the format `[-]func_name`"
                     ),
-                    report=False,
+                    should_report=False,
                 )
             direction, col = match.groups()
             orderby = [col] + orderby[1:]
@@ -230,7 +230,7 @@ def _parse_query_impl(body: Mapping[str, Any], entity: Entity) -> Query:
                     f"Invalid Order By clause {orderby}. The Clause was neither "
                     "a string nor a function call."
                 ),
-                report=False,
+                should_report=False,
             )
         orderby_parsed = parse_expression(
             tuplify(orderby), entity.get_data_model(), set()
@@ -308,7 +308,7 @@ def _validate_aliases(query: Union[CompositeQuery[QueryEntity], Query]) -> None:
                         f"Shadowing aliases detected for alias: {exp.alias}. "
                         + f"Expressions: {all_declared_aliases[exp.alias]}"
                     ),
-                    report=False,
+                    should_report=False,
                 )
             else:
                 all_declared_aliases[exp.alias] = exp
@@ -527,7 +527,7 @@ class AliasExpanderVisitor(ExpressionVisitor[Expression]):
                 # stack instead of a.
                 raise CyclicAliasException(
                     f"Cyclic aliases {name} resolves to {self.__alias_lookup_table[name]}",
-                    report=False,
+                    should_report=False,
                 )
             return exp
 

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -153,7 +153,7 @@ def parse_conditions_to_expr(
                         f"Invalid operator {op} for literal {literal}. Literal is a sequence. "
                         "Operator must be IN/NOT IN"
                     ),
-                    report=False,
+                    should_report=False,
                 )
             literals = tuple([Literal(None, lit) for lit in literal])
             return FunctionCall(None, "tuple", literals)
@@ -164,7 +164,7 @@ def parse_conditions_to_expr(
                         f"Invalid operator {op} for literal {literal}. Literal is not a sequence. "
                         "Operator cannot be IN/NOT IN"
                     ),
-                    report=False,
+                    should_report=False,
                 )
             return Literal(None, literal)
 
@@ -203,7 +203,7 @@ def parse_conditions_to_expr(
             if literal is not None:
                 raise ParsingException(
                     f"Right hand side operand {literal} provided to unary operator {op}",
-                    report=False,
+                    should_report=False,
                 )
             return unary_condition(OPERATOR_TO_FUNCTION[op], lhs)
 
@@ -211,7 +211,7 @@ def parse_conditions_to_expr(
             if literal is None:
                 raise ParsingException(
                     f"Missing right hand side operand for binary operator {op}",
-                    report=False,
+                    should_report=False,
                 )
             return binary_condition(
                 OPERATOR_TO_FUNCTION[op], lhs, preprocess_literal(op, literal)

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from typing import Any, Callable, Optional, Sequence, Set, TypeVar
 
 from snuba.clickhouse.columns import ColumnSet

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 from typing import Any, Callable, Optional, Sequence, Set, TypeVar
 
 from snuba.clickhouse.columns import ColumnSet
@@ -15,6 +14,7 @@ from snuba.query.parser.exceptions import ParsingException
 from snuba.query.parser.expressions import parse_expression
 from snuba.query.schema import POSITIVE_OPERATORS, UNARY_OPERATORS
 from snuba.util import is_condition
+from snuba.utils.snuba_exception import SnubaException
 
 TExpression = TypeVar("TExpression")
 

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -19,7 +19,7 @@ from snuba.utils.snuba_exception import SnubaException
 TExpression = TypeVar("TExpression")
 
 
-class InvalidConditionException(Exception):
+class InvalidConditionException(SnubaException):
     pass
 
 

--- a/snuba/query/parser/conditions.py
+++ b/snuba/query/parser/conditions.py
@@ -14,12 +14,12 @@ from snuba.query.parser.exceptions import ParsingException
 from snuba.query.parser.expressions import parse_expression
 from snuba.query.schema import POSITIVE_OPERATORS, UNARY_OPERATORS
 from snuba.util import is_condition
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 TExpression = TypeVar("TExpression")
 
 
-class InvalidConditionException(SnubaException):
+class InvalidConditionException(SerializableException):
     pass
 
 

--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -178,7 +178,8 @@ def parse_expression(
     if isinstance(val, str):
         return parse_string_to_expr(val)
     raise ParsingException(
-        f"Expression to parse can only be a function or a string: {val}", report=False
+        f"Expression to parse can only be a function or a string: {val}",
+        should_report=False,
     )
 
 
@@ -187,7 +188,7 @@ def parse_clickhouse_function(function: str) -> Expression:
         expression_tree = minimal_clickhouse_grammar.parse(function)
     except Exception as cause:
         raise ParsingException(
-            f"Cannot parse aggregation {function}", report=False
+            f"Cannot parse aggregation {function}", should_report=False
         ) from cause
 
     return ClickhouseVisitor().visit(expression_tree)  # type: ignore
@@ -241,5 +242,6 @@ def parse_aggregation(
 
     else:
         raise ParsingException(
-            f"Invalid aggregation format {aggregation_function} {column}", report=False
+            f"Invalid aggregation format {aggregation_function} {column}",
+            should_report=False,
         )

--- a/snuba/query/parser/functions.py
+++ b/snuba/query/parser/functions.py
@@ -128,7 +128,7 @@ def parse_function(
     if function_tuple is None:
         raise ParsingException(
             f"complex_column_expr was given an expr {expr} that is not a function at depth {depth}.",
-            report=False,
+            should_report=False,
         )
 
     name, args, alias = function_tuple

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -106,10 +106,10 @@ class FunctionCallsValidator(ExpressionValidator):
             for validator in global_validators:
                 validator.validate(exp.function_name, exp.parameters, data_source)
         except InvalidFunctionCall as exception:
-            raise InvalidExpressionException(
+            raise InvalidExpressionException.from_args(
                 exp,
                 f"Illegal call to function {exp.function_name}: {str(exception)}",
-                report=False,
+                should_report=False,
             ) from exception
 
         # Then do entity specific validation, if there are any
@@ -134,8 +134,8 @@ class FunctionCallsValidator(ExpressionValidator):
                     exp.function_name, exp.parameters, data_source
                 )
             except InvalidFunctionCall as exception:
-                raise InvalidExpressionException(
+                raise InvalidExpressionException.from_args(
                     exp,
                     f"Illegal call to function {exp.function_name}: {str(exception)}",
-                    report=False,
+                    should_report=False,
                 ) from exception

--- a/snuba/query/processors/custom_function.py
+++ b/snuba/query/processors/custom_function.py
@@ -13,7 +13,7 @@ from snuba.request.request_settings import RequestSettings
 
 class InvalidCustomFunctionCall(InvalidExpressionException):
     def __str__(self) -> str:
-        return f"Invalid custom function call {self.expression}: {self.message}"
+        return f"Invalid custom function call {self.extra_data.get('expression', '')}: {self.message}"
 
 
 def replace_in_expression(
@@ -91,10 +91,10 @@ class CustomFunction(QueryProcessor):
                         query.get_from_clause(),
                     )
                 except InvalidFunctionCall as exception:
-                    raise InvalidCustomFunctionCall(
+                    raise InvalidCustomFunctionCall.from_args(
                         expression,
                         f"Illegal call to function {expression.function_name}: {str(exception)}",
-                        report=False,
+                        should_report=False,
                     ) from exception
 
                 resolved_params = {

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -42,10 +42,10 @@ class HandledFunctionsProcessor(QueryProcessor):
         try:
             validator.validate(exp.function_name, exp.parameters, entity)
         except InvalidFunctionCall as err:
-            raise InvalidExpressionException(
+            raise InvalidExpressionException.from_args(
                 exp,
                 f"Illegal function call to {exp.function_name}: {str(err)}",
-                report=False,
+                should_report=False,
             ) from err
 
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:

--- a/snuba/query/processors/timeseries_processor.py
+++ b/snuba/query/processors/timeseries_processor.py
@@ -160,7 +160,7 @@ class TimeSeriesProcessor(QueryProcessor):
                 column_name = result.string("column_name")
                 raise InvalidQueryException(
                     f"Illegal datetime in condition on column {column_name}: '{literal.value}''",
-                    report=False,
+                    should_report=False,
                 ) from err
 
             return FunctionCall(

--- a/snuba/query/processors/type_converters/fixedstring_array_column_processor.py
+++ b/snuba/query/processors/type_converters/fixedstring_array_column_processor.py
@@ -18,7 +18,7 @@ class FixedStringArrayColumnProcessor(BaseTypeConverter):
                 (Literal(None, value=exp.value), Literal(None, self.fixed_length)),
             )
         except (AssertionError, ValueError):
-            raise ColumnTypeError("Not a valid UUID string", report=False)
+            raise ColumnTypeError("Not a valid UUID string", should_report=False)
 
     def _process_expressions(self, exp: Expression) -> Expression:
         # FixedString is converted to regular string just fine in query return

--- a/snuba/query/processors/type_converters/hexint_column_processor.py
+++ b/snuba/query/processors/type_converters/hexint_column_processor.py
@@ -8,7 +8,7 @@ class HexIntColumnProcessor(BaseTypeConverter):
             assert isinstance(exp.value, str)
             return Literal(alias=exp.alias, value=int(exp.value, 16))
         except (AssertionError, ValueError):
-            raise ColumnTypeError("Invalid hexint", report=False)
+            raise ColumnTypeError("Invalid hexint", should_report=False)
 
     def _process_expressions(self, exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in self.columns:

--- a/snuba/query/processors/type_converters/uuid_array_column_processor.py
+++ b/snuba/query/processors/type_converters/uuid_array_column_processor.py
@@ -18,7 +18,7 @@ class UUIDArrayColumnProcessor(BaseTypeConverter):
             new_val = str(uuid.UUID(exp.value))
             return FunctionCall(exp.alias, "toUUID", (Literal(None, value=new_val),))
         except (AssertionError, ValueError):
-            raise ColumnTypeError("Not a valid UUID string", report=False)
+            raise ColumnTypeError("Not a valid UUID string", should_report=False)
 
     def _process_expressions(self, exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in self.columns:

--- a/snuba/query/processors/type_converters/uuid_column_processor.py
+++ b/snuba/query/processors/type_converters/uuid_column_processor.py
@@ -11,7 +11,7 @@ class UUIDColumnProcessor(BaseTypeConverter):
             new_val = str(uuid.UUID(exp.value))
             return Literal(alias=exp.alias, value=new_val)
         except (AssertionError, ValueError):
-            raise ColumnTypeError("Not a valid UUID string", report=False)
+            raise ColumnTypeError("Not a valid UUID string", should_report=False)
 
     def _process_expressions(self, exp: Expression) -> Expression:
         if isinstance(exp, Column) and exp.column_name in self.columns:

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -830,7 +830,7 @@ def parse_snql_query_initial(
         parsed.set_limit(1000)
     elif limit > 10000:
         raise ParsingException(
-            "queries cannot have a limit higher than 10000", report=False
+            "queries cannot have a limit higher than 10000", should_report=False
         )
 
     if parsed.get_offset() is None:
@@ -1181,12 +1181,12 @@ def validate_entities_with_query(
         except InvalidQueryException as e:
             raise ParsingException(
                 f"validation failed for entity {query.get_from_clause().key.value}: {e}",
-                report=e.extra_data.get("report", True),
+                should_report=e.should_report,
             )
         except InvalidExpressionException as e:
             raise ParsingException(
                 f"validation failed for entity {query.get_from_clause().key.value}: {e}",
-                report=e.extra_data.get("report", True),
+                should_report=e.should_report,
             )
     else:
         from_clause = query.get_from_clause()
@@ -1201,12 +1201,12 @@ def validate_entities_with_query(
                 except InvalidQueryException as e:
                     raise ParsingException(
                         f"validation failed for entity {node.data_source.key.value}: {e}",
-                        report=e.extra_data.get("report", True),
+                        should_report=e.should_report,
                     )
                 except InvalidExpressionException as e:
                     raise ParsingException(
                         f"validation failed for entity {node.data_source.key.value}: {e}",
-                        report=e.extra_data.get("report", True),
+                        should_report=e.should_report,
                     )
 
 

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1181,12 +1181,12 @@ def validate_entities_with_query(
         except InvalidQueryException as e:
             raise ParsingException(
                 f"validation failed for entity {query.get_from_clause().key.value}: {e}",
-                report=e.report,
+                report=e.extra_data.get("report", True),
             )
         except InvalidExpressionException as e:
             raise ParsingException(
                 f"validation failed for entity {query.get_from_clause().key.value}: {e}",
-                report=e.report,
+                report=e.extra_data.get("report", True),
             )
     else:
         from_clause = query.get_from_clause()
@@ -1201,12 +1201,12 @@ def validate_entities_with_query(
                 except InvalidQueryException as e:
                     raise ParsingException(
                         f"validation failed for entity {node.data_source.key.value}: {e}",
-                        report=e.report,
+                        report=e.extra_data.get("report", True),
                     )
                 except InvalidExpressionException as e:
                     raise ParsingException(
                         f"validation failed for entity {node.data_source.key.value}: {e}",
-                        report=e.report,
+                        report=e.extra_data.get("report", True),
                     )
 
 

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -6,7 +6,7 @@ from snuba.query.expressions import Expression
 from snuba.utils.snuba_exception import SnubaException
 
 
-class InvalidFunctionCall(Exception):
+class InvalidFunctionCall(SnubaException):
     pass
 
 

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from abc import ABC, abstractmethod
 from typing import Sequence
 

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -1,9 +1,9 @@
-from snuba.utils.snuba_exception import SnubaException
 from abc import ABC, abstractmethod
 from typing import Sequence
 
 from snuba.query.data_source import DataSource
 from snuba.query.expressions import Expression
+from snuba.utils.snuba_exception import SnubaException
 
 
 class InvalidFunctionCall(Exception):

--- a/snuba/query/validation/__init__.py
+++ b/snuba/query/validation/__init__.py
@@ -3,10 +3,10 @@ from typing import Sequence
 
 from snuba.query.data_source import DataSource
 from snuba.query.expressions import Expression
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class InvalidFunctionCall(SnubaException):
+class InvalidFunctionCall(SerializableException):
     pass
 
 

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -82,10 +82,10 @@ class NoTimeBasedConditionValidator(QueryValidator):
         top_level = get_first_level_and_conditions(condition) if condition else []
         for cond in top_level:
             if self.match.match(cond):
-                raise InvalidExpressionException(
+                raise InvalidExpressionException.from_args(
                     cond,
                     f"Cannot have existing conditions on time field {self.required_time_column}",
-                    report=False,
+                    should_report=False,
                 )
 
 

--- a/snuba/request/exceptions.py
+++ b/snuba/request/exceptions.py
@@ -1,7 +1,7 @@
 from snuba.utils.snuba_exception import SnubaException
 
 
-class InvalidJsonRequestException(Exception):
+class InvalidJsonRequestException(SnubaException):
     """
     Common parent class for exceptions signaling the json payload
     of the request was not valid.

--- a/snuba/request/exceptions.py
+++ b/snuba/request/exceptions.py
@@ -1,4 +1,6 @@
 from snuba.utils.snuba_exception import SnubaException
+
+
 class InvalidJsonRequestException(Exception):
     """
     Common parent class for exceptions signaling the json payload

--- a/snuba/request/exceptions.py
+++ b/snuba/request/exceptions.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 class InvalidJsonRequestException(Exception):
     """
     Common parent class for exceptions signaling the json payload

--- a/snuba/request/exceptions.py
+++ b/snuba/request/exceptions.py
@@ -1,7 +1,7 @@
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class InvalidJsonRequestException(SnubaException):
+class InvalidJsonRequestException(SerializableException):
     """
     Common parent class for exceptions signaling the json payload
     of the request was not valid.

--- a/snuba/state/cache/abstract.py
+++ b/snuba/state/cache/abstract.py
@@ -1,9 +1,8 @@
-from snuba.utils.snuba_exception import SnubaException
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Optional, TypeVar
 
 from snuba.utils.metrics.timer import Timer
-
+from snuba.utils.snuba_exception import SnubaException
 
 TValue = TypeVar("TValue")
 

--- a/snuba/state/cache/abstract.py
+++ b/snuba/state/cache/abstract.py
@@ -2,12 +2,12 @@ from abc import ABC, abstractmethod
 from typing import Callable, Generic, Optional, TypeVar
 
 from snuba.utils.metrics.timer import Timer
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 TValue = TypeVar("TValue")
 
 
-class ExecutionError(SnubaException):
+class ExecutionError(SerializableException):
     pass
 
 

--- a/snuba/state/cache/abstract.py
+++ b/snuba/state/cache/abstract.py
@@ -7,7 +7,7 @@ from snuba.utils.snuba_exception import SnubaException
 TValue = TypeVar("TValue")
 
 
-class ExecutionError(Exception):
+class ExecutionError(SnubaException):
     pass
 
 

--- a/snuba/state/cache/abstract.py
+++ b/snuba/state/cache/abstract.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from abc import ABC, abstractmethod
 from typing import Callable, Generic, Optional, TypeVar
 

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 import logging
 import time
 import uuid
@@ -11,6 +10,7 @@ from typing import Iterator, Mapping, MutableMapping, Optional, Sequence, Type
 
 from snuba import state
 from snuba.redis import redis_client as rds
+from snuba.utils.snuba_exception import SnubaException
 
 logger = logging.getLogger("snuba.state.rate_limit")
 

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -10,7 +10,7 @@ from typing import Iterator, Mapping, MutableMapping, Optional, Sequence, Type
 
 from snuba import state
 from snuba.redis import redis_client as rds
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 logger = logging.getLogger("snuba.state.rate_limit")
 
@@ -32,7 +32,7 @@ class RateLimitParameters:
     concurrent_limit: Optional[int]
 
 
-class RateLimitExceeded(SnubaException):
+class RateLimitExceeded(SerializableException):
     """
     Exception thrown when the rate limit is exceeded
     """

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -32,7 +32,7 @@ class RateLimitParameters:
     concurrent_limit: Optional[int]
 
 
-class RateLimitExceeded(Exception):
+class RateLimitExceeded(SnubaException):
     """
     Exception thrown when the rate limit is exceeded
     """

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 import logging
 import time
 import uuid

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from __future__ import annotations
 
 import logging

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 from __future__ import annotations
 
 import logging
@@ -36,6 +35,7 @@ from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_legacy_query, parse_snql_query
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
+from snuba.utils.snuba_exception import SnubaException
 
 SUBSCRIPTION_REFERRER = "subscription"
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -42,7 +42,7 @@ SUBSCRIPTION_REFERRER = "subscription"
 logger = logging.getLogger("snuba.subscriptions")
 
 
-class InvalidSubscriptionError(Exception):
+class InvalidSubscriptionError(SnubaException):
     pass
 
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -35,14 +35,14 @@ from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_legacy_query, parse_snql_query
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 SUBSCRIPTION_REFERRER = "subscription"
 
 logger = logging.getLogger("snuba.subscriptions")
 
 
-class InvalidSubscriptionError(SnubaException):
+class InvalidSubscriptionError(SerializableException):
     pass
 
 

--- a/snuba/utils/snuba_exception.py
+++ b/snuba/utils/snuba_exception.py
@@ -41,9 +41,12 @@ def _get_registry() -> _ExceptionRegistry:
 
 class SnubaException(Exception):
     def __init__(
-        self, message: str, should_report: bool = True, **extra_data: JsonSerializable
+        self,
+        message: Optional[str] = None,
+        should_report: bool = True,
+        **extra_data: JsonSerializable
     ) -> None:
-        self.message = message
+        self.message = message or ""
         self.extra_data = extra_data or {}
         # whether or not the error should be reported to sentry
         self.should_report = should_report

--- a/snuba/utils/snuba_exception.py
+++ b/snuba/utils/snuba_exception.py
@@ -53,6 +53,7 @@ class SnubaException(Exception):
 
     @classmethod
     def from_dict(cls, edict: SnubaExceptionDict) -> "SnubaException":
+        assert edict["__type__"] == "SnubaException"
         defined_exception = _get_registry().get_class_by_name(edict.get("__name__", ""))
         if defined_exception is not None:
             return defined_exception(
@@ -73,9 +74,11 @@ class SnubaException(Exception):
     def from_standard_exception_instance(cls, exc: Exception) -> "SnubaException":
         if isinstance(exc, cls):
             return exc
-        return cast(
-            SnubaException,
-            type(exc.__class__.__name__, (cls,), {})(
-                message=str(exc), source="standard exception"
-            ),
+        return cls.from_dict(
+            {
+                "__type__": "SnubaException",
+                "__name__": exc.__class__.__name__,
+                "__message__": str(exc),
+                "__extra_data__": {"from_standard_exception": True},
+            }
         )

--- a/snuba/utils/snuba_exception.py
+++ b/snuba/utils/snuba_exception.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional, Type, TypedDict, Union, cast
 
-from snuba.utils.snuba_exception import SnubaException
-
 # mypy has not figured out recursive types yet so this can't be totally typesafe
 JsonSerializable = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
 
@@ -52,6 +50,16 @@ class SnubaException(Exception):
             "__message__": self.message,
             "__extra_data__": self.extra_data,
         }
+
+    # @classmethod
+    # def from_args(cls, **kwargs: JsonSerializable) -> "SnubaException":
+    #     """SnubaException does some metaprogramming magic in order to
+    #     be able to re-raise desrialized exceptions as if they were thrown by local
+    #     code. As such, the __init__ method of all SnubaException(s) must have the same signature
+
+    #     If you want to make a custom constructor for your SnubaException, override this function on the class
+    #     """
+    #     raise NotImplementedError
 
     @classmethod
     def from_dict(cls, edict: SnubaExceptionDict) -> "SnubaException":

--- a/snuba/utils/snuba_exception.py
+++ b/snuba/utils/snuba_exception.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, List, TypedDict, Union, cast
+
+JsonSerializable = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]
+
+
+class SnubaExceptionDict(TypedDict):
+    __type__: str
+    __name__: str
+    __message__: str
+    __extra_data__: Dict[str, JsonSerializable]
+
+
+class SnubaException(Exception):
+    def __init__(self, message: str, **extra_data: JsonSerializable) -> None:
+        self.message = message
+        self.extra_data = extra_data or {}
+
+    def to_dict(self) -> SnubaExceptionDict:
+        return {
+            "__type__": "SnubaException",
+            "__name__": self.__class__.__name__,
+            "__message__": self.message,
+            "__extra_data__": self.extra_data,
+        }
+
+    @classmethod
+    def from_dict(cls, edict: SnubaExceptionDict) -> "SnubaException":
+        return cast(
+            SnubaException,
+            type(edict["__name__"], (cls,), {})(
+                message=edict.get("__message__", ""), **edict.get("__extra_data__", {})
+            ),
+        )

--- a/snuba/utils/snuba_exception.py
+++ b/snuba/utils/snuba_exception.py
@@ -1,5 +1,6 @@
-from snuba.utils.snuba_exception import SnubaException
 from typing import Any, Dict, List, Optional, Type, TypedDict, Union, cast
+
+from snuba.utils.snuba_exception import SnubaException
 
 # mypy has not figured out recursive types yet so this can't be totally typesafe
 JsonSerializable = Union[str, int, float, bool, None, Dict[str, Any], List[Any]]

--- a/snuba/utils/snuba_exception.py
+++ b/snuba/utils/snuba_exception.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from typing import Any, Dict, List, Optional, Type, TypedDict, Union, cast
 
 # mypy has not figured out recursive types yet so this can't be totally typesafe

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping, NamedTuple
 from mypy_extensions import TypedDict
 
 from snuba.reader import Column, Result, transform_rows
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
 class QueryExtraData(TypedDict):
@@ -12,7 +12,7 @@ class QueryExtraData(TypedDict):
     experiments: Mapping[str, Any]
 
 
-class QueryException(SnubaException):
+class QueryException(SerializableException):
     """
     Exception raised during query execution that is used to carry extra data
     back up the stack to the HTTP response -- basically a ``QueryResult``,

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -1,9 +1,9 @@
-from snuba.utils.snuba_exception import SnubaException
 from typing import Any, Mapping, NamedTuple
 
 from mypy_extensions import TypedDict
 
 from snuba.reader import Column, Result, transform_rows
+from snuba.utils.snuba_exception import SnubaException
 
 
 class QueryExtraData(TypedDict):

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -12,7 +12,7 @@ class QueryExtraData(TypedDict):
     experiments: Mapping[str, Any]
 
 
-class QueryException(Exception):
+class QueryException(SnubaException):
     """
     Exception raised during query execution that is used to carry extra data
     back up the stack to the HTTP response -- basically a ``QueryResult``,

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from typing import Any, Mapping, NamedTuple
 
 from mypy_extensions import TypedDict

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -191,7 +191,7 @@ def handle_invalid_dataset(exception: InvalidDatasetError) -> Response:
 def handle_invalid_query(exception: InvalidQueryException) -> Response:
     # TODO: Remove this logging as soon as the query validation code is
     # mature enough that we can trust it.
-    if exception.report:
+    if exception.should_report:
         logger.warning("Invalid query", exc_info=exception)
     else:
         logger.info("Invalid query", exc_info=exception)

--- a/tests/clusters/fake_cluster.py
+++ b/tests/clusters/fake_cluster.py
@@ -6,10 +6,10 @@ from snuba.clusters.cluster import (
     ClickhouseCluster,
     ClickhouseNode,
 )
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 
 
-class ServerExplodedException(SnubaException):
+class ServerExplodedException(SerializableException):
     pass
 
 

--- a/tests/clusters/fake_cluster.py
+++ b/tests/clusters/fake_cluster.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from typing import Any, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple
 
 from snuba.clickhouse.native import ClickhousePool, Params

--- a/tests/clusters/fake_cluster.py
+++ b/tests/clusters/fake_cluster.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 from typing import Any, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple
 
 from snuba.clickhouse.native import ClickhousePool, Params
@@ -7,6 +6,7 @@ from snuba.clusters.cluster import (
     ClickhouseCluster,
     ClickhouseNode,
 )
+from snuba.utils.snuba_exception import SnubaException
 
 
 class ServerExplodedException(Exception):

--- a/tests/clusters/fake_cluster.py
+++ b/tests/clusters/fake_cluster.py
@@ -9,7 +9,7 @@ from snuba.clusters.cluster import (
 from snuba.utils.snuba_exception import SnubaException
 
 
-class ServerExplodedException(Exception):
+class ServerExplodedException(SnubaException):
     pass
 
 

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 import pytest
 
 from typing import Any, Sequence

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -1,23 +1,20 @@
-from snuba.utils.snuba_exception import SnubaException
-import pytest
-
 from typing import Any, Sequence
+
+import pytest
 
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.query.conditions import BooleanFunctions, ConditionFunctions
 from snuba.query.expressions import (
+    Argument,
     Column,
     Expression,
     FunctionCall,
     Lambda,
     Literal,
-    Argument,
-)
-from snuba.query.conditions import (
-    ConditionFunctions,
-    BooleanFunctions,
 )
 from snuba.query.parser.conditions import parse_conditions_to_expr
+from snuba.utils.snuba_exception import SnubaException
 
 test_conditions = [
     ([], None,),

--- a/tests/query/parser/test_conditions.py
+++ b/tests/query/parser/test_conditions.py
@@ -14,7 +14,6 @@ from snuba.query.expressions import (
     Literal,
 )
 from snuba.query.parser.conditions import parse_conditions_to_expr
-from snuba.utils.snuba_exception import SnubaException
 
 test_conditions = [
     ([], None,),

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -1,4 +1,3 @@
-from snuba.utils.snuba_exception import SnubaException
 from __future__ import annotations
 
 import random
@@ -15,6 +14,7 @@ from snuba.redis import redis_client
 from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import PassthroughCodec
+from snuba.utils.snuba_exception import SnubaException
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -83,7 +83,7 @@ def test_get_readthrough_missed_deadline(backend: Cache[bytes]) -> None:
 def test_get_readthrough_exception(backend: Cache[bytes]) -> None:
     key = "key"
 
-    class CustomException(Exception):
+    class CustomException(SnubaException):
         pass
 
     def function() -> bytes:
@@ -114,7 +114,7 @@ def test_get_readthrough_set_wait(backend: Cache[bytes]) -> None:
 def test_get_readthrough_set_wait_error(backend: Cache[bytes]) -> None:
     key = "key"
 
-    class CustomException(Exception):
+    class CustomException(SnubaException):
         pass
 
     def function() -> bytes:

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -1,3 +1,4 @@
+from snuba.utils.snuba_exception import SnubaException
 from __future__ import annotations
 
 import random

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -14,7 +14,7 @@ from snuba.redis import redis_client
 from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import PassthroughCodec
-from snuba.utils.snuba_exception import SnubaException
+from snuba.utils.serializable_exception import SerializableException
 from tests.assertions import assert_changes, assert_does_not_change
 
 
@@ -83,7 +83,7 @@ def test_get_readthrough_missed_deadline(backend: Cache[bytes]) -> None:
 def test_get_readthrough_exception(backend: Cache[bytes]) -> None:
     key = "key"
 
-    class CustomException(SnubaException):
+    class CustomException(SerializableException):
         pass
 
     def function() -> bytes:
@@ -114,7 +114,7 @@ def test_get_readthrough_set_wait(backend: Cache[bytes]) -> None:
 def test_get_readthrough_set_wait_error(backend: Cache[bytes]) -> None:
     key = "key"
 
-    class CustomException(SnubaException):
+    class CustomException(SerializableException):
         pass
 
     def function() -> bytes:

--- a/tests/utils/test_snuba_exception.py
+++ b/tests/utils/test_snuba_exception.py
@@ -5,13 +5,25 @@ def test_exception() -> None:
     class MyException(SnubaException):
         pass
 
+    message = "I am an exception beep boop"
     try:
-        raise MyException("poopoo", extra="data")
+        raise MyException(message, extra="data")
     except MyException as e:
-        assert e.message == "poopoo"
+        assert e.message == message
         assert e.extra_data["extra"] == "data"
         edict = e.to_dict()
         resurfaced_e = SnubaException.from_dict(edict)
-        assert resurfaced_e.__class__.__name__ == "MyException"
-        assert resurfaced_e.message == "poopoo"
+        assert isinstance(resurfaced_e, MyException)
+        assert resurfaced_e.message == message
         assert resurfaced_e.extra_data == {"extra": "data"}
+
+
+def test_from_standard_exception() -> None:
+    message = "I am an exception beep boop"
+    try:
+        raise Exception(message)
+    except Exception as e:
+        snubs_exc = SnubaException.from_standard_exception_instance(e)
+        assert isinstance(snubs_exc, SnubaException)
+        assert snubs_exc.__class__.__name__ == "Exception"
+        assert snubs_exc.message == message

--- a/tests/utils/test_snuba_exception.py
+++ b/tests/utils/test_snuba_exception.py
@@ -20,6 +20,8 @@ def test_exception() -> None:
 
 def test_from_standard_exception() -> None:
     message = "I am an exception beep boop"
+    snubs_exc = None
+    # We can create snuba exceptions from standard ones
     try:
         raise Exception(message)
     except Exception as e:
@@ -27,3 +29,12 @@ def test_from_standard_exception() -> None:
         assert isinstance(snubs_exc, SnubaException)
         assert snubs_exc.__class__.__name__ == "Exception"
         assert snubs_exc.message == message
+        assert snubs_exc.extra_data["from_standard_exception"]
+
+    # if we create a SnubaException from a standard exception
+    # before, we'll create the same one again
+    try:
+        raise Exception("Other message")
+    except Exception as e:
+        new_snubs_exc = SnubaException.from_standard_exception_instance(e)
+        assert isinstance(new_snubs_exc, snubs_exc.__class__)

--- a/tests/utils/test_snuba_exception.py
+++ b/tests/utils/test_snuba_exception.py
@@ -1,42 +1,53 @@
 from snuba.utils.snuba_exception import SnubaException
 
 
-def test_exception() -> None:
-    class MyException(SnubaException):
-        pass
+class MyException(SnubaException):
+    pass
 
-    message = "I am an exception beep boop"
+
+class MySubException(MyException):
+    pass
+
+
+exc_message = "I am an exception beep boop"
+
+
+def test_exception() -> None:
     try:
-        raise MyException(message, extra="data")
+        raise MyException(exc_message, extra="data")
     except MyException as e:
-        assert e.message == message
+        assert e.message == exc_message
         assert e.extra_data["extra"] == "data"
         edict = e.to_dict()
         resurfaced_e = SnubaException.from_dict(edict)
         assert isinstance(resurfaced_e, MyException)
-        assert resurfaced_e.message == message
+        assert resurfaced_e.message == exc_message
         assert resurfaced_e.extra_data == {"extra": "data"}
         assert resurfaced_e.should_report
 
 
 def test_from_standard_exception() -> None:
-    message = "I am an exception beep boop"
     snubs_exc = None
     # We can create snuba exceptions from standard ones
     try:
-        raise Exception(message)
+        raise Exception(exc_message)
     except Exception as e:
         snubs_exc = SnubaException.from_standard_exception_instance(e)
         assert isinstance(snubs_exc, SnubaException)
         assert snubs_exc.__class__.__name__ == "Exception"
-        assert snubs_exc.message == message
+        assert snubs_exc.message == exc_message
         assert snubs_exc.extra_data["from_standard_exception"]
         assert snubs_exc.should_report
 
     # if we create a SnubaException from a standard exception
-    # before, we'll create the same one again
+    # before, we'll create the same SnubaException subclass again
     try:
-        raise Exception("Other message")
+        raise Exception("message is unrelated to created type")
     except Exception as e:
         new_snubs_exc = SnubaException.from_standard_exception_instance(e)
         assert isinstance(new_snubs_exc, snubs_exc.__class__)
+
+
+def test_subclass_deserialization() -> None:
+    deserialized_sub_exception = SnubaException.from_dict(MySubException().to_dict())
+    assert isinstance(deserialized_sub_exception, MyException)

--- a/tests/utils/test_snuba_exception.py
+++ b/tests/utils/test_snuba_exception.py
@@ -1,0 +1,17 @@
+from snuba.utils.snuba_exception import SnubaException
+
+
+def test_exception() -> None:
+    class MyException(SnubaException):
+        pass
+
+    try:
+        raise MyException("poopoo", extra="data")
+    except MyException as e:
+        assert e.message == "poopoo"
+        assert e.extra_data["extra"] == "data"
+        edict = e.to_dict()
+        resurfaced_e = SnubaException.from_dict(edict)
+        assert resurfaced_e.__class__.__name__ == "MyException"
+        assert resurfaced_e.message == "poopoo"
+        assert resurfaced_e.extra_data == {"extra": "data"}

--- a/tests/utils/test_snuba_exception.py
+++ b/tests/utils/test_snuba_exception.py
@@ -16,6 +16,7 @@ def test_exception() -> None:
         assert isinstance(resurfaced_e, MyException)
         assert resurfaced_e.message == message
         assert resurfaced_e.extra_data == {"extra": "data"}
+        assert resurfaced_e.should_report
 
 
 def test_from_standard_exception() -> None:
@@ -30,6 +31,7 @@ def test_from_standard_exception() -> None:
         assert snubs_exc.__class__.__name__ == "Exception"
         assert snubs_exc.message == message
         assert snubs_exc.extra_data["from_standard_exception"]
+        assert snubs_exc.should_report
 
     # if we create a SnubaException from a standard exception
     # before, we'll create the same one again

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -8,12 +8,12 @@ from snuba.web.views import handle_invalid_query
 
 invalid_query_exception_test_cases = [
     pytest.param(
-        ParsingException("This should be reported at WARNING", report=True),
+        ParsingException("This should be reported at WARNING", should_report=True),
         "WARNING",
         id="Report exception",
     ),
     pytest.param(
-        ParsingException("This should be reported at INFO", report=False),
+        ParsingException("This should be reported at INFO", should_report=False),
         "INFO",
         id="Mute exception",
     ),


### PR DESCRIPTION
### Context

Following up from #2102 this PR implements a serializable exception class which can be serialized and reraised upon deserialization

### Solution

SerializableException is an extension of the Exception class that intends to be the base exceptions for all exceptions in Snuba. All Exception subclasses have already been replaced in this PR. In addition to serializability, SerializableException also adds whether the error should be reported to sentry as a first class citizen. 