### PR TITLE
feat(subscriptions): Support entity max aggregations

### DIFF
--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -101,14 +101,14 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
     def validate(self, query: Query, alias: Optional[str] = None) -> None:
         selected = query.get_selected_columns()
         if len(selected) > self.max_allowed_aggregations:
-            if self.max_allowed_aggregations == 1:
-                error_text = "A maximum of 1 aggregation is allowed in the select"
-            else:
-                error_text = (
-                    f"A maximum of {self.max_allowed_aggregations} aggregations are allowed in "
-                    f"the select"
-                )
-            raise InvalidQueryException(error_text)
+            aggregation_error_text = (
+                "1 aggregation is"
+                if self.max_allowed_aggregations == 1
+                else f"{self.max_allowed_aggregations} aggregations are"
+            )
+            raise InvalidQueryException(
+                f"A maximum of {aggregation_error_text} allowed in the select"
+            )
 
         disallowed = ["groupby", "having", "orderby"]
         for field in disallowed:

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -95,10 +95,20 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
     clauses are being used in the query, and that those clauses are in the correct structure.
     """
 
+    def __init__(self, max_allowed_aggregations: int) -> None:
+        self.max_allowed_aggregations = max_allowed_aggregations
+
     def validate(self, query: Query, alias: Optional[str] = None) -> None:
         selected = query.get_selected_columns()
-        if len(selected) != 1:
-            raise InvalidQueryException("only one aggregation in the select allowed")
+        if len(selected) > self.max_allowed_aggregations:
+            if self.max_allowed_aggregations == 1:
+                error_text = "A maximum of 1 aggregation is allowed in the select"
+            else:
+                error_text = (
+                    f"A maximum of {self.max_allowed_aggregations} aggregations are allowed in "
+                    f"the select"
+                )
+            raise InvalidQueryException(error_text)
 
         disallowed = ["groupby", "having", "orderby"]
         for field in disallowed:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -265,7 +265,9 @@ class SnQLSubscriptionData(SubscriptionData):
             raise InvalidSubscriptionError("Only simple queries are supported")
         entity = get_entity(from_clause.key)
 
-        SubscriptionAllowedClausesValidator().validate(query)
+        SubscriptionAllowedClausesValidator(
+            self.entity_subscription.MAX_ALLOWED_AGGREGATIONS
+        ).validate(query)
         if entity.required_time_column:
             NoTimeBasedConditionValidator(entity.required_time_column).validate(query)
 

--- a/snuba/subscriptions/entity_subscription.py
+++ b/snuba/subscriptions/entity_subscription.py
@@ -16,6 +16,8 @@ class SubscriptionType(Enum):
 
 
 class EntitySubscription(ABC):
+    MAX_ALLOWED_AGGREGATIONS: int = 1
+
     def __init__(self, data_dict: Mapping[str, Any]) -> None:
         ...
 
@@ -45,6 +47,8 @@ class EntitySubscription(ABC):
 
 
 class SessionsSubscription(EntitySubscription):
+    MAX_ALLOWED_AGGREGATIONS: int = 2
+
     def __init__(self, data_dict: Mapping[str, Any]) -> None:
         super().__init__(data_dict)
         try:

--- a/tests/datasets/validation/test_subscription_clauses_validator.py
+++ b/tests/datasets/validation/test_subscription_clauses_validator.py
@@ -34,7 +34,7 @@ tests = [
 
 @pytest.mark.parametrize("query", tests)  # type: ignore
 def test_subscription_clauses_validation(query: LogicalQuery) -> None:
-    validator = SubscriptionAllowedClausesValidator()
+    validator = SubscriptionAllowedClausesValidator(max_allowed_aggregations=1)
     validator.validate(query)
 
 
@@ -101,6 +101,6 @@ invalid_tests = [
 
 @pytest.mark.parametrize("query", invalid_tests)  # type: ignore
 def test_subscription_clauses_validation_failure(query: LogicalQuery) -> None:
-    validator = SubscriptionAllowedClausesValidator()
+    validator = SubscriptionAllowedClausesValidator(max_allowed_aggregations=1)
     with pytest.raises(InvalidQueryException):
         validator.validate(query)

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -146,7 +146,7 @@ TESTS_OVER_SESSIONS = [
             entity_subscription=create_entity_subscription("sessions"),
         ),
         InvalidQueryException,
-        id="Delegate subscription",
+        id="Snql subscription",
     ),
 ]
 

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -128,6 +128,26 @@ TESTS_OVER_SESSIONS = [
         None,
         id="Delegate subscription",
     ),
+    pytest.param(
+        SnQLSubscriptionData(
+            project_id=1,
+            query=(
+                """
+                MATCH (sessions) SELECT if(greater(sessions,0),
+                divide(sessions_crashed,sessions),null)
+                AS _crash_rate_alert_aggregate, identity(sessions) AS _total_sessions,
+                identity(sessions_crashed)
+                WHERE org_id = 1 AND project_id IN tuple(1) LIMIT 1
+                OFFSET 0 GRANULARITY 3600
+                """
+            ),
+            time_window=timedelta(minutes=120),
+            resolution=timedelta(minutes=1),
+            entity_subscription=create_entity_subscription("sessions"),
+        ),
+        InvalidQueryException,
+        id="Delegate subscription",
+    ),
 ]
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2083,48 +2083,6 @@ class TestCreateSubscriptionApi(BaseApiTest):
             "subscription_id": f"0/{expected_uuid.hex}",
         }
 
-    def test_delegate_with_sessions_entity_subscription(self) -> None:
-        expected_uuid = uuid.uuid1()
-
-        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
-            uuid4.return_value = expected_uuid
-            resp = self.app.post(
-                "{}/subscriptions".format("sessions"),
-                data=json.dumps(
-                    {
-                        "type": "delegate",
-                        "project_id": 1,
-                        "conditions": [],
-                        "aggregations": [
-                            [
-                                "if(greater(sessions,0),divide(sessions_crashed,sessions),null)",
-                                None,
-                                "_crash_rate_alert_aggregate",
-                            ],
-                            ["identity(sessions)", None, "_total_sessions"],
-                        ],
-                        "time_window": int(timedelta(minutes=10).total_seconds()),
-                        "resolution": int(timedelta(minutes=1).total_seconds()),
-                        "query": (
-                            """
-                            MATCH (sessions) SELECT if(greater(sessions,0),
-                            divide(sessions_crashed,sessions),null)
-                            AS _crash_rate_alert_aggregate, identity(sessions) AS _total_sessions
-                            WHERE org_id = 1 AND project_id IN tuple(1) LIMIT 1
-                            OFFSET 0 GRANULARITY 3600
-                            """
-                        ),
-                        "organization": 1,
-                    }
-                ).encode("utf-8"),
-            )
-
-        assert resp.status_code == 202
-        data = json.loads(resp.data)
-        assert data == {
-            "subscription_id": f"0/{expected_uuid.hex}",
-        }
-
     def test_delegate_with_bad_snql(self) -> None:
         expected_uuid = uuid.uuid1()
 
@@ -2153,52 +2111,6 @@ class TestCreateSubscriptionApi(BaseApiTest):
                 "type": "invalid_query",
             }
         }
-
-    def test_bad_delegate_with_sessions_entity_subscription(self) -> None:
-        expected_uuid = uuid.uuid1()
-
-        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
-            uuid4.return_value = expected_uuid
-            resp = self.app.post(
-                "{}/subscriptions".format("sessions"),
-                data=json.dumps(
-                    {
-                        "type": "delegate",
-                        "project_id": 1,
-                        "conditions": [],
-                        "aggregations": [
-                            [
-                                "if(greater(sessions,0),divide(sessions_crashed,sessions),null)",
-                                None,
-                                "_crash_rate_alert_aggregate",
-                            ],
-                            ["identity(sessions)", None, "_total_sessions"],
-                            ["identity(sessions_crashed)", None, None],
-                        ],
-                        "time_window": int(timedelta(minutes=10).total_seconds()),
-                        "resolution": int(timedelta(minutes=1).total_seconds()),
-                        "query": (
-                            """
-                            MATCH (sessions) SELECT if(greater(sessions,0),
-                            divide(sessions_crashed,sessions),null)
-                            AS _crash_rate_alert_aggregate, identity(sessions) AS _total_sessions,
-                            identity(sessions_crashed)
-                            WHERE org_id = 1 AND project_id IN tuple(1) LIMIT 1
-                            OFFSET 0 GRANULARITY 3600
-                            """
-                        ),
-                        "organization": 1,
-                    }
-                ).encode("utf-8"),
-            )
-            assert resp.status_code == 400
-            data = json.loads(resp.data)
-            assert data == {
-                "error": {
-                    "message": "A maximum of 2 aggregations are allowed in the select",
-                    "type": "invalid_query",
-                }
-            }
 
 
 class TestDeleteSubscriptionApi(BaseApiTest):

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -284,13 +284,17 @@ class TestSessionsApi(BaseSessionsMockTest, BaseApiTest):
             "message": "Minute-resolution queries are restricted to a 7-hour time window.",
         }
 
+
+class TestCreateSubscriptionApi(BaseApiTest):
+    dataset_name = "sessions"
+
     def test_delegate_with_sessions_entity_subscription(self) -> None:
         expected_uuid = uuid.uuid1()
 
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
             uuid4.return_value = expected_uuid
             resp = self.app.post(
-                "{}/subscriptions".format("sessions"),
+                "{}/subscriptions".format(self.dataset_name),
                 data=json.dumps(
                     {
                         "type": "delegate",
@@ -332,7 +336,7 @@ class TestSessionsApi(BaseSessionsMockTest, BaseApiTest):
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
             uuid4.return_value = expected_uuid
             resp = self.app.post(
-                "{}/subscriptions".format("sessions"),
+                "{}/subscriptions".format(self.dataset_name),
                 data=json.dumps(
                     {
                         "type": "delegate",


### PR DESCRIPTION
This PR:
- Adds the ability to set an entity specific number of allowed maximum aggregations for subscriptions in the `EntitySubscription` class