### PR TITLE
fix(ci): Run Sentry integration tests with Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           workdir: sentry
           cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
-          python-version: 3.8
+          python-version: 3.6
           snuba: false
           kafka: true
           clickhouse: true
@@ -205,7 +205,6 @@ jobs:
             --network sentry \
             snuba-test
           docker exec sentry_snuba snuba migrations migrate --force
-
 
       - name: Run snuba tests
         working-directory: sentry


### PR DESCRIPTION
Snuba's Python version is 3.8, however, Sentry uses 3.6, thus, fixing it.

There's currently some integration tests failing to complete because it is
installing a newer version of psycopg2-binary which makes the tests fail.

See [this commit][1] for details.

[1]: https://github.com/getsentry/sentry/commit/3f71db8928bf6e20eb821026ad6713b4b043f2bf