### PR TITLE
fix(ci): Add USE_REDIS_INDEXER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,9 @@ jobs:
       matrix:
         instance: [0, 1]
 
+    env:
+      USE_REDIS_INDEXER: 1
+
     steps:
       # Checkout codebase
       - name: Checkout snuba


### PR DESCRIPTION
I added the `USE_REDIS_INDEXER` env var to the snuba-integration tests [in Sentry](https://github.com/getsentry/sentry/blob/master/.github/workflows/snuba-integration-test.yml#L21) but didn't update in snuba to do the same.