### PR TITLE
feat(subscriptions): Subscription data store uses entity not dataset name

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -14,6 +14,7 @@ from arroyo.processing.strategies.batching import BatchProcessingStrategyFactory
 from arroyo.synchronized import SynchronizedConsumer
 
 from snuba import environment, settings
+from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
 from snuba.datasets.factory import DATASET_NAMES, enforce_table_writer, get_dataset
 from snuba.environment import setup_logging, setup_sentry
 from snuba.redis import redis_client
@@ -114,6 +115,9 @@ def subscriptions(
 
     dataset = get_dataset(dataset_name)
 
+    entity = dataset.get_default_entity()
+    entity_key = ENTITY_NAME_LOOKUP[entity]
+
     storage = dataset.get_default_entity().get_writable_storage()
     assert (
         storage is not None
@@ -200,7 +204,7 @@ def subscriptions(
                     {
                         index: SubscriptionScheduler(
                             RedisSubscriptionDataStore(
-                                redis_client, dataset, PartitionId(index)
+                                redis_client, entity_key, PartitionId(index)
                             ),
                             PartitionId(index),
                             cache_ttl=timedelta(seconds=schedule_ttl),

--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -2,8 +2,7 @@ import json
 
 from arroyo.backends.kafka import KafkaPayload
 
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
-from snuba.datasets.entity import Entity
+from snuba.datasets.entities import EntityKey
 from snuba.query.exceptions import InvalidQueryException
 from snuba.subscriptions.data import (
     DelegateSubscriptionData,
@@ -20,8 +19,8 @@ from snuba.utils.codecs import Codec, Encoder
 
 
 class SubscriptionDataCodec(Codec[bytes, SubscriptionData]):
-    def __init__(self, entity: Entity):
-        self.entity_key = ENTITY_NAME_LOOKUP[entity]
+    def __init__(self, entity_key: EntityKey):
+        self.entity_key = entity_key
 
     def encode(self, value: SubscriptionData) -> bytes:
         return json.dumps(value.to_dict()).encode("utf-8")

--- a/snuba/subscriptions/store.py
+++ b/snuba/subscriptions/store.py
@@ -2,8 +2,7 @@ import abc
 from typing import Iterable, Tuple
 from uuid import UUID
 
-from snuba.datasets.dataset import Dataset
-from snuba.datasets.factory import get_dataset_name
+from snuba.datasets.entities import EntityKey
 from snuba.redis import RedisClientType
 from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import PartitionId, SubscriptionData
@@ -44,11 +43,11 @@ class RedisSubscriptionDataStore(SubscriptionDataStore):
     KEY_TEMPLATE = "subscriptions:{}:{}"
 
     def __init__(
-        self, client: RedisClientType, dataset: Dataset, partition_id: PartitionId
+        self, client: RedisClientType, entity: EntityKey, partition_id: PartitionId
     ):
         self.client = client
-        self.codec = SubscriptionDataCodec(entity=dataset.get_default_entity())
-        self.__key = f"subscriptions:{get_dataset_name(dataset)}:{partition_id}"
+        self.codec = SubscriptionDataCodec(entity)
+        self.__key = f"subscriptions:{entity.value}:{partition_id}"
 
     def create(self, key: UUID, data: SubscriptionData) -> None:
         """

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -35,6 +35,7 @@ from snuba.clickhouse.http import JSONRowEncoder
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
 from snuba.datasets.factory import (
     InvalidDatasetError,
     get_dataset,
@@ -478,9 +479,9 @@ def handle_subscription_error(exception: InvalidSubscriptionError) -> Response:
 @application.route("/<dataset:dataset>/subscriptions", methods=["POST"])
 @util.time_request("subscription")
 def create_subscription(*, dataset: Dataset, timer: Timer) -> RespTuple:
-    subscription = SubscriptionDataCodec(entity=dataset.get_default_entity()).decode(
-        http_request.data
-    )
+    entity_key = ENTITY_NAME_LOOKUP[dataset.get_default_entity()]
+
+    subscription = SubscriptionDataCodec(entity_key).decode(http_request.data)
     identifier = SubscriptionCreator(dataset).create(subscription, timer)
     return (
         json.dumps({"subscription_id": str(identifier)}),

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timedelta
 
 from snuba import settings
+from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
@@ -17,6 +18,7 @@ class BaseSubscriptionTest:
         self.platforms = ["a", "b"]
         self.minutes = 20
         self.dataset = get_dataset("events")
+        self.entity_key = ENTITY_NAME_LOOKUP[self.dataset.get_default_entity()]
 
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -8,7 +8,6 @@ from typing import Callable, Optional
 import pytest
 
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.reader import Result
 from snuba.subscriptions.codecs import (
@@ -34,7 +33,9 @@ from snuba.utils.metrics.timer import Timer
 from snuba.utils.scheduler import ScheduledTask
 
 
-def build_legacy_subscription_data(organization=None) -> LegacySubscriptionData:
+def build_legacy_subscription_data(
+    organization: Optional[int] = None,
+) -> LegacySubscriptionData:
     if not organization:
         entity_subscription = EventsSubscription(data_dict={})
     else:
@@ -117,9 +118,7 @@ def assert_entity_subscription_on_subscription_class(organization, subscription)
 def test_basic(
     builder: Callable[[Optional[int]], SubscriptionData], organization: Optional[int]
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     data = builder(organization)
     assert codec.decode(codec.encode(data)) == data
@@ -130,9 +129,7 @@ def test_encode(
     builder: Callable[[Optional[int]], LegacySubscriptionData],
     organization: Optional[int],
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     subscription = builder(organization)
 
@@ -151,9 +148,7 @@ def test_encode_snql(
     builder: Callable[[Optional[int]], SnQLSubscriptionData],
     organization: Optional[int],
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     subscription = builder(organization)
 
@@ -171,9 +166,7 @@ def test_encode_delegate(
     builder: Callable[[Optional[int]], DelegateSubscriptionData],
     organization: Optional[int],
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     subscription = builder(organization)
 
@@ -193,9 +186,7 @@ def test_decode(
     builder: Callable[[Optional[int]], LegacySubscriptionData],
     organization: Optional[int],
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     subscription = builder(organization)
     data = {
@@ -216,9 +207,7 @@ def test_decode_snql(
     builder: Callable[[Optional[int]], SnQLSubscriptionData],
     organization: Optional[int],
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     subscription = builder(organization)
     data = {
@@ -239,9 +228,7 @@ def test_decode_delegate(
     builder: Callable[[Optional[int]], DelegateSubscriptionData],
     organization: Optional[int],
 ) -> None:
-    entity = (
-        get_entity(EntityKey.SESSIONS) if organization else get_entity(EntityKey.EVENTS)
-    )
+    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
     codec = SubscriptionDataCodec(entity)
     subscription = builder(organization)
     data = {

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Callable, Collection, Optional, Tuple
 
 from snuba import state
-from snuba.datasets.factory import get_dataset
+from snuba.datasets.entities import EntityKey
 from snuba.redis import redis_client
 from snuba.subscriptions.data import (
     LegacySubscriptionData,
@@ -23,7 +23,7 @@ class TestSubscriptionScheduler:
     def setup_method(self) -> None:
         self.now = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
         self.partition_id = PartitionId(1)
-        self.dataset = get_dataset("events")
+        self.entity_key = EntityKey("events")
 
     def build_subscription(self, resolution: timedelta) -> Subscription:
         return Subscription(
@@ -55,7 +55,7 @@ class TestSubscriptionScheduler:
         ] = None,
     ) -> None:
         store = RedisSubscriptionDataStore(
-            redis_client, self.dataset, self.partition_id,
+            redis_client, self.entity_key, self.partition_id,
         )
         for subscription in subscriptions:
             store.create(subscription.identifier.uuid, subscription.data)

--- a/tests/subscriptions/test_store.py
+++ b/tests/subscriptions/test_store.py
@@ -36,7 +36,9 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
         ]
 
     def build_store(self, key: int = 1) -> RedisSubscriptionDataStore:
-        return RedisSubscriptionDataStore(redis_client, self.dataset, PartitionId(key))
+        return RedisSubscriptionDataStore(
+            redis_client, self.entity_key, PartitionId(key)
+        )
 
     def test_create(self) -> None:
         store = self.build_store()

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -6,6 +6,7 @@ import pytest
 from pytest import raises
 
 from snuba import state
+from snuba.datasets.entities import EntityKey
 from snuba.datasets.factory import get_dataset
 from snuba.redis import redis_client
 from snuba.subscriptions.data import (
@@ -161,7 +162,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, self.dataset, identifier.partition,
+                    redis_client, self.entity_key, identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -271,7 +272,7 @@ class TestSessionsSubscriptionCreator:
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, dataset, identifier.partition,
+                    redis_client, EntityKey.SESSIONS, identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -294,7 +295,7 @@ class TestSubscriptionDeleter(BaseSubscriptionTest):
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, self.dataset, identifier.partition,
+                    redis_client, self.entity_key, identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -303,7 +304,7 @@ class TestSubscriptionDeleter(BaseSubscriptionTest):
         SubscriptionDeleter(self.dataset, identifier.partition).delete(identifier.uuid)
         assert (
             RedisSubscriptionDataStore(
-                redis_client, self.dataset, identifier.partition,
+                redis_client, self.entity_key, identifier.partition,
             ).all()
             == []
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ from snuba import settings, state
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
 from snuba.datasets.events_processor_base import InsertEvent, ReplacementType
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
@@ -2135,9 +2135,12 @@ class TestDeleteSubscriptionApi(BaseApiTest):
         data = json.loads(resp.data)
         subscription_id = data["subscription_id"]
         partition = subscription_id.split("/", 1)[0]
+
+        entity_key = ENTITY_NAME_LOOKUP[self.dataset.get_default_entity()]
+
         assert (
             len(
-                RedisSubscriptionDataStore(redis_client, self.dataset, partition,).all()  # type: ignore
+                RedisSubscriptionDataStore(redis_client, entity_key, partition,).all()  # type: ignore
             )
             == 1
         )
@@ -2147,8 +2150,7 @@ class TestDeleteSubscriptionApi(BaseApiTest):
         )
         assert resp.status_code == 202, resp
         assert (
-            RedisSubscriptionDataStore(redis_client, self.dataset, partition,).all()
-            == []
+            RedisSubscriptionDataStore(redis_client, entity_key, partition,).all() == []
         )
 
 


### PR DESCRIPTION
The RedisSubscriptionDataStore now stores subscriptions by entity name instead
of dataset name. This is a step towards making all subscriptions based on
an entity rather than a dataset to align with our API. Since multiple
entities (such as events and transactions) are likely to eventually become
part of the same dataset, we should ensure that subscriptions are stored separately
for each entity even if they later become part of the same dataset.

Since all dataset and entity names for our current subscriptions are the same,
no migration is required.