### PR TITLE
ref: Remove unused errors entity key

### DIFF
--- a/snuba/datasets/entities/__init__.py
+++ b/snuba/datasets/entities/__init__.py
@@ -7,7 +7,6 @@ class EntityKey(Enum):
     """
 
     DISCOVER = "discover"
-    ERRORS = "errors"
     EVENTS = "events"
     GROUPS = "groups"
     GROUPASSIGNEE = "groupassignee"

--- a/tests/web/test_project_finder.py
+++ b/tests/web/test_project_finder.py
@@ -18,7 +18,7 @@ ERRORS_SCHEMA = ColumnSet(
 
 
 SIMPLE_QUERY = Query(
-    Entity(EntityKey.ERRORS, ERRORS_SCHEMA),
+    Entity(EntityKey.EVENTS, ERRORS_SCHEMA),
     selected_columns=[
         SelectedExpression("alias", Column("_snuba_project", None, "project_id"),)
     ],


### PR DESCRIPTION
There is no errors entity, this removes the key which was defined
but not being used.