### PR TITLE
Fix deserialized exception message being swallowed by sentry

### DIFF
--- a/snuba/utils/serializable_exception.py
+++ b/snuba/utils/serializable_exception.py
@@ -96,6 +96,7 @@ class SerializableException(Exception):
         self.extra_data = extra_data or {}
         # whether or not the error should be reported to sentry
         self.should_report = should_report
+        super().__init__(message)
 
     def to_dict(self) -> SerializableExceptionDict:
         return {
@@ -156,6 +157,3 @@ class SerializableException(Exception):
 
     def __repr__(self) -> str:
         return cast(str, rapidjson.dumps(self.to_dict(), indent=2))
-
-    def __str__(self) -> str:
-        return self.message

--- a/snuba/utils/serializable_exception.py
+++ b/snuba/utils/serializable_exception.py
@@ -156,3 +156,6 @@ class SerializableException(Exception):
 
     def __repr__(self) -> str:
         return cast(str, rapidjson.dumps(self.to_dict(), indent=2))
+
+    def __str__(self) -> str:
+        return self.message


### PR DESCRIPTION
Sentry sdk uses `str` to get the `value` field of an exception. SerializableException was not calling the `super` constructor and thus its `str` method was misbehaving. This PR fixes that