### PR TITLE
feat(clcikhouse) Keep track of the number of connections from snuba to clickhouse

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -9,14 +9,18 @@ from uuid import UUID
 from clickhouse_driver import Client, errors
 from dateutil.tz import tz
 
-from snuba import settings, state
+from snuba import environment, settings, state
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
 from snuba.reader import Reader, Result, build_result_transformer
+from snuba.utils.metrics.gauge import ThreadSafeGauge
+from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger("snuba.clickhouse")
 
 Params = Optional[Union[Sequence[Any], Mapping[str, Any]]]
+
+metrics = MetricsWrapper(environment.metrics, "clickhouse.native")
 
 
 class ClickhousePool(object):
@@ -42,6 +46,7 @@ class ClickhousePool(object):
         self.client_settings = client_settings
 
         self.pool: queue.LifoQueue[Optional[Client]] = queue.LifoQueue(max_pool_size)
+        self.__gauge = ThreadSafeGauge(metrics, "connections")
 
         # Fill the queue up so that doing get() on it will block properly
         for _ in range(max_pool_size):
@@ -75,6 +80,7 @@ class ClickhousePool(object):
                 attempts_remaining -= 1
                 # Lazily create connection instances
                 if conn is None:
+                    self.__gauge.increment()
                     conn = self._create_conn()
 
                 try:
@@ -89,8 +95,10 @@ class ClickhousePool(object):
                     )
                     return result
                 except (errors.NetworkError, errors.SocketTimeoutError, EOFError) as e:
+                    metrics.increment("connection_error")
                     # Force a reconnection next time
                     conn = None
+                    self.__gauge.decrement()
                     if attempts_remaining == 0:
                         if isinstance(e, errors.Error):
                             raise ClickhouseError(e.message, code=e.code) from e


### PR DESCRIPTION
Keep track of the number of active connections per pod we have between api nodes and Clickhouse. 

This is meant to help in the investigation on the amount of health checks that we are sending to the query nodes.