### PR TITLE
feat(subscriptions): Add codec for scheduled subscription task

### DIFF
--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -69,7 +69,7 @@ class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult
         )
 
 
-class SubscriptionScheduledTaskEncoder(Encoder[bytes, ScheduledTask[Subscription]]):
+class SubscriptionScheduledTaskEncoder(Codec[bytes, ScheduledTask[Subscription]]):
     """
     Encodes/decodes a scheduled subscription to bytes for Kafka.
     Does not support non SnQL subscriptions.


### PR DESCRIPTION
Currently subscription scheduling and executing are done together
in a single process by the subscription worker. Soon this will be
split into two separate phases with the scheduled subscriptions published
to a new Kafka topic to be subsequently picked up by the executors.
We will need to be able to serialize the scheduled subscriptions into
bytes so they can be produced to Kafka.

This PR introduces a SubscriptionScheduledTaskEncoder codec which can
encode a ScheduledTask[Subscription] into bytes and those bytes back
to a ScheduledTask[Subscription]. The encoder is not being used yet.

Note that the encoder does not support non SnQL subscriptions.
This is to avoid unnecessary complexity as legacy subscriptions
are expected to be deprecated and completely removed from our
codebase soon.

Also fixes the typing issues in test_codec.py.