### PR TITLE
feat(subscriptions): Enable Sessions Subscriptions settings

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -146,7 +146,7 @@ TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
 
 # Metric Alerts Subscription Options
-ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", False)
+ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", True)
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:


### PR DESCRIPTION
Since the corresponding PR has been merged in Sentry https://github.com/getsentry/sentry/pull/28526, Would like to get this enabled to be able to EA the feature

Corresponding Ops ticket: https://github.com/getsentry/ops/pull/3980