### PR TITLE
ref(sentry-metrics): USE_INDEXER

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         instance: [0, 1]
 
     env:
-      USE_REDIS_INDEXER: 1
+      USE_INDEXER: 1
 
     steps:
       # Checkout codebase


### PR DESCRIPTION
Follow up needed when https://github.com/getsentry/sentry/pull/28914 is merged (these settings need to be consistent in both sentry and snuba)

Technically the indexer is no longer the redis one, I'm changing this to just be `USE_INDEXER` to indicate using the real one, vs the default which is the original mock indexer

https://github.com/getsentry/sentry/blob/bbb0afe520810d911b3d680b4a6338afd6057c23/src/sentry/conf/server.py#L1375