### PR TITLE
feat(subscriptions): Use scheduler command to debug commit log issues (temporarily)

### DIFF
--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -4,11 +4,10 @@ from typing import Any, Optional
 
 import click
 from arroyo import configure_metrics
-from arroyo.processing import StreamProcessor
 
 from snuba import environment
 from snuba.environment import setup_logging, setup_sentry
-from snuba.subscriptions.scheduler_consumer import SchedulerBuilder, Tick
+from snuba.subscriptions.scheduler_consumer import SchedulerBuilder
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 
@@ -64,7 +63,7 @@ def subscriptions_scheduler(
         entity_name, consumer_group, auto_offset_reset, delay_seconds, metrics,
     )
 
-    processor: StreamProcessor[Tick] = builder.build_consumer()
+    processor = builder.build_consumer()
 
     def handler(signum: int, frame: Any) -> None:
         processor.signal_shutdown()

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -282,7 +282,7 @@ class MeasureCommitLogOrderMetrics(ProcessingStrategy[KafkaPayload]):
         current_message = MessageDetails(commit.offset, commit.orig_message_ts)
 
         # Record metrics about in order vs out of order messages
-        last_message = self.__previous_messages[commit.partition]
+        last_message = self.__previous_messages.get(commit.partition)
         if last_message is not None:
             current_message = MessageDetails(commit.offset, commit.orig_message_ts)
             try:

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -216,14 +216,20 @@ class SchedulerBuilder:
         self.__delay_seconds = delay_seconds
         self.__metrics = metrics
 
-    def build_consumer(self) -> StreamProcessor[Tick]:
+    def build_consumer(self) -> StreamProcessor[KafkaPayload]:
         return StreamProcessor(
-            self.__build_tick_consumer(),
+            KafkaConsumer(
+                build_kafka_consumer_configuration(
+                    self.__commit_log_topic_spec.topic,
+                    self.__consumer_group,
+                    auto_offset_reset=self.__auto_offset_reset,
+                ),
+            ),
             Topic(self.__commit_log_topic_spec.topic_name),
             self.__build_strategy_factory(),
         )
 
-    def __build_strategy_factory(self) -> ProcessingStrategyFactory[Tick]:
+    def __build_strategy_factory(self) -> ProcessingStrategyFactory[KafkaPayload]:
         return SubscriptionSchedulerProcessingFactory(self.__partitions, self.__metrics)
 
     def __build_tick_consumer(self) -> CommitLogTickConsumer:
@@ -241,6 +247,70 @@ class SchedulerBuilder:
                 else None
             ),
         )
+
+
+class MeasureCommitLogOrderMetrics(ProcessingStrategy[KafkaPayload]):
+    """
+    This is an extremely minimalistic strategy that does absolutely nothing
+    except measure the extent to which commits are monotonically ordered
+    by partition in the snuba-commit-log.
+
+    It is intended to be temporary code to help debug some invalid interval
+    issues with the tick consumer in production.
+    """
+
+    def __init__(
+        self,
+        partitions: int,
+        metrics: MetricsBackend,
+        commit: Callable[[Mapping[Partition, Position]], None],
+    ) -> None:
+        self.__previous_messages: MutableMapping[Partition, MessageDetails] = {}
+        self.__partitions = partitions
+        self.__metrics = metrics
+        self.__commit = commit
+
+    def poll(self) -> None:
+        pass
+
+    def submit(self, message: Message[KafkaPayload]) -> None:
+        commit = commit_codec.decode(message.payload)
+
+        assert commit.partition.index < self.__partitions
+        assert commit.orig_message_ts is not None
+
+        current_message = MessageDetails(commit.offset, commit.orig_message_ts)
+
+        # Record metrics about in order vs out of order messages
+        last_message = self.__previous_messages[commit.partition]
+        if last_message is not None:
+            current_message = MessageDetails(commit.offset, commit.orig_message_ts)
+            try:
+                Interval(last_message.orig_message_ts, current_message.orig_message_ts)
+                self.__metrics.increment(
+                    "build_interval",
+                    tags={"valid": "true", "partition": str(commit.partition.index)},
+                )
+            except InvalidRangeError:
+                self.__metrics.increment(
+                    "build_interval",
+                    tags={"valid": "false", "partition": str(commit.partition.index)},
+                )
+
+        # Update self.__previous_messages
+        self.__previous_messages[commit.partition] = current_message
+
+        # Commit the offset for every message no matter what
+        self.__commit({message.partition: Position(message.offset, message.timestamp)})
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        pass
 
 
 class MeasurePartitionLag(ProcessingStrategy[Tick]):
@@ -295,12 +365,12 @@ class MeasurePartitionLag(ProcessingStrategy[Tick]):
         pass
 
 
-class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
+class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(self, partitions: int, metrics: MetricsBackend) -> None:
         self.__partitions = partitions
         self.__metrics = metrics
 
     def create(
         self, commit: Callable[[Mapping[Partition, Position]], None]
-    ) -> ProcessingStrategy[Tick]:
-        return MeasurePartitionLag(self.__partitions, self.__metrics, commit)
+    ) -> ProcessingStrategy[KafkaPayload]:
+        return MeasureCommitLogOrderMetrics(self.__partitions, self.__metrics, commit)

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -31,6 +31,7 @@ from tests.assertions import assert_changes
 from tests.backends.metrics import TestingMetricsBackend, Timing
 
 
+@pytest.mark.skip(reason="Skipping for measure commit log order experiment")
 def test_scheduler_consumer() -> None:
     settings.TOPIC_PARTITION_COUNTS = {"events": 2}
     importlib.reload(scheduler_consumer)


### PR DESCRIPTION
Upon turning on the scheduler process in production for testing, we experienced
a lot of issues with invalid intervals. The lower bound of the interval constructed
by the CommitLogTickConsumer was frequently higher than the upper bound, which is invalid.

One potential cause of this could be messages being out of their expected order in
the commit log. Though this is known to be possible due to consumer crashes, rebalancing, etc
the frequency with whicih this appeared to happen seemed unusual.

This PR aims to change the scheduler consumer to simply collect more information about
commit log ordering to understand how common out of order messages might be.
For each message consumed, we simply record whether it is earlier or later than the
last one we received for that partition.

In order to avoid introducing other bugs or complexities to interval calculations,
it tries to be as minimalistic as possible and uses just a standard consumer, not the
tick consumer.