### PR TITLE
feat(subscriptions): Add scheduler mode to stream loader

### DIFF
--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -15,7 +15,7 @@ from snuba.datasets.storages.errors_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.conditions_enforcer import ProjectIdEnforcer
-from snuba.subscriptions.utils import SchedulerMode
+from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
 schema = WritableTableSchema(
@@ -39,7 +39,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,
-        subscription_scheduler_mode=SchedulerMode.IMMEDIATE,
+        subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -15,6 +15,7 @@ from snuba.datasets.storages.errors_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.conditions_enforcer import ProjectIdEnforcer
+from snuba.subscriptions.utils import SchedulerMode
 from snuba.utils.streams.topics import Topic
 
 schema = WritableTableSchema(
@@ -38,6 +39,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,
+        subscription_scheduler_mode=SchedulerMode.IMMEDIATE,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -17,6 +17,7 @@ from snuba.datasets.storages.events_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.conditions_enforcer import ProjectIdEnforcer
+from snuba.subscriptions.utils import SchedulerMode
 from snuba.utils.streams.topics import Topic
 
 schema = WritableTableSchema(
@@ -39,6 +40,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS_LEGACY,
         commit_log_topic=Topic.COMMIT_LOG,
+        subscription_scheduler_mode=SchedulerMode.IMMEDIATE,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -17,7 +17,7 @@ from snuba.datasets.storages.events_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.conditions_enforcer import ProjectIdEnforcer
-from snuba.subscriptions.utils import SchedulerMode
+from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
 schema = WritableTableSchema(
@@ -40,7 +40,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS_LEGACY,
         commit_log_topic=Topic.COMMIT_LOG,
-        subscription_scheduler_mode=SchedulerMode.IMMEDIATE,
+        subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -23,6 +23,7 @@ from snuba.query.processors.conditions_enforcer import OrgIdEnforcer, ProjectIdE
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.request.request_settings import RequestSettings
+from snuba.subscriptions.utils import SchedulerMode
 from snuba.utils.streams.topics import Topic
 
 WRITE_LOCAL_TABLE_NAME = "sessions_raw_local"
@@ -121,6 +122,7 @@ if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
         processor=SessionsProcessor(),
         default_topic=Topic.SESSIONS,
         commit_log_topic=Topic.SESSIONS_COMMIT_LOG,
+        subscription_scheduler_mode=SchedulerMode.WAIT_FOR_SLOWEST_PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_SESSIONS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_SESSIONS,
     )

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -23,7 +23,7 @@ from snuba.query.processors.conditions_enforcer import OrgIdEnforcer, ProjectIdE
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.request.request_settings import RequestSettings
-from snuba.subscriptions.utils import SchedulerMode
+from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
 WRITE_LOCAL_TABLE_NAME = "sessions_raw_local"
@@ -122,7 +122,7 @@ if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
         processor=SessionsProcessor(),
         default_topic=Topic.SESSIONS,
         commit_log_topic=Topic.SESSIONS_COMMIT_LOG,
-        subscription_scheduler_mode=SchedulerMode.WAIT_FOR_SLOWEST_PARTITION,
+        subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_SESSIONS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_SESSIONS,
     )

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -35,7 +35,7 @@ from snuba.query.processors.type_converters.hexint_column_processor import (
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
-from snuba.subscriptions.utils import SchedulerMode
+from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 from snuba.web.split import TimeSplitQueryStrategy
 
@@ -144,7 +144,7 @@ storage = WritableTableStorage(
         processor=TransactionsMessageProcessor(),
         default_topic=Topic.EVENTS,
         commit_log_topic=Topic.COMMIT_LOG,
-        subscription_scheduler_mode=SchedulerMode.IMMEDIATE,
+        subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_TRANSACTIONS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_TRANSACTIONS,
     ),

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -35,6 +35,7 @@ from snuba.query.processors.type_converters.hexint_column_processor import (
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
+from snuba.subscriptions.utils import SchedulerMode
 from snuba.utils.streams.topics import Topic
 from snuba.web.split import TimeSplitQueryStrategy
 
@@ -143,6 +144,7 @@ storage = WritableTableStorage(
         processor=TransactionsMessageProcessor(),
         default_topic=Topic.EVENTS,
         commit_log_topic=Topic.COMMIT_LOG,
+        subscription_scheduler_mode=SchedulerMode.IMMEDIATE,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_TRANSACTIONS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_TRANSACTIONS,
     ),

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -17,6 +17,7 @@ from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.snapshots import BulkLoadSource
 from snuba.snapshots.loaders import BulkLoader
 from snuba.snapshots.loaders.single_table import RowProcessor, SingleTableBulkLoader
+from snuba.subscriptions.utils import SchedulerMode
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.topics import Topic, get_topic_creation_config
 from snuba.writer import BatchWriter
@@ -67,17 +68,21 @@ class KafkaStreamLoader:
         pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
         replacement_topic_spec: Optional[KafkaTopicSpec] = None,
         commit_log_topic_spec: Optional[KafkaTopicSpec] = None,
+        subscription_scheduler_mode: Optional[SchedulerMode] = None,
         subscription_scheduled_topic_spec: Optional[KafkaTopicSpec] = None,
         subscription_result_topic_spec: Optional[KafkaTopicSpec] = None,
     ) -> None:
-        assert (subscription_scheduled_topic_spec is None) == (
-            subscription_result_topic_spec is None
+        assert (
+            (subscription_scheduler_mode is None)
+            == (subscription_scheduled_topic_spec is None)
+            == (subscription_result_topic_spec is None)
         )
 
         self.__processor = processor
         self.__default_topic_spec = default_topic_spec
         self.__replacement_topic_spec = replacement_topic_spec
         self.__commit_log_topic_spec = commit_log_topic_spec
+        self.__subscription_scheduler_mode = subscription_scheduler_mode
         self.__subscription_scheduled_topic_spec = subscription_scheduled_topic_spec
         self.__subscription_result_topic_spec = subscription_result_topic_spec
         self.__pre_filter = pre_filter
@@ -101,6 +106,9 @@ class KafkaStreamLoader:
     def get_commit_log_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__commit_log_topic_spec
 
+    def get_subscription_scheduler_mode(self) -> Optional[SchedulerMode]:
+        return self.__subscription_scheduler_mode
+
     def get_subscription_scheduled_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__subscription_scheduled_topic_spec
 
@@ -114,6 +122,7 @@ def build_kafka_stream_loader_from_settings(
     pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
     replacement_topic: Optional[Topic] = None,
     commit_log_topic: Optional[Topic] = None,
+    subscription_scheduler_mode: Optional[SchedulerMode] = None,
     subscription_scheduled_topic: Optional[Topic] = None,
     subscription_result_topic: Optional[Topic] = None,
 ) -> KafkaStreamLoader:
@@ -150,6 +159,7 @@ def build_kafka_stream_loader_from_settings(
         pre_filter,
         replacement_topic_spec,
         commit_log_topic_spec,
+        subscription_scheduler_mode=subscription_scheduler_mode,
         subscription_scheduled_topic_spec=subscription_scheduled_topic_spec,
         subscription_result_topic_spec=subscription_result_topic_spec,
     )

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -17,7 +17,7 @@ from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.snapshots import BulkLoadSource
 from snuba.snapshots.loaders import BulkLoader
 from snuba.snapshots.loaders.single_table import RowProcessor, SingleTableBulkLoader
-from snuba.subscriptions.utils import SchedulerMode
+from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.topics import Topic, get_topic_creation_config
 from snuba.writer import BatchWriter
@@ -68,7 +68,7 @@ class KafkaStreamLoader:
         pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
         replacement_topic_spec: Optional[KafkaTopicSpec] = None,
         commit_log_topic_spec: Optional[KafkaTopicSpec] = None,
-        subscription_scheduler_mode: Optional[SchedulerMode] = None,
+        subscription_scheduler_mode: Optional[SchedulingWatermarkMode] = None,
         subscription_scheduled_topic_spec: Optional[KafkaTopicSpec] = None,
         subscription_result_topic_spec: Optional[KafkaTopicSpec] = None,
     ) -> None:
@@ -106,7 +106,7 @@ class KafkaStreamLoader:
     def get_commit_log_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__commit_log_topic_spec
 
-    def get_subscription_scheduler_mode(self) -> Optional[SchedulerMode]:
+    def get_subscription_scheduler_mode(self) -> Optional[SchedulingWatermarkMode]:
         return self.__subscription_scheduler_mode
 
     def get_subscription_scheduled_topic_spec(self) -> Optional[KafkaTopicSpec]:
@@ -122,7 +122,7 @@ def build_kafka_stream_loader_from_settings(
     pre_filter: Optional[StreamMessageFilter[KafkaPayload]] = None,
     replacement_topic: Optional[Topic] = None,
     commit_log_topic: Optional[Topic] = None,
-    subscription_scheduler_mode: Optional[SchedulerMode] = None,
+    subscription_scheduler_mode: Optional[SchedulingWatermarkMode] = None,
     subscription_scheduled_topic: Optional[Topic] = None,
     subscription_result_topic: Optional[Topic] = None,
 ) -> KafkaStreamLoader:

--- a/snuba/subscriptions/utils.py
+++ b/snuba/subscriptions/utils.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class SchedulerMode(Enum):
+    IMMEDIATE = "immediate"
+    WAIT_FOR_SLOWEST_PARTITION = "wait-for-slowest"

--- a/snuba/subscriptions/utils.py
+++ b/snuba/subscriptions/utils.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
 
-class SchedulerMode(Enum):
-    IMMEDIATE = "immediate"
-    WAIT_FOR_SLOWEST_PARTITION = "wait-for-slowest"
+class SchedulingWatermarkMode(Enum):
+    PARTITION = "partition"
+    GLOBAL = "global"


### PR DESCRIPTION
The Kafka stream loader defines the scheduler watermark mode that applies to
the subscriptions on a specific storage. The scheduler mode is
associated in code with the storage / topic and should not need
to be changed by users when running subscriptions. Generally speaking,
"partition" mode will apply to semantically partitioned topics and
"global" mode applies for non semantically partitioned topics
where we will wait for all partitions to reach a timestamp before
executing the subscriptions associated with that particular timestamp.
The mode must be specified if subscriptions are supported for that storage.