### PR TITLE
feat(subscriptions): Switch the scheduler back to use the tick consumer

### DIFF
--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -29,8 +29,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--followed-consumer-group",
-    # TODO: Temporarily set to false for roll out, should be required afterwards
-    required=False,
+    required=True,
     help="Name of the consumer group to follow",
 )
 @click.option(
@@ -46,8 +45,7 @@ def subscriptions_scheduler(
     *,
     entity_name: str,
     consumer_group: str,
-    # TODO: Temporarily optional
-    followed_consumer_group: Optional[str],
+    followed_consumer_group: str,
     auto_offset_reset: str,
     schedule_ttl: int,
     log_level: Optional[str],

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -31,7 +31,6 @@ from tests.assertions import assert_changes
 from tests.backends.metrics import TestingMetricsBackend, Timing
 
 
-@pytest.mark.skip(reason="Skipping for measure commit log order experiment")
 def test_scheduler_consumer() -> None:
     settings.TOPIC_PARTITION_COUNTS = {"events": 2}
     importlib.reload(scheduler_consumer)


### PR DESCRIPTION
Now that we are properly filtering commit log messages by the consumer
group being followed, let's try the tick consumer again. We shouldn't
see the invalid intervals anymore.

The --followed-consumer-group option is now required.