### PR TITLE
perf(subscriptions): Add minimum tick interval option for subscriptions

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -90,6 +90,7 @@ logger = logging.getLogger(__name__)
 @click.option("--result-topic")
 @click.option("--log-level", help="Logging level to use.")
 @click.option("--delay-seconds", type=int)
+@click.option("--min-tick-interval-ms", type=click.IntRange(1, 1000))
 def subscriptions(
     *,
     dataset_name: str,
@@ -107,6 +108,7 @@ def subscriptions(
     result_topic: Optional[str],
     log_level: Optional[str],
     delay_seconds: Optional[int],
+    min_tick_interval_ms: Optional[int],
 ) -> None:
     """Evaluates subscribed queries for a dataset."""
 
@@ -164,6 +166,9 @@ def subscriptions(
         time_shift=(
             timedelta(seconds=delay_seconds * -1) if delay_seconds is not None else None
         ),
+        min_interval=timedelta(milliseconds=min_tick_interval_ms)
+        if min_tick_interval_ms is not None
+        else None,
     )
 
     producer = ProducerEncodingWrapper(

--- a/snuba/subscriptions/consumer.py
+++ b/snuba/subscriptions/consumer.py
@@ -92,11 +92,15 @@ class TickConsumer(Consumer[Tick]):
     # the consumer.
 
     def __init__(
-        self, consumer: Consumer[Any], time_shift: Optional[timedelta] = None
+        self,
+        consumer: Consumer[Any],
+        time_shift: Optional[timedelta] = None,
+        min_interval: Optional[timedelta] = None,
     ) -> None:
         self.__consumer = consumer
         self.__previous_messages: MutableMapping[Partition, MessageDetails] = {}
         self.__time_shift = time_shift if time_shift is not None else timedelta()
+        self.__min_interval = min_interval
 
     def subscribe(
         self,
@@ -130,6 +134,12 @@ class TickConsumer(Consumer[Tick]):
         if previous_message is not None:
             try:
                 time_interval = Interval(previous_message.timestamp, message.timestamp)
+                if (
+                    self.__min_interval is not None
+                    and time_interval.upper - time_interval.lower < self.__min_interval
+                ):
+                    return None
+
             except InvalidRangeError:
                 logger.warning(
                     "Could not construct valid time interval between %r and %r!",


### PR DESCRIPTION
This is an experiment to see if we can improve the performance of the subscription
worker by creating fewer ticks which span larger intervals, which will result in
less calls to later parts of the subscriptions pipeline and messages submitted
to the processing strategy.

The subscriptions CLI now supports a --min-tick-interval-ms option, which can
be a value between 1 and 1000. If a value is passed, a tick will only be
created when we get messages spanning an interval larger than this range. This
results in fewer tick message but each covering a larger range.

We should only attempt to use this option (at least for now) on the experimental
sessions subscriptions consumer, and not events or transactions.