### PR TITLE
feat(metrics): Add metrics consumer to devserver

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -137,6 +137,23 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
         ),
     ]
 
+    if settings.ENABLE_DEV_FEATURES:
+        daemons += [
+            (
+                "metrics-consumer",
+                [
+                    "snuba",
+                    "multistorage-consumer",
+                    "--storage=metrics_counters_buckets",
+                    "--storage=metrics_distributions_buckets",
+                    "--storage=metrics_buckets",
+                    "--auto-offset-reset=latest",
+                    "--log-level=debug",
+                    "--consumer-group=metrics_group",
+                ],
+            ),
+        ]
+
     if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
         daemons += [
             (


### PR DESCRIPTION
Add a metrics consumer to devserver if dev features are enabled.

Open question: Is the multistorage consumer suitable for this purpose?