### PR TITLE
feat(subscriptions): Add consumer queue options to subscriptions

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -83,13 +83,11 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
     "--queued-max-messages-kbytes",
-    default=settings.DEFAULT_QUEUED_MAX_MESSAGE_KBYTES,
     type=int,
     help="Maximum number of kilobytes per topic+partition in the local consumer queue.",
 )
 @click.option(
     "--queued-min-messages",
-    default=settings.DEFAULT_QUEUED_MIN_MESSAGES,
     type=int,
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
@@ -115,8 +113,8 @@ def subscriptions(
     bootstrap_servers: Sequence[str],
     max_batch_size: int,
     max_batch_time_ms: int,
-    queued_max_messages_kbytes: int,
-    queued_min_messages: int,
+    queued_max_messages_kbytes: Optional[int],
+    queued_min_messages: Optional[int],
     max_query_workers: Optional[int],
     schedule_ttl: int,
     result_topic: Optional[str],


### PR DESCRIPTION
This adds the ability to override the default queued.min.messages and
queued.max.messages.kbytes librdkafka settings on the subscriptions consumer,
allowing us to provide different values for each subscriptions consumer.

The immediate motivation for this change is to try and reduce the consumer group
lag on the sessions consumer by increasing the buffer size.

We already support these two options in the main snuba consumer and replacer
processes, this change adds the same settings to subscriptions.