### PR TITLE
feat(subscriptions): Scheduled task encoder should encode a KafkaPayload

### DIFF
--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -381,11 +381,12 @@ def test_subscription_task_encoder() -> None:
 
     encoded = encoder.encode(task)
 
-    assert encoded == (
+    assert encoded.key == b"1/91b46cb6224f11ecb2ddacde48001122"
+
+    assert encoded.value == (
         b"{"
         b'"timestamp":"1970-01-01T00:00:00",'
         b'"task":{'
-        b'"identifier":"1/91b46cb6224f11ecb2ddacde48001122",'
         b'"data":{"type":"snql","project_id":1,"time_window":60,"resolution":60,"query":"MATCH events SELECT count()"}}'
         b"}"
     )


### PR DESCRIPTION
The scheduled task encoder is now responsible for encoding a ScheduledTask
into a KafkaPayload and vice versa. This way it can be used more easily
by the subscriptions scheduler to encode a scheduled task so it can be
passed directly to a Kafka producer, and by the subscriptions executor
to decode a message received from the consumer directly back into a ScheduledTask.

This codec is not currently being used anywhere but will be integrated into
the scheduler (and eventually the executor as well) in a follow up.