### PR TITLE
ref(sentry-metrics): Enable metrics dataset

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -137,7 +137,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
         ),
     ]
 
-    if settings.ENABLE_DEV_FEATURES and "metrics" not in settings.DISABLED_DATASETS:
+    if settings.ENABLE_SENTRY_METRICS:
         daemons += [
             (
                 "metrics-consumer",

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -137,7 +137,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
         ),
     ]
 
-    if settings.ENABLE_SENTRY_METRICS:
+    if settings.ENABLE_SENTRY_METRICS_DEV:
         daemons += [
             (
                 "metrics-consumer",

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -29,7 +29,7 @@ class StorageSetKey(Enum):
 
 
 # Storage sets enabled only when development features are enabled.
-DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({StorageSetKey.METRICS})
+DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({})
 
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -37,11 +37,7 @@ def get_entity(name: EntityKey) -> Entity:
     from snuba.datasets.entities.spans import SpansEntity
     from snuba.datasets.entities.transactions import TransactionsEntity
 
-    dev_entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {
-        EntityKey.METRICS_SETS: MetricsSetsEntity,
-        EntityKey.METRICS_COUNTERS: MetricsCountersEntity,
-        EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
-    }
+    dev_entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {}
 
     entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {
         EntityKey.DISCOVER: DiscoverEntity,
@@ -56,6 +52,9 @@ def get_entity(name: EntityKey) -> Entity:
         EntityKey.SPANS: SpansEntity,
         EntityKey.DISCOVER_TRANSACTIONS: DiscoverTransactionsEntity,
         EntityKey.DISCOVER_EVENTS: DiscoverEventsEntity,
+        EntityKey.METRICS_SETS: MetricsSetsEntity,
+        EntityKey.METRICS_COUNTERS: MetricsCountersEntity,
+        EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
         **(dev_entity_factories if settings.ENABLE_DEV_FEATURES else {}),
     }
 

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -9,13 +9,14 @@ from snuba.utils.serializable_exception import SerializableException
 DATASETS_IMPL: MutableMapping[str, Dataset] = {}
 DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
 
-DEV_DATASET_NAMES: Set[str] = {"metrics"}
+DEV_DATASET_NAMES: Set[str] = set()
 
 DATASET_NAMES: Set[str] = {
     "discover",
     "events",
     "groupassignee",
     "groupedmessage",
+    "metrics",
     "outcomes",
     "outcomes_raw",
     "sessions",

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -46,7 +46,9 @@ CDC_STORAGES: Mapping[StorageKey, CdcStorage] = {
     **(DEV_CDC_STORAGES if settings.ENABLE_DEV_FEATURES else {}),
 }
 
-DEV_WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
+DEV_WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {}
+
+METRICS_WRITEABLE_STORAGES = {
     metrics_counters_buckets.get_storage_key(): metrics_counters_buckets,
     metrics_distributions_buckets.get_storage_key(): metrics_distributions_buckets,
     metrics_sets_buckets.get_storage_key(): metrics_sets_buckets,
@@ -54,6 +56,7 @@ DEV_WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
 
 WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
     **CDC_STORAGES,
+    **METRICS_WRITEABLE_STORAGES,
     **{
         storage.get_storage_key(): storage
         for storage in [
@@ -69,13 +72,16 @@ WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
     **(DEV_WRITABLE_STORAGES if settings.ENABLE_DEV_FEATURES else {}),
 }
 
-DEV_NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
+DEV_NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {}
+
+METRICS_NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
     metrics_counters_storage.get_storage_key(): metrics_counters_storage,
     metrics_distributions_storage.get_storage_key(): metrics_distributions_storage,
     metrics_sets_storage.get_storage_key(): metrics_sets_storage,
 }
 
 NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
+    **METRICS_NON_WRITABLE_STORAGES,
     **{
         storage.get_storage_key(): storage
         for storage in [

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -162,7 +162,7 @@ distributions_storage = ReadableTableStorage(
                 Column(
                     "percentiles",
                     AggregateFunction(
-                        "quantiles(0.5, 0.75, 0.9, 0.95, 0.99, 1)", [Float(64)]
+                        "quantiles(0.5, 0.75, 0.9, 0.95, 0.99)", [Float(64)]
                     ),
                 ),
                 Column("min", AggregateFunction("min", [Float(64)])),

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -153,6 +153,9 @@ TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 # Map the Zookeeper path for the replicated merge tree to something else
 CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
 
+# Enable Sentry Metrics (used for the snuba metrics consumer)
+ENABLE_SENTRY_METRICS = os.environ.get("ENABLE_SENTRY_METRICS", False)
+
 # Metric Alerts Subscription Options
 ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", False)
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -18,7 +18,7 @@ ADMIN_PORT = int(os.environ.get("ADMIN_PORT", 1219))
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 
 DEFAULT_DATASET_NAME = "events"
-DISABLED_DATASETS: Set[str] = {"metrics"}
+DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
@@ -141,7 +141,7 @@ COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 
 # Migrations in skipped groups will not be run
-SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics", "querylog", "spans_experimental"}
+SKIPPED_MIGRATION_GROUPS: Set[str] = {"querylog", "spans_experimental"}
 
 MAX_RESOLUTION_FOR_JITTER = 60
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -154,7 +154,7 @@ TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
 
 # Enable Sentry Metrics (used for the snuba metrics consumer)
-ENABLE_SENTRY_METRICS = os.environ.get("ENABLE_SENTRY_METRICS", False)
+ENABLE_SENTRY_METRICS_DEV = os.environ.get("ENABLE_SENTRY_METRICS_DEV", False)
 
 # Metric Alerts Subscription Options
 ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", False)

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -12,7 +12,7 @@ USE_RESULT_CACHE = True
 
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 
-SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics"}
+SKIPPED_MIGRATION_GROUPS: Set[str] = set()
 
 # Sometimes we want the raw structure of an expression
 # rather than the pretty formatted one. If you're debugging

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -207,7 +207,7 @@ def test_no_schema_differences() -> None:
 def test_settings_skipped_group() -> None:
     from snuba.migrations import runner
 
-    with patch("snuba.settings.SKIPPED_MIGRATION_GROUPS", {"querylog", "metrics"}):
+    with patch("snuba.settings.SKIPPED_MIGRATION_GROUPS", {"querylog"}):
         runner.Runner().run_all(force=True)
 
     connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(


### PR DESCRIPTION
In preparation for sentry metrics to be tested out in production, we need to remove it from the `DISABLED_DATASETS` and other dev only settings. 

**BEFORE MERGING**
* This should be merged after we have the necessary provisions (https://github.com/getsentry/ops/pull/3977 and https://github.com/getsentry/ops/pull/4020)
* In addition, we need to make sure the clickhouse cluster is in the prod config (as well as the single tenant one: https://github.com/getsentry/single-tenant/pull/426) before merging. 
