### PR TITLE
fix(ci) Add required env variables for Sentry tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         with:
           workdir: sentry
           cache-files-hash: ${{ hashFiles('sentry/requirements**.txt') }}
-          python-version: 3.6
+          python-version: 3.8
           snuba: false
           kafka: true
           clickhouse: true


### PR DESCRIPTION
The MATRIX_INSTANCE_TOTAL and MIGRATIONS_TEST_MIGRATE variables need to be set
for the sentry tests to run. Add those to the github workflow.