### PR TITLE
ref(ci): Remove USE_INDEXER env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,6 @@ jobs:
         instance: [0, 1]
 
     env:
-      USE_INDEXER: 1
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 2
       MIGRATIONS_TEST_MIGRATE: 1


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/29446 the `USE_INDEXER` env var has been removed, so we can remove that in snuba as well. 