### PR TITLE
Add the snql query to the breadcrumbs in sentry

### DIFF
--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -125,6 +125,14 @@ def build_request(
             "snuba_query_raw",
             textwrap.wrap(repr(request.body), 100, break_long_words=False),
         )
+        sentry_sdk.add_breadcrumb(
+            category="query_info",
+            level="info",
+            message="snql query",
+            data={
+                "query": textwrap.wrap(repr(request.body), 100, break_long_words=False)
+            },
+        )
 
         timer.mark("validate_schema")
         return request

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -128,7 +128,7 @@ def build_request(
         sentry_sdk.add_breadcrumb(
             category="query_info",
             level="info",
-            message="snql query",
+            message="snuba_query_raw",
             data={
                 "query": textwrap.wrap(repr(request.body), 100, break_long_words=False)
             },

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -427,6 +427,7 @@ def dataset_query(
     except QueryException as exception:
         status = 500
         details: Mapping[str, Any]
+
         cause = exception.__cause__
         if isinstance(cause, RateLimitExceeded):
             status = 429

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 import os
+import textwrap
 import time
 from datetime import datetime
 from functools import partial
@@ -427,7 +428,16 @@ def dataset_query(
     except QueryException as exception:
         status = 500
         details: Mapping[str, Any]
-
+        sentry_sdk.add_breadcrumb(
+            category="query_error",
+            level="info",
+            message="Offending snql query",
+            data={
+                "query": textwrap.wrap(
+                    body.get("query", ""), 100, break_long_words=False
+                )
+            },
+        )
         cause = exception.__cause__
         if isinstance(cause, RateLimitExceeded):
             status = 429

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -1,7 +1,6 @@
 import functools
 import logging
 import os
-import textwrap
 import time
 from datetime import datetime
 from functools import partial
@@ -428,16 +427,6 @@ def dataset_query(
     except QueryException as exception:
         status = 500
         details: Mapping[str, Any]
-        sentry_sdk.add_breadcrumb(
-            category="query_error",
-            level="info",
-            message="Offending snql query",
-            data={
-                "query": textwrap.wrap(
-                    body.get("query", ""), 100, break_long_words=False
-                )
-            },
-        )
         cause = exception.__cause__
         if isinstance(cause, RateLimitExceeded):
             status = 429


### PR DESCRIPTION
We get query errors in sentry but can never figure out what the offending snql is unless we captured it in a trace. Since this is fairly important just put it in the breadcrumbs