### PR TITLE
Runtime changes slack notifications

### DIFF
--- a/snuba/admin/slack/client.py
+++ b/snuba/admin/slack/client.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from typing import Any, Dict, MutableMapping, Optional, Union
+
+import requests
+
+from snuba import settings
+from snuba.admin.slack.utils import build_blocks
+
+
+class SlackClient(object):
+    @property
+    def token(self) -> Optional[str]:
+        return settings.SLACK_API_TOKEN
+
+    def post_message(
+        self, message: MutableMapping[str, Any], channel: Optional[str] = None
+    ) -> None:
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+
+        if channel:
+            message["channel"] = channel
+
+        try:
+            resp = requests.post(
+                "https://slack.com/api/chat.postMessage", headers=headers, json=message,
+            )
+        except Exception:
+            # todo: log non 200 failures
+            return
+
+        # todo: slack is annoying be a 200 could still be a failed case
+        # you have to check the "ok" param in the response, so we should
+        # check for ok: False and log those failures too.
+        print(resp.status_code)
+        print(resp.content)
+
+
+class RuntimeConfigSlackClient(object):
+    def __init__(self) -> None:
+        self.client = SlackClient()
+        # feed-sns-admin channel
+        self.channel_id = settings.SNUBA_SLACK_CHANNEL_ID
+
+    def notify(
+        self,
+        action: str,
+        option_data: Dict[str, Union[str, float, int]],
+        user: str,
+        timestamp: Optional[str] = None,
+    ) -> None:
+        # Option data has the config option itself, and then the old or new values
+        # {
+        #     "option": "enable_events_read_only_table",
+        #     "old": 0,
+        #     "new": 1,
+        # }
+        if not timestamp:
+            time = datetime.now()
+            timestamp = time.strftime("%B %d, %Y %H:%M:%S %p")
+
+        blocks = build_blocks(option_data, action, timestamp, user)
+        payload: MutableMapping[str, Any] = {"blocks": blocks}
+
+        self.client.post_message(message=payload, channel=self.channel_id)
+
+
+runtime_config_slack_client = RuntimeConfigSlackClient()

--- a/snuba/admin/slack/utils.py
+++ b/snuba/admin/slack/utils.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List, Optional, Union
+
+
+def build_blocks(data: Any, action: str, timestamp: str, user: str) -> List[Any]:
+    return [build_section(data, action), build_context(user, timestamp, action)]
+
+
+def build_text(data: Any, action: str) -> Optional[str]:
+    base = "*Runtime Config Option:*"
+    removed = f"~```{{'{data['option']}': {data['old']}}}```~"
+    added = f"```{{'{data['option']}': {data['new']}}}```"
+    updated = f"{removed} {added}"
+
+    if action == "Removed":
+        return f"{base} :put_litter_in_its_place:\n\n {removed}"
+    elif action == "Added":
+        return f"{base} :new:\n\n {added}"
+    elif action == "Updated":
+        return f"{base} :up: :date:\n\n {updated}"
+    else:
+        # todo: raise error, cause slack won't accept this
+        # if it is none
+        return None
+
+
+def build_section(data: Any, action: str) -> Any:
+    text = build_text(data, action)
+    return {
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": text},
+        "accessory": {
+            "type": "button",
+            "text": {"type": "plain_text", "text": "Audit Log"},
+            # todo: should link to our audit log
+            "url": "https://google.com",
+        },
+    }
+
+
+def build_context(
+    user: str, timestamp: str, action: str
+) -> Dict[str, Union[str, List[Dict[str, str]]]]:
+    return {
+        "type": "context",
+        "elements": [
+            {"type": "mrkdwn", "text": f"{action} at *{timestamp}* by *<{user}>*"}
+        ],
+    }

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -6,3 +6,22 @@ application = Flask(__name__, static_url_path="", static_folder="dist")
 @application.route("/")
 def root() -> Response:
     return application.send_static_file("index.html")
+
+
+@application.route("/test-slack")
+def test_slack() -> Response:
+    from typing import Dict, Union
+
+    from snuba.admin.slack.client import runtime_config_slack_client
+
+    data: Dict[str, Union[str, float, int]] = {
+        "option": "enable_events_read_only_table",
+        "old": 0,
+        "new": 1,
+    }
+
+    runtime_config_slack_client.notify(
+        action="Removed", option_data=data, user="meredith@sentry.io"
+    )
+
+    return application.send_static_file("index.html")

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -76,6 +76,10 @@ CONFIG_MEMOIZE_TIMEOUT = 10
 # Sentry Options
 SENTRY_DSN = None
 
+# Snuba Admin Options
+SLACK_API_TOKEN = os.environ.get("SLACK_API_TOKEN")
+SNUBA_SLACK_CHANNEL_ID = os.environ.get("SNUBA_SLACK_CHANNEL_ID")
+
 # Snuba Options
 
 SNAPSHOT_LOAD_PRODUCT = "snuba"

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -19,3 +19,7 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics"}
 # something and you're at your wit's end, try setting this to False
 # to explore the unrefined Expression structure
 PRETTY_FORMAT_EXPRESSIONS = True
+
+# Admin
+SLACK_API_TOKEN = os.getenv("SLACK_API_TOKEN")
+SNUBA_SLACK_CHANNEL_ID = os.getenv("SNUBA_SLACK_CHANNEL_ID")

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -19,7 +19,3 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {"metrics"}
 # something and you're at your wit's end, try setting this to False
 # to explore the unrefined Expression structure
 PRETTY_FORMAT_EXPRESSIONS = True
-
-# Admin
-SLACK_API_TOKEN = os.getenv("SLACK_API_TOKEN")
-SNUBA_SLACK_CHANNEL_ID = os.getenv("SNUBA_SLACK_CHANNEL_ID")


### PR DESCRIPTION
Most basic of basic slack app to send notifications about changes to runtime config:

**updated config**: 
> ![Screen Shot 2021-11-02 at 5 00 32 PM](https://user-images.githubusercontent.com/15368179/139969674-01eda8cc-8986-46e3-a755-d853307e66f1.png)

**new config**:
> ![Screen Shot 2021-11-02 at 5 10 32 PM](https://user-images.githubusercontent.com/15368179/139969676-b82e7157-2819-4d9c-9607-f6b09b916236.png)

**removed config**:
>![Screen Shot 2021-11-02 at 5 16 41 PM](https://user-images.githubusercontent.com/15368179/139969690-24f83549-d798-4b29-bd75-d2f8c02263f5.png)

To test locally:
1. Have a test slack workspace you want to build the app on
1. Go to https://api.slack.com/apps and click on **Create New App** (create it on your test workspace)
1. Give your app a bot scope of `chat.write` (under **OAuth & Permissions** section)
1. Under settings click **Install App**
1. Add bot app to your desired channel (only one for now)
1. export `SLACK_API_TOKEN` in your terminal (token is under **OAuth & Permissions** section)
1. export `SNUBA_SLACK_CHANNEL_ID` in your terminal (see https://github.com/getsentry/snuba/pull/2185#issuecomment-958545503)
