### PR TITLE
fix(logging): Don't use name in extra for log entries

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -241,7 +241,7 @@ def _run_and_apply_column_names(
                 "Duplicated alias definition in select clause",
                 extra={
                     "alias": alias,
-                    "name": name,
+                    "column_name": name,
                     "existing_name": alias_name_mapping[alias],
                 },
                 exc_info=True,


### PR DESCRIPTION
Logging's makeRecord already has a parameter called name. When we use it
in extra info, exception is thrown.

### Testing
Before
`Traceback (most recent call last):
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 90, in sentry_patched_wsgi_app
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/wsgi.py", line 140, in __call__
    reraise(*_capture_exception(hub))
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/sentry_sdk/_compat.py", line 54, in reraise
    raise value
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/wsgi.py", line 133, in __call__
    rv = self.app(
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/sentry_sdk/integrations/flask.py", line 90, in <lambda>
    return SentryWsgiMiddleware(lambda *a, **kw: old_app(self, *a, **kw))(
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 2309, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 2295, in wsgi_app
    response = self.handle_exception(e)
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 1741, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/_compat.py", line 35, in reraise
    raise value
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/nikharsaxena/workspace/snuba/.venv/lib/python3.8/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/util.py", line 152, in wrapper
    return func(*args, **kwargs)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/web/views.py", line 365, in snql_dataset_query_view
    return dataset_query(dataset, body, timer)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/util.py", line 270, in wrapper
    return func(*args, **kwargs)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/web/views.py", line 387, in dataset_query
    result = parse_and_run_query(dataset, request, timer)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/util.py", line 270, in wrapper
    return func(*args, **kwargs)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/web/query.py", line 114, in parse_and_run_query
    result = _run_query_pipeline(
  File "/Users/nikharsaxena/workspace/snuba/./snuba/web/query.py", line 171, in _run_query_pipeline
    dataset.get_query_pipeline_builder()
  File "/Users/nikharsaxena/workspace/snuba/./snuba/pipeline/simple_pipeline.py", line 74, in execute
    return query_plan.execution_strategy.execute(
  File "/Users/nikharsaxena/workspace/snuba/./snuba/util.py", line 270, in wrapper
    return func(*args, **kwargs)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/datasets/plans/single_storage.py", line 72, in execute
    return process_and_run_query(query, request_settings)
  File "/Users/nikharsaxena/workspace/snuba/./snuba/datasets/plans/single_storage.py", line 58, in process_and_run_query
    return runner(query, request_settings, self.__cluster.get_reader())
  File "/Users/nikharsaxena/workspace/snuba/./snuba/web/query.py", line 240, in _run_and_apply_column_names
    logger.warning(
  File "/Users/nikharsaxena/.pyenv/versions/3.8.11/lib/python3.8/logging/__init__.py", line 1458, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/nikharsaxena/.pyenv/versions/3.8.11/lib/python3.8/logging/__init__.py", line 1587, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
  File "/Users/nikharsaxena/.pyenv/versions/3.8.11/lib/python3.8/logging/__init__.py", line 1561, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'name' in LogRecord"`

After
`2021-11-10 13:56:43,135 Duplicated alias definition in select clause`