### PR TITLE
log(replaced_groups): Add tags PostReplacementConsistencyEnforcer span

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -286,6 +286,7 @@ def get_projects_query_flags(
         op="function", description="execute_redis_pipeline"
     ) as span:
         results = p.execute()
+
         # getting size of str(results) since sys.getsizeof() doesn't count recursively
         span.set_tag("results_size", sys.getsizeof(str(results)))
 

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -286,7 +286,7 @@ def get_projects_query_flags(
         op="function", description="execute_redis_pipeline"
     ) as span:
         results = p.execute()
-        span.set_tag("results", results)
+        # getting size of str(results) since sys.getsizeof() doesn't count recursively
         span.set_tag("results_size", sys.getsizeof(str(results)))
 
     with sentry_sdk.start_span(op="function", description="process_redis_results"):


### PR DESCRIPTION
## Overview
- Span tells us redis pipeline execution is the bottleneck
- Need to figure out why that is
- Possibly a correlation between size of results and time taken to execute

## Changes
- Added a bunch of tags just to log the results
