### PR TITLE
fix(validation): Disable warnings on outcomes entity

### DIFF
--- a/snuba/datasets/entities/outcomes.py
+++ b/snuba/datasets/entities/outcomes.py
@@ -17,10 +17,7 @@ from snuba.query.processors.object_id_rate_limiter import (
 )
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
-from snuba.query.validation.validators import (
-    ColumnValidationMode,
-    EntityRequiredColumnValidator,
-)
+from snuba.query.validation.validators import EntityRequiredColumnValidator
 from snuba.utils.schemas import Column
 
 outcomes_data_model = EntityColumnSet(
@@ -66,7 +63,8 @@ class OutcomesEntity(Entity):
             writable_storage=writable_storage,
             validators=[EntityRequiredColumnValidator({"org_id"})],
             required_time_column="timestamp",
-            validate_data_model=ColumnValidationMode.WARN,
+            # Logged way too many events to Sentry
+            # validate_data_model=ColumnValidationMode.WARN,
         )
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:

--- a/snuba/datasets/entities/outcomes.py
+++ b/snuba/datasets/entities/outcomes.py
@@ -17,7 +17,10 @@ from snuba.query.processors.object_id_rate_limiter import (
 )
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.timeseries_extension import TimeSeriesExtension
-from snuba.query.validation.validators import EntityRequiredColumnValidator
+from snuba.query.validation.validators import (
+    ColumnValidationMode,
+    EntityRequiredColumnValidator,
+)
 from snuba.utils.schemas import Column
 
 outcomes_data_model = EntityColumnSet(
@@ -63,8 +66,8 @@ class OutcomesEntity(Entity):
             writable_storage=writable_storage,
             validators=[EntityRequiredColumnValidator({"org_id"})],
             required_time_column="timestamp",
-            # Logged way too many events to Sentry
-            # validate_data_model=ColumnValidationMode.WARN,
+            # WARN mode logged way too many events to Sentry
+            validate_data_model=ColumnValidationMode.DO_NOTHING,
         )
 
     def get_extensions(self) -> Mapping[str, QueryExtension]:


### PR DESCRIPTION
## Overview
- Enabling Sentry warnings for invalid queries on the outcomes entity caused a flood of warnings ~12k events in 10 minutes

## Changes
- Disabled warnings on outcomes till we can figure out a way to sample or reduce number of events we log