### PR TITLE
ref(validators): Add DateTime signature validators

### DIFF
--- a/snuba/query/functions.py
+++ b/snuba/query/functions.py
@@ -145,6 +145,7 @@ REGULAR_FUNCTIONS = {
     "toUInt64",
     "toFloat64",
     # dates and times
+    "toStartOfMinute",
     "toStartOfDay",
     "toStartOfHour",
     "toStartOfYear",

--- a/snuba/query/parser/validation/functions.py
+++ b/snuba/query/parser/validation/functions.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List, Mapping
 
-from snuba.clickhouse.columns import Array, String
+from snuba.clickhouse.columns import Array, DateTime, String
 from snuba.datasets.entities.factory import get_entity
 from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
@@ -18,8 +18,16 @@ from snuba.query.validation.signature import Any, Column, SignatureValidator
 
 logger = logging.getLogger(__name__)
 
+DateTimeValidator = SignatureValidator([Column({DateTime})], enforce=False)
 
 default_validators: Mapping[str, FunctionCallValidator] = {
+    "toStartOfMinute": DateTimeValidator,
+    "toStartOfHour": DateTimeValidator,
+    "toStartOfDay": DateTimeValidator,
+    "toStartOfYear": DateTimeValidator,
+    # Techincally this can be called with either a datetime or string
+    # but seems okay to be more restrictive for now
+    "toUnixTimestamp": DateTimeValidator,
     # like and notLike need to take care of Arrays as well since
     # Arrays are exploded into strings if they are part of the arrayjoin
     # clause.


### PR DESCRIPTION
**context:**
A while back I added some global function validating (in https://github.com/getsentry/snuba/pull/2067) that allowed use to check if the function names were valid. This didn't add checks for whether the functions were called with the right arguments though.

**`DateTimeValidator`**
Just wanted to take a stab at adding signature validation for a small chunk of ClickHouse functions. For now, the validation isn't enforce, so it should just log to Sentry if the validation fails. However, I'm not expecting it to since I think we would have been seeing ClickHouse errors if that was the case. 

Also probs makes sense to move the `default_validators` out of this file if we keep adding to it but I think that can be done later. 