### PR TITLE
fix(tests): Errors replacer tests

### DIFF
--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -130,7 +130,11 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         this query touches, returns whether or not this Query's time
         range overlaps that replacement.
         """
-        query_from, _ = get_time_range(query, "timestamp")
+        query_from, to = get_time_range(query, "timestamp")
+        print("Latest replacement time")
+        print(latest_replacement_time)
+        print("query from, to")
+        print(f"{query_from} - {to}")
         return (
             latest_replacement_time > query_from
             if latest_replacement_time and query_from

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -131,7 +131,6 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         range overlaps that replacement.
         """
         query_from, _ = get_time_range(query, "timestamp")
-
         return (
             latest_replacement_time > query_from
             if latest_replacement_time and query_from

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -130,11 +130,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         this query touches, returns whether or not this Query's time
         range overlaps that replacement.
         """
-        query_from, to = get_time_range(query, "timestamp")
-        print("Latest replacement time")
-        print(latest_replacement_time)
-        print("query from, to")
-        print(f"{query_from} - {to}")
+        query_from, _ = get_time_range(query, "timestamp")
+
         return (
             latest_replacement_time > query_from
             if latest_replacement_time and query_from

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from typing import Any, Callable, Optional, Tuple, Union
 
 import pytest
-import pytz
 import simplejson as json
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
@@ -50,10 +49,7 @@ class TestReplacer:
             self.storage, DummyMetricsBackend(strict=True)
         )
 
-        self.minutes = 180
-        self.base_time = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0
-        ) - timedelta(minutes=self.minutes)
+        self.base_time = datetime.now().replace(minute=0, second=0, microsecond=0)
 
         self.project_id = 1
         self.event = get_raw_event()
@@ -82,10 +78,8 @@ class TestReplacer:
             "selected_columns": [],
             "aggregations": [["count()", "", "count"]],
             "groupby": ["group_id"],
-            "from_date": (self.base_time - timedelta(minutes=self.minutes)).isoformat(),
-            "to_date": (
-                self.base_time + timedelta(minutes=2 * self.minutes)
-            ).isoformat(),
+            "from_date": (self.base_time).isoformat(),
+            "to_date": (self.base_time + timedelta(hours=9)).isoformat(),
         }
 
         if group_id:
@@ -100,10 +94,8 @@ class TestReplacer:
             "conditions": [
                 ["event_id", "=", str(uuid.UUID(event_id)).replace("-", "")]
             ],
-            "from_date": (self.base_time - timedelta(minutes=self.minutes)).isoformat(),
-            "to_date": (
-                self.base_time + timedelta(minutes=2 * self.minutes)
-            ).isoformat(),
+            "from_date": (self.base_time).isoformat(),
+            "to_date": (self.base_time + timedelta(hours=9)).isoformat(),
         }
 
         data = json.loads(self.post(json.dumps(args)).data)["data"]
@@ -113,7 +105,7 @@ class TestReplacer:
         return int(data[0]["group_id"])
 
     def test_delete_groups_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message = (
             2,
             ReplacementType.END_DELETE_GROUPS,
@@ -151,7 +143,7 @@ class TestReplacer:
         "old_primary_hash", ["e3d704f3542b44a621ebed70dc0efe13", False, None]
     )
     def test_tombstone_events_process(self, old_primary_hash) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message_kwargs = {
             "project_id": self.project_id,
             "event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"],
@@ -191,8 +183,8 @@ class TestReplacer:
         assert replacement.query_time_flags == (None, self.project_id,)
 
     def test_tombstone_events_process_timestamp(self) -> None:
-        from_ts = datetime.now(tz=pytz.utc)
-        to_ts = datetime.now(tz=pytz.utc) + timedelta(3)
+        from_ts = datetime.now()
+        to_ts = datetime.now() + timedelta(3)
         message = (
             2,
             ReplacementType.TOMBSTONE_EVENTS,
@@ -223,7 +215,7 @@ class TestReplacer:
         assert replacement.query_time_flags == (None, self.project_id,)
 
     def test_replace_group_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message = (
             2,
             ReplacementType.REPLACE_GROUP,
@@ -255,7 +247,7 @@ class TestReplacer:
         assert replacement.query_time_flags == (None, self.project_id,)
 
     def test_merge_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message = (
             2,
             ReplacementType.END_MERGE,
@@ -291,7 +283,7 @@ class TestReplacer:
         )
 
     def test_unmerge_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message = (
             2,
             ReplacementType.END_UNMERGE,
@@ -330,7 +322,7 @@ class TestReplacer:
         assert replacement.get_query_time_flags() == errors_replacer.NeedsFinal()
 
     def test_unmerge_hierarchical_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
 
         message = (
             2,
@@ -368,7 +360,7 @@ class TestReplacer:
         assert replacement.query_time_flags == (None, self.project_id,)
 
     def test_delete_promoted_tag_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message = (
             2,
             ReplacementType.END_DELETE_TAG,
@@ -403,7 +395,7 @@ class TestReplacer:
         )
 
     def test_delete_unpromoted_tag_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now()
         message = (
             2,
             ReplacementType.END_DELETE_TAG,
@@ -445,7 +437,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.utcnow()
 
         project_id = self.project_id
 
@@ -561,7 +553,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.utcnow()
 
         project_id = self.project_id
 
@@ -600,7 +592,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.utcnow()
 
         project_id = self.project_id
 

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -49,7 +49,13 @@ class TestReplacer:
             self.storage, DummyMetricsBackend(strict=True)
         )
 
-        self.base_time = datetime.now().replace(minute=0, second=0, microsecond=0)
+        # Total query time range is 24h before to 24h after now to account
+        # for local machine time zones
+        self.from_time = datetime.now().replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(days=1)
+
+        self.to_time = self.from_time + timedelta(days=2)
 
         self.project_id = 1
         self.event = get_raw_event()
@@ -78,8 +84,8 @@ class TestReplacer:
             "selected_columns": [],
             "aggregations": [["count()", "", "count"]],
             "groupby": ["group_id"],
-            "from_date": (self.base_time).isoformat(),
-            "to_date": (self.base_time + timedelta(hours=9)).isoformat(),
+            "from_date": self.from_time.isoformat(),
+            "to_date": self.to_time.isoformat(),
         }
 
         if group_id:
@@ -94,8 +100,8 @@ class TestReplacer:
             "conditions": [
                 ["event_id", "=", str(uuid.UUID(event_id)).replace("-", "")]
             ],
-            "from_date": (self.base_time).isoformat(),
-            "to_date": (self.base_time + timedelta(hours=9)).isoformat(),
+            "from_date": self.from_time.isoformat(),
+            "to_date": self.to_time.isoformat(),
         }
 
         data = json.loads(self.post(json.dumps(args)).data)["data"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2028,7 +2028,9 @@ class TestApi(SimpleAPITest):
             "groupby": "project_id",
             "aggregations": [["count()", "", "count"]],
             "conditions": [["group_id", "=", group_id]],
-            "from_date": (self.base_time - timedelta(minutes=self.minutes)).isoformat(),
+            "from_date": (
+                self.base_time - timedelta(minutes=2 * self.minutes)
+            ).isoformat(),
             "to_date": (self.base_time + timedelta(minutes=self.minutes)).isoformat(),
         }
         result = json.loads(self.post(json.dumps(query)).data)


### PR DESCRIPTION
## Overview
- Replaced groups optimization surrounding replacement times caused some errors replacer API tests to break due to time zone difference
- Was not caught till tests were run locally on a machine not set to UTC

## Changes
- Updated the time ranges for queries testing the replacer in the API tests

## Testing
- Changes tested by setting timestamps to UTC, EST, and PST