### PR TITLE
chore: upgrade clickhouse-driver to 0.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ black==19.10b0
 certifi==2018.4.16
 chardet==3.0.4
 click==7.1.2
-clickhouse-driver==0.2.1
+clickhouse-driver==0.2.2
 colorama==0.3.9
 confluent-kafka==1.5.0
 coverage==5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ black==19.10b0
 certifi==2018.4.16
 chardet==3.0.4
 click==7.1.2
-clickhouse-driver==0.1.5
+clickhouse-driver==0.2.1
 colorama==0.3.9
 confluent-kafka==1.5.0
 coverage==5.0


### PR DESCRIPTION
**context:**
We introduced a new clickhouse cluster for metrics in https://github.com/getsentry/ops/pull/4118, however, this cluster runs a new version of clickhouse: 21.8.8 [latest (at the time) stable altinity version](https://docs.altinity.com/altinitystablebuilds/releasenotes/releases/21.8/). The old clickhouse-driver is not compatible with the new clickhouse version so we need to update the driver.

**Test Plan**
- [x] Run snuba/sentry tests locally
- [x] Test snuba api queries locally
- [x] Run tests in CI
- [ ] Deploy and monitor
- [ ] _Revert if things are on :fire:_