### PR TITLE
feat(suspect-spans): Start emitting spans.exclusive_time as float32

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -161,5 +161,8 @@ storage = WritableTableStorage(
     ),
     query_splitters=[TimeSplitQueryStrategy(timestamp_col="finish_ts")],
     mandatory_condition_checkers=[ProjectIdEnforcer()],
-    writer_options={"insert_allow_materialized_columns": 1},
+    writer_options={
+        "insert_allow_materialized_columns": 1,
+        "input_format_skip_unknown_fields": 1,
+    },
 )

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -335,11 +335,13 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["spans.op"] = []
             processed["spans.group"] = []
             processed["spans.exclusive_time"] = []
+            processed["spans.exclusive_time_32"] = []
 
             for op, group, exclusive_time in sorted(processed_spans):
                 processed["spans.op"].append(op)
                 processed["spans.group"].append(group)
                 processed["spans.exclusive_time"].append(exclusive_time)
+                processed["spans.exclusive_time_32"].append(exclusive_time)
 
             # The hash and exclusive_time is being stored in the spans columns
             # so there is no need to store it again in the context array.

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -228,6 +228,7 @@ class TransactionEvent:
             "spans.op": [span[0] for span in spans],
             "spans.group": [span[1] for span in spans],
             "spans.exclusive_time": [span[2] for span in spans],
+            "spans.exclusive_time_32": [span[2] for span in spans],
         }
 
         if self.ipv4:
@@ -396,6 +397,7 @@ class TestTransactionsProcessor:
         result["spans.op"] = ["navigation"]
         result["spans.group"] = [int("a" * 16, 16)]
         result["spans.exclusive_time"] = [1.2345]
+        result["spans.exclusive_time_32"] = [1.2345]
 
         assert TransactionsMessageProcessor().process_message(
             payload, meta


### PR DESCRIPTION
Begin emitting `spans.exclusive_time_32` with `input_format_skip_unknown_fields`
set to 1. This is step 1 and 2 of the migration process as explained at
 https://github.com/getsentry/snuba/pull/2105#issuecomment-928220731