### PR TITLE
ref(errors_replacer): Refactor `ProjectsQueryFlags.group_ids_to_exclude`

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -221,7 +221,7 @@ class ProjectsQueryFlags:
     FINAL overall.
 
     - needs_final: Whether or not any project was set as final.
-    - group_ids_to_exclude: A list of group id's that have been replaced, and
+    - group_ids_to_exclude: A set of group id's that have been replaced, and
     the replacement has not yet been merged in the database. These groups should be
     excluded from the data a Query looks through.
     - replacement_types: A set of all replacement types across replacements for the
@@ -282,8 +282,8 @@ class ProjectsQueryFlags:
             needs_final: Sequence[timestamp]...,
             _: Sequence[num_removed_elements]...,
             exclude_groups: Sequence[List[group_id]]...,
-            needs_final_replacement_types: Sequece[Optional[str]]...,
-            _: Sequemce[num_removed_elements]...,
+            needs_final_replacement_types: Sequence[Optional[str]]...,
+            _: Sequence[num_removed_elements]...,
             groups_replacement_types: Sequence[List[str]]...,
             latest_exclude_groups_replacements: Sequence[Optional[Tuple[group_id, datetime]]]...
         ]

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -230,7 +230,7 @@ class ProjectsQueryFlags:
     """
 
     needs_final: bool
-    group_ids_to_exclude: Sequence[int]
+    group_ids_to_exclude: Set[int]
     replacement_types: Set[str]
     latest_replacement_time: Optional[datetime]
 
@@ -299,13 +299,11 @@ class ProjectsQueryFlags:
 
         needs_final = any(needs_final_result)
 
-        exclude_groups = sorted(
-            {
-                int(group_id)
-                for exclude_groups_result in exclude_groups_results
-                for group_id in exclude_groups_result
-            }
-        )
+        exclude_groups = {
+            int(group_id)
+            for exclude_groups_result in exclude_groups_results
+            for group_id in exclude_groups_result
+        }
 
         needs_final_replacement_types = {
             replacement_type.decode("utf-8")

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -616,14 +616,14 @@ class TestReplacer:
         project_ids = [1, 2, 3]
         assert ProjectsQueryFlags.load_from_redis(
             project_ids, ReplacerState.ERRORS
-        ) == ProjectsQueryFlags(False, [], set(), None)
+        ) == ProjectsQueryFlags(False, set(), set(), None)
 
         errors_replacer.set_project_needs_final(
             100, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
         assert ProjectsQueryFlags.load_from_redis(
             project_ids, ReplacerState.ERRORS
-        ) == ProjectsQueryFlags(False, [], set(), None)
+        ) == ProjectsQueryFlags(False, set(), set(), None)
 
         errors_replacer.set_project_needs_final(
             1, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
@@ -633,10 +633,10 @@ class TestReplacer:
             flags.needs_final,
             flags.group_ids_to_exclude,
             flags.replacement_types,
-        ) == (True, [], {ReplacementType.EXCLUDE_GROUPS},)
+        ) == (True, set(), {ReplacementType.EXCLUDE_GROUPS},)
         assert ProjectsQueryFlags.load_from_redis(
             project_ids, ReplacerState.EVENTS
-        ) == ProjectsQueryFlags(False, [], set(), None)
+        ) == ProjectsQueryFlags(False, set(), set(), None)
 
         errors_replacer.set_project_needs_final(
             2, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
@@ -646,7 +646,7 @@ class TestReplacer:
             flags.needs_final,
             flags.group_ids_to_exclude,
             flags.replacement_types,
-        ) == (True, [], {ReplacementType.EXCLUDE_GROUPS},)
+        ) == (True, set(), {ReplacementType.EXCLUDE_GROUPS},)
 
     def test_query_time_flags_groups(self) -> None:
         """
@@ -670,7 +670,7 @@ class TestReplacer:
             flags.replacement_types,
         ) == (
             False,
-            [1, 2, 3, 4],
+            {1, 2, 3, 4},
             {ReplacementType.EXCLUDE_GROUPS, ReplacementType.START_MERGE},
         )
 
@@ -691,7 +691,7 @@ class TestReplacer:
             flags.replacement_types,
         ) == (
             False,
-            [1, 2, 3, 4, 5, 6],
+            {1, 2, 3, 4, 5, 6},
             {
                 ReplacementType.EXCLUDE_GROUPS,
                 # start_merge should show up from previous setter on project id 2
@@ -706,7 +706,7 @@ class TestReplacer:
             flags.replacement_types,
         ) == (
             False,
-            [1, 2, 3, 4],
+            {1, 2, 3, 4},
             {ReplacementType.EXCLUDE_GROUPS, ReplacementType.START_MERGE},
         )
         flags = ProjectsQueryFlags.load_from_redis([4], ReplacerState.ERRORS)
@@ -714,10 +714,10 @@ class TestReplacer:
             flags.needs_final,
             flags.group_ids_to_exclude,
             flags.replacement_types,
-        ) == (False, [1, 2], {ReplacementType.EXCLUDE_GROUPS},)
+        ) == (False, {1, 2}, {ReplacementType.EXCLUDE_GROUPS},)
         assert ProjectsQueryFlags.load_from_redis(
             project_ids, ReplacerState.EVENTS
-        ) == ProjectsQueryFlags(False, [], set(), None)
+        ) == ProjectsQueryFlags(False, set(), set(), None)
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """
@@ -743,7 +743,7 @@ class TestReplacer:
             flags.replacement_types,
         ) == (
             True,
-            [1, 2],
+            {1, 2},
             # exclude_groups from project setter, start_merge from group setter
             {ReplacementType.EXCLUDE_GROUPS, ReplacementType.START_MERGE},
         )


### PR DESCRIPTION
## Overview
- Noticed `ProjectsQueryFlags.group_ids_to_exclude` is a sorted list of exclude group ids
- Only other place it's really used is for defining the list for the `group_id NOT IN` clause
- Can just be a set instead of sorted list, which makes it easier for upcoming changes surrounding group ids

## Changes
- Changed `ProjectsQueryFlags.group_ids_to_exclude` to a `Set[int]` from a `Sequence[int]`
- Updated tests accordingly