### PR TITLE
fix(tests): Fix tests in arm64

### DIFF
--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -133,19 +133,21 @@ class HTTPWriteBatch:
         elif not chunk_size > 0:
             raise ValueError("chunk size must be greater than zero")
 
-        encoding_header = {"Content-Encoding": encoding} if encoding else {}
+        headers = {
+            "X-ClickHouse-User": user,
+            "Connection": "keep-alive",
+            "Accept-Encoding": "gzip,deflate",
+        }
+        if password != '':
+            headers["X-ClickHouse-Key"] = password
+        if encoding:
+            headers["Content-Encoding"] = encoding
 
         self.__result = executor.submit(
             pool.urlopen,
             "POST",
             "/?" + urlencode({**options, "query": statement.build_statement()}),
-            headers={
-                "X-ClickHouse-User": user,
-                "X-ClickHouse-Key": password,
-                "Connection": "keep-alive",
-                "Accept-Encoding": "gzip,deflate",
-                **encoding_header,
-            },
+            headers=headers,
             body=body,
         )
 


### PR DESCRIPTION
On arm64 laptops we run a different docker image for clickhouse:
`altinity/clickhouse-server:21.6.1.6734-testing-arm`.

When running the tests against this image we'd get an error like:

```
______________________________________________________ ERROR at setup of TestApi.test_error_handler _______________________________________________________
Traceback (most recent call last):
  File "/Users/dan/code/snuba/tests/test_api.py", line 50, in setup_method
    self.generate_fizzbuzz_events()
  File "/Users/dan/code/snuba/tests/test_api.py", line 148, in generate_fizzbuzz_events
    self.write_events(events)
  File "/Users/dan/code/snuba/tests/test_api.py", line 72, in write_events
    write_processed_messages(self.storage, processed_messages)
  File "/Users/dan/code/snuba/tests/helpers.py", line 21, in write_processed_messages
    BatchWriterEncoderWrapper(
  File "/Users/dan/code/snuba/snuba/writer.py", line 34, in write
    return self.__writer.write(map(self.__encoder.encode, values))
  File "/Users/dan/code/snuba/snuba/clickhouse/http.py", line 245, in write
    batch.join()
  File "/Users/dan/code/snuba/snuba/clickhouse/http.py", line 195, in join
    raise HTTPError(
urllib3.exceptions.HTTPError: Received unexpected 400 response:
```

I traced this down to passing an empty password to `X-ClickHouse-Key`. If I put in a random string
ClickHouse returned an authentication error, and with an empty string it'd just 400. Not including
the header at all allowed the query to succeed.

My assumption here is that this is caused by some change when we bump the ClickHouse version, and
that we'd need to make this change to upgrade ClickHouse at some point anyway.