### PR TITLE
feat(suspect-spans): Start emitting spans.exclusive_time_32 column

### DIFF
--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -335,11 +335,13 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["spans.op"] = []
             processed["spans.group"] = []
             processed["spans.exclusive_time"] = []
+            processed["spans.exclusive_time_32"] = []
 
             for op, group, exclusive_time in sorted(processed_spans):
                 processed["spans.op"].append(op)
                 processed["spans.group"].append(group)
                 processed["spans.exclusive_time"].append(exclusive_time)
+                processed["spans.exclusive_time_32"].append(exclusive_time)
 
             # The hash and exclusive_time is being stored in the spans columns
             # so there is no need to store it again in the context array.

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -228,6 +228,7 @@ class TransactionEvent:
             "spans.op": [span[0] for span in spans],
             "spans.group": [span[1] for span in spans],
             "spans.exclusive_time": [span[2] for span in spans],
+            "spans.exclusive_time_32": [span[2] for span in spans],
         }
 
         if self.ipv4:
@@ -396,6 +397,7 @@ class TestTransactionsProcessor:
         result["spans.op"] = ["navigation"]
         result["spans.group"] = [int("a" * 16, 16)]
         result["spans.exclusive_time"] = [1.2345]
+        result["spans.exclusive_time_32"] = [1.2345]
 
         assert TransactionsMessageProcessor().process_message(
             payload, meta


### PR DESCRIPTION
As part of the migration for spans.exclusive_time from Float64 to Float32, start
emitting the new 32 bit column now. This is needed because
`input_format_skip_unknown_fields` allows Clickhouse to ignore extra unknown
fields but will error if the nested spans column is missing 1 or more columns.

Depends on #2232 so transactions processor does not error with the new column.