### PR TITLE
Rename onpremise to self-hosted

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,27 +40,27 @@ steps:
       - "-v"
       - "--remove-orphans"
   - name: "gcr.io/$PROJECT_ID/docker-compose"
-    id: get-onpremise-repo
+    id: get-self-hosted-repo
     waitFor:
       # We need to wait until unit-tests finish as `pytest` tries
-      # to run tests under onpremise repo too
+      # to run tests under self-hosted repo too
       - unit-tests
     entrypoint: "bash"
     args:
       - "-e"
       - "-c"
       - |
-        mkdir onpremise && cd onpremise
-        curl -L "https://github.com/getsentry/onpremise/archive/master.tar.gz" | tar xzf - --strip-components=1
+        mkdir self-hosted && cd self-hosted
+        curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
   - name: "gcr.io/$PROJECT_ID/docker-compose"
     id: e2e-test
     waitFor:
       - runtime-image
       - unit-tests-cleanup
-      - get-onpremise-repo
+      - get-self-hosted-repo
     entrypoint: "bash"
-    dir: onpremise
+    dir: self-hosted
     args:
       - "-e"
       - "-c"
@@ -102,7 +102,7 @@ steps:
 images: ['us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
 timeout: 2640s
 options:
-  # We need more memory for Webpack builds & e2e onpremise tests
+  # We need more memory for Webpack builds & e2e self-hosted tests
   machineType: "N1_HIGHCPU_8"
   env:
     - "CI=1"


### PR DESCRIPTION
https://github.com/getsentry/self-hosted/issues/796

Didn't touch migrations files as those are largely historical at this point.