### PR TITLE
fix(metric): Restore final flag in Queries metrics

### DIFF
--- a/snuba/query/composite.py
+++ b/snuba/query/composite.py
@@ -62,6 +62,7 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
             granularity=granularity,
         )
         self.__from_clause = from_clause
+        self.__final = False
 
     def __repr__(self) -> str:
         from snuba.query.formatters.tracing import format_query
@@ -106,7 +107,10 @@ class CompositeQuery(Query, Generic[TSimpleDataSource]):
         self.__from_clause = from_clause
 
     def get_final(self) -> bool:
-        return False
+        return self.__final
+
+    def set_final(self, final: bool) -> None:
+        self.__final = final
 
     def _get_expressions_impl(self) -> Iterable[Expression]:
         return []

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -119,6 +119,7 @@ def parse_and_run_query(
             robust=robust,
             concurrent_queries_gauge=concurrent_queries_gauge,
         )
+        request.query.set_final(result.extra["stats"]["final"])
         if not request.settings.get_dry_run():
             record_query(request, timer, query_metadata, result.extra)
     except QueryException as error:


### PR DESCRIPTION
## Overview
- `snuba.api.query.count` metric had its `final` tag always set to `false`
- This is probably due to Snuba query `__final` attribute and `get_final()` being hardcoded to `False` and `set_final()` was never used

## Changes
- After a Query is run through the pipeline, the results come with a `stats` dictionary that contains a `final` flag which tells us whether or not the Query will be final when passed to ClickHouse
- Updated the Query classes to appropriately use `set_final()` and `get_final()`, which should fix the metric issue