### PR TITLE
feat(metric-alerts): Add MetricsCountersSubscription [INGEST-625]

### DIFF
--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -1,12 +1,7 @@
 from typing import Any, Mapping, Optional, Sequence, Set, Union
 
 from snuba.query.dsl import literals_tuple
-from snuba.query.expressions import (
-    Expression,
-    FunctionCall,
-    Literal,
-    OptionalScalarType,
-)
+from snuba.query.expressions import Expression, FunctionCall, Literal
 from snuba.query.matchers import Any as AnyPattern
 from snuba.query.matchers import AnyExpression, AnyOptionalString
 from snuba.query.matchers import Column as ColumnPattern
@@ -304,7 +299,7 @@ def build_match(
     ops: Sequence[str],
     param_type: Any,
     alias: Optional[str] = None,
-    key: OptionalScalarType = None,
+    key: Optional[str] = None,
 ) -> Or[Expression]:
     # The IN condition has to be checked separately since each parameter
     # has to be checked individually.
@@ -312,7 +307,7 @@ def build_match(
     pattern: Union[ColumnPattern, SubscriptableReferencePattern]
     if key is not None:
         pattern = SubscriptableReferencePattern(
-            table_name=alias_match, column_name=String(col), key=AnyPattern(str)
+            table_name=alias_match, column_name=String(col), key=String(key)
         )
     else:
         pattern = ColumnPattern(table_name=alias_match, column_name=String(col))

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -1,7 +1,12 @@
-from typing import Any, Mapping, Optional, Sequence, Set
+from typing import Any, Mapping, Optional, Sequence, Set, Union
 
 from snuba.query.dsl import literals_tuple
-from snuba.query.expressions import Expression, FunctionCall, Literal
+from snuba.query.expressions import (
+    Expression,
+    FunctionCall,
+    Literal,
+    OptionalScalarType,
+)
 from snuba.query.matchers import Any as AnyPattern
 from snuba.query.matchers import AnyExpression, AnyOptionalString
 from snuba.query.matchers import Column as ColumnPattern
@@ -9,6 +14,7 @@ from snuba.query.matchers import FunctionCall as FunctionCallPattern
 from snuba.query.matchers import Integer
 from snuba.query.matchers import Literal as LiteralPattern
 from snuba.query.matchers import Or, Param, Pattern, String
+from snuba.query.matchers import SubscriptableReference as SubscriptableReferencePattern
 
 
 class ConditionFunctions:
@@ -294,12 +300,25 @@ def is_condition(exp: Expression) -> bool:
 
 
 def build_match(
-    col: str, ops: Sequence[str], param_type: Any, alias: Optional[str] = None
+    col: str,
+    ops: Sequence[str],
+    param_type: Any,
+    alias: Optional[str] = None,
+    key: OptionalScalarType = None,
 ) -> Or[Expression]:
     # The IN condition has to be checked separately since each parameter
     # has to be checked individually.
     alias_match = AnyOptionalString() if alias is None else String(alias)
-    column_match = Param("column", ColumnPattern(alias_match, String(col)))
+    pattern: Union[ColumnPattern, SubscriptableReferencePattern]
+    if key is not None:
+        pattern = SubscriptableReferencePattern(
+            table_name=alias_match, column_name=String(col), key=AnyPattern(str)
+        )
+    else:
+        pattern = ColumnPattern(table_name=alias_match, column_name=String(col))
+
+    column_match = Param("column", pattern)
+
     return Or(
         [
             FunctionCallPattern(

--- a/snuba/query/matchers.py
+++ b/snuba/query/matchers.py
@@ -357,6 +357,7 @@ class SubscriptableReference(Pattern[SubscriptableReferenceExpr]):
     If column_name and key arguments are provided, they have to match, otherwise they are ignored.
     """
 
+    table_name: Optional[Pattern[Optional[str]]] = None
     column_name: Optional[Pattern[str]] = None
     key: Optional[Pattern[str]] = None
 
@@ -365,6 +366,12 @@ class SubscriptableReference(Pattern[SubscriptableReferenceExpr]):
             return None
 
         result = MatchResult()
+
+        if self.table_name is not None:
+            partial_result = self.table_name.match(node.column.table_name)
+            if partial_result is None:
+                return None
+            result = result.merge(partial_result)
 
         if self.column_name is not None:
             partial_result = self.column_name.match(node.column.column_name)

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1166,7 +1166,10 @@ def _align_max_days_date_align(
 
     # If there is an = or IN condition on time, we don't need to do any of this
     match = build_match(
-        entity.required_time_column, [ConditionFunctions.EQ], datetime, alias
+        col=entity.required_time_column,
+        ops=[ConditionFunctions.EQ],
+        param_type=datetime,
+        alias=alias,
     )
     if any(match.match(cond) for cond in old_top_level):
         return old_top_level

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -144,19 +144,13 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
     clauses are being used in the query, and that those clauses are in the correct structure.
     """
 
-    def __init__(self, max_allowed_aggregations: int) -> None:
-        self.max_allowed_aggregations = max_allowed_aggregations
-
-    def validate(
-        self,
-        query: Query,
-        alias: Optional[str] = None,
-        disallowed: Optional[Sequence[str]] = None,
+    def __init__(
+        self, max_allowed_aggregations: int, disallowed_aggregations: Sequence[str]
     ) -> None:
-        if disallowed is None:
-            raise InvalidQueryException(
-                "Disallowed clauses list is a required attribute"
-            )
+        self.max_allowed_aggregations = max_allowed_aggregations
+        self.disallowed_aggregations = disallowed_aggregations
+
+    def validate(self, query: Query, alias: Optional[str] = None,) -> None:
         selected = query.get_selected_columns()
         if len(selected) > self.max_allowed_aggregations:
             aggregation_error_text = (
@@ -168,7 +162,7 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
                 f"A maximum of {aggregation_error_text} allowed in the select"
             )
 
-        for field in disallowed:
+        for field in self.disallowed_aggregations:
             if getattr(query, f"get_{field}")():
                 raise InvalidQueryException(
                     f"invalid clause {field} in subscription query"

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -12,6 +12,8 @@ from snuba.query.conditions import (
     get_first_level_and_conditions,
 )
 from snuba.query.exceptions import InvalidExpressionException, InvalidQueryException
+from snuba.query.expressions import Column
+from snuba.query.expressions import SubscriptableReference as SubscriptableReferenceExpr
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +62,9 @@ class EntityRequiredColumnValidator(QueryValidator):
         missing = set()
         if self.required_columns:
             for col in self.required_columns:
-                match = build_match(col, [ConditionFunctions.EQ], int, alias)
+                match = build_match(
+                    col=col, ops=[ConditionFunctions.EQ], param_type=int, alias=alias
+                )
                 found = any(match.match(cond) for cond in top_level)
                 if not found:
                     missing.add(col)
@@ -115,15 +119,15 @@ class NoTimeBasedConditionValidator(QueryValidator):
     def __init__(self, required_time_column: str) -> None:
         self.required_time_column = required_time_column
         self.match = build_match(
-            required_time_column,
-            [
+            col=required_time_column,
+            ops=[
                 ConditionFunctions.EQ,
                 ConditionFunctions.LT,
                 ConditionFunctions.LTE,
                 ConditionFunctions.GT,
                 ConditionFunctions.GTE,
             ],
-            datetime,
+            param_type=datetime,
         )
 
     def validate(self, query: Query, alias: Optional[str] = None) -> None:
@@ -150,6 +154,47 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
         self.max_allowed_aggregations = max_allowed_aggregations
         self.disallowed_aggregations = disallowed_aggregations
 
+    @staticmethod
+    def _validate_groupby_fields_have_matching_conditions(
+        query: Query, alias: Optional[str] = None
+    ) -> None:
+        """
+        Method that insures that for every field in the group by clause, there should be a
+        matching a condition. For example, if we had in our groupby clause [project_id, tags[3]],
+        we should have the following conditions in the where clause `project_id = 3 AND tags[3]
+        IN array(1,2,3)`. This is necessary because we want to avoid the case where an
+        unspecified number of buckets is returned.
+        """
+        condition = query.get_condition()
+        top_level = get_first_level_and_conditions(condition) if condition else []
+
+        for exp in query.get_groupby():
+            key = None
+            if isinstance(exp, SubscriptableReferenceExpr):
+                column_name = str(exp.column.column_name)
+                key = exp.key.value
+            elif isinstance(exp, Column):
+                column_name = exp.column_name
+            else:
+                raise InvalidQueryException(
+                    "Unhandled column type in group by validation"
+                )
+
+            match = build_match(
+                col=column_name,
+                ops=[ConditionFunctions.EQ],
+                param_type=int,
+                alias=alias,
+                key=key,
+            )
+            found = any(match.match(cond) for cond in top_level)
+
+            if not found:
+                raise InvalidQueryException(
+                    f"Every field in groupby must have a corresponding condition in "
+                    f"where clause. missing condition for field {exp}"
+                )
+
     def validate(self, query: Query, alias: Optional[str] = None,) -> None:
         selected = query.get_selected_columns()
         if len(selected) > self.max_allowed_aggregations:
@@ -167,6 +212,9 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
                 raise InvalidQueryException(
                     f"invalid clause {field} in subscription query"
                 )
+
+        if "groupby" not in self.disallowed_aggregations:
+            self._validate_groupby_fields_have_matching_conditions(query, alias)
 
 
 class GranularityValidator(QueryValidator):

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -167,12 +167,11 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
         """
         condition = query.get_condition()
         top_level = get_first_level_and_conditions(condition) if condition else []
-
         for exp in query.get_groupby():
-            key = None
+            key: Optional[str] = None
             if isinstance(exp, SubscriptableReferenceExpr):
                 column_name = str(exp.column.column_name)
-                key = exp.key.value
+                key = str(exp.key.value)
             elif isinstance(exp, Column):
                 column_name = exp.column_name
             else:

--- a/snuba/subscriptions/entity_subscription.py
+++ b/snuba/subscriptions/entity_subscription.py
@@ -52,7 +52,7 @@ class EntitySubscription(ABC):
 
 class EntitySubscriptionValidation:
     MAX_ALLOWED_AGGREGATIONS: int = 1
-    disallowed: Sequence[str] = ["groupby", "having", "orderby"]
+    disallowed_aggregations: Sequence[str] = ["groupby", "having", "orderby"]
 
     def validate_query(self, query: Union[CompositeQuery[Entity], Query]) -> None:
         # TODO: Support composite queries with multiple entities.
@@ -61,9 +61,9 @@ class EntitySubscriptionValidation:
             raise InvalidSubscriptionError("Only simple queries are supported")
         entity = get_entity(from_clause.key)
 
-        SubscriptionAllowedClausesValidator(self.MAX_ALLOWED_AGGREGATIONS).validate(
-            query, disallowed=self.disallowed
-        )
+        SubscriptionAllowedClausesValidator(
+            self.MAX_ALLOWED_AGGREGATIONS, self.disallowed_aggregations
+        ).validate(query)
         if entity.required_time_column:
             NoTimeBasedConditionValidator(entity.required_time_column).validate(query)
 
@@ -126,7 +126,7 @@ class TransactionsSubscription(BaseEventsSubscription):
 
 class MetricsCountersSubscription(SessionsSubscription):
     MAX_ALLOWED_AGGREGATIONS: int = 3
-    disallowed = ["having", "orderby"]
+    disallowed_aggregations = ["having", "orderby"]
 
 
 ENTITY_SUBSCRIPTION_TO_KEY_MAPPER: Mapping[Type[EntitySubscription], EntityKey] = {

--- a/snuba/subscriptions/entity_subscription.py
+++ b/snuba/subscriptions/entity_subscription.py
@@ -52,6 +52,7 @@ class EntitySubscription(ABC):
 
 class EntitySubscriptionValidation:
     MAX_ALLOWED_AGGREGATIONS: int = 1
+    disallowed: Sequence[str] = ["groupby", "having", "orderby"]
 
     def validate_query(self, query: Union[CompositeQuery[Entity], Query]) -> None:
         # TODO: Support composite queries with multiple entities.
@@ -61,7 +62,7 @@ class EntitySubscriptionValidation:
         entity = get_entity(from_clause.key)
 
         SubscriptionAllowedClausesValidator(self.MAX_ALLOWED_AGGREGATIONS).validate(
-            query
+            query, disallowed=self.disallowed
         )
         if entity.required_time_column:
             NoTimeBasedConditionValidator(entity.required_time_column).validate(query)
@@ -123,10 +124,16 @@ class TransactionsSubscription(BaseEventsSubscription):
     ...
 
 
+class MetricsCountersSubscription(SessionsSubscription):
+    MAX_ALLOWED_AGGREGATIONS: int = 3
+    disallowed = ["having", "orderby"]
+
+
 ENTITY_SUBSCRIPTION_TO_KEY_MAPPER: Mapping[Type[EntitySubscription], EntityKey] = {
     SessionsSubscription: EntityKey.SESSIONS,
     EventsSubscription: EntityKey.EVENTS,
     TransactionsSubscription: EntityKey.TRANSACTIONS,
+    MetricsCountersSubscription: EntityKey.METRICS_COUNTERS,
 }
 
 ENTITY_KEY_TO_SUBSCRIPTION_MAPPER: Mapping[EntityKey, Type[EntitySubscription]] = {

--- a/tests/datasets/validation/test_subscription_clauses_validator.py
+++ b/tests/datasets/validation/test_subscription_clauses_validator.py
@@ -1,14 +1,25 @@
+from typing import cast
+
 import pytest
 
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
-from snuba.query.conditions import binary_condition
+from snuba.query.conditions import (
+    BooleanFunctions,
+    ConditionFunctions,
+    binary_condition,
+)
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.validation.validators import SubscriptionAllowedClausesValidator
+from snuba.subscriptions.entity_subscription import (
+    ENTITY_KEY_TO_SUBSCRIPTION_MAPPER,
+    EntitySubscription,
+    EntitySubscriptionValidation,
+)
 
 tests = [
     pytest.param(
@@ -29,13 +40,56 @@ tests = [
         ),
         id="no extra clauses",
     ),
+    pytest.param(
+        LogicalQuery(
+            QueryEntity(
+                EntityKey.METRICS_COUNTERS,
+                get_entity(EntityKey.METRICS_COUNTERS).get_data_model(),
+            ),
+            selected_columns=[SelectedExpression("value", Column(None, None, "value"))],
+            condition=binary_condition(
+                BooleanFunctions.AND,
+                binary_condition(
+                    ConditionFunctions.EQ,
+                    Column(None, None, "metric_id"),
+                    Literal(None, 123),
+                ),
+                binary_condition(
+                    BooleanFunctions.AND,
+                    binary_condition(
+                        "equals",
+                        Column("_snuba_project_id", None, "project_id"),
+                        Literal(None, 1),
+                    ),
+                    binary_condition(
+                        "equals",
+                        Column("_snuba_org_id", None, "org_id"),
+                        Literal(None, 1),
+                    ),
+                ),
+            ),
+            groupby=[
+                Column("_snuba_project_id", None, "project_id"),
+                Column("_snuba_tags[3]", None, "tags[3]"),
+            ],
+        ),
+        id="groupby is allowed in metrics counters subscriptions",
+    ),
 ]
 
 
 @pytest.mark.parametrize("query", tests)  # type: ignore
 def test_subscription_clauses_validation(query: LogicalQuery) -> None:
+    class EntityKeySubscription(EntitySubscriptionValidation, EntitySubscription):
+        ...
+
+    entity_subscription_cls = cast(
+        EntityKeySubscription,
+        ENTITY_KEY_TO_SUBSCRIPTION_MAPPER[query.get_from_clause().key],
+    )
+
     validator = SubscriptionAllowedClausesValidator(max_allowed_aggregations=1)
-    validator.validate(query)
+    validator.validate(query, disallowed=entity_subscription_cls.disallowed)
 
 
 invalid_tests = [

--- a/tests/datasets/validation/test_subscription_clauses_validator.py
+++ b/tests/datasets/validation/test_subscription_clauses_validator.py
@@ -62,14 +62,22 @@ tests = [
                 binary_condition(
                     BooleanFunctions.AND,
                     binary_condition(
-                        "equals",
-                        Column("_snuba_project_id", None, "project_id"),
-                        Literal(None, 1),
+                        BooleanFunctions.AND,
+                        binary_condition(
+                            "equals",
+                            Column("_snuba_project_id", None, "project_id"),
+                            Literal(None, 1),
+                        ),
+                        binary_condition(
+                            "equals",
+                            Column("_snuba_org_id", None, "org_id"),
+                            Literal(None, 1),
+                        ),
                     ),
                     binary_condition(
                         "equals",
-                        Column("_snuba_org_id", None, "org_id"),
-                        Literal(None, 1),
+                        Column("_snuba_tags[3]", None, "tags[3]"),
+                        Literal(None, 2),
                     ),
                 ),
             ),
@@ -154,6 +162,41 @@ invalid_tests = [
             ],
         ),
         id="no orderby clauses",
+    ),
+    pytest.param(
+        LogicalQuery(
+            QueryEntity(
+                EntityKey.METRICS_COUNTERS,
+                get_entity(EntityKey.METRICS_COUNTERS).get_data_model(),
+            ),
+            selected_columns=[SelectedExpression("value", Column(None, None, "value"))],
+            condition=binary_condition(
+                BooleanFunctions.AND,
+                binary_condition(
+                    ConditionFunctions.EQ,
+                    Column(None, None, "metric_id"),
+                    Literal(None, 123),
+                ),
+                binary_condition(
+                    BooleanFunctions.AND,
+                    binary_condition(
+                        "equals",
+                        Column("_snuba_project_id", None, "project_id"),
+                        Literal(None, 1),
+                    ),
+                    binary_condition(
+                        "equals",
+                        Column("_snuba_org_id", None, "org_id"),
+                        Literal(None, 1),
+                    ),
+                ),
+            ),
+            groupby=[
+                Column("_snuba_project_id", None, "project_id"),
+                Column("_snuba_tags[3]", None, "tags[3]"),
+            ],
+        ),
+        id="tags[3] is in the group by clause but has no matching condition",
     ),
 ]
 

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -302,7 +302,7 @@ test_cases = [
     ),
     (
         "subscriptable match with column",
-        SubscriptableReference(String("stuff")),
+        SubscriptableReference(column_name=String("stuff")),
         SubscriptableReferenceExpr(
             None, ColumnExpr(None, None, "stuff"), LiteralExpr(None, "things")
         ),
@@ -318,7 +318,7 @@ test_cases = [
     ),
     (
         "subscriptable match with column and key",
-        SubscriptableReference(String("stuff"), String("things")),
+        SubscriptableReference(column_name=String("stuff"), key=String("things")),
         SubscriptableReferenceExpr(
             None, ColumnExpr(None, None, "stuff"), LiteralExpr(None, "things")
         ),
@@ -326,11 +326,27 @@ test_cases = [
     ),
     (
         "subscriptable match with wrong column and key",
-        SubscriptableReference(String("notstuff"), String("things")),
+        SubscriptableReference(column_name=String("notstuff"), key=String("things")),
         SubscriptableReferenceExpr(
             None, ColumnExpr(None, None, "stuff"), LiteralExpr(None, "things")
         ),
         None,
+    ),
+    (
+        "Matches a column with all fields",
+        SubscriptableReference(
+            table_name=Param("p_table_name", AnyOptionalString()),
+            column_name=Param("col_name", String("notstuff")),
+            key=Param("key", String("things")),
+        ),
+        SubscriptableReferenceExpr(
+            alias=None,
+            column=ColumnExpr(None, "table_name", "notstuff"),
+            key=LiteralExpr(None, "things"),
+        ),
+        MatchResult(
+            {"p_table_name": "table_name", "col_name": "notstuff", "key": "things"}
+        ),
     ),
 ]
 

--- a/tests/subscriptions/subscriptions_utils.py
+++ b/tests/subscriptions/subscriptions_utils.py
@@ -10,6 +10,7 @@ from snuba.subscriptions.data import (
 from snuba.subscriptions.entity_subscription import (
     EntitySubscription,
     EventsSubscription,
+    MetricsCountersSubscription,
     SessionsSubscription,
 )
 
@@ -36,5 +37,7 @@ def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
 def create_entity_subscription(dataset_name: str = "events") -> EntitySubscription:
     if dataset_name == "sessions":
         return SessionsSubscription(data_dict={"organization": 1})
+    elif dataset_name == "metrics":
+        return MetricsCountersSubscription(data_dict={"organization": 1})
     else:
         return EventsSubscription(data_dict={})

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -28,6 +28,7 @@ from snuba.subscriptions.data import (
 from snuba.subscriptions.entity_subscription import (
     EntitySubscription,
     EventsSubscription,
+    MetricsCountersSubscription,
     SessionsSubscription,
     SubscriptionType,
 )
@@ -35,15 +36,20 @@ from snuba.utils.metrics.timer import Timer
 
 
 def build_snql_subscription_data(
-    organization: Optional[int] = None,
+    organization: Optional[int] = None, use_metrics: bool = False,
 ) -> SnQLSubscriptionData:
     entity_subscription: EntitySubscription
     if not organization:
         entity_subscription = EventsSubscription(data_dict={})
     else:
-        entity_subscription = SessionsSubscription(
-            data_dict={"organization": organization},
-        )
+        if use_metrics:
+            entity_subscription = MetricsCountersSubscription(
+                data_dict={"organization": organization},
+            )
+        else:
+            entity_subscription = SessionsSubscription(
+                data_dict={"organization": organization},
+            )
     return SnQLSubscriptionData(
         project_id=5,
         time_window=timedelta(minutes=500),
@@ -54,16 +60,21 @@ def build_snql_subscription_data(
 
 
 SNQL_CASES = [
-    pytest.param(build_snql_subscription_data, None, id="snql",),
-    pytest.param(build_snql_subscription_data, 1, id="snql",),
+    pytest.param(build_snql_subscription_data, None, False, id="snql",),
+    pytest.param(build_snql_subscription_data, None, True, id="snql",),
+    pytest.param(build_snql_subscription_data, 1, False, id="snql",),
+    pytest.param(build_snql_subscription_data, 1, True, id="snql",),
 ]
 
 
 def assert_entity_subscription_on_subscription_class(
-    organization: Optional[int], subscription: SubscriptionData,
+    organization: Optional[int], subscription: SubscriptionData, use_metrics: bool
 ) -> None:
     if organization:
-        assert isinstance(subscription.entity_subscription, SessionsSubscription)
+        subscription_cls = (
+            MetricsCountersSubscription if use_metrics else SessionsSubscription
+        )
+        assert isinstance(subscription.entity_subscription, subscription_cls)
         assert subscription.entity_subscription.organization == organization
     else:
         assert isinstance(subscription.entity_subscription, EventsSubscription)
@@ -71,24 +82,35 @@ def assert_entity_subscription_on_subscription_class(
             getattr(subscription.entity_subscription, "organization")
 
 
-@pytest.mark.parametrize("builder, organization", [*SNQL_CASES])
+def get_entity_key(organization: Optional[int], use_metrics: bool) -> EntityKey:
+    if organization and use_metrics:
+        entity_key = EntityKey.METRICS_COUNTERS
+    elif organization:
+        entity_key = EntityKey.SESSIONS
+    else:
+        entity_key = EntityKey.EVENTS
+    return entity_key
+
+
+@pytest.mark.parametrize("builder, organization, use_metrics", [*SNQL_CASES])
 def test_basic(
-    builder: Callable[[Optional[int]], SubscriptionData], organization: Optional[int]
+    builder: Callable[[Optional[int], bool], SubscriptionData],
+    organization: Optional[int],
+    use_metrics: bool,
 ) -> None:
-    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
-    codec = SubscriptionDataCodec(entity)
-    data = builder(organization)
+    codec = SubscriptionDataCodec(get_entity_key(organization, use_metrics))
+    data = builder(organization, use_metrics)
     assert codec.decode(codec.encode(data)) == data
 
 
-@pytest.mark.parametrize("builder, organization", SNQL_CASES)
+@pytest.mark.parametrize("builder, organization, use_metrics", SNQL_CASES)
 def test_encode_snql(
-    builder: Callable[[Optional[int]], SnQLSubscriptionData],
+    builder: Callable[[Optional[int], bool], SnQLSubscriptionData],
     organization: Optional[int],
+    use_metrics: bool,
 ) -> None:
-    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
-    codec = SubscriptionDataCodec(entity)
-    subscription = builder(organization)
+    codec = SubscriptionDataCodec(get_entity_key(organization, use_metrics))
+    subscription = builder(organization, use_metrics)
 
     payload = codec.encode(subscription)
     data = json.loads(payload.decode("utf-8"))
@@ -96,17 +118,19 @@ def test_encode_snql(
     assert data["time_window"] == int(subscription.time_window.total_seconds())
     assert data["resolution"] == int(subscription.resolution.total_seconds())
     assert data["query"] == subscription.query
-    assert_entity_subscription_on_subscription_class(organization, subscription)
+    assert_entity_subscription_on_subscription_class(
+        organization, subscription, use_metrics
+    )
 
 
-@pytest.mark.parametrize("builder, organization", SNQL_CASES)
+@pytest.mark.parametrize("builder, organization, use_metrics", SNQL_CASES)
 def test_decode_snql(
-    builder: Callable[[Optional[int]], SnQLSubscriptionData],
+    builder: Callable[[Optional[int], bool], SnQLSubscriptionData],
     organization: Optional[int],
+    use_metrics: bool,
 ) -> None:
-    entity = EntityKey.SESSIONS if organization else EntityKey.EVENTS
-    codec = SubscriptionDataCodec(entity)
-    subscription = builder(organization)
+    codec = SubscriptionDataCodec(get_entity_key(organization, use_metrics))
+    subscription = builder(organization, use_metrics)
     data = {
         "type": SubscriptionType.SNQL.value,
         "project_id": subscription.project_id,
@@ -228,6 +252,62 @@ def test_sessions_subscription_task_result_encoder() -> None:
     assert payload["subscription_id"] == str(
         task_result.task.task.subscription.identifier
     )
+    assert payload["request"] == request.body
+    assert payload["result"] == result
+    assert payload["timestamp"] == task_result.task.timestamp.isoformat()
+
+
+def test_metrics_subscription_task_result_encoder() -> None:
+    codec = SubscriptionTaskResultEncoder()
+
+    timestamp = datetime.now()
+
+    entity_subscription = MetricsCountersSubscription(data_dict={"organization": 1})
+    subscription_data = SnQLSubscriptionData(
+        project_id=1,
+        query=(
+            """
+            MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
+            WHERE org_id = 1 AND project_id IN array(1) AND metric_id = 7
+            """
+        ),
+        time_window=timedelta(minutes=1),
+        resolution=timedelta(minutes=1),
+        entity_subscription=entity_subscription,
+    )
+
+    # XXX: This seems way too coupled to the dataset.
+    request = subscription_data.build_request(
+        get_dataset("metrics"), timestamp, None, Timer("timer")
+    )
+    result: Result = {
+        "data": [
+            {"project_id": 1, "tags[3]": 13, "value": 8},
+            {"project_id": 1, "tags[3]": 4, "value": 46},
+        ],
+        "meta": [
+            {"name": "project_id", "type": "UInt64"},
+            {"name": "tags[3]", "type": "UInt64"},
+            {"name": "value", "type": "Float64"},
+        ],
+    }
+
+    task_result = SubscriptionTaskResult(
+        ScheduledTask(
+            timestamp,
+            Subscription(
+                SubscriptionIdentifier(PartitionId(1), uuid.uuid1()), subscription_data,
+            ),
+        ),
+        (request, result),
+    )
+
+    message = codec.encode(task_result)
+    data = json.loads(message.value.decode("utf-8"))
+    assert data["version"] == 2
+    payload = data["payload"]
+
+    assert payload["subscription_id"] == str(task_result.task.task.identifier)
     assert payload["request"] == request.body
     assert payload["result"] == result
     assert payload["timestamp"] == task_result.task.timestamp.isoformat()

--- a/tests/subscriptions/test_entity_subscriptions.py
+++ b/tests/subscriptions/test_entity_subscriptions.py
@@ -8,6 +8,7 @@ from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.subscriptions.entity_subscription import (
     EntitySubscription,
     EventsSubscription,
+    MetricsCountersSubscription,
     SessionsSubscription,
     TransactionsSubscription,
 )
@@ -33,6 +34,18 @@ TESTS = [
         {"data_dict": {}},
         InvalidQueryException,
         id="Sessions subscription",
+    ),
+    pytest.param(
+        MetricsCountersSubscription,
+        {"data_dict": {"organization": 1}},
+        None,
+        id="Metrics counters subscription",
+    ),
+    pytest.param(
+        MetricsCountersSubscription,
+        {"data_dict": {}},
+        InvalidQueryException,
+        id="Metrics counters subscription",
     ),
 ]
 
@@ -86,6 +99,16 @@ TESTS_CONDITIONS_SNQL_METHOD = [
         ],
         True,
         id="Sessions subscription of type SNQL",
+    ),
+    pytest.param(
+        MetricsCountersSubscription(data_dict={"organization": 1}),
+        [
+            binary_condition(
+                ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 1),
+            ),
+        ],
+        True,
+        id="Metrics counters subscription of type SNQL",
     ),
 ]
 

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -9,6 +9,7 @@ from snuba import state
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
+from snuba.query.exceptions import InvalidQueryException
 from snuba.redis import redis_client
 from snuba.subscriptions.data import SnQLSubscriptionData, SubscriptionData
 from snuba.subscriptions.entity_subscription import InvalidSubscriptionError
@@ -57,21 +58,6 @@ TESTS_CREATE_SESSIONS = [
     ),
 ]
 
-TESTS_CREATE_METRICS = [
-    pytest.param(
-        SnQLSubscriptionData(
-            project_id=123,
-            query=(
-                """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
-                WHERE org_id = 1 AND project_id IN array(1) AND metric_id = 7"""
-            ),
-            time_window=timedelta(minutes=10),
-            resolution=timedelta(minutes=1),
-            entity_subscription=create_entity_subscription(dataset_name="metrics"),
-        ),
-        id="Snql subscription",
-    ),
-]
 
 TESTS_INVALID = [
     pytest.param(
@@ -121,14 +107,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset)
         with raises(QueryException):
             creator.create(
-                SnQLSubscriptionData(
-                    project_id=123,
-                    resolution=timedelta(minutes=1),
-                    time_window=timedelta(minutes=10),
-                    query="MATCH (events) SELECT count() AS count WHERE platfo IN tuple('a')",
-                    entity_subscription=create_entity_subscription(),
-                ),
-                self.timer,
+                subscription, self.timer,
             )
 
     def test_invalid_aggregation(self) -> None:
@@ -222,13 +201,63 @@ class TestSessionsSubscriptionCreator:
         )
 
 
+TESTS_CREATE_METRICS = [
+    pytest.param(
+        SnQLSubscriptionData(
+            project_id=123,
+            query=(
+                """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
+                WHERE org_id = 1 AND project_id IN array(1) AND metric_id = 7 AND tags[3] IN
+                array(6,7)"""
+            ),
+            time_window=timedelta(minutes=10),
+            resolution=timedelta(minutes=1),
+            entity_subscription=create_entity_subscription(dataset_name="metrics"),
+        ),
+        id="Snql subscription",
+    ),
+]
+
+
+TESTS_INVALID_METRICS = [
+    pytest.param(
+        SnQLSubscriptionData(
+            project_id=123,
+            query=(
+                """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
+                WHERE org_id = 1 AND project_id IN array(1) AND metric_id = 7"""
+            ),
+            time_window=timedelta(minutes=10),
+            resolution=timedelta(minutes=1),
+            entity_subscription=create_entity_subscription(dataset_name="metrics"),
+        ),
+        id="Snql subscription",
+    ),
+    pytest.param(
+        SnQLSubscriptionData(
+            project_id=123,
+            query=(
+                """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
+                WHERE org_id = 1 AND metric_id = 7 AND tags[3] IN array(6,7)"""
+            ),
+            time_window=timedelta(minutes=10),
+            resolution=timedelta(minutes=1),
+            entity_subscription=create_entity_subscription(dataset_name="metrics"),
+        ),
+        id="Snql subscription",
+    ),
+]
+
+
 class TestMetricsCountersSubscriptionCreator:
     timer = Timer("test")
 
+    def setup_method(self) -> None:
+        self.dataset = get_dataset("metrics")
+
     @pytest.mark.parametrize("subscription", TESTS_CREATE_METRICS)
     def test(self, subscription: SubscriptionData) -> None:
-        dataset = get_dataset("metrics")
-        creator = SubscriptionCreator(dataset)
+        creator = SubscriptionCreator(self.dataset)
         # XXX (ahmed): hack to circumvent using the default entity of a dataset as the default
         # entity for the metrics dataset is METRICS_SETS, and this subscription type is currently
         # not supported. Will add a fix shortly that relies on passing the entity key rather
@@ -251,6 +280,16 @@ class TestMetricsCountersSubscriptionCreator:
             )[0][1]
             == subscription
         )
+
+    @pytest.mark.parametrize("subscription", TESTS_INVALID_METRICS)
+    def test_missing_conditions_for_groupby_clause(
+        self, subscription: SubscriptionData
+    ) -> None:
+        creator = SubscriptionCreator(self.dataset)
+        with raises(InvalidQueryException):
+            creator.create(
+                subscription, self.timer,
+            )
 
 
 class TestSubscriptionDeleter(BaseSubscriptionTest):

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -31,7 +31,10 @@ from snuba.subscriptions.data import (
     SubscriptionIdentifier,
     SubscriptionTaskResult,
 )
-from snuba.subscriptions.entity_subscription import SessionsSubscription
+from snuba.subscriptions.entity_subscription import (
+    MetricsCountersSubscription,
+    SessionsSubscription,
+)
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import SubscriptionDataStore
 from snuba.subscriptions.utils import Tick
@@ -72,7 +75,7 @@ class Datetime(Pattern[datetime]):
 
 
 @pytest.fixture(
-    ids=["SnQL", "Crash Rate Alert Snql"],
+    ids=["SnQL", "Crash Rate Alert Snql", "Crash Rate Alert Metrics Snql"],
     params=[
         SnQLSubscriptionData(
             project_id=1,
@@ -94,6 +97,16 @@ class Datetime(Pattern[datetime]):
             resolution=timedelta(minutes=1),
             entity_subscription=create_entity_subscription(dataset_name="sessions"),
         ),
+        SnQLSubscriptionData(
+            project_id=123,
+            query=(
+                """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
+                WHERE org_id = 1 AND project_id IN array(1) AND metric_id = 7 """
+            ),
+            time_window=timedelta(minutes=10),
+            resolution=timedelta(minutes=1),
+            entity_subscription=create_entity_subscription(dataset_name="metrics"),
+        ),
     ],
 )
 def subscription_data(request: Any) -> SubscriptionData:
@@ -109,9 +122,11 @@ def subscription_rollout() -> Generator[None, None, None]:
 
 
 def test_subscription_worker(subscription_data: SubscriptionData) -> None:
-    uses_sessions_dataset = isinstance(
-        subscription_data.entity_subscription, SessionsSubscription
-    )
+    dataset_name = "events"
+    if isinstance(subscription_data.entity_subscription, SessionsSubscription):
+        dataset_name = "sessions"
+    if isinstance(subscription_data.entity_subscription, MetricsCountersSubscription):
+        dataset_name = "metrics"
 
     broker: Broker[SubscriptionTaskResult] = Broker(
         MemoryMessageStorage(), TestingClock()
@@ -133,9 +148,7 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
 
     metrics = DummyMetricsBackend(strict=True)
 
-    dataset = (
-        get_dataset("events") if not uses_sessions_dataset else get_dataset("sessions")
-    )
+    dataset = get_dataset(dataset_name)
     worker = SubscriptionWorker(
         dataset,
         ThreadPoolExecutor(),
@@ -157,7 +170,7 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
         timestamps=Interval(now - (frequency * evaluations), now),
     )
 
-    topic = Topic("events") if not uses_sessions_dataset else Topic("sessions")
+    topic = Topic(dataset_name)
     result_futures = worker.process_message(Message(Partition(topic, 0), 0, tick, now))
 
     assert result_futures is not None and len(result_futures) == evaluations
@@ -182,7 +195,7 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
         assert message.payload.task.timestamp == timestamp
         assert message.payload == SubscriptionTaskResult(task, future_result)
 
-        timestamp_field = "timestamp" if not uses_sessions_dataset else "started"
+        timestamp_field = "timestamp" if dataset_name != "sessions" else "started"
         from_pattern = FunctionCall(
             String(ConditionFunctions.GTE),
             (
@@ -203,7 +216,7 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
         assert any([from_pattern.match(e) for e in conditions])
         assert any([to_pattern.match(e) for e in conditions])
 
-        if uses_sessions_dataset:
+        if dataset_name == "sessions":
             expected_result = {
                 "meta": [
                     {
@@ -213,6 +226,15 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
                     {"type": "UInt64", "name": "_total_sessions"},
                 ],
                 "data": [{"_crash_rate_alert_aggregate": None, "_total_sessions": 0}],
+            }
+        elif dataset_name == "metrics":
+            expected_result = {
+                "data": [],
+                "meta": [
+                    {"name": "project_id", "type": "UInt64"},
+                    {"name": "tags[3]", "type": "UInt64"},
+                    {"name": "value", "type": "Float64"},
+                ],
             }
         else:
             expected_result = {

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -101,7 +101,8 @@ class Datetime(Pattern[datetime]):
             project_id=123,
             query=(
                 """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
-                WHERE org_id = 1 AND project_id IN array(1) AND metric_id = 7 """
+                WHERE org_id = 1 AND project_id IN array(1) AND tags[3] IN array(3,4,
+                5) AND metric_id=7"""
             ),
             time_window=timedelta(minutes=10),
             resolution=timedelta(minutes=1),


### PR DESCRIPTION
This PR:-
- adds MetricsCountersEntitySubscription class to create crash rate alerts for metrics which accepts a maximum of 3 aggregations and accepts a group by clause 

Group by clause is required here because:
- This is the Snql query that currently gets crash free percentage from metrics
https://github.com/getsentry/sentry/blob/1564d0e3c6a421721d211b3e87fdd786ec7959f3/src/sentry/release_health/metrics.py#L217-L232

And this query returns a json that looks like this 
```
[{‘project_id’: 56, ‘tags[320]’: 321, ‘value’: 2.0}, {‘project_id’: 56, ‘tags[320]’: 328, ‘value’: 1.0}]
```

If we were to remove the group by clause, we would merely get something that looks like this 
```
[{'value': 10.0}]
```
Which doesn't really help us determine the crash free percentage as this is merely the total sum of the sessions 
- Adds validation that ensures that any field in the `groupby` clause has a matching condition (either `IN` or `=`)