### PR TITLE
ref(subscriptions): Decouple subscription logic from datasets [INGEST-627]

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -14,8 +14,13 @@ from arroyo.processing.strategies.batching import BatchProcessingStrategyFactory
 from arroyo.synchronized import SynchronizedConsumer
 
 from snuba import environment, settings
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
-from snuba.datasets.factory import DATASET_NAMES, enforce_table_writer, get_dataset
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import (
+    ENTITY_NAME_LOOKUP,
+    enforce_table_writer,
+    get_entity,
+)
+from snuba.datasets.factory import DATASET_NAMES, get_dataset
 from snuba.environment import setup_logging, setup_sentry
 from snuba.redis import redis_client
 from snuba.subscriptions.codecs import SubscriptionTaskResultEncoder
@@ -42,6 +47,9 @@ logger = logging.getLogger(__name__)
     default="events",
     type=click.Choice(DATASET_NAMES),
     help="The dataset to target",
+)
+@click.option(
+    "--entity", "entity_name", help="The entity to target",
 )
 @click.option("--topic")
 @click.option("--partitions", type=int)
@@ -104,6 +112,7 @@ logger = logging.getLogger(__name__)
 def subscriptions(
     *,
     dataset_name: str,
+    entity_name: Optional[str],
     topic: Optional[str],
     partitions: Optional[int],
     commit_log_topic: Optional[str],
@@ -129,15 +138,19 @@ def subscriptions(
 
     dataset = get_dataset(dataset_name)
 
-    entity = dataset.get_default_entity()
-    entity_key = ENTITY_NAME_LOOKUP[entity]
+    if not entity_name:
+        entity = dataset.get_default_entity()
+        entity_key = ENTITY_NAME_LOOKUP[entity]
+    else:
+        entity_key = EntityKey(entity_name)
+        entity = get_entity(entity_key)
 
-    storage = dataset.get_default_entity().get_writable_storage()
+    storage = entity.get_writable_storage()
     assert (
         storage is not None
-    ), f"Dataset {dataset_name} does not have a writable storage by default."
+    ), f"Entity {entity_key} does not have a writable storage by default."
 
-    loader = enforce_table_writer(dataset).get_stream_loader()
+    loader = enforce_table_writer(entity).get_stream_loader()
     commit_log_topic_spec = loader.get_commit_log_topic_spec()
     assert commit_log_topic_spec is not None
 

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -3,6 +3,7 @@ from typing import Callable, MutableMapping
 from snuba import settings
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
+from snuba.datasets.table_storage import TableWriter
 from snuba.utils.serializable_exception import SerializableException
 
 
@@ -65,3 +66,12 @@ def get_entity(name: EntityKey) -> Entity:
         raise InvalidEntityError(f"entity {name!r} does not exist") from error
 
     return entity
+
+
+def enforce_table_writer(entity: Entity) -> TableWriter:
+    writable_storage = entity.get_writable_storage()
+
+    assert (
+        writable_storage is not None
+    ), f"Entity {ENTITY_NAME_LOOKUP[entity]} does not have a writable storage."
+    return writable_storage.get_table_writer()

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -2,7 +2,6 @@ from typing import Callable, MutableMapping, Sequence, Set
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.table_storage import TableWriter
 from snuba.util import with_span
 from snuba.utils.serializable_exception import SerializableException
 
@@ -80,14 +79,3 @@ def get_dataset_name(dataset: Dataset) -> str:
 
 def get_enabled_dataset_names() -> Sequence[str]:
     return [name for name in DATASET_NAMES if name not in settings.DISABLED_DATASETS]
-
-
-# TODO: This should be removed and moved to the Entity since Datasets no longer control
-# storages.
-def enforce_table_writer(dataset: Dataset) -> TableWriter:
-    writable_storage = dataset.get_default_entity().get_writable_storage()
-
-    assert (
-        writable_storage is not None
-    ), f"Dataset{dataset} does not have a writable storage."
-    return writable_storage.get_table_writer()

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -10,6 +10,7 @@ from typing import (
     Mapping,
     MutableMapping,
     MutableSequence,
+    Optional,
     Sequence,
     Text,
     Tuple,
@@ -35,6 +36,7 @@ from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
+from snuba.datasets.entity import Entity
 from snuba.datasets.factory import (
     InvalidDatasetError,
     get_dataset,
@@ -57,7 +59,7 @@ from snuba.util import with_span
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.web import QueryException
-from snuba.web.converters import DatasetConverter
+from snuba.web.converters import DatasetConverter, EntityConverter
 from snuba.web.query import parse_and_run_query
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
 
@@ -138,6 +140,7 @@ application = Flask(__name__, static_url_path="")
 application.testing = settings.TESTING
 application.debug = settings.DEBUG
 application.url_map.converters["dataset"] = DatasetConverter
+application.url_map.converters["entity"] = EntityConverter
 
 
 @application.errorhandler(InvalidJsonRequestException)
@@ -435,13 +438,18 @@ def handle_subscription_error(exception: InvalidSubscriptionError) -> Response:
     )
 
 
+@application.route("/<dataset:dataset>/<entity:entity>/subscriptions", methods=["POST"])
 @application.route("/<dataset:dataset>/subscriptions", methods=["POST"])
 @util.time_request("subscription")
-def create_subscription(*, dataset: Dataset, timer: Timer) -> RespTuple:
-    entity_key = ENTITY_NAME_LOOKUP[dataset.get_default_entity()]
+def create_subscription(
+    *, dataset: Dataset, timer: Timer, entity: Optional[Entity] = None
+) -> RespTuple:
+    if not entity:
+        entity = dataset.get_default_entity()
+    entity_key = ENTITY_NAME_LOOKUP[entity]
 
     subscription = SubscriptionDataCodec(entity_key).decode(http_request.data)
-    identifier = SubscriptionCreator(dataset).create(subscription, timer)
+    identifier = SubscriptionCreator(dataset, entity_key).create(subscription, timer)
     return (
         json.dumps({"subscription_id": str(identifier)}),
         202,
@@ -450,10 +458,19 @@ def create_subscription(*, dataset: Dataset, timer: Timer) -> RespTuple:
 
 
 @application.route(
+    "/<dataset:dataset>/<entity:entity>/subscriptions/<int:partition>/<key>",
+    methods=["DELETE"],
+)
+@application.route(
     "/<dataset:dataset>/subscriptions/<int:partition>/<key>", methods=["DELETE"]
 )
-def delete_subscription(*, dataset: Dataset, partition: int, key: str) -> RespTuple:
-    SubscriptionDeleter(dataset, PartitionId(partition)).delete(UUID(key))
+def delete_subscription(
+    *, dataset: Dataset, partition: int, key: str, entity: Optional[Entity] = None
+) -> RespTuple:
+    if not entity:
+        entity = dataset.get_default_entity()
+    entity_key = ENTITY_NAME_LOOKUP[entity]
+    SubscriptionDeleter(entity_key, PartitionId(partition)).delete(UUID(key))
     return "ok", 202, {"Content-Type": "text/plain"}
 
 

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -104,7 +104,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
     @pytest.mark.parametrize("subscription", TESTS_CREATE)
     def test(self, subscription: SubscriptionData) -> None:
-        creator = SubscriptionCreator(self.dataset)
+        creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         identifier = creator.create(subscription, self.timer)
         assert (
             cast(
@@ -118,7 +118,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
     @pytest.mark.parametrize("subscription", TESTS_INVALID)
     def test_invalid_condition_column(self, subscription: SubscriptionData) -> None:
-        creator = SubscriptionCreator(self.dataset)
+        creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(QueryException):
             creator.create(
                 SnQLSubscriptionData(
@@ -132,7 +132,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             )
 
     def test_invalid_aggregation(self) -> None:
-        creator = SubscriptionCreator(self.dataset)
+        creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(QueryException):
             creator.create(
                 SnQLSubscriptionData(
@@ -146,7 +146,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             )
 
     def test_invalid_time_window(self) -> None:
-        creator = SubscriptionCreator(self.dataset)
+        creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(InvalidSubscriptionError):
             creator.create(
                 SnQLSubscriptionData(
@@ -189,7 +189,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             )
 
     def test_invalid_resolution(self) -> None:
-        creator = SubscriptionCreator(self.dataset)
+        creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(InvalidSubscriptionError):
             creator.create(
                 SnQLSubscriptionData(
@@ -209,7 +209,7 @@ class TestSessionsSubscriptionCreator:
     @pytest.mark.parametrize("subscription", TESTS_CREATE_SESSIONS)
     def test(self, subscription: SubscriptionData) -> None:
         dataset = get_dataset("sessions")
-        creator = SubscriptionCreator(dataset)
+        creator = SubscriptionCreator(dataset, EntityKey.SESSIONS)
         identifier = creator.create(subscription, self.timer)
         assert (
             cast(
@@ -255,7 +255,7 @@ class TestMetricsCountersSubscriptionCreator:
 
 class TestSubscriptionDeleter(BaseSubscriptionTest):
     def test(self) -> None:
-        creator = SubscriptionCreator(self.dataset)
+        creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         subscription = SnQLSubscriptionData(
             project_id=1,
             query="MATCH (events) SELECT count() AS count",
@@ -274,7 +274,9 @@ class TestSubscriptionDeleter(BaseSubscriptionTest):
             == subscription
         )
 
-        SubscriptionDeleter(self.dataset, identifier.partition).delete(identifier.uuid)
+        SubscriptionDeleter(self.entity_key, identifier.partition).delete(
+            identifier.uuid
+        )
         assert (
             RedisSubscriptionDataStore(
                 redis_client, self.entity_key, identifier.partition,

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -228,7 +228,7 @@ class TestMetricsCountersSubscriptionCreator:
     @pytest.mark.parametrize("subscription", TESTS_CREATE_METRICS)
     def test(self, subscription: SubscriptionData) -> None:
         dataset = get_dataset("metrics")
-        creator = SubscriptionCreator(dataset)
+        creator = SubscriptionCreator(dataset, entity_key=EntityKey.METRICS_COUNTERS)
         # XXX (ahmed): hack to circumvent using the default entity of a dataset as the default
         # entity for the metrics dataset is METRICS_SETS, and this subscription type is currently
         # not supported. Will add a fix shortly that relies on passing the entity key rather

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2169,7 +2169,14 @@ class TestApi(SimpleAPITest):
 class TestCreateSubscriptionApi(BaseApiTest):
     dataset_name = "events"
 
-    def test(self) -> None:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "events/subscriptions",  # Only dataset in url
+            "events/events/subscriptions",  # dataset and entity in url
+        ],
+    )
+    def test(self, url: str) -> None:
         expected_uuid = uuid.uuid1()
 
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
@@ -2245,9 +2252,16 @@ class TestDeleteSubscriptionApi(BaseApiTest):
     dataset_name = "events"
     dataset = get_dataset(dataset_name)
 
-    def test(self) -> None:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "events/subscriptions",  # Only dataset in url
+            "events/events/subscriptions",  # dataset and entity in url
+        ],
+    )
+    def test(self, url: str) -> None:
         resp = self.app.post(
-            "{}/subscriptions".format(self.dataset_name),
+            url,
             data=json.dumps(
                 {
                     "project_id": 1,

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -286,13 +286,20 @@ class TestSessionsApi(BaseSessionsMockTest, BaseApiTest):
 class TestCreateSubscriptionApi(BaseApiTest):
     dataset_name = "sessions"
 
-    def test_snql_with_sessions_entity_subscription(self) -> None:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "sessions/subscriptions",  # Only dataset in url
+            "sessions/sessions/subscriptions",  # dataset and entity in url
+        ],
+    )
+    def test_snql_with_sessions_entity_subscription(self, url: str) -> None:
         expected_uuid = uuid.uuid1()
 
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
             uuid4.return_value = expected_uuid
             resp = self.app.post(
-                "{}/subscriptions".format(self.dataset_name),
+                url,
                 data=json.dumps(
                     {
                         "project_id": 1,

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -3,9 +3,11 @@ from typing import Optional
 
 import pytest
 import rapidjson
+
 from snuba.clickhouse.errors import ClickhouseWriterError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
-from snuba.datasets.factory import enforce_table_writer, get_dataset
+from snuba.datasets.entities.factory import enforce_table_writer
+from snuba.datasets.factory import get_dataset
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 
 
@@ -14,12 +16,12 @@ class TestHTTPBatchWriter:
     metrics = DummyMetricsBackend(strict=True)
 
     def test_empty_batch(self) -> None:
-        enforce_table_writer(self.dataset).get_batch_writer(metrics=self.metrics).write(
-            []
-        )
+        enforce_table_writer(self.dataset.get_default_entity()).get_batch_writer(
+            metrics=self.metrics
+        ).write([])
 
     def test_error_handling(self) -> None:
-        table_writer = enforce_table_writer(self.dataset)
+        table_writer = enforce_table_writer(self.dataset.get_default_entity())
 
         with pytest.raises(ClickhouseWriterError) as error:
             table_writer.get_batch_writer(
@@ -53,7 +55,7 @@ def test_gzip_load() -> None:
 
     dataset = get_dataset("groupedmessage")
     metrics = DummyMetricsBackend(strict=True)
-    writer = enforce_table_writer(dataset).get_bulk_writer(
+    writer = enforce_table_writer(dataset.get_default_entity()).get_bulk_writer(
         metrics,
         "gzip",
         [


### PR DESCRIPTION
Decouples subscription creation and deletion logic from datasets to also consider entities since dataset to entity is not a 1-to-1 relation