### PR TITLE
feat(consumer-util): Expose metric of consumer utilization

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -2,6 +2,7 @@ import signal
 from typing import Any, Optional, Sequence
 
 import click
+import rapidjson
 from arroyo import configure_metrics
 
 from snuba import environment, settings
@@ -92,6 +93,11 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
+@click.option(
+    "--stats-collection-frequency-ms",
+    type=click.IntRange(100, 1000),
+    help="The frequency of collecting statistics from librdkafka.",
+)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -110,6 +116,7 @@ def consumer(
     processes: Optional[int],
     input_block_size: Optional[int],
     output_block_size: Optional[int],
+    stats_collection_frequency_ms: Optional[int],
     log_level: Optional[str] = None,
     profile_path: Optional[str] = None,
 ) -> None:
@@ -126,6 +133,10 @@ def consumer(
     )
     configure_metrics(StreamMetricsAdapter(metrics))
 
+    def stats_callback(stats_json: str) -> None:
+        stats = rapidjson.loads(stats_json)
+        metrics.gauge("total_queue_size", stats["replyq"])
+
     consumer_builder = ConsumerBuilder(
         storage_key=storage_key,
         kafka_params=KafkaParameters(
@@ -137,6 +148,7 @@ def consumer(
             auto_offset_reset=auto_offset_reset,
             queued_max_messages_kbytes=queued_max_messages_kbytes,
             queued_min_messages=queued_min_messages,
+            stats_collection_frequency_ms=stats_collection_frequency_ms,
         ),
         processing_params=ProcessingParameters(
             processes=processes,
@@ -147,6 +159,7 @@ def consumer(
         max_batch_time_ms=max_batch_time_ms,
         metrics=metrics,
         profile_path=profile_path,
+        stats_callback=stats_callback,
     )
 
     if stateful_consumer:


### PR DESCRIPTION
librdkafka exposes the metric called replyq which tells the number of operations which are awaiting in the queue for application to poll. Documentation of the metric can be found here https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md#top-level

The metric is a gauge so it gives us an indication of point in time size of the queue. Exposing this metric would allow us to know if the queue is ever empty and if yes, we could start fine tuning some parameters.

The current PR just adds the option to be able to capture the metrics. To enable the metrics, the CLI option would need to be added in the K8s configuration.

