### PR TITLE
ref(subscriptions): Deleting Legacy and Delegate Subscription logic

### DIFF
--- a/snuba/subscriptions/entity_subscription.py
+++ b/snuba/subscriptions/entity_subscription.py
@@ -10,7 +10,6 @@ from snuba.query.data_source.simple import Entity
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
-from snuba.query.types import Condition
 from snuba.query.validation.validators import (
     NoTimeBasedConditionValidator,
     SubscriptionAllowedClausesValidator,
@@ -18,9 +17,7 @@ from snuba.query.validation.validators import (
 
 
 class SubscriptionType(Enum):
-    LEGACY = "legacy"
     SNQL = "snql"
-    DELEGATE = "delegate"
 
 
 class InvalidSubscriptionError(Exception):
@@ -38,16 +35,6 @@ class EntitySubscription(ABC):
         """
         Returns a list of extra conditions that are entity specific and required for the
         snql subscriptions
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def get_entity_subscription_conditions_for_legacy(
-        self, offset: Optional[int] = None
-    ) -> Sequence[Condition]:
-        """
-        Returns a list of extra conditions that are entity specific and required for the
-        legacy subscriptions
         """
         raise NotImplementedError
 
@@ -103,11 +90,6 @@ class SessionsSubscription(EntitySubscriptionValidation, EntitySubscription):
             ),
         ]
 
-    def get_entity_subscription_conditions_for_legacy(
-        self, offset: Optional[int] = None
-    ) -> Sequence[Condition]:
-        return []
-
     def to_dict(self) -> Mapping[str, Any]:
         return {"organization": self.organization}
 
@@ -128,14 +110,6 @@ class BaseEventsSubscription(EntitySubscriptionValidation, EntitySubscription, A
                 Literal(None, offset),
             )
         ]
-
-    def get_entity_subscription_conditions_for_legacy(
-        self, offset: Optional[int] = None
-    ) -> Sequence[Condition]:
-        if offset is None:
-            return []
-
-        return [[["ifNull", ["offset", 0]], "<=", offset]]
 
     def to_dict(self) -> Mapping[str, Any]:
         return {}

--- a/tests/subscriptions/test_entity_subscriptions.py
+++ b/tests/subscriptions/test_entity_subscriptions.py
@@ -89,39 +89,6 @@ TESTS_CONDITIONS_SNQL_METHOD = [
     ),
 ]
 
-TESTS_CONDITIONS_LEGACY_METHOD = [
-    pytest.param(
-        EventsSubscription(data_dict={}),
-        [[["ifNull", ["offset", 0]], "<=", 5]],
-        True,
-        id="Events subscription with offset of type LEGACY",
-    ),
-    pytest.param(
-        EventsSubscription(data_dict={}),
-        [],
-        False,
-        id="Events subscription with no offset of type LEGACY",
-    ),
-    pytest.param(
-        TransactionsSubscription(data_dict={}),
-        [[["ifNull", ["offset", 0]], "<=", 5]],
-        True,
-        id="Transactions subscription with offset of type LEGACY",
-    ),
-    pytest.param(
-        TransactionsSubscription(data_dict={}),
-        [],
-        False,
-        id="Transactions subscription with no offset of type LEGACY",
-    ),
-    pytest.param(
-        SessionsSubscription(data_dict={"organization": 1}),
-        [],
-        True,
-        id="Sessions subscription of type LEGACY",
-    ),
-]
-
 
 @pytest.mark.parametrize("entity_subscription, creation_dict, exception", TESTS)
 def test_basic(
@@ -148,21 +115,5 @@ def test_entity_subscription_methods_for_snql(
     offset = 5 if has_offset else None
     assert (
         entity_subscription.get_entity_subscription_conditions_for_snql(offset)
-        == expected_conditions
-    )
-
-
-@pytest.mark.parametrize(
-    "entity_subscription, expected_conditions, has_offset",
-    TESTS_CONDITIONS_LEGACY_METHOD,
-)
-def test_entity_subscription_functions_for_legacy(
-    entity_subscription: EntitySubscription,
-    expected_conditions: List[Any],
-    has_offset: bool,
-) -> None:
-    offset = 5 if has_offset else None
-    assert (
-        entity_subscription.get_entity_subscription_conditions_for_legacy(offset)
         == expected_conditions
     )

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -51,7 +51,7 @@ TESTS_CREATE_SESSIONS = [
             resolution=timedelta(minutes=1),
             entity_subscription=create_entity_subscription(dataset_name="sessions"),
         ),
-        id="Delegate subscription",
+        id="Snql subscription",
     ),
 ]
 

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -74,7 +74,7 @@ class Datetime(Pattern[datetime]):
 
 
 @pytest.fixture(
-    ids=["SnQL", "Crash Rate Alert Delegate"],
+    ids=["SnQL", "Crash Rate Alert Snql"],
     params=[
         SnQLSubscriptionData(
             project_id=1,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2214,7 +2214,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
             }
         }
 
-    def test_delegate(self) -> None:
+    def test_with_bad_snql(self) -> None:
         expected_uuid = uuid.uuid1()
 
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
@@ -2223,36 +2223,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
                 "{}/subscriptions".format(self.dataset_name),
                 data=json.dumps(
                     {
-                        "type": "delegate",
                         "project_id": 1,
-                        "conditions": [["platform", "IN", ["a"]]],
-                        "aggregations": [["count()", "", "count"]],
-                        "time_window": int(timedelta(minutes=10).total_seconds()),
-                        "resolution": int(timedelta(minutes=1).total_seconds()),
-                        "query": "MATCH (events) SELECT count() AS count WHERE platform IN tuple('a') AND project_id = 1",
-                    }
-                ).encode("utf-8"),
-            )
-
-        assert resp.status_code == 202
-        data = json.loads(resp.data)
-        assert data == {
-            "subscription_id": f"0/{expected_uuid.hex}",
-        }
-
-    def test_delegate_with_bad_snql(self) -> None:
-        expected_uuid = uuid.uuid1()
-
-        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
-            uuid4.return_value = expected_uuid
-            resp = self.app.post(
-                "{}/subscriptions".format(self.dataset_name),
-                data=json.dumps(
-                    {
-                        "type": "delegate",
-                        "project_id": 1,
-                        "conditions": [["platform", "IN", ["a"]]],
-                        "aggregations": [["count()", "", "count"]],
                         "time_window": int(timedelta(minutes=10).total_seconds()),
                         "resolution": int(timedelta(minutes=1).total_seconds()),
                         "query": "MATCH (events) SELECT count() AS count BY project_id WHERE platform IN tuple('a')",

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -286,7 +286,7 @@ class TestSessionsApi(BaseSessionsMockTest, BaseApiTest):
 class TestCreateSubscriptionApi(BaseApiTest):
     dataset_name = "sessions"
 
-    def test_delegate_with_sessions_entity_subscription(self) -> None:
+    def test_snql_with_sessions_entity_subscription(self) -> None:
         expected_uuid = uuid.uuid1()
 
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
@@ -295,17 +295,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
                 "{}/subscriptions".format(self.dataset_name),
                 data=json.dumps(
                     {
-                        "type": "delegate",
                         "project_id": 1,
-                        "conditions": [],
-                        "aggregations": [
-                            [
-                                "if(greater(sessions,0),divide(sessions_crashed,sessions),null)",
-                                None,
-                                "_crash_rate_alert_aggregate",
-                            ],
-                            ["identity(sessions)", None, "_total_sessions"],
-                        ],
                         "time_window": int(timedelta(minutes=10).total_seconds()),
                         "resolution": int(timedelta(minutes=1).total_seconds()),
                         "query": (
@@ -328,7 +318,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
             "subscription_id": f"0/{expected_uuid.hex}",
         }
 
-    def test_bad_delegate_with_sessions_entity_subscription(self) -> None:
+    def test_bad_snql_with_sessions_entity_subscription(self) -> None:
         expected_uuid = uuid.uuid1()
 
         with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
@@ -337,18 +327,7 @@ class TestCreateSubscriptionApi(BaseApiTest):
                 "{}/subscriptions".format(self.dataset_name),
                 data=json.dumps(
                     {
-                        "type": "delegate",
                         "project_id": 1,
-                        "conditions": [],
-                        "aggregations": [
-                            [
-                                "if(greater(sessions,0),divide(sessions_crashed,sessions),null)",
-                                None,
-                                "_crash_rate_alert_aggregate",
-                            ],
-                            ["identity(sessions)", None, "_total_sessions"],
-                            ["identity(sessions_crashed)", None, None],
-                        ],
                         "time_window": int(timedelta(minutes=10).total_seconds()),
                         "resolution": int(timedelta(minutes=1).total_seconds()),
                         "query": (


### PR DESCRIPTION
Hacks out logic that has to do with legacy subscription and delegate subscription data classes since these have been removed

Follow up on #2169 