### PR TITLE
ref(sentry-metrics): Rename metrics consumer group for dev

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -149,7 +149,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     "--storage=metrics_buckets",
                     "--auto-offset-reset=latest",
                     "--log-level=debug",
-                    "--consumer-group=metrics_group",
+                    "--consumer-group=snuba-metrics-consumers",
                 ],
             ),
         ]


### PR DESCRIPTION
Updated the snuba metrics consumer in https://github.com/getsentry/ops/pull/4171, so doing the same here