### PR TITLE
feat: Add subscriptions executor command

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -6,7 +6,7 @@ from arroyo import configure_metrics
 
 from snuba import environment
 from snuba.environment import setup_logging, setup_sentry
-from snuba.subscriptions.executor_consumer import ExecutorBuilder
+from snuba.subscriptions.executor_consumer import build_executor_consumer
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 
@@ -69,7 +69,7 @@ def subscriptions_executor(
 
     configure_metrics(StreamMetricsAdapter(metrics))
 
-    builder = ExecutorBuilder(
+    processor = build_executor_consumer(
         dataset_name,
         entity_name,
         consumer_group,
@@ -77,8 +77,6 @@ def subscriptions_executor(
         auto_offset_reset,
         metrics,
     )
-
-    processor = builder.build_consumer()
 
     def handler(signum: int, frame: Any) -> None:
         processor.signal_shutdown()

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -1,0 +1,89 @@
+import signal
+from typing import Any, Optional
+
+import click
+from arroyo import configure_metrics
+
+from snuba import environment
+from snuba.environment import setup_logging, setup_sentry
+from snuba.subscriptions.executor_consumer import ExecutorBuilder
+from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
+
+
+@click.command()
+@click.option(
+    "--dataset",
+    "dataset_name",
+    required=True,
+    type=click.Choice(["events", "transactions"]),
+    help="The dataset to target.",
+)
+@click.option(
+    "--entity",
+    "entity_name",
+    required=True,
+    type=click.Choice(["events", "transactions"]),
+    help="The entity to target.",
+)
+@click.option(
+    "--consumer-group",
+    default="snuba-subscription-scheduler",
+    help="Consumer group used for consuming the scheduled subscription topic/s.",
+)
+@click.option(
+    "--max-concurrent-queries",
+    default=20,
+    type=int,
+    help="Max concurrent ClickHouse queries",
+)
+@click.option(
+    "--auto-offset-reset",
+    default="error",
+    type=click.Choice(["error", "earliest", "latest"]),
+    help="Kafka consumer auto offset reset.",
+)
+@click.option("--log-level", help="Logging level to use.")
+def subscriptions_executor(
+    *,
+    dataset_name: str,
+    entity_name: str,
+    consumer_group: str,
+    max_concurrent_queries: int,
+    auto_offset_reset: str,
+    log_level: Optional[str]
+) -> None:
+    """
+    The subscription's executor consumes scheduled subscriptions from the scheduled
+    subscription topic for that entity, executes the queries on ClickHouse and publishes
+    results on the results topic.
+
+    It currently only supports executing subscriptions on a single dataset/entity.
+    """
+    setup_logging(log_level)
+    setup_sentry()
+
+    metrics = MetricsWrapper(
+        environment.metrics, "subscriptions.scheduler", tags={"entity": entity_name}
+    )
+
+    configure_metrics(StreamMetricsAdapter(metrics))
+
+    builder = ExecutorBuilder(
+        dataset_name,
+        entity_name,
+        consumer_group,
+        max_concurrent_queries,
+        auto_offset_reset,
+        metrics,
+    )
+
+    processor = builder.build_consumer()
+
+    def handler(signum: int, frame: Any) -> None:
+        processor.signal_shutdown()
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+    processor.run()

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -16,19 +16,19 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     "--dataset",
     "dataset_name",
     required=True,
-    type=click.Choice(["events", "transactions"]),
+    type=click.Choice(["events", "transactions", "sessions"]),
     help="The dataset to target.",
 )
 @click.option(
     "--entity",
     "entity_name",
     required=True,
-    type=click.Choice(["events", "transactions"]),
+    type=click.Choice(["events", "transactions", "sessions"]),
     help="The entity to target.",
 )
 @click.option(
     "--consumer-group",
-    default="snuba-subscription-scheduler",
+    default="snuba-subscription-executor",
     help="Consumer group used for consuming the scheduled subscription topic/s.",
 )
 @click.option(

--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
     "--entity",
     "entity_name",
     required=True,
-    type=click.Choice(["events", "transactions"]),
+    type=click.Choice(["events", "transactions", "sessions"]),
     help="The entity to target",
 )
 @click.option(

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -4,7 +4,6 @@ import logging
 from typing import Callable, Mapping, Optional
 
 from arroyo import Message, Partition, Topic
-from arroyo.backends.abstract import Consumer
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
@@ -20,61 +19,46 @@ from snuba.utils.streams.configuration_builder import build_kafka_consumer_confi
 logger = logging.getLogger(__name__)
 
 
-class ExecutorBuilder:
-    def __init__(
-        self,
-        dataset_name: str,
-        entity_name: str,
-        consumer_group: str,
-        max_concurrent_queries: int,
-        auto_offset_reset: str,
-        metrics: MetricsBackend,
-    ) -> None:
-        # Validate that a valid dataset/entity pair was passed in
-        dataset = get_dataset(dataset_name)
-        dataset_entity_names = [
-            ENTITY_NAME_LOOKUP[e].value for e in dataset.get_all_entities()
-        ]
-        assert entity_name in dataset_entity_names
+def build_executor_consumer(
+    dataset_name: str,
+    entity_name: str,
+    consumer_group: str,
+    max_concurrent_queries: int,
+    auto_offset_reset: str,
+    metrics: MetricsBackend,
+) -> StreamProcessor[KafkaPayload]:
+    # Validate that a valid dataset/entity pair was passed in
+    dataset = get_dataset(dataset_name)
+    dataset_entity_names = [
+        ENTITY_NAME_LOOKUP[e].value for e in dataset.get_all_entities()
+    ]
+    assert (
+        entity_name in dataset_entity_names
+    ), f"Entity {entity_name} does not exist in dataset {dataset_name}"
 
-        self.__entity_key = EntityKey(entity_name)
-        self.__entity = get_entity(self.__entity_key)
-        self.__dataset = dataset
-        self.__consumer_group = consumer_group
-        self.__max_concurrent_queries = max_concurrent_queries
-        self.__auto_offset_reset = auto_offset_reset
-        self.__metrics = metrics
+    entity_key = EntityKey(entity_name)
+    entity = get_entity(entity_key)
+    storage = entity.get_writable_storage()
 
-        storage = self.__entity.get_writable_storage()
+    assert (
+        storage is not None
+    ), f"Entity {entity_name} does not have a writable storage by default."
 
-        assert (
-            storage is not None
-        ), f"Entity {entity_name} does not have a writable storage by default."
+    stream_loader = storage.get_table_writer().get_stream_loader()
+    scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
+    assert scheduled_topic_spec is not None
 
-        stream_loader = storage.get_table_writer().get_stream_loader()
-
-        scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
-        assert scheduled_topic_spec is not None
-        self.__scheduled_topic_spec = scheduled_topic_spec
-
-    def build_consumer(self) -> StreamProcessor[KafkaPayload]:
-        return StreamProcessor(
-            self.__build_kafka_consumer(),
-            Topic(self.__scheduled_topic_spec.topic_name),
-            self.__build_strategy_factory(),
-        )
-
-    def __build_kafka_consumer(self) -> Consumer[KafkaPayload]:
-        return KafkaConsumer(
+    return StreamProcessor(
+        KafkaConsumer(
             build_kafka_consumer_configuration(
-                self.__scheduled_topic_spec.topic,
-                self.__consumer_group,
-                auto_offset_reset=self.__auto_offset_reset,
+                scheduled_topic_spec.topic,
+                consumer_group,
+                auto_offset_reset=auto_offset_reset,
             ),
-        )
-
-    def __build_strategy_factory(self) -> ProcessingStrategyFactory[KafkaPayload]:
-        return SubscriptionExecutorProcessingFactory()
+        ),
+        Topic(scheduled_topic_spec.topic_name),
+        SubscriptionExecutorProcessingFactory(),
+    )
 
 
 class Noop(ProcessingStrategy[KafkaPayload]):

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from concurrent.futures import Future
+from typing import Callable, Mapping, NamedTuple, Optional, Tuple
+
+from arroyo import Message, Partition, Topic
+from arroyo.backends.abstract import Consumer
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.processing import StreamProcessor
+from arroyo.processing.strategies import ProcessingStrategy
+from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
+from arroyo.types import Position
+
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
+from snuba.datasets.factory import get_dataset
+from snuba.reader import Result
+from snuba.request import Request
+from snuba.utils.metrics import MetricsBackend
+from snuba.utils.streams.configuration_builder import build_kafka_consumer_configuration
+
+logger = logging.getLogger(__name__)
+
+
+class SubscriptionResultFuture(NamedTuple):
+    message: Message[KafkaPayload]
+    future: Future[Tuple[Request, Result]]
+
+
+class ExecutorBuilder:
+    def __init__(
+        self,
+        dataset_name: str,
+        entity_name: str,
+        consumer_group: str,
+        max_concurrent_queries: int,
+        auto_offset_reset: str,
+        metrics: MetricsBackend,
+    ) -> None:
+        # Validate that a valid dataset/entity pair was passed in
+        dataset = get_dataset(dataset_name)
+        dataset_entity_names = [
+            ENTITY_NAME_LOOKUP[e].value for e in dataset.get_all_entities()
+        ]
+        assert entity_name in dataset_entity_names
+
+        self.__entity_key = EntityKey(entity_name)
+        self.__entity = get_entity(self.__entity_key)
+        self.__dataset = dataset
+        self.__consumer_group = consumer_group
+        self.__max_concurrent_queries = max_concurrent_queries
+        self.__auto_offset_reset = auto_offset_reset
+        self.__metrics = metrics
+
+        storage = self.__entity.get_writable_storage()
+
+        assert (
+            storage is not None
+        ), f"Entity {entity_name} does not have a writable storage by default."
+
+        stream_loader = storage.get_table_writer().get_stream_loader()
+
+        scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
+        assert scheduled_topic_spec is not None
+        self.__scheduled_topic_spec = scheduled_topic_spec
+
+    def build_consumer(self) -> StreamProcessor[KafkaPayload]:
+        return StreamProcessor(
+            self.__build_kafka_consumer(),
+            Topic(self.__scheduled_topic_spec.topic_name),
+            self.__build_strategy_factory(),
+        )
+
+    def __build_kafka_consumer(self) -> Consumer[KafkaPayload]:
+        return KafkaConsumer(
+            build_kafka_consumer_configuration(
+                self.__scheduled_topic_spec.topic,
+                self.__consumer_group,
+                auto_offset_reset=self.__auto_offset_reset,
+            ),
+        )
+
+    def __build_strategy_factory(self) -> ProcessingStrategyFactory[KafkaPayload]:
+        return SubscriptionExecutorProcessingFactory()
+
+
+class Noop(ProcessingStrategy[KafkaPayload]):
+    """
+    Placeholder.
+    """
+
+    def __init__(self, commit: Callable[[Mapping[Partition, Position]], None]):
+        self.__commit = commit
+
+    def poll(self) -> None:
+        pass
+
+    def submit(self, message: Message[KafkaPayload]) -> None:
+        self.__commit({message.partition: Position(message.offset, message.timestamp)})
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        pass
+
+
+class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPayload]):
+    def create(
+        self, commit: Callable[[Mapping[Partition, Position]], None]
+    ) -> ProcessingStrategy[KafkaPayload]:
+        return Noop(commit)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import logging
-from concurrent.futures import Future
-from typing import Callable, Mapping, NamedTuple, Optional, Tuple
+from typing import Callable, Mapping, Optional
 
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer
@@ -15,17 +14,10 @@ from arroyo.types import Position
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
 from snuba.datasets.factory import get_dataset
-from snuba.reader import Result
-from snuba.request import Request
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.configuration_builder import build_kafka_consumer_configuration
 
 logger = logging.getLogger(__name__)
-
-
-class SubscriptionResultFuture(NamedTuple):
-    message: Message[KafkaPayload]
-    future: Future[Tuple[Request, Result]]
 
 
 class ExecutorBuilder:

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -1,8 +1,10 @@
 import uuid
 from datetime import datetime, timedelta
 
+import pytest
 from arroyo import Topic
 from arroyo.backends.kafka import KafkaProducer
+from confluent_kafka.admin import AdminClient
 
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -18,12 +20,21 @@ from snuba.subscriptions.data import (
 from snuba.subscriptions.entity_subscription import EventsSubscription
 from snuba.subscriptions.executor_consumer import ExecutorBuilder
 from snuba.subscriptions.utils import Tick
-from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
+from snuba.utils.manage_topics import create_topics
+from snuba.utils.streams.configuration_builder import (
+    build_kafka_producer_configuration,
+    get_default_kafka_configuration,
+)
+from snuba.utils.streams.topics import Topic as SnubaTopic
 from snuba.utils.types import Interval
 from tests.backends.metrics import TestingMetricsBackend
 
 
+@pytest.mark.ci_only
 def test_executor_consumer() -> None:
+    admin_client = AdminClient(get_default_kafka_configuration())
+    create_topics(admin_client, [SnubaTopic.SUBSCRIPTION_SCHEDULED_EVENTS])
+
     dataset_name = "events"
     entity_name = "events"
     entity_key = EntityKey(entity_name)

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -1,0 +1,94 @@
+import uuid
+from datetime import datetime, timedelta
+
+from arroyo import Topic
+from arroyo.backends.kafka import KafkaProducer
+
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.subscriptions.codecs import SubscriptionScheduledTaskEncoder
+from snuba.subscriptions.data import (
+    PartitionId,
+    ScheduledSubscriptionTask,
+    SnQLSubscriptionData,
+    Subscription,
+    SubscriptionIdentifier,
+    SubscriptionWithTick,
+)
+from snuba.subscriptions.entity_subscription import EventsSubscription
+from snuba.subscriptions.executor_consumer import ExecutorBuilder
+from snuba.subscriptions.utils import Tick
+from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
+from snuba.utils.types import Interval
+from tests.backends.metrics import TestingMetricsBackend
+
+
+def test_executor_consumer() -> None:
+    dataset_name = "events"
+    entity_name = "events"
+    entity_key = EntityKey(entity_name)
+    entity = get_entity(entity_key)
+    storage = entity.get_writable_storage()
+    assert storage is not None
+    stream_loader = storage.get_table_writer().get_stream_loader()
+
+    scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
+    assert scheduled_topic_spec is not None
+
+    topic = Topic(scheduled_topic_spec.topic.name)
+
+    consumer_group = str(uuid.uuid1().hex)
+    auto_offset_reset = "latest"
+    builder = ExecutorBuilder(
+        dataset_name,
+        entity_name,
+        consumer_group,
+        2,
+        auto_offset_reset,
+        TestingMetricsBackend(),
+    )
+
+    executor = builder.build_consumer()
+
+    # Produce a scheduled task to the scheduled subscriptions topic
+    producer = KafkaProducer(
+        build_kafka_producer_configuration(scheduled_topic_spec.topic)
+    )
+
+    subscription_data = SnQLSubscriptionData(
+        project_id=1,
+        query="MATCH events SELECT count()",
+        time_window=timedelta(minutes=1),
+        resolution=timedelta(minutes=1),
+        entity_subscription=EventsSubscription(data_dict={}),
+    )
+
+    subscription_id = uuid.UUID("91b46cb6224f11ecb2ddacde48001122")
+
+    epoch = datetime(1970, 1, 1)
+
+    task = ScheduledSubscriptionTask(
+        timestamp=epoch,
+        task=SubscriptionWithTick(
+            Subscription(
+                SubscriptionIdentifier(PartitionId(1), subscription_id),
+                subscription_data,
+            ),
+            Tick(
+                0, Interval(0, 1), Interval(datetime(1970, 1, 1), datetime(1970, 1, 2)),
+            ),
+        ),
+    )
+
+    encoder = SubscriptionScheduledTaskEncoder(entity_key)
+
+    encoded_task = encoder.encode(task)
+
+    fut = producer.produce(topic, payload=encoded_task)
+    fut.result()
+
+    producer.close()
+
+    executor._run_once()
+
+    executor._shutdown()

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -79,6 +79,7 @@ def test_executor_consumer() -> None:
     task = ScheduledSubscriptionTask(
         timestamp=epoch,
         task=SubscriptionWithTick(
+            entity_key,
             Subscription(
                 SubscriptionIdentifier(PartitionId(1), subscription_id),
                 subscription_data,
@@ -89,7 +90,7 @@ def test_executor_consumer() -> None:
         ),
     )
 
-    encoder = SubscriptionScheduledTaskEncoder(entity_key)
+    encoder = SubscriptionScheduledTaskEncoder()
 
     encoded_task = encoder.encode(task)
 

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -18,7 +18,7 @@ from snuba.subscriptions.data import (
     SubscriptionWithTick,
 )
 from snuba.subscriptions.entity_subscription import EventsSubscription
-from snuba.subscriptions.executor_consumer import ExecutorBuilder
+from snuba.subscriptions.executor_consumer import build_executor_consumer
 from snuba.subscriptions.utils import Tick
 from snuba.utils.manage_topics import create_topics
 from snuba.utils.streams.configuration_builder import (
@@ -50,7 +50,7 @@ def test_executor_consumer() -> None:
 
     consumer_group = str(uuid.uuid1().hex)
     auto_offset_reset = "latest"
-    builder = ExecutorBuilder(
+    executor = build_executor_consumer(
         dataset_name,
         entity_name,
         consumer_group,
@@ -58,8 +58,6 @@ def test_executor_consumer() -> None:
         auto_offset_reset,
         TestingMetricsBackend(),
     )
-
-    executor = builder.build_consumer()
 
     # Produce a scheduled task to the scheduled subscriptions topic
     producer = KafkaProducer(


### PR DESCRIPTION
Subscription execution forms the second part of the subscriptions pipeline.
The executor's job is to consume the scheduled subscriptions from the scheduled
subscription topic, run the queries on ClickHouse and produce the results to
the results topic for Sentry.

This change simply introduces the executor CLI command. It builds the consumer
and processing strategy, however that strategy doesn't really do anything yet
except commit offsets. The processing strategies that are responsible for actually
running the query on ClickHouse and producing the results will be added separately.

Currently only a single dataset/entity pair is supported by the subscriptions
executor and a separate executor needs to be run for each entity.