### PR TITLE
feat(subscriptions): Write entity to scheduled topic

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -222,6 +222,7 @@ def subscriptions(
                     executor,
                     {
                         index: SubscriptionScheduler(
+                            entity_key,
                             RedisSubscriptionDataStore(
                                 redis_client, entity_key, PartitionId(index)
                             ),

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -236,6 +236,7 @@ class Subscription(NamedTuple):
 
 
 class SubscriptionWithTick(NamedTuple):
+    entity: EntityKey
     subscription: Subscription
     tick: Tick
 

--- a/snuba/subscriptions/scheduler_load_testing.py
+++ b/snuba/subscriptions/scheduler_load_testing.py
@@ -33,6 +33,7 @@ class LoadTestingSubscriptionScheduler(SubscriptionSchedulerBase):
         # Make `load_factor` copies of the scheduler and the store
         self.__scheduler_copies = [
             SubscriptionScheduler(
+                entity_key,
                 RedisSubscriptionDataStore(redis_client, entity_key, partition_id),
                 partition_id,
                 cache_ttl,

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -365,7 +365,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
         commit: Callable[[Mapping[Partition, Position]], None],
     ) -> None:
         self.__schedulers = schedulers
-        self.__encoder = SubscriptionScheduledTaskEncoder(entity_key)
+        self.__encoder = SubscriptionScheduledTaskEncoder()
         self.__producer = producer
         self.__scheduled_topic = Topic(scheduled_topic_spec.topic_name)
         self.__commit = commit

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -149,6 +149,7 @@ def test_subscription_task_result_encoder() -> None:
         ScheduledSubscriptionTask(
             timestamp,
             SubscriptionWithTick(
+                EntityKey.EVENTS,
                 Subscription(
                     SubscriptionIdentifier(PartitionId(1), uuid.uuid1()),
                     subscription_data,
@@ -214,6 +215,7 @@ def test_sessions_subscription_task_result_encoder() -> None:
         ScheduledSubscriptionTask(
             timestamp,
             SubscriptionWithTick(
+                EntityKey.EVENTS,
                 Subscription(
                     SubscriptionIdentifier(PartitionId(1), uuid.uuid1()),
                     subscription_data,
@@ -233,14 +235,16 @@ def test_sessions_subscription_task_result_encoder() -> None:
     assert data["version"] == 2
     payload = data["payload"]
 
-    assert payload["subscription_id"] == str(task_result.task.task[0].identifier)
+    assert payload["subscription_id"] == str(
+        task_result.task.task.subscription.identifier
+    )
     assert payload["request"] == request.body
     assert payload["result"] == result
     assert payload["timestamp"] == task_result.task.timestamp.isoformat()
 
 
 def test_subscription_task_encoder() -> None:
-    encoder = SubscriptionScheduledTaskEncoder(EntityKey.EVENTS)
+    encoder = SubscriptionScheduledTaskEncoder()
 
     subscription_data = SnQLSubscriptionData(
         project_id=1,
@@ -257,6 +261,7 @@ def test_subscription_task_encoder() -> None:
     tick = Tick(0, Interval(1, 5), Interval(datetime(1970, 1, 1), datetime(1970, 1, 2)))
 
     subscription_with_tick = SubscriptionWithTick(
+        EntityKey.EVENTS,
         Subscription(
             SubscriptionIdentifier(PartitionId(1), subscription_id), subscription_data
         ),
@@ -272,6 +277,7 @@ def test_subscription_task_encoder() -> None:
     assert encoded.value == (
         b"{"
         b'"timestamp":"1970-01-01T00:00:00",'
+        b'"entity":"events",'
         b'"task":{'
         b'"data":{"type":"snql","project_id":1,"time_window":60,"resolution":60,"query":"MATCH events SELECT count()"}},'
         b'"tick":{"partition":0,"offsets":[1,5],"timestamps":["1970-01-01T00:00:00","1970-01-02T00:00:00"]}'

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -43,7 +43,7 @@ class TestSubscriptionScheduler:
         return Tick(None, Interval(1, 5), Interval(self.now + lower, self.now + upper))
 
     def sort_key(self, task: ScheduledSubscriptionTask) -> Tuple[datetime, uuid.UUID]:
-        return task.timestamp, task.task[0].identifier.uuid
+        return task.timestamp, task.task.subscription.identifier.uuid
 
     def run_test(
         self,
@@ -64,6 +64,7 @@ class TestSubscriptionScheduler:
             store.create(subscription.identifier.uuid, subscription.data)
 
         scheduler = SubscriptionScheduler(
+            EntityKey.EVENTS,
             store,
             self.partition_id,
             timedelta(minutes=1),
@@ -88,7 +89,9 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now + timedelta(minutes=-10 + i),
-                    SubscriptionWithTick(subscription, self.build_tick(start, end)),
+                    SubscriptionWithTick(
+                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    ),
                 )
                 for i in range(10)
             ],
@@ -106,7 +109,9 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now + timedelta(minutes=-10 + i),
-                    SubscriptionWithTick(subscription, self.build_tick(start, end)),
+                    SubscriptionWithTick(
+                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    ),
                 )
                 for i in range(10)
             ],
@@ -131,7 +136,9 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now,
-                    SubscriptionWithTick(subscription, self.build_tick(start, end)),
+                    SubscriptionWithTick(
+                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    ),
                 )
             ],
         )
@@ -148,7 +155,9 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now,
-                    SubscriptionWithTick(subscription, self.build_tick(start, end)),
+                    SubscriptionWithTick(
+                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    ),
                 )
             ],
         )
@@ -161,13 +170,17 @@ class TestSubscriptionScheduler:
         expected = [
             ScheduledSubscriptionTask(
                 self.now + timedelta(minutes=-10 + i),
-                SubscriptionWithTick(subscription, self.build_tick(start, end)),
+                SubscriptionWithTick(
+                    EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                ),
             )
             for i in range(10)
         ] + [
             ScheduledSubscriptionTask(
                 self.now + timedelta(minutes=-10 + i),
-                SubscriptionWithTick(other_subscription, self.build_tick(start, end)),
+                SubscriptionWithTick(
+                    EntityKey.EVENTS, other_subscription, self.build_tick(start, end)
+                ),
             )
             for i in range(0, 10, 2)
         ]

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -535,6 +535,7 @@ def test_produce_scheduled_subscription_message() -> None:
 
     schedulers = {
         partition_index: SubscriptionScheduler(
+            entity_key,
             store,
             PartitionId(partition_index),
             cache_ttl=timedelta(seconds=300),
@@ -570,7 +571,7 @@ def test_produce_scheduled_subscription_message() -> None:
     strategy.submit(message)
 
     # 3 subscriptions should be scheduled (2 x subscription 1, 1 x subscription 2)
-    codec = SubscriptionScheduledTaskEncoder(entity_key)
+    codec = SubscriptionScheduledTaskEncoder()
 
     # 2 subscriptions scheduled at epoch
     first_message = broker_storage.consume(partition, 0)

--- a/tests/subscriptions/test_task_builder.py
+++ b/tests/subscriptions/test_task_builder.py
@@ -4,6 +4,7 @@ from typing import Sequence, Tuple
 import pytest
 
 from snuba import state
+from snuba.datasets.entities import EntityKey
 from snuba.subscriptions.data import (
     ScheduledSubscriptionTask,
     Subscription,
@@ -42,6 +43,7 @@ TEST_CASES = [
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
                     SubscriptionWithTick(
+                        EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(ALIGNED_TIMESTAMP, ALIGNED_TIMESTAMP + 60),
                     ),
@@ -82,6 +84,7 @@ TEST_CASES = [
                     # to the minute without jitter.
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
                     SubscriptionWithTick(
+                        EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
                             ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
@@ -123,6 +126,7 @@ TEST_CASES = [
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
                     SubscriptionWithTick(
+                        EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
                             ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
@@ -145,6 +149,7 @@ TEST_CASES = [
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
                     SubscriptionWithTick(
+                        EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=2), 0),
                         build_tick(ALIGNED_TIMESTAMP, ALIGNED_TIMESTAMP + 60),
                     ),
@@ -170,6 +175,7 @@ TEST_CASES = [
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
                     SubscriptionWithTick(
+                        EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
                             ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
@@ -208,6 +214,7 @@ TEST_CASES = [
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP + 60),
                     SubscriptionWithTick(
+                        EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
                             ALIGNED_TIMESTAMP + UUIDS[0].int % 60 + 60,
@@ -253,7 +260,9 @@ def test_sequences(
                 datetime.fromtimestamp(timestamp) + timedelta(minutes=1),
             ),
         )
-        ret = builder.get_task(SubscriptionWithTick(subscription, tick), timestamp)
+        ret = builder.get_task(
+            SubscriptionWithTick(EntityKey.EVENTS, subscription, tick), timestamp
+        )
         if ret:
             output.append((timestamp, ret))
 

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -12,6 +12,7 @@ from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.utils.clock import TestingClock
 
 from snuba import state
+from snuba.datasets.entities import EntityKey
 from snuba.datasets.factory import get_dataset
 from snuba.query.conditions import ConditionFunctions, get_first_level_and_conditions
 from snuba.query.matchers import (
@@ -141,7 +142,11 @@ def test_subscription_worker(subscription_data: SubscriptionData) -> None:
     worker = SubscriptionWorker(
         dataset,
         ThreadPoolExecutor(),
-        {0: SubscriptionScheduler(store, PartitionId(0), timedelta(), metrics)},
+        {
+            0: SubscriptionScheduler(
+                EntityKey.SESSIONS, store, PartitionId(0), timedelta(), metrics
+            )
+        },
         broker.get_producer(),
         result_topic,
         metrics,
@@ -249,7 +254,11 @@ def test_subscription_worker_consistent(subscription_data: SubscriptionData) -> 
         ThreadPoolExecutor(),
         {
             0: SubscriptionScheduler(
-                store, PartitionId(0), timedelta(), DummyMetricsBackend(strict=True)
+                EntityKey.EVENTS,
+                store,
+                PartitionId(0),
+                timedelta(),
+                DummyMetricsBackend(strict=True),
             )
         },
         broker.get_producer(),


### PR DESCRIPTION
In order for the subscriptions executor to be able to handle more than one
entity on a scheduled topic we need to include the entity information into the
Kafka message. Currently the scheduled subscription task codec depends on
knowing the entity key in order to decode the message - this information will no
longer be available when more than one entity's subscriptions are in the same topic
(and will be passed via the executor CLI command).

Since the executor is not running yet and we are never decoding messages
we can safely make this change.