### PR TITLE
feat(subscriptions): Executor command takes multiple entities

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -16,7 +16,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     "--dataset",
     "dataset_name",
     required=True,
-    type=click.Choice(["events", "transactions", "sessions", "discover"]),
+    type=click.Choice(["events", "transactions", "sessions"]),
     help="The dataset to target.",
 )
 @click.option(

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -1,5 +1,5 @@
 import signal
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import click
 from arroyo import configure_metrics
@@ -16,13 +16,14 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     "--dataset",
     "dataset_name",
     required=True,
-    type=click.Choice(["events", "transactions", "sessions"]),
+    type=click.Choice(["events", "transactions", "sessions", "discover"]),
     help="The dataset to target.",
 )
 @click.option(
     "--entity",
-    "entity_name",
+    "entity_names",
     required=True,
+    multiple=True,
     type=click.Choice(["events", "transactions", "sessions"]),
     help="The entity to target.",
 )
@@ -47,7 +48,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 def subscriptions_executor(
     *,
     dataset_name: str,
-    entity_name: str,
+    entity_names: Sequence[str],
     consumer_group: str,
     max_concurrent_queries: int,
     auto_offset_reset: str,
@@ -64,14 +65,16 @@ def subscriptions_executor(
     setup_sentry()
 
     metrics = MetricsWrapper(
-        environment.metrics, "subscriptions.scheduler", tags={"entity": entity_name}
+        environment.metrics,
+        "subscriptions.scheduler",
+        tags={"entity": ",".join(entity_names)},
     )
 
     configure_metrics(StreamMetricsAdapter(metrics))
 
     processor = build_executor_consumer(
         dataset_name,
-        entity_name,
+        entity_names,
         consumer_group,
         max_concurrent_queries,
         auto_offset_reset,

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -50,6 +50,9 @@ class KafkaTopicSpec:
     def topic_creation_config(self) -> Mapping[str, str]:
         return get_topic_creation_config(self.__topic)
 
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, KafkaTopicSpec) and self.topic == other.topic
+
 
 def get_topic_name(topic: Topic) -> str:
     return settings.KAFKA_TOPIC_MAP.get(topic.value, topic.value)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -67,7 +67,7 @@ def build_executor_consumer(
         assert get_topics_for_entity(entity_name) == (
             scheduled_topic_spec,
             result_topic_spec,
-        )
+        ), "All entities must have same scheduled and result topics"
 
     return StreamProcessor(
         KafkaConsumer(

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable, Mapping, Optional
+from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
@@ -13,6 +13,7 @@ from arroyo.types import Position
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
 from snuba.datasets.factory import get_dataset
+from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.configuration_builder import build_kafka_consumer_configuration
 
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 def build_executor_consumer(
     dataset_name: str,
-    entity_name: str,
+    entity_names: Sequence[str],
     consumer_group: str,
     max_concurrent_queries: int,
     auto_offset_reset: str,
@@ -32,21 +33,41 @@ def build_executor_consumer(
     dataset_entity_names = [
         ENTITY_NAME_LOOKUP[e].value for e in dataset.get_all_entities()
     ]
-    assert (
-        entity_name in dataset_entity_names
-    ), f"Entity {entity_name} does not exist in dataset {dataset_name}"
 
-    entity_key = EntityKey(entity_name)
-    entity = get_entity(entity_key)
-    storage = entity.get_writable_storage()
+    # Only entities in the same dataset with the same scheduled and result topics
+    # may be run together
 
-    assert (
-        storage is not None
-    ), f"Entity {entity_name} does not have a writable storage by default."
+    def get_topics_for_entity(
+        entity_name: str,
+    ) -> Tuple[KafkaTopicSpec, KafkaTopicSpec]:
+        assert (
+            entity_name in dataset_entity_names
+        ), f"Entity {entity_name} does not exist in dataset {dataset_name}"
 
-    stream_loader = storage.get_table_writer().get_stream_loader()
-    scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
-    assert scheduled_topic_spec is not None
+        entity = get_entity(EntityKey(entity_name))
+        storage = entity.get_writable_storage()
+
+        assert (
+            storage is not None
+        ), f"Entity {entity_name} does not have a writable storage by default."
+
+        stream_loader = storage.get_table_writer().get_stream_loader()
+
+        scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
+        assert scheduled_topic_spec is not None
+
+        result_topic_spec = stream_loader.get_subscription_result_topic_spec()
+        assert result_topic_spec is not None
+
+        return scheduled_topic_spec, result_topic_spec
+
+    scheduled_topic_spec, result_topic_spec = get_topics_for_entity(entity_names[0])
+
+    for entity_name in entity_names[1:]:
+        assert get_topics_for_entity(entity_name) == (
+            scheduled_topic_spec,
+            result_topic_spec,
+        )
 
     return StreamProcessor(
         KafkaConsumer(

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -52,7 +52,7 @@ def test_executor_consumer() -> None:
     auto_offset_reset = "latest"
     executor = build_executor_consumer(
         dataset_name,
-        entity_name,
+        [entity_name],
         consumer_group,
         2,
         auto_offset_reset,


### PR DESCRIPTION
The executor command can now take multiple entities as long as those entities:
- match the dataset value which is passed
- have the same scheduled topic defined
- have the same result topic defined

In the future we may want to make this more flexible by providing a way to override
the scheduled and result topics - but for now they must all be the same in the code.

The entity name is not being used by the executor process yet. Later we will filter
scheduled subscriptions with entity names that do not match any of the values provided.