### PR TITLE
feat: Record timings in the subscription scheduler

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -280,7 +280,6 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
         metrics: MetricsBackend,
         load_factor: int,
     ) -> None:
-        self.__entity_key = entity_key
         self.__mode = mode
         self.__partitions = partitions
         self.__producer = producer
@@ -309,17 +308,17 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
         mode = SchedulingWatermarkMode.GLOBAL
 
         schedule_step = ProduceScheduledSubscriptionMessage(
-            self.__entity_key,
             self.__schedulers,
             self.__producer,
             self.__scheduled_topic_spec,
             commit,
+            self.__metrics,
         )
 
         return TickBuffer(
             mode,
             self.__partitions,
             self.__buffer_size,
-            ProvideCommitStrategy(self.__partitions, schedule_step),
+            ProvideCommitStrategy(self.__partitions, schedule_step, self.__metrics),
             self.__metrics,
         )

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -96,7 +96,9 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
         if should_commit:
             self.__offset_low_watermark = message.offset
 
-        self.__metrics.timing("ProvideCommitStrategy.submit", time.time() - start)
+        self.__metrics.timing(
+            "ProvideCommitStrategy.submit", (time.time() - start) * 1000
+        )
 
     def __should_commit(self, message: Message[Tick]) -> bool:
         return (
@@ -280,7 +282,7 @@ class TickBuffer(ProcessingStrategy[Tick]):
                 (self.__latest_ts - earliest_ts).total_seconds() * 1000,
             )
 
-            self.__metrics.timing("TickBuffer.submit", time.time() - start)
+            self.__metrics.timing("TickBuffer.submit", (time.time() - start) * 1000)
 
     def close(self) -> None:
         self.__closed = True
@@ -418,7 +420,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                 )
 
         self.__metrics.timing(
-            "ProduceScheduledSubscriptionMessage.poll", time.time() - start
+            "ProduceScheduledSubscriptionMessage.poll", (time.time() - start) * 1000
         )
 
     def submit(self, message: Message[CommittableTick]) -> None:
@@ -448,7 +450,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
         )
 
         self.__metrics.timing(
-            "ProduceScheduledSubscriptionMessage.submit", time.time() - start
+            "ProduceScheduledSubscriptionMessage.submit", (time.time() - start) * 1000
         )
 
     def close(self) -> None:

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -22,7 +22,6 @@ from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.types import Position
 
-from snuba.datasets.entities import EntityKey
 from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.subscriptions.codecs import SubscriptionScheduledTaskEncoder
 from snuba.subscriptions.data import SubscriptionScheduler
@@ -53,10 +52,14 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
     """
 
     def __init__(
-        self, partitions: int, next_step: ProcessingStrategy[CommittableTick],
+        self,
+        partitions: int,
+        next_step: ProcessingStrategy[CommittableTick],
+        metrics: MetricsBackend,
     ) -> None:
         self.__partitions = partitions
         self.__next_step = next_step
+        self.__metrics = metrics
 
         # Store the last message we received for each partition so know when
         # to commit offsets.
@@ -72,6 +75,8 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
         self.__next_step.poll()
 
     def submit(self, message: Message[Tick]) -> None:
+        start = time.time()
+
         assert not self.__closed
 
         # Update self.__offset_high_watermark
@@ -90,6 +95,8 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
         )
         if should_commit:
             self.__offset_low_watermark = message.offset
+
+        self.__metrics.timing("ProvideCommitStrategy.submit", time.time() - start)
 
     def __should_commit(self, message: Message[Tick]) -> bool:
         return (
@@ -193,6 +200,8 @@ class TickBuffer(ProcessingStrategy[Tick]):
         self.__next_step.poll()
 
     def submit(self, message: Message[Tick]) -> None:
+        start = time.time()
+
         assert not self.__closed
 
         # If the scheduler mode is immediate or there is only one partition
@@ -270,6 +279,8 @@ class TickBuffer(ProcessingStrategy[Tick]):
                 "partition_lag_ms",
                 (self.__latest_ts - earliest_ts).total_seconds() * 1000,
             )
+
+            self.__metrics.timing("TickBuffer.submit", time.time() - start)
 
     def close(self) -> None:
         self.__closed = True
@@ -358,17 +369,18 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
 
     def __init__(
         self,
-        entity_key: EntityKey,
         schedulers: Mapping[int, SubscriptionScheduler],
         producer: Producer[KafkaPayload],
         scheduled_topic_spec: KafkaTopicSpec,
         commit: Callable[[Mapping[Partition, Position]], None],
+        metrics: MetricsBackend,
     ) -> None:
         self.__schedulers = schedulers
         self.__encoder = SubscriptionScheduledTaskEncoder()
         self.__producer = producer
         self.__scheduled_topic = Topic(scheduled_topic_spec.topic_name)
         self.__commit = commit
+        self.__metrics = metrics
         self.__closed = False
 
         # Stores each tick with it's futures
@@ -378,6 +390,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
         self.__max_buffer_size = 10000
 
     def poll(self) -> None:
+        start = time.time()
         # Remove completed tasks from the queue and raise if an exception occurred.
         # This method does not attempt to recover from any exception.
         # Also commits any offsets required.
@@ -404,7 +417,12 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                     }
                 )
 
+        self.__metrics.timing(
+            "ProduceScheduledSubscriptionMessage.poll", time.time() - start
+        )
+
     def submit(self, message: Message[CommittableTick]) -> None:
+        start = time.time()
         assert not self.__closed
 
         # If queue is full, raise MessageRejected to tell the stream
@@ -427,6 +445,10 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                     for task in tasks
                 ]
             ),
+        )
+
+        self.__metrics.timing(
+            "ProduceScheduledSubscriptionMessage.submit", time.time() - start
         )
 
     def close(self) -> None:

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -136,9 +136,7 @@ def test_tick_buffer_wait_slowest() -> None:
 
     assert next_step.submit.call_count == 1
     assert next_step.submit.call_args_list == [mock.call(message_1_0)]
-    assert metrics_backend.calls == [
-        Timing("partition_lag_ms", 6000.0, None),
-    ]
+    assert Timing("partition_lag_ms", 6000.0, None) in metrics_backend.calls
 
     next_step.reset_mock()
     metrics_backend.calls = []
@@ -164,9 +162,7 @@ def test_tick_buffer_wait_slowest() -> None:
         mock.call(message_0_0),
         mock.call(message_1_1),
     ]
-    assert metrics_backend.calls == [
-        Timing("partition_lag_ms", 5000.0, None),
-    ]
+    assert Timing("partition_lag_ms", 5000.0, None) in metrics_backend.calls
 
     next_step.reset_mock()
     metrics_backend.calls = []
@@ -194,9 +190,7 @@ def test_tick_buffer_wait_slowest() -> None:
         mock.call(message_0_1),
         mock.call(message_1_2),
     ]
-    assert metrics_backend.calls == [
-        Timing("partition_lag_ms", 0.0, None),
-    ]
+    assert Timing("partition_lag_ms", 0.0, None) in metrics_backend.calls
 
     next_step.reset_mock()
     metrics_backend.calls = []

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -542,7 +542,6 @@ def test_produce_scheduled_subscription_message() -> None:
     commit = mock.Mock()
 
     strategy = ProduceScheduledSubscriptionMessage(
-        entity_key,
         schedulers,
         producer,
         KafkaTopicSpec(SnubaTopic.SUBSCRIPTION_SCHEDULED_EVENTS),

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -243,7 +243,7 @@ def make_message_for_next_step(
 def test_provide_commit_strategy() -> None:
     epoch = datetime(1970, 1, 1)
     next_step = mock.Mock()
-    strategy = ProvideCommitStrategy(2, next_step)
+    strategy = ProvideCommitStrategy(2, next_step, TestingMetricsBackend())
 
     topic = Topic("messages")
     partition = Partition(topic, 0)
@@ -350,7 +350,7 @@ def test_tick_buffer_with_commit_strategy() -> None:
         SchedulingWatermarkMode.GLOBAL,
         2,
         10,
-        ProvideCommitStrategy(2, next_step),
+        ProvideCommitStrategy(2, next_step, metrics_backend),
         metrics_backend,
     )
 
@@ -546,6 +546,7 @@ def test_produce_scheduled_subscription_message() -> None:
         producer,
         KafkaTopicSpec(SnubaTopic.SUBSCRIPTION_SCHEDULED_EVENTS),
         commit,
+        metrics_backend,
     )
 
     message = Message(


### PR DESCRIPTION
Records a bunch of metrics in each of the subscription scheduler processing
steps. The goal of this is to get a sense of which processing steps are the
ones where the scheduler is spending the most time (and may be worth trying
to improve).