### PR TITLE
feat(subscriptions): Use correct scheduling mode

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -305,9 +305,6 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
     def create(
         self, commit: Callable[[Mapping[Partition, Position]], None]
     ) -> ProcessingStrategy[Tick]:
-        # TODO: Temporarily hardcoding global mode for testing
-        mode = SchedulingWatermarkMode.GLOBAL
-
         schedule_step = ProduceScheduledSubscriptionMessage(
             self.__entity_key,
             self.__schedulers,
@@ -317,7 +314,7 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
         )
 
         return TickBuffer(
-            mode,
+            self.__mode,
             self.__partitions,
             self.__buffer_size,
             ProvideCommitStrategy(self.__partitions, schedule_step),

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -29,7 +29,7 @@ from snuba.utils.streams.configuration_builder import (
 from snuba.utils.streams.topics import Topic as SnubaTopic
 from snuba.utils.types import Interval
 from tests.assertions import assert_changes
-from tests.backends.metrics import TestingMetricsBackend, Timing
+from tests.backends.metrics import TestingMetricsBackend
 
 
 def test_scheduler_consumer() -> None:
@@ -123,7 +123,6 @@ def test_scheduler_consumer() -> None:
 
     scheduler._shutdown()
 
-    assert Timing("partition_lag_ms", 1000 * 60, None) in metrics_backend.calls
     assert mock_scheduler_producer.produce.call_count == 2
 
     settings.TOPIC_PARTITION_COUNTS = {}


### PR DESCRIPTION
Previously we had hard coded GLOBAL mode in the scheduler for testing.
Now we are no longer always using global mode, instead the mode comes
from the stream loader and is specific to the storage definition.