### PR TITLE
feat(subscriptions): Default load factor comes from settings

### DIFF
--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -6,7 +6,7 @@ import click
 from arroyo import configure_metrics
 from arroyo.backends.kafka import KafkaProducer
 
-from snuba import environment
+from snuba import environment, settings
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.environment import setup_logging, setup_sentry
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--load-factor",
     type=int,
-    default=1,
+    default=settings.SUBSCRIPTIONS_SCHEDULER_LOAD_FACTOR,
     help="Temporary option to simulate additional load. To be removed after testing.",
 )
 def subscriptions_scheduler(
@@ -60,7 +60,7 @@ def subscriptions_scheduler(
     schedule_ttl: int,
     log_level: Optional[str],
     delay_seconds: Optional[int],
-    load_factor: int = 1,
+    load_factor: int,
 ) -> None:
     """
     The subscriptions scheduler's job is to schedule subscriptions for a single entity.

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -163,6 +163,9 @@ ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", 
 SUBSCRIPTIONS_DEFAULT_BUFFER_SIZE = 10000
 SUBSCRIPTIONS_ENTITY_BUFFER_SIZE: Mapping[str, int] = {}  # (entity name, buffer size)
 
+# Temporary setting for subscription scheduler test
+SUBSCRIPTIONS_SCHEDULER_LOAD_FACTOR = 1
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment


### PR DESCRIPTION
This change uses settings.SUBSCRIPTIONS_SCHEDULER_LOAD_FACTOR
as the default value for the load test. This allows us to
scale the load test up and down via code changes (and without
involvement from ops).