### PR TITLE
fix(subscriptions): Fix executor metrics namespace

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -64,7 +64,7 @@ def subscriptions_executor(
     setup_sentry()
 
     metrics = MetricsWrapper(
-        environment.metrics, "subscriptions.scheduler", tags={"entity": entity_name}
+        environment.metrics, "subscriptions.executor", tags={"entity": entity_name}
     )
 
     configure_metrics(StreamMetricsAdapter(metrics))


### PR DESCRIPTION
Incorrectly copied from scheduler, we need to actually put the executor
metrics under a different namespace.