### PR TITLE
perf: Omit redundant information from scheduled subscription message

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -237,10 +237,10 @@ class Subscription(NamedTuple):
     data: SubscriptionData
 
 
-class SubscriptionWithTick(NamedTuple):
+class SubscriptionWithMetadata(NamedTuple):
     entity: EntityKey
     subscription: Subscription
-    tick: Tick
+    tick_upper_offset: int
 
 
 @dataclass(frozen=True)
@@ -254,7 +254,7 @@ class ScheduledSubscriptionTask:
     timestamp: datetime
 
     # The task that should be executed.
-    task: SubscriptionWithTick
+    task: SubscriptionWithMetadata
 
 
 class SubscriptionScheduler(ABC):

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -405,8 +405,6 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
             if not tick_subscription.subscription_future.done():
                 break
 
-            tick_subscription.subscription_future.result()
-
             self.__queue.popleft()
 
             if tick_subscription.should_commit:

--- a/snuba/subscriptions/utils.py
+++ b/snuba/subscriptions/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Mapping, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 from snuba.utils.types import Interval
 
@@ -28,25 +28,4 @@ class Tick(NamedTuple):
             self.partition,
             self.offsets,
             Interval(self.timestamps.lower + delta, self.timestamps.upper + delta),
-        )
-
-    def to_dict(self) -> Mapping[str, Any]:
-        return {
-            "partition": self.partition,
-            "offsets": [self.offsets.lower, self.offsets.upper],
-            "timestamps": [
-                self.timestamps.lower.isoformat(),
-                self.timestamps.upper.isoformat(),
-            ],
-        }
-
-    @classmethod
-    def from_dict(cls, data: Mapping[str, Any]) -> Tick:
-        return cls(
-            data["partition"],
-            Interval(data["offsets"][0], data["offsets"][1]),
-            Interval(
-                datetime.fromisoformat(data["timestamps"][0]),
-                datetime.fromisoformat(data["timestamps"][1]),
-            ),
         )

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -22,7 +22,7 @@ from snuba.subscriptions.data import (
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
-    SubscriptionWithTick,
+    SubscriptionWithMetadata,
 )
 from snuba.subscriptions.entity_subscription import (
     EntitySubscription,
@@ -30,10 +30,8 @@ from snuba.subscriptions.entity_subscription import (
     SessionsSubscription,
     SubscriptionType,
 )
-from snuba.subscriptions.utils import Tick
 from snuba.subscriptions.worker import SubscriptionTaskResult
 from snuba.utils.metrics.timer import Timer
-from snuba.utils.types import Interval
 
 
 def build_snql_subscription_data(
@@ -148,17 +146,13 @@ def test_subscription_task_result_encoder() -> None:
     task_result = SubscriptionTaskResult(
         ScheduledSubscriptionTask(
             timestamp,
-            SubscriptionWithTick(
+            SubscriptionWithMetadata(
                 EntityKey.EVENTS,
                 Subscription(
                     SubscriptionIdentifier(PartitionId(1), uuid.uuid1()),
                     subscription_data,
                 ),
-                Tick(
-                    0,
-                    Interval(1, 5),
-                    Interval(datetime(1970, 1, 1), datetime(1970, 1, 2)),
-                ),
+                5,
             ),
         ),
         (request, result),
@@ -214,17 +208,13 @@ def test_sessions_subscription_task_result_encoder() -> None:
     task_result = SubscriptionTaskResult(
         ScheduledSubscriptionTask(
             timestamp,
-            SubscriptionWithTick(
+            SubscriptionWithMetadata(
                 EntityKey.EVENTS,
                 Subscription(
                     SubscriptionIdentifier(PartitionId(1), uuid.uuid1()),
                     subscription_data,
                 ),
-                Tick(
-                    0,
-                    Interval(1, 5),
-                    Interval(datetime(1970, 1, 1), datetime(1970, 1, 2)),
-                ),
+                5,
             ),
         ),
         (request, result),
@@ -258,17 +248,17 @@ def test_subscription_task_encoder() -> None:
 
     epoch = datetime(1970, 1, 1)
 
-    tick = Tick(0, Interval(1, 5), Interval(datetime(1970, 1, 1), datetime(1970, 1, 2)))
+    tick_upper_offset = 5
 
-    subscription_with_tick = SubscriptionWithTick(
+    subscription_with_metadata = SubscriptionWithMetadata(
         EntityKey.EVENTS,
         Subscription(
             SubscriptionIdentifier(PartitionId(1), subscription_id), subscription_data
         ),
-        tick,
+        tick_upper_offset,
     )
 
-    task = ScheduledSubscriptionTask(timestamp=epoch, task=subscription_with_tick)
+    task = ScheduledSubscriptionTask(timestamp=epoch, task=subscription_with_metadata)
 
     encoded = encoder.encode(task)
 
@@ -280,7 +270,7 @@ def test_subscription_task_encoder() -> None:
         b'"entity":"events",'
         b'"task":{'
         b'"data":{"type":"snql","project_id":1,"time_window":60,"resolution":60,"query":"MATCH events SELECT count()"}},'
-        b'"tick":{"partition":0,"offsets":[1,5],"timestamps":["1970-01-01T00:00:00","1970-01-02T00:00:00"]}'
+        b'"tick_upper_offset":5'
         b"}"
     )
 

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -11,7 +11,7 @@ from snuba.subscriptions.data import (
     SnQLSubscriptionData,
     Subscription,
     SubscriptionIdentifier,
-    SubscriptionWithTick,
+    SubscriptionWithMetadata,
 )
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
@@ -89,8 +89,10 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now + timedelta(minutes=-10 + i),
-                    SubscriptionWithTick(
-                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    SubscriptionWithMetadata(
+                        EntityKey.EVENTS,
+                        subscription,
+                        self.build_tick(start, end).offsets.upper,
                     ),
                 )
                 for i in range(10)
@@ -109,8 +111,10 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now + timedelta(minutes=-10 + i),
-                    SubscriptionWithTick(
-                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    SubscriptionWithMetadata(
+                        EntityKey.EVENTS,
+                        subscription,
+                        self.build_tick(start, end).offsets.upper,
                     ),
                 )
                 for i in range(10)
@@ -136,8 +140,10 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now,
-                    SubscriptionWithTick(
-                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    SubscriptionWithMetadata(
+                        EntityKey.EVENTS,
+                        subscription,
+                        self.build_tick(start, end).offsets.upper,
                     ),
                 )
             ],
@@ -155,8 +161,10 @@ class TestSubscriptionScheduler:
             expected=[
                 ScheduledSubscriptionTask(
                     self.now,
-                    SubscriptionWithTick(
-                        EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                    SubscriptionWithMetadata(
+                        EntityKey.EVENTS,
+                        subscription,
+                        self.build_tick(start, end).offsets.upper,
                     ),
                 )
             ],
@@ -170,16 +178,20 @@ class TestSubscriptionScheduler:
         expected = [
             ScheduledSubscriptionTask(
                 self.now + timedelta(minutes=-10 + i),
-                SubscriptionWithTick(
-                    EntityKey.EVENTS, subscription, self.build_tick(start, end)
+                SubscriptionWithMetadata(
+                    EntityKey.EVENTS,
+                    subscription,
+                    self.build_tick(start, end).offsets.upper,
                 ),
             )
             for i in range(10)
         ] + [
             ScheduledSubscriptionTask(
                 self.now + timedelta(minutes=-10 + i),
-                SubscriptionWithTick(
-                    EntityKey.EVENTS, other_subscription, self.build_tick(start, end)
+                SubscriptionWithMetadata(
+                    EntityKey.EVENTS,
+                    other_subscription,
+                    self.build_tick(start, end).offsets.upper,
                 ),
             )
             for i in range(0, 10, 2)

--- a/tests/subscriptions/test_task_builder.py
+++ b/tests/subscriptions/test_task_builder.py
@@ -8,7 +8,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.subscriptions.data import (
     ScheduledSubscriptionTask,
     Subscription,
-    SubscriptionWithTick,
+    SubscriptionWithMetadata,
 )
 from snuba.subscriptions.scheduler import (
     DelegateTaskBuilder,
@@ -42,7 +42,7 @@ TEST_CASES = [
                 ALIGNED_TIMESTAMP,
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
-                    SubscriptionWithTick(
+                    SubscriptionWithMetadata(
                         EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(ALIGNED_TIMESTAMP, ALIGNED_TIMESTAMP + 60),
@@ -83,7 +83,7 @@ TEST_CASES = [
                     # jitter so that the query time range is still aligned
                     # to the minute without jitter.
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
-                    SubscriptionWithTick(
+                    SubscriptionWithMetadata(
                         EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
@@ -125,7 +125,7 @@ TEST_CASES = [
                 ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
-                    SubscriptionWithTick(
+                    SubscriptionWithMetadata(
                         EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
@@ -148,7 +148,7 @@ TEST_CASES = [
                 ALIGNED_TIMESTAMP,
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
-                    SubscriptionWithTick(
+                    SubscriptionWithMetadata(
                         EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=2), 0),
                         build_tick(ALIGNED_TIMESTAMP, ALIGNED_TIMESTAMP + 60),
@@ -174,7 +174,7 @@ TEST_CASES = [
                 ALIGNED_TIMESTAMP + UUIDS[0].int % 60,
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP),
-                    SubscriptionWithTick(
+                    SubscriptionWithMetadata(
                         EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
@@ -213,7 +213,7 @@ TEST_CASES = [
                 ALIGNED_TIMESTAMP + UUIDS[0].int % 60 + 60,
                 ScheduledSubscriptionTask(
                     datetime.fromtimestamp(ALIGNED_TIMESTAMP + 60),
-                    SubscriptionWithTick(
+                    SubscriptionWithMetadata(
                         EntityKey.EVENTS,
                         build_subscription(timedelta(minutes=1), 0),
                         build_tick(
@@ -261,7 +261,7 @@ def test_sequences(
             ),
         )
         ret = builder.get_task(
-            SubscriptionWithTick(EntityKey.EVENTS, subscription, tick), timestamp
+            SubscriptionWithMetadata(EntityKey.EVENTS, subscription, tick), timestamp
         )
         if ret:
             output.append((timestamp, ret))


### PR DESCRIPTION
This change attempts to improve the performance of the scheduler by
reducing the size of the scheduled message and minimizing the amount
of work that the encoder needs to do. Previously we were encoding
and producing the entire tick to the scheduled subscription topic.
However the only part we actually need in order to build the request
is the upper offset.