### PR TITLE
feat(subscriptions): Execute query submits SubscriptionTaskResult to next step

### DIFF
--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -13,10 +13,10 @@ from snuba.subscriptions.data import (
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
+    SubscriptionTaskResult,
     SubscriptionWithTick,
 )
 from snuba.subscriptions.utils import Tick
-from snuba.subscriptions.worker import SubscriptionTaskResult
 from snuba.utils.codecs import Codec, Encoder
 
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractclassmethod, abstractmethod
+from concurrent.futures import Future
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import partial
@@ -13,6 +14,7 @@ from typing import (
     NewType,
     Optional,
     Sequence,
+    Tuple,
     Union,
 )
 from uuid import UUID
@@ -30,6 +32,7 @@ from snuba.query.conditions import (
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.logical import Query
+from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.request_settings import SubscriptionRequestSettings
 from snuba.request.schema import RequestSchema
@@ -273,3 +276,13 @@ class SubscriptionScheduler(ABC):
         ascending order.
         """
         raise NotImplementedError
+
+
+class SubscriptionTaskResultFuture(NamedTuple):
+    task: ScheduledSubscriptionTask
+    future: Future[Tuple[Request, Result]]
+
+
+class SubscriptionTaskResult(NamedTuple):
+    task: ScheduledSubscriptionTask
+    result: Tuple[Request, Result]

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -6,8 +6,8 @@ import logging
 import math
 import random
 import time
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from typing import List, Mapping, NamedTuple, Optional, Sequence, Tuple
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Mapping, Optional, Sequence, Tuple
 
 from arroyo import Message, Topic
 from arroyo.backends.abstract import Producer
@@ -19,7 +19,12 @@ from snuba.datasets.factory import get_dataset_name
 from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.request_settings import SubscriptionRequestSettings
-from snuba.subscriptions.data import ScheduledSubscriptionTask, SubscriptionScheduler
+from snuba.subscriptions.data import (
+    ScheduledSubscriptionTask,
+    SubscriptionScheduler,
+    SubscriptionTaskResult,
+    SubscriptionTaskResultFuture,
+)
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
@@ -31,16 +36,6 @@ from snuba.utils.threaded_function_delegator import ThreadedFunctionDelegator
 from snuba.web.query import parse_and_run_query
 
 logger = logging.getLogger("snuba.subscriptions")
-
-
-class SubscriptionTaskResultFuture(NamedTuple):
-    task: ScheduledSubscriptionTask
-    future: Future[Tuple[Request, Result]]
-
-
-class SubscriptionTaskResult(NamedTuple):
-    task: ScheduledSubscriptionTask
-    result: Tuple[Request, Result]
 
 
 class SubscriptionWorker(

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -22,6 +22,7 @@ from snuba.subscriptions.data import (
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
+    SubscriptionTaskResult,
     SubscriptionWithTick,
 )
 from snuba.subscriptions.entity_subscription import (
@@ -31,7 +32,6 @@ from snuba.subscriptions.entity_subscription import (
     SubscriptionType,
 )
 from snuba.subscriptions.utils import Tick
-from snuba.subscriptions.worker import SubscriptionTaskResult
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.types import Interval
 

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -170,7 +170,7 @@ def test_execute_query_strategy() -> None:
 
     assert next_step.submit.call_args[0][0].timestamp == message.timestamp
     assert next_step.submit.call_args[0][0].offset == message.offset
-    assert next_step.submit.call_args[0][0].payload.result()[1] == {
+    assert next_step.submit.call_args[0][0].payload.result[1] == {
         "data": [{"count()": 0}],
         "meta": [{"name": "count()", "type": "UInt64"}],
     }

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -29,16 +29,13 @@ from snuba.subscriptions.data import (
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
+    SubscriptionTaskResult,
 )
 from snuba.subscriptions.entity_subscription import SessionsSubscription
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.store import SubscriptionDataStore
 from snuba.subscriptions.utils import Tick
-from snuba.subscriptions.worker import (
-    SubscriptionTaskResult,
-    SubscriptionWorker,
-    handle_nan,
-)
+from snuba.subscriptions.worker import SubscriptionWorker, handle_nan
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from snuba.utils.types import Interval
 from tests.backends.metrics import Increment, TestingMetricsBackend


### PR DESCRIPTION
The next processing step after ExecuteQuery will be responsible for encoding the
SubscriptionTaskResult and producing it to the result topic. Since we are going to
reuse the SubscriptionTaskResultEncoder (from the existing pipeline) we need to use
the same SubscriptionTaskResult class (previously they were two distinct classes
in the old and new pipeline).

Since the future is already completed by the time we pass the task to the next step
we should also just submit the actual SubscriptionTaskResult instead of the
SubscriptionTaskResultFuture.