### PR TITLE
feat(subscriptions): Use float for timestamp instead of date time string

### DIFF
--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -73,7 +73,7 @@ class SubscriptionScheduledTaskEncoder(Codec[KafkaPayload, ScheduledSubscription
                 str,
                 rapidjson.dumps(
                     {
-                        "timestamp": value.timestamp.isoformat(),
+                        "timestamp": value.timestamp.timestamp(),
                         "entity": entity.value,
                         "task": {"data": value.task.subscription.data.to_dict()},
                         "tick_upper_offset": tick_upper_offset,
@@ -95,7 +95,7 @@ class SubscriptionScheduledTaskEncoder(Codec[KafkaPayload, ScheduledSubscription
         entity_key = EntityKey(scheduled_subscription_dict["entity"])
 
         return ScheduledSubscriptionTask(
-            datetime.fromisoformat(scheduled_subscription_dict["timestamp"]),
+            datetime.fromtimestamp(scheduled_subscription_dict["timestamp"]),
             SubscriptionWithMetadata(
                 entity_key,
                 Subscription(

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -266,7 +266,7 @@ def test_subscription_task_encoder() -> None:
 
     assert encoded.value == (
         b"{"
-        b'"timestamp":"1970-01-01T00:00:00",'
+        b'"timestamp":28800.0,'
         b'"entity":"events",'
         b'"task":{'
         b'"data":{"type":"snql","project_id":1,"time_window":60,"resolution":60,"query":"MATCH events SELECT count()"}},'


### PR DESCRIPTION
Smaller and faster to decode. This change is safe to deploy since we are
not running an executor (and hence decoding) yet.