### PR TITLE
feat(admin): validate by node list in query admin tool

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -94,8 +94,8 @@ class ActivePartitions(SystemQuery):
 
 
 def _is_valid_node(host: str, port: int, cluster: ClickhouseCluster) -> bool:
-    connection_id = cluster.get_connection_id()
-    return host == connection_id.hostname and port == connection_id.tcp_port
+    nodes = cluster.get_local_nodes()
+    return any(node.host_name == host and node.port == port for node in nodes)
 
 
 def run_system_query_on_host_by_name(


### PR DESCRIPTION
Rather than enforce using the main query node, validate by the list of nodes in the ClickHouse cluster