### PR TITLE
feat(admin): Allow % in extra part of system query

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -166,7 +166,7 @@ SYSTEM_QUERY_RE = re.compile(
         (FROM|from)
         \s
         system.[a-z_]+
-        (?P<extra>\s[\w\s,=+\(\)']+)?
+        (?P<extra>\s[\w\s,=+\(\)'%]+)?
         ;? # Optional semicolon
         $ # End
     """,


### PR DESCRIPTION
Support queries like 'WHERE some_column LIKE '%something%'