### PR TITLE
feat(freight): Deploy subscriptions executor with Freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -33,6 +33,8 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-scheduler
   - image: us.gcr.io/sentryio/snuba:{sha}
+    name: events-subscriptions-executor
+  - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: sessions-subscriptions-consumer


### PR DESCRIPTION
Just noticed that https://github.com/getsentry/snuba/commit/ffad626c8e8701fc5bddcdc6d8a84c508c8c90b7
didn't get deployed since we never actually added the executor here.