### PR TITLE
Fix redundant clause optimizer not capturing experiment data

### DIFF
--- a/snuba/query/processors/mapping_optimizer.py
+++ b/snuba/query/processors/mapping_optimizer.py
@@ -268,6 +268,8 @@ class MappingOptimizer(QueryProcessor):
                     if requested_tag in tag_eq_match_strings:
                         if should_apply_optimization:
                             query.add_experiment("redundant_clause_removed", 1)
+                            # the clause is redundant, thus we continue the loop
+                            # and do not add it to useful_conditions
                             continue
                         else:
                             query.add_experiment("redundant_clause_removed", 0)

--- a/tests/query/processors/test_mapping_optimizer_no_useless_conditions.py
+++ b/tests/query/processors/test_mapping_optimizer_no_useless_conditions.py
@@ -337,7 +337,7 @@ def test_experiment() -> None:
         killswitch="tags_hash_map_enabled",
     ).process_query(query, HTTPRequestSettings())
     assert query.get_experiment_value("tags_redundant_optimizer_enabled") == 0
-    assert query.get_experiment_value("redundant_clause_removed") is None
+    assert query.get_experiment_value("redundant_clause_removed") == 0
     assert query == build_query(
         selected_columns=[Column("count", None, "count")],
         condition=and_exp(tag_existence_expression(), tag_equality_expression()),


### PR DESCRIPTION
### Problem
The redundant clause optimizer was capturing when it was applying the optimization but not when it wasn't. This made analyzing its effects difficult

### Solution
At the moment the optimization is supposed to be applied, add an experiment value for when it is not. 