### PR TITLE
fix(arm64) Fix tests so they work on arm64 as well

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import calendar
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -169,7 +171,7 @@ def get_raw_event() -> InsertEvent:
     }
 
 
-def get_raw_transaction() -> InsertEvent:
+def get_raw_transaction(span_id: str | None = None) -> InsertEvent:
     now = datetime.utcnow().replace(
         minute=0, second=0, microsecond=0, tzinfo=timezone.utc
     )
@@ -177,7 +179,7 @@ def get_raw_transaction() -> InsertEvent:
     end_timestamp = now - timedelta(seconds=2)
     event_received = now - timedelta(seconds=1)
     trace_id = uuid.UUID("7400045b-25c4-43b8-8591-4600aa83ad04")
-    span_id = "8841662216cc598b"
+    span_id = "8841662216cc598b" if not span_id else span_id
 
     return {
         "project_id": PROJECT_ID,

--- a/tests/migrations/test_runner_individual.py
+++ b/tests/migrations/test_runner_individual.py
@@ -119,7 +119,7 @@ def generate_transactions() -> None:
     rows = []
 
     for i in range(5):
-        raw_transaction = get_raw_transaction()
+        raw_transaction = get_raw_transaction(f"{i}" * 16)
         # Older versions of this table did not have measurements
         del raw_transaction["data"]["measurements"]
         del raw_transaction["data"]["breakdowns"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ class TestCli(object):
         """
         Check that the consumer daemon runs until it is killed
         """
-        proc = subprocess.Popen(["snuba", "consumer"])
+        proc = subprocess.Popen(["snuba", "consumer", "--storage", "events"])
         time.sleep(1)
         proc.poll()
         assert proc.returncode is None  # still running

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -293,8 +293,8 @@ class TestSnQLApi(BaseApiTest):
                         {
                             "query": f"""MATCH (events)
                             SELECT event_id, title, transaction, tags[a], tags[b], message, project_id
-                            WHERE timestamp >= toDateTime('2021-01-01')
-                            AND timestamp < toDateTime('2022-01-01')
+                            WHERE timestamp >= toDateTime('{self.base_time.isoformat()}')
+                            AND timestamp < toDateTime('{self.next_time.isoformat()}')
                             AND project_id IN tuple({self.project_id})
                             LIMIT 5""",
                         }

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -70,7 +70,7 @@ class TestTransactionsApi(BaseApiTest):
                 # project N sends an event every Nth minute
                 if tock % p == 0:
                     trace_id = "7400045b25c443b885914600aa83ad04"
-                    span_id = "8841662216cc598b"
+                    span_id = f"8841662216cc598b{tock}"[-16:]
                     processed = (
                         self.storage.get_table_writer()
                         .get_stream_loader()
@@ -176,7 +176,7 @@ class TestTransactionsApi(BaseApiTest):
                 {
                     "dataset": "transactions",
                     "project": 1,
-                    "selected_columns": ["transaction_name", "ip_address"],
+                    "selected_columns": ["transaction_name", "ip_address", "span_id"],
                     "from_date": (self.base_time - self.skew).isoformat(),
                     "to_date": (self.base_time + self.skew).isoformat(),
                     "orderby": "start_ts",
@@ -194,7 +194,7 @@ class TestTransactionsApi(BaseApiTest):
                 {
                     "dataset": "transactions",
                     "project": 1,
-                    "selected_columns": ["transaction_op", "platform"],
+                    "selected_columns": ["transaction_op", "platform", "span_id"],
                     "from_date": (self.base_time - self.skew).isoformat(),
                     "to_date": (self.base_time + self.skew).isoformat(),
                     "orderby": "start_ts",
@@ -213,7 +213,7 @@ class TestTransactionsApi(BaseApiTest):
                 {
                     "dataset": "transactions",
                     "project": 1,
-                    "selected_columns": ["transaction_name"],
+                    "selected_columns": ["transaction_name", "span_id"],
                     "conditions": [
                         [
                             "start_ts",
@@ -274,6 +274,7 @@ class TestTransactionsApi(BaseApiTest):
                     "selected_columns": ["event_id", "ip_address", "project_id"],
                     "from_date": (self.base_time - self.skew).isoformat(),
                     "to_date": (self.base_time + self.skew).isoformat(),
+                    "orderby": ["finish_ts"],
                 }
             ),
         )
@@ -303,7 +304,7 @@ class TestTransactionsApi(BaseApiTest):
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 1
         assert data["data"][0]["event_id"] == first_event_id
-        assert data["data"][0]["span_id"] == "8841662216cc598b"
+        assert data["data"][0]["span_id"] == "841662216cc598b1"
 
     def test_trace_column_formatting(self) -> None:
         response = self.post(
@@ -599,7 +600,7 @@ class TestTransactionsApi(BaseApiTest):
                     "dataset": "transactions",
                     "project": 1,
                     "selected_columns": ["event_id", "span_id"],
-                    "conditions": [["span_id", "=", "8841662216cc598b"]],
+                    "conditions": [["span_id", "=", "841662216cc598b1"]],
                     "limit": 1,
                     "orderby": ["event_id"],
                     "from_date": (self.base_time - self.skew).isoformat(),
@@ -610,7 +611,7 @@ class TestTransactionsApi(BaseApiTest):
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
 
-        assert data["data"][0]["span_id"] == "8841662216cc598b"
+        assert data["data"][0]["span_id"] == "841662216cc598b1"
 
         response = self.post(
             json.dumps(
@@ -618,7 +619,7 @@ class TestTransactionsApi(BaseApiTest):
                     "dataset": "transactions",
                     "project": 1,
                     "selected_columns": ["event_id", "span_id"],
-                    "conditions": [["span_id", "IN", ["8841662216cc598b"]]],
+                    "conditions": [["span_id", "IN", ["841662216cc598b1"]]],
                     "limit": 1,
                     "orderby": ["event_id"],
                     "from_date": (self.base_time - self.skew).isoformat(),
@@ -629,7 +630,7 @@ class TestTransactionsApi(BaseApiTest):
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
 
-        assert data["data"][0]["span_id"] == "8841662216cc598b"
+        assert data["data"][0]["span_id"] == "841662216cc598b1"
 
     def test_limitby_multicolumn(self) -> None:
         query_str = """MATCH (transactions)


### PR DESCRIPTION
This is mostly fixing a bug with our current tests, where in the old version of
Clickhouse the events are not being merged before the tests run. In the new
version of Clickhouse the events are merged before the tests, and since the
fixtures all use the same span_id, they are actually only sending one event.
