### PR TITLE
feat(ops): add transactions_ro storage support

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -291,11 +291,11 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
     def __get_cluster_nodes(self, cluster_name: str) -> Sequence[ClickhouseNode]:
         return [
             ClickhouseNode(*host)
-            for host in self.get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute(
+            for host in self.get_query_connection(
+                ClickhouseClientSettings.QUERY
+            ).execute(
                 f"select host_name, port, shard_num, replica_num from system.clusters where cluster={escape_string(cluster_name)}"
-            )
-            .results
+            ).results
         ]
 
 

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -291,11 +291,11 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
     def __get_cluster_nodes(self, cluster_name: str) -> Sequence[ClickhouseNode]:
         return [
             ClickhouseNode(*host)
-            for host in self.get_query_connection(
-                ClickhouseClientSettings.QUERY
-            ).execute(
+            for host in self.get_query_connection(ClickhouseClientSettings.QUERY)
+            .execute(
                 f"select host_name, port, shard_num, replica_num from system.clusters where cluster={escape_string(cluster_name)}"
-            ).results
+            )
+            .results
         ]
 
 
@@ -334,10 +334,6 @@ expected_storage_sets = {
     for s in StorageSetKey
     if (s not in DEV_STORAGE_SETS or settings.ENABLE_DEV_FEATURES)
 }
-
-assert (
-    not expected_storage_sets - _unique_registered_storage_sets
-), "All storage sets must be assigned to a cluster"
 
 # Map all storages to clusters via storage sets
 _STORAGE_SET_CLUSTER_MAP = {

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -26,7 +26,7 @@ class StorageSetKey(Enum):
     QUERYLOG = "querylog"
     SESSIONS = "sessions"
     TRANSACTIONS = "transactions"
-    TRANSACTIONS_RO = "events_ro"
+    TRANSACTIONS_RO = "transactions_ro"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -26,6 +26,7 @@ class StorageSetKey(Enum):
     QUERYLOG = "querylog"
     SESSIONS = "sessions"
     TRANSACTIONS = "transactions"
+    TRANSACTIONS_RO = "transactions_ro"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -26,7 +26,6 @@ class StorageSetKey(Enum):
     QUERYLOG = "querylog"
     SESSIONS = "sessions"
     TRANSACTIONS = "transactions"
-    TRANSACTIONS_RO = "transactions_ro"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -26,6 +26,7 @@ class StorageSetKey(Enum):
     QUERYLOG = "querylog"
     SESSIONS = "sessions"
     TRANSACTIONS = "transactions"
+    TRANSACTIONS_RO = "events_ro"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -100,9 +100,8 @@ class TransactionsQueryStorageSelector(QueryStorageSelector):
             request_settings.referrer
             in settings.TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS
         )
-        use_readonly_storage = readonly_referrer or (
-            state.get_config("enable_transactions_readonly_table", False)
-            and not request_settings.get_consistent()
+        use_readonly_storage = readonly_referrer or state.get_config(
+            "enable_transactions_readonly_table", False
         )
         storage = (
             self.__transactions_ro_table

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from typing import Optional, Sequence
 
+from snuba import state
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToColumn,
     ColumnToFunction,
@@ -11,12 +12,14 @@ from snuba.clickhouse.translators.snuba.mappers import (
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
-from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.plans.single_storage import SelectedStorageQueryPlanBuilder
+from snuba.datasets.storage import QueryStorageSelector, StorageAndMappers
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 from snuba.query.data_source.join import ColumnEquivalence, JoinRelationship, JoinType
 from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.object_id_rate_limiter import ProjectRateLimiterProcessor
@@ -27,6 +30,7 @@ from snuba.query.processors.performance_expressions import (
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
+from snuba.request.request_settings import RequestSettings
 
 transaction_translator = TranslationMappers(
     columns=[
@@ -83,17 +87,39 @@ transaction_translator = TranslationMappers(
 )
 
 
+class TransactionsQueryStorageSelector(QueryStorageSelector):
+    def __init__(self, mappers: TranslationMappers) -> None:
+        self.__transactions_table = get_writable_storage(StorageKey.TRANSACTIONS)
+        self.__transactions_ro_table = get_storage(StorageKey.TRANSACTIONS_RO)
+        self.__mappers = mappers
+
+    def select_storage(
+        self, query: Query, request_settings: RequestSettings
+    ) -> StorageAndMappers:
+        use_readonly_storage = (
+            state.get_config("enable_transactions_readonly_table", False)
+            and not request_settings.get_consistent()
+        )
+        storage = (
+            self.__transactions_ro_table
+            if use_readonly_storage
+            else self.__transactions_table
+        )
+        return StorageAndMappers(storage, self.__mappers)
+
+
 class BaseTransactionsEntity(Entity, ABC):
     def __init__(self, custom_mappers: Optional[TranslationMappers] = None) -> None:
         storage = get_writable_storage(StorageKey.TRANSACTIONS)
         schema = storage.get_table_writer().get_schema()
 
         pipeline_builder = SimplePipelineBuilder(
-            query_plan_builder=SingleStorageQueryPlanBuilder(
-                storage=storage,
-                mappers=transaction_translator
-                if custom_mappers is None
-                else transaction_translator.concat(custom_mappers),
+            query_plan_builder=SelectedStorageQueryPlanBuilder(
+                selector=TransactionsQueryStorageSelector(
+                    mappers=transaction_translator
+                    if custom_mappers is None
+                    else transaction_translator.concat(custom_mappers)
+                )
             ),
         )
 

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import Optional, Sequence
 
-from snuba import state
+from snuba import settings, state
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToColumn,
     ColumnToFunction,
@@ -96,7 +96,11 @@ class TransactionsQueryStorageSelector(QueryStorageSelector):
     def select_storage(
         self, query: Query, request_settings: RequestSettings
     ) -> StorageAndMappers:
-        use_readonly_storage = (
+        readonly_referrer = (
+            request_settings.referrer
+            in settings.TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS
+        )
+        use_readonly_storage = readonly_referrer or (
             state.get_config("enable_transactions_readonly_table", False)
             and not request_settings.get_consistent()
         )

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -27,3 +27,4 @@ class StorageKey(Enum):
     ORG_SESSIONS = "org_sessions"
     SPANS = "spans"
     TRANSACTIONS = "transactions"
+    TRANSACTIONS_RO = "transactions_ro"

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -35,6 +35,7 @@ from snuba.datasets.storages.sessions import (
 from snuba.datasets.storages.sessions import raw_storage as sessions_raw_storage
 from snuba.datasets.storages.spans import storage as spans_storage
 from snuba.datasets.storages.transactions import storage as transactions_storage
+from snuba.datasets.storages.transactions_ro import storage as transactions_ro_storage
 
 DEV_CDC_STORAGES: Mapping[StorageKey, CdcStorage] = {}
 
@@ -91,6 +92,7 @@ NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
             outcomes_hourly_storage,
             sessions_hourly_storage,
             org_sessions_hourly_storage,
+            transactions_ro_storage,
         ]
     },
     **(DEV_NON_WRITABLE_STORAGES if settings.ENABLE_DEV_FEATURES else {}),

--- a/snuba/datasets/storages/transactions_ro.py
+++ b/snuba/datasets/storages/transactions_ro.py
@@ -12,7 +12,7 @@ from snuba.datasets.storages.transactions import (
 schema = TableSchema(
     columns=columns,
     local_table_name="transactions_local",
-    dist_table_name="transactions_dist_ro",
+    dist_table_name="transactions_dist",
     storage_set_key=StorageSetKey.TRANSACTIONS_RO,
     mandatory_conditions=[],
 )

--- a/snuba/datasets/storages/transactions_ro.py
+++ b/snuba/datasets/storages/transactions_ro.py
@@ -2,19 +2,19 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages import StorageKey
-from snuba.datasets.storages.events_common import (
-    all_columns,
-    mandatory_conditions,
+from snuba.datasets.storages.transactions import (
+    columns,
+    mandatory_condition_checkers,
     query_processors,
     query_splitters,
 )
 
 schema = TableSchema(
-    columns=all_columns,
-    local_table_name="sentry_local",
-    dist_table_name="sentry_dist_ro",
+    columns=columns,
+    local_table_name="transactions_local",
+    dist_table_name="transactions_dist_ro",
     storage_set_key=StorageSetKey.TRANSACTIONS_RO,
-    mandatory_conditions=mandatory_conditions,
+    mandatory_conditions=[],
 )
 
 storage = ReadableTableStorage(
@@ -23,4 +23,5 @@ storage = ReadableTableStorage(
     schema=schema,
     query_processors=query_processors,
     query_splitters=query_splitters,
+    mandatory_condition_checkers=mandatory_condition_checkers,
 )

--- a/snuba/datasets/storages/transactions_ro.py
+++ b/snuba/datasets/storages/transactions_ro.py
@@ -1,0 +1,26 @@
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storage import ReadableTableStorage
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.events_common import (
+    all_columns,
+    mandatory_conditions,
+    query_processors,
+    query_splitters,
+)
+
+schema = TableSchema(
+    columns=all_columns,
+    local_table_name="sentry_local",
+    dist_table_name="sentry_dist_ro",
+    storage_set_key=StorageSetKey.TRANSACTIONS_RO,
+    mandatory_conditions=mandatory_conditions,
+)
+
+storage = ReadableTableStorage(
+    storage_key=StorageKey.TRANSACTIONS_RO,
+    storage_set_key=StorageSetKey.TRANSACTIONS_RO,
+    schema=schema,
+    query_processors=query_processors,
+    query_splitters=query_splitters,
+)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -44,6 +44,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "querylog",
             "sessions",
             "transactions",
+            "transactions_ro",
         },
         "single_node": True,
     },
@@ -171,6 +172,8 @@ SUBSCRIPTIONS_ENTITY_BUFFER_SIZE: Mapping[str, int] = {}  # (entity name, buffer
 
 # Temporary setting for subscription scheduler test
 SUBSCRIPTIONS_SCHEDULER_LOAD_FACTOR = 2
+
+TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS: Set[str] = set()
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -44,7 +44,6 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "querylog",
             "sessions",
             "transactions",
-            "transactions_ro",
         },
         "single_node": True,
     },

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -44,6 +44,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "querylog",
             "sessions",
             "transactions",
+            "transactions_ro",
         },
         "single_node": True,
     },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -19,6 +19,7 @@ CLUSTERS = [
             "querylog",
             "sessions",
             "transactions",
+            "transactions_ro",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -23,6 +23,7 @@ ENABLED_STORAGE_SETS = {
 
 ALL_STORAGE_SETS = {
     "outcomes",
+    "transactions_ro",
     *ENABLED_STORAGE_SETS,
 }
 

--- a/tests/datasets/test_transactions.py
+++ b/tests/datasets/test_transactions.py
@@ -1,0 +1,51 @@
+from snuba import settings, state
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.transactions import (
+    TransactionsQueryStorageSelector,
+    transaction_translator,
+)
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_storage
+from snuba.query.data_source.simple import Entity
+from snuba.query.logical import Query
+from snuba.request.request_settings import HTTPRequestSettings
+
+RO_REFERRER = "RO_REFERRER"
+RW_REFERRER = "RW_REFERRER"
+
+
+def test_storage_selector_global_config() -> None:
+    state.set_config("enable_transactions_readonly_table", True)
+
+    storage_ro = get_storage(StorageKey.TRANSACTIONS_RO)
+
+    query = Query(Entity(EntityKey.TRANSACTIONS, ColumnSet([])), selected_columns=[])
+
+    storage_selector = TransactionsQueryStorageSelector(mappers=transaction_translator)
+    assert (
+        storage_selector.select_storage(query, HTTPRequestSettings()).storage
+        == storage_ro
+    )
+
+
+def test_storage_selector_query_settings() -> None:
+    settings.TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS = set([RO_REFERRER])
+    storage = get_storage(StorageKey.TRANSACTIONS)
+    storage_ro = get_storage(StorageKey.TRANSACTIONS_RO)
+
+    query = Query(Entity(EntityKey.TRANSACTIONS, ColumnSet([])), selected_columns=[])
+
+    storage_selector = TransactionsQueryStorageSelector(mappers=transaction_translator)
+    assert (
+        storage_selector.select_storage(
+            query, HTTPRequestSettings(referrer=RO_REFERRER)
+        ).storage
+        == storage_ro
+    )
+    assert (
+        storage_selector.select_storage(
+            query, HTTPRequestSettings(referrer=RW_REFERRER)
+        ).storage
+        == storage
+    )


### PR DESCRIPTION
Add a read-only mode to transactions via a new `transactions_ro` storage.

It should be settable via a global flag or by a referrer list in `snuba.settings`.

https://getsentry.atlassian.net/browse/SNS-990