### PR TITLE
fix(subscriptions) Fix the shutdown process of the scheduler

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -462,6 +462,8 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
     def terminate(self) -> None:
         self.__closed = True
 
+        self.__producer.close()
+
     def join(self, timeout: Optional[float] = None) -> None:
         start = time.time()
 
@@ -485,3 +487,5 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                         )
                     }
                 )
+
+        self.__producer.close()


### PR DESCRIPTION
The new subscriptions scheduler is not shutting down the producer when it terminates. 
This would make the scheduler hang waiting when we close it. 
This fixes it.