### PR TITLE
use https instead of git

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 19.10b0
     hooks:
       - id: black
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:
       - id: check-case-conflict


### PR DESCRIPTION
Prefer https:// over git://.

See: https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective