### PR TITLE
Enforce uniq in HAVING and SELECT

### DIFF
--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -38,6 +38,9 @@ from snuba.query.processors.type_converters.uuid_array_column_processor import (
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
+from snuba.query.processors.uniq_in_select_and_having import (
+    UniqInSelectAndHavingProcessor,
+)
 from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 required_columns = [
@@ -154,6 +157,7 @@ prewhere_candidates = [
 ]
 
 query_processors = [
+    UniqInSelectAndHavingProcessor(),
     PostReplacementConsistencyEnforcer(
         project_column="project_id", replacer_state_name=ReplacerState.ERRORS,
     ),

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -39,6 +39,9 @@ from snuba.query.processors.type_converters.hexint_column_processor import (
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
+from snuba.query.processors.uniq_in_select_and_having import (
+    UniqInSelectAndHavingProcessor,
+)
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 from snuba.web.split import TimeSplitQueryStrategy
@@ -113,6 +116,7 @@ schema = WritableTableSchema(
 )
 
 query_processors = [
+    UniqInSelectAndHavingProcessor(),
     MappingColumnPromoter(
         mapping_specs={
             "tags": {

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -122,6 +122,37 @@ class ExpressionVisitor(ABC, Generic[TVisited]):
         raise NotImplementedError
 
 
+class NoopVisitor(ExpressionVisitor[None]):
+    """A noop visitor that will traverse every node but will not
+    return anything. Good for extending for search purposes
+    """
+
+    def visit_literal(self, exp: Literal) -> None:
+        return None
+
+    def visit_column(self, exp: Column) -> None:
+        return None
+
+    def visit_subscriptable_reference(self, exp: SubscriptableReference) -> None:
+        return exp.column.accept(self)
+
+    def visit_function_call(self, exp: FunctionCall) -> None:
+        for param in exp.parameters:
+            param.accept(self)
+        return None
+
+    def visit_curried_function_call(self, exp: CurriedFunctionCall) -> None:
+        for param in exp.parameters:
+            param.accept(self)
+        return exp.internal_function.accept(self)
+
+    def visit_argument(self, exp: Argument) -> None:
+        return None
+
+    def visit_lambda(self, exp: Lambda) -> None:
+        return exp.transformation.accept(self)
+
+
 class StringifyVisitor(ExpressionVisitor[str]):
     """Visitor implementation to turn an expression into a string format
     Usage:

--- a/snuba/query/processors/uniq_in_select_and_having.py
+++ b/snuba/query/processors/uniq_in_select_and_having.py
@@ -32,10 +32,8 @@ class _ExpressionOrAliasMatcher(NoopVisitor):
         for param in exp.parameters:
             param.accept(self)
         for i, exp_to_match in enumerate(self.expressions_to_match):
-            if (
-                isinstance(exp_to_match, FunctionCall)
-                and exp_to_match.function_name == exp.function_name
-                and exp_to_match.functional_eq(exp)
+            if isinstance(exp_to_match, FunctionCall) and exp_to_match.functional_eq(
+                exp
             ):
                 self.found_expressions[i] = True
 

--- a/snuba/query/processors/uniq_in_select_and_having.py
+++ b/snuba/query/processors/uniq_in_select_and_having.py
@@ -1,13 +1,22 @@
+"""This is a hacky query processor put in for the purpose of
+mitigating clickhouse crashes. When a query is sent to clickhouse
+which has a `uniq` in the `HAVING` clause but not in the `SELECT`
+clause, the query node will crash. This may be fixed with future versions
+of clickhouse but we have not upgraded yet. This exists as a check so that we
+return an exception to the user but don't crash the clickhouse query node
+"""
+
+from dataclasses import fields
 from typing import List, Sequence
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
-from snuba.query.expressions import Column, FunctionCall, NoopVisitor
+from snuba.query.exceptions import InvalidQueryException
+from snuba.query.expressions import Column, Expression, FunctionCall, NoopVisitor
 from snuba.request.request_settings import RequestSettings
-from snuba.utils.serializable_exception import SerializableException
 
 
-class MismatchedAggregationException(SerializableException):
+class MismatchedAggregationException(InvalidQueryException):
     pass
 
 
@@ -24,6 +33,24 @@ class _FunctionNameFindingVisitor(NoopVisitor):
         return None
 
 
+def _expressions_equal_ignore_aliases(exp1: Expression, exp2: Expression) -> bool:
+    if type(exp1) != type(exp2):
+        return False
+    fields_equal = True
+    for field in fields(exp1):
+        if field.name == "alias":
+            continue
+        field_val1 = getattr(exp1, field.name)
+        field_val2 = getattr(exp2, field.name)
+        if isinstance(field_val1, Expression):
+            fields_equal &= _expressions_equal_ignore_aliases(field_val1, field_val2)
+        else:
+            fields_equal &= field_val1 == field_val2
+        if not fields_equal:
+            return False
+    return fields_equal
+
+
 class _ExpressionOrAliasMatcher(NoopVisitor):
     def __init__(self, expressions_to_match: Sequence[FunctionCall]):
         self.expressions_to_match = expressions_to_match
@@ -38,7 +65,10 @@ class _ExpressionOrAliasMatcher(NoopVisitor):
         for param in exp.parameters:
             param.accept(self)
         for i, exp_to_match in enumerate(self.expressions_to_match):
-            if exp_to_match.function_name == exp.function_name and exp_to_match == exp:
+            if (
+                exp_to_match.function_name == exp.function_name
+                and _expressions_equal_ignore_aliases(exp_to_match, exp)
+            ):
                 self.found_expressions[i] = True
 
 
@@ -48,13 +78,13 @@ class UniqInSelectAndHavingProcessor(QueryProcessor):
         if not having_clause:
             return None
         selected_columns = query.get_selected_columns()
-        visitor = _FunctionNameFindingVisitor("uniq")
-        having_clause.accept(visitor)
-        if visitor.found_functions:
-            matcher = _ExpressionOrAliasMatcher(visitor.found_functions)
+        uniq_finder = _FunctionNameFindingVisitor("uniq")
+        having_clause.accept(uniq_finder)
+        if uniq_finder.found_functions:
+            matcher = _ExpressionOrAliasMatcher(uniq_finder.found_functions)
             for col in selected_columns:
                 col.expression.accept(matcher)
             if not all(matcher.found_expressions):
                 raise MismatchedAggregationException(
-                    f"Aggregation is in HAVING clause but not SELECT: {visitor.found_functions}"
+                    f"Aggregation is in HAVING clause but not SELECT: {uniq_finder.found_functions}"
                 )

--- a/snuba/query/processors/uniq_in_select_and_having.py
+++ b/snuba/query/processors/uniq_in_select_and_having.py
@@ -13,7 +13,7 @@ from typing import List, Sequence
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.exceptions import InvalidQueryException
-from snuba.query.expressions import Column, Expression, FunctionCall, NoopVisitor
+from snuba.query.expressions import Expression, FunctionCall, NoopVisitor
 from snuba.request.request_settings import RequestSettings
 from snuba.state import get_config
 
@@ -58,11 +58,6 @@ class _ExpressionOrAliasMatcher(NoopVisitor):
         self.expressions_to_match = expressions_to_match
         self.found_expressions = [False] * len(expressions_to_match)
 
-    def visit_column(self, exp: Column) -> None:
-        for i, exp_to_match in enumerate(self.expressions_to_match):
-            if exp_to_match.alias is not None and exp_to_match.alias == exp.column_name:
-                self.found_expressions[i] = True
-
     def visit_function_call(self, exp: FunctionCall) -> None:
         for param in exp.parameters:
             param.accept(self)
@@ -94,4 +89,4 @@ class UniqInSelectAndHavingProcessor(QueryProcessor):
                 if should_throw:
                     raise error
                 else:
-                    logging.exception(error)
+                    logging.warning(str(error))

--- a/snuba/query/processors/uniq_in_select_and_having.py
+++ b/snuba/query/processors/uniq_in_select_and_having.py
@@ -1,0 +1,60 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.expressions import Column, FunctionCall, NoopVisitor
+from snuba.request.request_settings import RequestSettings
+from snuba.utils.serializable_exception import SerializableException
+
+
+class MismatchedAggregationException(SerializableException):
+    pass
+
+
+class _FunctionNameFindingVisitor(NoopVisitor):
+    def __init__(self, function_name_to_find: str):
+        self.function_name_to_find = function_name_to_find
+        self.found_functions: List[FunctionCall] = []
+
+    def visit_function_call(self, exp: FunctionCall) -> None:
+        for param in exp.parameters:
+            param.accept(self)
+        if exp.function_name == self.function_name_to_find:
+            self.found_functions.append(exp)
+        return None
+
+
+class _ExpressionOrAliasMatcher(NoopVisitor):
+    def __init__(self, expressions_to_match: Sequence[FunctionCall]):
+        self.expressions_to_match = expressions_to_match
+        self.found_expressions = [False] * len(expressions_to_match)
+
+    def visit_column(self, exp: Column) -> None:
+        for i, exp_to_match in enumerate(self.expressions_to_match):
+            if exp_to_match.alias is not None and exp_to_match.alias == exp.column_name:
+                self.found_expressions[i] = True
+
+    def visit_function_call(self, exp: FunctionCall) -> None:
+        for param in exp.parameters:
+            param.accept(self)
+        for i, exp_to_match in enumerate(self.expressions_to_match):
+            if exp_to_match.function_name == exp.function_name and exp_to_match == exp:
+                self.found_expressions[i] = True
+
+
+class UniqInSelectAndHavingProcessor(QueryProcessor):
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        having_clause = query.get_having()
+        if not having_clause:
+            return None
+        selected_columns = query.get_selected_columns()
+        visitor = _FunctionNameFindingVisitor("uniq")
+        having_clause.accept(visitor)
+        if visitor.found_functions:
+            matcher = _ExpressionOrAliasMatcher(visitor.found_functions)
+            for col in selected_columns:
+                col.expression.accept(matcher)
+            if not all(matcher.found_expressions):
+                raise MismatchedAggregationException(
+                    f"Aggregation is in HAVING clause but not SELECT: {visitor.found_functions}"
+                )

--- a/tests/datasets/test_context_promotion.py
+++ b/tests/datasets/test_context_promotion.py
@@ -10,7 +10,7 @@ from snuba.datasets.factory import get_dataset
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
-from snuba.query.expressions import Column, FunctionCall, Literal, StringifyVisitor
+from snuba.query.expressions import Column, FunctionCall, Literal, NoopVisitor
 from snuba.reader import Reader
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.request.schema import RequestSchema
@@ -99,15 +99,12 @@ def test_span_id_promotion(entity: Entity, expected_table_name: str) -> None:
             )
         ]
 
-        # The only reason this extends StringifyVisitor is because it has all the other
-        # visit methods implemented. Really all we care about is the equality comparison
-        # to span_id
-        class SpanIdVerifier(StringifyVisitor):
+        class SpanIdVerifier(NoopVisitor):
             def __init__(self) -> None:
                 self.found_span_condition = False
                 super().__init__()
 
-            def visit_function_call(self, exp: FunctionCall) -> str:
+            def visit_function_call(self, exp: FunctionCall) -> None:
                 if exp.function_name == "equals" and exp.parameters[0] == Column(
                     None, None, "span_id"
                 ):

--- a/tests/datasets/test_tags_hashmap.py
+++ b/tests/datasets/test_tags_hashmap.py
@@ -2,7 +2,7 @@ from snuba.clickhouse.query import Query
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
-from snuba.query.expressions import Column, FunctionCall, StringifyVisitor
+from snuba.query.expressions import Column, FunctionCall, NoopVisitor
 from snuba.reader import Reader
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.request.schema import RequestSchema
@@ -50,14 +50,11 @@ def test_tags_hashmap_optimization() -> None:
     # --------------------------------------------------------------------
 
     def query_verifier(query: Query, settings: RequestSettings, reader: Reader) -> None:
-        # The only reason this extends StringifyVisitor is because it has all the other
-        # visit methods implemented.
-        class ConditionVisitor(StringifyVisitor):
-            def __init__(self, level: int = 0, initial_indent: int = 0) -> None:
+        class ConditionVisitor(NoopVisitor):
+            def __init__(self) -> None:
                 self.found_hashmap_condition = False
-                super().__init__(level=level, initial_indent=initial_indent)
 
-            def visit_function_call(self, exp: FunctionCall) -> str:
+            def visit_function_call(self, exp: FunctionCall) -> None:
                 assert exp.function_name != "arrayElement"
                 if (
                     exp.function_name == "has"

--- a/tests/query/processors/test_uniq_in_select_and_having.py
+++ b/tests/query/processors/test_uniq_in_select_and_having.py
@@ -9,6 +9,7 @@ from snuba.query.processors.uniq_in_select_and_having import (
     UniqInSelectAndHavingProcessor,
 )
 from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state import set_config
 from tests.query.processors.query_builders import build_query
 
 
@@ -79,6 +80,7 @@ VALID_QUERY_CASES = [
 
 @pytest.mark.parametrize("input_query", deepcopy(INVALID_QUERY_CASES))
 def test_invalid_uniq_queries(input_query: ClickhouseQuery) -> None:
+    set_config("throw_on_uniq_select_and_having", True)
     with pytest.raises(MismatchedAggregationException):
         UniqInSelectAndHavingProcessor().process_query(
             input_query, HTTPRequestSettings()

--- a/tests/query/processors/test_uniq_in_select_and_having.py
+++ b/tests/query/processors/test_uniq_in_select_and_having.py
@@ -1,0 +1,66 @@
+from copy import deepcopy
+
+import pytest
+
+from snuba.clickhouse.query import Query as ClickhouseQuery
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.processors.uniq_in_select_and_having import (
+    MismatchedAggregationException,
+    UniqInSelectAndHavingProcessor,
+)
+from snuba.request.request_settings import HTTPRequestSettings
+from tests.query.processors.query_builders import build_query
+
+
+def uniq_user_expression(alias: str = None) -> FunctionCall:
+    return FunctionCall(
+        None,
+        "greater",
+        (FunctionCall(alias, "uniq", (Column(None, None, "user"),)), Literal(None, 1)),
+    )
+
+
+INVALID_QUERY_CASES = [
+    pytest.param(
+        build_query(
+            selected_columns=[
+                Column("_snuba_project_id", None, "project_id"),
+                Column(None, None, "transaction_name"),
+            ],
+            condition=None,
+            having=uniq_user_expression(),
+        ),
+        id="prod issue repro",
+    ),
+]
+
+VALID_QUERY_CASES = [
+    pytest.param(
+        build_query(
+            selected_columns=[
+                Column("_snuba_project_id", None, "project_id"),
+                Column(None, None, "transaction_name"),
+                Column(None, None, "my_alias"),
+            ],
+            condition=None,
+            having=uniq_user_expression(alias="my_alias"),
+        ),
+        id="alias in the select",
+    )
+]
+
+
+@pytest.mark.parametrize("input_query", deepcopy(INVALID_QUERY_CASES))
+def test_invalid_uniq_queries(input_query: ClickhouseQuery) -> None:
+    with pytest.raises(MismatchedAggregationException):
+        UniqInSelectAndHavingProcessor().process_query(
+            input_query, HTTPRequestSettings()
+        )
+
+
+@pytest.mark.parametrize("input_query", deepcopy(VALID_QUERY_CASES))
+def test_valid_uniq_queries(input_query: ClickhouseQuery) -> None:
+    og_query = deepcopy(input_query)
+    UniqInSelectAndHavingProcessor().process_query(input_query, HTTPRequestSettings())
+    # query should not change
+    assert og_query == input_query

--- a/tests/query/test_expressions.py
+++ b/tests/query/test_expressions.py
@@ -1,5 +1,4 @@
 import uuid
-from copy import deepcopy
 from dataclasses import replace
 from datetime import datetime
 from typing import Set
@@ -293,7 +292,7 @@ def test_format(test_expr, expected_str) -> None:
     assert repr(test_expr) == expected_str
 
 
-@pytest.mark.parametrize("test_expr,_formatted_str", deepcopy(TEST_CASES))
+@pytest.mark.parametrize("test_expr,_formatted_str", TEST_CASES)
 def test_functional_eq(test_expr, _formatted_str):
     mangled_expr = test_expr.transform(
         lambda expr: replace(expr, alias=uuid.uuid4().hex)

--- a/tests/query/test_expressions.py
+++ b/tests/query/test_expressions.py
@@ -1,3 +1,6 @@
+import uuid
+from copy import deepcopy
+from dataclasses import replace
 from datetime import datetime
 from typing import Set
 
@@ -199,97 +202,101 @@ def test_hash() -> None:
     assert len(s) == 6
 
 
-@pytest.mark.parametrize(
-    "test_expr,expected_str",
-    [
-        (Column(None, "t1", "c1"), "t1.c1"),
-        (Column(None, None, "c1"), "c1"),
-        (Literal(None, "meowmeow"), "'meowmeow'"),
-        (Literal(None, 123), "123"),
-        (Literal(None, False), "False"),
-        (
-            Literal(None, datetime(2020, 4, 20, 16, 20)),
-            "datetime(2020-04-20T16:20:00)",
+TEST_CASES = [
+    (Column(None, "t1", "c1"), "t1.c1"),
+    (Column(None, None, "c1"), "c1"),
+    (Literal(None, "meowmeow"), "'meowmeow'"),
+    (Literal(None, 123), "123"),
+    (Literal(None, False), "False"),
+    (Literal(None, datetime(2020, 4, 20, 16, 20)), "datetime(2020-04-20T16:20:00)",),
+    (Literal(None, datetime(2020, 4, 20, 16, 20).date()), "date(2020-04-20)"),
+    (Literal(None, None), "None"),
+    (
+        SubscriptableReference(
+            "catsound",
+            column=Column(None, "cats", "sounds"),
+            key=Literal(None, "meow"),
         ),
-        (Literal(None, datetime(2020, 4, 20, 16, 20).date()), "date(2020-04-20)"),
-        (Literal(None, None), "None"),
-        (
-            SubscriptableReference(
-                "catsound",
-                column=Column(None, "cats", "sounds"),
-                key=Literal(None, "meow"),
-            ),
-            "cats.sounds['meow'] AS `catsound`",
+        "cats.sounds['meow'] AS `catsound`",
+    ),
+    (
+        SubscriptableReference(
+            "catsound",
+            column=Column("kittysounds", "cats", "sounds"),
+            key=Literal(None, "meow"),
         ),
-        (
-            SubscriptableReference(
-                "catsound",
-                column=Column("kittysounds", "cats", "sounds"),
-                key=Literal(None, "meow"),
-            ),
-            "(cats.sounds AS `kittysounds`)['meow'] AS `catsound`",
-        ),
-        (Column("alias", None, "c1"), "c1 AS `alias`"),
-        (
-            FunctionCall(
-                None, "f1", (Column(None, "t1", "c1"), Column(None, "t1", "c2"))
-            ),
-            """f1(
+        "(cats.sounds AS `kittysounds`)['meow'] AS `catsound`",
+    ),
+    (Column("alias", None, "c1"), "c1 AS `alias`"),
+    (
+        FunctionCall(None, "f1", (Column(None, "t1", "c1"), Column(None, "t1", "c2"))),
+        """f1(
   t1.c1,
   t1.c2
 )""",
-        ),
-        (
-            CurriedFunctionCall(
-                None,
-                FunctionCall(
-                    None, "f1", (Column(None, "t1", "c1"), Column(None, "t1", "c2"))
-                ),
-                (Literal(None, "hello"), Literal(None, "kitty")),
+    ),
+    (
+        CurriedFunctionCall(
+            None,
+            FunctionCall(
+                None, "f1", (Column(None, "t1", "c1"), Column(None, "t1", "c2"))
             ),
-            """f1(
+            (Literal(None, "hello"), Literal(None, "kitty")),
+        ),
+        """f1(
   t1.c1,
   t1.c2
 )(
   'hello',
   'kitty'
 )""",
-        ),
-        (
-            FunctionCall(
-                None,
-                "f1",
-                (
-                    FunctionCall(None, "fnested", (Column(None, "t1", "c1"),)),
-                    Column(None, "t1", "c2"),
-                ),
+    ),
+    (
+        FunctionCall(
+            None,
+            "f1",
+            (
+                FunctionCall(None, "fnested", (Column(None, "t1", "c1"),)),
+                Column(None, "t1", "c2"),
             ),
-            """f1(
+        ),
+        """f1(
   fnested(
     t1.c1
   ),
   t1.c2
 )""",
-        ),
-        (
-            Lambda(
+    ),
+    (
+        Lambda(
+            None,
+            ("a", "b", "c"),
+            FunctionCall(
                 None,
-                ("a", "b", "c"),
-                FunctionCall(
-                    None,
-                    "some_func",
-                    (Argument(None, "a"), Argument(None, "b"), Argument(None, "c")),
-                ),
+                "some_func",
+                (Argument(None, "a"), Argument(None, "b"), Argument(None, "c")),
             ),
-            """(a,b,c ->
+        ),
+        """(a,b,c ->
   some_func(
     a,
     b,
     c
   )
 )""",
-        ),
-    ],
-)
+    ),
+]
+
+
+@pytest.mark.parametrize("test_expr,expected_str", TEST_CASES)
 def test_format(test_expr, expected_str) -> None:
     assert repr(test_expr) == expected_str
+
+
+@pytest.mark.parametrize("test_expr,_formatted_str", deepcopy(TEST_CASES))
+def test_functional_eq(test_expr, _formatted_str):
+    mangled_expr = test_expr.transform(
+        lambda expr: replace(expr, alias=uuid.uuid4().hex)
+    )
+    assert test_expr != mangled_expr
+    assert mangled_expr.functional_eq(test_expr)


### PR DESCRIPTION
### Context
This is a hacky query processor put in for the purpose of
mitigating clickhouse crashes. When a query is sent to clickhouse
which has a `uniq` in the `HAVING` clause but not in the `SELECT`
clause, the query node will crash. This may be fixed with future versions
of clickhouse but we have not upgraded yet. This exists as a check so that we
return an exception to the user but don't crash the clickhouse query node

### Solution

* add query processor to catch this case, make it throw an exception
* Add query processor to transaction storage 

### Feedback desired
* General approach, is it acceptable?
* Any other cases I should test for?
* What's a good way to dry run it? My thought is to send the error to sentry when it happens, hide this behind a runtime config