### PR TITLE
fix(scheduler) Remove the shutdown of the producer from the strategy

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -389,8 +389,6 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
     def terminate(self) -> None:
         self.__closed = True
 
-        self.__producer.close()
-
     def join(self, timeout: Optional[float] = None) -> None:
         start = time.time()
         while self.__queue:
@@ -406,4 +404,3 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             self.__commit(
                 {message.partition: Position(message.offset, message.timestamp)}
             )
-        self.__producer.close()

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -462,8 +462,6 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
     def terminate(self) -> None:
         self.__closed = True
 
-        self.__producer.close()
-
     def join(self, timeout: Optional[float] = None) -> None:
         start = time.time()
 
@@ -487,5 +485,3 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                         )
                     }
                 )
-
-        self.__producer.close()

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -167,6 +167,8 @@ def test_executor_consumer() -> None:
         data["payload"]["subscription_id"] == "1/91b46cb6224f11ecb2ddacde48001122"
     ), "Invalid subscription id"
 
+    result_producer.close()
+
 
 def generate_message(
     entity_key: EntityKey,


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/2332 was the wrong way to fix the shutdown issue.

The producer was already being closed in the CLI script. 
Closing it in the strategy actually was counter productive because it would not be reopened in case of rebalancing crashing the consumer.

This removes the close statements from the processing strategies and relies on the one at the end of the script. It also add a similar close statement to the test.