### PR TITLE
approach check: Metrics direct write to aggregateFunction column

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -152,6 +152,17 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     "--consumer-group=metrics_group",
                 ],
             ),
+            (
+                "metrics-direct-write-consumer",
+                [
+                    "snuba",
+                    "multistorage-consumer",
+                    "--storage=metrics_distributions",
+                    "--auto-offset-reset=latest",
+                    "--log-level=debug",
+                    "--consumer-group=metrics_direct_write_group",
+                ],
+            ),
         ]
 
     if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -75,7 +75,8 @@ class InsertStatement:
         columns_statement = (
             f"({','.join(self.__column_names)}) " if self.__column_names else ""
         )
-        format_statement = f" FORMAT {self.__format}" if self.__format else ""
+        # FIXME maybe but idk what other use empty format has
+        format_statement = f" FORMAT {self.__format}" if self.__format else "VALUES"
         return f"INSERT INTO {self.__database}.{self.__table_name} {columns_statement} {format_statement}"
 
 
@@ -138,7 +139,7 @@ class HTTPWriteBatch:
             "Connection": "keep-alive",
             "Accept-Encoding": "gzip,deflate",
         }
-        if password != '':
+        if password != "":
             headers["X-ClickHouse-Key"] = password
         if encoding:
             headers["Content-Encoding"] = encoding

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -251,6 +251,28 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
             buffer_size=buffer_size,
         )
 
+    def get_values_batch_writer(
+        self,
+        metrics: MetricsBackend,
+        insert_statement: InsertStatement,
+        encoding: Optional[str],
+        options: ClickhouseWriterOptions,
+        chunk_size: Optional[int],
+        buffer_size: int,
+    ) -> BatchWriter[bytes]:
+        return HTTPBatchWriter(
+            host=self.__query_node.host_name,
+            port=self.__http_port,
+            user=self.__user,
+            password=self.__password,
+            metrics=metrics,
+            statement=insert_statement.with_database(self.__database),
+            encoding=encoding,
+            options=options,
+            chunk_size=chunk_size,
+            buffer_size=buffer_size,
+        )
+
     def is_single_node(self) -> bool:
         """
         This will be used to determine:
@@ -334,6 +356,10 @@ expected_storage_sets = {
     for s in StorageSetKey
     if (s not in DEV_STORAGE_SETS or settings.ENABLE_DEV_FEATURES)
 }
+
+assert (
+    not expected_storage_sets - _unique_registered_storage_sets
+), "All storage sets must be assigned to a cluster"
 
 # Map all storages to clusters via storage sets
 _STORAGE_SET_CLUSTER_MAP = {

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -298,11 +298,7 @@ class MockReplacementBatchWriter(ProcessingStep[ReplacementBatch]):
 
 
 class ProcessedMessageBatchWriter(
-    ProcessingStep[
-        Union[
-            None, JSONRowInsertBatch, ReplacementBatch, InsertBatchInterpretExpressions
-        ]
-    ]
+    ProcessingStep[Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch]]
 ):
     def __init__(
         self,
@@ -325,12 +321,7 @@ class ProcessedMessageBatchWriter(
     def submit(
         self,
         message: Message[
-            Union[
-                None,
-                JSONRowInsertBatch,
-                ReplacementBatch,
-                InsertBatchInterpretExpressions,
-            ]
+            Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch]
         ],
     ) -> None:
         assert not self.__closed
@@ -462,12 +453,7 @@ class MultistorageCollector(
         Sequence[
             Tuple[
                 StorageKey,
-                Union[
-                    None,
-                    JSONRowInsertBatch,
-                    ReplacementBatch,
-                    InsertBatchInterpretExpressions,
-                ],
+                Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch],
             ]
         ]
     ]
@@ -477,12 +463,7 @@ class MultistorageCollector(
         steps: Mapping[
             StorageKey,
             ProcessingStep[
-                Union[
-                    None,
-                    JSONRowInsertBatch,
-                    ReplacementBatch,
-                    InsertBatchInterpretExpressions,
-                ]
+                Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch]
             ],
         ],
     ):
@@ -501,10 +482,7 @@ class MultistorageCollector(
                 Tuple[
                     StorageKey,
                     Union[
-                        None,
-                        JSONRowInsertBatch,
-                        ReplacementBatch,
-                        InsertBatchInterpretExpressions,
+                        None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch,
                     ],
                 ]
             ]
@@ -578,9 +556,7 @@ def process_message_multistorage(
 ) -> Sequence[
     Tuple[
         StorageKey,
-        Union[
-            None, JSONRowInsertBatch, ReplacementBatch, InsertBatch, ValuesInsertBatch
-        ],
+        Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch],
     ]
 ]:
     # XXX: Avoid circular import on KafkaMessageMetadata, remove when that type
@@ -595,13 +571,7 @@ def process_message_multistorage(
     results: MutableSequence[
         Tuple[
             StorageKey,
-            Union[
-                None,
-                JSONRowInsertBatch,
-                InsertBatch,
-                ReplacementBatch,
-                ValuesInsertBatch,
-            ],
+            Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch],
         ]
     ] = []
 
@@ -623,7 +593,7 @@ def process_message_multistorage(
                     ),
                 )
             )
-        if isinstance(result, InsertBatchInterpretExpressions):
+        elif isinstance(result, InsertBatchInterpretExpressions):
             results.append(
                 (
                     storage_key,
@@ -743,12 +713,7 @@ class MultistorageConsumerProcessingStrategyFactory(
         Sequence[
             Tuple[
                 StorageKey,
-                Union[
-                    None,
-                    JSONRowInsertBatch,
-                    ReplacementBatch,
-                    InsertBatchInterpretExpressions,
-                ],
+                Union[None, JSONRowInsertBatch, ReplacementBatch, ValuesInsertBatch],
             ]
         ]
     ]:

--- a/snuba/datasets/metrics_processor.py
+++ b/snuba/datasets/metrics_processor.py
@@ -5,6 +5,7 @@ from typing import Any, Mapping, Optional
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.processor import (
     InsertBatch,
+    InsertBatchInterpretExpressions,
     MessageProcessor,
     ProcessedMessage,
     _ensure_valid_date,
@@ -19,6 +20,9 @@ class MetricsProcessor(MessageProcessor, ABC):
     @abstractmethod
     def _process_values(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
         raise NotImplementedError
+
+    def _contains_interpretable_values(self) -> bool:
+        return False
 
     def process_message(
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
@@ -54,7 +58,11 @@ class MetricsProcessor(MessageProcessor, ABC):
             "partition": metadata.partition,
             "offset": metadata.offset,
         }
-        return InsertBatch([processed], None)
+
+        if self._contains_interpretable_values():
+            return InsertBatchInterpretExpressions([processed])
+        else:
+            return InsertBatch([processed], None)
 
 
 class SetsMetricsProcessor(MetricsProcessor):
@@ -91,3 +99,22 @@ class DistributionsMetricsProcessor(MetricsProcessor):
                 v, (int, float)
             ), "Illegal value in set. Int expected: {v}"
         return {"values": values}
+
+
+class DistributionsMetricsProcessorDirectWriter(MetricsProcessor):
+    def _contains_interpretable_values(self) -> bool:
+        return True
+
+    def _should_process(self, message: Mapping[str, Any]) -> bool:
+        return message["type"] is not None and message["type"] == "d"
+
+    def _process_values(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
+        values = message["value"]
+        for v in values:
+            assert isinstance(
+                v, (int, float)
+            ), "Illegal value in set. Int expected: {v}"
+        escaped_array = "[" + ",".join([str(v) for v in values]) + "]"
+        return {
+            "percentiles": f"arrayReduce('quantilesState(0.5,0.75,0.9,0.95,0.99)', {escaped_array})"
+        }

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -68,6 +68,7 @@ WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
             sessions_raw_storage,
             transactions_storage,
             spans_storage,
+            metrics_distributions_storage,
         ]
     },
     **(DEV_WRITABLE_STORAGES if settings.ENABLE_DEV_FEATURES else {}),

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -15,6 +15,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.metrics_processor import (
     CounterMetricsProcessor,
     DistributionsMetricsProcessor,
+    DistributionsMetricsProcessorDirectWriter,
     SetsMetricsProcessor,
 )
 from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
@@ -149,10 +150,10 @@ counters_storage = ReadableTableStorage(
 )
 
 
-distributions_storage = ReadableTableStorage(
+distributions_storage = WritableTableStorage(
     storage_key=StorageKey.METRICS_DISTRIBUTIONS,
     storage_set_key=StorageSetKey.METRICS,
-    schema=TableSchema(
+    schema=WritableTableSchema(
         local_table_name="metrics_distributions_local",
         dist_table_name="metrics_distributions_dist",
         storage_set_key=StorageSetKey.METRICS,
@@ -174,4 +175,7 @@ distributions_storage = ReadableTableStorage(
         ),
     ),
     query_processors=[ArrayJoinKeyValueOptimizer("tags")],
+    stream_loader=build_kafka_stream_loader_from_settings(
+        DistributionsMetricsProcessorDirectWriter(), default_topic=Topic.METRICS,
+    ),
 )

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -200,6 +200,24 @@ class TableWriter:
     def get_schema(self) -> WritableTableSchema:
         return self.__table_schema
 
+    def get_values_writer(
+        self,
+        metrics: MetricsBackend,
+        options: ClickhouseWriterOptions = None,
+        table_name: Optional[str] = None,
+        chunk_size: int = settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
+    ) -> BatchWriter[JSONRow]:
+        table_name = table_name or self.__table_schema.get_table_name()
+
+        return get_cluster(self.__storage_set).get_batch_writer(
+            metrics,
+            InsertStatement(table_name),
+            encoding=None,
+            options=options,
+            chunk_size=chunk_size,
+            buffer_size=0,
+        )
+
     def get_batch_writer(
         self,
         metrics: MetricsBackend,

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -22,6 +22,18 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.topics import Topic, get_topic_creation_config
 from snuba.writer import BatchWriter
 
+# FIXME
+DISTRIBUTIONS_COLUMN_SET = [
+    "org_id",
+    "project_id",
+    "metric_id",
+    "timestamp",
+    "tags.key",
+    "tags.value",
+    "percentiles",
+    "retention_days",
+]
+
 
 class KafkaTopicSpec:
     def __init__(self, topic: Topic) -> None:
@@ -206,12 +218,13 @@ class TableWriter:
         options: ClickhouseWriterOptions = None,
         table_name: Optional[str] = None,
         chunk_size: int = settings.CLICKHOUSE_HTTP_CHUNK_SIZE,
-    ) -> BatchWriter[JSONRow]:
+    ) -> BatchWriter[bytes]:
         table_name = table_name or self.__table_schema.get_table_name()
 
-        return get_cluster(self.__storage_set).get_batch_writer(
+        return get_cluster(self.__storage_set).get_values_batch_writer(
             metrics,
-            InsertStatement(table_name),
+            # FIXME
+            InsertStatement(table_name).with_columns(DISTRIBUTIONS_COLUMN_SET),
             encoding=None,
             options=options,
             chunk_size=chunk_size,

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -34,12 +34,16 @@ class InsertBatch(NamedTuple):
     origin_timestamp: Optional[datetime]
 
 
+class InsertBatchInterpretExpressions(NamedTuple):
+    rowsAsValues: Sequence[WriterTableRow]
+
+
 class ReplacementBatch(NamedTuple):
     key: str
     values: Sequence[Any]
 
 
-ProcessedMessage = Union[InsertBatch, ReplacementBatch]
+ProcessedMessage = Union[InsertBatch, ReplacementBatch, InsertBatchInterpretExpressions]
 
 
 class MessageProcessor(ABC):


### PR DESCRIPTION
I know this sucks in its current state so don't worry, it will be polished before merge or a real approval process

Basically I want to validate that this is, at a very high level and ignoring the ugly details, the right way to split out processing for metrics if we want to write with the format `VALUES()`. That is:
- creating a new type of `InsertBatchInterpretExpressions` to indicate to the next step to use the `VALUES` format for insertion (or a format that allows for execution of things like `arrayReduce('quantilesState(0.5,0.75,0.9,0.95,0.99)', [1.0, 2.0, ...])` on insert)
- creating a new type of `ValuesInsertBatch` for direct use by the writer
- creating a new insert batch writer for the VALUES format
- adding `ValuesInsertBatch` handling to the generic multi-storage consumer message processor
- changing the MetricsProcessor to return `InsertBatchInterpretExpressions` for direct writes

This successfully writes to the AggregateFunction column, though it's not handling things like Datetime(s) or being smart about escaping