### PR TITLE
fix(admin): Allow math operators

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -119,12 +119,12 @@ SYSTEM_QUERY_RE = re.compile(
         ^ # Start
         (SELECT|select)
         \s
-        (?P<select_statement>[\w\s,\(\)]+|\*)
+        (?P<select_statement>[\w\s,()*+\-\/]+|\*)
         \s
         (FROM|from)
         \s
         system.[a-z_]+
-        (?P<extra>\s[\w\s,=+\(\)'%]+)?
+        (?P<extra>\s[\w\s,=()*+<>'%\-\/]+)?
         ;? # Optional semicolon
         $ # End
     """,


### PR DESCRIPTION
snuba-admin currently does not provide mechanisms to run queries which
have math operators in them. The change allows those operators.

Here's the test showing that the match happens

```json
[
  [
    {
      "content": "SELECT toUInt8(toMonday(now()) - toMonday(min(min_time))) / 7 AS weeks_ago, table, count() AS count, sum(bytes_on_disk) AS size FROM system.parts WHERE (min_time > (now() - ((90 * 3600) * 24))) AND (min_time < now()) GROUP BY toMonday(min_time), table ORDER BY table ASC, toMonday(min_time) DESC",
      "isParticipating": true,
      "groupNum": 0,
      "groupName": null,
      "startPos": 0,
      "endPos": 295
    },
    {
      "content": "SELECT",
      "isParticipating": true,
      "groupNum": 1,
      "groupName": 1,
      "startPos": 0,
      "endPos": 6
    },
    {
      "content": "toUInt8(toMonday(now()) - toMonday(min(min_time))) / 7 AS weeks_ago, table, count() AS count, sum(bytes_on_disk) AS size",
      "isParticipating": true,
      "groupNum": 2,
      "groupName": "select_statement",
      "startPos": 7,
      "endPos": 127
    },
    {
      "content": "FROM",
      "isParticipating": true,
      "groupNum": 3,
      "groupName": 3,
      "startPos": 128,
      "endPos": 132
    },
    {
      "content": " WHERE (min_time > (now() - ((90 * 3600) * 24))) AND (min_time < now()) GROUP BY toMonday(min_time), table ORDER BY table ASC, toMonday(min_time) DESC",
      "isParticipating": true,
      "groupNum": 4,
      "groupName": "extra",
      "startPos": 145,
      "endPos": 295
    }
  ]
]
```