### PR TITLE
feat(suspect-spans): Add array has processor

### DIFF
--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -19,6 +19,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.events_bool_contexts import EventsBooleanContextsProcessor
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
+from snuba.query.processors.array_has_optimizer import ArrayHasOptimizer
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
 )
@@ -141,6 +142,7 @@ query_processors = [
     # same conditions the bloom filter optimizer is looking for
     BloomFilterOptimizer("spans", ["op", "group"], ["exclusive_time_32"]),
     ArrayJoinOptimizer("spans", ["op", "group"], ["exclusive_time_32"]),
+    ArrayHasOptimizer(["spans.op", "spans.group"]),
     HexIntArrayColumnProcessor({"spans.group"}),
     PrewhereProcessor(
         ["event_id", "trace_id", "span_id", "transaction_name", "transaction", "title"]

--- a/snuba/query/processors/array_has_optimizer.py
+++ b/snuba/query/processors/array_has_optimizer.py
@@ -1,0 +1,62 @@
+from typing import Sequence
+
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.expressions import Column as ColumnExpr
+from snuba.query.expressions import Expression
+from snuba.query.expressions import FunctionCall as FunctionCallExpr
+from snuba.query.expressions import Literal as LiteralExpr
+from snuba.query.matchers import (
+    Any,
+    Column,
+    FunctionCall,
+    Integer,
+    Literal,
+    Or,
+    Param,
+    String,
+)
+from snuba.request.request_settings import RequestSettings
+
+"""
+This optimizer is necessary because SnQL does not permit conditions like
+`has(col, val)`, instead it requires them to be written as `has(col, val) = 1`.
+This way of writing the condition does not allow ClickHouse to leverage any
+bloomfilter index on the column.
+
+This optimizer rewrites these conditions and such that Clickhouse is able to
+leverage the bloom filter index if they exist.
+"""
+
+
+class ArrayHasOptimizer(QueryProcessor):
+    def __init__(self, array_columns: Sequence[str]):
+        column_name = Param("col", Or([String(column) for column in array_columns]))
+
+        self.__array_has_pattern = FunctionCall(
+            String("equals"),
+            (
+                FunctionCall(
+                    String("has"),
+                    (Column(column_name=column_name), Literal(Param("val", Any(str))),),
+                ),
+                Literal(Integer(1)),
+            ),
+        )
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        def replace_expression(expr: Expression) -> Expression:
+            match = self.__array_has_pattern.match(expr)
+
+            # The arrayJoins we are looking for are not present, so skip this entirely
+            if match is None:
+                return expr
+
+            col = match.string("col")
+            val = match.string("val")
+
+            return FunctionCallExpr(
+                None, "has", (ColumnExpr(None, None, col), LiteralExpr(None, val)),
+            )
+
+        query.transform_expressions(replace_expression)

--- a/snuba/query/processors/array_has_optimizer.py
+++ b/snuba/query/processors/array_has_optimizer.py
@@ -53,7 +53,7 @@ class ArrayHasOptimizer(QueryProcessor):
         def replace_expression(expr: Expression) -> Expression:
             match = self.__array_has_pattern.match(expr)
 
-            # The arrayJoins we are looking for are not present, so skip this entirely
+            # The has condition we are looking for are not present, so skip this entirely
             if match is None:
                 return expr
 

--- a/tests/query/processors/test_array_has_optimizer.py
+++ b/tests/query/processors/test_array_has_optimizer.py
@@ -1,0 +1,210 @@
+from typing import Optional
+
+import pytest
+
+from snuba.clickhouse.query import Query as ClickhouseQuery
+from snuba.query.conditions import combine_and_conditions
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.processors.array_has_optimizer import ArrayHasOptimizer
+from snuba.request.request_settings import HTTPRequestSettings
+from tests.query.processors.query_builders import build_query
+
+spans_ops = Column(None, None, "spans.op")
+spans_groups = Column(None, None, "spans.group")
+
+array_has_tests = [
+    pytest.param(build_query(), None, id="no conditions"),
+    pytest.param(
+        build_query(
+            condition=FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+        ),
+        FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+        id="one has condition",
+    ),
+    pytest.param(
+        build_query(
+            condition=combine_and_conditions(
+                [
+                    FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                    FunctionCall(None, "has", (spans_groups, Literal(None, "a" * 16))),
+                ],
+            ),
+        ),
+        combine_and_conditions(
+            [
+                FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                FunctionCall(None, "has", (spans_groups, Literal(None, "a" * 16))),
+            ],
+        ),
+        id="two has conditions",
+    ),
+    pytest.param(
+        build_query(
+            condition=FunctionCall(
+                None,
+                "equals",
+                (
+                    FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                    Literal(None, 1),
+                ),
+            ),
+        ),
+        FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+        id="one has condition wrapped in equals 1",
+    ),
+    pytest.param(
+        build_query(
+            condition=FunctionCall(
+                None,
+                "equals",
+                (
+                    FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                    Literal(None, 0),
+                ),
+            ),
+        ),
+        FunctionCall(
+            None,
+            "equals",
+            (
+                FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                Literal(None, 0),
+            ),
+        ),
+        id="one has condition wrapped in equals 0",
+    ),
+    pytest.param(
+        build_query(
+            condition=combine_and_conditions(
+                [
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                            Literal(None, 1),
+                        ),
+                    ),
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            FunctionCall(
+                                None, "has", (spans_groups, Literal(None, "a" * 16))
+                            ),
+                            Literal(None, 1),
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        combine_and_conditions(
+            [
+                FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                FunctionCall(None, "has", (spans_groups, Literal(None, "a" * 16))),
+            ],
+        ),
+        id="two has conditions wrapped in equals 1",
+    ),
+    pytest.param(
+        build_query(
+            condition=combine_and_conditions(
+                [
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                            Literal(None, 0),
+                        ),
+                    ),
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            FunctionCall(
+                                None, "has", (spans_groups, Literal(None, "a" * 16))
+                            ),
+                            Literal(None, 0),
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        combine_and_conditions(
+            [
+                FunctionCall(
+                    None,
+                    "equals",
+                    (
+                        FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                        Literal(None, 0),
+                    ),
+                ),
+                FunctionCall(
+                    None,
+                    "equals",
+                    (
+                        FunctionCall(
+                            None, "has", (spans_groups, Literal(None, "a" * 16))
+                        ),
+                        Literal(None, 0),
+                    ),
+                ),
+            ],
+        ),
+        id="two has conditions wrapped in equals 0",
+    ),
+    pytest.param(
+        build_query(
+            condition=combine_and_conditions(
+                [
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                            Literal(None, 1),
+                        ),
+                    ),
+                    FunctionCall(
+                        None,
+                        "equals",
+                        (
+                            FunctionCall(
+                                None, "has", (spans_groups, Literal(None, "a" * 16))
+                            ),
+                            Literal(None, 0),
+                        ),
+                    ),
+                ],
+            ),
+        ),
+        combine_and_conditions(
+            [
+                FunctionCall(None, "has", (spans_ops, Literal(None, "db"))),
+                FunctionCall(
+                    None,
+                    "equals",
+                    (
+                        FunctionCall(
+                            None, "has", (spans_groups, Literal(None, "a" * 16))
+                        ),
+                        Literal(None, 0),
+                    ),
+                ),
+            ],
+        ),
+        id="two has conditions one wrapped in equals 1, other wrapped in equals 0",
+    ),
+]
+
+
+@pytest.mark.parametrize("query, expected_conditions", array_has_tests)
+def test_array_has_optimizer(
+    query: ClickhouseQuery, expected_conditions: Optional[Expression],
+) -> None:
+    request_settings = HTTPRequestSettings()
+    array_has_processor = ArrayHasOptimizer(["spans.op", "spans.group"])
+    array_has_processor.process_query(query, request_settings)
+    assert query.get_condition() == expected_conditions


### PR DESCRIPTION
SnQL only allows for conditions of the form `LHS OPERATOR RHS`. This means that
conditions like `has(column, value)` are currently illegal, and has to be
written as `has(column, value) = 1` to satisfy this constraint. This causes
problems with Clickhouse when it's not able to use the bloomfilter index for
these conditions. This change rewrites such conditions to remove the surrounding
`... = 1` so that Clickhouse is able to properly leverage the bloomfilter index.