### PR TITLE
feat: Deploy subscription executor

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -33,6 +33,8 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-scheduler
   - image: us.gcr.io/sentryio/snuba:{sha}
+    name: events-subscriptions-executor
+  - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: sessions-subscriptions-consumer


### PR DESCRIPTION
Since `executor_sample_rate` is currently set to 0, this won't run any ClickHouse queries
or attempt to produce anything, just committing offsets.

According to https://github.com/getsentry/snuba/pull/2323 there was an issue that was
not diagnosed when we attempted to do this last month. Giving it another shot so we
can at least get hold of the stack trace even if this still fails.