### PR TITLE
feat(subscriptions): Ensure that we commit if the sample rate is zero

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -145,6 +145,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
             self.__max_concurrent_queries,
             self.__metrics,
             ProduceResult(self.__producer, self.__result_topic, commit),
+            commit,
         )
 
 


### PR DESCRIPTION
We need to make sure we commit offsets during rollout so our Kafka offset
does not go out of retention. Currently if the sample rate is set to
zero we will never commit.