### PR TITLE
feat(subscriptions): Cache crc32 subscription ID

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -4,6 +4,7 @@ import logging
 import time
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
+from functools import lru_cache
 from typing import Callable, Deque, Mapping, Optional, Sequence, Tuple, cast
 from zlib import crc32
 
@@ -149,6 +150,13 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
         )
 
 
+@lru_cache(maxsize=50000)
+def subscription_id_to_float(subscription_id: str) -> float:
+    # Converts a subscription ID string to a float between 0 and 1
+    # Used for sampling query execution by subscription ID during rollout
+    return (crc32(subscription_id.encode("utf-8")) & 0xFFFFFFFF) / 2 ** 32
+
+
 class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
     """
     Decodes a scheduled subscription task from the Kafka payload, builds
@@ -274,8 +282,8 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
         subscription_id = str(task.task.subscription.identifier)
         should_execute = (
-            (crc32(subscription_id.encode("utf-8")) & 0xFFFFFFFF) / 2 ** 32
-        ) < executor_sample_rate
+            subscription_id_to_float(subscription_id) < executor_sample_rate
+        )
 
         entity_name = task.task.entity.value
 


### PR DESCRIPTION
crc32 can be a bit slow. Since we are constantly running this function
on the same set of subscription IDs, lets cache the results.