### PR TITLE
feat(consumer): Add support for VALUES format when writing to ClickHouse

### DIFF
--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Optional, Sequence
 
 from snuba import util
@@ -9,6 +10,11 @@ from snuba.clusters.cluster import get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.schemas import RelationalSource, Schema
 from snuba.query.expressions import FunctionCall
+
+
+class WriteFormat(Enum):
+    JSON = "json"
+    VALUES = "values"
 
 
 @dataclass(frozen=True)

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -11,7 +11,7 @@ from snuba.clusters.cluster import (
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.plans.split_strategy import QuerySplitStrategy
 from snuba.datasets.schemas import Schema
-from snuba.datasets.schemas.tables import WritableTableSchema
+from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import KafkaStreamLoader, TableWriter
 from snuba.query.expressions import Expression
@@ -169,6 +169,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         replacer_processor: Optional[ReplacerProcessor[Any]] = None,
         writer_options: ClickhouseWriterOptions = None,
+        write_format: WriteFormat = WriteFormat.JSON,
     ) -> None:
         super().__init__(
             storage_key,
@@ -185,6 +186,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             stream_loader=stream_loader,
             replacer_processor=replacer_processor,
             writer_options=writer_options,
+            write_format=write_format,
         )
 
     def get_table_writer(self) -> TableWriter:

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -3,7 +3,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.errors_processor import ErrorsProcessor
 from snuba.datasets.errors_replacer import ErrorsReplacer, ReplacerState
 from snuba.datasets.message_filters import KafkaHeaderFilter
-from snuba.datasets.schemas.tables import WritableTableSchema
+from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors_common import (
@@ -45,6 +45,8 @@ storage = WritableTableStorage(
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),
+    # This is the default, just showing where it goes for the PR
+    write_format=WriteFormat.JSON,
     replacer_processor=ErrorsReplacer(
         schema=schema,
         required_columns=required_columns,

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -34,6 +34,13 @@ class InsertBatch(NamedTuple):
     origin_timestamp: Optional[datetime]
 
 
+# Indicates that we need an encoder that will interpolate
+# aggregate function calls defined in
+# https://clickhouse.com/docs/en/sql-reference/data-types/aggregatefunction/
+class AggregateInsertBatch(InsertBatch):
+    pass
+
+
 class ReplacementBatch(NamedTuple):
     key: str
     values: Sequence[Any]

--- a/tests/clickhouse/test_http.py
+++ b/tests/clickhouse/test_http.py
@@ -17,11 +17,12 @@ def test_encode_preserves_column_order(values_encoder: ValuesRowEncoder) -> None
             "col1": FunctionCall(
                 None,
                 "test",
-                (FunctionCall(None, "inner", (Literal(None, "inner_arg"),)),),
+                tuple(
+                    [FunctionCall(None, "inner", tuple([Literal(None, "inner_arg")]))]
+                ),
             ),
         }
     )
-    print(encoded)
     assert encoded == "(test(inner('inner_arg')),5,'test_string')".encode("utf-8")
 
 

--- a/tests/clickhouse/test_http.py
+++ b/tests/clickhouse/test_http.py
@@ -1,0 +1,25 @@
+import pytest
+
+from snuba.clickhouse.http import ValuesRowEncoder
+from snuba.query.expressions import FunctionCall, Literal
+
+
+@pytest.fixture
+def values_encoder() -> ValuesRowEncoder:
+    return ValuesRowEncoder(["col1", "col2", "col3"])
+
+
+def test_encode_preserves_column_order(values_encoder: ValuesRowEncoder) -> None:
+    encoded = values_encoder.encode(
+        {
+            "col2": Literal(None, 5),
+            "col3": Literal(None, "test_string"),
+            "col1": FunctionCall(None, "test", tuple()),
+        }
+    )
+    assert encoded == "(test(),5,'test_string')".encode("utf-8")
+
+
+def test_encode_fails_on_non_expression(values_encoder: ValuesRowEncoder) -> None:
+    with (pytest.raises(TypeError)):
+        values_encoder.encode({"col1": "string not wrapped by a literal object"})

--- a/tests/clickhouse/test_http.py
+++ b/tests/clickhouse/test_http.py
@@ -14,10 +14,15 @@ def test_encode_preserves_column_order(values_encoder: ValuesRowEncoder) -> None
         {
             "col2": Literal(None, 5),
             "col3": Literal(None, "test_string"),
-            "col1": FunctionCall(None, "test", tuple()),
+            "col1": FunctionCall(
+                None,
+                "test",
+                (FunctionCall(None, "inner", (Literal(None, "inner_arg"),)),),
+            ),
         }
     )
-    assert encoded == "(test(),5,'test_string')".encode("utf-8")
+    print(encoded)
+    assert encoded == "(test(inner('inner_arg')),5,'test_string')".encode("utf-8")
 
 
 def test_encode_fails_on_non_expression(values_encoder: ValuesRowEncoder) -> None:

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -15,8 +15,8 @@ from arroyo.types import Position
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.consumer import (
+    BytesInsertBatch,
     InsertBatchWriter,
-    JSONRowInsertBatch,
     MultistorageConsumerProcessingStrategyFactory,
     ProcessedMessageBatchWriter,
     ReplacementBatchWriter,
@@ -112,12 +112,12 @@ def test_streaming_consumer_strategy() -> None:
 
 
 def test_json_row_batch_pickle_simple() -> None:
-    batch = JSONRowInsertBatch([b"foo", b"bar", b"baz"], datetime(2021, 1, 1, 11, 0, 1))
+    batch = BytesInsertBatch([b"foo", b"bar", b"baz"], datetime(2021, 1, 1, 11, 0, 1))
     assert pickle.loads(pickle.dumps(batch)) == batch
 
 
 def test_json_row_batch_pickle_out_of_band() -> None:
-    batch = JSONRowInsertBatch([b"foo", b"bar", b"baz"], datetime(2021, 1, 1, 11, 0, 1))
+    batch = BytesInsertBatch([b"foo", b"bar", b"baz"], datetime(2021, 1, 1, 11, 0, 1))
 
     buffers: MutableSequence[PickleBuffer] = []
     data = pickle.dumps(batch, protocol=5, buffer_callback=buffers.append)
@@ -131,7 +131,8 @@ def get_row_count(storage: Storage) -> int:
     return int(
         storage.get_cluster()
         .get_query_connection(ClickhouseClientSettings.INSERT)
-        .execute(f"SELECT count() FROM {schema.get_local_table_name()}").results[0][0]
+        .execute(f"SELECT count() FROM {schema.get_local_table_name()}")
+        .results[0][0]
     )
 
 


### PR DESCRIPTION
This is necessary for an upcoming change which will write aggregate expressions directly in the insert.

Functional changes:
- support for inserting using the VALUES format (https://clickhouse.com/docs/en/interfaces/formats/#data-format-values) at the WritableTableStorage level
- support in the multistorage consumer for serializing to the VALUES format (including a new ValuesRowEncoder)
- added a new type of return from processing called `AggregateInsertBatch` to indicate to callers that the data being returned needs to be interpreted by Clickhouse (e.g. it can contain function call expressions)

This was split out of https://github.com/getsentry/snuba/pull/2346 to be more readable (without the additional metrics changes). There will be an upcoming PR based off this one to support direct metrics aggregate writing