### PR TITLE
perf(subscriptions): Add metrics to SubscriptionScheduler.find()

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -422,7 +422,6 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
         )
 
     def submit(self, message: Message[CommittableTick]) -> None:
-        start = time.time()
         assert not self.__closed
 
         # If queue is full, raise MessageRejected to tell the stream
@@ -442,11 +441,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
             (time.time() - start_find_tasks) * 1000,
         )
 
-        start_encoding = time.time()
         encoded_tasks = [self.__encoder.encode(task) for task in tasks]
-        self.__metrics.timing(
-            "ScheduledSubscriptionTask.encode", (time.time() - start_encoding) * 1000
-        )
 
         self.__queue.append(
             message,
@@ -456,10 +451,6 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                     for task in encoded_tasks
                 ]
             ),
-        )
-
-        self.__metrics.timing(
-            "ProduceScheduledSubscriptionMessage.submit", (time.time() - start) * 1000
         )
 
     def close(self) -> None:

--- a/tests/subscriptions/test_task_builder.py
+++ b/tests/subscriptions/test_task_builder.py
@@ -17,6 +17,7 @@ from snuba.subscriptions.scheduler import (
     Tags,
     TaskBuilder,
 )
+from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from tests.subscriptions.subscriptions_utils import UUIDS, build_subscription
 
 ALIGNED_TIMESTAMP = 1625518080  # Aligned to start of a minute
@@ -144,7 +145,7 @@ TEST_CASES = [
         id="Do not apply jitter if resolution is above threshold",
     ),
     pytest.param(
-        DelegateTaskBuilder(),
+        DelegateTaskBuilder(DummyMetricsBackend()),
         "jittered",
         [
             (ALIGNED_TIMESTAMP, build_subscription(timedelta(minutes=1), 0)),
@@ -174,7 +175,7 @@ TEST_CASES = [
         id="Delegate returns the jittered one.",
     ),
     pytest.param(
-        DelegateTaskBuilder(),
+        DelegateTaskBuilder(DummyMetricsBackend()),
         "transition_jitter",
         [
             (ALIGNED_TIMESTAMP + 30, build_subscription(timedelta(minutes=1), 0)),


### PR DESCRIPTION
This function seems to be taking a really long time relative to other parts
of the scheduler. This change adds a bunch of timings to this function to see
if we can isolate the issue further.

Also cleans up a couple metrics we were previously recording but don't need anymore.