### PR TITLE
fix(subscriptions): Fix executor shutdown

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -1,4 +1,5 @@
 import signal
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from typing import Any, Optional, Sequence
 
@@ -107,6 +108,8 @@ def subscriptions_executor(
         )
     )
 
+    executor = ThreadPoolExecutor(max_concurrent_queries)
+
     processor = build_executor_consumer(
         dataset_name,
         entity_names,
@@ -115,6 +118,7 @@ def subscriptions_executor(
         max_concurrent_queries,
         auto_offset_reset,
         metrics,
+        executor,
         override_result_topic,
     )
 
@@ -124,5 +128,5 @@ def subscriptions_executor(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with closing(producer):
+    with closing(producer), executor:
         processor.run()

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -113,6 +113,7 @@ def test_executor_consumer() -> None:
         2,
         auto_offset_reset,
         TestingMetricsBackend(),
+        ThreadPoolExecutor(2),
         override_result_topic=scheduled_result_topic_spec.topic.value,
     )
     for i in range(1, 5):


### PR DESCRIPTION
The executor shouldn't be shutdown by the strategy since it is only
created once and passed in. This caused the executor to be incorrectly
shut down in some scenarios, e.g. rebalancing. Now we only shutdown
the executor when the process is interrupted or terminated.