### PR TITLE
fix(admin): Support unassigned storage sets

### DIFF
--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -27,7 +27,7 @@ def _get_local_nodes(storage_key: StorageKey) -> Sequence[Node]:
             {"host": node.host_name, "port": node.port}
             for node in storage.get_cluster().get_local_nodes()
         ]
-    except AssertionError:
+    except (AssertionError, KeyError):
         # If cluster_name is not defined just return an empty list
         return []
 


### PR DESCRIPTION
We have the TRANSACTIONS_V2 storage set now which is not assigned to
a cluster in settings yet. This causes the /clickhouse_nodes API call to fail.
This fixes that by just returning an empty list for that storage.