### PR TITLE
fix(admin): Fix fetching storage nodes (again)

### DIFF
--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -40,4 +40,6 @@ def get_storage_info() -> Sequence[Storage]:
             "local_nodes": _get_local_nodes(storage_key),
         }
         for storage_key in sorted(STORAGES, key=lambda storage_key: storage_key.value)
+        # HACK: Transactions_v2 is temporarily not assigned to a cluster
+        if storage_key != StorageKey.TRANSACTIONS_V2
     ]


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/2365 did not fix the entire
problem since the issue also arises when we try to get the local table
name. This is a quick fix that manually excludes transactions_v2 from
the storage list so that the /clickhouse_nodes api call succeeds even
if it is not assigned to a storage set.