### PR TITLE
fix(tracing): Fix querying the query node in the tracing tool

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -21,7 +21,8 @@ class InvalidStorageError(SerializableException):
 
 
 def is_valid_node(host: str, port: int, cluster: ClickhouseCluster) -> bool:
-    nodes = cluster.get_local_nodes()
+    nodes = [*cluster.get_local_nodes(), cluster.get_query_node()]
+
     return any(node.host_name == host and node.port == port for node in nodes)
 
 

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -265,6 +265,9 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
     def get_database(self) -> str:
         return self.__database
 
+    def get_query_node(self) -> ClickhouseNode:
+        return self.__query_node
+
     def get_local_nodes(self) -> Sequence[ClickhouseNode]:
         if self.__single_node:
             return [self.__query_node]


### PR DESCRIPTION
The is_valid_node function previously only checked if the node
being queried was a valid local node since we only currently query
local nodes for system qeuries. Now we need to allow the
query node as well since this is what the tracing tool uses.

This fixes a bug introduced in https://github.com/getsentry/snuba/pull/2366
when we switched over to use the readonly user.