### PR TITLE
feat(admin): Add a new collapse component

### DIFF
--- a/snuba/admin/static/collapse.tsx
+++ b/snuba/admin/static/collapse.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { COLORS } from "./theme";
+
+function Collapse(props: { text: string; children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const { text, children } = props;
+  return (
+    <div>
+      <div style={header}>
+        <span style={collapsed ? downArrowContainer : rightArrowContainer}>
+          <a
+            style={collapsed ? downArrow : rightArrow}
+            onClick={() => setCollapsed((prev) => !prev)}
+          ></a>
+        </span>
+        <span style={indent}>{text}</span>
+      </div>
+      {collapsed && <div style={indent}>{children}</div>}
+    </div>
+  );
+}
+
+const header = {
+  fontSize: 16,
+  lineHeight: 1,
+  height: 20,
+  display: "flex",
+};
+
+const downArrowContainer = {
+  marginTop: -4,
+};
+
+const rightArrowContainer = {
+  marginTop: 0,
+};
+
+const arrow = {
+  border: `solid ${COLORS.TEXT_INACTIVE}`,
+  borderWidth: "0 2px 2px 0",
+  display: "inline-block",
+  padding: 4,
+  cursor: "pointer",
+};
+
+const rightArrow = {
+  ...arrow,
+  transform: "rotate(-45deg)",
+};
+
+const downArrow = {
+  ...arrow,
+  transform: "rotate(45deg)",
+};
+
+const indent = {
+  position: "absolute" as const,
+  marginLeft: 20,
+};
+
+export { Collapse };


### PR DESCRIPTION
This adds a collapse UI component to be used in the admin tool.
This is designed to be used to render query history in the system
queries and tracing tool, and replace the table within a table
layout that we have there now. It is not being used anywhere
yet and will be integrated in the future.

It takes a header as text and the body can be any react component.

Example usage:
```
<Collapse text="Some text header">
   <div>Some react component</div>
</Collapse>
```

Preview with a table inside:

![Screen Shot 2022-02-03 at 10 48 15 am](https://user-images.githubusercontent.com/1779792/152409775-200560c5-963d-46ec-84b9-4bc879cc578b.png)