### PR TITLE
ref: Add outcomes-billing-consumer to freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -29,6 +29,8 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: loadbalancer-outcomes-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
+    name: outcomes-billing-consumer
+  - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-scheduler


### PR DESCRIPTION
This is a new consumer added recently but it wasn't added to the freight config
file so it wasn't being deployed with all the other consumers.
