### PR TITLE
feat(profiling): Create the stacktraces table to store profiling data

### DIFF
--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple as PTuple, Union
 
 from snuba.utils.schemas import UUID, AggregateFunction, Any, Array, Column
 from snuba.utils.schemas import ColumnSet as BaseColumnSet
@@ -14,11 +14,13 @@ from snuba.utils.schemas import (
     Float,
     IPv4,
     IPv6,
+    NamedTuple,
     Nested,
     Nullable,
     ReadOnly,
     SchemaModifiers,
     String,
+    Tuple,
     TModifiers,
     TypeModifier,
     TypeModifiers,
@@ -41,12 +43,14 @@ __all__ = (
     "Float",
     "IPv4",
     "IPv6",
+    "NamedTuple",
     "Nested",
     "Nullable",
     "ReadOnly",
     "SchemaModifiers",
     "String",
     "TModifiers",
+    "Tuple",
     "TypeModifier",
     "TypeModifiers",
     "UInt",
@@ -69,7 +73,7 @@ class ColumnSet(BaseColumnSet):
     def __init__(
         self,
         columns: Sequence[
-            Union[Column[SchemaModifiers], Tuple[str, ColumnType[SchemaModifiers]]]
+            Union[Column[SchemaModifiers], PTuple[str, ColumnType[SchemaModifiers]]]
         ],
     ) -> None:
         for column in columns:
@@ -82,7 +86,7 @@ class ColumnSet(BaseColumnSet):
 
     def __add__(
         self,
-        other: Union[ColumnSet, Sequence[Tuple[str, ColumnType[SchemaModifiers]]]],
+        other: Union[ColumnSet, Sequence[PTuple[str, ColumnType[SchemaModifiers]]]],
     ) -> ColumnSet:
         if isinstance(other, ColumnSet):
             return ColumnSet([*self.columns, *other.columns])

--- a/snuba/clickhouse/columns.py
+++ b/snuba/clickhouse/columns.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence, Tuple as PTuple, Union
+from typing import Sequence, Union
 
 from snuba.utils.schemas import UUID, AggregateFunction, Any, Array, Column
 from snuba.utils.schemas import ColumnSet as BaseColumnSet
@@ -73,7 +73,7 @@ class ColumnSet(BaseColumnSet):
     def __init__(
         self,
         columns: Sequence[
-            Union[Column[SchemaModifiers], PTuple[str, ColumnType[SchemaModifiers]]]
+            Union[Column[SchemaModifiers], tuple[str, ColumnType[SchemaModifiers]]]
         ],
     ) -> None:
         for column in columns:
@@ -86,7 +86,7 @@ class ColumnSet(BaseColumnSet):
 
     def __add__(
         self,
-        other: Union[ColumnSet, Sequence[PTuple[str, ColumnType[SchemaModifiers]]]],
+        other: Union[ColumnSet, Sequence[tuple[str, ColumnType[SchemaModifiers]]]],
     ) -> ColumnSet:
         if isinstance(other, ColumnSet):
             return ColumnSet([*self.columns, *other.columns])

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -28,6 +28,7 @@ class StorageSetKey(Enum):
     TRANSACTIONS = "transactions"
     TRANSACTIONS_RO = "transactions_ro"
     TRANSACTIONS_V2 = "transactions_v2"
+    STACKTRACES = "stacktraces"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -33,7 +33,7 @@ class StorageSetKey(Enum):
 
 
 # Storage sets enabled only when development features are enabled.
-DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({StorageSetKey.PROFILES})
+DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({})
 
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -32,7 +32,7 @@ class StorageSetKey(Enum):
 
 
 # Storage sets enabled only when development features are enabled.
-DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({})
+DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({StorageSetKey.PROFILES})
 
 # Storage sets in a group share the same query and distributed nodes but
 # do not have the same local node cluster configuration.

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -28,7 +28,7 @@ class StorageSetKey(Enum):
     TRANSACTIONS = "transactions"
     TRANSACTIONS_RO = "transactions_ro"
     TRANSACTIONS_V2 = "transactions_v2"
-    STACKTRACES = "stacktraces"
+    PROFILES = "profiles"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -17,7 +17,7 @@ class MigrationGroup(Enum):
     SESSIONS = "sessions"
     QUERYLOG = "querylog"
     SPANS_EXPERIMENTAL = "spans_experimental"
-    STACKTRACES = "stacktraces"
+    PROFILES = "profiles"
 
 
 # Migration groups are mandatory by default, unless they are on this list
@@ -26,7 +26,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.SESSIONS,
     MigrationGroup.QUERYLOG,
     MigrationGroup.SPANS_EXPERIMENTAL,
-    MigrationGroup.STACKTRACES,
+    MigrationGroup.PROFILES,
 }
 
 
@@ -203,12 +203,13 @@ class SpansExperimentalLoader(DirectoryLoader):
     def get_migrations(self) -> Sequence[str]:
         return ["0001_spans_experimental"]
 
-class StacktracesLoader(DirectoryLoader):
+
+class ProfilesLoader(DirectoryLoader):
     def __init__(self) -> None:
-        super().__init__("snuba.migrations.snuba_migrations.stacktraces")
+        super().__init__("snuba.migrations.snuba_migrations.profiles")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_stacktraces"]
+        return ["0001_profiles"]
 
 
 _REGISTERED_GROUPS = {
@@ -221,7 +222,7 @@ _REGISTERED_GROUPS = {
     MigrationGroup.SESSIONS: SessionsLoader(),
     MigrationGroup.QUERYLOG: QuerylogLoader(),
     MigrationGroup.SPANS_EXPERIMENTAL: SpansExperimentalLoader(),
-    MigrationGroup.STACKTRACES: StacktracesLoader(),
+    MigrationGroup.PROFILES: ProfilesLoader(),
 }
 
 

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -17,6 +17,7 @@ class MigrationGroup(Enum):
     SESSIONS = "sessions"
     QUERYLOG = "querylog"
     SPANS_EXPERIMENTAL = "spans_experimental"
+    STACKTRACES = "stacktraces"
 
 
 # Migration groups are mandatory by default, unless they are on this list
@@ -25,6 +26,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.SESSIONS,
     MigrationGroup.QUERYLOG,
     MigrationGroup.SPANS_EXPERIMENTAL,
+    MigrationGroup.STACKTRACES,
 }
 
 
@@ -201,6 +203,13 @@ class SpansExperimentalLoader(DirectoryLoader):
     def get_migrations(self) -> Sequence[str]:
         return ["0001_spans_experimental"]
 
+class StacktracesLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.migrations.snuba_migrations.stacktraces")
+
+    def get_migrations(self) -> Sequence[str]:
+        return ["0001_stacktraces"]
+
 
 _REGISTERED_GROUPS = {
     MigrationGroup.SYSTEM: SystemLoader(),
@@ -212,6 +221,7 @@ _REGISTERED_GROUPS = {
     MigrationGroup.SESSIONS: SessionsLoader(),
     MigrationGroup.QUERYLOG: QuerylogLoader(),
     MigrationGroup.SPANS_EXPERIMENTAL: SpansExperimentalLoader(),
+    MigrationGroup.STACKTRACES: StacktracesLoader(),
 }
 
 

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -45,11 +45,11 @@ class Migration(migration.ClickhouseNodeMigration):
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.STACKTRACES,
-                table_name="stacktraces_local",
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    storage_set=StorageSetKey.STACKTRACES,
+                    storage_set=StorageSetKey.PROFILES,
                     order_by="(organization_id, project_id, transaction_id)",
                     ttl="received + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
@@ -62,18 +62,18 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.STACKTRACES, table_name="stacktraces_local",
+                storage_set=StorageSetKey.PROFILES, table_name="profiles_local",
             )
         ]
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.CreateTable(
-                storage_set=StorageSetKey.STACKTRACES,
-                table_name="stacktraces_dist",
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="stacktraces_local",
+                    local_table_name="profiles_local",
                     sharding_key="cityHash64(transaction_id)",
                 ),
             )
@@ -82,6 +82,6 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.STACKTRACES, table_name="stacktraces_dist",
+                storage_set=StorageSetKey.PROFILES, table_name="profiles_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -49,7 +49,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="profiles_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    order_by="(organization_id, project_id, toStartOfDay(received), transaction_id)",
+                    order_by="(organization_id, project_id, toStartOfDay(received), cityHash64(transaction_id))",
                     partition_by="(retention_days, toMonday(received))",
                     sample_by="cityHash64(transaction_id)",
                     settings={"index_granularity": "8192"},

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -12,7 +12,7 @@ columns: List[Column[Modifiers]] = [
     Column("transaction_id", UUID()),
     Column("received", DateTime()),
     # profiling data
-    Column("stacktrace", String(Modifiers(codecs=["LZ4HC(9)"]))),
+    Column("profile", String(Modifiers(codecs=["LZ4HC(9)"]))),
     Column("symbols", String(Modifiers(codecs=["LZ4HC(9)"]))),
     # filtering data
     Column("android_api_level", UInt(32, Modifiers(nullable=True))),

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -33,7 +33,6 @@ columns: List[Column[Modifiers]] = [
     Column("version", NamedTuple((("name", String()), ("code", String())))),
     # internal data
     Column("retention_days", UInt(16)),
-    Column("deleted", UInt(8)),
     Column("partition", UInt(16)),
     Column("offset", UInt(64)),
 ]
@@ -55,7 +54,6 @@ class Migration(migration.ClickhouseNodeMigration):
                     settings={"index_granularity": "8192"},
                     storage_set=StorageSetKey.PROFILES,
                     ttl="received + toIntervalDay(retention_days)",
-                    version_column="deleted",
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -49,12 +49,13 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="profiles_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    storage_set=StorageSetKey.PROFILES,
-                    order_by="(organization_id, project_id, transaction_id)",
-                    ttl="received + toIntervalDay(retention_days)",
+                    order_by="(organization_id, project_id, toStartOfDay(received), transaction_id)",
+                    partition_by="(retention_days, toMonday(received))",
+                    sample_by="cityHash64(transaction_id)",
                     settings={"index_granularity": "8192"},
+                    storage_set=StorageSetKey.PROFILES,
+                    ttl="received + toIntervalDay(retention_days)",
                     version_column="deleted",
-                    partition_by="(organization_id, project_id, toMonday(received))",
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -35,7 +35,7 @@ columns: List[Column[Modifiers]] = [
     Column("retention_days", UInt(16)),
     Column("deleted", UInt(8)),
     Column("partition", UInt(16)),
-    Column("offset", UInt(16)),
+    Column("offset", UInt(64)),
 ]
 
 

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -1,0 +1,95 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import (
+    UUID,
+    Column,
+    DateTime,
+    String,
+    UInt,
+    Tuple,
+    NamedTuple,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+columns: List[Column[Modifiers]] = [
+    # primary key
+    Column("project_id", UInt(64)),
+    Column("transaction_id", UUID()),
+
+    # profiling data
+    Column("stacktrace", String(Modifiers(codecs=["LZ4HC(9)"]))),
+    Column("symbols", String(Modifiers(codecs=["LZ4HC(9)"]))),
+
+    # filtering data
+    Column("trace_id", UUID()),
+    Column("transaction_name", String(Modifiers(low_cardinality=True))),
+    Column("environment", String(Modifiers(nullable=True, low_cardinality=True))),
+
+    Column("version", NamedTuple((("name", String), ("code", String)), Modifiers(low_cardinality=True))),
+    Column("platform", String(Modifiers(low_cardinality=True))),
+    Column("android_api_level", UInt(32, Modifiers(nullable=True))),
+    Column("device_classification", String(Modifiers(low_cardinality=True))),
+    Column("device_locale", String(Modifiers(low_cardinality=True))),
+    Column("device_manufacturer", String(Modifiers(low_cardinality=True))),
+    Column("device_model", String(Modifiers(low_cardinality=True))),
+    Column("device_os_build_number", String(Modifiers(low_cardinality=True))),
+    Column("device_os_name", String(Modifiers(low_cardinality=True))),
+    Column("device_os_version", String(Modifiers(low_cardinality=True))),
+
+    Column("error_code", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("error_description", String(Modifiers(low_cardinality=True, nullable=True))),
+
+    Column("duration_ns", UInt(64)),
+    Column("ingested_at_ts", DateTime()),
+
+    # internal data
+    Column("retention_days", UInt(16, Modifiers(default=30))),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.STACKTRACES,
+                table_name="stacktraces_local",
+                columns=columns,
+                engine=table_engines.ReplacingMergeTree(
+                    storage_set=StorageSetKey.STACKTRACES,
+                    order_by="(project_id, transaction_id, ingested_at_ts)",
+                    ttl="finish_ts + toIntervalDay(retention_days)",
+                    settings={"index_granularity": "8192"},
+                ),
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.STACKTRACES, table_name="stacktraces_local",
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.STACKTRACES,
+                table_name="stacktraces_dist",
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="stacktraces_local",
+                    sharding_key="cityHash64(project_id, transaction_name)",
+                ),
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.STACKTRACES, table_name="stacktraces_dist",
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -48,7 +48,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
-                    order_by="(organiation_id, project_id, transaction_id, received)",
+                    order_by="(organization_id, project_id, transaction_id, received)",
                     ttl="received + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
                     version_column="version",

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -24,12 +24,6 @@ columns: List[Column[Modifiers]] = [
     Column("symbols", String(Modifiers(codecs=["LZ4HC(9)"]))),
 
     # filtering data
-    Column("trace_id", UUID()),
-    Column("transaction_name", String(Modifiers(low_cardinality=True))),
-    Column("environment", String(Modifiers(nullable=True, low_cardinality=True))),
-
-    Column("version", NamedTuple((("name", String()), ("code", String())))),
-    Column("platform", String(Modifiers(low_cardinality=True))),
     Column("android_api_level", UInt(32, Modifiers(nullable=True))),
     Column("device_classification", String(Modifiers(low_cardinality=True))),
     Column("device_locale", String(Modifiers(low_cardinality=True))),
@@ -38,11 +32,14 @@ columns: List[Column[Modifiers]] = [
     Column("device_os_build_number", String(Modifiers(low_cardinality=True))),
     Column("device_os_name", String(Modifiers(low_cardinality=True))),
     Column("device_os_version", String(Modifiers(low_cardinality=True))),
-
+    Column("duration_ns", UInt(64)),
+    Column("environment", String(Modifiers(nullable=True, low_cardinality=True))),
     Column("error_code", String(Modifiers(low_cardinality=True, nullable=True))),
     Column("error_description", String(Modifiers(low_cardinality=True, nullable=True))),
-
-    Column("duration_ns", UInt(64)),
+    Column("platform", String(Modifiers(low_cardinality=True))),
+    Column("trace_id", UUID()),
+    Column("transaction_name", String(Modifiers(low_cardinality=True))),
+    Column("version", NamedTuple((("name", String()), ("code", String())))),
 
     # internal data
     Column("retention_days", UInt(16)),

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -1,13 +1,6 @@
 from typing import List, Sequence
 
-from snuba.clickhouse.columns import (
-    UUID,
-    Column,
-    DateTime,
-    String,
-    UInt,
-    NamedTuple,
-)
+from snuba.clickhouse.columns import UUID, Column, DateTime, NamedTuple, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -18,11 +11,9 @@ columns: List[Column[Modifiers]] = [
     Column("project_id", UInt(64)),
     Column("transaction_id", UUID()),
     Column("received", DateTime()),
-
     # profiling data
     Column("stacktrace", String(Modifiers(codecs=["LZ4HC(9)"]))),
     Column("symbols", String(Modifiers(codecs=["LZ4HC(9)"]))),
-
     # filtering data
     Column("android_api_level", UInt(32, Modifiers(nullable=True))),
     Column("device_classification", String(Modifiers(low_cardinality=True))),
@@ -40,7 +31,6 @@ columns: List[Column[Modifiers]] = [
     Column("trace_id", UUID()),
     Column("transaction_name", String(Modifiers(low_cardinality=True))),
     Column("version", NamedTuple((("name", String()), ("code", String())))),
-
     # internal data
     Column("retention_days", UInt(16)),
 ]

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -41,7 +41,7 @@ columns: List[Column[Modifiers]] = [
     Column("error_description", String(Modifiers(low_cardinality=True, nullable=True))),
 
     Column("duration_ns", UInt(64)),
-    Column("received_ts", DateTime()),
+    Column("received", DateTime()),
 
     # internal data
     Column("retention_days", UInt(16)),
@@ -59,7 +59,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.MergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
-                    order_by="(project_id, transaction_id, received_ts)",
+                    order_by="(project_id, transaction_id, received)",
                     ttl="finish_ts + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
                 ),

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -58,7 +58,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 engine=table_engines.MergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
                     order_by="(organiation_id, project_id, transaction_id, received)",
-                    ttl="finish_ts + toIntervalDay(retention_days)",
+                    ttl="received + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
                 ),
             )

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -41,7 +41,7 @@ columns: List[Column[Modifiers]] = [
     Column("error_description", String(Modifiers(low_cardinality=True, nullable=True))),
 
     Column("duration_ns", UInt(64)),
-    Column("ingested_at_ts", DateTime()),
+    Column("received_ts", DateTime()),
 
     # internal data
     Column("retention_days", UInt(16)),
@@ -59,7 +59,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.MergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
-                    order_by="(project_id, transaction_id, ingested_at_ts)",
+                    order_by="(project_id, transaction_id, received_ts)",
                     ttl="finish_ts + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
                 ),

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -27,7 +27,7 @@ columns: List[Column[Modifiers]] = [
     Column("transaction_name", String(Modifiers(low_cardinality=True))),
     Column("environment", String(Modifiers(nullable=True, low_cardinality=True))),
 
-    Column("version", NamedTuple((("name", String), ("code", String)), Modifiers(low_cardinality=True))),
+    Column("version", NamedTuple((("name", String()), ("code", String())), Modifiers(low_cardinality=True))),
     Column("platform", String(Modifiers(low_cardinality=True))),
     Column("android_api_level", UInt(32, Modifiers(nullable=True))),
     Column("device_classification", String(Modifiers(low_cardinality=True))),
@@ -45,7 +45,7 @@ columns: List[Column[Modifiers]] = [
     Column("ingested_at_ts", DateTime()),
 
     # internal data
-    Column("retention_days", UInt(16, Modifiers(default=30))),
+    Column("retention_days", UInt(16)),
 ]
 
 
@@ -58,7 +58,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.STACKTRACES,
                 table_name="stacktraces_local",
                 columns=columns,
-                engine=table_engines.ReplacingMergeTree(
+                engine=table_engines.MergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
                     order_by="(project_id, transaction_id, ingested_at_ts)",
                     ttl="finish_ts + toIntervalDay(retention_days)",

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -33,7 +33,7 @@ columns: List[Column[Modifiers]] = [
     Column("version", NamedTuple((("name", String()), ("code", String())))),
     # internal data
     Column("retention_days", UInt(16)),
-    Column("version", UInt(16)),
+    Column("deleted", UInt(8)),
     Column("partition", UInt(16)),
     Column("offset", UInt(16)),
 ]
@@ -53,7 +53,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     order_by="(organization_id, project_id, transaction_id)",
                     ttl="received + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
-                    version_column="version",
+                    version_column="deleted",
                     partition_by="(organization_id, project_id, toMonday(received))",
                 ),
             )

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -6,7 +6,6 @@ from snuba.clickhouse.columns import (
     DateTime,
     String,
     UInt,
-    Tuple,
     NamedTuple,
 )
 from snuba.clusters.storage_sets import StorageSetKey
@@ -27,7 +26,7 @@ columns: List[Column[Modifiers]] = [
     Column("transaction_name", String(Modifiers(low_cardinality=True))),
     Column("environment", String(Modifiers(nullable=True, low_cardinality=True))),
 
-    Column("version", NamedTuple((("name", String()), ("code", String())), Modifiers(low_cardinality=True))),
+    Column("version", NamedTuple((("name", String()), ("code", String())))),
     Column("platform", String(Modifiers(low_cardinality=True))),
     Column("android_api_level", UInt(32, Modifiers(nullable=True))),
     Column("device_classification", String(Modifiers(low_cardinality=True))),

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -33,6 +33,7 @@ columns: List[Column[Modifiers]] = [
     Column("version", NamedTuple((("name", String()), ("code", String())))),
     # internal data
     Column("retention_days", UInt(16)),
+    Column("version", UInt(16)),
 ]
 
 
@@ -45,11 +46,12 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.STACKTRACES,
                 table_name="stacktraces_local",
                 columns=columns,
-                engine=table_engines.MergeTree(
+                engine=table_engines.ReplacingMergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
                     order_by="(organiation_id, project_id, transaction_id, received)",
                     ttl="received + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
+                    version_column="version",
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
+++ b/snuba/migrations/snuba_migrations/stacktraces/0001_stacktraces.py
@@ -14,8 +14,10 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 columns: List[Column[Modifiers]] = [
     # primary key
+    Column("organization_id", UInt(64)),
     Column("project_id", UInt(64)),
     Column("transaction_id", UUID()),
+    Column("received", DateTime()),
 
     # profiling data
     Column("stacktrace", String(Modifiers(codecs=["LZ4HC(9)"]))),
@@ -41,7 +43,6 @@ columns: List[Column[Modifiers]] = [
     Column("error_description", String(Modifiers(low_cardinality=True, nullable=True))),
 
     Column("duration_ns", UInt(64)),
-    Column("received", DateTime()),
 
     # internal data
     Column("retention_days", UInt(16)),
@@ -59,7 +60,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.MergeTree(
                     storage_set=StorageSetKey.STACKTRACES,
-                    order_by="(project_id, transaction_id, received)",
+                    order_by="(organiation_id, project_id, transaction_id, received)",
                     ttl="finish_ts + toIntervalDay(retention_days)",
                     settings={"index_granularity": "8192"},
                 ),

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -93,8 +93,8 @@ class ReplacingMergeTree(MergeTree):
     def __init__(
         self,
         storage_set: StorageSetKey,
-        version_column: str,
         order_by: str,
+        version_column: Optional[str] = None,
         partition_by: Optional[str] = None,
         sample_by: Optional[str] = None,
         ttl: Optional[str] = None,

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -108,10 +108,14 @@ class ReplacingMergeTree(MergeTree):
 
     def _get_engine_type(self, cluster: ClickhouseCluster, table_name: str) -> str:
         if cluster.is_single_node():
-            return f"ReplacingMergeTree({self.__version_column})"
+            if self.__version_column:
+                return f"ReplacingMergeTree({self.__version_column})"
+            return "ReplacingMergeTree()"
         else:
             zoo_path = self._get_zookeeper_path(cluster, table_name)
-            return f"ReplicatedReplacingMergeTree({zoo_path}, '{{replica}}', {self.__version_column})"
+            if self.__version_column:
+                return f"ReplicatedReplacingMergeTree({zoo_path}, '{{replica}}', {self.__version_column})"
+            return f"ReplicatedReplacingMergeTree({zoo_path}, '{{replica}}')"
 
 
 class SummingMergeTree(MergeTree):

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -46,6 +46,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "transactions",
             "transactions_ro",
             "transactions_v2",
+            "stacktraces",
         },
         "single_node": True,
     },

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -24,15 +24,21 @@ DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "default")
+CLICKHOUSE_HTTP_PORT = int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123))
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {
-        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
-        "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
-        "user": os.environ.get("CLICKHOUSE_USER", "default"),
-        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
-        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
-        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
+        "host": CLICKHOUSE_HOST,
+        "port": CLICKHOUSE_PORT,
+        "user": CLICKHOUSE_USER,
+        "password": CLICKHOUSE_PASSWORD,
+        "database": CLICKHOUSE_DATABASE,
+        "http_port": CLICKHOUSE_HTTP_PORT,
         "storage_sets": {
             "cdc",
             "discover",
@@ -46,6 +52,18 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "transactions",
             "transactions_ro",
             "transactions_v2",
+        },
+        "single_node": True,
+    },
+    {
+        "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", CLICKHOUSE_HOST),
+        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", CLICKHOUSE_PORT)),
+        "user": os.environ.get("CLICKHOUSE_PROFILING_USER", CLICKHOUSE_USER),
+        "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", CLICKHOUSE_PASSWORD),
+        "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", CLICKHOUSE_DATABASE),
+        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", CLICKHOUSE_HTTP_PORT)),
+        "storage_sets": {
+            "stacktraces",
         },
         "single_node": True,
     },

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -24,21 +24,15 @@ DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
-CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
-CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
-CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
-CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "default")
-CLICKHOUSE_HTTP_PORT = int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123))
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {
-        "host": CLICKHOUSE_HOST,
-        "port": CLICKHOUSE_PORT,
-        "user": CLICKHOUSE_USER,
-        "password": CLICKHOUSE_PASSWORD,
-        "database": CLICKHOUSE_DATABASE,
-        "http_port": CLICKHOUSE_HTTP_PORT,
+        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
+        "user": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
+        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
         "storage_sets": {
             "cdc",
             "discover",
@@ -52,18 +46,6 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "transactions",
             "transactions_ro",
             "transactions_v2",
-        },
-        "single_node": True,
-    },
-    {
-        "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", CLICKHOUSE_HOST),
-        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", CLICKHOUSE_PORT)),
-        "user": os.environ.get("CLICKHOUSE_PROFILING_USER", CLICKHOUSE_USER),
-        "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", CLICKHOUSE_PASSWORD),
-        "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", CLICKHOUSE_DATABASE),
-        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", CLICKHOUSE_HTTP_PORT)),
-        "storage_sets": {
-            "stacktraces",
         },
         "single_node": True,
     },

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -155,7 +155,7 @@ COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 
 # Migrations in skipped groups will not be run
-SKIPPED_MIGRATION_GROUPS: Set[str] = {"querylog", "spans_experimental"}
+SKIPPED_MIGRATION_GROUPS: Set[str] = {"querylog", "spans_experimental", "profiles"}
 
 MAX_RESOLUTION_FOR_JITTER = 60
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -46,7 +46,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "transactions",
             "transactions_ro",
             "transactions_v2",
-            "stacktraces",
+            "profiles",
         },
         "single_node": True,
     },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -1,13 +1,20 @@
 import os
 
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
+CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
+CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
+CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "default")
+CLICKHOUSE_HTTP_PORT = int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123))
+
 CLUSTERS = [
     {
-        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
-        "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
-        "user": os.environ.get("CLICKHOUSE_USER", "default"),
-        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
-        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
-        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
+        "host": CLICKHOUSE_HOST,
+        "port": CLICKHOUSE_PORT,
+        "user": CLICKHOUSE_USER,
+        "password": CLICKHOUSE_PASSWORD,
+        "database": CLICKHOUSE_DATABASE,
+        "http_port": CLICKHOUSE_HTTP_PORT,
         "storage_sets": {
             "cdc",
             "discover",
@@ -27,12 +34,12 @@ CLUSTERS = [
         "distributed_cluster_name": "cluster_one_sh",
     },
     {
-        "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", "localhost"),
-        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", 9001)),
-        "user": os.environ.get("CLICKHOUSE_PROFILING_USER", "default"),
-        "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", ""),
-        "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", "default"),
-        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", 8124)),
+        "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", CLICKHOUSE_HOST),
+        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", CLICKHOUSE_PORT)),
+        "user": os.environ.get("CLICKHOUSE_PROFILING_USER", CLICKHOUSE_USER),
+        "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", CLICKHOUSE_PASSWORD),
+        "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", CLICKHOUSE_DATABASE),
+        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", CLICKHOUSE_HTTP_PORT)),
         "storage_sets": {
             "stacktraces",
         },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -28,11 +28,11 @@ CLUSTERS = [
     },
     {
         "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", "localhost"),
-        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", 9000)),
+        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", 9001)),
         "user": os.environ.get("CLICKHOUSE_PROFILING_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", ""),
         "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", "default"),
-        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", 8123)),
+        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", 8124)),
         "storage_sets": {
             "stacktraces",
         },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -37,12 +37,16 @@ CLUSTERS = [
         "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", CLICKHOUSE_HOST),
         "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", CLICKHOUSE_PORT)),
         "user": os.environ.get("CLICKHOUSE_PROFILING_USER", CLICKHOUSE_USER),
-        "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", CLICKHOUSE_PASSWORD),
-        "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", CLICKHOUSE_DATABASE),
-        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", CLICKHOUSE_HTTP_PORT)),
-        "storage_sets": {
-            "stacktraces",
-        },
+        "password": os.environ.get(
+            "CLICKHOUSE_PROFILING_PASSWORD", CLICKHOUSE_PASSWORD
+        ),
+        "database": os.environ.get(
+            "CLICKHOUSE_PROFILING_DATABASE", CLICKHOUSE_DATABASE
+        ),
+        "http_port": int(
+            os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", CLICKHOUSE_HTTP_PORT)
+        ),
+        "storage_sets": {"profiles"},
         "single_node": False,
         "cluster_name": "profiling_cluster",
         "distributed_cluster_name": "profiling_cluster",

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -1,20 +1,13 @@
 import os
 
-CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "localhost")
-CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT", 9000))
-CLICKHOUSE_USER = os.environ.get("CLICKHOUSE_USER", "default")
-CLICKHOUSE_PASSWORD = os.environ.get("CLICKHOUSE_PASSWORD", "")
-CLICKHOUSE_DATABASE = os.environ.get("CLICKHOUSE_DATABASE", "default")
-CLICKHOUSE_HTTP_PORT = int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123))
-
 CLUSTERS = [
     {
-        "host": CLICKHOUSE_HOST,
-        "port": CLICKHOUSE_PORT,
-        "user": CLICKHOUSE_USER,
-        "password": CLICKHOUSE_PASSWORD,
-        "database": CLICKHOUSE_DATABASE,
-        "http_port": CLICKHOUSE_HTTP_PORT,
+        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
+        "user": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
+        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8123)),
         "storage_sets": {
             "cdc",
             "discover",
@@ -28,27 +21,10 @@ CLUSTERS = [
             "transactions",
             "transactions_ro",
             "transactions_v2",
+            "profiles",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",
         "distributed_cluster_name": "cluster_one_sh",
-    },
-    {
-        "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", CLICKHOUSE_HOST),
-        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", CLICKHOUSE_PORT)),
-        "user": os.environ.get("CLICKHOUSE_PROFILING_USER", CLICKHOUSE_USER),
-        "password": os.environ.get(
-            "CLICKHOUSE_PROFILING_PASSWORD", CLICKHOUSE_PASSWORD
-        ),
-        "database": os.environ.get(
-            "CLICKHOUSE_PROFILING_DATABASE", CLICKHOUSE_DATABASE
-        ),
-        "http_port": int(
-            os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", CLICKHOUSE_HTTP_PORT)
-        ),
-        "storage_sets": {"profiles"},
-        "single_node": False,
-        "cluster_name": "profiling_cluster",
-        "distributed_cluster_name": "profiling_cluster",
     },
 ]

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -26,4 +26,18 @@ CLUSTERS = [
         "cluster_name": "cluster_one_sh",
         "distributed_cluster_name": "cluster_one_sh",
     },
+    {
+        "host": os.environ.get("CLICKHOUSE_PROFILING_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PROFILING_PORT", 9000)),
+        "user": os.environ.get("CLICKHOUSE_PROFILING_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PROFILING_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_PROFILING_DATABASE", "default"),
+        "http_port": int(os.environ.get("CLICKHOUSE_PROFILING_HTTP_PORT", 8123)),
+        "storage_sets": {
+            "stacktraces",
+        },
+        "single_node": False,
+        "cluster_name": "profiling_cluster",
+        "distributed_cluster_name": "profiling_cluster",
+    },
 ]

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -10,7 +10,6 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
-    Tuple as PTuple,
     Type,
     TypeVar,
     Union,
@@ -157,7 +156,7 @@ class Column(Generic[TModifiers]):
 
     @staticmethod
     def to_columns(
-        columns: Sequence[Union[Column[TModifiers], PTuple[str, ColumnType[TModifiers]]]]
+        columns: Sequence[Union[Column[TModifiers], tuple[str, ColumnType[TModifiers]]]]
     ) -> Sequence[Column[TModifiers]]:
         return [Column(*col) if not isinstance(col, Column) else col for col in columns]
 
@@ -356,7 +355,7 @@ class Nested(ColumnType[TModifiers]):
     def __init__(
         self,
         nested_columns: Sequence[
-            Union[Column[TModifiers], PTuple[str, ColumnType[TModifiers]]]
+            Union[Column[TModifiers], tuple[str, ColumnType[TModifiers]]]
         ],
         modifiers: Optional[TModifiers] = None,
     ) -> None:
@@ -533,7 +532,7 @@ class DateTime(ColumnType[TModifiers]):
 
 class Enum(ColumnType[TModifiers]):
     def __init__(
-        self, values: Sequence[PTuple[str, int]], modifiers: Optional[TModifiers] = None,
+        self, values: Sequence[tuple[str, int]], modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.values = values
@@ -561,7 +560,7 @@ class Enum(ColumnType[TModifiers]):
 
 class Tuple(ColumnType[TModifiers]):
     def __init__(
-        self, types: PTuple[ColumnType[TModifiers], ...], modifiers: Optional[TModifiers] = None,
+        self, types: tuple[ColumnType[TModifiers], ...], modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.types = types
@@ -589,7 +588,7 @@ class Tuple(ColumnType[TModifiers]):
 
 class NamedTuple(ColumnType[TModifiers]):
     def __init__(
-        self, types: PTuple[PTuple[str, ColumnType[TModifiers]], ...], modifiers: Optional[TModifiers] = None,
+        self, types: tuple[tuple[str, ColumnType[TModifiers]], ...], modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.types = types

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -561,7 +561,7 @@ class Enum(ColumnType[TModifiers]):
 
 class Tuple(ColumnType[TModifiers]):
     def __init__(
-        self, types: PTuple[ColumnType, ...], modifiers: Optional[TModifiers] = None,
+        self, types: PTuple[ColumnType[TModifiers], ...], modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.types = types
@@ -573,7 +573,7 @@ class Tuple(ColumnType[TModifiers]):
         return (
             self.__class__ == other.__class__
             and self.get_modifiers() == cast(Enum[TModifiers], other).get_modifiers()
-            and self.types == cast(PTuple[TModifiers], other).types
+            and self.types == cast(Tuple[TModifiers], other).types
         )
 
     def _for_schema_impl(self) -> str:
@@ -589,7 +589,7 @@ class Tuple(ColumnType[TModifiers]):
 
 class NamedTuple(ColumnType[TModifiers]):
     def __init__(
-        self, types: PTuple[PTuple[str, ColumnType], ...], modifiers: Optional[TModifiers] = None,
+        self, types: PTuple[PTuple[str, ColumnType[TModifiers]], ...], modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.types = types
@@ -601,7 +601,7 @@ class NamedTuple(ColumnType[TModifiers]):
         return (
             self.__class__ == other.__class__
             and self.get_modifiers() == cast(Enum[TModifiers], other).get_modifiers()
-            and self.types == cast(PTuple[TModifiers], other).types
+            and self.types == cast(Tuple[TModifiers], other).types
         )
 
     def _for_schema_impl(self) -> str:

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -574,12 +574,12 @@ class Tuple(ColumnType[TModifiers]):
     def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.get_modifiers() == cast(Enum[TModifiers], other).get_modifiers()
+            and self.get_modifiers() == cast(Tuple[TModifiers], other).get_modifiers()
             and self.types == cast(Tuple[TModifiers], other).types
         )
 
     def _for_schema_impl(self) -> str:
-        return "Tuple({})".format(", ".join([repr(t) for t in self.types]))
+        return "Tuple({})".format(", ".join([t.for_schema() for t in self.types]))
 
     def set_modifiers(self, modifiers: Optional[TModifiers]) -> Tuple[TModifiers]:
         return Tuple(types=self.types, modifiers=modifiers)
@@ -609,7 +609,8 @@ class NamedTuple(ColumnType[TModifiers]):
     def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.get_modifiers() == cast(Enum[TModifiers], other).get_modifiers()
+            and self.get_modifiers()
+            == cast(NamedTuple[TModifiers], other).get_modifiers()
             and self.types == cast(NamedTuple[TModifiers], other).types
         )
 

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -558,15 +558,18 @@ class Enum(ColumnType[TModifiers]):
     def get_raw(self) -> Enum[TModifiers]:
         return Enum(self.values)
 
+
 class Tuple(ColumnType[TModifiers]):
     def __init__(
-        self, types: tuple[ColumnType[TModifiers], ...], modifiers: Optional[TModifiers] = None,
+        self,
+        types: tuple[ColumnType[TModifiers], ...],
+        modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.types = types
 
     def _repr_content(self) -> str:
-        return ", ".join("{}".format(v) for v in self.types)
+        return ", ".join("{}".format(v.__class__.__name__) for v in self.types)
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -576,9 +579,7 @@ class Tuple(ColumnType[TModifiers]):
         )
 
     def _for_schema_impl(self) -> str:
-        return "Tuple({})".format(
-            ", ".join("{}".format(t) for t in self.types)
-        )
+        return "Tuple({})".format(", ".join("{}".format(t) for t in self.types))
 
     def set_modifiers(self, modifiers: Optional[TModifiers]) -> Tuple[TModifiers]:
         return Tuple(types=self.types, modifiers=modifiers)
@@ -586,15 +587,20 @@ class Tuple(ColumnType[TModifiers]):
     def get_raw(self) -> Tuple[TModifiers]:
         return Tuple(self.types)
 
+
 class NamedTuple(ColumnType[TModifiers]):
     def __init__(
-        self, types: tuple[tuple[str, ColumnType[TModifiers]], ...], modifiers: Optional[TModifiers] = None,
+        self,
+        types: tuple[tuple[str, ColumnType[TModifiers]], ...],
+        modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.types = types
 
     def _repr_content(self) -> str:
-        return ", ".join("{} {}".format(t[0], t[1]) for t in self.types)
+        return ", ".join(
+            "{} {}".format(t[0], t[1].__class__.__name__) for t in self.types
+        )
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -613,5 +619,3 @@ class NamedTuple(ColumnType[TModifiers]):
 
     def get_raw(self) -> NamedTuple[TModifiers]:
         return NamedTuple(self.types)
-
-

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -597,12 +597,6 @@ class NamedTuple(ColumnType[TModifiers]):
         super().__init__(modifiers)
         self.types = tuple(Column(*t) for t in types)
 
-    def flatten(self, name: str) -> Sequence[FlattenedColumn]:
-        return [
-            FlattenedColumn(name, column.name, Array(column.type))
-            for column in self.types
-        ]
-
     def _repr_content(self) -> str:
         return repr(self.types)
 

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -601,7 +601,7 @@ class NamedTuple(ColumnType[TModifiers]):
         return (
             self.__class__ == other.__class__
             and self.get_modifiers() == cast(Enum[TModifiers], other).get_modifiers()
-            and self.types == cast(Tuple[TModifiers], other).types
+            and self.types == cast(NamedTuple[TModifiers], other).types
         )
 
     def _for_schema_impl(self) -> str:


### PR DESCRIPTION
This PR aims to create the table necessary to store profiling data in ClickHouse.

I also added 2 new type of columns to be able to use a `Tuple` type in ClickHouse. This helps to consider the version as one value with 2 components which can't be separated. 