### PR TITLE
fix(conn) - increase retry count by 1 in ClickhousePool.execute

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -111,7 +111,7 @@ class ClickhousePool(object):
         try:
             conn = self.pool.get(block=True)
 
-            attempts_remaining = 2
+            attempts_remaining = 3
             while attempts_remaining > 0:
                 attempts_remaining -= 1
                 # Lazily create connection instances


### PR DESCRIPTION
Increase clickhouse request retry count by 1 to mitigate connectivity issues we've been experiencing in production