### PR TITLE
perf(subscriptions): Avoid slow delegate task builder where possible

### DIFF
--- a/snuba/subscriptions/scheduler.py
+++ b/snuba/subscriptions/scheduler.py
@@ -295,7 +295,31 @@ class SubscriptionScheduler(SubscriptionSchedulerBase):
 
         self.__subscriptions: List[Subscription] = []
         self.__last_refresh: Optional[datetime] = None
-        self.__builder = DelegateTaskBuilder()
+
+        self.__delegate_builder = DelegateTaskBuilder()
+        self.__jittered_builder = JitteredTaskBuilder()
+        self.__immediate_builder = ImmediateTaskBuilder()
+
+        self.__reset_builder()
+
+    def __reset_builder(self) -> None:
+        """
+        Use the jittered or immediate builder directly if we can as it is faster.
+        If we are in transition between the two modes, we must use the delegate builder.
+        This function is called for every tick.
+        """
+        general_mode = TaskBuilderMode(
+            state.get_config(
+                "subscription_primary_task_builder", TaskBuilderMode.JITTERED
+            )
+        )
+        if general_mode == TaskBuilderMode.JITTERED:
+            self.__builder: TaskBuilder = self.__jittered_builder
+        elif general_mode == TaskBuilderMode.IMMEDIATE:
+            self.__builder = self.__immediate_builder
+        else:
+            # We are transitioning between jittered and immediate mode. We must use the delegate builder.
+            self.__builder = self.__delegate_builder
 
     def __get_subscriptions(self) -> List[Subscription]:
         current_time = datetime.now()
@@ -323,6 +347,7 @@ class SubscriptionScheduler(SubscriptionSchedulerBase):
         return self.__subscriptions
 
     def find(self, tick: Tick) -> Iterator[ScheduledSubscriptionTask]:
+        self.__reset_builder()
         start_get_subscriptions = datetime.now()
 
         interval = tick.timestamps


### PR DESCRIPTION
The delegate task builder is much slower than using the immediate
or jittered one since it has to check which mode to apply for
every subscription within the tick individually. This change uses
the immediate or jittered task builder directly for the whole tick
if we are not in a transition mode. This is checked at the start
of each tick.