### PR TITLE
ref(subscriptions): Remove unnecessary assertion

### DIFF
--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -92,7 +92,6 @@ class SubscriptionScheduledTaskEncoder(Codec[KafkaPayload, ScheduledSubscription
         subscription_identifier = value.key.decode("utf-8")
 
         scheduled_subscription_dict = rapidjson.loads(payload_value.decode("utf-8"))
-        assert scheduled_subscription_dict["task"]["data"]["type"] == "snql"
 
         entity_key = EntityKey(scheduled_subscription_dict["entity"])
 


### PR DESCRIPTION
Since legacy subscriptions are deprecated, we no longer need this assertion.
Once this is removed and the executor is deployed with this change, we can
go a step further and remove the "type" from the scheduled subscription payload
completely.