### PR TITLE
fix(admin): Fix the system query tool

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -5,6 +5,7 @@ from clickhouse_driver.errors import ErrorCodes
 from snuba.admin.clickhouse.common import InvalidCustomQuery, get_ro_node_connection
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.utils.serializable_exception import SerializableException
 
 
@@ -22,7 +23,9 @@ def _run_sql_query_on_host(
     """
     Run the SQL query. It should be validated before getting to this point
     """
-    connection = get_ro_node_connection(clickhouse_host, clickhouse_port, storage_name)
+    connection = get_ro_node_connection(
+        clickhouse_host, clickhouse_port, storage_name, ClickhouseClientSettings.QUERY
+    )
     query_result = connection.execute(query=sql, with_column_types=True)
 
     return query_result

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -3,6 +3,7 @@ from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
 )
 from snuba.clickhouse.native import ClickhouseResult
+from snuba.clusters.cluster import ClickhouseClientSettings
 
 
 def validate_trace_query(sql_query: str) -> None:
@@ -26,6 +27,8 @@ def validate_trace_query(sql_query: str) -> None:
 def run_query_and_get_trace(storage_name: str, query: str) -> ClickhouseResult:
     validate_trace_query(query)
 
-    connection = get_ro_query_node_connection(storage_name)
+    connection = get_ro_query_node_connection(
+        storage_name, ClickhouseClientSettings.TRACING
+    )
     query_result = connection.execute(query=query, capture_trace=True)
     return query_result

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -45,7 +45,7 @@ class ClickhouseClientSettings(Enum):
     )
     OPTIMIZE = ClickhouseClientSettingsType({}, 10000)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
-    TOOLING = ClickhouseClientSettingsType({"readonly": 2}, None)
+    TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(
         {
             # Replacing existing rows requires reconstructing the entire tuple for each


### PR DESCRIPTION
None of the system queries work currently because we are attempting to run them
with readonly=2 but we have only configured readonly=1 for this user.

Since system queries do not actually need the expanded permissions that come with
readonly=2 (ability to change settings queries) just run them with them readonly=1
instead. Tracing still runs with 2.