### PR TITLE
perf(subscriptions): Simplify SubscriptionData, only validate on creation

### DIFF
--- a/bin/mocks/mock-subscriptions
+++ b/bin/mocks/mock-subscriptions
@@ -6,7 +6,7 @@ from datetime import timedelta
 from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
 from snuba.datasets.factory import get_dataset
 from snuba.redis import redis_client
-from snuba.subscriptions.data import PartitionId, SnQLSubscriptionData
+from snuba.subscriptions.data import PartitionId, SubscriptionData
 from snuba.subscriptions.entity_subscription import ENTITY_KEY_TO_SUBSCRIPTION_MAPPER
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.subscription import SubscriptionCreator
@@ -49,7 +49,7 @@ timer = Timer("mock-subscriptions")
 for _ in range(parsed.number):
     project_id = random.choice(parsed.project)
 
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         query=f"MATCH ({entity_key.value}) SELECT count() AS count WHERE project_id = {project_id}",
         project_id=project_id,
         time_window=timedelta(minutes=1),

--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -9,7 +9,6 @@ from snuba.datasets.entities import EntityKey
 from snuba.query.exceptions import InvalidQueryException
 from snuba.subscriptions.data import (
     ScheduledSubscriptionTask,
-    SnQLSubscriptionData,
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
@@ -32,7 +31,7 @@ class SubscriptionDataCodec(Codec[bytes, SubscriptionData]):
         except json.JSONDecodeError:
             raise InvalidQueryException("Invalid JSON")
 
-        return SnQLSubscriptionData.from_dict(data, self.entity_key)
+        return SubscriptionData.from_dict(data, self.entity_key)
 
 
 class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult]):
@@ -67,8 +66,6 @@ class SubscriptionScheduledTaskEncoder(Codec[KafkaPayload, ScheduledSubscription
     def encode(self, value: ScheduledSubscriptionTask) -> KafkaPayload:
         entity, subscription, tick_upper_offset = value.task
 
-        assert isinstance(subscription.data, SnQLSubscriptionData)
-
         return KafkaPayload(
             str(subscription.identifier).encode("utf-8"),
             cast(
@@ -101,7 +98,7 @@ class SubscriptionScheduledTaskEncoder(Codec[KafkaPayload, ScheduledSubscription
                 entity_key,
                 Subscription(
                     SubscriptionIdentifier.from_string(subscription_identifier),
-                    SnQLSubscriptionData.from_dict(
+                    SubscriptionData.from_dict(
                         scheduled_subscription_dict["task"]["data"], entity_key
                     ),
                 ),

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractclassmethod, abstractmethod
+from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -68,63 +68,16 @@ class SubscriptionIdentifier:
         return cls(PartitionId(int(partition)), UUID(uuid))
 
 
-# This is a workaround for a mypy bug, found here: https://github.com/python/mypy/issues/5374
 @dataclass(frozen=True)
-class _SubscriptionData:
-    project_id: int
-    resolution: timedelta
-    time_window: timedelta
-    entity_subscription: EntitySubscription
-
-
-class SubscriptionData(ABC, _SubscriptionData):
+class SubscriptionData:
     """
     Represents the state of a subscription.
     """
 
-    def __post_init__(self) -> None:
-        if self.time_window < timedelta(minutes=1):
-            raise InvalidSubscriptionError(
-                "Time window must be greater than or equal to 1 minute"
-            )
-        elif self.time_window > timedelta(hours=24):
-            raise InvalidSubscriptionError(
-                "Time window must be less than or equal to 24 hours"
-            )
-
-        if self.resolution < timedelta(minutes=1):
-            raise InvalidSubscriptionError(
-                "Resolution must be greater than or equal to 1 minute"
-            )
-
-        if self.resolution.microseconds > 0:
-            raise InvalidSubscriptionError("Resolution does not support microseconds")
-
-    @abstractmethod
-    def build_request(
-        self,
-        dataset: Dataset,
-        timestamp: datetime,
-        offset: Optional[int],
-        timer: Timer,
-        metrics: Optional[MetricsBackend] = None,
-        referrer: str = SUBSCRIPTION_REFERRER,
-    ) -> Request:
-        raise NotImplementedError
-
-    @abstractclassmethod
-    def from_dict(
-        cls, data: Mapping[str, Any], entity_key: EntityKey
-    ) -> SubscriptionData:
-        raise NotImplementedError
-
-    @abstractmethod
-    def to_dict(self) -> Mapping[str, Any]:
-        raise NotImplementedError
-
-
-@dataclass(frozen=True)
-class SnQLSubscriptionData(SubscriptionData):
+    project_id: int
+    resolution: timedelta
+    time_window: timedelta
+    entity_subscription: EntitySubscription
     query: str
 
     def add_conditions(
@@ -174,10 +127,23 @@ class SnQLSubscriptionData(SubscriptionData):
 
         query.set_ast_condition(new_condition)
 
-    def validate_subscription(
-        self, query: Union[CompositeQuery[Entity], Query]
-    ) -> None:
-        self.entity_subscription.validate_query(query)
+    def validate(self) -> None:
+        if self.time_window < timedelta(minutes=1):
+            raise InvalidSubscriptionError(
+                "Time window must be greater than or equal to 1 minute"
+            )
+        elif self.time_window > timedelta(hours=24):
+            raise InvalidSubscriptionError(
+                "Time window must be less than or equal to 24 hours"
+            )
+
+        if self.resolution < timedelta(minutes=1):
+            raise InvalidSubscriptionError(
+                "Resolution must be greater than or equal to 1 minute"
+            )
+
+        if self.resolution.microseconds > 0:
+            raise InvalidSubscriptionError("Resolution does not support microseconds")
 
     def build_request(
         self,
@@ -199,7 +165,7 @@ class SnQLSubscriptionData(SubscriptionData):
             timer,
             referrer,
             [
-                self.validate_subscription,
+                self.entity_subscription.validate_query,
                 partial(self.add_conditions, timestamp, offset),
             ],
         )
@@ -208,12 +174,12 @@ class SnQLSubscriptionData(SubscriptionData):
     @classmethod
     def from_dict(
         cls, data: Mapping[str, Any], entity_key: EntityKey
-    ) -> SnQLSubscriptionData:
+    ) -> SubscriptionData:
         entity_subscription = ENTITY_KEY_TO_SUBSCRIPTION_MAPPER[entity_key](
             data_dict=data
         )
 
-        return SnQLSubscriptionData(
+        return SubscriptionData(
             project_id=data["project_id"],
             time_window=timedelta(seconds=data["time_window"]),
             resolution=timedelta(seconds=data["resolution"]),

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -32,6 +32,7 @@ class SubscriptionCreator:
         )
 
     def create(self, data: SubscriptionData, timer: Timer) -> SubscriptionIdentifier:
+        data.validate()
         self._test_request(data, timer)
 
         identifier = SubscriptionIdentifier(

--- a/tests/subscriptions/subscriptions_utils.py
+++ b/tests/subscriptions/subscriptions_utils.py
@@ -5,8 +5,8 @@ from uuid import UUID
 from snuba.datasets.entities import EntityKey
 from snuba.subscriptions.data import (
     PartitionId,
-    SnQLSubscriptionData,
     Subscription,
+    SubscriptionData,
     SubscriptionIdentifier,
 )
 from snuba.subscriptions.entity_subscription import (
@@ -25,7 +25,7 @@ def build_subscription(resolution: timedelta, sequence: int) -> Subscription:
     entity_subscription = EventsSubscription(data_dict={})
     return Subscription(
         SubscriptionIdentifier(PartitionId(1), UUIDS[sequence]),
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             time_window=timedelta(minutes=5),
             resolution=resolution,

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -18,8 +18,8 @@ from snuba.subscriptions.codecs import (
 from snuba.subscriptions.data import (
     PartitionId,
     ScheduledSubscriptionTask,
-    SnQLSubscriptionData,
     Subscription,
+    SubscriptionData,
     SubscriptionIdentifier,
     SubscriptionTaskResult,
     SubscriptionWithMetadata,
@@ -38,9 +38,9 @@ from tests.subscriptions.subscriptions_utils import create_entity_subscription
 
 def build_snql_subscription_data(
     entity_key: EntityKey, organization: Optional[int] = None,
-) -> SnQLSubscriptionData:
+) -> SubscriptionData:
 
-    return SnQLSubscriptionData(
+    return SubscriptionData(
         project_id=5,
         time_window=timedelta(minutes=500),
         resolution=timedelta(minutes=1),
@@ -60,9 +60,7 @@ SNQL_CASES = [
 
 
 def assert_entity_subscription_on_subscription_class(
-    organization: Optional[int],
-    subscription: SnQLSubscriptionData,
-    entity_key: EntityKey,
+    organization: Optional[int], subscription: SubscriptionData, entity_key: EntityKey,
 ) -> None:
     subscription_cls = ENTITY_KEY_TO_SUBSCRIPTION_MAPPER[entity_key]
     if organization:
@@ -76,7 +74,7 @@ def assert_entity_subscription_on_subscription_class(
 
 @pytest.mark.parametrize("builder, organization, entity_key", SNQL_CASES)
 def test_basic(
-    builder: Callable[[EntityKey, Optional[int]], SnQLSubscriptionData],
+    builder: Callable[[EntityKey, Optional[int]], SubscriptionData],
     organization: Optional[int],
     entity_key: EntityKey,
 ) -> None:
@@ -87,7 +85,7 @@ def test_basic(
 
 @pytest.mark.parametrize("builder, organization, entity_key", SNQL_CASES)
 def test_encode_snql(
-    builder: Callable[[EntityKey, Optional[int]], SnQLSubscriptionData],
+    builder: Callable[[EntityKey, Optional[int]], SubscriptionData],
     organization: Optional[int],
     entity_key: EntityKey,
 ) -> None:
@@ -107,7 +105,7 @@ def test_encode_snql(
 
 @pytest.mark.parametrize("builder, organization, entity_key", SNQL_CASES)
 def test_decode_snql(
-    builder: Callable[[EntityKey, Optional[int]], SnQLSubscriptionData],
+    builder: Callable[[EntityKey, Optional[int]], SubscriptionData],
     organization: Optional[int],
     entity_key: EntityKey,
 ) -> None:
@@ -131,7 +129,7 @@ def test_subscription_task_result_encoder() -> None:
     timestamp = datetime.now()
 
     entity_subscription = EventsSubscription(data_dict={})
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         project_id=1,
         query="MATCH (events) SELECT count() AS count",
         time_window=timedelta(minutes=1),
@@ -183,7 +181,7 @@ def test_sessions_subscription_task_result_encoder() -> None:
     timestamp = datetime.now()
 
     entity_subscription = SessionsSubscription(data_dict={"organization": 1})
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         project_id=1,
         query=(
             """
@@ -265,7 +263,7 @@ def test_metrics_subscription_task_result_encoder(
     timestamp = datetime.now()
 
     entity_subscription = subscription_cls(data_dict={"organization": 1})
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         project_id=1,
         query=(
             f"""
@@ -324,7 +322,7 @@ def test_metrics_subscription_task_result_encoder(
 def test_subscription_task_encoder() -> None:
     encoder = SubscriptionScheduledTaskEncoder()
 
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         project_id=1,
         query="MATCH events SELECT count()",
         time_window=timedelta(minutes=1),

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -7,7 +7,7 @@ from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.factory import get_dataset
 from snuba.query.exceptions import InvalidQueryException
-from snuba.subscriptions.data import SnQLSubscriptionData, SubscriptionData
+from snuba.subscriptions.data import SubscriptionData
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import parse_and_run_query
 from tests.subscriptions import BaseSubscriptionTest
@@ -16,7 +16,7 @@ from tests.test_sessions_api import BaseSessionsMockTest
 
 TESTS = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             query=(
                 "MATCH (events) "
@@ -32,7 +32,7 @@ TESTS = [
         id="SnQL subscription",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             query=(
                 "MATCH (events) "
@@ -48,7 +48,7 @@ TESTS = [
         id="SnQL subscription with 2 many aggregates",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             query=(
                 "MATCH (events) "
@@ -67,7 +67,7 @@ TESTS = [
 
 TESTS_OVER_SESSIONS = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             query=(
                 """

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -24,8 +24,8 @@ from snuba.subscriptions.codecs import SubscriptionScheduledTaskEncoder
 from snuba.subscriptions.data import (
     PartitionId,
     ScheduledSubscriptionTask,
-    SnQLSubscriptionData,
     Subscription,
+    SubscriptionData,
     SubscriptionIdentifier,
     SubscriptionTaskResult,
     SubscriptionWithMetadata,
@@ -122,7 +122,7 @@ def test_executor_consumer() -> None:
         executor._run_once()
 
     # Produce a scheduled task to the scheduled subscriptions topic
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         project_id=1,
         query="MATCH (events) SELECT count()",
         time_window=timedelta(minutes=1),
@@ -198,7 +198,7 @@ def generate_message(
                     entity_key,
                     Subscription(
                         subscription_identifier,
-                        SnQLSubscriptionData(
+                        SubscriptionData(
                             project_id=1,
                             time_window=timedelta(minutes=1),
                             resolution=timedelta(minutes=1),
@@ -313,7 +313,7 @@ def test_produce_result() -> None:
 
     strategy = ProduceResult(producer, result_topic.name, commit)
 
-    subscription_data = SnQLSubscriptionData(
+    subscription_data = SubscriptionData(
         project_id=1,
         query="MATCH (events) SELECT count() AS count",
         time_window=timedelta(minutes=1),

--- a/tests/subscriptions/test_partitioner.py
+++ b/tests/subscriptions/test_partitioner.py
@@ -4,7 +4,7 @@ import pytest
 
 from snuba import settings
 from snuba.datasets.table_storage import KafkaTopicSpec
-from snuba.subscriptions.data import SnQLSubscriptionData, SubscriptionData
+from snuba.subscriptions.data import SubscriptionData
 from snuba.subscriptions.partitioner import TopicSubscriptionDataPartitioner
 from snuba.utils.streams.topics import Topic
 from tests.subscriptions import BaseSubscriptionTest
@@ -12,7 +12,7 @@ from tests.subscriptions.subscriptions_utils import create_entity_subscription
 
 TESTS = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query="MATCH (events) SELECT count() AS count WHERE platform IN tuple('a')",
             time_window=timedelta(minutes=10),
@@ -22,7 +22,7 @@ TESTS = [
         id="Legacy subscription",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 "MATCH (events) "

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -8,8 +8,8 @@ from snuba.redis import redis_client
 from snuba.subscriptions.data import (
     PartitionId,
     ScheduledSubscriptionTask,
-    SnQLSubscriptionData,
     Subscription,
+    SubscriptionData,
     SubscriptionIdentifier,
     SubscriptionWithMetadata,
 )
@@ -30,7 +30,7 @@ class TestSubscriptionScheduler:
     def build_subscription(self, resolution: timedelta) -> Subscription:
         return Subscription(
             SubscriptionIdentifier(self.partition_id, uuid.uuid4()),
-            SnQLSubscriptionData(
+            SubscriptionData(
                 project_id=1,
                 query="MATCH (events) SELECT count() AS count",
                 time_window=timedelta(minutes=1),

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -51,7 +51,7 @@ def test_scheduler_consumer() -> None:
     mock_scheduler_producer = mock.Mock()
 
     from snuba.redis import redis_client
-    from snuba.subscriptions.data import PartitionId, SnQLSubscriptionData
+    from snuba.subscriptions.data import PartitionId, SubscriptionData
     from snuba.subscriptions.entity_subscription import EventsSubscription
     from snuba.subscriptions.store import RedisSubscriptionDataStore
 
@@ -63,7 +63,7 @@ def test_scheduler_consumer() -> None:
     )
     store.create(
         uuid.uuid4(),
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             time_window=timedelta(minutes=1),
             resolution=timedelta(minutes=1),

--- a/tests/subscriptions/test_scheduler_load_testing.py
+++ b/tests/subscriptions/test_scheduler_load_testing.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 from snuba.datasets.entities import EntityKey
 from snuba.redis import redis_client
-from snuba.subscriptions.data import PartitionId, SnQLSubscriptionData
+from snuba.subscriptions.data import PartitionId, SubscriptionData
 from snuba.subscriptions.entity_subscription import EventsSubscription
 from snuba.subscriptions.scheduler_load_testing import LoadTestingSubscriptionScheduler
 from snuba.subscriptions.store import RedisSubscriptionDataStore
@@ -21,7 +21,7 @@ def test_scheduler_load_testing() -> None:
     store = RedisSubscriptionDataStore(redis_client, entity_key, partition_id)
     store.create(
         uuid.uuid4(),
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             time_window=timedelta(minutes=1),
             resolution=timedelta(minutes=1),

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -17,7 +17,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.redis import redis_client
 from snuba.subscriptions.codecs import SubscriptionScheduledTaskEncoder
-from snuba.subscriptions.data import PartitionId, SnQLSubscriptionData
+from snuba.subscriptions.data import PartitionId, SubscriptionData
 from snuba.subscriptions.entity_subscription import EventsSubscription
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.scheduler_processing_strategy import (
@@ -502,7 +502,7 @@ def test_produce_scheduled_subscription_message() -> None:
     # Subscription 1
     store.create(
         uuid.uuid4(),
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=1,
             time_window=timedelta(minutes=1),
             resolution=timedelta(minutes=1),
@@ -514,7 +514,7 @@ def test_produce_scheduled_subscription_message() -> None:
     # Subscription 2
     store.create(
         uuid.uuid4(),
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=2,
             time_window=timedelta(minutes=2),
             resolution=timedelta(minutes=2),

--- a/tests/subscriptions/test_store.py
+++ b/tests/subscriptions/test_store.py
@@ -3,7 +3,7 @@ from typing import Sequence
 from uuid import uuid1
 
 from snuba.redis import redis_client
-from snuba.subscriptions.data import PartitionId, SnQLSubscriptionData, SubscriptionData
+from snuba.subscriptions.data import PartitionId, SubscriptionData
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from tests.subscriptions import BaseSubscriptionTest
 from tests.subscriptions.subscriptions_utils import create_entity_subscription
@@ -13,14 +13,14 @@ class TestRedisSubscriptionStore(BaseSubscriptionTest):
     @property
     def subscription(self) -> Sequence[SubscriptionData]:
         return [
-            SnQLSubscriptionData(
+            SubscriptionData(
                 project_id=self.project_id,
                 query="MATCH (events) SELECT count() WHERE in(platform, 'a')",
                 time_window=timedelta(minutes=500),
                 resolution=timedelta(minutes=1),
                 entity_subscription=create_entity_subscription(),
             ),
-            SnQLSubscriptionData(
+            SubscriptionData(
                 project_id=self.project_id,
                 time_window=timedelta(minutes=500),
                 resolution=timedelta(minutes=1),

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -9,7 +9,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.factory import get_dataset
 from snuba.query.exceptions import InvalidQueryException
 from snuba.redis import redis_client
-from snuba.subscriptions.data import SnQLSubscriptionData, SubscriptionData
+from snuba.subscriptions.data import SubscriptionData
 from snuba.subscriptions.entity_subscription import InvalidSubscriptionError
 from snuba.subscriptions.store import RedisSubscriptionDataStore
 from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDeleter
@@ -20,7 +20,7 @@ from tests.subscriptions.subscriptions_utils import create_entity_subscription
 
 TESTS_CREATE = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 "MATCH (events) "
@@ -38,7 +38,7 @@ TESTS_CREATE = [
 
 TESTS_CREATE_SESSIONS = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (sessions) SELECT if(greater(sessions,0),
@@ -58,7 +58,7 @@ TESTS_CREATE_SESSIONS = [
 
 TESTS_INVALID = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 "MATCH (events) "
@@ -105,7 +105,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(QueryException):
             creator.create(
-                SnQLSubscriptionData(
+                SubscriptionData(
                     project_id=123,
                     resolution=timedelta(minutes=1),
                     time_window=timedelta(minutes=10),
@@ -119,7 +119,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(InvalidSubscriptionError):
             creator.create(
-                SnQLSubscriptionData(
+                SubscriptionData(
                     project_id=123,
                     resolution=timedelta(minutes=1),
                     time_window=timedelta(),
@@ -131,7 +131,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
         with raises(InvalidSubscriptionError):
             creator.create(
-                SnQLSubscriptionData(
+                SubscriptionData(
                     project_id=123,
                     query=(
                         "MATCH (events) "
@@ -148,7 +148,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
 
         with raises(InvalidSubscriptionError):
             creator.create(
-                SnQLSubscriptionData(
+                SubscriptionData(
                     project_id=123,
                     resolution=timedelta(minutes=1),
                     time_window=timedelta(hours=48),
@@ -162,7 +162,7 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(InvalidSubscriptionError):
             creator.create(
-                SnQLSubscriptionData(
+                SubscriptionData(
                     project_id=123,
                     resolution=timedelta(),
                     time_window=timedelta(minutes=1),
@@ -194,7 +194,7 @@ class TestSessionsSubscriptionCreator:
 
 TESTS_CREATE_METRICS = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
@@ -211,7 +211,7 @@ TESTS_CREATE_METRICS = [
         id="Metrics Counters Snql subscription",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (metrics_sets) SELECT uniq(value) AS value BY project_id, tags[3]
@@ -230,7 +230,7 @@ TESTS_CREATE_METRICS = [
 
 TESTS_INVALID_METRICS = [
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
@@ -245,7 +245,7 @@ TESTS_INVALID_METRICS = [
         id="Metrics Counters subscription missing tags[3] condition",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
@@ -260,7 +260,7 @@ TESTS_INVALID_METRICS = [
         id="Metrics Counters subscription missing project_id condition",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (metrics_sets) SELECT uniq(value) AS value BY project_id, tags[3]
@@ -273,7 +273,7 @@ TESTS_INVALID_METRICS = [
         id="Metrics Sets subscription missing tags[3] condition",
     ),
     pytest.param(
-        SnQLSubscriptionData(
+        SubscriptionData(
             project_id=123,
             query=(
                 """MATCH (metrics_sets) SELECT uniq(value) AS value BY project_id, tags[3]
@@ -322,7 +322,7 @@ class TestMetricsCountersSubscriptionCreator:
 class TestSubscriptionDeleter(BaseSubscriptionTest):
     def test(self) -> None:
         creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
-        subscription = SnQLSubscriptionData(
+        subscription = SubscriptionData(
             project_id=1,
             query="MATCH (events) SELECT count() AS count",
             time_window=timedelta(minutes=10),

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -25,7 +25,6 @@ from snuba.query.matchers import (
 )
 from snuba.subscriptions.data import (
     PartitionId,
-    SnQLSubscriptionData,
     Subscription,
     SubscriptionData,
     SubscriptionIdentifier,
@@ -71,14 +70,14 @@ class Datetime(Pattern[datetime]):
 
 
 SUBSCRIPTION_FIXTURES = [
-    SnQLSubscriptionData(
+    SubscriptionData(
         project_id=1,
         query=("MATCH (events) SELECT count() AS count"),
         time_window=timedelta(minutes=60),
         resolution=timedelta(minutes=1),
         entity_subscription=create_entity_subscription(),
     ),
-    SnQLSubscriptionData(
+    SubscriptionData(
         project_id=123,
         query=(
             """MATCH (sessions) SELECT if(greater(sessions,0),
@@ -91,7 +90,7 @@ SUBSCRIPTION_FIXTURES = [
         resolution=timedelta(minutes=1),
         entity_subscription=create_entity_subscription(EntityKey.SESSIONS, 1),
     ),
-    SnQLSubscriptionData(
+    SubscriptionData(
         project_id=123,
         query=(
             """MATCH (metrics_counters) SELECT sum(value) AS value BY project_id, tags[3]
@@ -102,7 +101,7 @@ SUBSCRIPTION_FIXTURES = [
         resolution=timedelta(minutes=1),
         entity_subscription=create_entity_subscription(EntityKey.METRICS_COUNTERS, 1),
     ),
-    SnQLSubscriptionData(
+    SubscriptionData(
         project_id=123,
         query=(
             """MATCH (metrics_sets) SELECT uniq(value) AS value BY project_id, tags[3]


### PR DESCRIPTION
This PR does 2 things:

1. Consolidates the SubscriptionData class into a single one, instead of a SnQLSubscriptionData
class which inherits from a SubscriptionData class which inherits from another _SubscriptionData class.
Since don't need to support non-SnQL subscription data anymore so we don't need the base class.

2. Moves validation out of `__post__init__` into a separate validate() function. The validate() function
is now only called upon initial creation of the subscription and not every single time it's loaded from
the store or decoded from already scheduled task data.