### PR TITLE
fix(cron): Allow transactions_v2 storage for cron jobs

### DIFF
--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -24,7 +24,7 @@ from snuba.environment import setup_logging, setup_sentry
 @click.option(
     "--storage",
     "storage_name",
-    type=click.Choice(["events", "errors", "transactions"]),
+    type=click.Choice(["events", "errors", "transactions", "transactions_v2"]),
     help="The storage to target",
     required=True,
 )

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -19,7 +19,7 @@ from snuba.environment import setup_logging, setup_sentry
 @click.option(
     "--storage",
     "storage_name",
-    type=click.Choice(["events", "errors", "transactions"]),
+    type=click.Choice(["events", "errors", "transactions", "transactions_v2"]),
     help="The storage to target",
     required=True,
 )


### PR DESCRIPTION
In order to run the cron jobs on the new storages we need to allow
passing in the new storage