### PR TITLE
feat(ratelimits): Referrer based load shedder

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -25,6 +25,7 @@ from snuba.query.processors.handled_functions import HandledFunctionsProcessor
 from snuba.query.processors.object_id_rate_limiter import (
     ProjectRateLimiterProcessor,
     ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
 )
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
@@ -189,6 +190,7 @@ class BaseEventsEntity(Entity, ABC):
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
             HandledFunctionsProcessor("exception_stacks.mechanism_handled"),
+            ReferrerRateLimiterProcessor(),
             ProjectReferrerRateLimiter("project_id"),
             ProjectRateLimiterProcessor(project_column="project_id"),
         ]

--- a/snuba/query/processors/object_id_rate_limiter.py
+++ b/snuba/query/processors/object_id_rate_limiter.py
@@ -153,8 +153,8 @@ class ReferrerRateLimiterProcessor(ObjectIDRateLimiterProcessor):
         super().__init__(
             "nocolumn",
             REFERRER_RATE_LIMIT_NAME,
-            "project_referrer_per_second_limit",
-            "project_referrer_concurrent_limit",
+            "referrer_per_second_limit",
+            "referrer_concurrent_limit",
             request_settings_field="referrer",
         )
 

--- a/snuba/query/processors/object_id_rate_limiter.py
+++ b/snuba/query/processors/object_id_rate_limiter.py
@@ -29,12 +29,14 @@ class ObjectIDRateLimiterProcessor(QueryProcessor):
         per_second_name: str,
         concurrent_name: str,
         request_settings_field: Optional[str] = None,
+        default_limit: int = DEFAULT_LIMIT,
     ) -> None:
         self.object_column = object_column
         self.rate_limit_name = rate_limit_name
         self.per_second_name = per_second_name
         self.concurrent_name = concurrent_name
         self.request_settings_field = request_settings_field
+        self.default_limit = default_limit
 
     def _is_already_applied(self, request_settings: RequestSettings) -> bool:
         existing = request_settings.get_rate_limit_params()
@@ -66,8 +68,8 @@ class ObjectIDRateLimiterProcessor(QueryProcessor):
             return
         object_rate_limit, object_concurrent_limit = get_configs(
             [
-                (self.per_second_name, DEFAULT_LIMIT),
-                (self.concurrent_name, DEFAULT_LIMIT),
+                (self.per_second_name, self.default_limit),
+                (self.concurrent_name, self.default_limit),
             ]
         )
         obj_id = self.get_object_id(query, request_settings)
@@ -81,6 +83,38 @@ class ObjectIDRateLimiterProcessor(QueryProcessor):
             ]
         )
 
+        rate_limit = RateLimitParameters(
+            rate_limit_name=self.rate_limit_name,
+            bucket=str(obj_id),
+            per_second_limit=per_second,
+            concurrent_limit=concurr,
+        )
+
+        request_settings.add_rate_limit(rate_limit)
+
+
+class OnlyIfConfiguredRateLimitProcessor(ObjectIDRateLimiterProcessor):
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        # If the settings don't already have an object rate limit, add one
+        if self._is_already_applied(request_settings):
+            return
+        object_rate_limit, object_concurrent_limit = get_configs(
+            [(self.per_second_name, None), (self.concurrent_name, None)]
+        )
+        obj_id = self.get_object_id(query, request_settings)
+        if obj_id is None:
+            return
+        # don't enforce any limit that isn't specified
+        (per_second, concurr) = get_configs(
+            [
+                (f"{self.per_second_name}_{obj_id}", object_rate_limit),
+                (f"{self.concurrent_name}_{obj_id}", object_concurrent_limit),
+            ]
+        )
+
+        # Specific objects can have their rate limits overridden
+        if per_second is None and concurr is None:
+            return
         rate_limit = RateLimitParameters(
             rate_limit_name=self.rate_limit_name,
             bucket=str(obj_id),
@@ -145,7 +179,7 @@ class ProjectReferrerRateLimiter(ObjectIDRateLimiterProcessor):
         request_settings.add_rate_limit(rate_limit)
 
 
-class ReferrerRateLimiterProcessor(ObjectIDRateLimiterProcessor):
+class ReferrerRateLimiterProcessor(OnlyIfConfiguredRateLimitProcessor):
     """This is more of a load shedder than a rate limiter. we limit a specific
     referrer regardless of customer"""
 
@@ -158,9 +192,7 @@ class ReferrerRateLimiterProcessor(ObjectIDRateLimiterProcessor):
             request_settings_field="referrer",
         )
 
-    def get_object_id(
-        self, query: Query, request_settings: RequestSettings
-    ) -> Optional[str]:
+    def get_object_id(self, query: Query, request_settings: RequestSettings) -> str:
         return request_settings.referrer
 
 

--- a/snuba/query/processors/object_id_rate_limiter.py
+++ b/snuba/query/processors/object_id_rate_limiter.py
@@ -9,6 +9,7 @@ from snuba.state.rate_limit import (
     ORGANIZATION_RATE_LIMIT_NAME,
     PROJECT_RATE_LIMIT_NAME,
     PROJECT_REFERRER_RATE_LIMIT_NAME,
+    REFERRER_RATE_LIMIT_NAME,
     RateLimitParameters,
 )
 
@@ -142,6 +143,25 @@ class ProjectReferrerRateLimiter(ObjectIDRateLimiterProcessor):
         )
 
         request_settings.add_rate_limit(rate_limit)
+
+
+class ReferrerRateLimiterProcessor(ObjectIDRateLimiterProcessor):
+    """This is more of a load shedder than a rate limiter. we limit a specific
+    referrer regardless of customer"""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "nocolumn",
+            REFERRER_RATE_LIMIT_NAME,
+            "project_referrer_per_second_limit",
+            "project_referrer_concurrent_limit",
+            request_settings_field="referrer",
+        )
+
+    def get_object_id(
+        self, query: Query, request_settings: RequestSettings
+    ) -> Optional[str]:
+        return request_settings.referrer
 
 
 class ProjectRateLimiterProcessor(ObjectIDRateLimiterProcessor):

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -18,7 +18,7 @@ logger = logging.getLogger("snuba.state.rate_limit")
 ORGANIZATION_RATE_LIMIT_NAME = "organization"
 PROJECT_RATE_LIMIT_NAME = "project"
 PROJECT_REFERRER_RATE_LIMIT_NAME = "project_referrer"
-REFERRER_RATE_LIMIT_NAME = "project_referrer"
+REFERRER_RATE_LIMIT_NAME = "referrer"
 GLOBAL_RATE_LIMIT_NAME = "global"
 TABLE_RATE_LIMIT_NAME = "table"
 

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -18,6 +18,7 @@ logger = logging.getLogger("snuba.state.rate_limit")
 ORGANIZATION_RATE_LIMIT_NAME = "organization"
 PROJECT_RATE_LIMIT_NAME = "project"
 PROJECT_REFERRER_RATE_LIMIT_NAME = "project_referrer"
+REFERRER_RATE_LIMIT_NAME = "project_referrer"
 GLOBAL_RATE_LIMIT_NAME = "global"
 TABLE_RATE_LIMIT_NAME = "table"
 

--- a/tests/query/processors/test_referrer_rate_limiter.py
+++ b/tests/query/processors/test_referrer_rate_limiter.py
@@ -1,93 +1,78 @@
-import pytest
-
 from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.entities import EntityKey
 from snuba.query import SelectedExpression
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
-from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.object_id_rate_limiter import ReferrerRateLimiterProcessor
 from snuba.request.request_settings import HTTPRequestSettings
-from snuba.state.rate_limit import PROJECT_RATE_LIMIT_NAME
+from snuba.state.rate_limit import REFERRER_RATE_LIMIT_NAME
 
-tests = [
-    pytest.param(
+conditions = [
+    binary_condition(
+        ConditionFunctions.EQ,
+        Column("_snuba_project_id", None, "project_id"),
+        Literal(None, 1),
+    ),
+    binary_condition(
+        ConditionFunctions.IN,
+        Column("_snuba_project_id", None, "project_id"),
+        FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 2))),
+    ),
+    binary_condition(
+        "and",
         binary_condition(
             ConditionFunctions.EQ,
             Column("_snuba_project_id", None, "project_id"),
-            Literal(None, 1),
+            Literal(None, 3),
         ),
-        1,
-        id="simple project column",
-    ),
-    pytest.param(
         binary_condition(
             ConditionFunctions.IN,
             Column("_snuba_project_id", None, "project_id"),
-            FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 2))),
+            FunctionCall(None, "array", (Literal(None, 4), Literal(None, 5))),
         ),
-        2,
-        id="multiple project column",
-    ),
-    pytest.param(
-        binary_condition(
-            "and",
-            binary_condition(
-                ConditionFunctions.EQ,
-                Column("_snuba_project_id", None, "project_id"),
-                Literal(None, 3),
-            ),
-            binary_condition(
-                ConditionFunctions.IN,
-                Column("_snuba_project_id", None, "project_id"),
-                FunctionCall(None, "array", (Literal(None, 4), Literal(None, 5))),
-            ),
-        ),
-        3,
-        id="all sorts of projects",
     ),
 ]
 
-
-@pytest.mark.parametrize("unprocessed, project_id", tests)
-def test_project_rate_limit_processor(unprocessed: Expression, project_id: int) -> None:
-    query = Query(
+queries = [
+    Query(
         QueryEntity(EntityKey.EVENTS, ColumnSet([])),
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
-        condition=unprocessed,
+        condition=c,
     )
+    for c in conditions
+]
+
+
+def test_project_rate_limit_processor() -> None:
+
     settings = HTTPRequestSettings(referrer="foo")
 
     num_before = len(settings.get_rate_limit_params())
-    ReferrerRateLimiterProcessor().process_query(query, settings)
+    for query in queries:
+        ReferrerRateLimiterProcessor().process_query(query, settings)
     assert len(settings.get_rate_limit_params()) == num_before + 1
     rate_limiter = settings.get_rate_limit_params()[-1]
-    assert rate_limiter.rate_limit_name == PROJECT_RATE_LIMIT_NAME
+    assert rate_limiter.rate_limit_name == REFERRER_RATE_LIMIT_NAME
     assert rate_limiter.bucket == "foo"
     assert rate_limiter.per_second_limit == 1000
     assert rate_limiter.concurrent_limit == 1000
 
 
-# @pytest.mark.parametrize("unprocessed, project_id", tests)
-# def test_project_rate_limit_processor_overridden(
-#     unprocessed: Expression, project_id: int
-# ) -> None:
-#     query = Query(
-#         QueryEntity(EntityKey.EVENTS, ColumnSet([])),
-#         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
-#         condition=unprocessed,
-#     )
-#     settings = HTTPRequestSettings()
-#     state.set_config(f"project_per_second_limit_{project_id}", 5)
-#     state.set_config(f"project_concurrent_limit_{project_id}", 10)
-#
-#     num_before = len(settings.get_rate_limit_params())
-#     ProjectRateLimiterProcessor("project_id").process_query(query, settings)
-#     assert len(settings.get_rate_limit_params()) == num_before + 1
-#     rate_limiter = settings.get_rate_limit_params()[-1]
-#     assert rate_limiter.rate_limit_name == PROJECT_RATE_LIMIT_NAME
-#     assert rate_limiter.bucket == str(project_id)
-#     assert rate_limiter.per_second_limit == 5
-#     assert rate_limiter.concurrent_limit == 10
+def test_project_rate_limit_processor_overridden() -> None:
+    referrer_name = "foo"
+    settings = HTTPRequestSettings(referrer="foo")
+    state.set_config(f"referrer_per_second_limit_{referrer_name}", 5)
+    state.set_config(f"referrer_concurrent_limit_{referrer_name}", 10)
+
+    num_before = len(settings.get_rate_limit_params())
+    for query in queries:
+        ReferrerRateLimiterProcessor().process_query(query, settings)
+    assert len(settings.get_rate_limit_params()) == num_before + 1
+    rate_limiter = settings.get_rate_limit_params()[-1]
+    assert rate_limiter.rate_limit_name == REFERRER_RATE_LIMIT_NAME
+    assert rate_limiter.bucket == referrer_name
+    assert rate_limiter.per_second_limit == 5
+    assert rate_limiter.concurrent_limit == 10

--- a/tests/query/processors/test_referrer_rate_limiter.py
+++ b/tests/query/processors/test_referrer_rate_limiter.py
@@ -1,0 +1,93 @@
+import pytest
+
+from snuba import state
+from snuba.clickhouse.columns import ColumnSet
+from snuba.datasets.entities import EntityKey
+from snuba.query import SelectedExpression
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.logical import Query
+from snuba.query.processors.object_id_rate_limiter import ReferrerRateLimiterProcessor
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state.rate_limit import PROJECT_RATE_LIMIT_NAME
+
+tests = [
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.EQ,
+            Column("_snuba_project_id", None, "project_id"),
+            Literal(None, 1),
+        ),
+        1,
+        id="simple project column",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.IN,
+            Column("_snuba_project_id", None, "project_id"),
+            FunctionCall(None, "tuple", (Literal(None, 2), Literal(None, 2))),
+        ),
+        2,
+        id="multiple project column",
+    ),
+    pytest.param(
+        binary_condition(
+            "and",
+            binary_condition(
+                ConditionFunctions.EQ,
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 3),
+            ),
+            binary_condition(
+                ConditionFunctions.IN,
+                Column("_snuba_project_id", None, "project_id"),
+                FunctionCall(None, "array", (Literal(None, 4), Literal(None, 5))),
+            ),
+        ),
+        3,
+        id="all sorts of projects",
+    ),
+]
+
+
+@pytest.mark.parametrize("unprocessed, project_id", tests)
+def test_project_rate_limit_processor(unprocessed: Expression, project_id: int) -> None:
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=unprocessed,
+    )
+    settings = HTTPRequestSettings(referrer="foo")
+
+    num_before = len(settings.get_rate_limit_params())
+    ReferrerRateLimiterProcessor().process_query(query, settings)
+    assert len(settings.get_rate_limit_params()) == num_before + 1
+    rate_limiter = settings.get_rate_limit_params()[-1]
+    assert rate_limiter.rate_limit_name == PROJECT_RATE_LIMIT_NAME
+    assert rate_limiter.bucket == "foo"
+    assert rate_limiter.per_second_limit == 1000
+    assert rate_limiter.concurrent_limit == 1000
+
+
+# @pytest.mark.parametrize("unprocessed, project_id", tests)
+# def test_project_rate_limit_processor_overridden(
+#     unprocessed: Expression, project_id: int
+# ) -> None:
+#     query = Query(
+#         QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+#         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+#         condition=unprocessed,
+#     )
+#     settings = HTTPRequestSettings()
+#     state.set_config(f"project_per_second_limit_{project_id}", 5)
+#     state.set_config(f"project_concurrent_limit_{project_id}", 10)
+#
+#     num_before = len(settings.get_rate_limit_params())
+#     ProjectRateLimiterProcessor("project_id").process_query(query, settings)
+#     assert len(settings.get_rate_limit_params()) == num_before + 1
+#     rate_limiter = settings.get_rate_limit_params()[-1]
+#     assert rate_limiter.rate_limit_name == PROJECT_RATE_LIMIT_NAME
+#     assert rate_limiter.bucket == str(project_id)
+#     assert rate_limiter.per_second_limit == 5
+#     assert rate_limiter.concurrent_limit == 10


### PR DESCRIPTION
Add the ability to rate limit based on referrer.

`referrer_per_second_limit_{referrer_name}`
`referrer_concurrent_limit_{referrer_name}`

This allows us to shed load when a specific referrer is putting too much strain on the system. It should only be used in emergencies