### PR TITLE
perf(quota) Make max thread configurable per referrer and project

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -27,6 +27,7 @@ from snuba.query.processors.object_id_rate_limiter import (
     ProjectReferrerRateLimiter,
     ReferrerRateLimiterProcessor,
 )
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
@@ -193,6 +194,7 @@ class BaseEventsEntity(Entity, ABC):
             ReferrerRateLimiterProcessor(),
             ProjectReferrerRateLimiter("project_id"),
             ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]
 
 

--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -1,6 +1,7 @@
-from typing import Sequence
+from typing import Optional, Sequence
 
 from snuba.request.request_settings import RequestSettings
+from snuba.state.quota import ResourceQuota
 from snuba.state.rate_limit import RateLimitParameters
 
 
@@ -68,3 +69,9 @@ class RateLimiterDelegate(RequestSettings):
 
     def add_rate_limit(self, rate_limit_param: RateLimitParameters) -> None:
         self.__rate_limit_params.append(self.__append_prefix(rate_limit_param))
+
+    def get_resource_quota(self) -> Optional[ResourceQuota]:
+        return self.__delegate.get_resource_quota()
+
+    def set_resource_quota(self, quota: ResourceQuota) -> None:
+        self.__delegate.set_resource_quota(quota)

--- a/snuba/query/processors/quota_processor.py
+++ b/snuba/query/processors/quota_processor.py
@@ -36,4 +36,4 @@ class ResourceQuotaProcessor(QueryProcessor):
             return
 
         assert isinstance(thread_quota, int)
-        request_settings.add_resource_quota(ResourceQuota(max_threads=thread_quota))
+        request_settings.set_resource_quota(ResourceQuota(max_threads=thread_quota))

--- a/snuba/query/processors/quota_processor.py
+++ b/snuba/query/processors/quota_processor.py
@@ -1,0 +1,39 @@
+from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
+from snuba.query.logical import Query
+from snuba.query.processors import QueryProcessor
+from snuba.request.request_settings import RequestSettings
+from snuba.state import get_config
+from snuba.state.quota import ResourceQuota
+
+ENABLED_CONFIG = "resource_quota_processor_enabled"
+REFERRER_PROJECT_CONFIG = "referrer_project_thread_quota"
+
+
+class ResourceQuotaProcessor(QueryProcessor):
+    """
+    Applies a referrer/project thread quota to the query.
+    """
+
+    def __init__(self, project_field: str):
+        self.__project_field = project_field
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        enabled = get_config(ENABLED_CONFIG, 1)
+        if not enabled:
+            return
+
+        project_ids = get_object_ids_in_query_ast(query, self.__project_field)
+        if not project_ids:
+            return
+
+        # TODO: Like for the rate limiter Add logic for multiple IDs
+        project_id = str(project_ids.pop())
+        thread_quota = get_config(
+            f"{REFERRER_PROJECT_CONFIG}_{request_settings.referrer}_{project_id}"
+        )
+
+        if not thread_quota:
+            return
+
+        assert isinstance(thread_quota, int)
+        request_settings.add_resource_quota(ResourceQuota(max_threads=thread_quota))

--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -64,7 +64,7 @@ class RequestSettings(ABC):
         pass
 
     @abstractmethod
-    def add_resource_quota(self, quota: ResourceQuota) -> None:
+    def set_resource_quota(self, quota: ResourceQuota) -> None:
         pass
 
 
@@ -132,7 +132,7 @@ class HTTPRequestSettings(RequestSettings):
     def get_resource_quota(self) -> Optional[ResourceQuota]:
         return self.__resource_quota
 
-    def add_resource_quota(self, quota: ResourceQuota) -> None:
+    def set_resource_quota(self, quota: ResourceQuota) -> None:
         self.__resource_quota = quota
 
 
@@ -189,5 +189,5 @@ class SubscriptionRequestSettings(RequestSettings):
     def get_resource_quota(self) -> Optional[ResourceQuota]:
         return None
 
-    def add_resource_quota(self, quota: ResourceQuota) -> None:
+    def set_resource_quota(self, quota: ResourceQuota) -> None:
         pass

--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
+from snuba.state.quota import ResourceQuota
 from snuba.state.rate_limit import RateLimitParameters
 
 
@@ -58,6 +59,14 @@ class RequestSettings(ABC):
     def add_rate_limit(self, rate_limit_param: RateLimitParameters) -> None:
         pass
 
+    @abstractmethod
+    def get_resource_quota(self) -> Optional[ResourceQuota]:
+        pass
+
+    @abstractmethod
+    def add_resource_quota(self, quota: ResourceQuota) -> None:
+        pass
+
 
 class HTTPRequestSettings(RequestSettings):
     """
@@ -88,6 +97,7 @@ class HTTPRequestSettings(RequestSettings):
         self.__team = team
         self.__feature = feature
         self.__rate_limit_params: List[RateLimitParameters] = []
+        self.__resource_quota: Optional[ResourceQuota] = None
 
     def get_turbo(self) -> bool:
         return self.__turbo
@@ -118,6 +128,12 @@ class HTTPRequestSettings(RequestSettings):
 
     def add_rate_limit(self, rate_limit_param: RateLimitParameters) -> None:
         self.__rate_limit_params.append(rate_limit_param)
+
+    def get_resource_quota(self) -> Optional[ResourceQuota]:
+        return self.__resource_quota
+
+    def add_resource_quota(self, quota: ResourceQuota) -> None:
+        self.__resource_quota = quota
 
 
 class SubscriptionRequestSettings(RequestSettings):
@@ -169,3 +185,6 @@ class SubscriptionRequestSettings(RequestSettings):
 
     def add_rate_limit(self, rate_limit_param: RateLimitParameters) -> None:
         pass
+
+    def get_resource_quota(self) -> Optional[ResourceQuota]:
+        return None

--- a/snuba/request/request_settings.py
+++ b/snuba/request/request_settings.py
@@ -188,3 +188,6 @@ class SubscriptionRequestSettings(RequestSettings):
 
     def get_resource_quota(self) -> Optional[ResourceQuota]:
         return None
+
+    def add_resource_quota(self, quota: ResourceQuota) -> None:
+        pass

--- a/snuba/state/quota.py
+++ b/snuba/state/quota.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ResourceQuota:
+    """
+    Tracks the quota a client can use when running a query.
+
+    As of now we only represent that in threads.
+    """
+
+    thread_quota: int

--- a/snuba/state/quota.py
+++ b/snuba/state/quota.py
@@ -9,4 +9,4 @@ class ResourceQuota:
     As of now we only represent that in threads.
     """
 
-    thread_quota: int
+    max_threads: int

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -279,12 +279,17 @@ def execute_query_with_rate_limits(
             PROJECT_RATE_LIMIT_NAME
         )
 
+        thread_quota = request_settings.get_resource_quota()
         if (
-            "max_threads" in query_settings
+            ("max_threads" in query_settings or thread_quota is not None)
             and project_rate_limit_stats is not None
             and project_rate_limit_stats.concurrent > 1
         ):
-            maxt = query_settings["max_threads"]
+            maxt = (
+                query_settings["max_threads"]
+                if thread_quota is None
+                else thread_quota.max_threads
+            )
             query_settings["max_threads"] = max(
                 1, maxt - project_rate_limit_stats.concurrent + 1
             )

--- a/tests/query/processors/test_quota.py
+++ b/tests/query/processors/test_quota.py
@@ -1,0 +1,76 @@
+from typing import Optional
+
+import pytest
+
+from snuba import state
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.entity_data_model import EntityColumnSet
+from snuba.query import SelectedExpression
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, Literal
+from snuba.query.logical import Query
+from snuba.query.processors.quota_processor import (
+    ENABLED_CONFIG,
+    REFERRER_PROJECT_CONFIG,
+    ResourceQuotaProcessor,
+)
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state.quota import ResourceQuota
+
+tests = [
+    pytest.param(
+        0,
+        "some_referrer",
+        f"{REFERRER_PROJECT_CONFIG}_some_referrer_1",
+        None,
+        id="Processor disabled",
+    ),
+    pytest.param(
+        1,
+        "some_other_referrer",
+        f"{REFERRER_PROJECT_CONFIG}_some_referrer_1",
+        None,
+        id="Different referrer",
+    ),
+    pytest.param(
+        1,
+        "some_referrer",
+        f"{REFERRER_PROJECT_CONFIG}_some_referrer_2",
+        None,
+        id="Different project",
+    ),
+    pytest.param(
+        1,
+        "some_referrer",
+        f"{REFERRER_PROJECT_CONFIG}_some_referrer_1",
+        ResourceQuota(max_threads=5),
+        id="Apply quota",
+    ),
+]
+
+
+@pytest.mark.parametrize("enabled, referrer, config_to_set, expected_quota", tests)
+def test_apply_quota(
+    enabled: int,
+    referrer: str,
+    config_to_set: str,
+    expected_quota: Optional[ResourceQuota],
+) -> None:
+    state.set_config(ENABLED_CONFIG, enabled)
+    state.set_config(config_to_set, 5)
+
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, EntityColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=binary_condition(
+            ConditionFunctions.EQ,
+            Column("_snuba_project_id", None, "project_id"),
+            Literal(None, 1),
+        ),
+    )
+    settings = HTTPRequestSettings()
+    settings.referrer = referrer
+
+    ResourceQuotaProcessor("project_id").process_query(query, settings)
+    assert settings.get_resource_quota() == expected_quota


### PR DESCRIPTION
Configuring the rate limiter works to protect the system though it does not help when we have continuous moderate load that is far from being limited by concurrency. By having low concurrency every query uses a large amount of threads.
This is ok for the UI for a short period of time, but it is a problem when it comes from script that hit the api continuously. 
This allows to manually set the max thread config setting by runtime config and reduce quota for specific referrer/projects.

A further improvement would be to support a proper quota system where the max_thread field is calculated based on the past behavior of the project and adapted to enforce a quota over a period of time.