### PR TITLE
feat(errors upgrade) Set up query path for the errors v2 storage

### DIFF
--- a/snuba/datasets/entities/clickhouse_upgrade.py
+++ b/snuba/datasets/entities/clickhouse_upgrade.py
@@ -1,8 +1,7 @@
 from enum import Enum
 from random import random
-from typing import Mapping, NamedTuple, Optional
+from typing import NamedTuple, Optional, cast
 
-from snuba import settings
 from snuba.state import get_config
 
 
@@ -31,7 +30,6 @@ class RolloutSelector:
     There are multiple way to configure this rollout:
     First choice: which query should be trusted:
     - check runtime config if the default secondary should be trusted
-    - check settings if the default secondary should be trusted
     - check global rollout if the default secondary should be trusted
     Now we know which query will be trusted. hould we run the second ?
     Check the configs and settings in the same order.
@@ -45,41 +43,24 @@ class RolloutSelector:
         self.__config_prefix = config_prefix
 
     def __is_query_rolled_out(
-        self,
-        referrer: str,
-        config_referrer_prefix: str,
-        settings_referrer: Mapping[str, float],
-        general_rollout_config: str,
-        general_rollout_setting: float,
+        self, referrer: str, config_referrer_prefix: str, general_rollout_config: str,
     ) -> bool:
         rollout_percentage = get_config(
             f"rollout_upgraded_{self.__config_prefix}_{config_referrer_prefix}_{referrer}",
             None,
         )
-        if rollout_percentage is None and referrer in settings_referrer:
-            rollout_percentage = settings_referrer[referrer]
         if rollout_percentage is None:
-            rollout_percentage = get_config(general_rollout_config, None)
-        if rollout_percentage is None:
-            rollout_percentage = general_rollout_setting
+            rollout_percentage = get_config(general_rollout_config, 0.0)
 
-        return random() <= rollout_percentage
+        return random() <= cast(float, rollout_percentage)
 
     def choose(self, referrer: str) -> Choice:
         trust_secondary = self.__is_query_rolled_out(
-            referrer,
-            "trust",
-            settings.ERRORS_UPGRADE_TRUST_SECONDARY,
-            f"rollout_upgraded_{self.__config_prefix}_trust",
-            settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL,
+            referrer, "trust", f"rollout_upgraded_{self.__config_prefix}_trust",
         )
 
         execute_both = self.__is_query_rolled_out(
-            referrer,
-            "execute",
-            settings.ERRORS_UPGRADE_EXECUTE_BOTH,
-            f"rollout_upgraded_{self.__config_prefix}_execute",
-            settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL,
+            referrer, "execute", f"rollout_upgraded_{self.__config_prefix}_execute",
         )
 
         primary = (

--- a/snuba/datasets/entities/clickhouse_upgrade.py
+++ b/snuba/datasets/entities/clickhouse_upgrade.py
@@ -1,0 +1,96 @@
+from enum import Enum
+from random import random
+from typing import Mapping, NamedTuple, Optional
+
+from snuba import settings
+from snuba.state import get_config
+
+
+class Option(Enum):
+    ERRORS = 1
+    ERRORS_V2 = 2
+
+
+class Choice(NamedTuple):
+    primary: Option
+    secondary: Optional[Option]
+
+
+class RolloutSelector:
+    """
+    Takes the rollout decisions during the upgrade to Clickhouse 21.8.
+    This class assumes that there are two storages to choose from before
+    running a query.
+    The main pipeline builder needs a decision on which queries to run
+    (both storages or only one) and which result to trust.
+
+    This class can return one storage (which is the only one the query
+    will run onto) or two storages, in that case the first will be the
+    trusted one.
+
+    There are multiple way to configure this rollout:
+    First choice: which query should be trusted:
+    - check runtime config if the default secondary should be trusted
+    - check settings if the default secondary should be trusted
+    - check global rollout if the default secondary should be trusted
+    Now we know which query will be trusted. hould we run the second ?
+    Check the configs and settings in the same order.
+    """
+
+    def __init__(
+        self, default_primary: Option, default_secondary: Option, config_prefix: str
+    ) -> None:
+        self.__default_primary = default_primary
+        self.__default_secondary = default_secondary
+        self.__config_prefix = config_prefix
+
+    def __is_query_rolled_out(
+        self,
+        referrer: str,
+        config_referrer_prefix: str,
+        settings_referrer: Mapping[str, float],
+        general_rollout_config: str,
+        general_rollout_setting: float,
+    ) -> bool:
+        rollout_percentage = get_config(
+            f"rollout_upgraded_{self.__config_prefix}_{config_referrer_prefix}_{referrer}",
+            None,
+        )
+        if rollout_percentage is None and referrer in settings_referrer:
+            rollout_percentage = settings_referrer[referrer]
+        if rollout_percentage is None:
+            rollout_percentage = get_config(general_rollout_config, None)
+        if rollout_percentage is None:
+            rollout_percentage = general_rollout_setting
+
+        return random() <= rollout_percentage
+
+    def choose(self, referrer: str) -> Choice:
+        trust_secondary = self.__is_query_rolled_out(
+            referrer,
+            "trust",
+            settings.ERRORS_UPGRADE_TRUST_SECONDARY,
+            f"rollout_upgraded_{self.__config_prefix}_trust",
+            settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL,
+        )
+
+        execute_both = self.__is_query_rolled_out(
+            referrer,
+            "execute",
+            settings.ERRORS_UPGRADE_EXECUTE_BOTH,
+            f"rollout_upgraded_{self.__config_prefix}_execute",
+            settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL,
+        )
+
+        primary = (
+            self.__default_secondary if trust_secondary else self.__default_primary
+        )
+        if not execute_both:
+            return Choice(primary, None)
+        else:
+            return Choice(
+                primary,
+                self.__default_secondary
+                if not trust_secondary
+                else self.__default_primary,
+            )

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -145,14 +145,13 @@ class ErrorsV2QueryStorageSelector(QueryStorageSelector):
         return StorageAndMappers(self.__errors_table, self.__mappers)
 
 
-def selector_function(query: Query, referrer: str) -> Tuple[str, List[str]]:
+def v2_selector_function(query: Query, referrer: str) -> Tuple[str, List[str]]:
     if settings.ERRORS_UPGRADE_BEGINING_OF_TIME is None or not isinstance(
         query, ProcessableQuery
     ):
         return ("errors_v1", [])
 
     range = get_time_range(query, "timestamp")
-    print(range)
     if range[0] is None or range[0] < settings.ERRORS_UPGRADE_BEGINING_OF_TIME:
         return ("errors_v1", [])
 
@@ -202,7 +201,7 @@ class BaseEventsEntity(Entity, ABC):
                     "errors_v1": v1_pipeline_builder,
                     "errors_v2": v2_pipeline_builder,
                 },
-                selector_func=selector_function,
+                selector_func=v2_selector_function,
                 callback_func=None,
             )
         else:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -186,6 +186,13 @@ TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS: Set[str] = set()
 # rather than using materialized views
 WRITE_METRICS_AGG_DIRECTLY = False
 
+# This is used to rollout specific referrers during the errors Clickhosue upgrade.
+# This mapping decides when to trust the upgraded version
+ERRORS_UPGRADE_TRUST_SECONDARY: Mapping[str, float] = {}
+ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = 0.0
+ERRORS_UPGRADE_EXECUTE_BOTH: Mapping[str, float] = {}
+ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = 0.0
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -188,13 +188,6 @@ TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS: Set[str] = set()
 # rather than using materialized views
 WRITE_METRICS_AGG_DIRECTLY = False
 
-# This is used to rollout specific referrers during the errors Clickhosue upgrade.
-# This mapping decides when to trust the upgraded version
-ERRORS_UPGRADE_TRUST_SECONDARY: Mapping[str, float] = {}
-ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = 0.0
-ERRORS_UPGRADE_EXECUTE_BOTH: Mapping[str, float] = {}
-ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = 0.0
-
 # Place the actual time we start ingesting on the new version.
 ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = None
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Mapping, MutableMapping, Sequence, Set
+from datetime import datetime
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
 from snuba.settings.validation import validate_settings
 
@@ -192,6 +193,9 @@ ERRORS_UPGRADE_TRUST_SECONDARY: Mapping[str, float] = {}
 ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = 0.0
 ERRORS_UPGRADE_EXECUTE_BOTH: Mapping[str, float] = {}
 ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = 0.0
+
+# Place the actual time we start ingesting on the new version.
+ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = None
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -189,7 +189,7 @@ TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS: Set[str] = set()
 WRITE_METRICS_AGG_DIRECTLY = False
 
 # Place the actual time we start ingesting on the new version.
-ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = None
+ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 2, 23, 0, 0, 0)
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/tests/datasets/entities/test_clickhouse_upgrade_rollout.py
+++ b/tests/datasets/entities/test_clickhouse_upgrade_rollout.py
@@ -2,7 +2,6 @@ from typing import Optional
 
 import pytest
 
-from snuba import settings
 from snuba.datasets.entities.clickhouse_upgrade import Choice, Option, RolloutSelector
 from snuba.state import set_config
 
@@ -13,22 +12,14 @@ TESTS = [
         0.0,
         0.0,
         0.0,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
         Choice(Option.ERRORS, None),
         id="Nothing is rolled out",
     ),
     pytest.param(
         "another_referrer",
         1.0,
-        1.0,
-        0.0,
         0.0,
         1.0,
-        1.0,
-        0.0,
         0.0,
         Choice(Option.ERRORS, None),
         id="Global not rolled out. Query referrer different",
@@ -37,63 +28,25 @@ TESTS = [
         "configreferrer",
         0.0,
         0.0,
-        0.0,
-        0.0,
-        None,
         None,
         1.0,
-        0.0,
         Choice(Option.ERRORS, Option.ERRORS_V2),
         id="Execute both globally rolled out",
     ),
     pytest.param(
         "configreferrer",
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-        None,
-        None,
         None,
         1.0,
-        Choice(Option.ERRORS, Option.ERRORS_V2),
-        id="Execute both globally rolled out (setting)",
-    ),
-    pytest.param(
-        "configreferrer",
-        None,
         None,
         1.0,
-        0.0,
-        None,
-        None,
-        1.0,
-        0.0,
         Choice(Option.ERRORS_V2, Option.ERRORS),
         id="Execute both globally rolled out. Trust V2",
     ),
     pytest.param(
         "configreferrer",
-        None,
-        None,
-        None,
         1.0,
-        None,
-        None,
-        None,
         1.0,
-        Choice(Option.ERRORS_V2, Option.ERRORS),
-        id="Execute both globally rolled out (setting). Trust V2",
-    ),
-    pytest.param(
-        "configreferrer",
-        None,
-        None,
-        None,
-        1.0,
-        None,
-        None,
-        None,
+        0.0,
         0.0,
         Choice(Option.ERRORS_V2, None),
         id="Trust and execute only V2",
@@ -101,38 +54,17 @@ TESTS = [
     pytest.param(
         "configreferrer",
         1.0,
-        None,
-        0.0,
         0.0,
         1.0,
         None,
-        None,
-        0.0,
         Choice(Option.ERRORS_V2, Option.ERRORS),
         id="Trust and execute V2 rolled out by referrer",
     ),
     pytest.param(
         "configreferrer",
-        None,
-        1.0,
-        0.0,
         0.0,
         1.0,
-        None,
-        None,
         0.0,
-        Choice(Option.ERRORS_V2, Option.ERRORS),
-        id="Trust and execute V2 rolled out by referrer. Settings",
-    ),
-    pytest.param(
-        "configreferrer",
-        0.0,
-        None,
-        1.0,
-        1.0,
-        0.0,
-        None,
-        1.0,
         1.0,
         Choice(Option.ERRORS, None),
         id="Override by referrer global config.",
@@ -141,45 +73,27 @@ TESTS = [
 
 
 @pytest.mark.parametrize(
-    "query_referrer, referrer_trust_config, referrer_trust_setting, global_trust_config, global_trust_setting, referrer_execute_config, referrer_execute_setting, global_execute_config, global_execute_setting, expceted",
+    "query_referrer, referrer_trust_config, global_trust_config, referrer_execute_config, global_execute_config, expceted",
     TESTS,
 )
 def test_rollout_percentage(
     query_referrer: str,
     referrer_trust_config: Optional[float],
-    referrer_trust_setting: Optional[float],
     global_trust_config: Optional[float],
-    global_trust_setting: float,
     referrer_execute_config: Optional[float],
-    referrer_execute_setting: Optional[float],
     global_execute_config: Optional[float],
-    global_execute_setting: float,
     expceted: Choice,
 ) -> None:
     set_config(
         "rollout_upgraded_errors_trust_configreferrer", referrer_trust_config,
     )
-    if referrer_trust_setting is not None:
-        settings.ERRORS_UPGRADE_TRUST_SECONDARY = {
-            "configreferrer": referrer_trust_setting
-        }
     set_config("rollout_upgraded_errors_trust", global_trust_config)
-    settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = global_trust_setting
 
     set_config(
         "rollout_upgraded_errors_execute_configreferrer", referrer_execute_config,
     )
-    if referrer_execute_setting is not None:
-        settings.ERRORS_UPGRADE_EXECUTE_BOTH = {
-            "configreferrer": referrer_execute_setting
-        }
     set_config("rollout_upgraded_errors_execute", global_execute_config)
-    settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = global_execute_setting
 
     rollout_selector = RolloutSelector(Option.ERRORS, Option.ERRORS_V2, "errors")
 
     assert rollout_selector.choose(query_referrer) == expceted
-
-    # Reset settings
-    settings.ERRORS_UPGRADE_TRUST_SECONDARY = {}
-    settings.ERRORS_UPGRADE_EXECUTE_BOTH = {}

--- a/tests/datasets/entities/test_clickhouse_upgrade_rollout.py
+++ b/tests/datasets/entities/test_clickhouse_upgrade_rollout.py
@@ -1,0 +1,185 @@
+from typing import Optional
+
+import pytest
+
+from snuba import settings
+from snuba.datasets.entities.clickhouse_upgrade import Choice, Option, RolloutSelector
+from snuba.state import set_config
+
+TESTS = [
+    pytest.param(
+        "configreferrer",
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        Choice(Option.ERRORS, None),
+        id="Nothing is rolled out",
+    ),
+    pytest.param(
+        "another_referrer",
+        1.0,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+        0.0,
+        0.0,
+        Choice(Option.ERRORS, None),
+        id="Global not rolled out. Query referrer different",
+    ),
+    pytest.param(
+        "configreferrer",
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        None,
+        None,
+        1.0,
+        0.0,
+        Choice(Option.ERRORS, Option.ERRORS_V2),
+        id="Execute both globally rolled out",
+    ),
+    pytest.param(
+        "configreferrer",
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        None,
+        None,
+        None,
+        1.0,
+        Choice(Option.ERRORS, Option.ERRORS_V2),
+        id="Execute both globally rolled out (setting)",
+    ),
+    pytest.param(
+        "configreferrer",
+        None,
+        None,
+        1.0,
+        0.0,
+        None,
+        None,
+        1.0,
+        0.0,
+        Choice(Option.ERRORS_V2, Option.ERRORS),
+        id="Execute both globally rolled out. Trust V2",
+    ),
+    pytest.param(
+        "configreferrer",
+        None,
+        None,
+        None,
+        1.0,
+        None,
+        None,
+        None,
+        1.0,
+        Choice(Option.ERRORS_V2, Option.ERRORS),
+        id="Execute both globally rolled out (setting). Trust V2",
+    ),
+    pytest.param(
+        "configreferrer",
+        None,
+        None,
+        None,
+        1.0,
+        None,
+        None,
+        None,
+        0.0,
+        Choice(Option.ERRORS_V2, None),
+        id="Trust and execute only V2",
+    ),
+    pytest.param(
+        "configreferrer",
+        1.0,
+        None,
+        0.0,
+        0.0,
+        1.0,
+        None,
+        None,
+        0.0,
+        Choice(Option.ERRORS_V2, Option.ERRORS),
+        id="Trust and execute V2 rolled out by referrer",
+    ),
+    pytest.param(
+        "configreferrer",
+        None,
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        None,
+        None,
+        0.0,
+        Choice(Option.ERRORS_V2, Option.ERRORS),
+        id="Trust and execute V2 rolled out by referrer. Settings",
+    ),
+    pytest.param(
+        "configreferrer",
+        0.0,
+        None,
+        1.0,
+        1.0,
+        0.0,
+        None,
+        1.0,
+        1.0,
+        Choice(Option.ERRORS, None),
+        id="Override by referrer global config.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "query_referrer, referrer_trust_config, referrer_trust_setting, global_trust_config, global_trust_setting, referrer_execute_config, referrer_execute_setting, global_execute_config, global_execute_setting, expceted",
+    TESTS,
+)
+def test_rollout_percentage(
+    query_referrer: str,
+    referrer_trust_config: Optional[float],
+    referrer_trust_setting: Optional[float],
+    global_trust_config: Optional[float],
+    global_trust_setting: float,
+    referrer_execute_config: Optional[float],
+    referrer_execute_setting: Optional[float],
+    global_execute_config: Optional[float],
+    global_execute_setting: float,
+    expceted: Choice,
+) -> None:
+    set_config(
+        "rollout_upgraded_errors_trust_configreferrer", referrer_trust_config,
+    )
+    if referrer_trust_setting is not None:
+        settings.ERRORS_UPGRADE_TRUST_SECONDARY = {
+            "configreferrer": referrer_trust_setting
+        }
+    set_config("rollout_upgraded_errors_trust", global_trust_config)
+    settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = global_trust_setting
+
+    set_config(
+        "rollout_upgraded_errors_execute_configreferrer", referrer_execute_config,
+    )
+    if referrer_execute_setting is not None:
+        settings.ERRORS_UPGRADE_EXECUTE_BOTH = {
+            "configreferrer": referrer_execute_setting
+        }
+    set_config("rollout_upgraded_errors_execute", global_execute_config)
+    settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = global_execute_setting
+
+    rollout_selector = RolloutSelector(Option.ERRORS, Option.ERRORS_V2, "errors")
+
+    assert rollout_selector.choose(query_referrer) == expceted
+
+    # Reset settings
+    settings.ERRORS_UPGRADE_TRUST_SECONDARY = {}
+    settings.ERRORS_UPGRADE_EXECUTE_BOTH = {}

--- a/tests/datasets/test_upgrade_selector.py
+++ b/tests/datasets/test_upgrade_selector.py
@@ -12,6 +12,7 @@ from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.logical import Query
+from snuba.state import set_config
 
 query = Query(
     QueryEntity(EntityKey.EVENTS, EntityColumnSet([])),
@@ -92,15 +93,12 @@ def test_selector_function(
         condition=time_condition,
     )
 
+    set_config("rollout_upgraded_errors_trust", trust_secondary)
+    set_config("rollout_upgraded_errors_execute", exec_both)
+
     previous_time = settings.ERRORS_UPGRADE_BEGINING_OF_TIME
     settings.ERRORS_UPGRADE_BEGINING_OF_TIME = beginning_of_time
-    previous_trust_rollout = settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL
-    settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = trust_secondary
-    previous_exec_both = settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL
-    settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = exec_both
 
     assert selector_function(query, "test") == expected_value
 
     settings.ERRORS_UPGRADE_BEGINING_OF_TIME = previous_time
-    settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = previous_trust_rollout
-    settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = previous_exec_both

--- a/tests/datasets/test_upgrade_selector.py
+++ b/tests/datasets/test_upgrade_selector.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+from typing import List, Optional, Tuple
+
+import pytest
+
+from snuba import settings
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.entity_data_model import EntityColumnSet
+from snuba.datasets.entities.events import selector_function
+from snuba.query import SelectedExpression
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.expressions import Column, Expression, Literal
+from snuba.query.logical import Query
+
+query = Query(
+    QueryEntity(EntityKey.EVENTS, EntityColumnSet([])),
+    selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+    condition=binary_condition(
+        ConditionFunctions.EQ,
+        Column("_snuba_project_id", None, "project_id"),
+        Literal(None, 1),
+    ),
+)
+
+TESTS = [
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, None, "timestamp"),
+            Literal(None, datetime(2022, 1, 1, 0, 0, 0)),
+        ),
+        None,
+        1.0,
+        1.0,
+        ("errors_v1", []),
+        id="No beginning of time, disabled.",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, None, "timestamp"),
+            Literal(None, datetime(2021, 1, 1, 0, 0, 0)),
+        ),
+        datetime(2022, 1, 1, 0, 0, 0),
+        1.0,
+        1.0,
+        ("errors_v1", []),
+        id="Out of time range, disabled.",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, None, "timestamp"),
+            Literal(None, datetime(2022, 1, 1, 0, 0, 0)),
+        ),
+        datetime(2021, 1, 1, 0, 0, 0),
+        1.0,
+        0.0,
+        ("errors_v1", ["errors_v2"]),
+        id="In range, run both.",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, None, "timestamp"),
+            Literal(None, datetime(2022, 1, 1, 0, 0, 0)),
+        ),
+        datetime(2021, 1, 1, 0, 0, 0),
+        1.0,
+        1.0,
+        ("errors_v2", ["errors_v1"]),
+        id="In range, run both and trust the second.",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "time_condition, beginning_of_time, exec_both, trust_secondary, expected_value",
+    TESTS,
+)
+def test_selector_function(
+    time_condition: Expression,
+    beginning_of_time: Optional[datetime],
+    exec_both: float,
+    trust_secondary: float,
+    expected_value: Tuple[str, List[str]],
+) -> None:
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, EntityColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=time_condition,
+    )
+
+    previous_time = settings.ERRORS_UPGRADE_BEGINING_OF_TIME
+    settings.ERRORS_UPGRADE_BEGINING_OF_TIME = beginning_of_time
+    previous_trust_rollout = settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL
+    settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = trust_secondary
+    previous_exec_both = settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL
+    settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = exec_both
+
+    assert selector_function(query, "test") == expected_value
+
+    settings.ERRORS_UPGRADE_BEGINING_OF_TIME = previous_time
+    settings.ERRORS_UPGRADE_TRUST_SECONDARY_GLOBAL = previous_trust_rollout
+    settings.ERRORS_UPGRADE_EXECUTE_BOTH_GLOBAL = previous_exec_both

--- a/tests/datasets/test_upgrade_selector.py
+++ b/tests/datasets/test_upgrade_selector.py
@@ -6,7 +6,7 @@ import pytest
 from snuba import settings
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.entity_data_model import EntityColumnSet
-from snuba.datasets.entities.events import selector_function
+from snuba.datasets.entities.events import v2_selector_function
 from snuba.query import SelectedExpression
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
@@ -99,6 +99,6 @@ def test_selector_function(
     previous_time = settings.ERRORS_UPGRADE_BEGINING_OF_TIME
     settings.ERRORS_UPGRADE_BEGINING_OF_TIME = beginning_of_time
 
-    assert selector_function(query, "test") == expected_value
+    assert v2_selector_function(query, "test") == expected_value
 
     settings.ERRORS_UPGRADE_BEGINING_OF_TIME = previous_time


### PR DESCRIPTION
This includes most of what is needed to direct a portion of errors queries to the new storage `errors_v2`.
It uses the PipelineDelegator to run two queries in parallel and compare the results.
It introduces `RolloutSelector` to define the rollout policy. So we can control the amount of queries that go to `errors_vs` by referrer and rely on `errors_v2` for the production results when needed.

Still to do:
- add a callback to compare the results
- register errors_v2_ro