### PR TITLE
ci: Change machineType for Google Cloud Build to E2_HIGHCPU_8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -103,7 +103,7 @@ images: ['us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
 timeout: 2640s
 options:
   # We need more memory for Webpack builds & e2e self-hosted tests
-  machineType: "N1_HIGHCPU_8"
+  machineType: "E2_HIGHCPU_8"
   env:
     - "CI=1"
     - "SNUBA_IMAGE=us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"


### PR DESCRIPTION
See https://github.com/getsentry/sentry/pull/31950 for more details.