### PR TITLE
fix(functions) Add MergeIf as a valid function suffix

### DIFF
--- a/snuba/query/functions.py
+++ b/snuba/query/functions.py
@@ -87,6 +87,7 @@ _AGGREGATION_SUFFIXES = {
     "SampleState",
     "State",
     "Merge",
+    "MergeIf",
     "MergeState",
     "ForEach",
     "OrDefault",


### PR DESCRIPTION
Some of the proposed metrics queries are doing MergeIf functions instead of just
If functions. Add that prefix to list of allowed functions.
