### PR TITLE
fix(replacer): Add errors_v2 storage option

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -26,7 +26,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--storage",
     "storage_name",
-    type=click.Choice(["events", "errors"]),
+    type=click.Choice(["events", "errors", "errors_v2"]),
     help="The storage to consume/run replacements for (currently only events supported)",
     required=True,
 )


### PR DESCRIPTION
In order to run replacements on the errors_v2 storage, we need to allow passing it as a command line option. This PR does exactly that.