### PR TITLE
fix(snql) Correctly assign aliases to expressions with none

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -103,7 +103,7 @@ images: ['us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA']
 timeout: 2640s
 options:
   # We need more memory for Webpack builds & e2e self-hosted tests
-  machineType: "N1_HIGHCPU_8"
+  machineType: "E2_HIGHCPU_8"
   env:
     - "CI=1"
     - "SNUBA_IMAGE=us.gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -714,6 +714,8 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
             return exp
 
         alias = exp.alias or node.text.strip()
+        if not isinstance(exp, Column) and exp.alias is None:
+            exp = replace(exp, alias=alias)
         return SelectedExpression(alias, exp)
 
     def visit_select_columns(
@@ -1305,11 +1307,6 @@ def validate_entities_with_query(
                 f"validation failed for entity {query.get_from_clause().key.value}: {e}",
                 should_report=e.should_report,
             )
-        except InvalidExpressionException as e:
-            raise ParsingException(
-                f"validation failed for entity {query.get_from_clause().key.value}: {e}",
-                should_report=e.should_report,
-            )
     else:
         from_clause = query.get_from_clause()
         if isinstance(from_clause, JoinClause):
@@ -1321,11 +1318,6 @@ def validate_entities_with_query(
                     for v in entity.get_validators():
                         v.validate(query, alias)
                 except InvalidQueryException as e:
-                    raise ParsingException(
-                        f"validation failed for entity {node.data_source.key.value}: {e}",
-                        should_report=e.should_report,
-                    )
-                except InvalidExpressionException as e:
                     raise ParsingException(
                         f"validation failed for entity {node.data_source.key.value}: {e}",
                         should_report=e.should_report,

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -27,7 +27,9 @@ TEST_CASES = [
         "uniq(value)",
         EntityKey.METRICS_SETS,
         FunctionCall(
-            None, "uniqCombined64Merge", (Column("_snuba_value", None, "value"),),
+            "_snuba_uniq(value)",
+            "uniqCombined64Merge",
+            (Column("_snuba_value", None, "value"),),
         ),
         id="Test sets entity",
     ),
@@ -35,7 +37,9 @@ TEST_CASES = [
         "metrics_counters",
         "sum(value)",
         EntityKey.METRICS_COUNTERS,
-        FunctionCall(None, "sumMerge", (Column("_snuba_value", None, "value"),),),
+        FunctionCall(
+            "_snuba_sum(value)", "sumMerge", (Column("_snuba_value", None, "value"),),
+        ),
         id="Test counters entity",
     ),
     pytest.param(
@@ -43,7 +47,7 @@ TEST_CASES = [
         "sumIf(value, cond())",
         EntityKey.METRICS_COUNTERS,
         FunctionCall(
-            None,
+            "_snuba_sumIf(value, cond())",
             "sumMergeIf",
             (
                 Column("_snuba_value", None, "value"),
@@ -56,7 +60,7 @@ TEST_CASES = [
         "metrics_distributions",
         "max(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall(None, "maxMerge", (Column(None, None, "max"),),),
+        FunctionCall("_snuba_max(value)", "maxMerge", (Column(None, None, "max"),),),
         id="Test distribution max",
     ),
     pytest.param(
@@ -64,7 +68,7 @@ TEST_CASES = [
         "maxIf(value, cond())",
         EntityKey.METRICS_DISTRIBUTIONS,
         FunctionCall(
-            None,
+            "_snuba_maxIf(value, cond())",
             "maxMergeIf",
             (Column(None, None, "max"), FunctionCall(None, "cond", tuple()),),
         ),
@@ -74,7 +78,7 @@ TEST_CASES = [
         "metrics_distributions",
         "min(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall(None, "minMerge", (Column(None, None, "min"),),),
+        FunctionCall("_snuba_min(value)", "minMerge", (Column(None, None, "min"),),),
         id="Test distribution min",
     ),
     pytest.param(
@@ -82,7 +86,7 @@ TEST_CASES = [
         "minIf(value, cond())",
         EntityKey.METRICS_DISTRIBUTIONS,
         FunctionCall(
-            None,
+            "_snuba_minIf(value, cond())",
             "minMergeIf",
             (Column(None, None, "min"), FunctionCall(None, "cond", tuple()),),
         ),
@@ -92,7 +96,7 @@ TEST_CASES = [
         "metrics_distributions",
         "avg(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall(None, "avgMerge", (Column(None, None, "avg"),),),
+        FunctionCall("_snuba_avg(value)", "avgMerge", (Column(None, None, "avg"),),),
         id="Test distribution avg",
     ),
     pytest.param(
@@ -100,7 +104,7 @@ TEST_CASES = [
         "avgIf(value, cond())",
         EntityKey.METRICS_DISTRIBUTIONS,
         FunctionCall(
-            None,
+            "_snuba_avgIf(value, cond())",
             "avgMergeIf",
             (Column(None, None, "avg"), FunctionCall(None, "cond", tuple()),),
         ),
@@ -110,7 +114,9 @@ TEST_CASES = [
         "metrics_distributions",
         "count(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall(None, "countMerge", (Column(None, None, "count"),),),
+        FunctionCall(
+            "_snuba_count(value)", "countMerge", (Column(None, None, "count"),),
+        ),
         id="Test distribution count",
     ),
     pytest.param(
@@ -118,7 +124,7 @@ TEST_CASES = [
         "quantiles(0.5, 0.75, 0.9, 0.95, 0.99)(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
         CurriedFunctionCall(
-            None,
+            "_snuba_quantiles(0.5, 0.75, 0.9, 0.95, 0.99)(value)",
             FunctionCall(
                 None,
                 "quantilesMerge",
@@ -133,7 +139,7 @@ TEST_CASES = [
         "quantilesIf(0.5, 0.75, 0.9, 0.95, 0.99)(value, cond())",
         EntityKey.METRICS_DISTRIBUTIONS,
         CurriedFunctionCall(
-            None,
+            "_snuba_quantilesIf(0.5, 0.75, 0.9, 0.95, 0.99)(value, cond())",
             FunctionCall(
                 None,
                 "quantilesMergeIf",
@@ -148,7 +154,9 @@ TEST_CASES = [
         "avg(something_else)",
         EntityKey.METRICS_DISTRIBUTIONS,
         FunctionCall(
-            None, "avg", (Column("_snuba_something_else", None, "something_else"),),
+            "_snuba_avg(something_else)",
+            "avg",
+            (Column("_snuba_something_else", None, "something_else"),),
         ),
         id="Test that a column other than value is not transformed",
     ),

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -67,7 +67,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
@@ -87,7 +89,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
@@ -107,7 +111,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
@@ -127,7 +133,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
                 SelectedExpression("d", Column("_snuba_d", None, "d")),
@@ -156,7 +164,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
@@ -176,7 +186,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
             ],
@@ -195,7 +207,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("c", Column("_snuba_c", None, "c")),
                 SelectedExpression(
@@ -221,12 +235,14 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression(
                     "3* foo(c) AS foo",
                     FunctionCall(
-                        None,
+                        "_snuba_3* foo(c) AS foo",
                         "multiply",
                         (
                             Literal(None, 3),
@@ -256,12 +272,14 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression(
                     "3*foo(c) AS foo",
                     FunctionCall(
-                        None,
+                        "_snuba_3*foo(c) AS foo",
                         "multiply",
                         (
                             Literal(None, 3),
@@ -362,12 +380,14 @@ test_cases = [
                 SelectedExpression("d", Column("_snuba_d", None, "d")),
                 SelectedExpression(
                     "2+7",
-                    FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
+                    FunctionCall(
+                        "_snuba_2+7", "plus", (Literal(None, 2), Literal(None, 7))
+                    ),
                 ),
                 SelectedExpression(
                     "(2*(4-5)+3)",
                     FunctionCall(
-                        None,
+                        "_snuba_(2*(4-5)+3)",
                         "plus",
                         (
                             FunctionCall(
@@ -395,7 +415,9 @@ test_cases = [
             condition=required_condition,
             groupby=[
                 Column("_snuba_d", None, "d"),
-                FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
+                FunctionCall(
+                    "_snuba_2+7", "plus", (Literal(None, 2), Literal(None, 7))
+                ),
             ],
             order_by=[OrderBy(OrderByDirection.DESC, Column("_snuba_f", None, "f"))],
             limit=1000,
@@ -413,12 +435,14 @@ test_cases = [
                 SelectedExpression("d", Column("_snuba_d", None, "d")),
                 SelectedExpression(
                     "2+7",
-                    FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
+                    FunctionCall(
+                        "_snuba_2+7", "plus", (Literal(None, 2), Literal(None, 7))
+                    ),
                 ),
                 SelectedExpression(
                     "(2*(4-5)+3)",
                     FunctionCall(
-                        None,
+                        "_snuba_(2*(4-5)+3)",
                         "plus",
                         (
                             FunctionCall(
@@ -448,7 +472,9 @@ test_cases = [
             condition=required_condition,
             groupby=[
                 Column("_snuba_d", None, "d"),
-                FunctionCall(None, "plus", (Literal(None, 2), Literal(None, 7))),
+                FunctionCall(
+                    "_snuba_2+7", "plus", (Literal(None, 2), Literal(None, 7))
+                ),
             ],
             order_by=[OrderBy(OrderByDirection.DESC, Column("_snuba_f", None, "f"))],
             limit=1000,
@@ -472,7 +498,7 @@ test_cases = [
                 SelectedExpression(
                     "3*foo(c) AS foo",
                     FunctionCall(
-                        None,
+                        "_snuba_3*foo(c) AS foo",
                         "multiply",
                         (
                             Literal(None, 3),
@@ -681,12 +707,14 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression(
                     "3*foo(c) AS foo",
                     FunctionCall(
-                        None,
+                        "_snuba_3*foo(c) AS foo",
                         "multiply",
                         (
                             Literal(None, 3),
@@ -715,12 +743,14 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression(
                     "3*foo(c) AS foo",
                     FunctionCall(
-                        None,
+                        "_snuba_3*foo(c) AS foo",
                         "multiply",
                         (
                             Literal(None, 3),
@@ -846,7 +876,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("e.c", Column("_snuba_e.c", "e", "c")),
             ],
@@ -930,7 +962,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("t.c", Column("_snuba_t.c", "t", "c")),
             ],
@@ -1033,7 +1067,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("ga.c", Column("_snuba_ga.c", "ga", "c")),
             ],
@@ -1172,7 +1208,9 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("e.a", Column("_snuba_e.a", "e", "a")),
                 SelectedExpression("t.b", Column("_snuba_t.b", "t", "b")),
@@ -1379,12 +1417,14 @@ test_cases = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression(
                     "3*foo(c) AS foo",
                     FunctionCall(
-                        None,
+                        "_snuba_3*foo(c) AS foo",
                         "multiply",
                         (
                             Literal(None, 3),

--- a/tests/query/snql/test_query_column_validation.py
+++ b/tests/query/snql/test_query_column_validation.py
@@ -116,7 +116,9 @@ time_validation_tests = [
             selected_columns=[
                 SelectedExpression(
                     "4-5",
-                    FunctionCall(None, "minus", (Literal(None, 4), Literal(None, 5))),
+                    FunctionCall(
+                        "_snuba_4-5", "minus", (Literal(None, 4), Literal(None, 5))
+                    ),
                 ),
                 SelectedExpression("e.c", Column("_snuba_e.c", "e", "c")),
             ],

--- a/tests/query/snql/test_snql_anonymizer.py
+++ b/tests/query/snql/test_snql_anonymizer.py
@@ -20,7 +20,7 @@ test_cases = [
         f"MATCH (events) SELECT 4-5, c,d,e WHERE {added_condition} LIMIT 5 BY c,d,e",
         (
             "MATCH Entity(events) "
-            "SELECT minus(-1337, -1337), c, d, e "
+            "SELECT (minus(-1337, -1337) AS `4-5`), c, d, e "
             "WHERE equals(project_id, -1337) "
             "AND greaterOrEquals(timestamp, toDateTime('$S')) "
             "AND less(timestamp, toDateTime('$S')) "
@@ -81,7 +81,7 @@ test_cases = [
         WHERE or(equals(arrayExists(a, '=', 'RuntimeException'), 1), equals(arrayAll(b, 'NOT IN', tuple('Stack', 'Arithmetic')), 1)) = 1 AND {added_condition}""",
         (
             "MATCH Entity(events) "
-            "SELECT minus(-1337, -1337), multiply(-1337, (foo(c) AS foo)), c "
+            "SELECT (minus(-1337, -1337) AS `4-5`), (multiply(-1337, (foo(c) AS foo)) AS `3*foo(c) AS foo`), c "
             "WHERE equals((equals(arrayExists(a, '$S', '$S'), -1337) "
             "OR equals(arrayAll(b, '$S', tuple('$S', '$S')), -1337)), -1337) "
             "AND equals(project_id, -1337) "
@@ -103,7 +103,7 @@ test_cases = [
             "LEFT e, Entity(events) "
             "TYPE JoinType.INNER RIGHT ga, Entity(groupassignee)\n ON e.event_id ga.group_id "
             "TYPE JoinType.INNER RIGHT t, Entity(transactions)\n ON e.event_id t.event_id "
-            "SELECT minus(-1337, -1337), ga.c "
+            "SELECT (minus(-1337, -1337) AS `4-5`), ga.c "
             "WHERE equals(e.project_id, -1337) "
             "AND greaterOrEquals(e.timestamp, toDateTime('$S')) "
             "AND less(e.timestamp, toDateTime('$S')) "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1941,10 +1941,9 @@ class TestApi(SimpleAPITest):
         )
 
         val = (
-            "SELECT arrayMap((x -> replaceAll(toString(x), '-', '')), "
-            f"arraySlice(hierarchical_hashes, 0, 2)) FROM {errors_table_name} PREWHERE"
+            "SELECT (arrayMap((x -> replaceAll(toString(x), '-', '')), "
+            f"arraySlice(hierarchical_hashes, 0, 2)) AS `_snuba_arraySlice(hierarchical_hashes, 0, 2)`) FROM {errors_table_name} PREWHERE"
         )
-
         assert result["sql"].startswith(val)
 
     def test_backslashes_in_query(self) -> None:
@@ -1994,10 +1993,9 @@ class TestApi(SimpleAPITest):
         )
 
         val = (
-            "SELECT arrayJoin((arrayMap((x -> replaceAll(toString(x), '-', '')), "
-            f"hierarchical_hashes) AS _snuba_hierarchical_hashes)) FROM {errors_table_name} PREWHERE"
+            "SELECT (arrayJoin((arrayMap((x -> replaceAll(toString(x), '-', '')), "
+            f"hierarchical_hashes) AS _snuba_hierarchical_hashes)) AS `_snuba_arrayJoin(hierarchical_hashes)`) FROM {errors_table_name} PREWHERE"
         )
-
         assert result["sql"].startswith(val)
 
     def test_test_endpoints(self) -> None:

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -597,6 +597,38 @@ class TestSnQLApi(BaseApiTest):
         )
         assert response.status_code == 200
 
+    def test_missing_alias_bug(self) -> None:
+        response = self.post(
+            "/events/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (events)
+                    SELECT group_id, count(), divide(uniq(tags[url]) AS a+*, 1)
+                    BY group_id
+                    WHERE timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    AND project_id = {self.project_id}
+                    ORDER BY count() DESC
+                    LIMIT 3
+                    """,
+                    "dataset": "events",
+                    "team": "sns",
+                    "feature": "test",
+                    "debug": True,
+                }
+            ),
+        )
+        assert response.status_code == 200
+        result = json.loads(response.data)
+        assert len(result["data"]) > 0
+        assert "count()" in result["data"][0]
+        assert "divide(uniq(tags[url]) AS a+*, 1)" in result["data"][0]
+        assert {"name": "count()", "type": "UInt64"} in result["meta"]
+        assert {
+            "name": "divide(uniq(tags[url]) AS a+*, 1)",
+            "type": "Float64",
+        } in result["meta"]
+
     def test_invalid_column(self) -> None:
         response = self.post(
             "/outcomes/snql",


### PR DESCRIPTION
If a non-Column expression inside a SelectedExpression does not have an alias
assigned, give it the same expression as the SelectedExpression, which in this
case is the raw string passed into the parser.

This prevents a warning later that an expression is missing an alias when the
results are being processed. Once this is out and working I will remove the
warning here: https://github.com/getsentry/snuba/blob/master/snuba/web/query.py#L256
