### PR TITLE
fix: Avoid warning on duplicate aliases

### DIFF
--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from typing import Any, Mapping, NamedTuple
 
 from mypy_extensions import TypedDict
 
-from snuba.reader import Column, Result, transform_rows
+from snuba.reader import Column, Result, Row, transform_rows
 from snuba.utils.serializable_exception import SerializableException
 
 
@@ -30,17 +32,26 @@ class QueryResult(NamedTuple):
     extra: QueryExtraData
 
 
-def transform_column_names(result: QueryResult, mapping: Mapping[str, str]) -> None:
+def transform_column_names(
+    result: QueryResult, mapping: Mapping[str, list[str]]
+) -> None:
     """
     Replaces the column names in a ResultSet object in place.
     """
 
-    transform_rows(
-        result.result,
-        lambda row: {mapping.get(key, key): value for key, value in row.items()},
-    )
+    def transformer(row: Row) -> Row:
+        new_row: Row = {}
+        for key, value in row.items():
+            column_names = mapping.get(key, [key])
+            for c in column_names:
+                new_row[c] = value
+        return new_row
 
-    result.result["meta"] = [
-        Column(name=mapping.get(c["name"], c["name"]), type=c["type"])
-        for c in result.result["meta"]
-    ]
+    transform_rows(result.result, transformer)
+
+    new_meta = []
+    for c in result.result["meta"]:
+        names = mapping.get(c["name"], [c["name"]])
+        for n in names:
+            new_meta.append(Column(name=n, type=c["type"]))
+    result.result["meta"] = new_meta

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -597,6 +597,34 @@ class TestSnQLApi(BaseApiTest):
         )
         assert response.status_code == 200
 
+    def test_duplicate_alias_bug(self) -> None:
+        response = self.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (discover)
+                    SELECT count() AS count, tags[url] AS url, tags[url] AS http.url
+                    BY tags[url] AS http.url, tags[url] AS url
+                    WHERE timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    AND project_id IN array({self.project_id})
+                    ORDER BY count() AS count DESC
+                    LIMIT 51 OFFSET 0
+                    """,
+                    "dataset": "discover",
+                    "team": "sns",
+                    "feature": "test",
+                }
+            ),
+        )
+        assert response.status_code == 200
+        result = json.loads(response.data)
+        assert len(result["data"]) > 0
+        assert "url" in result["data"][0]
+        assert "http.url" in result["data"][0]
+        assert {"name": "url", "type": "String"} in result["meta"]
+        assert {"name": "http.url", "type": "String"} in result["meta"]
+
     def test_invalid_column(self) -> None:
         response = self.post(
             "/outcomes/snql",

--- a/tests/web/test_results.py
+++ b/tests/web/test_results.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from typing import Mapping
 
 import pytest
+
 from snuba.reader import Column, Result
 from snuba.web import QueryExtraData, QueryResult, transform_column_names
 
@@ -43,9 +46,9 @@ TEST_CASES = [
             extra=QueryExtraData(stats={}, sql="..."),
         ),
         {
-            "_snuba_event_id": "event_id",
-            "_snuba_duration": "duration",
-            "_snuba_message": "message",
+            "_snuba_event_id": ["event_id"],
+            "_snuba_duration": ["duration"],
+            "_snuba_message": ["message"],
         },
         id="Result without final, complete mapping",
     ),
@@ -93,9 +96,9 @@ TEST_CASES = [
             extra=QueryExtraData(stats={}, sql="..."),
         ),
         {
-            "_snuba_event_id": "event_id",
-            "_snuba_duration": "duration",
-            "_snuba_message": "message",
+            "_snuba_event_id": ["event_id"],
+            "_snuba_duration": ["duration"],
+            "_snuba_message": ["message"],
         },
         id="Result with final, complete mapping",
     ),
@@ -144,7 +147,7 @@ TEST_CASES = [
             ),
             extra=QueryExtraData(stats={}, sql="..."),
         ),
-        {"_snuba_event_id": "event_id"},
+        {"_snuba_event_id": ["event_id"]},
         id="Incomplete mapping",
     ),
 ]
@@ -152,7 +155,7 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("in_result, out_result, mapping", TEST_CASES)
 def test_transformation(
-    in_result: QueryResult, out_result: QueryResult, mapping: Mapping[str, str]
+    in_result: QueryResult, out_result: QueryResult, mapping: Mapping[str, list[str]]
 ) -> None:
     transform_column_names(in_result, mapping)
 


### PR DESCRIPTION
There are checks to make sure that different expressions can't have the same
alias, so the only way to hit the warning case when building the response is
an edge case where the same expression has two different aliases. Currently
in that case we would log a warning and only return one of the columns in
the response. Instead, don't log a warning and return both columns with
the same values.
