### PR TITLE
ref(consumer-util): add replyq metric to multistorage consumer

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -95,7 +95,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 )
 @click.option(
     "--stats-collection-frequency-ms",
-    type=click.IntRange(100, 1000),
+    type=click.IntRange(100, 2000),
     help="The frequency of collecting statistics from librdkafka.",
 )
 def consumer(
@@ -135,7 +135,7 @@ def consumer(
 
     def stats_callback(stats_json: str) -> None:
         stats = rapidjson.loads(stats_json)
-        metrics.gauge("total_queue_size", stats.get("replyq", 0))
+        metrics.gauge("librdkafka.total_queue_size", stats.get("replyq", 0))
 
     consumer_builder = ConsumerBuilder(
         storage_key=storage_key,

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -93,11 +93,6 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
-@click.option(
-    "--stats-collection-frequency-ms",
-    type=click.IntRange(100, 2000),
-    help="The frequency of collecting statistics from librdkafka.",
-)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -116,7 +111,6 @@ def consumer(
     processes: Optional[int],
     input_block_size: Optional[int],
     output_block_size: Optional[int],
-    stats_collection_frequency_ms: Optional[int],
     log_level: Optional[str] = None,
     profile_path: Optional[str] = None,
 ) -> None:
@@ -148,7 +142,6 @@ def consumer(
             auto_offset_reset=auto_offset_reset,
             queued_max_messages_kbytes=queued_max_messages_kbytes,
             queued_min_messages=queued_min_messages,
-            stats_collection_frequency_ms=stats_collection_frequency_ms,
         ),
         processing_params=ProcessingParameters(
             processes=processes,

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -82,7 +82,7 @@ logger = logging.getLogger(__name__)
 @click.option("--log-level")
 @click.option(
     "--stats-collection-frequency-ms",
-    type=click.IntRange(100, 1000),
+    type=click.IntRange(100, 2000),
     help="The frequency of collecting statistics from librdkafka.",
 )
 def multistorage_consumer(
@@ -212,7 +212,7 @@ def multistorage_consumer(
 
         def stats_callback(stats_json: str) -> None:
             stats = rapidjson.loads(stats_json)
-            metrics.gauge("total_queue_size", stats.get("replyq", 0))
+            metrics.gauge("librdkafka.total_queue_size", stats.get("replyq", 0))
 
         consumer_configuration.update(
             {

--- a/snuba/cli/test_consumer.py
+++ b/snuba/cli/test_consumer.py
@@ -132,7 +132,6 @@ def test_consumer(
             auto_offset_reset=auto_offset_reset,
             queued_max_messages_kbytes=queued_max_messages_kbytes,
             queued_min_messages=queued_min_messages,
-            stats_collection_frequency_ms=None,
         ),
         processing_params=ProcessingParameters(
             processes=processes,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -23,6 +23,7 @@ from snuba.datasets.storages.factory import get_writable_storage
 from snuba.environment import setup_sentry
 from snuba.processor import MessageProcessor
 from snuba.snapshots import SnapshotId
+from snuba.state import get_config
 from snuba.stateful_consumer.control_protocol import TransactionData
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.streams.configuration_builder import (
@@ -47,7 +48,6 @@ class KafkaParameters:
     auto_offset_reset: str
     queued_max_messages_kbytes: int
     queued_min_messages: int
-    stats_collection_frequency_ms: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -133,14 +133,7 @@ class ConsumerBuilder:
             else:
                 self.commit_log_topic = None
 
-        if kafka_params.stats_collection_frequency_ms is not None:
-            self.stats_collection_frequency_ms = (
-                kafka_params.stats_collection_frequency_ms
-            )
-            assert stats_callback is not None
-            self.stats_callback = stats_callback
-        else:
-            self.stats_collection_frequency_ms = 0
+        self.stats_callback = stats_callback
 
         # XXX: This can result in a producer being built in cases where it's
         # not actually required.
@@ -189,10 +182,13 @@ class ConsumerBuilder:
             queued_min_messages=self.queued_min_messages,
         )
 
-        if self.stats_collection_frequency_ms > 0:
+        stats_collection_frequency_ms = get_config(
+            f"stats_collection_freq_ms_{self.group_id}", 0
+        )
+        if stats_collection_frequency_ms and stats_collection_frequency_ms > 0:
             configuration.update(
                 {
-                    "statistics.interval.ms": self.stats_collection_frequency_ms,
+                    "statistics.interval.ms": stats_collection_frequency_ms,
                     "stats_cb": self.stats_callback,
                 }
             )


### PR DESCRIPTION
This is basically the same thing as https://github.com/getsentry/snuba/pull/2245, but applied to the multistorage consumers. (again for reference, the stats definitions for librdkafka can be found [here](https://github.com/edenhill/librdkafka/blob/master/STATISTICS.mdl)). 

 
* **cli command vs. runtime config**: ~we could limit by consumer group in the runtime config, but there can be multiple consumers in the same consumer group so for now I just want to be able to test reporting these metrics for specific consumers to make sure things look ok~ Changed to use the runtime config, lets try it out with a low risk consumer group and go from there
* **more stats metrics**: testing locally `replyq` seemed to be the correct metric for queue size. As for other stats metrics, I don't think I understand what the values represent enough at the moment to add them to the list. I think once we fine tune what frequency we want for the callback, we should have no problem adding to the list 