### PR TITLE
ref(querylog) Add the Clickhouse error code to the querylog stats

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -172,6 +172,7 @@ def update_query_metadata_and_stats(
     trace_id: Optional[str],
     status: QueryStatus,
     profile_data: Optional[Mapping[str, Any]] = None,
+    error_code: Optional[int] = None,
 ) -> MutableMapping[str, Any]:
     """
     If query logging is enabled then logs details about the query and its status, as
@@ -179,6 +180,8 @@ def update_query_metadata_and_stats(
     Also updates stats with any relevant information and returns the updated dict.
     """
     stats.update(query_settings)
+    if error_code is not None:
+        stats["error_code"] = error_code
     sql_anonymized = format_query_anonymized(query).get_sql()
     start, end = get_time_range_estimate(query)
 
@@ -496,8 +499,10 @@ def raw_query(
         if isinstance(cause, RateLimitExceeded):
             stats = update_with_status(QueryStatus.RATE_LIMITED)
         else:
+            error_code = None
             with configure_scope() as scope:
                 if isinstance(cause, ClickhouseError):
+                    error_code = cause.code
                     scope.fingerprint = ["{{default}}", str(cause.code)]
                     if scope.span:
                         if cause.code == errors.ErrorCodes.TOO_SLOW:
@@ -514,7 +519,7 @@ def raw_query(
                         sentry_sdk.set_tag("timeout", "cache_timeout")
 
                 logger.exception("Error running query: %s\n%s", sql, cause)
-            stats = update_with_status(QueryStatus.ERROR)
+            stats = update_with_status(QueryStatus.ERROR, error_code=error_code)
         raise QueryException(
             {
                 "stats": stats,

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -245,3 +245,111 @@ def test_missing_fields() -> None:
             ],
             None,
         )
+
+
+def test_error_code() -> None:
+    request_body = {
+        "selected_columns": ["event_id"],
+        "orderby": "event_id",
+        "sample": 0.1,
+        "limit": 100,
+        "offset": 50,
+        "project": 1,
+    }
+
+    query = Query(
+        Entity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model())
+    )
+
+    request = Request(
+        uuid.UUID("a" * 32).hex,
+        request_body,
+        query,
+        "",
+        HTTPRequestSettings(referrer="search"),
+    )
+
+    time = TestingClock()
+
+    timer = Timer("test", clock=time)
+    time.sleep(0.01)
+
+    message = SnubaQueryMetadata(
+        request=request,
+        start_timestamp=datetime.utcnow() - timedelta(days=3),
+        end_timestamp=datetime.utcnow(),
+        dataset="events",
+        timer=timer,
+        query_list=[
+            ClickhouseQueryMetadata(
+                sql="select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100",
+                sql_anonymized="select event_id from sentry_dist sample 0.1 prewhere project_id in ($I) limit 50, 100",
+                start_timestamp=datetime.utcnow() - timedelta(days=3),
+                end_timestamp=datetime.utcnow(),
+                stats={"sample": 10, "error_code": 386},
+                status=QueryStatus.SUCCESS,
+                profile=ClickhouseQueryProfile(
+                    time_range=10,
+                    table="events",
+                    all_columns={"timestamp", "tags"},
+                    multi_level_condition=False,
+                    where_profile=FilterProfile(
+                        columns={"timestamp"}, mapping_cols={"tags"},
+                    ),
+                    groupby_cols=set(),
+                    array_join_cols=set(),
+                ),
+                trace_id="b" * 32,
+            )
+        ],
+        projects={2},
+        snql_anonymized=request.snql_anonymized,
+    ).to_dict()
+
+    processor = (
+        get_writable_storage(StorageKey.QUERYLOG)
+        .get_table_writer()
+        .get_stream_loader()
+        .get_processor()
+    )
+
+    assert processor.process_message(
+        message, KafkaMessageMetadata(0, 0, datetime.now())
+    ) == InsertBatch(
+        [
+            {
+                "request_id": str(uuid.UUID("a" * 32)),
+                "request_body": '{"limit": 100, "offset": 50, "orderby": "event_id", "project": 1, "sample": 0.1, "selected_columns": ["event_id"]}',
+                "referrer": "search",
+                "dataset": "events",
+                "projects": [2],
+                "organization": None,
+                "timestamp": timer.for_json()["timestamp"],
+                "duration_ms": 10,
+                "status": "success",
+                "clickhouse_queries.sql": [
+                    "select event_id from sentry_dist sample 0.1 prewhere project_id in (1) limit 50, 100"
+                ],
+                "clickhouse_queries.status": ["success"],
+                "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
+                "clickhouse_queries.duration_ms": [0],
+                "clickhouse_queries.stats": ['{"error_code": 386, "sample": 10}'],
+                "clickhouse_queries.final": [0],
+                "clickhouse_queries.cache_hit": [0],
+                "clickhouse_queries.sample": [10.0],
+                "clickhouse_queries.max_threads": [0],
+                "clickhouse_queries.num_days": [10],
+                "clickhouse_queries.clickhouse_table": [""],
+                "clickhouse_queries.query_id": [""],
+                "clickhouse_queries.is_duplicate": [0],
+                "clickhouse_queries.consistent": [0],
+                "clickhouse_queries.all_columns": [["tags", "timestamp"]],
+                "clickhouse_queries.or_conditions": [False],
+                "clickhouse_queries.where_columns": [["timestamp"]],
+                "clickhouse_queries.where_mapping_columns": [["tags"]],
+                "clickhouse_queries.groupby_columns": [[]],
+                "clickhouse_queries.array_join_columns": [[]],
+            }
+        ],
+        None,
+    )


### PR DESCRIPTION
The stats of each query in the query list will now have an "error_code" field if
the query failed in Clickhouse.
