### PR TITLE
metrics(replacer): Consumer group per replacement processed

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -485,7 +485,11 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
         type_ = message.action_type
 
         if type_ in REPLACEMENT_EVENT_TYPES:
-            metrics.increment("process", 1, tags={"type": type_})
+            metrics.increment(
+                "process",
+                1,
+                tags={"type": type_, "consumer_group": message.metadata.consumer_group},
+            )
 
         if type_ in (
             ReplacementType.START_DELETE_GROUPS,

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -350,7 +350,9 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
 
     def process_message(self, message: Message[KafkaPayload]) -> Optional[Replacement]:
         metadata = ReplacementMessageMetadata(
-            partition_index=message.partition.index, offset=message.offset,
+            partition_index=message.partition.index,
+            offset=message.offset,
+            consumer_group=self.__consumer_group,
         )
 
         if self._message_already_processed(metadata):

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -19,6 +19,7 @@ class ReplacementMessageMetadata(NamedTuple):
 
     partition_index: int
     offset: int
+    consumer_group: str
 
 
 class ReplacementMessage(NamedTuple):

--- a/tests/replacer/test_cluster_replacements.py
+++ b/tests/replacer/test_cluster_replacements.py
@@ -142,7 +142,7 @@ REPLACEMENT_TYPE = (
     ReplacementType.EXCLUDE_GROUPS
 )  # Arbitrary replacement type, no impact on tests
 
-REPLACEMENT_MESSAGE_METADATA = ReplacementMessageMetadata(0, 0)
+REPLACEMENT_MESSAGE_METADATA = ReplacementMessageMetadata(0, 0, "")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- We're adding a new consumer group for replacements
- We'd like to see replacements metrics split by consumer groups and update some alerts