### PR TITLE
feat(errors_v2): Support readonly storage for errors_v2

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -29,6 +29,7 @@ class StorageSetKey(Enum):
     TRANSACTIONS_RO = "transactions_ro"
     TRANSACTIONS_V2 = "transactions_v2"
     ERRORS_V2 = "errors_v2"
+    ERRORS_V2_RO = "errors_v2_ro"
     PROFILES = "profiles"
 
 
@@ -39,7 +40,10 @@ DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset({})
 # do not have the same local node cluster configuration.
 # Joins can be performed across storage sets in the same group.
 JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
-    {frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC})}
+    {
+        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC}),
+        frozenset({StorageSetKey.ERRORS_V2, StorageSetKey.ERRORS_V2_RO}),
+    }
 )
 
 

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -138,15 +138,18 @@ class ErrorsQueryStorageSelector(QueryStorageSelector):
 class ErrorsV2QueryStorageSelector(QueryStorageSelector):
     def __init__(self, mappers: TranslationMappers) -> None:
         self.__errors_table = get_writable_storage(StorageKey.ERRORS_V2)
-        # TODO: Register ERRORS_V2_RO and then remove comment
-        # self.__errors_ro_table = get_storage(StorageKey.ERRORS_RO)
+        self.__errors_ro_table = get_storage(StorageKey.ERRORS_V2_RO)
         self.__mappers = mappers
 
     def select_storage(
         self, query: Query, request_settings: RequestSettings
     ) -> StorageAndMappers:
-        # TODO: Register ERRORS_V2_RO and support the ro storage
-        return StorageAndMappers(self.__errors_table, self.__mappers)
+        use_readonly_storage = not request_settings.get_consistent()
+
+        storage = (
+            self.__errors_ro_table if use_readonly_storage else self.__errors_table
+        )
+        return StorageAndMappers(storage, self.__mappers)
 
 
 def v2_selector_function(query: Query, referrer: str) -> Tuple[str, List[str]]:

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -30,3 +30,4 @@ class StorageKey(Enum):
     TRANSACTIONS_RO = "transactions_ro"
     TRANSACTIONS_V2 = "transactions_v2"
     ERRORS_V2 = "errors_v2"
+    ERRORS_V2_RO = "errors_v2_ro"

--- a/snuba/datasets/storages/errors_v2_ro.py
+++ b/snuba/datasets/storages/errors_v2_ro.py
@@ -1,0 +1,26 @@
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storage import ReadableTableStorage
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.errors_common import (
+    all_columns,
+    mandatory_conditions,
+    query_processors,
+    query_splitters,
+)
+
+schema = TableSchema(
+    columns=all_columns,
+    local_table_name="errors_local",
+    dist_table_name="errors_dist_ro",
+    storage_set_key=StorageSetKey.ERRORS_V2_RO,
+    mandatory_conditions=mandatory_conditions,
+)
+
+storage = ReadableTableStorage(
+    storage_key=StorageKey.ERRORS_V2_RO,
+    storage_set_key=StorageSetKey.ERRORS_V2_RO,
+    schema=schema,
+    query_processors=query_processors,
+    query_splitters=query_splitters,
+)

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -7,8 +7,8 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.discover import storage as discover_storage
 from snuba.datasets.storages.errors import storage as errors_storage
 from snuba.datasets.storages.errors_ro import storage as errors_ro_storage
-from snuba.datasets.storages.errors_ro import storage as errors_v2_ro_storage
 from snuba.datasets.storages.errors_v2 import storage as errors_v2_storage
+from snuba.datasets.storages.errors_v2_ro import storage as errors_v2_ro_storage
 from snuba.datasets.storages.events import storage as events_storage
 from snuba.datasets.storages.events_ro import storage as events_ro_storage
 from snuba.datasets.storages.groupassignees import storage as groupassignees_storage

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -7,6 +7,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.discover import storage as discover_storage
 from snuba.datasets.storages.errors import storage as errors_storage
 from snuba.datasets.storages.errors_ro import storage as errors_ro_storage
+from snuba.datasets.storages.errors_ro import storage as errors_v2_ro_storage
 from snuba.datasets.storages.errors_v2 import storage as errors_v2_storage
 from snuba.datasets.storages.events import storage as events_storage
 from snuba.datasets.storages.events_ro import storage as events_ro_storage
@@ -100,6 +101,7 @@ NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
             sessions_hourly_storage,
             org_sessions_hourly_storage,
             transactions_ro_storage,
+            errors_v2_ro_storage,
         ]
     },
     **(DEV_NON_WRITABLE_STORAGES if settings.ENABLE_DEV_FEATURES else {}),

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -48,6 +48,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "transactions_ro",
             "transactions_v2",
             "errors_v2",
+            "errors_v2_ro",
             "profiles",
         },
         "single_node": True,

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -22,6 +22,7 @@ CLUSTERS = [
             "transactions_ro",
             "transactions_v2",
             "errors_v2",
+            "errors_v2_ro",
             "profiles",
         },
         "single_node": False,


### PR DESCRIPTION
The PR enables errors_v2_ro storage which is a readable storage which
would be selected if consistent queries are not required.