### PR TITLE
feat: Uniq function killswitch

### DIFF
--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -22,6 +22,7 @@ from snuba.query.data_source.simple import Table
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.processors.conditions_enforcer import MandatoryConditionEnforcer
 from snuba.query.processors.mandatory_condition_applier import MandatoryConditionApplier
+from snuba.query.processors.uniq_killswitch import UniqKillswitchProcessor
 from snuba.request.request_settings import RequestSettings
 
 # TODO: Importing snuba.web here is just wrong. What's need to be done to avoid this
@@ -207,6 +208,7 @@ class SelectedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
             *self.__post_processors,
             MandatoryConditionApplier(),
             MandatoryConditionEnforcer(storage.get_mandatory_condition_checkers()),
+            UniqKillswitchProcessor(),
         ]
 
         return [

--- a/snuba/query/processors/uniq_killswitch.py
+++ b/snuba/query/processors/uniq_killswitch.py
@@ -9,8 +9,22 @@ from snuba.request.request_settings import RequestSettings
 
 class UniqKillswitchProcessor(QueryProcessor):
     """
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    USE ONLY IN CASE OF EMERGENCY
+    THIS PROCESSOR BEING TURNED ON RETURNS INCORRECT
+    RESULTS.
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    Usage:
+        In Runtime config, set the following flags:
+
+        uniq_killswitch_tables=errors_dist,discover_dist,transactions_dist,(etc)
+        uniq_killswitch_referrers=search,tsdb-modelid:4,(etc)
+
     This processor removes uniq() expressions from the query and replaces them with zero.
-    The reason for doing this is because uniq() queries are suspected to be causing ClickHouse to segfault.
+    The reason for doing this is because uniq() queries are suspected to be
+    causing ClickHouse to segfault under very specific consequences we do
+    not understand.
     Since it returns incorrect results, it is only to be used in case of emergency.
 
     Example usage:
@@ -39,8 +53,8 @@ class UniqKillswitchProcessor(QueryProcessor):
 
         def process_functions(exp: Expression) -> Expression:
             if isinstance(exp, FunctionCall):
-                if exp.function_name == "uniq":
-                    return Literal(exp.alias, 0)
+                if exp.function_name in ("uniq", "uniqIf"):
+                    return Literal(exp.alias, 1)
 
             return exp
 

--- a/snuba/query/processors/uniq_killswitch.py
+++ b/snuba/query/processors/uniq_killswitch.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from snuba import state
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.expressions import Expression, FunctionCall, Literal
+from snuba.request.request_settings import RequestSettings
+
+
+class UniqKillswitchProcessor(QueryProcessor):
+    """
+    This processor removes uniq() expressions from the query and replaces them with zero.
+    The reason for doing this is because uniq() queries are suspected to be causing ClickHouse to segfault.
+    Since it returns incorrect results, it is only to be used in case of emergency.
+
+    Example usage:
+    - Enable for all queries to the following tables
+        - uniq_killswitch_tables=errors_dist,errors_ro_dist
+    - Enable for referrer
+        - uniq_killswitch_referrers=referrer1,referrer2,referrer3
+
+    `uniq_killswitch_tables` and `uniq_killswitch_referrers` are independent
+    and uniq will be removed from all tables and referrers specified.
+    """
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        table_config = state.get_config("uniq_killswitch_tables")
+        referrer_config = state.get_config("uniq_killswitch_referrers")
+
+        table_names: list[str] = [] if table_config is None else table_config.split(",")
+        referrers: list[str] = [] if referrer_config is None else referrer_config.split(
+            ","
+        )
+        table_name = query.get_from_clause().table_name
+
+        should_transform_uniq = (
+            request_settings.referrer in referrers or table_name in table_names
+        )
+
+        def process_functions(exp: Expression) -> Expression:
+            if isinstance(exp, FunctionCall):
+                if exp.function_name == "uniq":
+                    return Literal(exp.alias, 0)
+
+            return exp
+
+        if should_transform_uniq:
+            query.transform_expressions(process_functions)

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -43,6 +43,7 @@ from snuba.query.expressions import (
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.processors.conditions_enforcer import MandatoryConditionEnforcer
 from snuba.query.processors.mandatory_condition_applier import MandatoryConditionApplier
+from snuba.query.processors.uniq_killswitch import UniqKillswitchProcessor
 from snuba.reader import Reader
 from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
@@ -185,6 +186,7 @@ TEST_CASES = [
                     *events_storage.get_query_processors(),
                     MandatoryConditionApplier(),
                     MandatoryConditionEnforcer([]),
+                    UniqKillswitchProcessor(),
                 ],
             ),
             None,
@@ -369,6 +371,7 @@ TEST_CASES = [
                         *events_storage.get_query_processors(),
                         MandatoryConditionApplier(),
                         MandatoryConditionEnforcer([]),
+                        UniqKillswitchProcessor(),
                     ],
                 ),
                 "groups": SubqueryProcessors(

--- a/tests/query/processors/test_uniq_killswitch.py
+++ b/tests/query/processors/test_uniq_killswitch.py
@@ -29,7 +29,7 @@ test_data = [
         Query(
             Table("events", ColumnSet([])),
             selected_columns=[
-                SelectedExpression("alias", Literal("alias", 0),),
+                SelectedExpression("alias", Literal("alias", 1),),
                 SelectedExpression(
                     "alias2",
                     FunctionCall("alias2", "count", (Column(None, None, "column2"),)),

--- a/tests/query/processors/test_uniq_killswitch.py
+++ b/tests/query/processors/test_uniq_killswitch.py
@@ -1,0 +1,65 @@
+from copy import deepcopy
+
+import pytest
+
+from snuba import state
+from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.query import Query
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Table
+from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.processors.uniq_killswitch import UniqKillswitchProcessor
+from snuba.request.request_settings import HTTPRequestSettings
+
+test_data = [
+    (
+        Query(
+            Table("events", ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "alias",
+                    FunctionCall("alias", "uniq", (Column(None, None, "column1"),)),
+                ),
+                SelectedExpression(
+                    "alias2",
+                    FunctionCall("alias2", "count", (Column(None, None, "column2"),)),
+                ),
+            ],
+        ),
+        Query(
+            Table("events", ColumnSet([])),
+            selected_columns=[
+                SelectedExpression("alias", Literal("alias", 0),),
+                SelectedExpression(
+                    "alias2",
+                    FunctionCall("alias2", "count", (Column(None, None, "column2"),)),
+                ),
+            ],
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("input_query, expected_query", test_data)
+def test_kill_uniq_processor(input_query: Query, expected_query: Query) -> None:
+    # Matching referrer
+    state.set_config("uniq_killswitch_referrers", "test,test2")
+    copy = deepcopy(input_query)
+    UniqKillswitchProcessor().process_query(copy, HTTPRequestSettings(referrer="test"))
+    assert copy == expected_query
+    assert copy != input_query
+
+    # Non matching referrer
+    state.set_config("uniq_killswitch_referrers", "test,test2")
+    copy = deepcopy(input_query)
+    UniqKillswitchProcessor().process_query(
+        copy, HTTPRequestSettings(referrer="something_else")
+    )
+    assert copy != expected_query
+    assert copy == input_query
+
+    # Set tables
+    state.set_config("uniq_killswitch_tables", "events")
+    copy = deepcopy(input_query)
+    UniqKillswitchProcessor().process_query(copy, HTTPRequestSettings())
+    assert copy == expected_query

--- a/tests/query/processors/test_uniq_killswitch.py
+++ b/tests/query/processors/test_uniq_killswitch.py
@@ -40,13 +40,13 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize("input_query, expected_query", test_data)
-def test_kill_uniq_processor(input_query: Query, expected_query: Query) -> None:
+@pytest.mark.parametrize("input_query, transformed_query", test_data)
+def test_kill_uniq_processor(input_query: Query, transformed_query: Query) -> None:
     # Matching referrer
     state.set_config("uniq_killswitch_referrers", "test,test2")
     copy = deepcopy(input_query)
     UniqKillswitchProcessor().process_query(copy, HTTPRequestSettings(referrer="test"))
-    assert copy == expected_query
+    assert copy == transformed_query
     assert copy != input_query
 
     # Non matching referrer
@@ -55,11 +55,11 @@ def test_kill_uniq_processor(input_query: Query, expected_query: Query) -> None:
     UniqKillswitchProcessor().process_query(
         copy, HTTPRequestSettings(referrer="something_else")
     )
-    assert copy != expected_query
+    assert copy != transformed_query
     assert copy == input_query
 
     # Set tables
     state.set_config("uniq_killswitch_tables", "events")
     copy = deepcopy(input_query)
     UniqKillswitchProcessor().process_query(copy, HTTPRequestSettings())
-    assert copy == expected_query
+    assert copy == transformed_query

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -751,4 +751,4 @@ class TestSnQLApi(BaseApiTest):
 
         # Set referrer killswitch
         state.set_config("uniq_killswitch_referrers", "test")
-        assert run_query()["data"] == [{"uniq_project": 0}]
+        assert run_query()["data"] == [{"uniq_project": 1}]


### PR DESCRIPTION
Adds a killswitch for the uniq() function, only to be used in cases of emergency.
It can be turned on by table or by referrer (or a combination of both).
Since it returns incorrect results for uniq(), it should not be turned on under
normal circumstances.