### PR TITLE
ref(makefile): Add backend-typing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ api-tests:
 	SNUBA_SETTINGS=test pytest -vv tests/*_api.py
 
 backend-typing:
-	mypy snuba --strict --warn-unreachable --config-file mypy.ini --ignore-missing-imports
+	mypy snuba --strict --warn-unreachable --config-file mypy.ini
 
 install-python-dependencies:
 	pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ tests: test
 api-tests:
 	SNUBA_SETTINGS=test pytest -vv tests/*_api.py
 
+backend-typing:
+	mypy snuba --strict --warn-unreachable --config-file mypy.ini --ignore-missing-imports
+
 install-python-dependencies:
 	pip install -e .
 	pip install -r requirements-test.txt

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,9 @@ ignore_missing_imports = True
 [mypy-clickhouse_driver]
 ignore_missing_imports = True
 
+[mypy-clickhouse_driver.errors]
+ignore_missing_imports = True
+
 [mypy-confluent_kafka]
 ignore_missing_imports = True
 


### PR DESCRIPTION
sentry's makefile uses [`backend-typing`](https://github.com/getsentry/sentry/blob/master/Makefile#L133) so I thought it might be nice to just keep the same naming even though we don't have much of a frontend except for admin