### PR TITLE
fix(similarity) Fix logging again

### DIFF
--- a/snuba/datasets/entities/clickhouse_upgrade.py
+++ b/snuba/datasets/entities/clickhouse_upgrade.py
@@ -239,9 +239,9 @@ def split_metadata(result: QueryResult) -> SplitSchema:
     for column in metadata:
         if column["type"] in (
             "String",
-            "Datetime",
+            "Datetime('Universal')",
             "UUID",
-            "Date",
+            "Date('Universal')",
             "LowCardinality(String)",
         ):
             keys.append(column["name"])

--- a/snuba/datasets/entities/clickhouse_upgrade.py
+++ b/snuba/datasets/entities/clickhouse_upgrade.py
@@ -164,15 +164,13 @@ def comparison_callback(
             exc_info=True,
         )
 
-    if score >= 0.99 and random() < cast(
-        float, get_config("upgrade_log_perfect_match", 0.0)
-    ):
+    if score >= 0.99:
         # This is just a sanity check to ensure the algorithm makes sense
-        log("Pipeline delegator perfect match",)
-    elif score >= 0.75 and random() < cast(
-        float, get_config("upgrade_log_avg_match", 0.0)
-    ):
-        log("Pipeline delegator average match",)
+        if random() < cast(float, get_config("upgrade_log_perfect_match", 0.0)):
+            log("Pipeline delegator perfect match",)
+    elif score >= 0.75:
+        if random() < cast(float, get_config("upgrade_log_avg_match", 0.0)):
+            log("Pipeline delegator average match",)
     elif random() < cast(float, get_config("upgrade_log_low_similarity", 0.0)):
         log("Pipeline delegator low similarity",)
 

--- a/tests/datasets/entities/test_clickhouse_upgrade_callback.py
+++ b/tests/datasets/entities/test_clickhouse_upgrade_callback.py
@@ -20,7 +20,7 @@ def test_split_metadata() -> None:
         result={
             "meta": [
                 {"name": "field1", "type": "String"},
-                {"name": "field2", "type": "Datetime"},
+                {"name": "field2", "type": "Datetime('Universal')"},
                 {"name": "field3", "type": "Float64"},
                 {"name": "field4", "type": "Enum"},
             ],


### PR DESCRIPTION
Fix the logging condition.
I was logging average matches and low matches even in case of perfect matches because the if statement was wrong.
If the match was perfect but the log was not rolled out for that case I would end up logging a low match by mistake.