### PR TITLE
fix: Remove transactions v2 hack from Snuba admin

### DIFF
--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -40,6 +40,4 @@ def get_storage_info() -> Sequence[Storage]:
             "local_nodes": _get_local_nodes(storage_key),
         }
         for storage_key in sorted(STORAGES, key=lambda storage_key: storage_key.value)
-        # HACK: Transactions_v2 is temporarily not assigned to a cluster
-        if storage_key != StorageKey.TRANSACTIONS_V2
     ]


### PR DESCRIPTION
We needed to include this hack earlier because of the way transactions_v2 was rolled out
(included in code before added to cluster settings). This is no longer the case and we
want to see transactions_v2 in snuba admin so removing it.