### PR TITLE
feat: Include the UniqInSelectAndHavingProcessor in Discover queries

### DIFF
--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -33,6 +33,9 @@ from snuba.query.processors.type_converters.hexint_column_processor import (
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
+from snuba.query.processors.uniq_in_select_and_having import (
+    UniqInSelectAndHavingProcessor,
+)
 from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 columns = ColumnSet(
@@ -81,6 +84,7 @@ storage = ReadableTableStorage(
     storage_set_key=StorageSetKey.DISCOVER,
     schema=schema,
     query_processors=[
+        UniqInSelectAndHavingProcessor(),
         MappingColumnPromoter(
             mapping_specs={
                 "tags": {


### PR DESCRIPTION
Errors and transactions queries include the UniqInSelectAndHavingProcessor
to avoid certain types queries that would cause ClickHouse query nodes to crash.
We should probably include it in Discover as well.