### PR TITLE
fix(prewhere) Exclude columns from the prewhere candidates if they are in a uniq expression

### DIFF
--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -66,7 +66,10 @@ class PrewhereProcessor(QueryProcessor):
 
         for col in uniq_cols:
             if col in prewhere_keys:
-                metrics.increment("uniq_col_in_prewhere_candidate")
+                metrics.increment(
+                    "uniq_col_in_prewhere_candidate",
+                    tags={"column": col, "referrer": request_settings.referrer},
+                )
 
         prewhere_keys = [key for key in prewhere_keys if key not in uniq_cols]
 

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -171,6 +171,35 @@ test_data = [
         ),
         True,
     ),
+    pytest.param(
+        {"conditions": [[["uniq", ["environment"]], "=", "abc"]]},
+        [
+            "event_id",
+            "release",
+            "message",
+            "transaction_name",
+            "environment",
+            "project_id",
+        ],
+        [],
+        FunctionCall(
+            None,
+            OPERATOR_TO_FUNCTION["="],
+            (
+                FunctionCall(
+                    None, "uniq", (Column("_snuba_environment", None, "environment"),),
+                ),
+                Literal(None, "abc"),
+            ),
+        ),
+        FunctionCall(
+            None,
+            OPERATOR_TO_FUNCTION["="],
+            (Column("_snuba_project_id", None, "project_id"), Literal(None, 1),),
+        ),
+        False,
+        id="Do not promote a column that is in a uniq function",
+    ),
 ]
 
 


### PR DESCRIPTION
We identified some queries that can cause a segfault on the clickhosue server if this pattern is present.
```
SELECT
   uniq(something)
PREWHERE something = 'asd'
```
The issue is probably narrower than that but this is the first step to prevent this from happening.
Basically if a column is in a uniq expression anywhere in the query, it will become ineligible for prewhere