### PR TITLE
ref: Change QueryException to show inner error

### DIFF
--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -5,7 +5,6 @@ from typing import Any, Mapping, NamedTuple
 from mypy_extensions import TypedDict
 
 from snuba.reader import Column, Result, Row, transform_rows
-from snuba.utils.serializable_exception import SerializableException
 
 
 class QueryExtraData(TypedDict):
@@ -14,7 +13,7 @@ class QueryExtraData(TypedDict):
     experiments: Mapping[str, Any]
 
 
-class QueryException(SerializableException):
+class QueryException(Exception):
     """
     Exception raised during query execution that is used to carry extra data
     back up the stack to the HTTP response -- basically a ``QueryResult``,
@@ -25,6 +24,9 @@ class QueryException(SerializableException):
 
     def __init__(self, extra: QueryExtraData):
         self.extra = extra
+
+    def __str__(self) -> str:
+        return f"{self.__cause__} {super().__str__()}"
 
 
 class QueryResult(NamedTuple):


### PR DESCRIPTION
If a QueryException was `str`, it would json encode the extra_data and no
context on what the inner error was. This isn't a big deal locally, but when
looking at these errors in Sentry, the exception is buried in the inner errors
and makes it harder to diagnose and understand errors. I also think it is
causing Sentry to group errors that it shouldn't.

Add the inner exception message to the `str` of the QueryException so it is
easily readable in Sentry and makes debugging easier.
