### PR TITLE
ref: Remove the ability to run a replacer on the events storage

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -26,7 +26,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--storage",
     "storage_name",
-    type=click.Choice(["events", "errors", "errors_v2"]),
+    type=click.Choice(["errors", "errors_v2"]),
     help="The storage to consume/run replacements for (currently only events supported)",
     required=True,
 )

--- a/snuba/datasets/storages/events.py
+++ b/snuba/datasets/storages/events.py
@@ -1,23 +1,18 @@
 from snuba import util
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.errors_replacer import ErrorsReplacer
 from snuba.datasets.events_processor import EventsProcessor
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.events_common import (
     all_columns,
-    get_promoted_tags,
-    get_tag_column_map,
     mandatory_conditions,
     promoted_tag_columns,
     query_processors,
     query_splitters,
-    required_columns,
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.conditions_enforcer import ProjectIdEnforcer
-from snuba.replacers.replacer_processor import ReplacerState
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -39,7 +34,6 @@ storage = WritableTableStorage(
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=EventsProcessor(promoted_tag_columns),
         default_topic=Topic.EVENTS,
-        replacement_topic=Topic.EVENT_REPLACEMENTS_LEGACY,
         commit_log_topic=Topic.COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
@@ -47,12 +41,4 @@ storage = WritableTableStorage(
     ),
     query_splitters=query_splitters,
     mandatory_condition_checkers=[ProjectIdEnforcer()],
-    replacer_processor=ErrorsReplacer(
-        schema=schema,
-        required_columns=[col.escaped for col in required_columns],
-        tag_column_map=get_tag_column_map(),
-        promoted_tags=get_promoted_tags(),
-        state_name=ReplacerState.EVENTS,
-        use_promoted_prewhere=True,
-    ),
 )

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -7,7 +7,6 @@ from snuba.datasets.schemas.tables import WritableTableSchema
 
 
 class ReplacerState(Enum):
-    EVENTS = "events"
     ERRORS = "errors"
     ERRORS_V2 = "errors_v2"
 

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -21,7 +21,6 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
     topic_names = {
         "events",
         "event-replacements",
-        "event-replacements-legacy",
         "snuba-commit-log",
         "snuba-sessions-commit-log",
         "snuba-metrics-commit-log",

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -8,7 +8,7 @@ from snuba import settings
 class Topic(Enum):
     EVENTS = "events"
     EVENT_REPLACEMENTS = "event-replacements"
-    EVENT_REPLACEMENTS_LEGACY = "event-replacements-legacy"
+    # EVENT_REPLACEMENTS_LEGACY = "event-replacements-legacy"
     COMMIT_LOG = "snuba-commit-log"
     CDC = "cdc"
     METRICS = "snuba-metrics"

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -8,7 +8,6 @@ from snuba import settings
 class Topic(Enum):
     EVENTS = "events"
     EVENT_REPLACEMENTS = "event-replacements"
-    # EVENT_REPLACEMENTS_LEGACY = "event-replacements-legacy"
     COMMIT_LOG = "snuba-commit-log"
     CDC = "cdc"
     METRICS = "snuba-metrics"

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -129,12 +129,12 @@ def test_with_turbo(query: ClickhouseQuery) -> None:
 def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> None:
     set_project_needs_final(
         2,
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
     PostReplacementConsistencyEnforcer(
-        "project_id", ReplacerState.EVENTS
+        "project_id", ReplacerState.ERRORS
     ).process_query(query, HTTPRequestSettings())
 
     assert query.get_condition() == build_in("project_id", [2])
@@ -155,12 +155,12 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
     PostReplacementConsistencyEnforcer(
-        "project_id", ReplacerState.EVENTS
+        "project_id", ReplacerState.ERRORS
     ).process_query(query, HTTPRequestSettings())
 
     assert query.get_condition() == build_and(
@@ -186,12 +186,12 @@ def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
     PostReplacementConsistencyEnforcer(
-        "project_id", ReplacerState.EVENTS
+        "project_id", ReplacerState.ERRORS
     ).process_query(query, HTTPRequestSettings())
 
     assert query.get_condition() == build_in("project_id", [2])
@@ -203,7 +203,7 @@ def test_query_overlaps_replacements_processor(
     query_with_timestamp: ClickhouseQuery,
     query_with_future_timestamp: ClickhouseQuery,
 ) -> None:
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     # replacement time unknown, default to "overlaps" but no groups to exclude so shouldn't be final
     enforcer._set_query_final(query_with_timestamp, True)
@@ -215,7 +215,7 @@ def test_query_overlaps_replacements_processor(
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
     enforcer._set_query_final(query_with_timestamp, False)
@@ -238,12 +238,12 @@ def test_single_no_replacements(query_with_single_group_id: ClickhouseQuery) -> 
     Query is looking for a group that has not been replaced, but the project itself
     has replacements.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [105, 106, 107],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -262,12 +262,12 @@ def test_single_too_many_exclude(query_with_single_group_id: ClickhouseQuery) ->
     Query is looking for a group that has been replaced, and there are too many
     groups to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -289,12 +289,12 @@ def test_single_not_too_many_exclude(
     Query is looking for a group that has been replaced, and there are not too many
     groups to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -316,12 +316,12 @@ def test_multiple_disjoint_replaced(
     Query is looking for multiple groups and there are replaced groups, but these
     sets of group ids are disjoint. (No queried groups have been replaced)
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [110, 120, 130],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -342,12 +342,12 @@ def test_multiple_fewer_exclude_than_queried(
     Query is looking for multiple groups and there are replaced groups, but there
     are fewer excluded groups than queried groups.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [101],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -369,12 +369,12 @@ def test_multiple_too_many_excludes(
     Query is looking for multiple groups and there are too many groups to exclude, but
     there are fewer groups queried for than replaced.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -397,12 +397,12 @@ def test_multiple_not_too_many_excludes(
     Query is looking for multiple groups and there are not too many groups to exclude, but
     there are fewer groups queried for than replaced.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -421,12 +421,12 @@ def test_no_groups_not_too_many_excludes(query: ClickhouseQuery) -> None:
     """
     Query has no groups, and not too many to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 
@@ -444,12 +444,12 @@ def test_no_groups_too_many_excludes(query: ClickhouseQuery) -> None:
     """
     Query has no groups, and too many to exclude.
     """
-    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.EVENTS)
+    enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
     set_project_exclude_groups(
         2,
         [100, 101, 102],
-        ReplacerState.EVENTS,
+        ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
     )
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -1,5 +1,4 @@
 import importlib
-import re
 from datetime import datetime, timedelta
 from functools import partial
 from typing import MutableMapping
@@ -10,10 +9,9 @@ from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
 
 from snuba import replacer, settings
-from snuba.clickhouse import DATETIME_FORMAT
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets import errors_replacer
-from snuba.datasets.errors_replacer import NeedsFinal, ProjectsQueryFlags
+from snuba.datasets.errors_replacer import ProjectsQueryFlags
 from snuba.datasets.events_processor_base import ReplacementType
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
@@ -36,7 +34,7 @@ class TestReplacer:
 
         self.app = application.test_client()
         self.app.post = partial(self.app.post, headers={"referer": "test"})
-        self.storage = get_storage(StorageKey.EVENTS)
+        self.storage = get_storage(StorageKey.ERRORS)
 
         self.replacer = replacer.ReplacerWorker(
             self.storage, CONSUMER_GROUP, DummyMetricsBackend(strict=True),
@@ -70,7 +68,7 @@ class TestReplacer:
         data = clickhouse.execute(
             f"""
             SELECT group_id, count()
-            FROM sentry_local
+            FROM errors_local
             FINAL
             WHERE deleted = 0
             AND project_id = {project_id}
@@ -79,342 +77,6 @@ class TestReplacer:
         ).results
 
         return [{"group_id": row[0], "count": row[1]} for row in data]
-
-    def test_delete_groups_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.END_DELETE_GROUPS,
-            {
-                "project_id": self.project_id,
-                "group_ids": [1, 2, 3],
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE group_id IN (%(group_ids)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE group_id IN (%(group_ids)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert replacement.query_args == {
-            "group_ids": "1, 2, 3",
-            "project_id": self.project_id,
-            "required_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days",
-            "select_columns": "event_id, project_id, group_id, timestamp, 1, retention_days",
-            "timestamp": timestamp.strftime(DATETIME_FORMAT),
-        }
-        assert replacement.query_time_flags == (
-            errors_replacer.EXCLUDE_GROUPS,
-            self.project_id,
-            [1, 2, 3],
-        )
-
-    def test_merge_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.END_MERGE,
-            {
-                "project_id": self.project_id,
-                "new_group_id": 2,
-                "previous_group_ids": [1, 2],
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE group_id IN (%(previous_group_ids)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE group_id IN (%(previous_group_ids)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "previous_group_ids": ", ".join(str(gid) for gid in [1, 2]),
-            "project_id": self.project_id,
-            "timestamp": timestamp.strftime(DATETIME_FORMAT),
-        }
-        assert replacement.query_time_flags == (
-            errors_replacer.EXCLUDE_GROUPS,
-            self.project_id,
-            [1, 2],
-        )
-
-    def test_unmerge_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.END_UNMERGE,
-            {
-                "project_id": self.project_id,
-                "previous_group_id": 1,
-                "new_group_id": 2,
-                "hashes": ["a" * 32, "b" * 32],
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        query_args = {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "hashes": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
-            "previous_group_id": 1,
-            "project_id": self.project_id,
-            "timestamp": timestamp.strftime(DATETIME_FORMAT),
-            "table_name": "foo",
-        }
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.get_count_query("foo")).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE primary_hash IN (%(hashes)s) WHERE group_id = %(previous_group_id)s AND project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-            % query_args
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.get_insert_query("foo")).strip()
-            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE primary_hash IN (%(hashes)s) WHERE group_id = %(previous_group_id)s AND project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-            % query_args
-        )
-
-        assert replacement.get_query_time_flags() == NeedsFinal()
-
-    def test_unmerge_hierarchical_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.END_UNMERGE_HIERARCHICAL,
-            {
-                "project_id": self.project_id,
-                "previous_group_id": 1,
-                "new_group_id": 2,
-                "hierarchical_hash": "a" * 32,
-                "primary_hash": "b" * 32,
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE primary_hash = %(primary_hash)s WHERE group_id = %(previous_group_id)s AND has(hierarchical_hashes, %(hierarchical_hash)s) AND project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE primary_hash = %(primary_hash)s WHERE group_id = %(previous_group_id)s AND has(hierarchical_hashes, %(hierarchical_hash)s) AND project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, 2, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "hierarchical_hash": "toFixedString('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 32)",
-            "primary_hash": "'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'",
-            "previous_group_id": 1,
-            "project_id": self.project_id,
-            "timestamp": timestamp.strftime(DATETIME_FORMAT),
-        }
-        assert replacement.query_time_flags == (None, self.project_id,)
-
-    def test_delete_promoted_tag_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.END_DELETE_TAG,
-            {
-                "project_id": self.project_id,
-                "tag": "sentry:user",
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE %(tag_column)s IS NOT NULL WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE %(tag_column)s IS NOT NULL WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, NULL, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'sentry:user')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'sentry:user'), arrayEnumerate(`tags.value`))), _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "tag_column": "`sentry:user`",
-            "tag_str": "'sentry:user'",
-            "project_id": self.project_id,
-            "timestamp": timestamp.strftime(DATETIME_FORMAT),
-        }
-        assert replacement.query_time_flags == (
-            errors_replacer.NEEDS_FINAL,
-            self.project_id,
-        )
-
-    def test_delete_unpromoted_tag_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.END_DELETE_TAG,
-            {
-                "project_id": self.project_id,
-                "tag": "foo:bar",
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE has(`tags.key`, %(tag_str)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(all_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE has(`tags.key`, %(tag_str)s) WHERE project_id = %(project_id)s AND received <= CAST('%(timestamp)s' AS DateTime) AND NOT deleted"
-        )
-
-        assert replacement.query_args == {
-            "all_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, tags.key, tags.value, _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "select_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days, platform, message, primary_hash, hierarchical_hashes, received, search_message, title, location, user_id, username, email, ip_address, geo_country_code, geo_region, geo_city, sdk_name, sdk_version, type, version, offset, partition, message_timestamp, os_build, os_kernel_version, device_name, device_brand, device_locale, device_uuid, device_model_id, device_arch, device_battery_level, device_orientation, device_simulator, device_online, device_charging, level, logger, server_name, transaction, environment, `sentry:release`, `sentry:dist`, `sentry:user`, site, url, app_device, device, device_family, runtime, runtime_name, browser, browser_name, os, os_name, os_rooted, arrayFilter(x -> (indexOf(`tags.key`, x) != indexOf(`tags.key`, 'foo:bar')), `tags.key`), arrayMap(x -> arrayElement(`tags.value`, x), arrayFilter(x -> x != indexOf(`tags.key`, 'foo:bar'), arrayEnumerate(`tags.value`))), _tags_flattened, contexts.key, contexts.value, http_method, http_referer, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.filename, exception_frames.package, exception_frames.module, exception_frames.function, exception_frames.in_app, exception_frames.colno, exception_frames.lineno, exception_frames.stack_level, culprit, sdk_integrations, modules.name, modules.version",
-            "tag_column": "`foo:bar`",
-            "tag_str": "'foo:bar'",
-            "project_id": self.project_id,
-            "timestamp": timestamp.strftime(DATETIME_FORMAT),
-        }
-        assert replacement.query_time_flags == (
-            errors_replacer.NEEDS_FINAL,
-            self.project_id,
-        )
-
-    def test_delete_groups_insert(self) -> None:
-        self.event["project_id"] = self.project_id
-        self.event["group_id"] = 1
-        write_unprocessed_events(self.storage, [self.event])
-
-        assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
-
-        timestamp = datetime.now(tz=pytz.utc)
-
-        project_id = self.project_id
-
-        message: Message[KafkaPayload] = Message(
-            Partition(Topic("replacements"), 1),
-            42,
-            KafkaPayload(
-                None,
-                json.dumps(
-                    (
-                        2,
-                        ReplacementType.END_DELETE_GROUPS,
-                        {
-                            "project_id": project_id,
-                            "group_ids": [1],
-                            "datetime": timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                        },
-                    )
-                ).encode("utf-8"),
-                [],
-            ),
-            datetime.now(),
-        )
-
-        processed = self.replacer.process_message(message)
-        self.replacer.flush_batch([processed])
-
-        assert self._issue_count(self.project_id) == []
-
-        # Count is still zero after Redis flushed and parts merged
-        self._clear_redis_and_force_merge()
-        assert self._issue_count(self.project_id) == []
-
-    def test_merge_insert(self) -> None:
-        self.event["project_id"] = self.project_id
-        self.event["group_id"] = 1
-        write_unprocessed_events(self.storage, [self.event])
-
-        assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
-
-        timestamp = datetime.now(tz=pytz.utc)
-
-        project_id = self.project_id
-
-        message: Message[KafkaPayload] = Message(
-            Partition(Topic("replacements"), 1),
-            42,
-            KafkaPayload(
-                None,
-                json.dumps(
-                    (
-                        2,
-                        ReplacementType.END_MERGE,
-                        {
-                            "project_id": project_id,
-                            "new_group_id": 2,
-                            "previous_group_ids": [1],
-                            "datetime": timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                        },
-                    )
-                ).encode("utf-8"),
-                [],
-            ),
-            datetime.now(),
-        )
-
-        processed = self.replacer.process_message(message)
-        self.replacer.flush_batch([processed])
-
-        assert self._issue_count(1) == [{"count": 1, "group_id": 2}]
-
-    def test_unmerge_insert(self) -> None:
-        self.event["project_id"] = self.project_id
-        self.event["group_id"] = 1
-        self.event["primary_hash"] = "a" * 32
-        write_unprocessed_events(self.storage, [self.event])
-
-        assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
-
-        timestamp = datetime.now(tz=pytz.utc)
-
-        project_id = self.project_id
-
-        message: Message[KafkaPayload] = Message(
-            Partition(Topic("replacements"), 1),
-            42,
-            KafkaPayload(
-                None,
-                json.dumps(
-                    (
-                        2,
-                        ReplacementType.END_UNMERGE,
-                        {
-                            "project_id": project_id,
-                            "previous_group_id": 1,
-                            "new_group_id": 2,
-                            "hashes": ["a" * 32],
-                            "datetime": timestamp.strftime(PAYLOAD_DATETIME_FORMAT),
-                        },
-                    )
-                ).encode("utf-8"),
-                [],
-            ),
-            datetime.now(),
-        )
-
-        processed = self.replacer.process_message(message)
-        self.replacer.flush_batch([processed])
-
-        assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 2}]
 
     def test_unmerge_hierarchical_insert(self) -> None:
         self.event["project_id"] = self.project_id
@@ -481,7 +143,7 @@ class TestReplacer:
             data = clickhouse.execute(
                 f"""
                 SELECT group_id, count()
-                FROM sentry_local
+                FROM errors_local
                 FINAL
                 WHERE deleted = 0
                 AND project_id = {project_id}
@@ -637,9 +299,6 @@ class TestReplacer:
             flags.group_ids_to_exclude,
             flags.replacement_types,
         ) == (True, set(), {ReplacementType.EXCLUDE_GROUPS},)
-        assert ProjectsQueryFlags.load_from_redis(
-            project_ids, ReplacerState.EVENTS
-        ) == ProjectsQueryFlags(False, set(), set(), None)
 
         errors_replacer.set_project_needs_final(
             2, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
@@ -718,9 +377,6 @@ class TestReplacer:
             flags.group_ids_to_exclude,
             flags.replacement_types,
         ) == (False, {1, 2}, {ReplacementType.EXCLUDE_GROUPS},)
-        assert ProjectsQueryFlags.load_from_redis(
-            project_ids, ReplacerState.EVENTS
-        ) == ProjectsQueryFlags(False, set(), set(), None)
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """
@@ -750,88 +406,3 @@ class TestReplacer:
             # exclude_groups from project setter, start_merge from group setter
             {ReplacementType.EXCLUDE_GROUPS, ReplacementType.START_MERGE},
         )
-
-    def test_tombstone_events_process_noop(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.TOMBSTONE_EVENTS,
-            {
-                "project_id": self.project_id,
-                "event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"],
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "old_primary_hash": "e3d704f3542b44a621ebed70dc0efe13",
-            },
-        )
-
-        assert self.replacer.process_message(self._wrap(message)) is None
-
-    def test_tombstone_events_process(self) -> None:
-        timestamp = datetime.now(tz=pytz.utc)
-        message = (
-            2,
-            ReplacementType.TOMBSTONE_EVENTS,
-            {
-                "project_id": self.project_id,
-                "event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"],
-                "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert replacement is not None
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == "SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == "INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted"
-        )
-
-        assert replacement.query_args == {
-            "event_ids": "cityHash64('00e24a150d7f4ee4b142b61b4d893b6d')",
-            "project_id": self.project_id,
-            "required_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days",
-            "select_columns": "event_id, project_id, group_id, timestamp, 1, retention_days",
-        }
-
-        assert replacement.query_time_flags == (None, self.project_id,)
-
-    def test_tombstone_events_process_timestamp(self) -> None:
-        from_ts = datetime.now(tz=pytz.utc)
-        to_ts = datetime.now(tz=pytz.utc) + timedelta(3)
-        message = (
-            2,
-            ReplacementType.TOMBSTONE_EVENTS,
-            {
-                "project_id": self.project_id,
-                "event_ids": ["00e24a150d7f4ee4b142b61b4d893b6d"],
-                "from_timestamp": from_ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                "to_timestamp": to_ts.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-            },
-        )
-
-        replacement = self.replacer.process_message(self._wrap(message))
-
-        assert replacement is not None
-
-        assert (
-            re.sub("[\n ]+", " ", replacement.count_query_template).strip()
-            == f"SELECT count() FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}')"
-        )
-        assert (
-            re.sub("[\n ]+", " ", replacement.insert_query_template).strip()
-            == f"INSERT INTO %(table_name)s (%(required_columns)s) SELECT %(select_columns)s FROM %(table_name)s FINAL PREWHERE cityHash64(toString(event_id)) IN (%(event_ids)s) WHERE project_id = %(project_id)s AND NOT deleted AND timestamp >= toDateTime('{from_ts.strftime(DATETIME_FORMAT)}') AND timestamp <= toDateTime('{to_ts.strftime(DATETIME_FORMAT)}')"
-        )
-
-        assert replacement.query_args == {
-            "event_ids": "cityHash64('00e24a150d7f4ee4b142b61b4d893b6d')",
-            "project_id": self.project_id,
-            "required_columns": "event_id, project_id, group_id, timestamp, deleted, retention_days",
-            "select_columns": "event_id, project_id, group_id, timestamp, 1, retention_days",
-        }
-
-        assert replacement.query_time_flags == (None, self.project_id,)


### PR DESCRIPTION
Events storage is deprecated, remove the ability to run a replacer
on it and simplify errors replacer code.

Most of the tests in test_replacer.py were already duplicated in
test_errors_replacer.py so could be deleted.