### PR TITLE
ref(snuba-admin): Add link to audit log

### DIFF
--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -31,8 +31,7 @@ def build_section(data: Any, action: str) -> Any:
         "accessory": {
             "type": "button",
             "text": {"type": "plain_text", "text": "Audit Log"},
-            # todo: should link to our audit log
-            # "url": "https://google.com",
+            "url": "https://snuba-admin.getsentry.net/#auditlog",
         },
     }
 

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
+from snuba import settings
+
 
 def build_blocks(data: Any, action: str, timestamp: str, user: str) -> List[Any]:
     return [build_section(data, action), build_context(user, timestamp, action)]
@@ -28,20 +30,19 @@ def build_section(data: Any, action: str) -> Any:
     return {
         "type": "section",
         "text": {"type": "mrkdwn", "text": text},
-        "accessory": {
-            "type": "button",
-            "text": {"type": "plain_text", "text": "Audit Log"},
-            "url": "https://snuba-admin.getsentry.net/#auditlog",
-        },
     }
 
 
 def build_context(
     user: str, timestamp: str, action: str
 ) -> Dict[str, Union[str, List[Dict[str, str]]]]:
+    url = f"{settings.ADMIN_URL}/#auditlog"
     return {
         "type": "context",
         "elements": [
-            {"type": "mrkdwn", "text": f"{action} at *{timestamp}* by *<{user}>*"}
+            {
+                "type": "mrkdwn",
+                "text": f"{action} at *<{url}|{timestamp}>* by *<{user}>*",
+            }
         ],
     }

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -15,6 +15,7 @@ PORT = 1218
 
 ADMIN_HOST = os.environ.get("ADMIN_HOST", "0.0.0.0")
 ADMIN_PORT = int(os.environ.get("ADMIN_PORT", 1219))
+ADMIN_URL = os.environ.get("ADMIN_URL", "http://localhost:1219")
 
 ADMIN_AUTH_PROVIDER = "NOOP"
 


### PR DESCRIPTION
Removed the button since it felt like it was taking up a lot of room and since we don't have a interactive url set up, every time you click it, it gives a warning (even though it does work)

Put the link in the timestamp instead:

> ![Screen Shot 2022-03-31 at 11 49 20 AM](https://user-images.githubusercontent.com/15368179/161128172-1e63cfab-5526-4452-85ad-0aa709f5c651.png)
