### PR TITLE
feat(subscriptions): Add a metric for debugging

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -412,6 +412,12 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
     def submit(self, message: Message[CommittableTick]) -> None:
         assert not self.__closed
 
+        # TODO: This metric is temporary for debugging
+        self.__metrics.increment(
+            "ProduceScheduledSubscriptionMessage.submit",
+            tags={"committable": str(message.payload.should_commit)},
+        )
+
         # If queue is full, raise MessageRejected to tell the stream
         # processor to pause consuming
         if len(self.__queue) >= self.__max_buffer_size:


### PR DESCRIPTION
We are experiencing an issue with the metrics scheduler where offsets
are not being committed regularly. Not sure yet what the root cause of
this is. This metric is intended to help determine whether the issue
is in the ProduceScheduledSubscriptionMessage or if it occurs earlier.