### PR TITLE
feat: Add a default value for stats_collection_freq_ms

### DIFF
--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -213,10 +213,12 @@ def multistorage_consumer(
         },
     )
     # Collect metrics from librdkafka if we have stats_collection_freq_ms set
-    # for the consumer group
+    # for the consumer group, or use the default.
     stats_collection_frequency_ms = get_config(
-        f"stats_collection_freq_ms_{consumer_group}", 0
+        f"stats_collection_freq_ms_{consumer_group}",
+        get_config("stats_collection_freq_ms", 0),
     )
+
     if stats_collection_frequency_ms and stats_collection_frequency_ms > 0:
 
         def stats_callback(stats_json: str) -> None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -185,8 +185,10 @@ class ConsumerBuilder:
         )
 
         stats_collection_frequency_ms = get_config(
-            f"stats_collection_freq_ms_{self.group_id}", 0
+            f"stats_collection_freq_ms_{self.group_id}",
+            get_config("stats_collection_freq_ms", 0),
         )
+
         if stats_collection_frequency_ms and stats_collection_frequency_ms > 0:
             configuration.update(
                 {


### PR DESCRIPTION
We don't necessarily want to set the config individually for each consumer group
for how often stats are collected, as it pollutes our config and it is easier to
use reasonable default values across all consumers. This change adds a default config
`stats_collection_freq_ms`, which is applied if a config is not specified for the
specific consumer group.