### PR TITLE
feat: Add metrics to help debug ProvideCommitStrategy

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -82,6 +82,11 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
 
         should_commit = self.__should_commit(message)
 
+        # TODO: Temporary metric for debugging
+        self.__metrics.increment(
+            "ProvideCommitStrategy.submit", tags={"should_commit": str(should_commit)}
+        )
+
         self.__next_step.submit(
             Message(
                 message.partition,
@@ -136,6 +141,8 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
             self.__offset_high_watermark is None
             or slowest.offset > self.__offset_high_watermark
         ):
+            # TODO: Temporary metric for debugging
+            self.__metrics.increment("update_offset_high_watermark")
             self.__offset_high_watermark = slowest.offset
 
     def close(self) -> None:


### PR DESCRIPTION
There are some indications that the ProvideCommitStrategy may not
be working exactly as it should. In particular, it is not marking
`should_commit=True` when it should be.

I'm not sure exactly where the error occurs yet, this change adds some
temporary metrics to help debug this.