### PR TITLE
fix(subscriptions): Fix recording partition lag

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -128,14 +128,14 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
             if partition_timestamp > fastest.payload.timestamps.lower:
                 fastest = partition_message
 
-            # Record the lag between the fastest and slowest partition
-            self.__metrics.timing(
-                "partition_lag_ms",
-                (
-                    fastest.payload.timestamps.lower - slowest.payload.timestamps.lower
-                ).total_seconds()
-                * 1000,
-            )
+        # Record the lag between the fastest and slowest partition
+        self.__metrics.timing(
+            "partition_lag_ms",
+            (
+                fastest.payload.timestamps.lower - slowest.payload.timestamps.lower
+            ).total_seconds()
+            * 1000,
+        )
 
         if (
             self.__offset_high_watermark is None


### PR DESCRIPTION
This metric seems to have been recorded incorrectly. It was indented
wrong causing it to be fired on every iteration of the loop instead of once
per tick.