### PR TITLE
feat(profiling): Add and remove some fields

### DIFF
--- a/snuba/datasets/entities/profiles.py
+++ b/snuba/datasets/entities/profiles.py
@@ -23,6 +23,7 @@ profile_columns = EntityColumnSet(
         Column("organization_id", UInt(64)),
         Column("project_id", UInt(64)),
         Column("transaction_id", UUID()),
+        Column("profile_id", UUID()),
         Column("received", DateTime()),
         Column("profile", String()),
         Column("symbols", String()),

--- a/snuba/datasets/entities/profiles.py
+++ b/snuba/datasets/entities/profiles.py
@@ -26,7 +26,6 @@ profile_columns = EntityColumnSet(
         Column("profile_id", UUID()),
         Column("received", DateTime()),
         Column("profile", String()),
-        Column("symbols", String()),
         Column("android_api_level", UInt(32, Modifiers(nullable=True))),
         Column("device_classification", String()),
         Column("device_locale", String()),

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -1,7 +1,6 @@
+from datetime import datetime
 from typing import Any, Mapping, Optional
 from uuid import UUID
-
-from dateutil.parser import parse
 
 from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
@@ -26,7 +25,7 @@ class ProfilesMessageProcessor(MessageProcessor):
                 "project_id": message["project_id"],
                 "transaction_id": str(UUID(message["transaction_id"])),
                 "profile_id": str(UUID(message["profile_id"])),
-                "received": parse(message["received"]),
+                "received": datetime.utcfromtimestamp(message["received"]),
                 "profile": message["profile"],
                 "android_api_level": message.get("android_api_level"),
                 "device_classification": message["device_classification"],

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -28,7 +28,6 @@ class ProfilesMessageProcessor(MessageProcessor):
                 "profile_id": str(UUID(message["profile_id"])),
                 "received": parse(message["received"]),
                 "profile": message["profile"],
-                "symbols": message["symbols"],
                 "android_api_level": message.get("android_api_level"),
                 "device_classification": message["device_classification"],
                 "device_locale": message["device_locale"],

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -25,6 +25,7 @@ class ProfilesMessageProcessor(MessageProcessor):
                 "organization_id": message["organization_id"],
                 "project_id": message["project_id"],
                 "transaction_id": str(UUID(message["transaction_id"])),
+                "profile_id": str(UUID(message["profile_id"])),
                 "received": parse(message["received"]),
                 "profile": message["profile"],
                 "symbols": message["symbols"],

--- a/snuba/datasets/storages/profiles.py
+++ b/snuba/datasets/storages/profiles.py
@@ -35,7 +35,6 @@ readable_columns = ColumnSet(
         ("profile_id", UUID()),
         ("received", DateTime()),
         ("profile", String()),
-        ("symbols", String()),
         ("android_api_level", UInt(32, Modifiers(nullable=True))),
         ("device_classification", String()),
         ("device_locale", String()),

--- a/snuba/datasets/storages/profiles.py
+++ b/snuba/datasets/storages/profiles.py
@@ -19,7 +19,7 @@ PROFILES_DIST_TABLE_NAME = "profiles_dist"
 
 
 processors = [
-    UUIDColumnProcessor(set(["transaction_id", "trace_id"])),
+    UUIDColumnProcessor(set(["profile_id", "transaction_id", "trace_id"])),
     TableRateLimit(),
 ]
 
@@ -32,6 +32,7 @@ readable_columns = ColumnSet(
         ("organization_id", UInt(64)),
         ("project_id", UInt(64)),
         ("transaction_id", UUID()),
+        ("profile_id", UUID()),
         ("received", DateTime()),
         ("profile", String()),
         ("symbols", String()),

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -14,7 +14,6 @@ columns: List[Column[Modifiers]] = [
     Column("received", DateTime()),
     # profiling data
     Column("profile", String(Modifiers(codecs=["LZ4HC(9)"]))),
-    Column("symbols", String(Modifiers(codecs=["LZ4HC(9)"]))),
     # filtering data
     Column("android_api_level", UInt(32, Modifiers(nullable=True))),
     Column("device_classification", String(Modifiers(low_cardinality=True))),


### PR DESCRIPTION
After some round of testings, we realized a few things:
- we don't need to store the symbols separately as the symbolicated version will be store in the profile column.
- we need to have an ID specific to the profile and not just copy the transaction_id
- `received` is a timestamp in Relay and there's no need to transform it as a RFC3339 string along the way to be parsed here as such, might as well just parse it as a timestamp here