### PR TITLE
feat(metrics) - create materialized views for polymorphic input tables

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -182,6 +182,7 @@ class MetricsLoader(DirectoryLoader):
             "0018_metrics_distributions_consolidated_granularity",
             "0019_aggregate_tables_add_ttl",
             "0020_polymorphic_buckets_table",
+            "0021_polymorphic_bucket_materialized_views",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/metrics/0021_polymorphic_bucket_materialized_views.py
+++ b/snuba/migrations/snuba_migrations/metrics/0021_polymorphic_bucket_materialized_views.py
@@ -28,7 +28,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 mv_name=get_polymorphic_mv_name("distributions"),
                 aggregation_col_schema=COL_SCHEMA_DISTRIBUTIONS,
                 aggregation_states=(
-                    "quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)((arrayJoin(values) AS values_rows)) as percentiles, "
+                    "quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)((arrayJoin(distribution_values) AS values_rows)) as percentiles, "
                     "minState(values_rows) as min, "
                     "maxState(values_rows) as max, "
                     "avgState(values_rows) as avg, "
@@ -48,13 +48,13 @@ class Migration(migration.ClickhouseNodeMigration):
                 metric_type="set",
             ),
             get_forward_view_migration_polymorphic_table(
-                source_table_name="metrics_counters_buckets_local",
+                source_table_name=self.raw_table_name,
                 table_name="metrics_counters_local",
                 mv_name=get_polymorphic_mv_name("counters"),
                 aggregation_col_schema=[
                     Column("value", AggregateFunction("sum", [Float(64)])),
                 ],
-                aggregation_states="sumState(value) as value",
+                aggregation_states="sumState(count_value) as value",
                 metric_type="counter",
             ),
         ]

--- a/snuba/migrations/snuba_migrations/metrics/0021_polymorphic_bucket_materialized_views.py
+++ b/snuba/migrations/snuba_migrations/metrics/0021_polymorphic_bucket_materialized_views.py
@@ -1,0 +1,75 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.snuba_migrations.metrics.templates import (
+    COL_SCHEMA_DISTRIBUTIONS,
+    get_forward_view_migration_polymorphic_table,
+    get_polymorphic_mv_name,
+)
+from snuba.utils.schemas import AggregateFunction, Column, Float, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Creates materialized view for all metrics types which writes to 10s, 1m, 1h, 1d granularities
+
+    The backward migration does *not* delete any data from the destination tables.
+    """
+
+    blocking = False
+    raw_table_name = "metrics_raw_local"
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            get_forward_view_migration_polymorphic_table(
+                source_table_name=self.raw_table_name,
+                table_name="metrics_distributions_local",
+                mv_name=get_polymorphic_mv_name("distributions"),
+                aggregation_col_schema=COL_SCHEMA_DISTRIBUTIONS,
+                aggregation_states=(
+                    "quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)((arrayJoin(values) AS values_rows)) as percentiles, "
+                    "minState(values_rows) as min, "
+                    "maxState(values_rows) as max, "
+                    "avgState(values_rows) as avg, "
+                    "sumState(values_rows) as sum, "
+                    "countState(values_rows) as count"
+                ),
+                metric_type="distribution",
+            ),
+            get_forward_view_migration_polymorphic_table(
+                source_table_name=self.raw_table_name,
+                table_name="metrics_sets_local",
+                mv_name=get_polymorphic_mv_name("sets"),
+                aggregation_col_schema=[
+                    Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+                ],
+                aggregation_states="uniqCombined64State(arrayJoin(set_values)) as value",
+                metric_type="set",
+            ),
+            get_forward_view_migration_polymorphic_table(
+                source_table_name="metrics_counters_buckets_local",
+                table_name="metrics_counters_local",
+                mv_name=get_polymorphic_mv_name("counters"),
+                aggregation_col_schema=[
+                    Column("value", AggregateFunction("sum", [Float(64)])),
+                ],
+                aggregation_states="sumState(value) as value",
+                metric_type="counter",
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS,
+                table_name=get_polymorphic_mv_name(mv_type),
+            )
+            for mv_type in ["sets", "counters", "distributions"]
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/migrations/snuba_migrations/metrics/templates.py
+++ b/snuba/migrations/snuba_migrations/metrics/templates.py
@@ -149,6 +149,31 @@ GROUP BY
     retention_days
 """
 
+MATVIEW_STATEMENT_POLYMORPHIC_TABLE = """
+SELECT
+    org_id,
+    project_id,
+    metric_id,
+    arrayJoin([10,60,3600,86400]) as granularity,
+    tags.key,
+    tags.value,
+    toDateTime(granularity * intDiv(toUnixTimestamp(timestamp), granularity)) as timestamp,
+    retention_days,
+    %(aggregation_states)s
+FROM %(raw_table_name)s
+WHERE materialization_version = 2
+  AND metric_type = '%(metric_type)s'
+GROUP BY
+    org_id,
+    project_id,
+    metric_id,
+    tags.key,
+    tags.value,
+    timestamp,
+    granularity,
+    retention_days
+"""
+
 
 def get_forward_migrations_local(
     source_table_name: str,
@@ -255,6 +280,30 @@ def get_forward_view_migration_local_consolidated(
     )
 
 
+def get_forward_view_migration_polymorphic_table(
+    source_table_name: str,
+    table_name: str,
+    mv_name: str,
+    aggregation_col_schema: Sequence[Column[Modifiers]],
+    aggregation_states: str,
+    metric_type: str,
+) -> operations.SqlOperation:
+    aggregated_cols = [*COMMON_AGGR_COLUMNS, *aggregation_col_schema]
+
+    return operations.CreateMaterializedView(
+        storage_set=StorageSetKey.METRICS,
+        view_name=mv_name,
+        destination_table_name=table_name,
+        columns=aggregated_cols,
+        query=MATVIEW_STATEMENT_POLYMORPHIC_TABLE
+        % {
+            "metric_type": metric_type,
+            "raw_table_name": source_table_name,
+            "aggregation_states": aggregation_states,
+        },
+    )
+
+
 def get_forward_migrations_dist(
     dist_table_name: str,
     local_table_name: str,
@@ -296,6 +345,10 @@ def get_mv_name(metric_type: str, granularity: int) -> str:
 
 def get_consolidated_mv_name(metric_type: str) -> str:
     return f"metrics_{metric_type}_consolidated_mv_local"
+
+
+def get_polymorphic_mv_name(metric_type: str) -> str:
+    return f"metrics_{metric_type}_polymorphic_mv_local"
 
 
 class MigrationArgs(TypedDict):

--- a/snuba/migrations/snuba_migrations/metrics/templates.py
+++ b/snuba/migrations/snuba_migrations/metrics/templates.py
@@ -161,7 +161,7 @@ SELECT
     retention_days,
     %(aggregation_states)s
 FROM %(raw_table_name)s
-WHERE materialization_version = 2
+WHERE materialization_version = 3
   AND metric_type = '%(metric_type)s'
 GROUP BY
     org_id,


### PR DESCRIPTION
This creates the 3 materialized views necessary for the polymorphic metrics input table.

I tested locally that this creates correct values in the aggregate tables for all 3 types.

If people don't find this to be "interesting" or useful enough on its own, I can do a PR that also includes the application processing logic and therefore uses that polymorphic table end to end

Follow-up of https://github.com/getsentry/snuba/pull/2504

The storage writer that lives on top of this: https://github.com/getsentry/snuba/pull/2510