### PR TITLE
fix(transactions): Remove unused columns

### DIFF
--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -68,10 +68,8 @@ columns = ColumnSet(
         ("http_method", String(Modifiers(nullable=True))),
         ("http_referer", String(Modifiers(nullable=True))),
         ("tags", Nested([("key", String()), ("value", String())])),
-        ("_tags_flattened", String()),
         ("_tags_hash_map", Array(UInt(64), Modifiers(readonly=True))),
         ("contexts", Nested([("key", String()), ("value", String())])),
-        ("_contexts_flattened", String()),
         ("measurements", Nested([("key", String()), ("value", Float(64))]),),
         ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))]),),
         (


### PR DESCRIPTION
The columns `_tags_flattened` and `_contexts_flattened` are not used.
This PR removes those columns from the column set. The migration to
remove the columns from tables will be done in a separate PR.