### PR TITLE
perf(pipeline delegator) Reduce impact of rate limiter delegator on SubscriptionRequestSettings

### DIFF
--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -27,10 +27,6 @@ class RateLimiterDelegate(RequestSettings):
         self.referrer = delegate.referrer
         self.__delegate = delegate
         self.__prefix = prefix
-        self.__rate_limit_params = [
-            self.__append_prefix(rate_limiter)
-            for rate_limiter in delegate.get_rate_limit_params()
-        ]
 
     def __append_prefix(self, rate_limiter: RateLimitParameters) -> RateLimitParameters:
         return RateLimitParameters(
@@ -65,10 +61,12 @@ class RateLimiterDelegate(RequestSettings):
         return self.__delegate.get_feature()
 
     def get_rate_limit_params(self) -> Sequence[RateLimitParameters]:
-        return self.__rate_limit_params
+        return [
+            self.__append_prefix(r) for r in self.__delegate.get_rate_limit_params()
+        ]
 
     def add_rate_limit(self, rate_limit_param: RateLimitParameters) -> None:
-        self.__rate_limit_params.append(self.__append_prefix(rate_limit_param))
+        self.__delegate.add_rate_limit(rate_limit_param)
 
     def get_resource_quota(self) -> Optional[ResourceQuota]:
         return self.__delegate.get_resource_quota()

--- a/tests/pipeline/test_settings_delegator.py
+++ b/tests/pipeline/test_settings_delegator.py
@@ -1,17 +1,46 @@
+from typing import Sequence, Type, Union
+
+import pytest
+
 from snuba.pipeline.settings_delegator import RateLimiterDelegate
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.request.request_settings import (
+    HTTPRequestSettings,
+    SubscriptionRequestSettings,
+)
 from snuba.state.rate_limit import RateLimitParameters
 
+test_cases = [
+    pytest.param(
+        HTTPRequestSettings,
+        [
+            RateLimitParameters(
+                rate_limit_name="rate_name",
+                bucket="secondary_project",
+                per_second_limit=10.0,
+                concurrent_limit=22,
+            ),
+            RateLimitParameters(
+                rate_limit_name="second_rate_name",
+                bucket="secondary_table",
+                per_second_limit=11.0,
+                concurrent_limit=23,
+            ),
+        ],
+        id="HTTP Request Settings",
+    ),
+    pytest.param(SubscriptionRequestSettings, [], id="Subscriptions request settings"),
+]
 
-def test_delegate() -> None:
-    settings = HTTPRequestSettings(
+
+@pytest.mark.parametrize("settings_class, expected_rate_limiters", test_cases)
+def test_delegate(
+    settings_class: Type[Union[HTTPRequestSettings, SubscriptionRequestSettings]],
+    expected_rate_limiters: Sequence[RateLimitParameters],
+) -> None:
+    settings = settings_class(
         referrer="test",
-        turbo=False,
         consistent=False,
-        debug=True,
         parent_api="parent",
-        dry_run=False,
-        legacy=False,
         team="team",
         feature="feature",
     )
@@ -36,17 +65,4 @@ def test_delegate() -> None:
     )
 
     assert settings_delegate.referrer == settings.referrer
-    assert settings_delegate.get_rate_limit_params() == [
-        RateLimitParameters(
-            rate_limit_name="rate_name",
-            bucket="secondary_project",
-            per_second_limit=10.0,
-            concurrent_limit=22,
-        ),
-        RateLimitParameters(
-            rate_limit_name="second_rate_name",
-            bucket="secondary_table",
-            per_second_limit=11.0,
-            concurrent_limit=23,
-        ),
-    ]
+    assert settings_delegate.get_rate_limit_params() == expected_rate_limiters


### PR DESCRIPTION
The current RateLimiterDelegate class has an issue: it replicates the state of the class it delegates to in order to keep the list of transformed rate limiter settings. 
This is not a great practice as it assumes the behavior of the delegate class is compliant with `HTTPRequestSettings`, thus breaking its abstraction. 
`SubscriptionRequestSettings` behave differently: it returns nothing as rate limiter config no matter what you add to it. So in practice `RateLimiterDelegate` does not respect its behavior because it overrides this behavior.

This has two negative consequences:
- functionally `RateLimiterDelegate` is not compliant with what `SubscriptionsRequestSettings` thus adding a rate limiter on subscriptions.
- In terms of performance it triggers the rate limiter infrastructure on subscriptions, which slows down the pipeline (and required us to scale out the production subscriptions consumer).

This changes the approach. `RateLimiterDelegate` does not store anything anymore. It fully delegates the state to the delegate class and , instead, it transforms the `RateLimitParameters` instances on the fly when returning them. This makes the behavior compatible with `SubscriptionsRequestSettings` (see added test).