### PR TITLE
perf(consumer) Prepare to remove the latency metric at every message

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -138,7 +138,7 @@ class InsertBatchWriter(ProcessingStep[BytesInsertBatch]):
                 "max_end_to_end_latency_ms", max_end_to_end_latency * 1000
             )
 
-        self.__metrics.timing("batch_write_ms", write_finish - write_start)
+        self.__metrics.timing("batch_write_ms", (write_finish - write_start) * 1000)
         rows = sum(len(message.payload.rows) for message in self.__messages)
         self.__metrics.increment("batch_write_msgs", rows)
 

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -107,9 +107,11 @@ class InsertBatchWriter(ProcessingStep[BytesInsertBatch]):
         write_finish = time.time()
 
         max_latency: Optional[float] = None
+        latency_sum = 0.0
         max_end_to_end_latency: Optional[float] = None
         for message in self.__messages:
             latency = write_finish - message.timestamp.timestamp()
+            latency_sum += latency
             if max_latency is None or latency > max_latency:
                 max_latency = latency
             self.__metrics.timing("latency_ms", latency * 1000)
@@ -128,6 +130,9 @@ class InsertBatchWriter(ProcessingStep[BytesInsertBatch]):
 
         if max_latency is not None:
             self.__metrics.timing("max_latency_ms", max_latency * 1000)
+            self.__metrics.timing(
+                "avg_latency_ms", (latency_sum / len(self.__messages)) * 1000
+            )
         if max_end_to_end_latency is not None:
             self.__metrics.timing(
                 "max_end_to_end_latency_ms", max_end_to_end_latency * 1000


### PR DESCRIPTION
We are logging a latency metric between clickhouse write an message timestamp at every message. This seems to contribute to up to 1 second latency for every batch, and likely it is the cause of some hard to explain backlog events.

The idea is to only log one latency per batch, as our SLO should be based on the max latency. 
Before replacing the existing metric, this PR starts by recording the max latency and the avg latency per batch to compare how consistent is with the current metric. If it is close enough, we can replace the existing one.