### PR TITLE
perf(consumers): Turn on parallel collect by default

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -75,7 +75,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option(
-    "--parallel-collect", is_flag=True, default=False,
+    "--parallel-collect", is_flag=True, default=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 @click.option(

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option(
-    "--parallel-collect", is_flag=True, default=False,
+    "--parallel-collect", is_flag=True, default=True,
 )
 @click.option("--processes", type=int)
 @click.option(

--- a/snuba/cli/test_consumer.py
+++ b/snuba/cli/test_consumer.py
@@ -66,7 +66,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option(
-    "--parallel-collect", is_flag=True, default=False,
+    "--parallel-collect", is_flag=True, default=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 @click.option(


### PR DESCRIPTION
Since there are benefits of using the parallel collect, we should turn
it on by default for all the consumers.