### PR TITLE
fix(metrics) - fix storage key for metrics_raw

### DIFF
--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -20,7 +20,7 @@ class StorageKey(Enum):
     METRICS_DISTRIBUTIONS = "metrics_distributions"
     METRICS_DISTRIBUTIONS_BUCKETS = "metrics_distributions_buckets"
     METRICS_SETS = "metrics_sets"
-    METRICS_POLYMORPHIC_BUCKET = "metrics_raw"
+    METRICS_RAW = "metrics_raw"
     OUTCOMES_RAW = "outcomes_raw"
     OUTCOMES_HOURLY = "outcomes_hourly"
     QUERYLOG = "querylog"

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -50,7 +50,7 @@ POST_VALUE_COLUMNS: Sequence[Column[SchemaModifiers]] = [
 ]
 
 polymorphic_bucket = WritableTableStorage(
-    storage_key=StorageKey.METRICS_POLYMORPHIC_BUCKET,
+    storage_key=StorageKey.METRICS_RAW,
     storage_set_key=StorageSetKey.METRICS,
     schema=WritableTableSchema(
         columns=ColumnSet(


### PR DESCRIPTION
The key and value of the enum in StorageKey need to be identical. This caused an issue when trying to deploy an ops change to run the metrics_raw consumer (https://getsentry.atlassian.net/browse/OPS-1481)

Tested locally that `snuba multistorage-consumer --storage=metrics_counters_buckets --storage=metrics_distributions_buckets --storage=metrics_buckets --storage=metrics_raw --consumer-group=metrics_group` starts successfully