### PR TITLE
fix(query): Long queries rejected at Snuba level

### DIFF
--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -27,6 +27,12 @@ class QueryException(SerializableException):
         self.extra = extra
 
 
+class QueryTooLongException(SerializableException):
+    """
+    Exception thrown when a query is too long for ClickHouse
+    """
+
+
 class QueryResult(NamedTuple):
     result: Result
     extra: QueryExtraData

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -29,7 +29,10 @@ class QueryException(SerializableException):
 
 class QueryTooLongException(SerializableException):
     """
-    Exception thrown when a query is too long for ClickHouse
+    Exception thrown when a query string is too long for ClickHouse.
+
+    There is a limit for the maximum size of a query (in bytes)
+    ClickHouse will process, this limit is defined in Snuba settings.
     """
 
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -64,7 +64,7 @@ from snuba.subscriptions.subscription import SubscriptionCreator, SubscriptionDe
 from snuba.util import with_span
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
-from snuba.web import QueryException
+from snuba.web import QueryException, QueryTooLongException
 from snuba.web.converters import DatasetConverter, EntityConverter
 from snuba.web.query import parse_and_run_query
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
@@ -476,6 +476,9 @@ def dataset_query(
                 "message": str(cause),
                 "code": cause.code,
             }
+        elif isinstance(cause, QueryTooLongException):
+            status = 400
+            details = {"type": "query-too-long", "message": str(cause)}
         elif isinstance(cause, Exception):
             details = {
                 "type": "unknown",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1345,6 +1345,25 @@ class TestApi(SimpleAPITest):
         )
         assert result["data"][0] == {"environment": "prød", "count": 90}
 
+    def test_query_too_long(self) -> None:
+        long_string = "A" * 270000
+        response = self.post(
+            json.dumps(
+                {
+                    "from_date": self.base_time.isoformat(),
+                    "project": [1],
+                    "conditions": [["platform", "NOT IN", [long_string]]],
+                    "selected_columns": ["project_id"],
+                    "to_date": (
+                        self.base_time + timedelta(minutes=self.minutes)
+                    ).isoformat(),
+                }
+            ),
+        )
+        data = json.loads(response.data)
+        assert data["error"]["type"] == "query-too-long"
+        assert response.status_code == 400
+
     def test_query_timing(self) -> None:
         result = json.loads(
             self.post(

--- a/tests/web/test_query_size.py
+++ b/tests/web/test_query_size.py
@@ -6,14 +6,14 @@ TENTH_PLUS_ONE = int(MAX_QUERY_SIZE_BYTES / 10) + 1
 A = "A"
 
 TEST_GROUPS = [
-    pytest.param(A, ">=0%", id="Under 10%"),
-    pytest.param(A * TENTH_PLUS_ONE, ">=10%", id="Greater than or equal to 10%"),
-    pytest.param(A * TENTH_PLUS_ONE * 5, ">=50%", id="Greater than or equal to 50%"),
-    pytest.param(A * TENTH_PLUS_ONE * 8, ">=80%", id="Greater than or equal to 80%"),
-    pytest.param(A * TENTH_PLUS_ONE * 10, ">=100%", id="Greater than or equal to 100%"),
+    pytest.param(1, ">=0%", id="Under 10%"),
+    pytest.param(TENTH_PLUS_ONE, ">=10%", id="Greater than or equal to 10%"),
+    pytest.param(TENTH_PLUS_ONE * 5, ">=50%", id="Greater than or equal to 50%"),
+    pytest.param(TENTH_PLUS_ONE * 8, ">=80%", id="Greater than or equal to 80%"),
+    pytest.param(MAX_QUERY_SIZE_BYTES, "100%", id="Greater than or equal to 100%"),
 ]
 
 
-@pytest.mark.parametrize("query, group", TEST_GROUPS)
-def test_query_size_group(query: str, group: str) -> None:
-    assert get_query_size_group(query) == group
+@pytest.mark.parametrize("query_size, group", TEST_GROUPS)
+def test_query_size_group(query_size: int, group: str) -> None:
+    assert get_query_size_group(query_size) == group


### PR DESCRIPTION
### Overview
- Currently when a query is too long for ClickHouse to process, we find out when we attempt to process it and ClickHouse tells us `Max query size exceeded.` We log this as an Error in Sentry
- With these changes Snuba will validate the size of the query and respond with a `400` (and an appropriate message) if the query size exceeds the max.

### Changes
- Introduced a `QueryTooLongException`
- Snuba API responds with a 400 when query is too long
- Got rid of `>=100%` query size group span tag in favor of `100%` as the maximum possible size group