### PR TITLE
fix(snql) Remove invalid time sentry logging

### DIFF
--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1289,7 +1289,9 @@ def _align_max_days_date_align(
     )
     to_date = to_date - timedelta(seconds=(to_date - to_date.min).seconds % date_align)
     if from_date > to_date:
-        raise ParsingException(f"invalid time conditions on entity {key.value}")
+        raise ParsingException(
+            f"invalid time conditions on entity {key.value}", should_report=False
+        )
 
     if max_days is not None and (to_date - from_date).days > max_days:
         from_date = to_date - timedelta(days=max_days)

--- a/tests/test_snql_sdk_api.py
+++ b/tests/test_snql_sdk_api.py
@@ -410,3 +410,20 @@ class TestSDKSnQLApi(BaseApiTest):
         assert metric_calls[0].value > 0
         assert metric_calls[0].tags["team"] == "sns"
         assert metric_calls[0].tags["feature"] == "test"
+
+    def test_invalid_time_conditions(self) -> None:
+        query = (
+            Query("events", Entity("events"))
+            .set_select([Function("count", [], "count")])
+            .set_where(
+                [
+                    Condition(Column("project_id"), Op.EQ, self.project_id),
+                    Condition(Column("timestamp"), Op.GTE, self.next_time),
+                    Condition(Column("timestamp"), Op.LT, self.base_time),
+                ]
+            )
+        )
+
+        response = self.post("/events/snql", data=query.snuba())
+        resp = json.loads(response.data)
+        assert response.status_code == 400, resp


### PR DESCRIPTION
This error comes up frequently and has not been an issue in Snuba for a long
time. Stop logging this error to Sentry and just return a 400.
