### PR TITLE
refactor(replacements): Remove avoided final metrics

### DIFF
--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -21,7 +21,6 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 logger = logging.getLogger(__name__)
 metrics = MetricsWrapper(environment.metrics, "processors.replaced_groups")
 FINAL_METRIC = "final"
-AVOID_FINAL_METRIC = "avoid_final"
 
 
 class PostReplacementConsistencyEnforcer(QueryProcessor):
@@ -57,20 +56,21 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
             list(project_ids), self.__replacer_state_name
         )
 
-        tags = self._initialize_tags(request_settings, flags)
-
         query_overlaps_replacement = self._query_overlaps_replacements(
             query, flags.latest_replacement_time
         )
 
-        metric_name = FINAL_METRIC if query_overlaps_replacement else AVOID_FINAL_METRIC
+        if not query_overlaps_replacement:
+            self._set_query_final(query, False)
+            return
 
+        tags = self._initialize_tags(request_settings, flags)
         set_final = False
 
         if flags.needs_final:
             tags["cause"] = "final_flag"
             metrics.increment(
-                name=metric_name, tags=tags,
+                name=FINAL_METRIC, tags=tags,
             )
             set_final = True
         elif flags.group_ids_to_exclude:
@@ -86,10 +86,10 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
             if len(groups_to_exclude) > max_group_ids_exclude:
                 tags["cause"] = "max_groups"
                 metrics.increment(
-                    name=metric_name, tags=tags,
+                    name=FINAL_METRIC, tags=tags,
                 )
                 set_final = True
-            elif query_overlaps_replacement and groups_to_exclude:
+            elif groups_to_exclude:
                 query.add_condition_to_ast(
                     not_in_condition(
                         FunctionCall(
@@ -101,17 +101,7 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
                     )
                 )
 
-            if (
-                len(flags.group_ids_to_exclude) > max_group_ids_exclude
-                and not set_final
-            ):
-                # Avoided what would have caused the query to be final
-                tags["cause"] = "avoided_max_groups"
-                metrics.increment(
-                    name=AVOID_FINAL_METRIC, tags=tags,
-                )
-
-        self._set_query_final(query, set_final and query_overlaps_replacement)
+        self._set_query_final(query, set_final)
 
     def _initialize_tags(
         self, request_settings: RequestSettings, flags: ProjectsQueryFlags


### PR DESCRIPTION
### Overview
- When FINAL query optimizations were applied, I introduced a metric to track how many queries were avoided being set to FINAL
    - #2138 
    - #2226
- It's been ~5 months since these changes and I don't think we need to continue tracking how well that optimization is doing

### Results
- Avoided ~14M FINAL queries in the past 5 months (this is a ~<strong>73%</strong> reduction in total FINAL queries over this time frame)
- Datadog [notebook](https://app.datadoghq.com/notebook/1503147/avoiding-final-metrics).
    - See `Total Final queries per Day` and `Final vs Avoided Final` charts

### Changes (in this PR)
- Removed `avoid_final` datadog metric
- Refactored `replaced_groups.py` to get rid of extra code which served to track this optimization