### PR TITLE
ref: Don't re-close consumer

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -220,7 +220,7 @@ def subscriptions(
     )
     metrics.gauge("executor.workers", getattr(executor, "_max_workers", 0))
 
-    with closing(consumer), executor, closing(producer):
+    with executor, closing(producer):
         batching_consumer = StreamProcessor(
             consumer,
             (


### PR DESCRIPTION
The StreamProcessor already handles closing the consumer on shutdown,
we don't need to call close() here.