### PR TITLE
feat(metrics) Increase the partition size of the raw metrics table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -185,6 +185,8 @@ class MetricsLoader(DirectoryLoader):
             "0019_aggregate_tables_add_ttl",
             "0020_polymorphic_buckets_table",
             "0021_polymorphic_bucket_materialized_views",
+            "0022_repartition_polymorphic_table",
+            "0023_polymorphic_repartitioned_bucket_matview",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/metrics/0022_repartition_polymorphic_table.py
+++ b/snuba/migrations/snuba_migrations/metrics/0022_repartition_polymorphic_table.py
@@ -1,0 +1,76 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.utils.schemas import Array, Column, DateTime, Float, Nested, String, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Create a polymorphic bucket table for metrics_sets,
+    metrics_distributions, and metrics_counters.
+    This is partitioned by 3 days intervals.
+    """
+
+    blocking = False
+    local_table_name = "metrics_raw_v2_local"
+    dist_table_name = "metrics_raw_v2_dist"
+
+    column_list: Sequence[Column[Modifiers]] = [
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("timestamp", DateTime()),
+        Column("tags", Nested([Column("key", UInt(64)), Column("value", UInt(64))]),),
+        Column("metric_type", String(Modifiers(low_cardinality=True))),
+        Column("set_values", Array(UInt(64))),
+        Column("count_value", Float(64)),
+        Column("distribution_values", Array(Float(64))),
+        Column("materialization_version", UInt(8)),
+        Column("retention_days", UInt(16)),
+        Column("partition", UInt(16)),
+        Column("offset", UInt(64)),
+    ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.METRICS,
+                table_name=self.local_table_name,
+                columns=self.column_list,
+                engine=table_engines.MergeTree(
+                    storage_set=StorageSetKey.METRICS,
+                    order_by="(use_case_id, metric_type, org_id, project_id, metric_id, timestamp)",
+                    partition_by="(toStartOfInterval(timestamp, INTERVAL 3 day))",
+                    ttl="timestamp + toIntervalDay(7)",
+                ),
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS, table_name=self.local_table_name
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.METRICS,
+                table_name=self.dist_table_name,
+                columns=self.column_list,
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name, sharding_key=None,
+                ),
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS, table_name=self.dist_table_name
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/metrics/0023_polymorphic_repartitioned_bucket_matview.py
+++ b/snuba/migrations/snuba_migrations/metrics/0023_polymorphic_repartitioned_bucket_matview.py
@@ -1,0 +1,74 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.snuba_migrations.metrics.templates import (
+    COL_SCHEMA_DISTRIBUTIONS,
+    get_forward_view_migration_polymorphic_table,
+    get_polymorphic_mv_v2_name,
+)
+from snuba.utils.schemas import AggregateFunction, Column, Float, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Creates materialized view for all metrics types which writes to 10s, 1m, 1h, 1d granularities
+    The backward migration does *not* delete any data from the destination tables.
+    """
+
+    blocking = False
+    raw_table_name = "metrics_raw_v2_local"
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            get_forward_view_migration_polymorphic_table(
+                source_table_name=self.raw_table_name,
+                table_name="metrics_distributions_local",
+                mv_name=get_polymorphic_mv_v2_name("distributions"),
+                aggregation_col_schema=COL_SCHEMA_DISTRIBUTIONS,
+                aggregation_states=(
+                    "quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)((arrayJoin(distribution_values) AS values_rows)) as percentiles, "
+                    "minState(values_rows) as min, "
+                    "maxState(values_rows) as max, "
+                    "avgState(values_rows) as avg, "
+                    "sumState(values_rows) as sum, "
+                    "countState(values_rows) as count"
+                ),
+                metric_type="distribution",
+            ),
+            get_forward_view_migration_polymorphic_table(
+                source_table_name=self.raw_table_name,
+                table_name="metrics_sets_local",
+                mv_name=get_polymorphic_mv_v2_name("sets"),
+                aggregation_col_schema=[
+                    Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+                ],
+                aggregation_states="uniqCombined64State(arrayJoin(set_values)) as value",
+                metric_type="set",
+            ),
+            get_forward_view_migration_polymorphic_table(
+                source_table_name=self.raw_table_name,
+                table_name="metrics_counters_local",
+                mv_name=get_polymorphic_mv_v2_name("counters"),
+                aggregation_col_schema=[
+                    Column("value", AggregateFunction("sum", [Float(64)])),
+                ],
+                aggregation_states="sumState(count_value) as value",
+                metric_type="counter",
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS,
+                table_name=get_polymorphic_mv_v2_name(mv_type),
+            )
+            for mv_type in ["sets", "counters", "distributions"]
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/migrations/snuba_migrations/metrics/templates.py
+++ b/snuba/migrations/snuba_migrations/metrics/templates.py
@@ -351,6 +351,10 @@ def get_polymorphic_mv_name(metric_type: str) -> str:
     return f"metrics_{metric_type}_polymorphic_mv_local"
 
 
+def get_polymorphic_mv_v2_name(metric_type: str) -> str:
+    return f"metrics_{metric_type}_polymorphic_mv_v2_local"
+
+
 class MigrationArgs(TypedDict):
     source_table_name: str
     table_name: str


### PR DESCRIPTION
Daily partition is appealing if most data is concentrated in the latest partition. Unfortunately it seems the content of an INSERT is more evenly divided across partitions. This generates one part per partition almost at every batch, which creates 5 parts every time increasing the number of inactive parts instead of reducing 
```
┌─partition───────────┬─active─┬───c─┬─formatReadableSize(sum(bytes_on_disk))─┐
│ 2022-03-12 00:00:00 │      1 │   4 │ 7.48 MiB                               │
│ 2022-03-13 00:00:00 │      0 │ 621 │ 72.55 MiB                              │
│ 2022-03-13 00:00:00 │      1 │  11 │ 65.22 MiB                              │
│ 2022-03-14 00:00:00 │      0 │ 810 │ 471.11 MiB                             │
│ 2022-03-14 00:00:00 │      1 │  10 │ 97.29 MiB                              │
│ 2022-03-15 00:00:00 │      0 │ 701 │ 278.61 MiB                             │
│ 2022-03-15 00:00:00 │      1 │   7 │ 175.70 MiB                             │
│ 2022-03-16 00:00:00 │      0 │ 541 │ 85.79 MiB                              │
│ 2022-03-16 00:00:00 │      1 │  11 │ 487.36 MiB                             │
│ 2022-03-17 00:00:00 │      0 │ 529 │ 200.09 MiB                             │
│ 2022-03-17 00:00:00 │      1 │  14 │ 14.73 GiB                              │
│ 2022-03-18 00:00:00 │      0 │ 523 │ 814.98 MiB                             │
│ 2022-03-18 00:00:00 │      1 │  16 │ 5.69 GiB                               │
└─────────────────────┴────────┴─────┴────────────────────────────────────────┘
```

So this pr makes the partitioning key more coarse. We try a 3 days partition.
This PR is almost identical to 
https://github.com/getsentry/snuba/pull/2504
https://github.com/getsentry/snuba/pull/2507
except for the partition key and the table names.

cc @onewland 