### PR TITLE
perf(subscriptions): Sample metric that is recorded on every task

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -62,6 +62,7 @@ DOGSTATSD_PORT = None
 DOGSTATSD_SAMPLING_RATES = {
     "subscriptions.receive_latency": 0.1,
     "subscriptions.process_message": 0.1,
+    "subscriptions.executor.latency": 0.1,
     "metrics.processor.set.size": 0.1,
     "metrics.processor.distribution.size": 0.1,
 }


### PR DESCRIPTION
Sample 10% of `subscriptions.executor.latency` metrics since it's
being recorded for every task. This is the same rate as `receive_latency`
and `process_message` which are recorded with the same frequency.