### PR TITLE
fix(profiles-consumer): Add to freight deployments

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -39,6 +39,8 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-executor
   - image: us.gcr.io/sentryio/snuba:{sha}
+    name: profiles-consumer
+  - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: sessions-subscriptions-consumer


### PR DESCRIPTION
Not sure if I got this right, but we've got a k8s diff showing up in `master` due to something similar to https://github.com/getsentry/snuba/pull/2458.

Diff:

```diff
ops/k8s on  master via 🐍 v3.10.2 (.ops-venv) on ☁️  michael@sentry.io(us-central1) took 17s
❯ sk diff snuba
--- default/snuba-profiles-consumer-production-Deployment.yaml.live
+++ default/snuba-profiles-consumer-production-Deployment.yaml.merged
@@ -4,7 +4,7 @@
-  generation: 3
+  generation: 4
@@ -343,7 +343,7 @@
         - name: UWSGI_DISABLE_WRITE_EXCEPTION
           value: 'true'
-        image: us.gcr.io/sentryio/snuba:c70e257a9dfbb754119cd7f1f091668a0a0fcb7c
+        image: us.gcr.io/sentryio/snuba:f4db68dda90c23322938ecb14faf17bc2deec9bc
         imagePullPolicy: IfNotPresent
         name: profiles-consumer
         resources:
```