### PR TITLE
ref: Increase the log level during subscription consumer shutdown

### DIFF
--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -260,6 +260,10 @@ def subscriptions(
         )
 
         def handler(signum: int, frame: Optional[Any]) -> None:
+            # TODO: Temporary code for debugging the shutdown sequence of the subscriptions
+            # consumer without updating arroyo or affecting other consumers.
+            logging.getLogger().setLevel(logging.DEBUG)
+
             batching_consumer.signal_shutdown()
 
         signal.signal(signal.SIGINT, handler)


### PR DESCRIPTION
We need to better understand what is happening during the shutdown
sequence of the subscriptions consumer. Increase the log level
to debug.