### PR TITLE
Revert "Revert "use re-partitioned polymorphic metrics table as main …

### DIFF
--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -63,8 +63,8 @@ polymorphic_bucket = WritableTableStorage(
                 *POST_VALUE_COLUMNS,
             ]
         ),
-        local_table_name="metrics_raw_local",
-        dist_table_name="metrics_raw_dist",
+        local_table_name="metrics_raw_v2_local",
+        dist_table_name="metrics_raw_v2_dist",
         storage_set_key=StorageSetKey.METRICS,
     ),
     query_processors=[],


### PR DESCRIPTION
…storage (#2531)""

This reverts commit 0d25069f759f2f1e5e4192dad8e5ec1bf268b306.

This should have been a redeploy with an orthogonal fix, incorrectly pushed a revert directly to master