### PR TITLE
fix(deployment) The profiles consumer is in cashloop. Removing it from freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -39,8 +39,6 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-executor
   - image: us.gcr.io/sentryio/snuba:{sha}
-    name: profiles-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: sessions-subscriptions-consumer


### PR DESCRIPTION
The profiles consumer is in crashloop.
This may prevent snuba deployment to go through. 
If that is not fixed and no safeguards is put in place, merge this and the deployment should be unblocked.