### PR TITLE
feat(optimize) Ensure the optimize job does not go past 11 pm

### DIFF
--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -29,7 +29,6 @@ def optimize(
     clickhouse_host: Optional[str],
     clickhouse_port: Optional[int],
     storage_name: str,
-    ignore_cutoff: Optional[bool] = False,
     log_level: Optional[str] = None,
 ) -> None:
     from datetime import datetime

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import Optional
 
 import click
@@ -80,7 +81,11 @@ def optimize(
         )
 
     if not ignore_cutoff:
-        last_midnight = datetime.now().replace(
+        # Adding 10 minutes to the current time before finding the midnight time
+        # to ensure this keeps working even if the system clock of the host that
+        # starts the pod is slightly ahead of the system clock of the host running
+        # the job. This prevents us from getting the wrong midnight.
+        last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
         cutoff: Optional[datetime] = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
 from snuba.settings.validation import validate_settings
@@ -196,6 +196,8 @@ TRANSACTIONS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(
 )
 
 MAX_ROWS_TO_CHECK_FOR_SIMILARITY = 1000
+
+OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:


### PR DESCRIPTION
We saw a few times the optimize job being restarted by Kubernetes after a few hours. 
That job is stateless so it restarts from scratch. If k8s restarts it too late, the job may end so late to overlap with the next day instance. This puts unnecessary load on the DB.

If we are about to start a new instance there is no point in finishing the previous one, so this adds a cutoff time to ensure the job does not go past a certain time of the dat provided in settings.

The proper fix would be to make the job stateful so that it picks up from where it left when restarted, though that is a large refactoring. This is at least a safeguard to prevent the overlap.