### PR TITLE
fix(dataset): Allow us to exclude some enabled datasets from health check

### DIFF
--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -82,3 +82,16 @@ def get_dataset_name(dataset: Dataset) -> str:
 
 def get_enabled_dataset_names() -> Sequence[str]:
     return [name for name in DATASET_NAMES if name not in settings.DISABLED_DATASETS]
+
+
+def get_online_dataset_names() -> Sequence[str]:
+    """
+    Allows us to have datasets enabled on Snuba but excluded from the
+    heathcheck in case they are not ready for production or we are
+    performing maintenance on them.
+    """
+    return [
+        name
+        for name in get_enabled_dataset_names()
+        if name not in settings.SKIP_HEALTH_CHECK_DATASETS
+    ]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -22,9 +22,6 @@ ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 
 DEFAULT_DATASET_NAME = "events"
 DISABLED_DATASETS: Set[str] = set()
-# Allows us to have datasets enabled on Snuba but excluded from the
-# heathcheck in case they are not ready for production or we are
-# performing maintenance on them.
 SKIP_HEALTH_CHECK_DATASETS: Set[str] = set()
 
 # Clickhouse Options

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -22,6 +22,10 @@ ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 
 DEFAULT_DATASET_NAME = "events"
 DISABLED_DATASETS: Set[str] = set()
+# Allows us to have datasets enabled on Snuba but excluded from the
+# heathcheck in case they are not ready for production or we are
+# performing maintenance on them.
+SKIP_HEALTH_CHECK_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -46,7 +46,7 @@ from snuba.datasets.factory import (
     InvalidDatasetError,
     get_dataset,
     get_dataset_name,
-    get_enabled_dataset_names,
+    get_online_dataset_names,
 )
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.query.exceptions import InvalidQueryException
@@ -114,7 +114,7 @@ def check_clickhouse() -> bool:
     Checks if all the tables in all the enabled datasets exist in ClickHouse
     """
     try:
-        datasets = [get_dataset(name) for name in get_enabled_dataset_names()]
+        datasets = [get_dataset(name) for name in get_online_dataset_names()]
         entities = itertools.chain(
             *[dataset.get_all_entities() for dataset in datasets]
         )

--- a/tests/datasets/test_factory.py
+++ b/tests/datasets/test_factory.py
@@ -1,10 +1,12 @@
 import pytest
 
+from snuba import settings
 from snuba.clusters.cluster import get_cluster
 from snuba.datasets.factory import (
     get_dataset,
     get_dataset_name,
     get_enabled_dataset_names,
+    get_online_dataset_names,
 )
 
 
@@ -27,3 +29,12 @@ def test_dataset_load(dataset_name: str) -> None:
     for entity in dataset.get_all_entities():
         for storage in entity.get_all_storages():
             get_cluster(storage.get_storage_set_key())
+
+
+def test_skip_healthcheck() -> None:
+    prev_set = settings.SKIP_HEALTH_CHECK_DATASETS
+    settings.SKIP_HEALTH_CHECK_DATASETS = {"profiles"}
+    assert "profiles" in get_enabled_dataset_names()
+    assert "profiles" not in get_online_dataset_names()
+
+    settings.SKIP_HEALTH_CHECK_DATASETS = prev_set


### PR DESCRIPTION
We now have a dataset that needs to be enabled in prod so reachable in prod by Sentry but that may not be in a stable state 100% of the time as it is not production ready yet. 
So our enabled/disabled dataset concept is not enough.

Adding a quick way to exclude a testing dataset from health check so that a problem with this dataset would not prevent snuba from deploying or impact the stability of snuba pods in any way.