### PR TITLE
fix(query): Wrap log function calls with ifNotFinite

### DIFF
--- a/snuba/query/processors/basic_functions.py
+++ b/snuba/query/processors/basic_functions.py
@@ -33,6 +33,12 @@ class BasicFunctionsProcessor(QueryProcessor):
                         "ifNull",
                         (replace(exp, alias=None), Literal(None, ""),),
                     )
+                if exp.function_name == "log":
+                    return FunctionCall(
+                        exp.alias,
+                        "ifNotFinite",
+                        (replace(exp, alias=None), Literal(None, 0),),
+                    )
             if isinstance(exp, CurriedFunctionCall):
                 if exp.internal_function.function_name == "top":
                     return replace(

--- a/tests/query/processors/test_functions_processor.py
+++ b/tests/query/processors/test_functions_processor.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.entities import EntityKey
 from snuba.query import SelectedExpression
@@ -164,6 +165,33 @@ test_data = [
                         (Column(None, None, "column1"),),
                     ),
                 )
+            ],
+        ),
+    ),
+    (
+        Query(
+            QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "alias",
+                    FunctionCall("alias", "log", (Column(None, None, "column1"),)),
+                ),
+            ],
+        ),
+        Query(
+            QueryEntity(EntityKey.EVENTS, ColumnSet([])),
+            selected_columns=[
+                SelectedExpression(
+                    "alias",
+                    FunctionCall(
+                        "alias",
+                        "ifNotFinite",
+                        (
+                            FunctionCall(None, "log", (Column(None, None, "column1"),)),
+                            Literal(None, 0),
+                        ),
+                    ),
+                ),
             ],
         ),
     ),

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -814,3 +814,31 @@ class TestSnQLApi(BaseApiTest):
         # assert json.loads(response.data)["error"]["message"] == error_message
 
         assert response.status_code == 500
+
+    def test_wrap_log_fn_with_ifnotfinite(self) -> None:
+        """
+        Test that wrapping the log function in ifNotFinite clickhouse function returns a 200 response
+        """
+        response = self.post(
+            "/events/snql",
+            data=json.dumps(
+                {
+                    "query": f"""
+                    MATCH (events SAMPLE 1.0)
+                    SELECT multiply(toUInt64(max(timestamp)), 1000) AS last_seen,
+                    count() AS times_seen,
+                    toUInt64(plus(multiply(log(times_seen), 600), last_seen)) AS priority,
+                    uniq(group_id) AS total
+                    BY group_id
+                    WHERE timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    AND project_id IN tuple({self.project_id})
+                    """,
+                    "dataset": "events",
+                    "team": "sns",
+                    "feature": "test",
+                }
+            ),
+        )
+
+        assert response.status_code == 200


### PR DESCRIPTION
### Context
In clickhouse version 21.8, running log function on value 0, returns infinite. Then any operation like addition/multiplication on infinite barfs. We do not see this on version 20.7. 

### Solution
Wrapped the call to log function with ifNotFinite so that if log(0) is run and an infinte result is returned, we substitute it with 0.

### Tests
Added unit test to validate the behavior and API test to ensure that a 200 is returned.