### PR TITLE
feat(metrics) write to new counters_aggregate table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -189,6 +189,7 @@ class MetricsLoader(DirectoryLoader):
             "0023_polymorphic_repartitioned_bucket_matview",
             "0024_metrics_distributions_add_histogram",
             "0025_metrics_counters_aggregate_v2",
+            "0026_metrics_counters_v2_writing_matview",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/metrics/0026_metrics_counters_v2_writing_matview.py
+++ b/snuba/migrations/snuba_migrations/metrics/0026_metrics_counters_v2_writing_matview.py
@@ -1,0 +1,50 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.snuba_migrations.metrics.templates import (
+    get_forward_view_migration_polymorphic_table_v3,
+    get_polymorphic_mv_v3_name,
+)
+from snuba.utils.schemas import AggregateFunction, Column, Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Creates materialized view for all metrics types which writes to 10s, 1m, 1h, 1d granularities
+    The backward migration does *not* delete any data from the destination tables.
+    """
+
+    blocking = False
+    table_name = "metrics_counters_v2_local"
+    raw_table_name = "metrics_raw_v2_local"
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            get_forward_view_migration_polymorphic_table_v3(
+                source_table_name=self.raw_table_name,
+                table_name=self.table_name,
+                aggregation_col_schema=[
+                    Column("value", AggregateFunction("sum", [Float(64)])),
+                ],
+                mv_name=get_polymorphic_mv_v3_name("counters"),
+                aggregation_states="sumState(count_value) as value",
+                metric_type="counter",
+                target_mat_version=4,
+                appended_where_clause="AND timestamp > toDateTime('2021-03-24 00:00:00')",
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS,
+                table_name=get_polymorphic_mv_v3_name("counters"),
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/migrations/snuba_migrations/metrics/templates.py
+++ b/snuba/migrations/snuba_migrations/metrics/templates.py
@@ -1,4 +1,4 @@
-from typing import Sequence, TypedDict
+from typing import Optional, Sequence, TypedDict
 
 from snuba.clickhouse.columns import (
     AggregateFunction,
@@ -13,6 +13,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.storages.tags_hash_map import INT_TAGS_HASH_MAP_COLUMN
 from snuba.migrations import operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.utils.schemas import String
 
 #: The granularity used for the initial materialized views.
 #: This might differ from snuba.datasets.metrics.DEFAULT_GRANULARITY at
@@ -204,6 +205,33 @@ GROUP BY
     retention_days
 """
 
+MATVIEW_STATEMENT_POLYMORPHIC_TABLE_V3 = """
+SELECT
+    use_case_id,
+    org_id,
+    project_id,
+    metric_id,
+    arrayJoin([10,60,3600,86400]) as granularity,
+    tags.key,
+    tags.value,
+    toDateTime(granularity * intDiv(toUnixTimestamp(timestamp), granularity)) as timestamp,
+    retention_days,
+    %(aggregation_states)s
+FROM %(raw_table_name)s
+WHERE materialization_version = %(target_mat_version)d
+  AND metric_type = '%(metric_type)s'
+  %(appended_where_clause)s
+GROUP BY
+    org_id,
+    project_id,
+    metric_id,
+    tags.key,
+    tags.value,
+    timestamp,
+    granularity,
+    retention_days
+"""
+
 
 def get_forward_migrations_local(
     source_table_name: str,
@@ -354,6 +382,38 @@ def get_forward_view_migration_polymorphic_table_v2(
             "metric_type": metric_type,
             "raw_table_name": source_table_name,
             "aggregation_states": aggregation_states,
+        },
+    )
+
+
+def get_forward_view_migration_polymorphic_table_v3(
+    source_table_name: str,
+    table_name: str,
+    mv_name: str,
+    aggregation_col_schema: Sequence[Column[Modifiers]],
+    aggregation_states: str,
+    metric_type: str,
+    target_mat_version: int,
+    appended_where_clause: Optional[str] = None,
+) -> operations.SqlOperation:
+    aggregated_cols = [
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+        *COMMON_AGGR_COLUMNS,
+        *aggregation_col_schema,
+    ]
+
+    return operations.CreateMaterializedView(
+        storage_set=StorageSetKey.METRICS,
+        view_name=mv_name,
+        destination_table_name=table_name,
+        columns=aggregated_cols,
+        query=MATVIEW_STATEMENT_POLYMORPHIC_TABLE_V3
+        % {
+            "metric_type": metric_type,
+            "raw_table_name": source_table_name,
+            "aggregation_states": aggregation_states,
+            "target_mat_version": target_mat_version,
+            "appended_where_clause": appended_where_clause,
         },
     )
 


### PR DESCRIPTION
Starts writing to metrics_counters_v2_local on `2021-03-24 00:00:00 UTC` (can be updated before merge, this is just a marker for backfilling which doesn't have to be super precise)

Assumes that materialization version is set to 4 following deploy of https://github.com/getsentry/snuba/pull/2525

Also assumes https://github.com/getsentry/snuba/pull/2539 is deployed and the table is created