### PR TITLE
fix(optimize) Fix tests that I broke when introducing the optimize cutoff time

### DIFF
--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -78,7 +78,9 @@ class TestReplacer:
         redis_client.flushdb()
         cluster = self.storage.get_cluster()
         clickhouse = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
-        run_optimize(clickhouse, self.storage, cluster.get_database())
+        run_optimize(
+            clickhouse, self.storage, cluster.get_database(), ignore_cutoff=True
+        )
 
     def _issue_count(self, project_id: int, group_id: Optional[int] = None) -> Any:
         args = {

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -122,7 +122,7 @@ class TestOptimize:
             )
         ] == [(a_month_earlier_monday, 90)]
 
-        optimize.optimize_partitions(clickhouse, database, table, parts)
+        optimize.optimize_partitions(clickhouse, database, table, parts, True)
 
         # all parts should be optimized
         parts = optimize.get_partitions_to_optimize(


### PR DESCRIPTION
I did not notice we actually had tests running the optimize jobs and that would be impacted by the cutoff time.
So this reintroduce the flag to ignore the cutoff to be used in tests to make the process deterministic no matter when it runs.