### PR TITLE
ops(profiles) - remove profiles consumer from freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -39,8 +39,6 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-executor
   - image: us.gcr.io/sentryio/snuba:{sha}
-    name: profiles-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: sessions-subscriptions-consumer


### PR DESCRIPTION
It's causing deploys to hang: https://freight.getsentry.net/deploys/snuba/production/1547

Semi-revert of https://github.com/getsentry/snuba/pull/2547