### PR TITLE
feat(rate limiters) Add recently created rate limiters across the board

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -48,7 +48,12 @@ from snuba.query.matchers import Or
 from snuba.query.matchers import String as StringMatch
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.processors.object_id_rate_limiter import ProjectRateLimiterProcessor
+from snuba.query.processors.object_id_rate_limiter import (
+    ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
+)
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
@@ -418,7 +423,10 @@ class DiscoverEntity(Entity):
             TimeSeriesProcessor({"time": "timestamp"}, ("timestamp",)),
             TagsExpanderProcessor(),
             BasicFunctionsProcessor(),
+            ReferrerRateLimiterProcessor(),
+            ProjectReferrerRateLimiter("project_id"),
             ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]
 
 

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -42,7 +42,10 @@ from snuba.query.processors.granularity_processor import GranularityProcessor
 from snuba.query.processors.object_id_rate_limiter import (
     OrganizationRateLimiterProcessor,
     ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
 )
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import (
     EntityRequiredColumnValidator,
@@ -117,8 +120,11 @@ class MetricsEntity(Entity, ABC):
         return [
             GranularityProcessor(),
             TimeSeriesProcessor({"bucketed_time": "timestamp"}, ("timestamp",)),
+            ReferrerRateLimiterProcessor(),
             OrganizationRateLimiterProcessor(org_column="org_id"),
+            ProjectReferrerRateLimiter("project_id"),
             ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
             TagsTypeTransformer(),
         ]
 

--- a/snuba/datasets/entities/outcomes.py
+++ b/snuba/datasets/entities/outcomes.py
@@ -11,6 +11,7 @@ from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.object_id_rate_limiter import (
     OrganizationRateLimiterProcessor,
+    ReferrerRateLimiterProcessor,
 )
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import (
@@ -71,5 +72,6 @@ class OutcomesEntity(Entity):
         return [
             BasicFunctionsProcessor(),
             TimeSeriesProcessor({"time": "timestamp"}, ("timestamp",)),
+            ReferrerRateLimiterProcessor(),
             OrganizationRateLimiterProcessor(org_column="org_id"),
         ]

--- a/snuba/datasets/entities/outcomes_raw.py
+++ b/snuba/datasets/entities/outcomes_raw.py
@@ -9,7 +9,10 @@ from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.object_id_rate_limiter import (
     OrganizationRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
 )
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
 
@@ -34,5 +37,8 @@ class OutcomesRawEntity(Entity):
         return [
             BasicFunctionsProcessor(),
             TimeSeriesProcessor({"time": "timestamp"}, ("timestamp",)),
+            ReferrerRateLimiterProcessor(),
             OrganizationRateLimiterProcessor(org_column="org_id"),
+            ProjectReferrerRateLimiter("project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]

--- a/snuba/datasets/entities/profiles.py
+++ b/snuba/datasets/entities/profiles.py
@@ -14,8 +14,10 @@ from snuba.query.processors import QueryProcessor
 from snuba.query.processors.object_id_rate_limiter import (
     OrganizationRateLimiterProcessor,
     ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
     ReferrerRateLimiterProcessor,
 )
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
 
 profile_columns = EntityColumnSet(
@@ -66,6 +68,8 @@ class ProfilesEntity(Entity, ABC):
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return [
             OrganizationRateLimiterProcessor(org_column="organization_id"),
-            ProjectRateLimiterProcessor(project_column="project_id"),
             ReferrerRateLimiterProcessor(),
+            ProjectReferrerRateLimiter("project_id"),
+            ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]

--- a/snuba/datasets/entities/sessions.py
+++ b/snuba/datasets/entities/sessions.py
@@ -32,7 +32,10 @@ from snuba.query.processors.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.object_id_rate_limiter import (
     OrganizationRateLimiterProcessor,
     ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
 )
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.timeseries_processor import (
     TimeSeriesProcessor,
     extract_granularity_from_query,
@@ -306,5 +309,9 @@ class OrgSessionsEntity(Entity):
             TimeSeriesProcessor(
                 {"bucketed_started": "started"}, ("started", "received")
             ),
+            ReferrerRateLimiterProcessor(),
             OrganizationRateLimiterProcessor(org_column="org_id"),
+            ProjectReferrerRateLimiter("project_id"),
+            ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -35,11 +35,16 @@ from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.query.processors.object_id_rate_limiter import ProjectRateLimiterProcessor
+from snuba.query.processors.object_id_rate_limiter import (
+    ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
+)
 from snuba.query.processors.performance_expressions import (
     apdex_processor,
     failure_rate_processor,
 )
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
@@ -212,7 +217,10 @@ class BaseTransactionsEntity(Entity, ABC):
             BasicFunctionsProcessor(),
             apdex_processor(),
             failure_rate_processor(),
+            ReferrerRateLimiterProcessor(),
+            ProjectReferrerRateLimiter("project_id"),
             ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]
 
 

--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -27,6 +27,7 @@ from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.null_column_caster import NullColumnCaster
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )
@@ -109,6 +110,7 @@ storage = ReadableTableStorage(
             ]
         ),
         NullColumnCaster([transactions_storage, error_storage]),
+        TableRateLimit(),
     ],
     query_splitters=[
         ColumnSplitQueryStrategy(

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -31,6 +31,7 @@ from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
 )
+from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -174,7 +175,7 @@ sets_storage = WritableTableStorage(
             ]
         ),
     ),
-    query_processors=[ArrayJoinKeyValueOptimizer("tags")],
+    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
     stream_loader=build_kafka_stream_loader_from_settings(
         SetsAggregateProcessor(), default_topic=Topic.METRICS,
     ),
@@ -195,7 +196,7 @@ counters_storage = WritableTableStorage(
             ]
         ),
     ),
-    query_processors=[ArrayJoinKeyValueOptimizer("tags")],
+    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
     stream_loader=build_kafka_stream_loader_from_settings(
         CounterAggregateProcessor(), default_topic=Topic.METRICS,
     ),
@@ -227,7 +228,7 @@ distributions_storage = WritableTableStorage(
             ]
         ),
     ),
-    query_processors=[ArrayJoinKeyValueOptimizer("tags")],
+    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
     stream_loader=build_kafka_stream_loader_from_settings(
         DistributionsAggregateProcessor(), default_topic=Topic.METRICS,
     ),


### PR DESCRIPTION
In the last few months we created a number of rate limiters for Snuba:
- table rate limiter
- referrer rate limiter
- project_referrer rate limiter
- quota control (that reduces the max_thread count)
We did not add them consistently to all datasets, entities and storages. 

This should cover everything.