### PR TITLE
generate migrations from CLI

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -8,6 +8,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.environment import setup_logging
 from snuba.migrations.connect import check_clickhouse_connections
 from snuba.migrations.errors import MigrationError
+from snuba.migrations.generation import generate
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
@@ -18,6 +19,21 @@ LOG_LEVELS = ["critical", "error", "warning", "info", "debug", "notset"]
 @click.group()
 def migrations() -> None:
     pass
+
+
+@migrations.command()
+@click.option("--group", required=True, help="Migration group")
+@click.option("--description", required=True, help="Description for the filename")
+def create(group: str, description: str) -> None:
+    """
+    Create a new migration
+    """
+    migration_group = MigrationGroup(group)
+    generate_result = generate(migration_group, description)
+    print(f"generated migration {generate_result.filename}")
+    print(
+        f"add {generate_result.groups_entry} to snuba/migrations/groups.py when ready"
+    )
 
 
 @migrations.command()

--- a/snuba/migrations/generation.py
+++ b/snuba/migrations/generation.py
@@ -1,0 +1,29 @@
+import datetime
+from dataclasses import dataclass
+
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+from snuba.migrations.groups import MigrationGroup
+
+env = Environment(
+    loader=PackageLoader("snuba", package_path="migrations"),
+    autoescape=select_autoescape(),
+)
+
+template = env.get_template("migration_template.py.jinja")
+
+
+@dataclass(frozen=True)
+class GenerationResult:
+    filename: str
+    groups_entry: str
+
+
+def generate(group_enum: MigrationGroup, description: str) -> GenerationResult:
+    group = group_enum.value
+    transformed_description = description.lower().replace(" ", "_")
+    filesystem_friendly_timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+    entry = f"{filesystem_friendly_timestamp}_{transformed_description}"
+    output_file = f"snuba/migrations/snuba_migrations/{group}/{entry}.py"
+    template.stream({"group": group, "description": description}).dump(output_file)
+    return GenerationResult(filename=output_file, groups_entry=entry)

--- a/snuba/migrations/migration_template.py.jinja
+++ b/snuba/migrations/migration_template.py.jinja
@@ -1,0 +1,37 @@
+from typing import Sequence
+
+# from snuba.clickhouse.columns import Column, Float
+from snuba.migrations import migration, operations
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    {{description}}
+    """
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            # operations.CreateTable()
+            # operations.AddColumn()
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            # operations.DropTable()
+            # operations.RemoveColumn()
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            #operations.CreateTable(
+            #   ...,
+            #   engine=table_engines.Distributed(
+            #        local_table_name=local_table_name, sharding_key=None,
+            #    ),
+            #),
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            #operations.DropTable(),
+        ]


### PR DESCRIPTION
This makes the prefix of migrations timestamp-based so two people don't have to coordinate to keep the ordering in sync. Inspired by some ruby on rails design decisions

Example run:
```
➜  snuba git:(migrations-cli-update) ✗ snuba migrations create --group metrics --description "add a column to a thing"                 
generated migration snuba/migrations/snuba_migrations/metrics/20220328102616_add_a_column_to_a_thing.py
add 20220328102616_add_a_column_to_a_thing to snuba/migrations/groups.py when ready
```

Output file from that command:
```
➜  snuba git:(migrations-cli-update) ✗ cat snuba/migrations/snuba_migrations/metrics/20220328102616_add_a_column_to_a_thing.py 
from typing import Sequence

# from snuba.clickhouse.columns import Column, Float
from snuba.migrations import migration, operations

class Migration(migration.ClickhouseNodeMigration):
    """
    add a column to a thing
    """
    blocking = False

    def forwards_local(self) -> Sequence[operations.SqlOperation]:
        return [
            # operations.CreateTable()
            # operations.AddColumn()
        ]

    def backwards_local(self) -> Sequence[operations.SqlOperation]:
        return [
            # operations.DropTable()
            # operations.RemoveColumn()
        ]

    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
        return [
            #operations.CreateTable(
            #   ...,
            #   engine=table_engines.Distributed(
            #        local_table_name=local_table_name, sharding_key=None,
            #    ),
            #),
        ]

    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
        return [
            #operations.DropTable(),
        ]%                                                            
```

Open to ideas for how to improve the template
