### PR TITLE
fix(metrics): Fix optimize metrics

### DIFF
--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -71,5 +71,7 @@ def optimize(
             ClickhouseClientSettings.OPTIMIZE
         )
 
-    num_dropped = run_optimize(connection, storage, database, before=today)
+    num_dropped = run_optimize(
+        connection, storage, database, before=today, clickhouse_host=clickhouse_host
+    )
     logger.info("Optimized %s partitions on %s" % (num_dropped, clickhouse_host))

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
-from typing import Callable
+from typing import Callable, Mapping
 
 import pytest
 
@@ -142,5 +142,7 @@ class TestOptimize:
             ),
         ],
     )
-    def test_metrics_tags(self, table, host, expected):
+    def test_metrics_tags(
+        self, table: str, host: str, expected: Mapping[str, str]
+    ) -> None:
         assert _get_metrics_tags(table, host) == expected

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -8,6 +8,7 @@ from snuba import optimize, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
+from snuba.optimize import _get_metrics_tags
 from snuba.processor import InsertBatch
 from tests.helpers import write_processed_messages
 
@@ -129,3 +130,17 @@ class TestOptimize:
             clickhouse, storage, database, table
         )
         assert parts == []
+
+    @pytest.mark.parametrize(
+        "table,host,expected",
+        [
+            ("errors_local", None, {"table": "errors_local"},),
+            (
+                "errors_local",
+                "some-hostname.domain.com",
+                {"table": "errors_local", "host": "some-hostname.domain.com"},
+            ),
+        ],
+    )
+    def test_metrics_tags(self, table, host, expected):
+        assert _get_metrics_tags(table, host) == expected


### PR DESCRIPTION
The optimize call is made on the one shard of each replica. Added a
host tag to each call of optimization to differentiate between calls
being made to each shard and differentiate tiger cluster from
errors cluster.