### PR TITLE
ref(discover): Change isHandled to check all the values in the array

### DIFF
--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -27,7 +27,7 @@ class HandledFunctionsProcessor(QueryProcessor):
     The implementation of these functions is too complex for clients to provide so
     these wrappers are required.
 
-    - The `isHandled` function searches an array field for null or 1.
+    - The `isHandled` function checks the entire array field is null or 1.
     - The `notHandled` function searches an array field for 0, null
       values will be excluded from the result.
 
@@ -55,7 +55,7 @@ class HandledFunctionsProcessor(QueryProcessor):
                     self.validate_parameters(exp, query.get_from_clause())
                     return FunctionCall(
                         exp.alias,
-                        "arrayExists",
+                        "arrayAll",
                         (
                             Lambda(
                                 None,
@@ -66,13 +66,13 @@ class HandledFunctionsProcessor(QueryProcessor):
                                         None, "isNull", (Argument(None, "x"),)
                                     ),
                                     binary_condition(
-                                        ConditionFunctions.EQ,
+                                        ConditionFunctions.NEQ,
                                         FunctionCall(
                                             None,
                                             "assumeNotNull",
                                             (Argument(None, "x"),),
                                         ),
-                                        Literal(None, 1),
+                                        Literal(None, 0),
                                     ),
                                 ),
                             ),

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -28,9 +28,9 @@ class HandledFunctionsProcessor(QueryProcessor):
     these wrappers are required.
 
     An event is considered unhandled if at least one of its stacktraces are
-    unhandled, regardless if the stacktraces are handled or null. And the inverse
-    should hold true for whether an event is considered handled, that all of its
-    stacktraces are either handled or null.
+    unhandled, regardless if the remaining stacktraces are handled or null. And the
+    inverse should hold true for whether an event is considered handled, that all of
+    its stacktraces are either handled or null.
 
     - The `isHandled` function checks the entire array field is null or 1.
     - The `notHandled` function searches an array field for at least one occurance of

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -33,7 +33,7 @@ class HandledFunctionsProcessor(QueryProcessor):
     its stacktraces are either handled or null.
 
     - The `isHandled` function checks the entire array field is null or 1.
-    - The `notHandled` function searches an array field for at least one occurance of
+    - The `notHandled` function searches an array field for at least one occurrence of
       0
 
     Both functions return 1 or 0 if a row matches.

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -27,9 +27,14 @@ class HandledFunctionsProcessor(QueryProcessor):
     The implementation of these functions is too complex for clients to provide so
     these wrappers are required.
 
+    An event is considered unhandled if at least one of its stacktraces are
+    unhandled, regardless if the stacktraces are handled or null. And the inverse
+    should hold true for whether an event is considered handled, that all of its
+    stacktraces are either handled or null.
+
     - The `isHandled` function checks the entire array field is null or 1.
-    - The `notHandled` function searches an array field for 0, null
-      values will be excluded from the result.
+    - The `notHandled` function searches an array field for at least one occurance of
+      0
 
     Both functions return 1 or 0 if a row matches.
     """

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -37,7 +37,7 @@ def test_handled_processor() -> None:
                 "result",
                 FunctionCall(
                     "result",
-                    "arrayExists",
+                    "arrayAll",
                     (
                         Lambda(
                             None,
@@ -46,11 +46,11 @@ def test_handled_processor() -> None:
                                 BooleanFunctions.OR,
                                 FunctionCall(None, "isNull", (Argument(None, "x"),)),
                                 binary_condition(
-                                    ConditionFunctions.EQ,
+                                    ConditionFunctions.NEQ,
                                     FunctionCall(
                                         None, "assumeNotNull", (Argument(None, "x"),)
                                     ),
-                                    Literal(None, 1),
+                                    Literal(None, 0),
                                 ),
                             ),
                         ),

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -71,7 +71,7 @@ def test_handled_processor() -> None:
         ClickhouseExpressionFormatter()
     )
     assert ret == (
-        "(arrayExists((x -> (isNull(x) OR equals(assumeNotNull(x), 1))), exception_stacks.mechanism_handled) AS result)"
+        "(arrayAll((x -> (isNull(x) OR notEquals(assumeNotNull(x), 0))), exception_stacks.mechanism_handled) AS result)"
     )
 
 


### PR DESCRIPTION
- Based on this conversation: ([slack](https://sentry.slack.com/archives/CA2V2LBDL/p1646674287100079)|[notion](https://www.notion.so/sentry/error-handled-and-unhandled-logic-f720e11193f6470890ec02d8ac587008))
- This changes isHandled to check that all values in the
  exception_stacks.mechanism_handled array are either Null or 1
  - This is cause currently isHandled() doesn't equal the reverse of
    notHandled() which results in `error.handled:1` and
    `error.unhandled:1` returning the same rows
- This keeps notHandled the same as before where there's at least a 0 in
  the array