### PR TITLE
chore(logging): downgrade warning log to info

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -128,7 +128,7 @@ class CommitLogTickConsumer(Consumer[Tick]):
                     previous_message.orig_message_ts, commit.orig_message_ts
                 )
             except InvalidRangeError:
-                logger.warning(
+                logger.info(
                     "Could not construct valid time interval between %r and %r!",
                     previous_message,
                     MessageDetails(commit.offset, commit.orig_message_ts),


### PR DESCRIPTION
This message shows up occasionally in sentry but is not usually actionable. We can keep it in the logs for when we need to debug something but there's no need to surface it to sentry as often as we do. 