### PR TITLE
test: Fix CLI test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ class TestCli(object):
         Check that the consumer daemon runs until it is killed
         """
         proc = subprocess.Popen(["snuba", "consumer", "--storage", "events"])
-        time.sleep(2)
+        time.sleep(3)
         proc.poll()
         assert proc.returncode is None  # still running
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,7 +9,7 @@ class TestCli(object):
         Check that the consumer daemon runs until it is killed
         """
         proc = subprocess.Popen(["snuba", "consumer", "--storage", "events"])
-        time.sleep(1)
+        time.sleep(2)
         proc.poll()
         assert proc.returncode is None  # still running
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ class TestCli(object):
         """
         Check that the consumer daemon runs until it is killed
         """
-        proc = subprocess.Popen(["snuba", "consumer", "--storage", "events"])
+        proc = subprocess.Popen(["snuba", "consumer", "--storage", "errors"])
         time.sleep(3)
         proc.poll()
         assert proc.returncode is None  # still running


### PR DESCRIPTION
This test wasn't actually passing because invalid arguments were being passed. The sleep was just shorter than it took to actually start the consumer.