### PR TITLE
feat: Upgrade sentry-arroyo and confluent-kafka-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ chardet==3.0.4
 click==7.1.2
 clickhouse-driver==0.2.2
 colorama==0.3.9
-confluent-kafka==1.5.0
+confluent-kafka==1.6.1
 coverage==5.0
 datadog==0.21.0
 deprecation==2.0.3
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==1.4
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-arroyo==0.0.11
+sentry-arroyo==0.0.12
 sentry-relay==0.8.9
 sentry-sdk==1.1.0
 simplejson==3.15.0


### PR DESCRIPTION
This upgrades confluent-kafka-python from 1.5.0 to 1.6.1 everywhere.