### PR TITLE
feat(consumers): Support the --cooperative-rebalancing option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==1.4
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-arroyo==0.0.12
+sentry-arroyo==0.0.13
 sentry-relay==0.8.9
 sentry-sdk==1.1.0
 simplejson==3.15.0

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -88,6 +88,13 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
+# TODO: For testing alternate rebalancing strategies. To be eventually removed.
+@click.option(
+    "--cooperative-rebalancing",
+    is_flag=True,
+    default=False,
+    help="Use cooperative-sticky partition assignment strategy",
+)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -107,6 +114,7 @@ def consumer(
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
     profile_path: Optional[str] = None,
+    cooperative_rebalancing: bool = False,
 ) -> None:
 
     setup_logging(log_level)

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -156,6 +156,7 @@ def consumer(
         profile_path=profile_path,
         stats_callback=stats_callback,
         parallel_collect=parallel_collect,
+        cooperative_rebalancing=cooperative_rebalancing,
     )
 
     consumer = consumer_builder.build_base_consumer()

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -89,6 +89,13 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--dead-letter-topic", help="Dead letter topic to send failed insert messages."
 )
+# TODO: For testing alternate rebalancing strategies. To be eventually removed.
+@click.option(
+    "--cooperative-rebalancing",
+    is_flag=True,
+    default=False,
+    help="Use cooperative-sticky partition assignment strategy",
+)
 def multistorage_consumer(
     storage_names: Sequence[str],
     consumer_group: str,
@@ -104,6 +111,7 @@ def multistorage_consumer(
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
     dead_letter_topic: Optional[str] = None,
+    cooperative_rebalancing: bool = False,
 ) -> None:
 
     DEFAULT_BLOCK_SIZE = int(32 * 1e6)
@@ -189,6 +197,9 @@ def multistorage_consumer(
         queued_max_messages_kbytes=queued_max_messages_kbytes,
         queued_min_messages=queued_min_messages,
     )
+
+    if cooperative_rebalancing is True:
+        consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
     for storage_key in storage_keys[1:]:
         if (

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -109,6 +109,13 @@ logger = logging.getLogger(__name__)
 @click.option("--log-level", help="Logging level to use.")
 @click.option("--delay-seconds", type=int)
 @click.option("--min-tick-interval-ms", type=click.IntRange(1, 1000))
+# TODO: For testing alternate rebalancing strategies. To be eventually removed.
+@click.option(
+    "--cooperative-rebalancing",
+    is_flag=True,
+    default=False,
+    help="Use cooperative-sticky partition assignment strategy",
+)
 def subscriptions(
     *,
     dataset_name: str,
@@ -130,6 +137,7 @@ def subscriptions(
     log_level: Optional[str],
     delay_seconds: Optional[int],
     min_tick_interval_ms: Optional[int],
+    cooperative_rebalancing: bool,
 ) -> None:
     """Evaluates subscribed queries for a dataset."""
 
@@ -165,18 +173,21 @@ def subscriptions(
 
     configure_metrics(StreamMetricsAdapter(metrics))
 
+    consumer_configuration = build_kafka_consumer_configuration(
+        loader.get_default_topic_spec().topic,
+        consumer_group,
+        auto_offset_reset=auto_offset_reset,
+        bootstrap_servers=bootstrap_servers,
+        queued_max_messages_kbytes=queued_max_messages_kbytes,
+        queued_min_messages=queued_min_messages,
+    )
+
+    if cooperative_rebalancing is True:
+        consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
+
     consumer = TickConsumer(
         SynchronizedConsumer(
-            KafkaConsumer(
-                build_kafka_consumer_configuration(
-                    loader.get_default_topic_spec().topic,
-                    consumer_group,
-                    auto_offset_reset=auto_offset_reset,
-                    bootstrap_servers=bootstrap_servers,
-                    queued_max_messages_kbytes=queued_max_messages_kbytes,
-                    queued_min_messages=queued_min_messages,
-                ),
-            ),
+            KafkaConsumer(consumer_configuration),
             KafkaConsumer(
                 build_kafka_consumer_configuration(
                     commit_log_topic_spec.topic,

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -65,6 +65,13 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     required=True,
     help="Override the result topic for testing",
 )
+# TODO: For testing alternate rebalancing strategies. To be eventually removed.
+@click.option(
+    "--cooperative-rebalancing",
+    is_flag=True,
+    default=False,
+    help="Use cooperative-sticky partition assignment strategy",
+)
 def subscriptions_executor(
     *,
     dataset_name: str,
@@ -74,6 +81,7 @@ def subscriptions_executor(
     auto_offset_reset: str,
     log_level: Optional[str],
     override_result_topic: str,
+    cooperative_rebalancing: bool,
 ) -> None:
     """
     The subscription's executor consumes scheduled subscriptions from the scheduled
@@ -121,6 +129,7 @@ def subscriptions_executor(
         metrics,
         executor,
         override_result_topic,
+        cooperative_rebalancing,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -80,6 +80,7 @@ class ConsumerBuilder:
         commit_retry_policy: Optional[RetryPolicy] = None,
         profile_path: Optional[str] = None,
         mock_parameters: Optional[MockParameters] = None,
+        cooperative_rebalancing: bool = False,
     ) -> None:
         self.storage = get_writable_storage(storage_key)
         self.bootstrap_servers = kafka_params.bootstrap_servers
@@ -150,6 +151,7 @@ class ConsumerBuilder:
         self.__profile_path = profile_path
         self.__mock_parameters = mock_parameters
         self.__parallel_collect = parallel_collect
+        self.__cooperative_rebalancing = cooperative_rebalancing
 
         if commit_retry_policy is None:
             commit_retry_policy = BasicRetryPolicy(
@@ -180,6 +182,9 @@ class ConsumerBuilder:
             queued_max_messages_kbytes=self.queued_max_messages_kbytes,
             queued_min_messages=self.queued_min_messages,
         )
+
+        if self.__cooperative_rebalancing is True:
+            configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
         stats_collection_frequency_ms = get_config(
             f"stats_collection_freq_ms_{self.group_id}",

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -64,7 +64,7 @@ def build_executor_consumer(
     executor: ThreadPoolExecutor,
     # TODO: Should be removed once testing is done
     override_result_topic: str,
-    cooperative_rebalancing: bool,
+    cooperative_rebalancing: bool = False,
 ) -> StreamProcessor[KafkaPayload]:
     # Validate that a valid dataset/entity pair was passed in
     dataset = get_dataset(dataset_name)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -64,6 +64,7 @@ def build_executor_consumer(
     executor: ThreadPoolExecutor,
     # TODO: Should be removed once testing is done
     override_result_topic: str,
+    cooperative_rebalancing: bool,
 ) -> StreamProcessor[KafkaPayload]:
     # Validate that a valid dataset/entity pair was passed in
     dataset = get_dataset(dataset_name)
@@ -106,14 +107,15 @@ def build_executor_consumer(
             result_topic_spec,
         ), "All entities must have same scheduled and result topics"
 
+    consumer_configuration = build_kafka_consumer_configuration(
+        scheduled_topic_spec.topic, consumer_group, auto_offset_reset=auto_offset_reset,
+    )
+
+    if cooperative_rebalancing is True:
+        consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
+
     return StreamProcessor(
-        KafkaConsumer(
-            build_kafka_consumer_configuration(
-                scheduled_topic_spec.topic,
-                consumer_group,
-                auto_offset_reset=auto_offset_reset,
-            ),
-        ),
+        KafkaConsumer(consumer_configuration),
         Topic(scheduled_topic_spec.topic_name),
         SubscriptionExecutorProcessingFactory(
             executor,


### PR DESCRIPTION
The consumers, multistorage-consumers, subscriptions consumer and
subscriptions-executor now support passing a --cooperative-rebalancing
flag which, if passed, will use the "cooperative-sticky" partition
assignment strategy.

Note that cooperative and non-cooperative strategies cannot be
combined in the same group so this cannot be deployed with a rolling
strategy. When enabling cooperative rebalancing for the first time,
all old consumers in the group should be stopped before restarting.