### PR TITLE
fix: Change column entity validator to WARN by default

### DIFF
--- a/snuba/datasets/entity.py
+++ b/snuba/datasets/entity.py
@@ -33,7 +33,7 @@ class Entity(Describable, ABC):
         writable_storage: Optional[WritableTableStorage],
         validators: Optional[Sequence[QueryValidator]],
         required_time_column: Optional[str],
-        validate_data_model: ColumnValidationMode = ColumnValidationMode.DO_NOTHING,
+        validate_data_model: ColumnValidationMode = ColumnValidationMode.WARN,
     ) -> None:
         self.__storages = storages
         self.__query_pipeline_builder = query_pipeline_builder

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -746,6 +746,29 @@ class TestSnQLApi(BaseApiTest):
         assert {"name": "url", "type": "String"} in result["meta"]
         assert {"name": "http.url", "type": "String"} in result["meta"]
 
+    @pytest.mark.xfail(reason="column validators are in warn only mode")
+    def test_invalid_column_handling(self) -> None:
+        response = self.post(
+            "/sessions/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (sessions)
+                    SELECT if(greater(users,0),divide(users_crashed,users),null) AS `_crash_rate_alert_aggregate`, identity(users) AS `_total_count`
+                    WHERE org_id = {self.org_id}
+                    AND not_exists = 2
+                    AND project_id IN tuple({self.project_id}) AND
+                    ifNull(tags[package], '') = 'some tag'
+                    AND environment = 'production'
+                    AND started >= toDateTime('{self.base_time.isoformat()}')
+                    AND started < toDateTime('{self.next_time.isoformat()}')
+                    LIMIT 1""",
+                    "dataset": "sessions",
+                    "parent_api": "/api/0/projects/{organization_slug}/{project_slug}/alert-rules/{alert_rule_id}/",
+                }
+            ),
+        )
+        assert response.status_code == 200
+
     def test_invalid_column(self) -> None:
         response = self.post(
             "/outcomes/snql",


### PR DESCRIPTION
We are not currently validating that columns referenced in queries are actually
available on the Entity. There was an initiative to do those checks, but it
stalled. This make any missing column errors throw a Sentry warning so we can
see how often our validators would catch broken queries. If things are working
as expected, we can turn the validators on by default and remove the xfail
from the test.
