### PR TITLE
cleanup(metrics) - remove unused metrics materialized views and tables

### DIFF
--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -11,18 +11,13 @@ from snuba.datasets.storages.errors_v2 import storage as errors_v2_storage
 from snuba.datasets.storages.errors_v2_ro import storage as errors_v2_ro_storage
 from snuba.datasets.storages.groupassignees import storage as groupassignees_storage
 from snuba.datasets.storages.groupedmessages import storage as groupedmessages_storage
-from snuba.datasets.storages.metrics import counters_buckets as metrics_counters_buckets
 from snuba.datasets.storages.metrics import counters_storage as metrics_counters_storage
-from snuba.datasets.storages.metrics import (
-    distributions_buckets as metrics_distributions_buckets,
-)
 from snuba.datasets.storages.metrics import (
     distributions_storage as metrics_distributions_storage,
 )
 from snuba.datasets.storages.metrics import (
     polymorphic_bucket as metrics_polymorphic_storage,
 )
-from snuba.datasets.storages.metrics import sets_buckets as metrics_sets_buckets
 from snuba.datasets.storages.metrics import sets_storage as metrics_sets_storage
 from snuba.datasets.storages.outcomes import (
     materialized_storage as outcomes_hourly_storage,
@@ -57,9 +52,6 @@ CDC_STORAGES: Mapping[StorageKey, CdcStorage] = {
 DEV_WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {}
 
 METRICS_WRITEABLE_STORAGES = {
-    metrics_counters_buckets.get_storage_key(): metrics_counters_buckets,
-    metrics_distributions_buckets.get_storage_key(): metrics_distributions_buckets,
-    metrics_sets_buckets.get_storage_key(): metrics_sets_buckets,
     metrics_distributions_storage.get_storage_key(): metrics_distributions_storage,
     metrics_sets_storage.get_storage_key(): metrics_sets_storage,
     metrics_counters_storage.get_storage_key(): metrics_counters_storage,

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -18,12 +18,7 @@ from snuba.datasets.metrics_aggregate_processor import (
     DistributionsAggregateProcessor,
     SetsAggregateProcessor,
 )
-from snuba.datasets.metrics_bucket_processor import (
-    CounterMetricsProcessor,
-    DistributionsMetricsProcessor,
-    PolymorphicMetricsProcessor,
-    SetsMetricsProcessor,
-)
+from snuba.datasets.metrics_bucket_processor import PolymorphicMetricsProcessor
 from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages import StorageKey
@@ -78,76 +73,6 @@ polymorphic_bucket = WritableTableStorage(
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_METRICS,
     ),
 )
-
-sets_buckets = WritableTableStorage(
-    storage_key=StorageKey.METRICS_BUCKETS,
-    storage_set_key=StorageSetKey.METRICS,
-    schema=WritableTableSchema(
-        columns=ColumnSet(
-            [
-                *PRE_VALUE_COLUMNS,
-                Column("set_values", Array(UInt(64))),
-                *POST_VALUE_COLUMNS,
-            ]
-        ),
-        local_table_name="metrics_buckets_local",
-        dist_table_name="metrics_buckets_dist",
-        storage_set_key=StorageSetKey.METRICS,
-    ),
-    query_processors=[],
-    stream_loader=build_kafka_stream_loader_from_settings(
-        processor=SetsMetricsProcessor(),
-        default_topic=Topic.METRICS,
-        commit_log_topic=Topic.METRICS_COMMIT_LOG,
-        subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_METRICS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_METRICS,
-    ),
-)
-
-counters_buckets = WritableTableStorage(
-    storage_key=StorageKey.METRICS_COUNTERS_BUCKETS,
-    storage_set_key=StorageSetKey.METRICS,
-    schema=WritableTableSchema(
-        columns=ColumnSet(
-            [*PRE_VALUE_COLUMNS, Column("value", Float(64)), *POST_VALUE_COLUMNS]
-        ),
-        local_table_name="metrics_counters_buckets_local",
-        dist_table_name="metrics_counters_buckets_dist",
-        storage_set_key=StorageSetKey.METRICS,
-    ),
-    query_processors=[],
-    stream_loader=build_kafka_stream_loader_from_settings(
-        processor=CounterMetricsProcessor(),
-        default_topic=Topic.METRICS,
-        commit_log_topic=Topic.METRICS_COMMIT_LOG,
-        subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_METRICS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_METRICS,
-    ),
-)
-
-distributions_buckets = WritableTableStorage(
-    storage_key=StorageKey.METRICS_DISTRIBUTIONS_BUCKETS,
-    storage_set_key=StorageSetKey.METRICS,
-    schema=WritableTableSchema(
-        columns=ColumnSet(
-            [
-                *PRE_VALUE_COLUMNS,
-                Column("values", Array(Float(64))),
-                *POST_VALUE_COLUMNS,
-            ]
-        ),
-        local_table_name="metrics_distributions_buckets_local",
-        dist_table_name="metrics_distributions_buckets_dist",
-        storage_set_key=StorageSetKey.METRICS,
-    ),
-    query_processors=[],
-    stream_loader=build_kafka_stream_loader_from_settings(
-        processor=DistributionsMetricsProcessor(), default_topic=Topic.METRICS,
-    ),
-)
-
 
 aggregated_columns = [
     Column("org_id", UInt(64)),

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -196,6 +196,7 @@ class MetricsLoader(DirectoryLoader):
             "0030_metrics_distributions_v2_writing_mv",
             "0031_metrics_sets_v2_writing_mv",
             "0032_redo_0030_and_0031_without_timestamps",
+            "0033_metrics_cleanup_old_views",
         ]
 
 

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -197,6 +197,7 @@ class MetricsLoader(DirectoryLoader):
             "0031_metrics_sets_v2_writing_mv",
             "0032_redo_0030_and_0031_without_timestamps",
             "0033_metrics_cleanup_old_views",
+            "0034_metrics_cleanup_old_tables",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/metrics/0024_metrics_distributions_add_histogram.py
+++ b/snuba/migrations/snuba_migrations/metrics/0024_metrics_distributions_add_histogram.py
@@ -37,11 +37,11 @@ class Migration(migration.ClickhouseNodeMigration):
         self, table_name: str
     ) -> Sequence[operations.SqlOperation]:
         return [
-            operations.DropColumn(
-                storage_set=StorageSetKey.METRICS,
-                table_name=table_name,
-                column_name="histogram_buckets",
-            )
+            # operations.DropColumn(
+            #     storage_set=StorageSetKey.METRICS,
+            #     table_name=table_name,
+            #     column_name="histogram_buckets",
+            # )
         ]
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/migrations/snuba_migrations/metrics/0033_metrics_cleanup_old_views.py
+++ b/snuba/migrations/snuba_migrations/metrics/0033_metrics_cleanup_old_views.py
@@ -1,0 +1,54 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Drop unused materialized views
+    """
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS, table_name=table_name
+            )
+            for table_name in [
+                "metrics_counters_consolidated_mv_local",
+                "metrics_counters_mv_10s_local",
+                "metrics_counters_mv_3600s_local",
+                "metrics_counters_mv_86400s_local",
+                "metrics_counters_mv_local",
+                "metrics_counters_polymorphic_mv_local",
+                "metrics_counters_polymorphic_mv_v2_local",
+                "metrics_counters_polymorphic_mv_v3_local",
+                "metrics_distributions_consolidated_mv_local",
+                "metrics_distributions_mv_10s_local",
+                "metrics_distributions_mv_3600s_local",
+                "metrics_distributions_mv_86400s_local",
+                "metrics_distributions_mv_local",
+                "metrics_distributions_polymorphic_mv_local",
+                "metrics_distributions_polymorphic_mv_v2_local",
+                "metrics_distributions_polymorphic_mv_v3_local",
+                "metrics_sets_consolidated_mv_local",
+                "metrics_sets_mv_10s_local",
+                "metrics_sets_mv_3600s_local",
+                "metrics_sets_mv_86400s_local",
+                "metrics_sets_mv_local",
+                "metrics_sets_polymorphic_mv_local",
+                "metrics_sets_polymorphic_mv_v2_local",
+                "metrics_sets_polymorphic_mv_v3_local",
+            ]
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/migrations/snuba_migrations/metrics/0034_metrics_cleanup_old_tables.py
+++ b/snuba/migrations/snuba_migrations/metrics/0034_metrics_cleanup_old_tables.py
@@ -1,0 +1,50 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Drop unused tables
+    """
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS, table_name=table_name
+            )
+            for table_name in [
+                "metrics_buckets_local",
+                "metrics_counters_buckets_local",
+                "metrics_counters_local",
+                "metrics_distributions_buckets_local",
+                "metrics_distributions_local",
+                "metrics_raw_local",
+                "metrics_sets_local",
+            ]
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.METRICS, table_name=table_name
+            )
+            for table_name in [
+                "metrics_buckets_dist",
+                "metrics_counters_buckets_dist",
+                "metrics_counters_dist",
+                "metrics_distributions_buckets_dist",
+                "metrics_distributions_dist",
+                "metrics_raw_dist",
+                "metrics_sets_dist",
+            ]
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []


### PR DESCRIPTION
Show tables before:

```
7b701b64404c :) show tables

SHOW TABLES

┌─name──────────────────────────────────────────┐
│ discover_local                                │
│ errors_local                                  │
│ groupassignee_local                           │
│ groupedmessage_local                          │
│ metrics_buckets_local                         │
│ metrics_counters_buckets_local                │
│ metrics_counters_consolidated_mv_local        │
│ metrics_counters_local                        │
│ metrics_counters_mv_10s_local                 │
│ metrics_counters_mv_3600s_local               │
│ metrics_counters_mv_86400s_local              │
│ metrics_counters_mv_local                     │
│ metrics_counters_polymorphic_mv_local         │
│ metrics_counters_polymorphic_mv_v2_local      │
│ metrics_counters_polymorphic_mv_v3_local      │
│ metrics_counters_polymorphic_mv_v4_local      │
│ metrics_counters_v2_local                     │
│ metrics_distributions_buckets_local           │
│ metrics_distributions_consolidated_mv_local   │
│ metrics_distributions_local                   │
│ metrics_distributions_mv_10s_local            │
│ metrics_distributions_mv_3600s_local          │
│ metrics_distributions_mv_86400s_local         │
│ metrics_distributions_mv_local                │
│ metrics_distributions_polymorphic_mv_local    │
│ metrics_distributions_polymorphic_mv_v2_local │
│ metrics_distributions_polymorphic_mv_v3_local │
│ metrics_distributions_polymorphic_mv_v4_local │
│ metrics_distributions_v2_local                │
│ metrics_raw_local                             │
│ metrics_raw_v2_local                          │
│ metrics_sets_consolidated_mv_local            │
│ metrics_sets_local                            │
│ metrics_sets_mv_10s_local                     │
│ metrics_sets_mv_3600s_local                   │
│ metrics_sets_mv_86400s_local                  │
│ metrics_sets_mv_local                         │
│ metrics_sets_polymorphic_mv_local             │
│ metrics_sets_polymorphic_mv_v2_local          │
│ metrics_sets_polymorphic_mv_v3_local          │
│ metrics_sets_polymorphic_mv_v4_local          │
│ metrics_sets_v2_local                         │
│ migrations_local                              │
│ outcomes_hourly_local                         │
│ outcomes_mv_hourly_local                      │
│ outcomes_raw_local                            │
│ sessions_hourly_local                         │
│ sessions_hourly_mv_local                      │
│ sessions_raw_local                            │
│ transactions_local                            │
└───────────────────────────────────────────────┘
```

after:
```
7b701b64404c :) show tables

SHOW TABLES

┌─name──────────────────────────────────────────┐
│ discover_local                                │
│ errors_local                                  │
│ groupassignee_local                           │
│ groupedmessage_local                          │
│ metrics_counters_polymorphic_mv_v4_local      │
│ metrics_counters_v2_local                     │
│ metrics_distributions_polymorphic_mv_v4_local │
│ metrics_distributions_v2_local                │
│ metrics_raw_v2_local                          │
│ metrics_sets_polymorphic_mv_v4_local          │
│ metrics_sets_v2_local                         │
│ migrations_local                              │
│ outcomes_hourly_local                         │
│ outcomes_mv_hourly_local                      │
│ outcomes_raw_local                            │
│ sessions_hourly_local                         │
│ sessions_hourly_mv_local                      │
│ sessions_raw_local                            │
│ transactions_local                            │
└───────────────────────────────────────────────┘
```