### PR TITLE
fix(metrics) - update a test with a hard-coded timestamp beyond database TTL

### DIFF
--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -154,7 +154,6 @@ class Runner:
                     raise MigrationError("Requires force to run blocking migrations")
 
         for migration_key in pending_migrations:
-            print(f"running {migration_key}")
             self._run_migration_impl(migration_key, force=force)
 
     def run_migration(

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -154,6 +154,7 @@ class Runner:
                     raise MigrationError("Requires force to run blocking migrations")
 
         for migration_key in pending_migrations:
+            print(f"running {migration_key}")
             self._run_migration_impl(migration_key, force=force)
 
     def run_migration(


### PR DESCRIPTION
Fix of a test failure that hit a TTL condition today at 1:35 PM PT