### PR TITLE
ref(devserver): update metrics-consumer command

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -143,11 +143,11 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "metrics-consumer",
                 [
                     "snuba",
-                    "multistorage-consumer",
+                    "consumer",
                     "--storage=metrics_raw",
                     "--auto-offset-reset=latest",
                     "--log-level=debug",
-                    "--consumer-group=metrics_group",
+                    "--consumer-group=snuba-metrics-consumers",
                 ],
             ),
         ]


### PR DESCRIPTION
When trying to run sentry tests that depend on the snuba image, I'm getting:

```
23:24:21 metrics-consumer | Usage: snuba multistorage-consumer [OPTIONS]
23:24:21 metrics-consumer | Try 'snuba multistorage-consumer --help' for help.
23:24:21 metrics-consumer |

23:24:21 metrics-consumer | Error: Invalid value for '--storage': invalid choice: metrics_counters_buckets. (choose from groupedmessages, groupassignees, metrics_distributions, metrics_sets, metrics_counters, metrics_raw, errors, outcomes_raw, querylog, sessions_raw, transactions, spans, transactions_v2, errors_v2, profiles)
```

While I can fix this by just using local snuba instead we should probs update this for other people (who have will be using `SENTRY_USE_METRICS_DEV` in sentry)