### PR TITLE
fix(subscription-verifier): Totals is not always present in result

### DIFF
--- a/snuba/subscriptions/verifier.py
+++ b/snuba/subscriptions/verifier.py
@@ -45,7 +45,7 @@ class SubscriptionResultData:
                 {
                     "data": self.result["data"],
                     "meta": self.result["meta"],
-                    "totals": self.result["totals"],
+                    "totals": self.result.get("totals"),
                 }
             ).encode("utf-8")
         ).hexdigest()


### PR DESCRIPTION
Not all subscriptions have "totals". Previously the verifier would
crash when it encountered a subscription without this key.