### PR TITLE
feat(subscriptions): Ignore stale subscriptions

### DIFF
--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -48,6 +48,11 @@ logger = logging.getLogger(__name__)
 @click.option("--schedule-ttl", type=int, default=60 * 5)
 @click.option("--log-level", help="Logging level to use.")
 @click.option("--delay-seconds", type=int)
+@click.option(
+    "--stale-threshold-seconds",
+    type=int,
+    help="Skip scheduling if timestamp is beyond this threshold compared to the system time",
+)
 def subscriptions_scheduler(
     *,
     entity_name: str,
@@ -57,6 +62,7 @@ def subscriptions_scheduler(
     schedule_ttl: int,
     log_level: Optional[str],
     delay_seconds: Optional[int],
+    stale_threshold_seconds: Optional[int],
 ) -> None:
     """
     The subscriptions scheduler's job is to schedule subscriptions for a single entity.
@@ -112,6 +118,11 @@ def subscriptions_scheduler(
         storage is not None
     ), f"Entity {entity_name} does not have a writable storage by default."
 
+    if stale_threshold_seconds is not None and delay_seconds is not None:
+        assert (
+            stale_threshold_seconds > delay_seconds
+        ), "stale_threshold_seconds must be greater than delay_seconds"
+
     stream_loader = storage.get_table_writer().get_stream_loader()
 
     scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
@@ -131,6 +142,7 @@ def subscriptions_scheduler(
         auto_offset_reset,
         schedule_ttl,
         delay_seconds,
+        stale_threshold_seconds,
         metrics,
     )
 

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -196,6 +196,7 @@ class SchedulerBuilder:
         auto_offset_reset: str,
         schedule_ttl: int,
         delay_seconds: Optional[int],
+        stale_threshold_seconds: Optional[int],
         metrics: MetricsBackend,
     ) -> None:
         self.__entity_key = EntityKey(entity_name)
@@ -229,6 +230,7 @@ class SchedulerBuilder:
         self.__auto_offset_reset = auto_offset_reset
         self.__schedule_ttl = schedule_ttl
         self.__delay_seconds = delay_seconds
+        self.__stale_threshold_seconds = stale_threshold_seconds
         self.__metrics = metrics
 
     def build_consumer(self) -> StreamProcessor[Tick]:
@@ -243,6 +245,7 @@ class SchedulerBuilder:
             self.__entity_key,
             self.__mode,
             self.__schedule_ttl,
+            self.__stale_threshold_seconds,
             self.__partitions,
             self.__producer,
             self.__scheduled_topic_spec,
@@ -273,12 +276,14 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
         entity_key: EntityKey,
         mode: SchedulingWatermarkMode,
         schedule_ttl: int,
+        stale_threshold_seconds: Optional[int],
         partitions: int,
         producer: Producer[KafkaPayload],
         scheduled_topic_spec: KafkaTopicSpec,
         metrics: MetricsBackend,
     ) -> None:
         self.__mode = mode
+        self.__stale_threshold_seconds = stale_threshold_seconds
         self.__partitions = partitions
         self.__producer = producer
         self.__scheduled_topic_spec = scheduled_topic_spec
@@ -309,6 +314,7 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
             self.__producer,
             self.__scheduled_topic_spec,
             commit,
+            self.__stale_threshold_seconds,
             self.__metrics,
         )
 

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -80,6 +80,7 @@ def test_scheduler_consumer() -> None:
         "latest",
         60 * 5,
         None,
+        None,
         metrics_backend,
     )
     scheduler = builder.build_consumer()


### PR DESCRIPTION
The subscriptions scheduler now supports passing --stale-threshold-seconds.
If a value is passed, subscriptions whose scheduled timestamp is more than
this number of seconds before the current time in the scheduler will be ignored.
This means that if the scheduler sees stale subscriptions they will be skipped
instead of scheduled for execution.

Under normal circumstances we should not really see stale subscriptions, however
there are a few situations where it happens.
- The main consumers were heavily backlogged for some reason
- Consumer or scheduler crashed for some time and we need to catch up
- In dev when devserver is stopped for an extended period of time

Since very delayed alerts are generally of little value to users, having the option
to skip them will be useful in some environments.