### PR TITLE
fix(query): Avoid race in pipeline delegator

### DIFF
--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -1,3 +1,5 @@
+import copy
+from dataclasses import replace
 from functools import partial
 from typing import Callable, List, Mapping, Optional, Tuple
 
@@ -89,12 +91,9 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
             if not get_config("pipeline_split_rate_limiter", 0):
                 return request
 
-            return Request(
-                id=request.id,
-                body=request.body,
-                query=request.query,
-                app_id=request.app_id,
-                snql_anonymized=request.snql_anonymized,
+            return replace(
+                request,
+                query=copy.deepcopy(request.query),
                 settings=RateLimiterDelegate(builder_id, request.settings),
             )
 


### PR DESCRIPTION
There's a data race which happens when the query is run via the
pipeline delegator. The same query object is modified by the entity
processors being run by different threads. To solve this race, we
create a copy of the query object and use it to avoid the race.