### PR TITLE
fix(tiger writes): Disable ignore write errors

### DIFF
--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -120,5 +120,4 @@ storage = WritableTableStorage(
         state_name=ReplacerState.ERRORS_V2,
         use_promoted_prewhere=False,
     ),
-    ignore_write_errors=True,
 )

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -44,5 +44,4 @@ storage = WritableTableStorage(
         "insert_allow_materialized_columns": 1,
         "input_format_skip_unknown_fields": 1,
     },
-    ignore_write_errors=True,
 )

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -213,6 +213,9 @@ def test_multistorage_strategy(
             strategy.join()
 
 
+@pytest.mark.skip(
+    reason="Writes to errors_v2 and transactions_v2 are no longer ignoring writes"
+)
 @patch("snuba.consumers.consumer.InsertBatchWriter.close")
 @pytest.mark.parametrize(
     "processes, input_block_size, output_block_size",


### PR DESCRIPTION
Now that we have been running inserts on the tiger cluster without
any issues for more than a month, its safe to not ignore the write
errors anymore for the consumers.