### PR TITLE
feat: Bump arroyo to 0.0.16

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     -   id: mypy
         files: snuba
         args: [--config-file, mypy.ini, --ignore-missing-imports, --strict, --warn-unreachable]
-        additional_dependencies: ['sentry-arroyo==0.0.8']
+        additional_dependencies: ['sentry-arroyo==0.0.16']
   - repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pytz==2018.4
 python-rapidjson==1.4
 redis==2.10.6
 redis-py-cluster==1.3.5
-sentry-arroyo==0.0.14
+sentry-arroyo==0.0.16
 sentry-relay==0.8.9
 sentry-sdk==1.1.0
 simplejson==3.15.0

--- a/snuba/state/stateful_count.py
+++ b/snuba/state/stateful_count.py
@@ -3,7 +3,7 @@ from typing import Sequence, Tuple
 
 from arroyo.processing.strategies.dead_letter_queue import (
     CountInvalidMessagePolicy,
-    InvalidMessage,
+    InvalidMessages,
 )
 
 from snuba.redis import redis_client
@@ -20,9 +20,9 @@ class StatefulCountInvalidMessagePolicy(CountInvalidMessagePolicy):
         self.__seconds = seconds
         super().__init__(limit, seconds, self._load_state())
 
-    def handle_invalid_message(self, e: InvalidMessage) -> None:
+    def handle_invalid_messages(self, e: InvalidMessages) -> None:
         self._add_to_redis()
-        super().handle_invalid_message(e)
+        super().handle_invalid_messages(e)
 
     def _add_to_redis(self) -> None:
         """


### PR DESCRIPTION
Includes changes to support incremental assignments in the stream processor.
This is required in order to switch to using the cooperative-sticky strategy
with Arroyo.