### PR TITLE
feat(subscriptions): Count the off by one results separately in verifier

### DIFF
--- a/snuba/subscriptions/verifier.py
+++ b/snuba/subscriptions/verifier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import time
@@ -43,7 +45,23 @@ class SubscriptionResultData:
             and self.to_dict() == cast(SubscriptionResultData, other).to_dict()
         )
 
-    def to_dict(self) -> Mapping[str, Any]:
+    def is_off_by_one(self, other: SubscriptionResultData) -> bool:
+        a = self.to_dict()
+        b = other.to_dict()
+        data_a = a.pop("data")
+        data_b = b.pop("data")
+
+        if (
+            a == b
+            and isinstance(data_a, int)
+            and isinstance(data_b, int)
+            and abs(data_a - data_b) == 1
+        ):
+            return True
+
+        return False
+
+    def to_dict(self) -> dict[str, Any]:
         return {
             "data": self.result["data"],
             "meta": self.result["meta"],
@@ -292,18 +310,29 @@ class ResultStore:
 
             non_matching_results = intersection_ids - matching_results
 
+            # Group the non matching results into those that are off than one,
+            # and those more different than off by one
+            off_by_one: Set[str] = set()
+            for id in non_matching_results:
+                if new_results[id].is_off_by_one(orig_results[id]):
+                    off_by_one.add(id)
+
             self.__metrics.increment(
                 METRIC_OUTCOME_NAME, len(matching_results), {"outcome": "same_result"},
             )
 
             self.__metrics.increment(
+                METRIC_OUTCOME_NAME, len(off_by_one), {"outcome": "off_by_one"},
+            )
+
+            self.__metrics.increment(
                 METRIC_OUTCOME_NAME,
-                len(non_matching_results),
+                len(non_matching_results) - len(off_by_one),
                 {"outcome": "different_result"},
             )
 
             # Log up to 100 subscription results per second
-            for id in list(non_matching_results)[:100]:
+            for id in list(off_by_one)[:100]:
                 logger.warning(
                     "Encountered non matching subscription result",
                     extra={

--- a/tests/subscriptions/test_verifier.py
+++ b/tests/subscriptions/test_verifier.py
@@ -169,7 +169,7 @@ def test_result_store() -> None:
 
     # Now we can record the now + 3 metrics.
     store.increment(ResultTopic.ORIGINAL, get_result_data(now + 5))
-    assert len(metrics.calls) == 4
+    assert len(metrics.calls) == 5
     assert (
         Increment("subscription_result_outcomes", 1, {"outcome": "missing_from_new"})
         in metrics.calls
@@ -180,6 +180,10 @@ def test_result_store() -> None:
     )
     assert (
         Increment("subscription_result_outcomes", 0, {"outcome": "same_result"})
+        in metrics.calls
+    )
+    assert (
+        Increment("subscription_result_outcomes", 0, {"outcome": "off_by_one"})
         in metrics.calls
     )
     assert (
@@ -195,7 +199,7 @@ def test_result_store() -> None:
 
     # The diff for now + 5 is 0 since we got 1 message in each topic
     store.increment(ResultTopic.ORIGINAL, get_result_data(now + 10))
-    assert len(metrics.calls) == 4
+    assert len(metrics.calls) == 5
     assert (
         Increment("subscription_result_outcomes", 0, {"outcome": "missing_from_new"})
         in metrics.calls
@@ -206,6 +210,10 @@ def test_result_store() -> None:
     )
     assert (
         Increment("subscription_result_outcomes", 1, {"outcome": "same_result"})
+        in metrics.calls
+    )
+    assert (
+        Increment("subscription_result_outcomes", 0, {"outcome": "off_by_one"})
         in metrics.calls
     )
     assert (


### PR DESCRIPTION
A number of results seem to be off by one in the new pipeline + Tiger vs the old
subscriptions pipeline + main ClickHouse cluster. Since there's not a great deal
we can do about these, this change counts those separately and does not log them
to Sentry so we get more visibility on those results that might be more significantly different.