### PR TITLE
fix(subscriptions): Fix InvalidRangeError when rebalancing occurs

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -103,7 +103,17 @@ class CommitLogTickConsumer(Consumer[Tick]):
         on_assign: Optional[Callable[[Mapping[Partition, int]], None]] = None,
         on_revoke: Optional[Callable[[Sequence[Partition]], None]] = None,
     ) -> None:
-        self.__consumer.subscribe(topics, on_assign=on_assign, on_revoke=on_revoke)
+        def revocation_callback(partitions: Sequence[Partition]) -> None:
+            for partition in partitions:
+                if partition in self.__previous_messages:
+                    del self.__previous_messages[partition]
+
+            if on_revoke is not None:
+                on_revoke(partitions)
+
+        self.__consumer.subscribe(
+            topics, on_assign=on_assign, on_revoke=revocation_callback
+        )
 
     def unsubscribe(self) -> None:
         self.__consumer.unsubscribe()


### PR DESCRIPTION
This fixes SNUBA-2R0.

We weren't properly resetting ticks and offsets stored internally in the
CommitLogTickConsumer on partition revocation. This made it possible for the
consumer to receive an earlier tick (after revocation and reassignment) and
attempt to construct an interval with the last one it saw before the revocation
happened, which is invalid. It also means it was possible that scheduling for
a tick was missed on rebalancing / deployment.