### PR TITLE
fix: Enable pre-commit CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,20 @@ jobs:
           python-version: 3.8
       - name: Setup pre-commit
         run: make setup-git
+      - uses: getsentry/paths-filter@v2
+        id: files
+        with:
+          # Enable listing of files matching each filter.
+          # Paths to files will be available in `${FILTER_NAME}_files` output variable.
+          # Paths will be escaped and space-delimited.
+          # Output is usable as command line argument list in linux shell
+          list-files: shell
+
+          # It doesn't make sense to lint deleted files.
+          # Therefore we specify we are only interested in added or modified files.
+          filters: |
+            all:
+              - added|modified: '**/*'
       - name: Run pre-commit checks
         # Run pre-commit to lint and format check files that were changed (but not deleted) compared to master.
         # XXX: there is a very small chance that it'll expand to exceed Linux's limits
@@ -25,7 +39,7 @@ jobs:
         # we skip the `no-commit-to-branch` because in CI we are in fact on master already
         # and we have merged to it
         run: |
-          SKIP=no-commit-to-branch pre-commit run --files $(git diff --diff-filter=d --name-only master)
+          SKIP=no-commit-to-branch pre-commit run --files ${{ steps.files.outputs.all_files }}
 
   typing:
     name: "mypy typing"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,6 @@ repos:
     hooks:
       - id: flake8
         language_version: python3.8
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.812'
-    hooks:
-    -   id: mypy
-        files: snuba
-        args: [--config-file, mypy.ini, --ignore-missing-imports, --strict, --warn-unreachable]
-        additional_dependencies: ['sentry-arroyo==0.0.16']
   - repo: https://github.com/pycqa/isort
     rev: 5.8.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ exclude: >
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -23,17 +23,17 @@ repos:
       - id: fix-encoding-pragma
         args: ["--remove"]
   - repo: https://github.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 4.0.1
     hooks:
       - id: flake8
         language_version: python3.8
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.10.1
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.2.0
     hooks:
       - id: no-commit-to-branch
         args: ['--branch', 'master']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,4 +130,3 @@ _Plus 124 more_
 - feat: Subscription executor has --override-result-topic option (#2281) by @lynnagara
 - feat(admin): Add UI component that loads the query node data (#2283) by @lynnagara
 - meta: Bump new development version (63881433)
-

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,4 +13,3 @@
 /cloudbuild.yaml                @getsentry/releases
 /scripts/bump-version.sh        @getsentry/releases
 /scripts/post-release.sh        @getsentry/releases
-

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ develop: install-python-dependencies setup-git
 
 setup-git:
 	mkdir -p .git/hooks && cd .git/hooks && ln -sf ../../config/hooks/* ./
-	pip install 'pre-commit==2.9.0'
+	pip install 'pre-commit==2.18.1'
 	pre-commit install --install-hooks
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ VERSION = "22.5.0.dev0"
 
 
 def get_requirements() -> Sequence[str]:
-    with open(u"requirements.txt") as fp:
+    with open("requirements.txt") as fp:
         return [x.strip() for x in fp.read().split("\n") if not x.startswith("#")]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from typing import Sequence
-from setuptools import setup, find_packages
 
+from setuptools import find_packages, setup
 
 VERSION = "22.5.0.dev0"
 

--- a/snuba/admin/notifications/base.py
+++ b/snuba/admin/notifications/base.py
@@ -37,11 +37,11 @@ class NotificationBase(ABC):
         timestamp: Optional[str] = None,
     ) -> None:
         """
-            Given
-            action: past-tense verb: 'created', 'removed', 'sent' etc.
-            data: any extra data that is need to notify
-            user: email address or other user identification of person taking action (could also be "auto")
-            timestamp: time the action occurred (or can be generated when notify is called)
+        Given
+        action: past-tense verb: 'created', 'removed', 'sent' etc.
+        data: any extra data that is need to notify
+        user: email address or other user identification of person taking action (could also be "auto")
+        timestamp: time the action occurred (or can be generated when notify is called)
         """
         raise NotImplementedError()
 
@@ -73,21 +73,21 @@ class RuntimeConfigLogClient(NotificationBase):
         timestamp: Optional[str] = None,
     ) -> None:
         """
-            Data has the runtime option, its old value, and new value.
-            If it's being removed, the new value will be `None`. Likewise
-            if it's being added, the old value will be `None`.
+        Data has the runtime option, its old value, and new value.
+        If it's being removed, the new value will be `None`. Likewise
+        if it's being added, the old value will be `None`.
 
-            example:
-                {
-                    "option": "enable_events_read_only_table",
-                    "old": 0, // or None if added
-                    "new": 1, // or None if removed
-                }
+        example:
+            {
+                "option": "enable_events_read_only_table",
+                "old": 0, // or None if added
+                "new": 1, // or None if removed
+            }
 
-            The text generated will look like:
-              * meredith@sentry.io added enable_events_read_only_table (value:1)
-              * meredith@sentry.io removed enable_events_read_only_table (value:0)
-              * meredith@sentry.io updated enable_events_read_only_table (from value:0 to value:1)
+        The text generated will look like:
+          * meredith@sentry.io added enable_events_read_only_table (value:1)
+          * meredith@sentry.io removed enable_events_read_only_table (value:0)
+          * meredith@sentry.io updated enable_events_read_only_table (from value:0 to value:1)
 
         """
 
@@ -112,16 +112,16 @@ class RuntimeConfigSlackClient(NotificationBase):
         timestamp: Optional[str] = None,
     ) -> None:
         """
-            Data has the runtime option, its old value, and new value.
-            If it's being removed, the new value will be `None`. Likewise
-            if it's being added, the old value will be `None`.
+        Data has the runtime option, its old value, and new value.
+        If it's being removed, the new value will be `None`. Likewise
+        if it's being added, the old value will be `None`.
 
-            example:
-                {
-                    "option": "enable_events_read_only_table",
-                    "old": 0, // or None if added
-                    "new": 1, // or None if removed
-                }
+        example:
+            {
+                "option": "enable_events_read_only_table",
+                "old": 0, // or None if added
+                "new": 1, // or None if removed
+            }
 
         """
         if not timestamp:

--- a/snuba/admin/notifications/slack/client.py
+++ b/snuba/admin/notifications/slack/client.py
@@ -26,7 +26,9 @@ class SlackClient(object):
 
         try:
             resp = requests.post(
-                "https://slack.com/api/chat.postMessage", headers=headers, json=message,
+                "https://slack.com/api/chat.postMessage",
+                headers=headers,
+                json=message,
             )
         except Exception as exc:
             logger.error(exc, exc_info=True)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -157,7 +157,8 @@ def clickhouse_trace_query() -> Response:
         return make_response(jsonify({"error": details}), 400)
     except Exception as err:
         return make_response(
-            jsonify({"error": {"type": "unknown", "message": str(err)}}), 500,
+            jsonify({"error": {"type": "unknown", "message": str(err)}}),
+            500,
         )
 
 
@@ -229,7 +230,9 @@ def configs() -> Response:
         ]
 
         return Response(
-            json.dumps(config_data), 200, {"Content-Type": "application/json"},
+            json.dumps(config_data),
+            200,
+            {"Content-Type": "application/json"},
         )
 
 
@@ -283,7 +286,9 @@ def config(config_key: str) -> Response:
             assert config_key != "", "Key cannot be empty string"
 
             state.set_config(
-                config_key, new_value, user=user,
+                config_key,
+                new_value,
+                user=user,
             )
             state.set_config_description(config_key, new_desc, user=user)
 

--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -7,15 +7,14 @@ import click
 @click.version_option()
 def main() -> None:
     """\b
-                     o
-                    O
-                    O
-                    o
-.oOo  'OoOo. O   o  OoOo. .oOoO'
-`Ooo.  o   O o   O  O   o O   o
-    O  O   o O   o  o   O o   O
-`OoO'  o   O `OoO'o `OoO' `OoO'o
-"""
+                         o
+                        O
+                        O
+                        o
+    .oOo  'OoOo. O   o  OoOo. .oOoO'
+    `Ooo.  o   O o   O  O   o O   o
+        O  O   o O   o  o   O o   O
+    `OoO'  o   O `OoO'o `OoO' `OoO'o"""
 
 
 for loader, module_name, is_pkg in walk_packages(__path__, __name__ + "."):  # type: ignore  # mypy issue #1422

--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -1,5 +1,6 @@
-import click
 from pkgutil import walk_packages
+
+import click
 
 
 @click.group()

--- a/snuba/cli/admin.py
+++ b/snuba/cli/admin.py
@@ -12,7 +12,11 @@ from snuba.environment import setup_logging
 @click.option("--processes", default=1)
 @click.option("--threads", default=1)
 def admin(
-    *, debug: bool, log_level: Optional[str], processes: int, threads: int,
+    *,
+    debug: bool,
+    log_level: Optional[str],
+    processes: int,
+    threads: int,
 ) -> None:
     from snuba import settings
 

--- a/snuba/cli/api.py
+++ b/snuba/cli/api.py
@@ -1,6 +1,6 @@
+import os
 from typing import Optional, Union
 
-import os
 import click
 
 from snuba.environment import setup_logging
@@ -18,7 +18,7 @@ def api(
     debug: bool,
     log_level: Optional[str],
     processes: int,
-    threads: int
+    threads: int,
 ) -> None:
     from snuba import settings
 
@@ -36,8 +36,9 @@ def api(
         if processes > 1 or threads > 1:
             raise click.ClickException("processes/threads can only be 1 in debug")
 
-        from snuba.web.views import application
         from werkzeug.serving import WSGIRequestHandler
+
+        from snuba.web.views import application
 
         setup_logging(log_level)
 

--- a/snuba/cli/bootstrap.py
+++ b/snuba/cli/bootstrap.py
@@ -15,7 +15,9 @@ from snuba.utils.streams.topics import Topic
 
 @click.command()
 @click.option(
-    "--bootstrap-server", multiple=True, help="Kafka bootstrap server to use.",
+    "--bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use.",
 )
 @click.option("--kafka/--no-kafka", default=True)
 @click.option("--migrate/--no-migrate", default=True)

--- a/snuba/cli/bulk_load.py
+++ b/snuba/cli/bulk_load.py
@@ -43,7 +43,10 @@ from snuba.writer import BufferedWriterWrapper
     help="Signals that the table is ready to pipe into Clickhouse. No need to parse.",
 )
 @click.option(
-    "--show-progress", default=False, is_flag=True, help="Shows a progress bar.",
+    "--show-progress",
+    default=False,
+    is_flag=True,
+    help="Shows a progress bar.",
 )
 @click.option("--log-level", help="Logging level to use.")
 def bulk_load(
@@ -69,7 +72,8 @@ def bulk_load(
 
     # TODO: Have a more abstract way to load sources if/when we support more than one.
     snapshot_source = PostgresSnapshot.load(
-        product=settings.SNAPSHOT_LOAD_PRODUCT, path=source,
+        product=settings.SNAPSHOT_LOAD_PRODUCT,
+        path=source,
     )
 
     loader = table_writer.get_bulk_loader(

--- a/snuba/cli/cleanup.py
+++ b/snuba/cli/cleanup.py
@@ -10,10 +10,13 @@ from snuba.environment import setup_logging, setup_sentry
 
 @click.command()
 @click.option(
-    "--clickhouse-host", help="Clickhouse server to write to.",
+    "--clickhouse-host",
+    help="Clickhouse server to write to.",
 )
 @click.option(
-    "--clickhouse-port", type=int, help="Clickhouse native port to write to.",
+    "--clickhouse-port",
+    type=int,
+    help="Clickhouse native port to write to.",
 )
 @click.option(
     "--dry-run",
@@ -49,7 +52,10 @@ def cleanup(
 
     storage = get_writable_storage(StorageKey(storage_name))
 
-    (clickhouse_user, clickhouse_password,) = storage.get_cluster().get_credentials()
+    (
+        clickhouse_user,
+        clickhouse_password,
+    ) = storage.get_cluster().get_credentials()
 
     cluster = storage.get_cluster()
     database = cluster.get_database()

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -21,7 +21,8 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.command()
 @click.option("--raw-events-topic", help="Topic to consume raw events from.")
 @click.option(
-    "--replacements-topic", help="Topic to produce replacement messages info.",
+    "--replacements-topic",
+    help="Topic to produce replacement messages info.",
 )
 @click.option(
     "--commit-log-topic",
@@ -33,7 +34,9 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Consumer group use for consuming the raw events topic.",
 )
 @click.option(
-    "--bootstrap-server", multiple=True, help="Kafka bootstrap server to use.",
+    "--bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use.",
 )
 @click.option(
     "--storage",
@@ -73,17 +76,22 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option(
-    "--parallel-collect", is_flag=True, default=True,
+    "--parallel-collect",
+    is_flag=True,
+    default=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 @click.option(
-    "--processes", type=int,
+    "--processes",
+    type=int,
 )
 @click.option(
-    "--input-block-size", type=int,
+    "--input-block-size",
+    type=int,
 )
 @click.option(
-    "--output-block-size", type=int,
+    "--output-block-size",
+    type=int,
 )
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)

--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -234,7 +234,9 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
     manager = Manager()
     for name, cmd in daemons:
         manager.add_process(
-            name, list2cmdline(cmd), quiet=False,
+            name,
+            list2cmdline(cmd),
+            quiet=False,
         )
 
     manager.loop()

--- a/snuba/cli/entities.py
+++ b/snuba/cli/entities.py
@@ -50,7 +50,8 @@ def list() -> None:
 
 @entities.command()
 @click.argument(
-    "entity_name", type=click.Choice([entity.value for entity in EntityKey]),
+    "entity_name",
+    type=click.Choice([entity.value for entity in EntityKey]),
 )
 def describe(entity_name: str) -> None:
     try:

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -39,7 +39,8 @@ logger = logging.getLogger(__name__)
     required=True,
 )
 @click.option(
-    "--consumer-group", default="snuba-consumers",
+    "--consumer-group",
+    default="snuba-consumers",
 )
 @click.option(
     "--commit-log-topic",
@@ -76,14 +77,18 @@ logger = logging.getLogger(__name__)
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option(
-    "--parallel-collect", is_flag=True, default=True,
+    "--parallel-collect",
+    is_flag=True,
+    default=True,
 )
 @click.option("--processes", type=int)
 @click.option(
-    "--input-block-size", type=int,
+    "--input-block-size",
+    type=int,
 )
 @click.option(
-    "--output-block-size", type=int,
+    "--output-block-size",
+    type=int,
 )
 @click.option("--log-level")
 @click.option(
@@ -260,7 +265,9 @@ def multistorage_consumer(
             build_kafka_producer_configuration(commit_log_topic_spec.topic)
         )
         consumer = KafkaConsumerWithCommitLog(
-            consumer_configuration, producer=producer, commit_log_topic=commit_log,
+            consumer_configuration,
+            producer=producer,
+            commit_log_topic=commit_log,
         )
 
     dead_letter_producer: Optional[KafkaProducer] = None

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -11,10 +11,13 @@ from snuba.environment import setup_logging, setup_sentry
 
 @click.command()
 @click.option(
-    "--clickhouse-host", help="Clickhouse server to write to.",
+    "--clickhouse-host",
+    help="Clickhouse server to write to.",
 )
 @click.option(
-    "--clickhouse-port", type=int, help="Clickhouse native port to write to.",
+    "--clickhouse-port",
+    type=int,
+    help="Clickhouse native port to write to.",
 )
 @click.option(
     "--storage",

--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -13,7 +13,8 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 
 @click.command()
 @click.option(
-    "--replacements-topic", help="Topic to consume replacement messages from.",
+    "--replacements-topic",
+    help="Topic to consume replacement messages from.",
 )
 @click.option(
     "--consumer-group",
@@ -21,7 +22,9 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Consumer group use for consuming the replacements topic.",
 )
 @click.option(
-    "--bootstrap-server", multiple=True, help="Kafka bootstrap server to use.",
+    "--bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use.",
 )
 @click.option(
     "--storage",

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -49,7 +49,9 @@ logger = logging.getLogger(__name__)
     help="The dataset to target",
 )
 @click.option(
-    "--entity", "entity_name", help="The entity to target",
+    "--entity",
+    "entity_name",
+    help="The entity to target",
 )
 @click.option("--topic")
 @click.option("--partitions", type=int)

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -114,7 +114,8 @@ def subscriptions_executor(
 
     producer = KafkaProducer(
         build_kafka_producer_configuration(
-            result_topic_spec.topic, override_params={"partitioner": "consistent"},
+            result_topic_spec.topic,
+            override_params={"partitioner": "consistent"},
         )
     )
 

--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -130,7 +130,8 @@ def subscriptions_scheduler(
 
     producer = KafkaProducer(
         build_kafka_producer_configuration(
-            scheduled_topic_spec.topic, override_params={"partitioner": "consistent"},
+            scheduled_topic_spec.topic,
+            override_params={"partitioner": "consistent"},
         )
     )
 

--- a/snuba/cli/subscriptions_verifier.py
+++ b/snuba/cli/subscriptions_verifier.py
@@ -48,7 +48,10 @@ def subscriptions_verifier(
     """
     setup_logging()
     setup_sentry()
-    metrics = MetricsWrapper(environment.metrics, "subscriptions.verifier",)
+    metrics = MetricsWrapper(
+        environment.metrics,
+        "subscriptions.verifier",
+    )
 
     configure_metrics(StreamMetricsAdapter(metrics))
 

--- a/snuba/cli/test_consumer.py
+++ b/snuba/cli/test_consumer.py
@@ -66,17 +66,22 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Minimum number of messages per topic+partition librdkafka tries to maintain in the local consumer queue.",
 )
 @click.option(
-    "--parallel-collect", is_flag=True, default=True,
+    "--parallel-collect",
+    is_flag=True,
+    default=True,
 )
 @click.option("--log-level", help="Logging level to use.")
 @click.option(
-    "--processes", type=int,
+    "--processes",
+    type=int,
 )
 @click.option(
-    "--input-block-size", type=int,
+    "--input-block-size",
+    type=int,
 )
 @click.option(
-    "--output-block-size", type=int,
+    "--output-block-size",
+    type=int,
 )
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
@@ -148,7 +153,8 @@ def test_consumer(
         parallel_collect=parallel_collect,
         profile_path=profile_path,
         mock_parameters=MockParameters(
-            avg_write_latency=avg_latency_ms, std_deviation=latency_std_deviation_ms,
+            avg_write_latency=avg_latency_ms,
+            std_deviation=latency_std_deviation_ms,
         ),
     )
 

--- a/snuba/clickhouse/escaping.py
+++ b/snuba/clickhouse/escaping.py
@@ -1,5 +1,4 @@
 import re
-
 from typing import Optional, Pattern
 
 ESCAPE_STRING_RE = re.compile(r"(['\\])")

--- a/snuba/clickhouse/formatter/query.py
+++ b/snuba/clickhouse/formatter/query.py
@@ -85,7 +85,8 @@ class DataSourceFormatter(DataSourceVisitor[FormattedNode, Table]):
 
 
 def _format_query_content(
-    query: FormattableQuery, expression_formatter_type: Type[ExpressionFormatterBase],
+    query: FormattableQuery,
+    expression_formatter_type: Type[ExpressionFormatterBase],
 ) -> Sequence[FormattedNode]:
     """
     Produces the content of the formatted query.
@@ -132,7 +133,9 @@ def _format_select(
 
 
 def _build_optional_string_node(
-    name: str, expression: Optional[Expression], formatter: ExpressionVisitor[str],
+    name: str,
+    expression: Optional[Expression],
+    formatter: ExpressionVisitor[str],
 ) -> Optional[StringNode]:
     return (
         StringNode(f"{name} {expression.accept(formatter)}")

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -153,7 +153,7 @@ class HTTPWriteBatch:
 
         self.__queue: Union[
             Queue[Union[bytes, None]], SimpleQueue[Union[bytes, None]]
-        ] = Queue(buffer_size) if buffer_size else SimpleQueue()
+        ] = (Queue(buffer_size) if buffer_size else SimpleQueue())
 
         body = self.__read_until_eof()
         if chunk_size > 1:

--- a/snuba/clickhouse/query_profiler.py
+++ b/snuba/clickhouse/query_profiler.py
@@ -111,7 +111,10 @@ def generate_profile(
             table="",
             all_columns=set(),
             multi_level_condition=False,
-            where_profile=FilterProfile(columns=set(), mapping_cols=set(),),
+            where_profile=FilterProfile(
+                columns=set(),
+                mapping_cols=set(),
+            ),
             groupby_cols=set(),
             array_join_cols=set(),
         )

--- a/snuba/clickhouse/translators/snuba/__init__.py
+++ b/snuba/clickhouse/translators/snuba/__init__.py
@@ -1,8 +1,7 @@
 from abc import ABC, abstractmethod
 
 from snuba.clickhouse.query import Expression
-from snuba.query.expressions import ExpressionVisitor
-from snuba.query.expressions import FunctionCall
+from snuba.query.expressions import ExpressionVisitor, FunctionCall
 
 
 class SnubaClickhouseTranslator(ExpressionVisitor[Expression], ABC):

--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -73,7 +73,8 @@ class CurriedFunctionCallMapper(
 
 class SubscriptableReferenceMapper(
     SnubaClickhouseMapper[
-        SubscriptableReference, Union[FunctionCall, Literal, SubscriptableReference],
+        SubscriptableReference,
+        Union[FunctionCall, Literal, SubscriptableReference],
     ],
 ):
     """

--- a/snuba/clickhouse/translators/snuba/defaults.py
+++ b/snuba/clickhouse/translators/snuba/defaults.py
@@ -23,14 +23,18 @@ from snuba.query.expressions import (
 
 class DefaultLiteralMapper(LiteralMapper):
     def attempt_map(
-        self, expression: Literal, children_translator: SnubaClickhouseStrictTranslator,
+        self,
+        expression: Literal,
+        children_translator: SnubaClickhouseStrictTranslator,
     ) -> Optional[Literal]:
         return expression
 
 
 class DefaultColumnMapper(ColumnMapper):
     def attempt_map(
-        self, expression: Column, children_translator: SnubaClickhouseStrictTranslator,
+        self,
+        expression: Column,
+        children_translator: SnubaClickhouseStrictTranslator,
     ) -> Optional[Column]:
         return expression
 
@@ -96,7 +100,9 @@ class DefaultArgumentMapper(ArgumentMapper):
 
 class DefaultLambdaMapper(LambdaMapper):
     def attempt_map(
-        self, expression: Lambda, children_translator: SnubaClickhouseStrictTranslator,
+        self,
+        expression: Lambda,
+        children_translator: SnubaClickhouseStrictTranslator,
     ) -> Optional[Lambda]:
         return Lambda(
             alias=expression.alias,

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -229,7 +229,8 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         return self.__user, self.__password
 
     def get_query_connection(
-        self, client_settings: ClickhouseClientSettings,
+        self,
+        client_settings: ClickhouseClientSettings,
     ) -> ClickhousePool:
         """
         Get a connection to the query node
@@ -237,7 +238,9 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         return self.get_node_connection(client_settings, self.__query_node)
 
     def get_node_connection(
-        self, client_settings: ClickhouseClientSettings, node: ClickhouseNode,
+        self,
+        client_settings: ClickhouseClientSettings,
+        node: ClickhouseNode,
     ) -> ClickhousePool:
         """
         Get a Clickhouse connection using the client settings provided. Reuse any
@@ -246,7 +249,11 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         """
 
         return self.__connection_cache.get_node_connection(
-            client_settings, node, self.__user, self.__password, self.__database,
+            client_settings,
+            node,
+            self.__user,
+            self.__password,
+            self.__database,
         )
 
     def get_reader(self) -> Reader:

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -333,7 +333,8 @@ def build_batch_writer(
     supports_replacements = replacements_producer is not None
 
     writer = table_writer.get_batch_writer(
-        metrics, {"load_balancing": "in_order", "insert_distributed_sync": 1},
+        metrics,
+        {"load_balancing": "in_order", "insert_distributed_sync": 1},
     )
 
     def build_writer() -> ProcessedMessageBatchWriter:
@@ -484,7 +485,8 @@ class MultistorageCollector(
     def __init__(
         self,
         steps: Mapping[
-            StorageKey, ProcessingStep[Union[None, BytesInsertBatch, ReplacementBatch]],
+            StorageKey,
+            ProcessingStep[Union[None, BytesInsertBatch, ReplacementBatch]],
         ],
         dead_letter_step: Optional[
             ProcessingStep[
@@ -700,7 +702,9 @@ def process_message_multistorage_identical_storages(
 
         if result is None:
             result = _process_message_multistorage_work(
-                metadata=metadata, storage_key=storage_key, storage_message=value,
+                metadata=metadata,
+                storage_key=storage_key,
+                storage_message=value,
             )
 
         intermediate_results[storage_key] = result
@@ -753,10 +757,13 @@ def build_multistorage_batch_writer(
     return ProcessedMessageBatchWriter(
         InsertBatchWriter(
             storage.get_table_writer().get_batch_writer(
-                metrics, {"load_balancing": "in_order", "insert_distributed_sync": 1},
+                metrics,
+                {"load_balancing": "in_order", "insert_distributed_sync": 1},
             ),
             MetricsWrapper(
-                metrics, "insertions", {"storage": storage.get_storage_key().value},
+                metrics,
+                "insertions",
+                {"storage": storage.get_storage_key().value},
             ),
         ),
         replacement_batch_writer,
@@ -772,7 +779,9 @@ def build_collector(
     dead_letter_step: Optional[DeadLetterStep] = None
     if producer and topic:
         dead_letter_step = DeadLetterStep(
-            producer=producer, topic=topic, metrics=metrics,
+            producer=producer,
+            topic=topic,
+            metrics=metrics,
         )
     return MultistorageCollector(
         {

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -204,7 +204,8 @@ class ConsumerBuilder:
 
         if self.commit_log_topic is None:
             consumer = KafkaConsumer(
-                configuration, commit_retry_policy=self.__commit_retry_policy,
+                configuration,
+                commit_retry_policy=self.__commit_retry_policy,
             )
         else:
             consumer = KafkaConsumerWithCommitLog(
@@ -271,7 +272,8 @@ class ConsumerBuilder:
 
         if self.__profile_path is not None:
             strategy_factory = ProcessingStrategyProfilerWrapperFactory(
-                strategy_factory, self.__profile_path,
+                strategy_factory,
+                self.__profile_path,
             )
 
         return strategy_factory

--- a/snuba/consumers/strict_consumer.py
+++ b/snuba/consumers/strict_consumer.py
@@ -77,7 +77,8 @@ class StrictConsumer:
         self.__consumer = self._create_consumer(consumer_config)
 
         def _on_partitions_assigned(
-            consumer: Consumer, partitions: Sequence[TopicPartition],
+            consumer: Consumer,
+            partitions: Sequence[TopicPartition],
         ) -> None:
             logger.info("New partitions assigned: %r", partitions)
             if self.__consuming:
@@ -91,7 +92,8 @@ class StrictConsumer:
                 self.__on_partitions_assigned(consumer, partitions)
 
         def _on_partitions_revoked(
-            consumer: Consumer, partitions: Sequence[TopicPartition],
+            consumer: Consumer,
+            partitions: Sequence[TopicPartition],
         ) -> None:
             logger.info("Partitions revoked: %r", partitions)
             if self.__on_partitions_revoked:
@@ -146,7 +148,9 @@ class StrictConsumer:
             if commit_decision == CommitDecision.COMMIT_THIS:
                 self.__consumer.commit(asynchronous=False)
             elif commit_decision == CommitDecision.COMMIT_PREV:
-                prev_watermark = watermarks.get((message.partition(), message.topic()),)
+                prev_watermark = watermarks.get(
+                    (message.partition(), message.topic()),
+                )
                 if prev_watermark is not None:
                     commit_pos = TopicPartition(
                         partition=message.partition(),

--- a/snuba/consumers/types.py
+++ b/snuba/consumers/types.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 from typing import NamedTuple
 
 

--- a/snuba/datasets/cdc/__init__.py
+++ b/snuba/datasets/cdc/__init__.py
@@ -1,4 +1,5 @@
 from typing import Any
+
 from snuba.datasets.storage import WritableTableStorage
 from snuba.snapshots.loaders.single_table import RowProcessor
 

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -51,12 +51,18 @@ class CdcMessageRow(ABC):
 
     @classmethod
     def from_wal(
-        cls, offset: int, columnnames: Sequence[str], columnvalues: Sequence[Any],
+        cls,
+        offset: int,
+        columnnames: Sequence[str],
+        columnvalues: Sequence[Any],
     ) -> CdcMessageRow:
         raise NotImplementedError
 
     @classmethod
-    def from_bulk(cls, row: Mapping[str, Any],) -> CdcMessageRow:
+    def from_bulk(
+        cls,
+        row: Mapping[str, Any],
+    ) -> CdcMessageRow:
         raise NotImplementedError
 
     @abstractmethod
@@ -76,7 +82,10 @@ class CdcProcessor(MessageProcessor):
         return []
 
     def _process_insert(
-        self, offset: int, columnnames: Sequence[str], columnvalues: Sequence[Any],
+        self,
+        offset: int,
+        columnnames: Sequence[str],
+        columnvalues: Sequence[Any],
     ) -> Sequence[WriterTableRow]:
         return [
             self._message_row_class.from_wal(
@@ -106,7 +115,9 @@ class CdcProcessor(MessageProcessor):
         return ret
 
     def _process_delete(
-        self, offset: int, key: Mapping[str, Any],
+        self,
+        offset: int,
+        key: Mapping[str, Any],
     ) -> Sequence[WriterTableRow]:
         return []
 

--- a/snuba/datasets/cdc/groupassignee_processor.py
+++ b/snuba/datasets/cdc/groupassignee_processor.py
@@ -5,10 +5,10 @@ from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence, Union
 
 from snuba.datasets.cdc.cdcprocessors import (
-    CdcProcessor,
     CdcMessageRow,
-    postgres_date_to_clickhouse,
+    CdcProcessor,
     parse_postgres_datetime,
+    postgres_date_to_clickhouse,
 )
 from snuba.writer import WriterTableRow
 

--- a/snuba/datasets/cdc/groupassignee_processor.py
+++ b/snuba/datasets/cdc/groupassignee_processor.py
@@ -30,7 +30,10 @@ class GroupAssigneeRow(CdcMessageRow):
 
     @classmethod
     def from_wal(
-        cls, offset: int, columnnames: Sequence[str], columnvalues: Sequence[Any],
+        cls,
+        offset: int,
+        columnnames: Sequence[str],
+        columnvalues: Sequence[Any],
     ) -> GroupAssigneeRow:
         raw_data = dict(zip(columnnames, columnvalues))
         return cls(
@@ -50,7 +53,10 @@ class GroupAssigneeRow(CdcMessageRow):
         )
 
     @classmethod
-    def from_bulk(cls, row: Mapping[str, Any],) -> GroupAssigneeRow:
+    def from_bulk(
+        cls,
+        row: Mapping[str, Any],
+    ) -> GroupAssigneeRow:
         return cls(
             offset=0,
             record_deleted=False,
@@ -79,11 +85,14 @@ class GroupAssigneeRow(CdcMessageRow):
 class GroupAssigneeProcessor(CdcProcessor):
     def __init__(self, postgres_table: str) -> None:
         super().__init__(
-            pg_table=postgres_table, message_row_class=GroupAssigneeRow,
+            pg_table=postgres_table,
+            message_row_class=GroupAssigneeRow,
         )
 
     def _process_delete(
-        self, offset: int, key: Mapping[str, Any],
+        self,
+        offset: int,
+        key: Mapping[str, Any],
     ) -> Sequence[WriterTableRow]:
         key_names = key["keynames"]
         key_values = key["keyvalues"]

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -48,7 +48,10 @@ class GroupedMessageRow(CdcMessageRow):
 
     @classmethod
     def from_wal(
-        cls, offset: int, columnnames: Sequence[str], columnvalues: Sequence[Any],
+        cls,
+        offset: int,
+        columnnames: Sequence[str],
+        columnvalues: Sequence[Any],
     ) -> GroupedMessageRow:
         raw_data = dict(zip(columnnames, columnvalues))
         return cls(
@@ -70,7 +73,10 @@ class GroupedMessageRow(CdcMessageRow):
         )
 
     @classmethod
-    def from_bulk(cls, row: Mapping[str, Any],) -> GroupedMessageRow:
+    def from_bulk(
+        cls,
+        row: Mapping[str, Any],
+    ) -> GroupedMessageRow:
         return cls(
             offset=None,
             project_id=int(row["project_id"]),
@@ -109,11 +115,14 @@ class GroupedMessageRow(CdcMessageRow):
 class GroupedMessageProcessor(CdcProcessor):
     def __init__(self, postgres_table: str):
         super(GroupedMessageProcessor, self).__init__(
-            pg_table=postgres_table, message_row_class=GroupedMessageRow,
+            pg_table=postgres_table,
+            message_row_class=GroupedMessageRow,
         )
 
     def _process_delete(
-        self, offset: int, key: Mapping[str, Any],
+        self,
+        offset: int,
+        key: Mapping[str, Any],
     ) -> Sequence[WriterTableRow]:
         key_names = key["keynames"]
         key_values = key["keyvalues"]

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Mapping, Optional, Sequence, Union
 
-from dataclasses import dataclass
 from snuba.datasets.cdc.cdcprocessors import (
-    CdcProcessor,
     CdcMessageRow,
-    postgres_date_to_clickhouse,
+    CdcProcessor,
     parse_postgres_datetime,
+    postgres_date_to_clickhouse,
 )
 from snuba.writer import WriterTableRow
 

--- a/snuba/datasets/cdc/types.py
+++ b/snuba/datasets/cdc/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Sequence, Union, TypedDict
+from typing import Any, Literal, Sequence, TypedDict, Union
 
 
 class BeginEvent(TypedDict):

--- a/snuba/datasets/cdc/types.py
+++ b/snuba/datasets/cdc/types.py
@@ -45,5 +45,9 @@ class CommitEvent(TypedDict):
 
 
 Event = Union[
-    BeginEvent, InsertEvent, UpdateEvent, DeleteEvent, CommitEvent,
+    BeginEvent,
+    InsertEvent,
+    UpdateEvent,
+    DeleteEvent,
+    CommitEvent,
 ]

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -63,7 +63,9 @@ EVENT_FUNCTIONS = FunctionCallMatch(
 
 
 def match_query_to_entity(
-    query: Query, events_only_columns: ColumnSet, transactions_only_columns: ColumnSet,
+    query: Query,
+    events_only_columns: ColumnSet,
+    transactions_only_columns: ColumnSet,
 ) -> EntityKey:
     # First check for a top level condition on the event type
     condition = query.get_condition()

--- a/snuba/datasets/entities/clickhouse_upgrade.py
+++ b/snuba/datasets/entities/clickhouse_upgrade.py
@@ -70,7 +70,10 @@ class RolloutSelector:
         self.__config_prefix = config_prefix
 
     def __is_query_rolled_out(
-        self, referrer: str, config_referrer_prefix: str, general_rollout_config: str,
+        self,
+        referrer: str,
+        config_referrer_prefix: str,
+        general_rollout_config: str,
     ) -> bool:
         rollout_percentage = get_config(
             f"rollout_upgraded_{self.__config_prefix}_{config_referrer_prefix}_{referrer}",
@@ -83,11 +86,15 @@ class RolloutSelector:
 
     def choose(self, referrer: str) -> Choice:
         trust_secondary = self.__is_query_rolled_out(
-            referrer, "trust", f"rollout_upgraded_{self.__config_prefix}_trust",
+            referrer,
+            "trust",
+            f"rollout_upgraded_{self.__config_prefix}_trust",
         )
 
         execute_both = self.__is_query_rolled_out(
-            referrer, "execute", f"rollout_upgraded_{self.__config_prefix}_execute",
+            referrer,
+            "execute",
+            f"rollout_upgraded_{self.__config_prefix}_execute",
         )
 
         primary = (
@@ -172,12 +179,18 @@ def comparison_callback(
     if score >= 0.99:
         # This is just a sanity check to ensure the algorithm makes sense
         if random() < cast(float, get_config("upgrade_log_perfect_match", 0.0)):
-            log("Pipeline delegator perfect match",)
+            log(
+                "Pipeline delegator perfect match",
+            )
     elif score >= 0.75:
         if random() < cast(float, get_config("upgrade_log_avg_match", 0.0)):
-            log("Pipeline delegator average match",)
+            log(
+                "Pipeline delegator average match",
+            )
     elif random() < cast(float, get_config("upgrade_log_low_similarity", 0.0)):
-        log("Pipeline delegator low similarity",)
+        log(
+            "Pipeline delegator low similarity",
+        )
 
 
 def calculate_score(

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -72,7 +72,9 @@ class DefaultNoneColumnMapper(ColumnMapper):
     columns: ColumnSet
 
     def attempt_map(
-        self, expression: Column, children_translator: SnubaClickhouseStrictTranslator,
+        self,
+        expression: Column,
+        children_translator: SnubaClickhouseStrictTranslator,
     ) -> Optional[FunctionCall]:
         if expression.column_name in self.columns:
             return identity(

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -66,10 +66,14 @@ errors_translators = TranslationMappers(
             "coalesce",
             (
                 FunctionCall(
-                    None, "IPv4NumToString", (Column(None, None, "ip_address_v4"),),
+                    None,
+                    "IPv4NumToString",
+                    (Column(None, None, "ip_address_v4"),),
                 ),
                 FunctionCall(
-                    None, "IPv6NumToString", (Column(None, None, "ip_address_v6"),),
+                    None,
+                    "IPv6NumToString",
+                    (Column(None, None, "ip_address_v6"),),
                 ),
             ),
         ),

--- a/snuba/datasets/entities/profiles.py
+++ b/snuba/datasets/entities/profiles.py
@@ -48,7 +48,9 @@ profile_columns = EntityColumnSet(
 
 
 class ProfilesEntity(Entity, ABC):
-    def __init__(self,) -> None:
+    def __init__(
+        self,
+    ) -> None:
         writable_storage = get_writable_storage(StorageKey.PROFILES)
 
         super().__init__(

--- a/snuba/datasets/entities/sessions.py
+++ b/snuba/datasets/entities/sessions.py
@@ -49,7 +49,10 @@ metrics = MetricsWrapper(environment.metrics, "api.sessions")
 
 def function_column(col_name: str, function_name: str) -> ColumnToFunction:
     return ColumnToFunction(
-        None, col_name, function_name, (Column(None, None, col_name),),
+        None,
+        col_name,
+        function_name,
+        (Column(None, None, col_name),),
     )
 
 
@@ -158,7 +161,10 @@ sessions_raw_translators = TranslationMappers(
         ),
         ColumnToFunction(None, "duration_avg", "avgIf", (duration, duration_condition)),
         ColumnToFunction(
-            None, "sessions", "sumIf", (quantity, eq(seq, Literal(None, 0))),
+            None,
+            "sessions",
+            "sumIf",
+            (quantity, eq(seq, Literal(None, 0))),
         ),
         ColumnToFunction(
             None, "sessions_crashed", "sumIf", (quantity, eq(status, Literal(None, 2)))

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -58,10 +58,14 @@ transaction_translator = TranslationMappers(
             "coalesce",
             (
                 FunctionCall(
-                    None, "IPv4NumToString", (Column(None, None, "ip_address_v4"),),
+                    None,
+                    "IPv4NumToString",
+                    (Column(None, None, "ip_address_v4"),),
                 ),
                 FunctionCall(
-                    None, "IPv6NumToString", (Column(None, None, "ip_address_v6"),),
+                    None,
+                    "IPv6NumToString",
+                    (Column(None, None, "ip_address_v6"),),
                 ),
             ),
         ),
@@ -170,7 +174,8 @@ class BaseTransactionsEntity(Entity, ABC):
 
         v2_pipeline_builder = SimplePipelineBuilder(
             query_plan_builder=SingleStorageQueryPlanBuilder(
-                storage=get_storage(StorageKey.TRANSACTIONS_V2), mappers=mappers,
+                storage=get_storage(StorageKey.TRANSACTIONS_V2),
+                mappers=mappers,
             )
         )
 

--- a/snuba/datasets/errors_processor.py
+++ b/snuba/datasets/errors_processor.py
@@ -17,7 +17,9 @@ class ErrorsProcessor(EventsProcessorBase):
         self._promoted_tag_columns = promoted_tag_columns
 
     def extract_promoted_tags(
-        self, output: MutableMapping[str, Any], tags: Mapping[str, Any],
+        self,
+        output: MutableMapping[str, Any],
+        tags: Mapping[str, Any],
     ) -> None:
         output.update(
             {
@@ -30,7 +32,9 @@ class ErrorsProcessor(EventsProcessorBase):
         return event["data"].get("type") != "transaction"
 
     def _extract_event_id(
-        self, output: MutableMapping[str, Any], event: InsertEvent,
+        self,
+        output: MutableMapping[str, Any],
+        event: InsertEvent,
     ) -> None:
         output["event_id"] = str(uuid.UUID(event["event_id"]))
 

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -368,7 +368,8 @@ class ProjectsQueryFlags:
         ]
 
         ProjectsQueryFlags._remove_stale_and_load_new_sorted_set_data(
-            p, [groups_key for groups_key, _ in exclude_groups_keys_and_types],
+            p,
+            [groups_key for groups_key, _ in exclude_groups_keys_and_types],
         )
 
         for _, needs_final_type_key in needs_final_keys_and_type_keys:
@@ -381,7 +382,10 @@ class ProjectsQueryFlags:
         # retrieve the latest timestamp for any exclude groups replacement
         for exclude_groups_key, _ in exclude_groups_keys_and_types:
             p.zrevrange(
-                exclude_groups_key, 0, 0, withscores=True,
+                exclude_groups_key,
+                0,
+                0,
+                withscores=True,
             )
 
     @staticmethod
@@ -732,7 +736,12 @@ def process_replace_group(
     query_time_flags = (None, project_id)
 
     return _build_group_replacement(
-        message, project_id, full_where, query_args, query_time_flags, all_columns,
+        message,
+        project_id,
+        full_where,
+        query_args,
+        query_time_flags,
+        all_columns,
     )
 
 
@@ -902,7 +911,12 @@ def process_merge(
     query_time_flags = (EXCLUDE_GROUPS, project_id, previous_group_ids)
 
     return _build_group_replacement(
-        message, project_id, where, query_args, query_time_flags, all_columns,
+        message,
+        project_id,
+        where,
+        query_args,
+        query_time_flags,
+        all_columns,
     )
 
 

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -1,19 +1,13 @@
+import logging
 from typing import Any, Mapping, MutableMapping
 
-import logging
 import _strptime  # NOQA fixes _strptime deferred import issue
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.events_format import extract_http, extract_user
 from snuba.datasets.events_processor_base import EventsProcessorBase, InsertEvent
-from snuba.processor import (
-    _boolify,
-    _floatify,
-    _hashify,
-    _unicodify,
-)
-
+from snuba.processor import _boolify, _floatify, _hashify, _unicodify
 
 logger = logging.getLogger("snuba.processor")
 

--- a/snuba/datasets/events_processor.py
+++ b/snuba/datasets/events_processor.py
@@ -17,7 +17,9 @@ class EventsProcessor(EventsProcessorBase):
         self._promoted_tag_columns = promoted_tag_columns
 
     def extract_promoted_tags(
-        self, output: MutableMapping[str, Any], tags: Mapping[str, Any],
+        self,
+        output: MutableMapping[str, Any],
+        tags: Mapping[str, Any],
     ) -> None:
         output.update(
             {
@@ -30,7 +32,9 @@ class EventsProcessor(EventsProcessorBase):
         return True
 
     def _extract_event_id(
-        self, output: MutableMapping[str, Any], event: InsertEvent,
+        self,
+        output: MutableMapping[str, Any],
+        event: InsertEvent,
     ) -> None:
         output["event_id"] = event["event_id"]
 

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -87,7 +87,9 @@ class EventsProcessorBase(MessageProcessor, ABC):
 
     @abstractmethod
     def _extract_event_id(
-        self, output: MutableMapping[str, Any], event: InsertEvent,
+        self,
+        output: MutableMapping[str, Any],
+        event: InsertEvent,
     ) -> None:
         raise NotImplementedError
 
@@ -102,7 +104,9 @@ class EventsProcessorBase(MessageProcessor, ABC):
 
     @abstractmethod
     def extract_promoted_tags(
-        self, output: MutableMapping[str, Any], tags: Mapping[str, Any],
+        self,
+        output: MutableMapping[str, Any],
+        tags: Mapping[str, Any],
     ) -> None:
         raise NotImplementedError
 
@@ -126,7 +130,9 @@ class EventsProcessorBase(MessageProcessor, ABC):
         raise NotImplementedError
 
     def extract_required(
-        self, output: MutableMapping[str, Any], event: InsertEvent,
+        self,
+        output: MutableMapping[str, Any],
+        event: InsertEvent,
     ) -> None:
         output["group_id"] = event["group_id"] or 0
 

--- a/snuba/datasets/metrics_aggregate_processor.py
+++ b/snuba/datasets/metrics_aggregate_processor.py
@@ -118,7 +118,8 @@ class SetsAggregateProcessor(MetricsAggregateProcessor):
 
         return {
             "value": _call(
-                "arrayReduce", (_literal("uniqState"), _array_literal(values)),
+                "arrayReduce",
+                (_literal("uniqState"), _array_literal(values)),
             )
         }
 
@@ -139,7 +140,11 @@ class CounterAggregateProcessor(MetricsAggregateProcessor):
 
         return {
             "value": _call(
-                "arrayReduce", (_literal("sumState"), _array_literal([value]),),
+                "arrayReduce",
+                (
+                    _literal("sumState"),
+                    _array_literal([value]),
+                ),
             ),
         }
 
@@ -169,19 +174,32 @@ class DistributionsAggregateProcessor(MetricsAggregateProcessor):
                 ),
             ),
             "min": _call(
-                "arrayReduce", (_literal("minState"), _array_literal([min(values)])),
+                "arrayReduce",
+                (_literal("minState"), _array_literal([min(values)])),
             ),
             "max": _call(
-                "arrayReduce", (_literal("maxState"), _array_literal([max(values)])),
+                "arrayReduce",
+                (_literal("maxState"), _array_literal([max(values)])),
             ),
             "avg": _call(
-                "arrayReduce", (_literal("avgState"), _array_literal(values),),
+                "arrayReduce",
+                (
+                    _literal("avgState"),
+                    _array_literal(values),
+                ),
             ),
             "sum": _call(
-                "arrayReduce", (_literal("sumState"), _array_literal([sum(values)]),),
+                "arrayReduce",
+                (
+                    _literal("sumState"),
+                    _array_literal([sum(values)]),
+                ),
             ),
             "count": _call(
                 "arrayReduce",
-                (_literal("countState"), _array_literal([float(len(values))]),),
+                (
+                    _literal("countState"),
+                    _array_literal([float(len(values))]),
+                ),
             ),
         }

--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -158,7 +158,10 @@ class QueryPlanExecutionStrategy(ABC, Generic[TQuery]):
 
     @abstractmethod
     def execute(
-        self, query: TQuery, request_settings: RequestSettings, runner: QueryRunner,
+        self,
+        query: TQuery,
+        request_settings: RequestSettings,
+        runner: QueryRunner,
     ) -> QueryResult:
         """
         Executes the Query passed in as parameter.

--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -45,7 +45,10 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy[Query]):
 
     @with_span()
     def execute(
-        self, query: Query, request_settings: RequestSettings, runner: QueryRunner,
+        self,
+        query: Query,
+        request_settings: RequestSettings,
+        runner: QueryRunner,
     ) -> QueryResult:
         def process_and_run_query(
             query: Query, request_settings: RequestSettings

--- a/snuba/datasets/plans/split_strategy.py
+++ b/snuba/datasets/plans/split_strategy.py
@@ -29,7 +29,10 @@ class QuerySplitStrategy(ABC):
 
     @abstractmethod
     def execute(
-        self, query: Query, request_settings: RequestSettings, runner: SplitQueryRunner,
+        self,
+        query: Query,
+        request_settings: RequestSettings,
+        runner: SplitQueryRunner,
     ) -> Optional[QueryResult]:
         """
         Executes and/or splits the query provided, like the equivalent method in

--- a/snuba/datasets/plans/translator/mapper.py
+++ b/snuba/datasets/plans/translator/mapper.py
@@ -8,7 +8,8 @@ TTranslator = TypeVar("TTranslator")
 
 
 class ExpressionMapper(
-    ABC, Generic[TExpIn, TExpOut, TTranslator],
+    ABC,
+    Generic[TExpIn, TExpOut, TTranslator],
 ):
     """
     One translation rule used by the a mapping expression translator to
@@ -24,7 +25,9 @@ class ExpressionMapper(
 
     @abstractmethod
     def attempt_map(
-        self, expression: TExpIn, children_translator: TTranslator,
+        self,
+        expression: TExpIn,
+        children_translator: TTranslator,
     ) -> Optional[TExpOut]:
         """
         Maps an expression if this rule matches such expression. If not, it returns None.

--- a/snuba/datasets/schemas/__init__.py
+++ b/snuba/datasets/schemas/__init__.py
@@ -76,10 +76,10 @@ class Schema(ABC):
 
             expected_type = expected_columns[column.flattened]
 
-            if column.type.get_raw() != expected_type.get_raw() or column.type.has_modifier(
-                Nullable
-            ) != expected_type.has_modifier(
-                Nullable
+            if (
+                column.type.get_raw() != expected_type.get_raw()
+                or column.type.has_modifier(Nullable)
+                != expected_type.has_modifier(Nullable)
             ):
                 errors.append(
                     "Column '%s' type differs between local ClickHouse and schema! (expected: %s, is: %s)"

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -141,7 +141,9 @@ promoted_context_columns = {"trace.trace_id": "trace_id", "trace.span_id": "span
 
 mandatory_conditions = [
     binary_condition(
-        ConditionFunctions.EQ, Column(None, None, "deleted"), Literal(None, 0),
+        ConditionFunctions.EQ,
+        Column(None, None, "deleted"),
+        Literal(None, 0),
     ),
 ]
 
@@ -159,7 +161,8 @@ prewhere_candidates = [
 query_processors = [
     UniqInSelectAndHavingProcessor(),
     PostReplacementConsistencyEnforcer(
-        project_column="project_id", replacer_state_name=ReplacerState.ERRORS,
+        project_column="project_id",
+        replacer_state_name=ReplacerState.ERRORS,
     ),
     MappingColumnPromoter(
         mapping_specs={
@@ -191,7 +194,9 @@ query_processors = [
 
 query_splitters = [
     ColumnSplitQueryStrategy(
-        id_column="event_id", project_column="project_id", timestamp_column="timestamp",
+        id_column="event_id",
+        project_column="project_id",
+        timestamp_column="timestamp",
     ),
     TimeSplitQueryStrategy(timestamp_col="timestamp"),
 ]

--- a/snuba/datasets/storages/errors_ro.py
+++ b/snuba/datasets/storages/errors_ro.py
@@ -1,15 +1,13 @@
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages import StorageKey
-
 from snuba.datasets.storages.errors_common import (
     all_columns,
     mandatory_conditions,
     query_processors,
     query_splitters,
 )
-
 
 schema = TableSchema(
     columns=all_columns,

--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -56,7 +56,8 @@ from snuba.utils.streams.topics import Topic
 query_processors = [
     UniqInSelectAndHavingProcessor(),
     PostReplacementConsistencyEnforcer(
-        project_column="project_id", replacer_state_name=ReplacerState.ERRORS_V2,
+        project_column="project_id",
+        replacer_state_name=ReplacerState.ERRORS_V2,
     ),
     MappingColumnPromoter(
         mapping_specs={

--- a/snuba/datasets/storages/events_bool_contexts.py
+++ b/snuba/datasets/storages/events_bool_contexts.py
@@ -84,7 +84,10 @@ class EventsBooleanContextsProcessor(QueryProcessor):
         matcher = FunctionCall(
             String("arrayElement"),
             (
-                Column(None, String("contexts.value"),),
+                Column(
+                    None,
+                    String("contexts.value"),
+                ),
                 FunctionCall(
                     String("indexOf"),
                     (

--- a/snuba/datasets/storages/outcomes.py
+++ b/snuba/datasets/storages/outcomes.py
@@ -88,7 +88,8 @@ raw_storage = WritableTableStorage(
     query_processors=[TableRateLimit()],
     mandatory_condition_checkers=[OrgIdEnforcer()],
     stream_loader=build_kafka_stream_loader_from_settings(
-        processor=OutcomesProcessor(), default_topic=Topic.OUTCOMES,
+        processor=OutcomesProcessor(),
+        default_topic=Topic.OUTCOMES,
     ),
 )
 

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -70,14 +70,16 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         if flags.needs_final:
             tags["cause"] = "final_flag"
             metrics.increment(
-                name=FINAL_METRIC, tags=tags,
+                name=FINAL_METRIC,
+                tags=tags,
             )
             set_final = True
         elif flags.group_ids_to_exclude:
             # If the number of groups to exclude exceeds our limit, the query
             # should just use final instead of the exclusion set.
             max_group_ids_exclude = get_config(
-                "max_group_ids_exclude", settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE,
+                "max_group_ids_exclude",
+                settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE,
             )
             assert isinstance(max_group_ids_exclude, int)
             groups_to_exclude = self._groups_to_exclude(
@@ -86,7 +88,8 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
             if len(groups_to_exclude) > max_group_ids_exclude:
                 tags["cause"] = "max_groups"
                 metrics.increment(
-                    name=FINAL_METRIC, tags=tags,
+                    name=FINAL_METRIC,
+                    tags=tags,
                 )
                 set_final = True
             elif groups_to_exclude:
@@ -126,7 +129,9 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
         query.set_from_clause(replace(query.get_from_clause(), final=final))
 
     def _query_overlaps_replacements(
-        self, query: Query, latest_replacement_time: Optional[datetime],
+        self,
+        query: Query,
+        latest_replacement_time: Optional[datetime],
     ) -> bool:
         """
         Given a Query and the latest replacement time for any project

--- a/snuba/datasets/storages/profiles.py
+++ b/snuba/datasets/storages/profiles.py
@@ -24,7 +24,8 @@ processors = [
 ]
 
 loader = build_kafka_stream_loader_from_settings(
-    processor=ProfilesMessageProcessor(), default_topic=Topic.PROFILES,
+    processor=ProfilesMessageProcessor(),
+    default_topic=Topic.PROFILES,
 )
 
 readable_columns = ColumnSet(

--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -70,6 +70,7 @@ storage = WritableTableStorage(
     schema=schema,
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
-        processor=QuerylogProcessor(), default_topic=Topic.QUERYLOG,
+        processor=QuerylogProcessor(),
+        default_topic=Topic.QUERYLOG,
     ),
 )

--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -70,8 +70,14 @@ columns = ColumnSet(
         ("tags", Nested([("key", String()), ("value", String())])),
         ("_tags_hash_map", Array(UInt(64), Modifiers(readonly=True))),
         ("contexts", Nested([("key", String()), ("value", String())])),
-        ("measurements", Nested([("key", String()), ("value", Float(64))]),),
-        ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))]),),
+        (
+            "measurements",
+            Nested([("key", String()), ("value", Float(64))]),
+        ),
+        (
+            "span_op_breakdowns",
+            Nested([("key", String()), ("value", Float(64))]),
+        ),
         (
             "spans",
             Nested(

--- a/snuba/datasets/storages/type_condition_optimizer.py
+++ b/snuba/datasets/storages/type_condition_optimizer.py
@@ -1,15 +1,8 @@
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
-
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralExpr
-from snuba.query.matchers import (
-    Column,
-    FunctionCall,
-    Literal,
-    String,
-)
-
+from snuba.query.matchers import Column, FunctionCall, Literal, String
 from snuba.request.request_settings import RequestSettings
 
 

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -312,7 +312,8 @@ class TableWriter:
         return self.__replacer_processor
 
     def __update_writer_options(
-        self, options: ClickhouseWriterOptions = None,
+        self,
+        options: ClickhouseWriterOptions = None,
     ) -> Mapping[str, Any]:
         if options is None:
             options = {}

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -133,14 +133,17 @@ class TransactionsMessageProcessor(MessageProcessor):
         return processed
 
     def _process_tags(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
 
         tags: Mapping[str, Any] = _as_dict_safe(event_dict["data"].get("tags", None))
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
         promoted_tags = {col: tags[col] for col in self.PROMOTED_TAGS if col in tags}
         processed["release"] = promoted_tags.get(
-            "sentry:release", event_dict.get("release"),
+            "sentry:release",
+            event_dict.get("release"),
         )
         processed["environment"] = promoted_tags.get("environment")
         processed["user"] = promoted_tags.get("sentry:user", "")
@@ -149,7 +152,9 @@ class TransactionsMessageProcessor(MessageProcessor):
         )
 
     def _process_measurements(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
         measurements = event_dict["data"].get("measurements")
         if measurements is not None:
@@ -176,7 +181,9 @@ class TransactionsMessageProcessor(MessageProcessor):
                 )
 
     def _process_breakdown(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
         breakdowns = event_dict["data"].get("breakdowns")
         if breakdowns is not None:
@@ -205,7 +212,9 @@ class TransactionsMessageProcessor(MessageProcessor):
                     )
 
     def _process_contexts_and_user(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
         contexts: MutableMapping[str, Any] = _as_dict_safe(
             event_dict["data"].get("contexts", None)
@@ -246,7 +255,9 @@ class TransactionsMessageProcessor(MessageProcessor):
                 processed["ip_address_v6"] = str(ip_address)
 
     def _process_request_data(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
         request = (
             event_dict["data"].get(
@@ -260,7 +271,9 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["http_referer"] = http_data["http_referer"]
 
     def _process_sdk_data(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
         sdk = event_dict["data"].get("sdk", None) or {}
         processed["sdk_name"] = _unicodify(sdk.get("name") or "")
@@ -282,7 +295,9 @@ class TransactionsMessageProcessor(MessageProcessor):
         return op, int(group, 16), exclusive_time
 
     def _process_spans(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> None:
         data = event_dict["data"]
         trace_context = data["contexts"]["trace"]
@@ -328,7 +343,9 @@ class TransactionsMessageProcessor(MessageProcessor):
             processed["spans.exclusive_time_32"].append(exclusive_time)
 
     def _sanitize_contexts(
-        self, processed: MutableMapping[str, Any], event_dict: EventDict,
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
     ) -> MutableMapping[str, Any]:
         """
         Contexts can store a lot of data. We don't want to store all the data in

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -19,7 +19,8 @@ def setup_logging(level: Optional[str] = None) -> None:
         level = settings.LOG_LEVEL
 
     logging.basicConfig(
-        level=getattr(logging, level.upper()), format=settings.LOG_FORMAT,
+        level=getattr(logging, level.upper()),
+        format=settings.LOG_FORMAT,
     )
 
 
@@ -42,5 +43,7 @@ def setup_sentry() -> None:
 
 
 metrics = create_metrics(
-    "snuba", tags=None, sample_rates=settings.DOGSTATSD_SAMPLING_RATES,
+    "snuba",
+    tags=None,
+    sample_rates=settings.DOGSTATSD_SAMPLING_RATES,
 )

--- a/snuba/migrations/columns.py
+++ b/snuba/migrations/columns.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence, List
 from dataclasses import dataclass
-from snuba.clickhouse.columns import TypeModifier, TypeModifiers, Nullable
+from typing import List, Optional, Sequence
+
+from snuba.clickhouse.columns import Nullable, TypeModifier, TypeModifiers
 
 
 @dataclass(frozen=True)

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -92,7 +92,10 @@ class CreateMaterializedView(SqlOperation):
 
 class RenameTable(SqlOperation):
     def __init__(
-        self, storage_set: StorageSetKey, old_table_name: str, new_table_name: str,
+        self,
+        storage_set: StorageSetKey,
+        old_table_name: str,
+        new_table_name: str,
     ):
         super().__init__(storage_set)
         self.__old_table_name = old_table_name

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -205,7 +205,9 @@ class Runner:
         migration_id = migration_key.migration_id
 
         context = Context(
-            migration_id, logger, partial(self._update_migration_status, migration_key),
+            migration_id,
+            logger,
+            partial(self._update_migration_status, migration_key),
         )
         migration = get_group_loader(migration_key.group).load_migration(migration_id)
 
@@ -265,7 +267,9 @@ class Runner:
         migration_id = migration_key.migration_id
 
         context = Context(
-            migration_id, logger, partial(self._update_migration_status, migration_key),
+            migration_id,
+            logger,
+            partial(self._update_migration_status, migration_key),
         )
         migration = get_group_loader(migration_key.group).load_migration(migration_id)
 

--- a/snuba/migrations/snuba_migrations/discover/0001_discover_merge_table.py
+++ b/snuba/migrations/snuba_migrations/discover/0001_discover_merge_table.py
@@ -1,6 +1,7 @@
 from typing import List, Sequence
 
 from snuba.clickhouse.columns import (
+    UUID,
     Column,
     DateTime,
     IPv4,
@@ -8,7 +9,6 @@ from snuba.clickhouse.columns import (
     Nested,
     String,
     UInt,
-    UUID,
 )
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations, table_engines

--- a/snuba/migrations/snuba_migrations/discover/0001_discover_merge_table.py
+++ b/snuba/migrations/snuba_migrations/discover/0001_discover_merge_table.py
@@ -60,7 +60,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.DISCOVER, table_name="discover_local",
+                storage_set=StorageSetKey.DISCOVER,
+                table_name="discover_local",
             )
         ]
 
@@ -71,7 +72,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="discover_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="discover_local", sharding_key=None,
+                    local_table_name="discover_local",
+                    sharding_key=None,
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/discover/0003_discover_fix_user_column.py
+++ b/snuba/migrations/snuba_migrations/discover/0003_discover_fix_user_column.py
@@ -21,7 +21,10 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.DISCOVER,
                 table_name=table_name,
-                column=Column("user", String(),),
+                column=Column(
+                    "user",
+                    String(),
+                ),
             )
         ]
 

--- a/snuba/migrations/snuba_migrations/discover/0006_discover_add_trace_id.py
+++ b/snuba/migrations/snuba_migrations/discover/0006_discover_add_trace_id.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, UUID
+from snuba.clickhouse.columns import UUID, Column
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/migrations/snuba_migrations/events/0003_errors.py
+++ b/snuba/migrations/snuba_migrations/events/0003_errors.py
@@ -125,7 +125,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="errors_local",
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_local",
             )
         ]
 
@@ -136,7 +137,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="errors_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="errors_local", sharding_key="event_hash",
+                    local_table_name="errors_local",
+                    sharding_key="event_hash",
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/events/0007_groupedmessages.py
+++ b/snuba/migrations/snuba_migrations/events/0007_groupedmessages.py
@@ -46,7 +46,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC, table_name="groupedmessage_local",
+                storage_set=StorageSetKey.CDC,
+                table_name="groupedmessage_local",
             )
         ]
 
@@ -57,7 +58,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="groupedmessage_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="groupedmessage_local", sharding_key=None,
+                    local_table_name="groupedmessage_local",
+                    sharding_key=None,
                 ),
             )
         ]
@@ -65,6 +67,7 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC, table_name="groupedmessage_dist",
+                storage_set=StorageSetKey.CDC,
+                table_name="groupedmessage_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/events/0008_groupassignees.py
+++ b/snuba/migrations/snuba_migrations/events/0008_groupassignees.py
@@ -39,7 +39,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC, table_name="groupassignee_local",
+                storage_set=StorageSetKey.CDC,
+                table_name="groupassignee_local",
             )
         ]
 
@@ -50,7 +51,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="groupassignee_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="groupassignee_local", sharding_key=None,
+                    local_table_name="groupassignee_local",
+                    sharding_key=None,
                 ),
             )
         ]
@@ -58,6 +60,7 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.CDC, table_name="groupassignee_dist",
+                storage_set=StorageSetKey.CDC,
+                table_name="groupassignee_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -47,7 +47,8 @@ def fix_order_by(_logger: logging.Logger) -> None:
 
     # There shouldn't be any data in the table yet
     assert (
-        clickhouse.execute(f"SELECT COUNT() FROM {TABLE_NAME} FINAL;").results[0][0] == 0
+        clickhouse.execute(f"SELECT COUNT() FROM {TABLE_NAME} FINAL;").results[0][0]
+        == 0
     ), f"{TABLE_NAME} is not empty"
 
     new_order_by = f"ORDER BY ({new_primary_key})"

--- a/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
+++ b/snuba/migrations/snuba_migrations/events/0010_groupedmessages_onpremise_compatibility.py
@@ -80,12 +80,14 @@ def ensure_drop_temporary_tables(_logger: logging.Logger) -> None:
     clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
     clickhouse.execute(
         operations.DropTable(
-            storage_set=StorageSetKey.CDC, table_name=TABLE_NAME_NEW,
+            storage_set=StorageSetKey.CDC,
+            table_name=TABLE_NAME_NEW,
         ).format_sql()
     )
     clickhouse.execute(
         operations.DropTable(
-            storage_set=StorageSetKey.CDC, table_name=TABLE_NAME_OLD,
+            storage_set=StorageSetKey.CDC,
+            table_name=TABLE_NAME_OLD,
         ).format_sql()
     )
 

--- a/snuba/migrations/snuba_migrations/events/0011_rebuild_errors.py
+++ b/snuba/migrations/snuba_migrations/events/0011_rebuild_errors.py
@@ -141,7 +141,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 after="tags",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="errors_local",
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_local",
             ),
             operations.RenameTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -164,7 +165,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="errors_dist_new",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="errors_local", sharding_key=sample_expr,
+                    local_table_name="errors_local",
+                    sharding_key=sample_expr,
                 ),
             ),
             operations.AddColumn(
@@ -177,7 +179,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 after="tags",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.EVENTS, table_name="errors_dist",
+                storage_set=StorageSetKey.EVENTS,
+                table_name="errors_dist",
             ),
             operations.RenameTable(
                 storage_set=StorageSetKey.EVENTS,
@@ -189,7 +192,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="errors_dist_ro",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="errors_local", sharding_key=sample_expr,
+                    local_table_name="errors_local",
+                    sharding_key=sample_expr,
                 ),
             ),
         ]

--- a/snuba/migrations/snuba_migrations/events/0013_errors_add_hierarchical_hashes.py
+++ b/snuba/migrations/snuba_migrations/events/0013_errors_add_hierarchical_hashes.py
@@ -18,13 +18,19 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
                 table_name="errors_local",
-                column=Column("hierarchical_hashes", Array(UUID()),),
+                column=Column(
+                    "hierarchical_hashes",
+                    Array(UUID()),
+                ),
                 after="primary_hash",
             ),
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
                 table_name="sentry_local",
-                column=Column("hierarchical_hashes", Array(FixedString(32)),),
+                column=Column(
+                    "hierarchical_hashes",
+                    Array(FixedString(32)),
+                ),
                 after="primary_hash",
             ),
         ]
@@ -50,7 +56,10 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.AddColumn(
                 storage_set=StorageSetKey.EVENTS,
                 table_name="sentry_dist",
-                column=Column("hierarchical_hashes", Array(FixedString(32)),),
+                column=Column(
+                    "hierarchical_hashes",
+                    Array(FixedString(32)),
+                ),
                 after="primary_hash",
             ),
         ]

--- a/snuba/migrations/snuba_migrations/events/0013_errors_add_hierarchical_hashes.py
+++ b/snuba/migrations/snuba_migrations/events/0013_errors_add_hierarchical_hashes.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, FixedString, Array, UUID
+from snuba.clickhouse.columns import UUID, Array, Column, FixedString
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 

--- a/snuba/migrations/snuba_migrations/metrics/0002_metrics_sets.py
+++ b/snuba/migrations/snuba_migrations/metrics/0002_metrics_sets.py
@@ -14,7 +14,9 @@ class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
-        return get_forward_migrations_local(**get_migration_args_for_sets(),)
+        return get_forward_migrations_local(
+            **get_migration_args_for_sets(),
+        )
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [

--- a/snuba/migrations/snuba_migrations/metrics/0020_polymorphic_buckets_table.py
+++ b/snuba/migrations/snuba_migrations/metrics/0020_polymorphic_buckets_table.py
@@ -22,7 +22,10 @@ class Migration(migration.ClickhouseNodeMigration):
         Column("project_id", UInt(64)),
         Column("metric_id", UInt(64)),
         Column("timestamp", DateTime()),
-        Column("tags", Nested([Column("key", UInt(64)), Column("value", UInt(64))]),),
+        Column(
+            "tags",
+            Nested([Column("key", UInt(64)), Column("value", UInt(64))]),
+        ),
         Column("metric_type", String(Modifiers(low_cardinality=True))),
         Column("set_values", Array(UInt(64))),
         Column("count_value", Float(64)),
@@ -62,7 +65,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=self.dist_table_name,
                 columns=self.column_list,
                 engine=table_engines.Distributed(
-                    local_table_name=self.local_table_name, sharding_key=None,
+                    local_table_name=self.local_table_name,
+                    sharding_key=None,
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/metrics/0022_repartition_polymorphic_table.py
+++ b/snuba/migrations/snuba_migrations/metrics/0022_repartition_polymorphic_table.py
@@ -23,7 +23,10 @@ class Migration(migration.ClickhouseNodeMigration):
         Column("project_id", UInt(64)),
         Column("metric_id", UInt(64)),
         Column("timestamp", DateTime()),
-        Column("tags", Nested([Column("key", UInt(64)), Column("value", UInt(64))]),),
+        Column(
+            "tags",
+            Nested([Column("key", UInt(64)), Column("value", UInt(64))]),
+        ),
         Column("metric_type", String(Modifiers(low_cardinality=True))),
         Column("set_values", Array(UInt(64))),
         Column("count_value", Float(64)),
@@ -63,7 +66,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=self.dist_table_name,
                 columns=self.column_list,
                 engine=table_engines.Distributed(
-                    local_table_name=self.local_table_name, sharding_key=None,
+                    local_table_name=self.local_table_name,
+                    sharding_key=None,
                 ),
             )
         ]

--- a/snuba/migrations/snuba_migrations/metrics/templates.py
+++ b/snuba/migrations/snuba_migrations/metrics/templates.py
@@ -54,7 +54,8 @@ COL_SCHEMA_DISTRIBUTIONS_V2: Sequence[Column[Modifiers]] = [
 
 
 def get_forward_bucket_table_local(
-    table_name: str, value_cols: Sequence[Column[Modifiers]],
+    table_name: str,
+    value_cols: Sequence[Column[Modifiers]],
 ) -> Sequence[operations.SqlOperation]:
     return [
         operations.CreateTable(
@@ -90,7 +91,8 @@ def get_forward_bucket_table_dist(
                 *POST_VALUES_BUCKETS_COLUMNS,
             ],
             engine=table_engines.Distributed(
-                local_table_name=local_table_name, sharding_key=None,
+                local_table_name=local_table_name,
+                sharding_key=None,
             ),
         ),
     ]
@@ -450,7 +452,10 @@ def get_forward_migrations_dist(
 
 def get_reverse_table_migration(table_name: str) -> Sequence[operations.SqlOperation]:
     return [
-        operations.DropTable(storage_set=StorageSetKey.METRICS, table_name=table_name,),
+        operations.DropTable(
+            storage_set=StorageSetKey.METRICS,
+            table_name=table_name,
+        ),
     ]
 
 

--- a/snuba/migrations/snuba_migrations/outcomes/0001_outcomes.py
+++ b/snuba/migrations/snuba_migrations/outcomes/0001_outcomes.py
@@ -90,10 +90,12 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="outcomes_mv_hourly_local",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.OUTCOMES, table_name="outcomes_hourly_local",
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_hourly_local",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.OUTCOMES, table_name="outcomes_raw_local",
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_raw_local",
             ),
         ]
 
@@ -104,7 +106,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="outcomes_raw_dist",
                 columns=raw_columns,
                 engine=table_engines.Distributed(
-                    local_table_name="outcomes_raw_local", sharding_key="org_id",
+                    local_table_name="outcomes_raw_local",
+                    sharding_key="org_id",
                 ),
             ),
             operations.CreateTable(
@@ -112,7 +115,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="outcomes_hourly_dist",
                 columns=hourly_columns,
                 engine=table_engines.Distributed(
-                    local_table_name="outcomes_hourly_local", sharding_key="org_id",
+                    local_table_name="outcomes_hourly_local",
+                    sharding_key="org_id",
                 ),
             ),
         ]
@@ -123,6 +127,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.OUTCOMES, table_name="outcomes_hourly_dist"
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.OUTCOMES, table_name="outcomes_raw_dist",
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_raw_dist",
             ),
         ]

--- a/snuba/migrations/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
+++ b/snuba/migrations/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
@@ -1,4 +1,5 @@
 from typing import Sequence
+
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 

--- a/snuba/migrations/snuba_migrations/outcomes/0004_outcomes_matview_additions.py
+++ b/snuba/migrations/snuba_migrations/outcomes/0004_outcomes_matview_additions.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, UInt, String, DateTime
+from snuba.clickhouse.columns import Column, DateTime, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/migrations/snuba_migrations/profiles/0001_profiles.py
@@ -62,7 +62,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.PROFILES, table_name="profiles_local",
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_local",
             )
         ]
 
@@ -82,6 +83,7 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.PROFILES, table_name="profiles_dist",
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/migrations/snuba_migrations/querylog/0001_querylog.py
@@ -72,7 +72,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.QUERYLOG, table_name="querylog_local",
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="querylog_local",
             )
         ]
 
@@ -83,7 +84,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="querylog_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="querylog_local", sharding_key=None,
+                    local_table_name="querylog_local",
+                    sharding_key=None,
                 ),
             )
         ]
@@ -91,6 +93,7 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.QUERYLOG, table_name="querylog_dist",
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="querylog_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/querylog/0002_status_type_change.py
+++ b/snuba/migrations/snuba_migrations/querylog/0002_status_type_change.py
@@ -41,7 +41,9 @@ class Migration(migration.ClickhouseNodeMigration):
         )
         return [
             operations.ModifyColumn(
-                StorageSetKey.QUERYLOG, table_name, Column("status", status_type),
+                StorageSetKey.QUERYLOG,
+                table_name,
+                Column("status", status_type),
             ),
             operations.ModifyColumn(
                 StorageSetKey.QUERYLOG,

--- a/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
+++ b/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
@@ -1,17 +1,11 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import (
-    UUID,
-    Column,
-    DateTime,
-    String,
-    UInt,
-)
+from snuba.clickhouse.columns import UUID, Column, DateTime, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
-from .matview import aggregate_columns_v1, create_matview_v1
 
+from .matview import aggregate_columns_v1, create_matview_v1
 
 raw_columns: Sequence[Column[Modifiers]] = [
     Column("session_id", UUID()),

--- a/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
+++ b/snuba/migrations/snuba_migrations/sessions/0001_sessions.py
@@ -61,10 +61,12 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="sessions_hourly_mv_local",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.SESSIONS, table_name="sessions_hourly_local",
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_hourly_local",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.SESSIONS, table_name="sessions_raw_local",
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_raw_local",
             ),
         ]
 
@@ -75,7 +77,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="sessions_raw_dist",
                 columns=raw_columns,
                 engine=table_engines.Distributed(
-                    local_table_name="sessions_raw_local", sharding_key="org_id",
+                    local_table_name="sessions_raw_local",
+                    sharding_key="org_id",
                 ),
             ),
             operations.CreateTable(
@@ -83,7 +86,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="sessions_hourly_dist",
                 columns=aggregate_columns_v1,
                 engine=table_engines.Distributed(
-                    local_table_name="sessions_hourly_local", sharding_key="org_id",
+                    local_table_name="sessions_hourly_local",
+                    sharding_key="org_id",
                 ),
             ),
         ]
@@ -91,9 +95,11 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.SESSIONS, table_name="sessions_hourly_dist",
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_hourly_dist",
             ),
             operations.DropTable(
-                storage_set=StorageSetKey.SESSIONS, table_name="sessions_raw_dist",
+                storage_set=StorageSetKey.SESSIONS,
+                table_name="sessions_raw_dist",
             ),
         ]

--- a/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
+++ b/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
@@ -29,7 +29,8 @@ new_dest_columns: Sequence[Tuple[Column[Modifiers], str]] = [
     ),
     (
         Column(
-            "sessions_crashed_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)]),
+            "sessions_crashed_preaggr",
+            AggregateFunction("sumIf", [UInt(32), UInt(8)]),
         ),
         "sessions_crashed",
     ),
@@ -42,7 +43,8 @@ new_dest_columns: Sequence[Tuple[Column[Modifiers], str]] = [
     ),
     (
         Column(
-            "sessions_errored_preaggr", AggregateFunction("sumIf", [UInt(32), UInt(8)]),
+            "sessions_errored_preaggr",
+            AggregateFunction("sumIf", [UInt(32), UInt(8)]),
         ),
         "sessions_errored",
     ),

--- a/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
+++ b/snuba/migrations/snuba_migrations/sessions/0002_sessions_aggregates.py
@@ -1,11 +1,6 @@
 from typing import Sequence, Tuple
 
-from snuba.clickhouse.columns import (
-    AggregateFunction,
-    Column,
-    String,
-    UInt,
-)
+from snuba.clickhouse.columns import AggregateFunction, Column, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/migrations/snuba_migrations/sessions/0003_sessions_matview.py
+++ b/snuba/migrations/snuba_migrations/sessions/0003_sessions_matview.py
@@ -12,8 +12,8 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.processor import MAX_UINT32, NIL_UUID
-from .matview import create_matview_v1
 
+from .matview import create_matview_v1
 
 aggregate_columns: Sequence[Column[Modifiers]] = [
     Column("org_id", UInt(64)),

--- a/snuba/migrations/snuba_migrations/spans_experimental/0001_spans_experimental.py
+++ b/snuba/migrations/snuba_migrations/spans_experimental/0001_spans_experimental.py
@@ -1,6 +1,7 @@
 from typing import List, Sequence
 
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
+
 from snuba.clickhouse.columns import UUID, Array, Column, DateTime, Nested, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.storages.tags_hash_map import TAGS_HASH_MAP_COLUMN

--- a/snuba/migrations/snuba_migrations/system/0001_migrations.py
+++ b/snuba/migrations/snuba_migrations/system/0001_migrations.py
@@ -10,7 +10,10 @@ columns: Sequence[Column[Modifiers]] = [
     Column("group", String()),
     Column("migration_id", String()),
     Column("timestamp", DateTime()),
-    Column("status", Enum([("completed", 0), ("in_progress", 1), ("not_started", 2)]),),
+    Column(
+        "status",
+        Enum([("completed", 0), ("in_progress", 1), ("not_started", 2)]),
+    ),
     Column("version", UInt(64, Modifiers(default="1"))),
 ]
 
@@ -46,7 +49,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.MIGRATIONS, table_name="migrations_local",
+                storage_set=StorageSetKey.MIGRATIONS,
+                table_name="migrations_local",
             )
         ]
 

--- a/snuba/migrations/snuba_migrations/transactions/0001_transactions.py
+++ b/snuba/migrations/snuba_migrations/transactions/0001_transactions.py
@@ -82,7 +82,8 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.TRANSACTIONS, table_name="transactions_local",
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
             )
         ]
 
@@ -102,6 +103,7 @@ class Migration(migration.ClickhouseNodeMigration):
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
-                storage_set=StorageSetKey.TRANSACTIONS, table_name="transactions_dist",
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_dist",
             )
         ]

--- a/snuba/migrations/snuba_migrations/transactions/0007_transactions_add_discover_cols.py
+++ b/snuba/migrations/snuba_migrations/transactions/0007_transactions_add_discover_cols.py
@@ -1,10 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import (
-    Column,
-    DateTime,
-    String,
-)
+from snuba.clickhouse.columns import Column, DateTime, String
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/migrations/snuba_migrations/transactions/0009_transactions_fix_title_and_message.py
+++ b/snuba/migrations/snuba_migrations/transactions/0009_transactions_fix_title_and_message.py
@@ -22,14 +22,16 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name=table_name,
                 column=Column(
-                    "title", String(Modifiers(materialized="transaction_name")),
+                    "title",
+                    String(Modifiers(materialized="transaction_name")),
                 ),
             ),
             operations.ModifyColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name=table_name,
                 column=Column(
-                    "message", String(Modifiers(materialized="transaction_name")),
+                    "message",
+                    String(Modifiers(materialized="transaction_name")),
                 ),
             ),
         ]

--- a/snuba/migrations/snuba_migrations/transactions/0010_transactions_nullable_trace_id.py
+++ b/snuba/migrations/snuba_migrations/transactions/0010_transactions_nullable_trace_id.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snuba.clickhouse.columns import Column, UUID
+from snuba.clickhouse.columns import UUID, Column
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -203,9 +203,9 @@ def optimize_partitions(
         hour=0, minute=0, second=0, microsecond=0
     )
     if not ignore_cutoff:
-        cutoff_time: Optional[
-            datetime
-        ] = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
+        cutoff_time: Optional[datetime] = (
+            last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
+        )
         logger.info("Cutoff time: %s", str(cutoff_time))
     else:
         cutoff_time = None

--- a/snuba/pipeline/composite.py
+++ b/snuba/pipeline/composite.py
@@ -52,7 +52,9 @@ class CompositeQueryPlanner(QueryPlanner[CompositeQueryPlan]):
     """
 
     def __init__(
-        self, query: CompositeQuery[Entity], settings: RequestSettings,
+        self,
+        query: CompositeQuery[Entity],
+        settings: RequestSettings,
     ) -> None:
         self.__query = query
         self.__settings = settings
@@ -453,9 +455,11 @@ class CompositeExecutionPipeline(QueryExecutionPipeline):
     def execute(self) -> QueryResult:
         plan = CompositeQueryPlanner(self.__query, self.__settings).build_best_plan()
         root_processors, aliased_processors = plan.get_plan_processors()
-        ProcessorsExecutor(root_processors, aliased_processors, self.__settings,).visit(
-            plan.query
-        )
+        ProcessorsExecutor(
+            root_processors,
+            aliased_processors,
+            self.__settings,
+        ).visit(plan.query)
 
         return plan.execution_strategy.execute(
             plan.query, self.__settings, self.__runner

--- a/snuba/pipeline/processors.py
+++ b/snuba/pipeline/processors.py
@@ -31,7 +31,8 @@ def _execute_clickhouse_processors(
 
 
 def execute_plan_processors(
-    query_plan: ClickhouseQueryPlan, settings: RequestSettings,
+    query_plan: ClickhouseQueryPlan,
+    settings: RequestSettings,
 ) -> None:
     """
     Executes the plan query processors but not the db ones (those
@@ -45,7 +46,8 @@ def execute_plan_processors(
 
 
 def execute_all_clickhouse_processors(
-    query_plan: ClickhouseQueryPlan, settings: RequestSettings,
+    query_plan: ClickhouseQueryPlan,
+    settings: RequestSettings,
 ) -> None:
     """
     Executes all Clickhouse query processing including the plan processors

--- a/snuba/pipeline/processors.py
+++ b/snuba/pipeline/processors.py
@@ -1,6 +1,7 @@
 from typing import Callable, Sequence
 
 import sentry_sdk
+
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.plans.query_plan import ClickhouseQueryPlan

--- a/snuba/pipeline/simple_pipeline.py
+++ b/snuba/pipeline/simple_pipeline.py
@@ -5,14 +5,11 @@ from snuba.datasets.plans.query_plan import (
     ClickhouseQueryPlanBuilder,
     QueryRunner,
 )
-from snuba.pipeline.processors import (
-    execute_entity_processors,
-    execute_plan_processors,
-)
+from snuba.pipeline.processors import execute_entity_processors, execute_plan_processors
 from snuba.pipeline.query_pipeline import (
-    QueryPlanner,
     QueryExecutionPipeline,
     QueryPipelineBuilder,
+    QueryPlanner,
 )
 from snuba.query.logical import Query as LogicalQuery
 from snuba.request import Request

--- a/snuba/pipeline/simple_pipeline.py
+++ b/snuba/pipeline/simple_pipeline.py
@@ -57,7 +57,10 @@ class SimpleExecutionPipeline(QueryExecutionPipeline):
     """
 
     def __init__(
-        self, request: Request, runner: QueryRunner, query_planner: EntityQueryPlanner,
+        self,
+        request: Request,
+        runner: QueryRunner,
+        query_planner: EntityQueryPlanner,
     ):
         self.__request = request
         self.__runner = runner
@@ -82,10 +85,14 @@ class SimplePipelineBuilder(QueryPipelineBuilder[ClickhouseQueryPlan]):
     ) -> QueryExecutionPipeline:
         assert isinstance(request.query, LogicalQuery)
         return SimpleExecutionPipeline(
-            request, runner, self.build_planner(request.query, request.settings),
+            request,
+            runner,
+            self.build_planner(request.query, request.settings),
         )
 
     def build_planner(
-        self, query: LogicalQuery, settings: RequestSettings,
+        self,
+        query: LogicalQuery,
+        settings: RequestSettings,
     ) -> EntityQueryPlanner:
         return EntityQueryPlanner(query, settings, self.__query_plan_builder)

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -24,8 +24,8 @@ from snuba.utils.serializable_exception import SerializableException
 from snuba.writer import WriterTableRow
 
 HASH_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
-MAX_UINT16 = 2 ** 16 - 1
-MAX_UINT32 = 2 ** 32 - 1
+MAX_UINT16 = 2**16 - 1
+MAX_UINT32 = 2**32 - 1
 NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
 

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -292,7 +292,9 @@ class Query(DataSource, ABC):
         def transform_expression_list(
             expressions: Sequence[Expression],
         ) -> Sequence[Expression]:
-            return list(map(lambda exp: exp.transform(func), expressions),)
+            return list(
+                map(lambda exp: exp.transform(func), expressions),
+            )
 
         self.__selected_columns = list(
             map(

--- a/snuba/query/conditions.py
+++ b/snuba/query/conditions.py
@@ -108,7 +108,10 @@ def __is_set_condition(exp: Expression, operator: str) -> bool:
     return False
 
 
-def in_condition(lhs: Expression, rhs: Sequence[Literal],) -> Expression:
+def in_condition(
+    lhs: Expression,
+    rhs: Sequence[Literal],
+) -> Expression:
     return __set_condition(ConditionFunctions.IN, lhs, rhs)
 
 
@@ -120,8 +123,15 @@ def is_in_condition_pattern(lhs: Pattern[Expression]) -> FunctionCallPattern:
     return __set_condition_pattern(lhs, ConditionFunctions.IN)
 
 
-def not_in_condition(lhs: Expression, rhs: Sequence[Literal],) -> Expression:
-    return __set_condition(ConditionFunctions.NOT_IN, lhs, rhs,)
+def not_in_condition(
+    lhs: Expression,
+    rhs: Sequence[Literal],
+) -> Expression:
+    return __set_condition(
+        ConditionFunctions.NOT_IN,
+        lhs,
+        rhs,
+    )
 
 
 def is_not_in_condition(exp: Expression) -> bool:

--- a/snuba/query/dsl.py
+++ b/snuba/query/dsl.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence
 
-from snuba.query.expressions import Expression, FunctionCall, Literal, Column
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 
 # Add here functions (only stateless stuff) used to make the AST less
 # verbose to build.

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -18,7 +18,10 @@ class ValidationException(InvalidQueryException):
 class InvalidExpressionException(ValidationException):
     @classmethod
     def from_args(
-        cls, expression: Expression, message: str, should_report: bool = True,
+        cls,
+        expression: Expression,
+        message: str,
+        should_report: bool = True,
     ) -> "InvalidExpressionException":
         return cls(message, should_report=should_report, expression=repr(expression))
 

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -329,7 +329,9 @@ class SubscriptableReference(Expression):
 
     def transform(self, func: Callable[[Expression], Expression]) -> Expression:
         transformed = replace(
-            self, column=self.column.transform(func), key=self.key.transform(func),
+            self,
+            column=self.column.transform(func),
+            key=self.key.transform(func),
         )
         return func(transformed)
 

--- a/snuba/query/formatters/tracing.py
+++ b/snuba/query/formatters/tracing.py
@@ -149,5 +149,8 @@ class TracingQueryFormatter(
             f"{node.join_type.name.upper()} JOIN",
             *_indent_str_list(node.right_node.accept(self), 1),
             "ON",
-            *_indent_str_list(on_list, 1,),
+            *_indent_str_list(
+                on_list,
+                1,
+            ),
         ]

--- a/snuba/query/joins/pre_processor.py
+++ b/snuba/query/joins/pre_processor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from copy import copy
 
+from copy import copy
 from typing import Mapping, MutableMapping, NamedTuple, Set
 
 from snuba.datasets.entities import EntityKey

--- a/snuba/query/joins/subquery_generator.py
+++ b/snuba/query/joins/subquery_generator.py
@@ -311,7 +311,11 @@ def generate_subqueries(query: CompositeQuery[Entity]) -> None:
             replace(
                 limitby,
                 columns=[
-                    _process_root(column, subqueries, alias_generator,)
+                    _process_root(
+                        column,
+                        subqueries,
+                        alias_generator,
+                    )
                     for column in limitby.columns
                 ],
             )

--- a/snuba/query/logical.py
+++ b/snuba/query/logical.py
@@ -9,7 +9,8 @@ from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Expression, ExpressionVisitor
 
 Aggregation = Union[
-    Tuple[Any, Any, Any], Sequence[Any],
+    Tuple[Any, Any, Any],
+    Sequence[Any],
 ]
 
 

--- a/snuba/query/parser/expressions.py
+++ b/snuba/query/parser/expressions.py
@@ -33,7 +33,7 @@ FUNCTION_NAME_REGEX = r"[a-zA-Z_][a-zA-Z0-9_]*"
 
 
 minimal_clickhouse_grammar = Grammar(
-    fr"""
+    rf"""
 # This root element is needed because of the ambiguity of the aggregation
 # function field which can mean a clickhouse function expression or the simple
 # name of a clickhouse function.
@@ -109,12 +109,16 @@ class ClickhouseVisitor(NodeVisitor):  # type: ignore
         return visit_arithmetic_term(node, visited_children)
 
     def visit_low_pri_arithmetic(
-        self, node: Node, visited_children: Tuple[Any, Expression, LowPriArithmetic],
+        self,
+        node: Node,
+        visited_children: Tuple[Any, Expression, LowPriArithmetic],
     ) -> Expression:
         return visit_low_pri_arithmetic(node, visited_children)
 
     def visit_high_pri_arithmetic(
-        self, node: Node, visited_children: Tuple[Any, Expression, HighPriArithmetic],
+        self,
+        node: Node,
+        visited_children: Tuple[Any, Expression, HighPriArithmetic],
     ) -> Expression:
         return visit_high_pri_arithmetic(node, visited_children)
 

--- a/snuba/query/processors/abstract_array_join_optimizer.py
+++ b/snuba/query/processors/abstract_array_join_optimizer.py
@@ -27,7 +27,10 @@ from snuba.query.matchers import (
 
 class AbstractArrayJoinOptimizer(QueryProcessor):
     def __init__(
-        self, column_name: str, key_names: Sequence[str], val_names: Sequence[str],
+        self,
+        column_name: str,
+        key_names: Sequence[str],
+        val_names: Sequence[str],
     ):
         assert key_names, "key_names cannot be empty"
         assert val_names, "val_names cannot be empty"
@@ -110,7 +113,8 @@ def find_pattern(query: Query, pattern: FunctionCall) -> bool:
 
 def _array_join_pattern(column_name: str) -> FunctionCall:
     return FunctionCall(
-        String("arrayJoin"), (Column(column_name=String(column_name)),),
+        String("arrayJoin"),
+        (Column(column_name=String(column_name)),),
     )
 
 

--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -31,7 +31,8 @@ def val_column(col_name: str) -> str:
 
 def array_join_pattern(column_name: str) -> FunctionCall:
     return FunctionCall(
-        String("arrayJoin"), (Column(column_name=String(key_column(column_name))),),
+        String("arrayJoin"),
+        (Column(column_name=String(key_column(column_name))),),
     )
 
 
@@ -296,7 +297,12 @@ def zip_columns(column1: ColumnExpr, column2: ColumnExpr) -> Expression:
                 None,
                 ("x", "y"),
                 FunctionCallExpr(
-                    None, "tuple", (Argument(None, "x"), Argument(None, "y"),),
+                    None,
+                    "tuple",
+                    (
+                        Argument(None, "x"),
+                        Argument(None, "y"),
+                    ),
                 ),
             ),
             column1,
@@ -323,7 +329,11 @@ def filter_key_values(
                     # A pair here is a tuple with two elements (key
                     # and value) and the index of the first element in
                     # Clickhouse is 1 instead of 0.
-                    tupleElement(None, Argument(None, "pair"), LiteralExpr(None, 1),),
+                    tupleElement(
+                        None,
+                        Argument(None, "pair"),
+                        LiteralExpr(None, 1),
+                    ),
                     keys,
                 ),
             ),
@@ -339,5 +349,12 @@ def filter_keys(column: Expression, keys: Sequence[LiteralExpr]) -> Expression:
     return FunctionCallExpr(
         None,
         "arrayFilter",
-        (Lambda(None, ("tag",), in_condition(Argument(None, "tag"), keys),), column,),
+        (
+            Lambda(
+                None,
+                ("tag",),
+                in_condition(Argument(None, "tag"), keys),
+            ),
+            column,
+        ),
     )

--- a/snuba/query/processors/arrayjoin_optimizer.py
+++ b/snuba/query/processors/arrayjoin_optimizer.py
@@ -23,7 +23,10 @@ from snuba.request.request_settings import RequestSettings
 
 class ArrayJoinOptimizer(AbstractArrayJoinOptimizer):
     def __init__(
-        self, column_name: str, key_names: Sequence[str], val_names: Sequence[str],
+        self,
+        column_name: str,
+        key_names: Sequence[str],
+        val_names: Sequence[str],
     ):
         super().__init__(column_name, key_names, val_names)
         self.__array_join_pattern = FunctionCall(
@@ -31,7 +34,8 @@ class ArrayJoinOptimizer(AbstractArrayJoinOptimizer):
             (
                 Column(
                     column_name=Param(
-                        "col", Or([String(column) for column in self.all_columns]),
+                        "col",
+                        Or([String(column) for column in self.all_columns]),
                     ),
                 ),
             ),
@@ -203,7 +207,9 @@ def filter_expression(
                     "tuple",
                     tuple(
                         FunctionCallExpr(
-                            None, "tuple", tuple(LiteralExpr(None, t) for t in tuples),
+                            None,
+                            "tuple",
+                            tuple(LiteralExpr(None, t) for t in tuples),
                         )
                         for tuples in multiple_filtered[indices]
                     ),

--- a/snuba/query/processors/basic_functions.py
+++ b/snuba/query/processors/basic_functions.py
@@ -25,19 +25,28 @@ class BasicFunctionsProcessor(QueryProcessor):
                     return FunctionCall(
                         exp.alias,
                         "ifNull",
-                        (replace(exp, alias=None), Literal(None, 0),),
+                        (
+                            replace(exp, alias=None),
+                            Literal(None, 0),
+                        ),
                     )
                 if exp.function_name == "emptyIfNull":
                     return FunctionCall(
                         exp.alias,
                         "ifNull",
-                        (replace(exp, alias=None), Literal(None, ""),),
+                        (
+                            replace(exp, alias=None),
+                            Literal(None, ""),
+                        ),
                     )
                 if exp.function_name == "log":
                     return FunctionCall(
                         exp.alias,
                         "ifNotFinite",
-                        (replace(exp, alias=None), Literal(None, 0),),
+                        (
+                            replace(exp, alias=None),
+                            Literal(None, 0),
+                        ),
                     )
             if isinstance(exp, CurriedFunctionCall):
                 if exp.internal_function.function_name == "top":

--- a/snuba/query/processors/bloom_filter_optimizer.py
+++ b/snuba/query/processors/bloom_filter_optimizer.py
@@ -56,7 +56,9 @@ def generate_bloom_filter_condition(
         combine_or_conditions(
             [
                 FunctionCallExpr(
-                    None, "has", (ColumnExpr(None, None, key), LiteralExpr(None, val)),
+                    None,
+                    "has",
+                    (ColumnExpr(None, None, key), LiteralExpr(None, val)),
                 )
                 for val in sorted(vals)
             ]

--- a/snuba/query/processors/custom_function.py
+++ b/snuba/query/processors/custom_function.py
@@ -68,7 +68,10 @@ class CustomFunction(QueryProcessor):
     """
 
     def __init__(
-        self, name: str, signature: Sequence[Tuple[str, ParamType]], body: Expression,
+        self,
+        name: str,
+        signature: Sequence[Tuple[str, ParamType]],
+        body: Expression,
     ) -> None:
         self.__function_name = name
         self.__param_names: Sequence[str] = []

--- a/snuba/query/processors/empty_tag_condition_processor.py
+++ b/snuba/query/processors/empty_tag_condition_processor.py
@@ -16,7 +16,8 @@ from snuba.request.request_settings import RequestSettings
 CONDITION_PATTERN = condition_pattern(
     {ConditionFunctions.EQ, ConditionFunctions.NEQ},
     FunctionCallPattern(
-        String("ifNull"), (mapping_pattern, LiteralPattern(String(""))),
+        String("ifNull"),
+        (mapping_pattern, LiteralPattern(String(""))),
     ),
     LiteralPattern(String("")),
     commutative=False,

--- a/snuba/query/processors/pattern_replacer.py
+++ b/snuba/query/processors/pattern_replacer.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query
-from snuba.query.matchers import Pattern, MatchResult, TMatchedType
+from snuba.query.matchers import MatchResult, Pattern, TMatchedType
 from snuba.query.processors import QueryProcessor
 from snuba.request.request_settings import RequestSettings
 

--- a/snuba/query/processors/slice_of_map_optimizer.py
+++ b/snuba/query/processors/slice_of_map_optimizer.py
@@ -31,7 +31,9 @@ class SliceOfMapOptimizer(QueryProcessor):
                     (
                         lambda_fn,
                         FunctionCall(
-                            None, "arraySlice", (innermost_exp,) + slice_args,
+                            None,
+                            "arraySlice",
+                            (innermost_exp,) + slice_args,
                         ),
                     ),
                 )

--- a/snuba/query/processors/slice_of_map_optimizer.py
+++ b/snuba/query/processors/slice_of_map_optimizer.py
@@ -1,7 +1,6 @@
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.expressions import Expression, FunctionCall
-
 from snuba.request.request_settings import RequestSettings
 
 

--- a/snuba/query/processors/timeseries_processor.py
+++ b/snuba/query/processors/timeseries_processor.py
@@ -31,7 +31,11 @@ class TimeSeriesProcessor(QueryProcessor):
         # The columns here might overlap with the columns that get replaced, so we have to search for transformed
         # columns.
         column_match = ColumnMatch(
-            None, Param("column_name", Or([String(tc) for tc in time_parse_columns]),),
+            None,
+            Param(
+                "column_name",
+                Or([String(tc) for tc in time_parse_columns]),
+            ),
         )
         self.condition_match = FunctionCallMatch(
             Or(
@@ -70,7 +74,8 @@ class TimeSeriesProcessor(QueryProcessor):
                                             String("intDiv"),
                                             (
                                                 FunctionCallMatch(
-                                                    String("toUInt32"), (column_match,),
+                                                    String("toUInt32"),
+                                                    (column_match,),
                                                 ),
                                                 LiteralMatch(Any(int)),
                                             ),

--- a/snuba/query/processors/type_converters/hexint_column_processor.py
+++ b/snuba/query/processors/type_converters/hexint_column_processor.py
@@ -27,7 +27,13 @@ class HexIntColumnProcessor(BaseTypeConverter):
             return FunctionCall(
                 exp.alias,
                 "lower",
-                (FunctionCall(None, "hex", (Column(None, None, exp.column_name),),),),
+                (
+                    FunctionCall(
+                        None,
+                        "hex",
+                        (Column(None, None, exp.column_name),),
+                    ),
+                ),
             )
 
         return exp

--- a/snuba/query/processors/type_converters/uuid_column_processor.py
+++ b/snuba/query/processors/type_converters/uuid_column_processor.py
@@ -24,7 +24,9 @@ class UUIDColumnProcessor(BaseTypeConverter):
                 "replaceAll",
                 (
                     FunctionCall(
-                        None, "toString", (Column(None, None, exp.column_name),),
+                        None,
+                        "toString",
+                        (Column(None, None, exp.column_name),),
                     ),
                     Literal(None, "-"),
                     Literal(None, ""),

--- a/snuba/query/snql/expression_visitor.py
+++ b/snuba/query/snql/expression_visitor.py
@@ -63,7 +63,8 @@ def get_arithmetic_function(
 
 
 def get_arithmetic_expression(
-    term: Expression, exp: Union[LowPriArithmetic, HighPriArithmetic, Sequence[Any]],
+    term: Expression,
+    exp: Union[LowPriArithmetic, HighPriArithmetic, Sequence[Any]],
 ) -> Expression:
     if isinstance(exp, Node):
         return term
@@ -117,14 +118,16 @@ def visit_arithmetic_term(
 
 
 def visit_low_pri_arithmetic(
-    node: Node, visited_children: Tuple[Any, Expression, LowPriArithmetic],
+    node: Node,
+    visited_children: Tuple[Any, Expression, LowPriArithmetic],
 ) -> Expression:
     _, term, exp = visited_children
     return get_arithmetic_expression(term, exp)
 
 
 def visit_high_pri_arithmetic(
-    node: Node, visited_children: Tuple[Any, Expression, HighPriArithmetic],
+    node: Node,
+    visited_children: Tuple[Any, Expression, HighPriArithmetic],
 ) -> Expression:
     _, term, exp = visited_children
 

--- a/snuba/query/snql/joins.py
+++ b/snuba/query/snql/joins.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import MutableMapping, NamedTuple, Optional, Sequence, Union
 
 from snuba.datasets.entities import EntityKey

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -299,7 +299,10 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
             ],
         ],
     ) -> Union[
-        CompositeQuery[QueryEntity], LogicalQuery, QueryEntity, JoinClause[QueryEntity],
+        CompositeQuery[QueryEntity],
+        LogicalQuery,
+        QueryEntity,
+        JoinClause[QueryEntity],
     ]:
         _, _, _, match = visited_children
         if isinstance(match, (CompositeQuery, LogicalQuery)):
@@ -354,7 +357,9 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
             raise ParsingException(f"{node.text} is not a valid entity name")
 
     def visit_relationships(
-        self, node: Node, visited_children: Tuple[RelationshipTuple, Any],
+        self,
+        node: Node,
+        visited_children: Tuple[RelationshipTuple, Any],
     ) -> Sequence[RelationshipTuple]:
         relationships = [visited_children[0]]
         if isinstance(visited_children[1], Node):
@@ -474,12 +479,16 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
         return visit_arithmetic_term(node, visited_children)
 
     def visit_low_pri_arithmetic(
-        self, node: Node, visited_children: Tuple[Any, Expression, LowPriArithmetic],
+        self,
+        node: Node,
+        visited_children: Tuple[Any, Expression, LowPriArithmetic],
     ) -> Expression:
         return visit_low_pri_arithmetic(node, visited_children)
 
     def visit_high_pri_arithmetic(
-        self, node: Node, visited_children: Tuple[Any, Expression, HighPriArithmetic],
+        self,
+        node: Node,
+        visited_children: Tuple[Any, Expression, HighPriArithmetic],
     ) -> Expression:
         return visit_high_pri_arithmetic(node, visited_children)
 
@@ -524,7 +533,9 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
         return conditions
 
     def visit_and_expression(
-        self, node: Node, visited_children: Tuple[Any, Expression, Node],
+        self,
+        node: Node,
+        visited_children: Tuple[Any, Expression, Node],
     ) -> Expression:
         _, left_condition, and_condition = visited_children
         args = [left_condition]
@@ -775,7 +786,9 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
         return exprs
 
     def visit_arrayjoin_optional(
-        self, node: Node, visited_children: List[Tuple[Any, Any, Any, Expression]],
+        self,
+        node: Node,
+        visited_children: List[Tuple[Any, Any, Any, Expression]],
     ) -> List[Expression]:
         exprs: List[Expression] = list()
         if visited_children is not None:
@@ -831,19 +844,25 @@ class SnQLVisitor(NodeVisitor):  # type: ignore
         return CurriedFunctionCall(alias, internal_f, param_list2)
 
     def visit_aliased_tag_column(
-        self, node: Node, visited_children: Tuple[Column, Any, Any, Any, Node],
+        self,
+        node: Node,
+        visited_children: Tuple[Column, Any, Any, Any, Node],
     ) -> SelectedExpression:
         column, _, _, _, alias = visited_children
         return SelectedExpression(self.__extract_alias_from_match(alias), column)
 
     def visit_aliased_subscriptable(
-        self, node: Node, visited_children: Tuple[Column, Any, Any, Any, Node],
+        self,
+        node: Node,
+        visited_children: Tuple[Column, Any, Any, Any, Node],
     ) -> SelectedExpression:
         column, _, _, _, alias = visited_children
         return SelectedExpression(self.__extract_alias_from_match(alias), column)
 
     def visit_aliased_column_name(
-        self, node: Node, visited_children: Tuple[Column, Any, Any, Any, Node],
+        self,
+        node: Node,
+        visited_children: Tuple[Column, Any, Any, Any, Node],
     ) -> SelectedExpression:
         column, _, _, _, alias = visited_children
         return SelectedExpression(self.__extract_alias_from_match(alias), column)
@@ -1025,7 +1044,10 @@ def _array_join_transformation(
                                 FunctionCall(
                                     None,
                                     OPERATOR_TO_FUNCTION[op],
-                                    (Argument(None, "x"), value,),
+                                    (
+                                        Argument(None, "x"),
+                                        value,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1301,7 +1323,8 @@ def _align_max_days_date_align(
             return exp
         elif exp == from_exp:
             return replace(
-                exp, parameters=(from_exp.parameters[0], Literal(None, from_date)),
+                exp,
+                parameters=(from_exp.parameters[0], Literal(None, from_date)),
             )
         elif exp == to_exp:
             return replace(
@@ -1440,7 +1463,9 @@ CustomProcessors = Sequence[
 
 
 def parse_snql_query(
-    body: str, dataset: Dataset, custom_processing: Optional[CustomProcessors] = None,
+    body: str,
+    dataset: Dataset,
+    custom_processing: Optional[CustomProcessors] = None,
 ) -> Tuple[Union[CompositeQuery[QueryEntity], LogicalQuery], str]:
     with sentry_sdk.start_span(op="parser", description="parse_snql_query_initial"):
         query = parse_snql_query_initial(body)
@@ -1450,7 +1475,8 @@ def parse_snql_query(
 
     with sentry_sdk.start_span(op="processor", description="post_processors"):
         _post_process(
-            query, POST_PROCESSORS,
+            query,
+            POST_PROCESSORS,
         )
 
     # Custom processing to tweak the AST before validation

--- a/snuba/query/types.py
+++ b/snuba/query/types.py
@@ -1,5 +1,6 @@
 from typing import Any, Sequence, Tuple, Union
 
 Condition = Union[
-    Tuple[Any, Any, Any], Sequence[Any],
+    Tuple[Any, Any, Any],
+    Sequence[Any],
 ]

--- a/snuba/query/validation/signature.py
+++ b/snuba/query/validation/signature.py
@@ -43,7 +43,8 @@ class Any(ParamType):
 
 
 COLUMN_PATTERN = ColumnMatcher(
-    table_name=None, column_name=Param("column_name", AnyMatcher(str)),
+    table_name=None,
+    column_name=Param("column_name", AnyMatcher(str)),
 )
 
 LITERAL_PATTERN = LiteralMatcher()

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -31,7 +31,11 @@ class QueryValidator(ABC):
     """
 
     @abstractmethod
-    def validate(self, query: Query, alias: Optional[str] = None,) -> None:
+    def validate(
+        self,
+        query: Query,
+        alias: Optional[str] = None,
+    ) -> None:
         """
         Validate that the query is correct. If the query is not valid, raise an
         Exception, otherwise return None. If the entity that calls this is part
@@ -194,7 +198,11 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
                     f"where clause. missing condition for field {exp}"
                 )
 
-    def validate(self, query: Query, alias: Optional[str] = None,) -> None:
+    def validate(
+        self,
+        query: Query,
+        alias: Optional[str] = None,
+    ) -> None:
         selected = query.get_selected_columns()
         if len(selected) > self.max_allowed_aggregations:
             aggregation_error_text = (
@@ -217,7 +225,7 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
 
 
 class GranularityValidator(QueryValidator):
-    """ Verify that the given granularity is a multiple of the configured value """
+    """Verify that the given granularity is a multiple of the configured value"""
 
     def __init__(self, minimum: int, required: bool = False):
         self.minimum = minimum

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -14,7 +14,9 @@ metrics = MetricsWrapper(environment.metrics, "api")
 
 
 def _record_timer_metrics(
-    request: Request, timer: Timer, query_metadata: SnubaQueryMetadata,
+    request: Request,
+    timer: Timer,
+    query_metadata: SnubaQueryMetadata,
 ) -> None:
     final = str(request.query.get_final())
     referrer = request.referrer or "none"
@@ -126,6 +128,7 @@ def _record_failure_building_request(
     # table would be useful.
     if settings.RECORD_QUERIES:
         timer.send_metrics_to(
-            metrics, tags={"status": status.value, "referrer": referrer or "none"},
+            metrics,
+            tags={"status": status.value, "referrer": referrer or "none"},
         )
         _add_tags(timer)

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -59,7 +59,7 @@ def _retry(max_retries: int) -> Callable[[RedisInitFunction], RedisInitFunction]
                     if KNOWN_TRANSIENT_INIT_FAILURE_MESSAGE in str(e):
                         # Exponentially increase the sleep starting from
                         # 0.5 seconds on each retry
-                        sleep_duration = 0.5 * (2 ** retry_counter)
+                        sleep_duration = 0.5 * (2**retry_counter)
                         time.sleep(sleep_duration)
                         retry_counter += 1
                         continue

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -81,7 +81,10 @@ class RoundRobinConnectionPool(ShardedConnectionPool):
     by one node each time `get_connections` is invoked.
     """
 
-    def __init__(self, cluster: ClickhouseCluster,) -> None:
+    def __init__(
+        self,
+        cluster: ClickhouseCluster,
+    ) -> None:
         self.__cluster = cluster
         self.__counter = 0
         self.__nodes: Mapping[int, List[ClickhouseNode]] = defaultdict(list)
@@ -219,14 +222,18 @@ class ShardedExecutor(InsertExecutor):
                     nodes[len(nodes) - remaining_attempts],
                 )
                 self.__runner(
-                    connection, query, records_count, metrics,
+                    connection,
+                    query,
+                    records_count,
+                    metrics,
                 )
                 return
             except Exception as e:
                 if remaining_attempts == 1:
                     raise
                 logger.warning(
-                    "Replacement processing failed on the main connection", exc_info=e,
+                    "Replacement processing failed on the main connection",
+                    exc_info=e,
                 )
 
     def execute(self, replacement: Replacement, records_count: int) -> int:
@@ -256,7 +263,8 @@ class ShardedExecutor(InsertExecutor):
         except Exception as e:
             count = self.__backup_executor.execute(replacement, records_count)
             logger.warning(
-                "Replacement processing failed on the main connection", exc_info=e,
+                "Replacement processing failed on the main connection",
+                exc_info=e,
             )
             return count
 
@@ -315,10 +323,14 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
 
             logger.info("Replacing %s rows took %sms" % (records_count, duration))
             metrics.timing(
-                "replacements.count", records_count, tags={"host": connection.host},
+                "replacements.count",
+                records_count,
+                tags={"host": connection.host},
             )
             metrics.timing(
-                "replacements.duration", duration, tags={"host": connection.host},
+                "replacements.duration",
+                duration,
+                tags={"host": connection.host},
             )
 
         query_table_name = self.__replacer_processor.get_schema().get_table_name()
@@ -371,7 +383,9 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
         if version == 2:
             return self.__replacer_processor.process_message(
                 ReplacementMessage(
-                    action_type=action_type, data=data, metadata=metadata,
+                    action_type=action_type,
+                    data=data,
+                    metadata=metadata,
                 )
             )
         else:
@@ -442,7 +456,8 @@ class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
             except ValueError as e:
                 redis_client.delete(key)
                 logger.warning(
-                    "Unexpected value found for an offset in Redis", exc_info=e,
+                    "Unexpected value found for an offset in Redis",
+                    exc_info=e,
                 )
                 self.__last_offset_processed_per_partition[key] = -1
 

--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -91,7 +91,8 @@ def build_request(
                 )
             elif settings_class == SubscriptionRequestSettings:
                 settings_obj = settings_class(
-                    referrer=referrer, consistent=_consistent_override(True, referrer),
+                    referrer=referrer,
+                    consistent=_consistent_override(True, referrer),
                 )
 
             app_id = get_app_id(settings_obj.get_app_id())
@@ -128,7 +129,8 @@ def build_request(
             raise exception
 
         span.set_data(
-            "snuba_query_parsed", repr(query).split("\n"),
+            "snuba_query_parsed",
+            repr(query).split("\n"),
         )
         span.set_data(
             "snuba_query_raw",

--- a/snuba/schemas.py
+++ b/snuba/schemas.py
@@ -3,7 +3,6 @@ from typing import Any, Generator, Mapping, MutableMapping
 
 import jsonschema
 
-
 Schema = Mapping[str, Any]  # placeholder for JSON schema
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -102,7 +102,7 @@ SNAPSHOT_LOAD_PRODUCT = "snuba"
 
 SNAPSHOT_CONTROL_TOPIC_INIT_TIMEOUT = 30
 BULK_CLICKHOUSE_BUFFER = 10000
-BULK_BINARY_LOAD_CHUNK = 2 ** 22  # 4 MB
+BULK_BINARY_LOAD_CHUNK = 2**22  # 4 MB
 
 # Processor/Writer Options
 
@@ -138,7 +138,7 @@ STATS_IN_RESPONSE = False
 PAYLOAD_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 REPLACER_MAX_BLOCK_SIZE = 512
-REPLACER_MAX_MEMORY_USAGE = 10 * (1024 ** 3)  # 10GB
+REPLACER_MAX_MEMORY_USAGE = 10 * (1024**3)  # 10GB
 # TLL of Redis key that denotes whether a project had replacements
 # run recently. Useful for decidig whether or not to add FINAL clause
 # to queries.

--- a/snuba/snapshots/postgres_snapshot.py
+++ b/snuba/snapshots/postgres_snapshot.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Generator, Iterable, NewType, Sequence
 
 import jsonschema
+
 from snuba import settings
 from snuba.snapshots import (
     BulkLoadSource,

--- a/snuba/snapshots/postgres_snapshot.py
+++ b/snuba/snapshots/postgres_snapshot.py
@@ -118,7 +118,8 @@ class PostgresSnapshot(BulkLoadSource):
         with open(meta_file_name, "r") as meta_file:
             json_desc = json.load(meta_file)
             jsonschema.validate(
-                json_desc, SNAPSHOT_METADATA_SCHEMA,
+                json_desc,
+                SNAPSHOT_METADATA_SCHEMA,
             )
 
             if json_desc["product"] != product:
@@ -159,7 +160,8 @@ class PostgresSnapshot(BulkLoadSource):
 
     @contextmanager
     def get_parsed_table_file(
-        self, table: str,
+        self,
+        table: str,
     ) -> Generator[Iterable[SnapshotTableRow], None, None]:
         table_desc = self.__descriptor.get_table(table)
         assert not table_desc.zip, "Cannot parse a gzip table file on the fly"
@@ -182,7 +184,10 @@ class PostgresSnapshot(BulkLoadSource):
                     if not expected_set <= existing_set:
                         raise ValueError(
                             "The table %s is missing columns %r "
-                            % (table, expected_set - existing_set,)
+                            % (
+                                table,
+                                expected_set - existing_set,
+                            )
                         )
 
                     if len(existing_set) != len(expected_set):

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -116,7 +116,10 @@ def get_typed_value(value: Any) -> Any:
 
 
 def set_config(
-    key: str, value: Optional[Any], user: Optional[str] = None, force: bool = False,
+    key: str,
+    value: Optional[Any],
+    user: Optional[str] = None,
+    force: bool = False,
 ) -> None:
     value = get_typed_value(value)
     enc_value = "{}".format(value).encode("utf-8") if value is not None else None

--- a/snuba/subscriptions/entity_subscription.py
+++ b/snuba/subscriptions/entity_subscription.py
@@ -101,7 +101,9 @@ class BaseEventsSubscription(EntitySubscriptionValidation, EntitySubscription, A
             binary_condition(
                 ConditionFunctions.LTE,
                 FunctionCall(
-                    None, "ifNull", (Column(None, None, "offset"), Literal(None, 0)),
+                    None,
+                    "ifNull",
+                    (Column(None, None, "offset"), Literal(None, 0)),
                 ),
                 Literal(None, offset),
             )

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -99,7 +99,9 @@ def build_executor_consumer(
         ), "All entities must have same scheduled and result topics"
 
     consumer_configuration = build_kafka_consumer_configuration(
-        scheduled_topic_spec.topic, consumer_group, auto_offset_reset=auto_offset_reset,
+        scheduled_topic_spec.topic,
+        consumer_group,
+        auto_offset_reset=auto_offset_reset,
     )
 
     # Collect metrics from librdkafka if we have stats_collection_freq_ms set

--- a/snuba/subscriptions/partitioner.py
+++ b/snuba/subscriptions/partitioner.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from binascii import crc32
 
 from snuba.datasets.table_storage import KafkaTopicSpec

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -152,7 +152,8 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
 
         # Record the lag between the fastest and slowest partition
         self.__metrics.timing(
-            "partition_lag_ms", (fastest - slowest).total_seconds() * 1000,
+            "partition_lag_ms",
+            (fastest - slowest).total_seconds() * 1000,
         )
 
         if (
@@ -356,7 +357,7 @@ class ScheduledSubscriptionQueue:
 
 
 class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
-    """"
+    """ "
     This strategy is responsible for producing a message for all of the subscriptions
     scheduled for a given tick.
 

--- a/snuba/subscriptions/subscription.py
+++ b/snuba/subscriptions/subscription.py
@@ -36,12 +36,14 @@ class SubscriptionCreator:
         self._test_request(data, timer)
 
         identifier = SubscriptionIdentifier(
-            self.__partitioner.build_partition_id(data), uuid1(),
+            self.__partitioner.build_partition_id(data),
+            uuid1(),
         )
         RedisSubscriptionDataStore(
             redis_client, self.entity_key, identifier.partition
         ).create(
-            identifier.uuid, data,
+            identifier.uuid,
+            data,
         )
         return identifier
 

--- a/snuba/subscriptions/verifier.py
+++ b/snuba/subscriptions/verifier.py
@@ -174,7 +174,9 @@ def build_verifier(
         SubscriptionResultConsumer(
             KafkaConsumer(
                 build_kafka_consumer_configuration(
-                    None, group_id=consumer_group, auto_offset_reset=auto_offset_reset,
+                    None,
+                    group_id=consumer_group,
+                    auto_offset_reset=auto_offset_reset,
                 )
             ),
             override_topics=[orig_result_topic, new_result_topic],
@@ -323,11 +325,15 @@ class ResultStore:
                     off_by_one.add(id)
 
             self.__metrics.increment(
-                METRIC_OUTCOME_NAME, len(matching_results), {"outcome": "same_result"},
+                METRIC_OUTCOME_NAME,
+                len(matching_results),
+                {"outcome": "same_result"},
             )
 
             self.__metrics.increment(
-                METRIC_OUTCOME_NAME, len(off_by_one), {"outcome": "off_by_one"},
+                METRIC_OUTCOME_NAME,
+                len(off_by_one),
+                {"outcome": "off_by_one"},
             )
 
             self.__metrics.increment(

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -85,7 +85,11 @@ class SubscriptionWorker(
         )
 
         request = task.task.subscription.data.build_request(
-            self.__dataset, task.timestamp, tick.offsets.upper, timer, self.__metrics,
+            self.__dataset,
+            task.timestamp,
+            tick.offsets.upper,
+            timer,
+            self.__metrics,
         )
         return self.__execute_query(request, timer, task)
 

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -256,8 +256,7 @@ def create_metrics(
 
 
 def with_span(op: str = "function") -> Callable[[F], F]:
-    """ Wraps a function call in a Sentry AM span
-    """
+    """Wraps a function call in a Sentry AM span"""
 
     def decorator(func: F) -> F:
         frame_info = inspect.stack()[1]

--- a/snuba/utils/codecs.py
+++ b/snuba/utils/codecs.py
@@ -21,7 +21,8 @@ class Decoder(Generic[TEncoded, TDecoded], ABC):
 
 
 class Codec(
-    Encoder[TEncoded, TDecoded], Decoder[TEncoded, TDecoded],
+    Encoder[TEncoded, TDecoded],
+    Decoder[TEncoded, TDecoded],
 ):
     pass
 

--- a/snuba/utils/iterators.py
+++ b/snuba/utils/iterators.py
@@ -1,6 +1,5 @@
 from typing import Iterable, Iterator, MutableSequence, Sequence, TypeVar
 
-
 T = TypeVar("T")
 
 

--- a/snuba/utils/metrics/gauge.py
+++ b/snuba/utils/metrics/gauge.py
@@ -7,7 +7,10 @@ from snuba.utils.metrics.types import Tags
 
 class Gauge:
     def __init__(
-        self, metrics: MetricsBackend, name: str, tags: Optional[Tags] = None,
+        self,
+        metrics: MetricsBackend,
+        name: str,
+        tags: Optional[Tags] = None,
     ) -> None:
         self.__metrics = metrics
         self.__name = name

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
         marks_ms: Mapping[str, int]
         tags: Tags
 
-
 else:
     from typing import Any
 

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -497,7 +497,11 @@ class UInt(ColumnType[TModifiers]):
 
 
 class Float(ColumnType[TModifiers]):
-    def __init__(self, size: int, modifiers: Optional[TModifiers] = None,) -> None:
+    def __init__(
+        self,
+        size: int,
+        modifiers: Optional[TModifiers] = None,
+    ) -> None:
         super().__init__(modifiers)
         assert size in (32, 64)
         self.size = size
@@ -532,7 +536,9 @@ class DateTime(ColumnType[TModifiers]):
 
 class Enum(ColumnType[TModifiers]):
     def __init__(
-        self, values: Sequence[tuple[str, int]], modifiers: Optional[TModifiers] = None,
+        self,
+        values: Sequence[tuple[str, int]],
+        modifiers: Optional[TModifiers] = None,
     ) -> None:
         super().__init__(modifiers)
         self.values = values

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -326,10 +326,12 @@ def execute_query_with_rate_limits(
         )
         if org_rate_limit_stats is not None:
             metrics.gauge(
-                name="org_concurrent", value=org_rate_limit_stats.concurrent,
+                name="org_concurrent",
+                value=org_rate_limit_stats.concurrent,
             )
             metrics.gauge(
-                name="org_per_second", value=org_rate_limit_stats.rate,
+                name="org_per_second",
+                value=org_rate_limit_stats.rate,
             )
 
         return execute_query(

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -9,6 +9,7 @@ from snuba import environment, settings, state, util
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_dsl.accessors import get_time_range
 from snuba.datasets.plans.split_strategy import QuerySplitStrategy, SplitQueryRunner
+from snuba.query import OrderByDirection, SelectedExpression
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,
     ConditionFunctions,
@@ -22,7 +23,6 @@ from snuba.query.expressions import CurriedFunctionCall as CurriedFunctionCallEx
 from snuba.query.expressions import Expression
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.expressions import Literal as LiteralExpr
-from snuba.query import OrderByDirection, SelectedExpression
 from snuba.query.matchers import AnyExpression, Column, FunctionCall, Or, Param, String
 from snuba.request.request_settings import RequestSettings
 from snuba.utils.metrics.wrapper import MetricsWrapper

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -82,7 +82,10 @@ class TimeSplitQueryStrategy(QuerySplitStrategy):
         self.__timestamp_col = timestamp_col
 
     def execute(
-        self, query: Query, request_settings: RequestSettings, runner: SplitQueryRunner,
+        self,
+        query: Query,
+        request_settings: RequestSettings,
+        runner: SplitQueryRunner,
     ) -> Optional[QueryResult]:
         """
         If a query is:
@@ -194,14 +197,20 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
     """
 
     def __init__(
-        self, id_column: str, project_column: str, timestamp_column: str,
+        self,
+        id_column: str,
+        project_column: str,
+        timestamp_column: str,
     ) -> None:
         self.__id_column = id_column
         self.__project_column = project_column
         self.__timestamp_column = timestamp_column
 
     def execute(
-        self, query: Query, request_settings: RequestSettings, runner: SplitQueryRunner,
+        self,
+        query: Query,
+        request_settings: RequestSettings,
+        runner: SplitQueryRunner,
     ) -> Optional[QueryResult]:
         """
         Split query in 2 steps if a large number of columns is being selected.
@@ -225,7 +234,10 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
         # Do not split if there is already a = or IN condition on an ID column
         id_column_matcher = FunctionCall(
             Or([String(ConditionFunctions.EQ), String(ConditionFunctions.IN)]),
-            (Column(None, String(self.__id_column)), AnyExpression(),),
+            (
+                Column(None, String(self.__id_column)),
+                AnyExpression(),
+            ),
         )
 
         for expr in query.get_condition() or []:
@@ -348,7 +360,8 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             self.__timestamp_column,
             "<",
             LiteralExpr(
-                None, (util.parse_datetime(max(timestamps)) + timedelta(seconds=1)),
+                None,
+                (util.parse_datetime(max(timestamps)) + timedelta(seconds=1)),
             ),
         )
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -92,7 +92,6 @@ except ImportError:
     def check_down_file_exists() -> bool:
         return False
 
-
 else:
 
     def check_down_file_exists() -> bool:
@@ -468,7 +467,8 @@ def dataset_query(
                 "message": str(cause),
             }
             logger.warning(
-                str(cause), exc_info=True,
+                str(cause),
+                exc_info=True,
             )
         elif isinstance(cause, ClickhouseError):
             details = {
@@ -507,7 +507,9 @@ def dataset_query(
 def handle_subscription_error(exception: InvalidSubscriptionError) -> Response:
     data = {"error": {"type": "subscription", "message": str(exception)}}
     return Response(
-        json.dumps(data, indent=4), 400, {"Content-Type": "application/json"},
+        json.dumps(data, indent=4),
+        400,
+        {"Content-Type": "application/json"},
     )
 
 
@@ -580,7 +582,8 @@ if application.debug or application.testing:
                 rows.extend(processed_message.rows)
 
         BatchWriterEncoderWrapper(
-            table_writer.get_batch_writer(metrics), JSONRowEncoder(),
+            table_writer.get_batch_writer(metrics),
+            JSONRowEncoder(),
         ).write(rows)
 
         return ("ok", 200, {"Content-Type": "text/plain"})

--- a/snuba/writer.py
+++ b/snuba/writer.py
@@ -82,7 +82,10 @@ class MockBatchWriter(BatchWriter[bytes]):
     """
 
     def __init__(
-        self, storage_key: StorageKey, avg_write_latency: int, std_deviation: int,
+        self,
+        storage_key: StorageKey,
+        avg_write_latency: int,
+        std_deviation: int,
     ) -> None:
         self.__latency_seconds = (avg_write_latency) / 1000
         self.__latency_deviation_ms = std_deviation

--- a/tests/clickhouse/test_columns.py
+++ b/tests/clickhouse/test_columns.py
@@ -37,8 +37,20 @@ TEST_CASES = [
         "UUID",
         id="UUIDs",
     ),
-    pytest.param(IPv4(None), IPv4(), IPv4(Modifier(nullable=True)), "IPv4", id="IPs",),
-    pytest.param(IPv6(None), IPv6(), IPv6(Modifier(nullable=True)), "IPv6", id="IPs",),
+    pytest.param(
+        IPv4(None),
+        IPv4(),
+        IPv4(Modifier(nullable=True)),
+        "IPv4",
+        id="IPs",
+    ),
+    pytest.param(
+        IPv6(None),
+        IPv6(),
+        IPv6(Modifier(nullable=True)),
+        "IPv6",
+        id="IPs",
+    ),
     pytest.param(
         FixedString(32, Modifier(nullable=True)),
         FixedString(32),
@@ -60,7 +72,13 @@ TEST_CASES = [
         "Nullable(Float64)",
         id="floats",
     ),
-    pytest.param(Date(), Date(), Date(Modifier(nullable=True)), "Date", id="dates",),
+    pytest.param(
+        Date(),
+        Date(),
+        Date(Modifier(nullable=True)),
+        "Date",
+        id="dates",
+    ),
     pytest.param(
         DateTime(),
         DateTime(),

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -174,7 +174,9 @@ test_expressions = [
                     ),
                 ),
                 binary_condition(
-                    ConditionFunctions.EQ, Column(None, None, "c4"), Literal(None, 4),
+                    ConditionFunctions.EQ,
+                    Column(None, None, "c4"),
+                    Literal(None, 4),
                 ),
             ),
             binary_condition(

--- a/tests/clickhouse/test_native.py
+++ b/tests/clickhouse/test_native.py
@@ -41,7 +41,8 @@ def test_concurrency_limit() -> None:
 
     connection.reset_mock(side_effect=True)
     connection.execute.side_effect = ClickhouseError(
-        "some error", code=errors.ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
+        "some error",
+        code=errors.ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES,
     )
 
     with pytest.raises(ClickhouseError):

--- a/tests/clickhouse/test_query_data.py
+++ b/tests/clickhouse/test_query_data.py
@@ -19,11 +19,15 @@ def test_format_clickhouse_specific_query() -> None:
             SelectedExpression("column2", Column(None, "table1", "column2")),
         ],
         condition=binary_condition(
-            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
+            "eq",
+            lhs=Column(None, None, "column1"),
+            rhs=Literal(None, "blabla"),
         ),
         groupby=[Column(None, None, "column1"), Column(None, "table1", "column2")],
         having=binary_condition(
-            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
+            "eq",
+            lhs=Column(None, None, "column1"),
+            rhs=Literal(None, 123),
         ),
         order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         array_join=[Column(None, None, "column1")],

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -65,7 +65,9 @@ test_cases = [
                 SelectedExpression("column3", Column("al", None, "column3")),
             ],
             condition=binary_condition(
-                "eq", lhs=Column("al", None, "column3"), rhs=Literal(None, "blabla"),
+                "eq",
+                lhs=Column("al", None, "column3"),
+                rhs=Literal(None, "blabla"),
             ),
             groupby=[
                 Column(None, None, "column1"),
@@ -74,7 +76,9 @@ test_cases = [
                 Column(None, None, "column4"),
             ],
             having=binary_condition(
-                "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
+                "eq",
+                lhs=Column(None, None, "column1"),
+                rhs=Literal(None, 123),
             ),
             order_by=[
                 OrderBy(OrderByDirection.ASC, Column(None, None, "column1")),
@@ -452,7 +456,9 @@ test_cases = [
                             ),
                         ],
                         condition=binary_condition(
-                            "eq", Column(None, None, "user"), Literal(None, "me"),
+                            "eq",
+                            Column(None, None, "user"),
+                            Literal(None, "me"),
                         ),
                     ),
                 ),
@@ -568,11 +574,15 @@ def test_format_clickhouse_specific_query() -> None:
             SelectedExpression("column2", Column(None, "table1", "column2")),
         ],
         condition=binary_condition(
-            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, "blabla"),
+            "eq",
+            lhs=Column(None, None, "column1"),
+            rhs=Literal(None, "blabla"),
         ),
         groupby=[Column(None, None, "column1"), Column(None, "table1", "column2")],
         having=binary_condition(
-            "eq", lhs=Column(None, None, "column1"), rhs=Literal(None, 123),
+            "eq",
+            lhs=Column(None, None, "column1"),
+            rhs=Literal(None, 123),
         ),
         order_by=[OrderBy(OrderByDirection.ASC, Column(None, None, "column1"))],
         array_join=[Column(None, None, "column1")],

--- a/tests/clickhouse/test_query_profiler.py
+++ b/tests/clickhouse/test_query_profiler.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.query_profiler import generate_profile

--- a/tests/clickhouse/test_query_profiler.py
+++ b/tests/clickhouse/test_query_profiler.py
@@ -32,7 +32,9 @@ test_cases = [
                 SelectedExpression(
                     "something",
                     FunctionCall(
-                        "something", "arrayJoin", (Column(None, None, "contexts.key"),),
+                        "something",
+                        "arrayJoin",
+                        (Column(None, None, "contexts.key"),),
                     ),
                 ),
             ],
@@ -53,7 +55,10 @@ test_cases = [
                     binary_condition(
                         ConditionFunctions.EQ,
                         build_mapping_expr(
-                            "tags[asd]", None, "tags", Literal(None, "asd"),
+                            "tags[asd]",
+                            None,
+                            "tags",
+                            Literal(None, "asd"),
                         ),
                         Literal(None, "sdf"),
                     ),
@@ -111,7 +116,8 @@ test_cases = [
             all_columns={"events.column2", "events.timestamp"},
             multi_level_condition=True,
             where_profile=FilterProfile(
-                columns={"events.timestamp"}, mapping_cols=set(),
+                columns={"events.timestamp"},
+                mapping_cols=set(),
             ),
             groupby_cols=set(),
             array_join_cols=set(),
@@ -146,7 +152,10 @@ test_cases = [
                         binary_condition(
                             ConditionFunctions.EQ,
                             build_mapping_expr(
-                                "tags[asd]", None, "tags", Literal(None, "asd"),
+                                "tags[asd]",
+                                None,
+                                "tags",
+                                Literal(None, "asd"),
                             ),
                             Literal(None, "sdf"),
                         ),
@@ -222,7 +231,8 @@ test_cases = [
             },
             multi_level_condition=True,
             where_profile=FilterProfile(
-                columns={"sentry_errors.timestamp"}, mapping_cols=set(),
+                columns={"sentry_errors.timestamp"},
+                mapping_cols=set(),
             ),
             groupby_cols=set(),
             array_join_cols=set(),
@@ -234,7 +244,8 @@ test_cases = [
 
 @pytest.mark.parametrize("query, profile", test_cases)
 def test_format_expressions(
-    query: ClickhouseQuery, profile: ClickhouseQueryProfile,
+    query: ClickhouseQuery,
+    profile: ClickhouseQueryProfile,
 ) -> None:
     generated_profile = generate_profile(query)
     assert generated_profile == profile
@@ -248,7 +259,10 @@ def test_serialization() -> None:
         table="events",
         all_columns={"col", "timestamp", "arrayjoin"},
         multi_level_condition=True,
-        where_profile=FilterProfile(columns={"timestamp"}, mapping_cols=set(),),
+        where_profile=FilterProfile(
+            columns={"timestamp"},
+            mapping_cols=set(),
+        ),
         groupby_cols={"col"},
         array_join_cols={"arrayjoin"},
     )

--- a/tests/clickhouse/translators/snuba/test_translation.py
+++ b/tests/clickhouse/translators/snuba/test_translation.py
@@ -59,7 +59,12 @@ def test_column_curried_function_translation() -> None:
         None,
         "duration_quantiles",
         FunctionCall(
-            None, "quantilesIfMerge", (Literal(None, 0.5), Literal(None, 0.9),)
+            None,
+            "quantilesIfMerge",
+            (
+                Literal(None, 0.5),
+                Literal(None, 0.9),
+            ),
         ),
         (Column(None, None, "duration_quantiles"),),
     ).attempt_map(
@@ -68,7 +73,12 @@ def test_column_curried_function_translation() -> None:
     ) == CurriedFunctionCall(
         "duration_quantiles",
         FunctionCall(
-            None, "quantilesIfMerge", (Literal(None, 0.5), Literal(None, 0.9),)
+            None,
+            "quantilesIfMerge",
+            (
+                Literal(None, 0.5),
+                Literal(None, 0.9),
+            ),
         ),
         (Column(None, None, "duration_quantiles"),),
     )

--- a/tests/clusters/fake_cluster.py
+++ b/tests/clusters/fake_cluster.py
@@ -97,7 +97,9 @@ class FakeClickhouseCluster(ClickhouseCluster):
             Tuple[ClickhouseNode, ClickhouseClientSettings], FakeClickhousePool
         ] = {}
 
-    def get_queries(self,) -> Mapping[str, Sequence[str]]:
+    def get_queries(
+        self,
+    ) -> Mapping[str, Sequence[str]]:
         return {
             key[0].host_name: self.__connections[key].get_queries()
             for key in self.__connections
@@ -122,7 +124,9 @@ class FakeClickhouseCluster(ClickhouseCluster):
         return [node[0] for node in self.__nodes.values()]
 
     def get_node_connection(
-        self, client_settings: ClickhouseClientSettings, node: ClickhouseNode,
+        self,
+        client_settings: ClickhouseClientSettings,
+        node: ClickhouseNode,
     ) -> ClickhousePool:
         settings, timeout = client_settings.value
         cache_key = (node, client_settings)

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytz
+
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.cdc.groupassignee_processor import (
@@ -171,7 +172,8 @@ class TestGroupassignee:
         ret = (
             self.storage.get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute("SELECT * FROM groupassignee_local;").results
+            .execute("SELECT * FROM groupassignee_local;")
+            .results
         )
         assert ret[0] == (
             42,  # offset
@@ -217,7 +219,8 @@ class TestGroupassignee:
         ret = (
             self.storage.get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute("SELECT * FROM groupassignee_local;").results
+            .execute("SELECT * FROM groupassignee_local;")
+            .results
         )
         assert ret[0] == (
             0,  # offset

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -237,7 +237,8 @@ class TestGroupedMessage:
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.INSERT)
-            .execute("SELECT * FROM groupedmessage_local;").results
+            .execute("SELECT * FROM groupedmessage_local;")
+            .results
         )
         assert ret[0] == (
             42,  # offset
@@ -279,7 +280,8 @@ class TestGroupedMessage:
         ret = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.QUERY)
-            .execute("SELECT * FROM groupedmessage_local;").results
+            .execute("SELECT * FROM groupedmessage_local;")
+            .results
         )
         assert ret[0] == (
             0,  # offset

--- a/tests/datasets/entities/test_clickhouse_upgrade_callback.py
+++ b/tests/datasets/entities/test_clickhouse_upgrade_callback.py
@@ -103,14 +103,20 @@ TESTS = [
 
 
 @pytest.mark.parametrize(
-    "row1, row2, expected", TESTS,
+    "row1, row2, expected",
+    TESTS,
 )
 def test_similarities(row1: SplitRow, row2: SplitRow, expected: float) -> None:
     assert abs(row_similarity(row1, row2) - expected) < 0.0001
 
 
 TESTS = [
-    pytest.param([], [], 1.0, id="Empty results",),
+    pytest.param(
+        [],
+        [],
+        1.0,
+        id="Empty results",
+    ),
     pytest.param(
         [{"key": "asd", "value1": 1.0, "value2": 1.0}],
         [],
@@ -191,12 +197,17 @@ TESTS = [
 
 
 @pytest.mark.parametrize(
-    "data_row1, data_row2, expected", TESTS,
+    "data_row1, data_row2, expected",
+    TESTS,
 )
 def test_similarity_results(
-    data_row1: MutableSequence[Row], data_row2: MutableSequence[Row], expected: float,
+    data_row1: MutableSequence[Row],
+    data_row2: MutableSequence[Row],
+    expected: float,
 ) -> None:
     schema = SplitSchema(
-        complete=True, key_cols=("key",), value_cols=("value1", "value2"),
+        complete=True,
+        key_cols=("key",),
+        value_cols=("value1", "value2"),
     )
     assert abs(calculate_score(data_row1, data_row2, schema) - expected) < 0.0001

--- a/tests/datasets/entities/test_clickhouse_upgrade_rollout.py
+++ b/tests/datasets/entities/test_clickhouse_upgrade_rollout.py
@@ -85,12 +85,14 @@ def test_rollout_percentage(
     expceted: Choice,
 ) -> None:
     set_config(
-        "rollout_upgraded_errors_trust_configreferrer", referrer_trust_config,
+        "rollout_upgraded_errors_trust_configreferrer",
+        referrer_trust_config,
     )
     set_config("rollout_upgraded_errors_trust", global_trust_config)
 
     set_config(
-        "rollout_upgraded_errors_execute_configreferrer", referrer_execute_config,
+        "rollout_upgraded_errors_execute_configreferrer",
+        referrer_execute_config,
     )
     set_config("rollout_upgraded_errors_execute", global_execute_config)
 

--- a/tests/datasets/plans/translator/test_mapping.py
+++ b/tests/datasets/plans/translator/test_mapping.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.translators.snuba.mappers import (

--- a/tests/datasets/plans/translator/test_mapping.py
+++ b/tests/datasets/plans/translator/test_mapping.py
@@ -53,7 +53,10 @@ test_cases = [
                     FunctionCall(
                         "alias2",
                         "f1",
-                        (Column(None, None, "column2"), Column(None, None, "column3"),),
+                        (
+                            Column(None, None, "column2"),
+                            Column(None, None, "column3"),
+                        ),
                     ),
                 ),
                 SelectedExpression(

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -52,7 +52,9 @@ def build_time_range(query_from: datetime, query_to: datetime) -> Expression:
             (Column(None, None, "timestamp"), Literal(None, query_from)),
         ),
         FunctionCall(
-            None, "less", (Column(None, None, "timestamp"), Literal(None, query_to)),
+            None,
+            "less",
+            (Column(None, None, "timestamp"), Literal(None, query_to)),
         ),
     )
 
@@ -72,7 +74,8 @@ def build_group_ids_condition() -> Expression:
 @pytest.fixture
 def query() -> ClickhouseQuery:
     return ClickhouseQuery(
-        Table("my_table", ColumnSet([])), condition=build_in("project_id", [2]),
+        Table("my_table", ColumnSet([])),
+        condition=build_in("project_id", [2]),
     )
 
 
@@ -103,14 +106,16 @@ def query_with_future_timestamp() -> ClickhouseQuery:
 @pytest.fixture
 def query_with_single_group_id() -> ClickhouseQuery:
     return ClickhouseQuery(
-        Table("my_table", ColumnSet([])), condition=build_group_id_condition(),
+        Table("my_table", ColumnSet([])),
+        condition=build_group_id_condition(),
     )
 
 
 @pytest.fixture
 def query_with_multiple_group_ids() -> ClickhouseQuery:
     return ClickhouseQuery(
-        Table("my_table", ColumnSet([])), condition=build_group_ids_condition(),
+        Table("my_table", ColumnSet([])),
+        condition=build_group_ids_condition(),
     )
 
 
@@ -172,7 +177,11 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
                 FunctionCall(
                     None,
                     "tuple",
-                    (Literal(None, 100), Literal(None, 101), Literal(None, 102),),
+                    (
+                        Literal(None, 100),
+                        Literal(None, 101),
+                        Literal(None, 102),
+                    ),
                 ),
             ),
         ),
@@ -435,7 +444,8 @@ def test_no_groups_not_too_many_excludes(query: ClickhouseQuery) -> None:
 
     enforcer.process_query(query, HTTPRequestSettings())
     assert query.get_condition() == build_and(
-        build_not_in("group_id", [100, 101, 102]), build_in("project_id", [2]),
+        build_not_in("group_id", [100, 101, 102]),
+        build_in("project_id", [2]),
     )
     assert not query.get_from_clause().final
 

--- a/tests/datasets/test_cdc_events.py
+++ b/tests/datasets/test_cdc_events.py
@@ -4,6 +4,7 @@ from functools import partial
 import pytest
 import pytz
 import simplejson as json
+
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend

--- a/tests/datasets/test_context_promotion.py
+++ b/tests/datasets/test_context_promotion.py
@@ -25,8 +25,16 @@ span_id_as_uint64 = int(span_id_hex, 16)
 @pytest.mark.parametrize(
     "entity, expected_table_name",
     [
-        pytest.param(get_entity(EntityKey.DISCOVER), "discover", id="discover",),
-        pytest.param(get_entity(EntityKey.EVENTS), "errors", id="events",),
+        pytest.param(
+            get_entity(EntityKey.DISCOVER),
+            "discover",
+            id="discover",
+        ),
+        pytest.param(
+            get_entity(EntityKey.EVENTS),
+            "errors",
+            id="events",
+        ),
     ],
 )
 def test_span_id_promotion(entity: Entity, expected_table_name: str) -> None:

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -152,7 +152,8 @@ test_data = [
 
 @pytest.mark.parametrize("query_body, expected_entity", test_data)
 def test_data_source(
-    query_body: MutableMapping[str, Any], expected_entity: EntityKey,
+    query_body: MutableMapping[str, Any],
+    expected_entity: EntityKey,
 ) -> None:
     dataset = get_dataset("discover")
     # HACK until these are converted to proper SnQL queries

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -49,7 +49,9 @@ class TestReplacer:
 
         self.storage = get_writable_storage(StorageKey.ERRORS)
         self.replacer = replacer.ReplacerWorker(
-            self.storage, CONSUMER_GROUP, DummyMetricsBackend(strict=True),
+            self.storage,
+            CONSUMER_GROUP,
+            DummyMetricsBackend(strict=True),
         )
 
         # Total query time range is 24h before to 24h after now to account
@@ -190,7 +192,10 @@ class TestReplacer:
             expected["old_primary_hash"] = "'e3d704f3-542b-44a6-21eb-ed70dc0efe13'"
 
         assert replacement.query_args == expected
-        assert replacement.query_time_flags == (None, self.project_id,)
+        assert replacement.query_time_flags == (
+            None,
+            self.project_id,
+        )
 
     def test_tombstone_events_process_timestamp(self) -> None:
         from_ts = datetime.now()
@@ -222,7 +227,10 @@ class TestReplacer:
             "required_columns": "event_id, primary_hash, project_id, group_id, timestamp, deleted, retention_days",
             "select_columns": "event_id, primary_hash, project_id, group_id, timestamp, 1, retention_days",
         }
-        assert replacement.query_time_flags == (None, self.project_id,)
+        assert replacement.query_time_flags == (
+            None,
+            self.project_id,
+        )
 
     def test_replace_group_process(self) -> None:
         timestamp = datetime.now()
@@ -254,7 +262,10 @@ class TestReplacer:
             "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, hierarchical_hashes, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, sdk_integrations, modules.name, modules.version",
             "select_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, 2, primary_hash, hierarchical_hashes, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, sdk_integrations, modules.name, modules.version",
         }
-        assert replacement.query_time_flags == (None, self.project_id,)
+        assert replacement.query_time_flags == (
+            None,
+            self.project_id,
+        )
 
     def test_merge_process(self) -> None:
         timestamp = datetime.now()
@@ -367,7 +378,10 @@ class TestReplacer:
             "timestamp": timestamp.strftime(DATETIME_FORMAT),
         }
 
-        assert replacement.query_time_flags == (None, self.project_id,)
+        assert replacement.query_time_flags == (
+            None,
+            self.project_id,
+        )
 
     def test_delete_promoted_tag_process(self) -> None:
         timestamp = datetime.now()
@@ -690,7 +704,13 @@ class TestReplacer:
             41,
             KafkaPayload(
                 None,
-                json.dumps((2, ReplacementType.END_UNMERGE, {},)).encode("utf-8"),
+                json.dumps(
+                    (
+                        2,
+                        ReplacementType.END_UNMERGE,
+                        {},
+                    )
+                ).encode("utf-8"),
                 [],
             ),
             datetime.now(),
@@ -701,7 +721,13 @@ class TestReplacer:
             42,
             KafkaPayload(
                 None,
-                json.dumps((2, ReplacementType.END_UNMERGE, {},)).encode("utf-8"),
+                json.dumps(
+                    (
+                        2,
+                        ReplacementType.END_UNMERGE,
+                        {},
+                    )
+                ).encode("utf-8"),
                 [],
             ),
             datetime.now(),
@@ -741,10 +767,16 @@ class TestReplacer:
         timestamp = datetime.now()
 
         partition_one: Message[KafkaPayload] = Message(
-            Partition(Topic("replacements"), 1), offset, payload, timestamp,
+            Partition(Topic("replacements"), 1),
+            offset,
+            payload,
+            timestamp,
         )
         partition_two: Message[KafkaPayload] = Message(
-            Partition(Topic("replacements"), 2), offset, payload, timestamp,
+            Partition(Topic("replacements"), 2),
+            offset,
+            payload,
+            timestamp,
         )
 
         processed = self.replacer.process_message(partition_one)

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -39,7 +39,9 @@ TEST_CASES = [
         "sum(value)",
         EntityKey.METRICS_COUNTERS,
         FunctionCall(
-            "_snuba_sum(value)", "sumMerge", (Column("_snuba_value", None, "value"),),
+            "_snuba_sum(value)",
+            "sumMerge",
+            (Column("_snuba_value", None, "value"),),
         ),
         id="Test counters entity",
     ),
@@ -61,7 +63,11 @@ TEST_CASES = [
         "metrics_distributions",
         "max(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall("_snuba_max(value)", "maxMerge", (Column(None, None, "max"),),),
+        FunctionCall(
+            "_snuba_max(value)",
+            "maxMerge",
+            (Column(None, None, "max"),),
+        ),
         id="Test distribution max",
     ),
     pytest.param(
@@ -71,7 +77,10 @@ TEST_CASES = [
         FunctionCall(
             "_snuba_maxIf(value, cond())",
             "maxMergeIf",
-            (Column(None, None, "max"), FunctionCall(None, "cond", tuple()),),
+            (
+                Column(None, None, "max"),
+                FunctionCall(None, "cond", tuple()),
+            ),
         ),
         id="Test distribution max with condition",
     ),
@@ -79,7 +88,11 @@ TEST_CASES = [
         "metrics_distributions",
         "min(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall("_snuba_min(value)", "minMerge", (Column(None, None, "min"),),),
+        FunctionCall(
+            "_snuba_min(value)",
+            "minMerge",
+            (Column(None, None, "min"),),
+        ),
         id="Test distribution min",
     ),
     pytest.param(
@@ -89,7 +102,10 @@ TEST_CASES = [
         FunctionCall(
             "_snuba_minIf(value, cond())",
             "minMergeIf",
-            (Column(None, None, "min"), FunctionCall(None, "cond", tuple()),),
+            (
+                Column(None, None, "min"),
+                FunctionCall(None, "cond", tuple()),
+            ),
         ),
         id="Test distribution min with condition",
     ),
@@ -97,7 +113,11 @@ TEST_CASES = [
         "metrics_distributions",
         "avg(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
-        FunctionCall("_snuba_avg(value)", "avgMerge", (Column(None, None, "avg"),),),
+        FunctionCall(
+            "_snuba_avg(value)",
+            "avgMerge",
+            (Column(None, None, "avg"),),
+        ),
         id="Test distribution avg",
     ),
     pytest.param(
@@ -107,7 +127,10 @@ TEST_CASES = [
         FunctionCall(
             "_snuba_avgIf(value, cond())",
             "avgMergeIf",
-            (Column(None, None, "avg"), FunctionCall(None, "cond", tuple()),),
+            (
+                Column(None, None, "avg"),
+                FunctionCall(None, "cond", tuple()),
+            ),
         ),
         id="Test distribution avg with condition",
     ),
@@ -116,7 +139,9 @@ TEST_CASES = [
         "count(value)",
         EntityKey.METRICS_DISTRIBUTIONS,
         FunctionCall(
-            "_snuba_count(value)", "countMerge", (Column(None, None, "count"),),
+            "_snuba_count(value)",
+            "countMerge",
+            (Column(None, None, "count"),),
         ),
         id="Test distribution count",
     ),
@@ -235,9 +260,13 @@ def test_metrics_processing(
         reader: Reader,
     ) -> QueryResult:
         assert query.get_selected_columns() == [
-            SelectedExpression("org_id", Column("_snuba_org_id", None, "org_id"),),
             SelectedExpression(
-                "project_id", Column("_snuba_project_id", None, "project_id"),
+                "org_id",
+                Column("_snuba_org_id", None, "org_id"),
+            ),
+            SelectedExpression(
+                "project_id",
+                Column("_snuba_project_id", None, "project_id"),
             ),
             SelectedExpression(
                 "tags[10]",
@@ -254,7 +283,10 @@ def test_metrics_processing(
                     ),
                 ),
             ),
-            SelectedExpression(column_name, translated_value,),
+            SelectedExpression(
+                column_name,
+                translated_value,
+            ),
         ]
         return QueryResult(
             result={"meta": [], "data": [], "totals": {}},

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -241,17 +241,32 @@ TEST_CASES_AGGREGATES = [
                     ),
                 ),
                 "min": _call(
-                    "arrayReduce", (_literal("minState"), _array_literal([324.12]),)
+                    "arrayReduce",
+                    (
+                        _literal("minState"),
+                        _array_literal([324.12]),
+                    ),
                 ),
                 "max": _call(
-                    "arrayReduce", (_literal("maxState"), _array_literal([567567]),)
+                    "arrayReduce",
+                    (
+                        _literal("maxState"),
+                        _array_literal([567567]),
+                    ),
                 ),
                 "avg": _call(
-                    "arrayReduce", (_literal("avgState"), _array_literal(DIST_VALUES),),
+                    "arrayReduce",
+                    (
+                        _literal("avgState"),
+                        _array_literal(DIST_VALUES),
+                    ),
                 ),
                 "sum": _call(
                     "arrayReduce",
-                    (_literal("sumState"), _array_literal([sum(DIST_VALUES)]),),
+                    (
+                        _literal("sumState"),
+                        _array_literal([sum(DIST_VALUES)]),
+                    ),
                 ),
                 "count": _call(
                     "arrayReduce",
@@ -403,10 +418,12 @@ TEST_CASES_POLYMORPHIC = [
 
 
 @pytest.mark.parametrize(
-    "message, expected_output", TEST_CASES_POLYMORPHIC,
+    "message, expected_output",
+    TEST_CASES_POLYMORPHIC,
 )
 def test_metrics_polymorphic_processor(
-    message: Mapping[str, Any], expected_output: Optional[Sequence[Mapping[str, Any]]],
+    message: Mapping[str, Any],
+    expected_output: Optional[Sequence[Mapping[str, Any]]],
 ) -> None:
     settings.DISABLED_DATASETS = set()
 

--- a/tests/datasets/test_nullable_field_casting.py
+++ b/tests/datasets/test_nullable_field_casting.py
@@ -20,7 +20,13 @@ from snuba.web import QueryResult
 
 @pytest.mark.parametrize(
     "entity, expected_table_name",
-    [pytest.param(get_entity(EntityKey.DISCOVER), "discover", id="discover",)],
+    [
+        pytest.param(
+            get_entity(EntityKey.DISCOVER),
+            "discover",
+            id="discover",
+        )
+    ],
 )
 def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> None:
     dataset_name = "discover"

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -72,7 +72,8 @@ def test_simple() -> None:
                     all_columns={"timestamp", "tags"},
                     multi_level_condition=False,
                     where_profile=FilterProfile(
-                        columns={"timestamp"}, mapping_cols={"tags"},
+                        columns={"timestamp"},
+                        mapping_cols={"tags"},
                     ),
                     groupby_cols=set(),
                     array_join_cols=set(),
@@ -182,7 +183,8 @@ def test_missing_fields() -> None:
                     all_columns={"timestamp", "tags"},
                     multi_level_condition=False,
                     where_profile=FilterProfile(
-                        columns={"timestamp"}, mapping_cols={"tags"},
+                        columns={"timestamp"},
+                        mapping_cols={"tags"},
                     ),
                     groupby_cols=set(),
                     array_join_cols=set(),

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
-from snuba.datasets.sessions_processor import SessionsProcessor
 from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.sessions_processor import SessionsProcessor
 from snuba.processor import InsertBatch
 
 

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -56,7 +56,11 @@ def test_sessions_processing() -> None:
                 "duration_quantiles",
                 CurriedFunctionCall(
                     "_snuba_duration_quantiles",
-                    FunctionCall(None, "quantilesIfMerge", quantiles,),
+                    FunctionCall(
+                        None,
+                        "quantilesIfMerge",
+                        quantiles,
+                    ),
                     (Column(None, None, "duration_quantiles"),),
                 ),
             ),
@@ -184,7 +188,8 @@ selector_tests = [
 
 
 @pytest.mark.parametrize(
-    "query_body, is_subscription, expected_table", selector_tests,
+    "query_body, is_subscription, expected_table",
+    selector_tests,
 )
 def test_select_storage(
     query_body: MutableMapping[str, Any], is_subscription: bool, expected_table: str

--- a/tests/datasets/test_transaction_translations.py
+++ b/tests/datasets/test_transaction_translations.py
@@ -17,7 +17,9 @@ from snuba.query.expressions import (
 
 test_data = [
     pytest.param(
-        Column(None, None, "group_id"), Literal(None, 0), id="basic column translation",
+        Column(None, None, "group_id"),
+        Literal(None, 0),
+        id="basic column translation",
     ),
     pytest.param(
         Column(None, None, "primary_hash"),
@@ -51,11 +53,21 @@ test_data = [
                 FunctionCall(
                     None,
                     "not",
-                    (FunctionCall(None, "identity", (Literal(None, None),),),),
+                    (
+                        FunctionCall(
+                            None,
+                            "identity",
+                            (Literal(None, None),),
+                        ),
+                    ),
                 ),
             ),
         ),
-        FunctionCall(None, "identity", (Literal(None, None),),),
+        FunctionCall(
+            None,
+            "identity",
+            (Literal(None, None),),
+        ),
         id="countIf not identity none mapper",
     ),
     pytest.param(
@@ -66,7 +78,13 @@ test_data = [
                 FunctionCall(
                     None,
                     "not",
-                    (FunctionCall(None, "identity", (Literal(None, 42),),),),
+                    (
+                        FunctionCall(
+                            None,
+                            "identity",
+                            (Literal(None, 42),),
+                        ),
+                    ),
                 ),
             ),
         ),
@@ -77,7 +95,13 @@ test_data = [
                 FunctionCall(
                     None,
                     "not",
-                    (FunctionCall(None, "identity", (Literal(None, 42),),),),
+                    (
+                        FunctionCall(
+                            None,
+                            "identity",
+                            (Literal(None, 42),),
+                        ),
+                    ),
                 ),
             ),
         ),
@@ -261,7 +285,14 @@ test_data = [
             "plus",
             (
                 Literal(None, 0),
-                FunctionCall(None, "multiply", (Literal(None, 0.0), Literal(None, 0),)),
+                FunctionCall(
+                    None,
+                    "multiply",
+                    (
+                        Literal(None, 0.0),
+                        Literal(None, 0),
+                    ),
+                ),
             ),
         ),
         FunctionCall(
@@ -269,7 +300,14 @@ test_data = [
             "plus",
             (
                 Literal(None, 0),
-                FunctionCall(None, "multiply", (Literal(None, 0.0), Literal(None, 0),)),
+                FunctionCall(
+                    None,
+                    "multiply",
+                    (
+                        Literal(None, 0.0),
+                        Literal(None, 0),
+                    ),
+                ),
             ),
         ),
         id="literals aren't cached",
@@ -279,7 +317,8 @@ test_data = [
 
 @pytest.mark.parametrize("expression, expected", test_data)
 def test_transaction_translation(
-    expression: Expression, expected: ClickhouseExpression,
+    expression: Expression,
+    expected: ClickhouseExpression,
 ) -> None:
     translator = SnubaClickhouseMappingTranslator(
         transaction_translation_mappers.concat(null_function_translation_mappers)

--- a/tests/datasets/validation/test_entity_validation.py
+++ b/tests/datasets/validation/test_entity_validation.py
@@ -21,7 +21,9 @@ required_column_tests = [
     pytest.param(
         EntityKey.SPANS,
         binary_condition(
-            "equals", Column("_snuba_project_id", None, "project_id"), Literal(None, 1),
+            "equals",
+            Column("_snuba_project_id", None, "project_id"),
+            Literal(None, 1),
         ),
         id="spans has project required with =",
     ),
@@ -91,7 +93,9 @@ def test_entity_required_column_validation(
 
 invalid_required_column_tests = [
     pytest.param(
-        EntityKey.EVENTS, None, id="entity has columns, but there are no conditions",
+        EntityKey.EVENTS,
+        None,
+        id="entity has columns, but there are no conditions",
     ),
     pytest.param(
         EntityKey.SPANS,
@@ -123,7 +127,10 @@ def test_entity_required_column_validation_failure(
 
 
 entity_contains_columns_tests = [
-    pytest.param(EntityKey.OUTCOMES, id="Validate Outcomes Entity Columns",)
+    pytest.param(
+        EntityKey.OUTCOMES,
+        id="Validate Outcomes Entity Columns",
+    )
 ]
 
 

--- a/tests/datasets/validation/test_no_time_condition_validator.py
+++ b/tests/datasets/validation/test_no_time_condition_validator.py
@@ -16,7 +16,9 @@ tests = [
     pytest.param(
         EntityKey.EVENTS,
         binary_condition(
-            "equals", Column("_snuba_project_id", None, "project_id"), Literal(None, 1),
+            "equals",
+            Column("_snuba_project_id", None, "project_id"),
+            Literal(None, 1),
         ),
         id="equals",
     ),

--- a/tests/datasets/validation/test_subscription_clauses_validator.py
+++ b/tests/datasets/validation/test_subscription_clauses_validator.py
@@ -150,7 +150,9 @@ invalid_tests = [
                 Literal(None, 1),
             ),
             having=binary_condition(
-                "greater", Column("_snuba_count", None, "count"), Literal(None, 1),
+                "greater",
+                Column("_snuba_count", None, "count"),
+                Literal(None, 1),
             ),
         ),
         id="no having clauses",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -201,7 +201,7 @@ def get_raw_transaction(span_id: str | None = None) -> Mapping[str, Any]:
             "timestamp": datetime.timestamp(end_timestamp),
             "tags": {
                 # Sentry
-                "environment": u"prød",
+                "environment": "prød",
                 "sentry:release": "1",
                 "sentry:dist": "dist1",
                 "url": "http://127.0.0.1:/query",

--- a/tests/migrations/test_runner_add_node.py
+++ b/tests/migrations/test_runner_add_node.py
@@ -51,7 +51,13 @@ def test_add_node() -> None:
     password = ""
     database = os.environ.get("CLICKHOUSE_DATABASE", "default")
 
-    client = ClickhousePool(host_name, port, user, password, database,)
+    client = ClickhousePool(
+        host_name,
+        port,
+        user,
+        password,
+        database,
+    )
 
     assert set(client.execute("SHOW TABLES").results) == set()
 

--- a/tests/migrations/test_runner_individual.py
+++ b/tests/migrations/test_runner_individual.py
@@ -176,7 +176,8 @@ def test_groupedmessages_compatibility() -> None:
         )
 
     runner.run_migration(
-        MigrationKey(MigrationGroup.EVENTS, migration_id), force=True,
+        MigrationKey(MigrationGroup.EVENTS, migration_id),
+        force=True,
     )
 
     outcome = perform_select_query(
@@ -194,7 +195,7 @@ def run_prior_migrations(
     migration_group: MigrationGroup, stop_migration_id: str, runner: Runner
 ) -> None:
 
-    """ Runs all migrations up to the migration denoted by migration ID
+    """Runs all migrations up to the migration denoted by migration ID
 
     Arguments:
     migration_group -- the group of the desired migration
@@ -226,7 +227,7 @@ def perform_select_query(
     connection: ClickhousePool,
 ) -> Sequence[Any]:
 
-    """ Performs a SELECT query, with optional WHERE and LIMIT clauses
+    """Performs a SELECT query, with optional WHERE and LIMIT clauses
 
     Arguments:
     columns -- a list of columns to be SELECTed

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -252,8 +252,14 @@ TEST_CASES = [
     pytest.param(
         CompositeQuery(
             from_clause=JoinClause(
-                left_node=IndividualNode(alias="err", data_source=events_ent,),
-                right_node=IndividualNode(alias="groups", data_source=groups_ent,),
+                left_node=IndividualNode(
+                    alias="err",
+                    data_source=events_ent,
+                ),
+                right_node=IndividualNode(
+                    alias="groups",
+                    data_source=groups_ent,
+                ),
                 keys=[
                     JoinCondition(
                         left=JoinConditionExpression("err", "group_id"),
@@ -265,10 +271,15 @@ TEST_CASES = [
             selected_columns=[
                 SelectedExpression(
                     "f_release",
-                    FunctionCall("f_release", "f", (Column(None, "err", "release"),),),
+                    FunctionCall(
+                        "f_release",
+                        "f",
+                        (Column(None, "err", "release"),),
+                    ),
                 ),
                 SelectedExpression(
-                    "_snuba_right", Column("_snuba_right", "groups", "right_col"),
+                    "_snuba_right",
+                    Column("_snuba_right", "groups", "right_col"),
                 ),
             ],
             condition=binary_condition(
@@ -353,7 +364,8 @@ TEST_CASES = [
                 ),
                 selected_columns=[
                     SelectedExpression(
-                        "f_release", Column("f_release", "err", "f_release"),
+                        "f_release",
+                        Column("f_release", "err", "f_release"),
                     ),
                     SelectedExpression(
                         "_snuba_right",
@@ -459,10 +471,12 @@ TEST_CASES = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "f_release", Column("f_release", "err", "f_release"),
+                    "f_release",
+                    Column("f_release", "err", "f_release"),
                 ),
                 SelectedExpression(
-                    "_snuba_right", Column("_snuba_right", "groups", "_snuba_right"),
+                    "_snuba_right",
+                    Column("_snuba_right", "groups", "_snuba_right"),
                 ),
             ],
         ),
@@ -502,7 +516,8 @@ def test_composite_planner(
 
     if plan.root_processors is not None and composite_plan.root_processors is not None:
         assert_subquery_processors_equality(
-            plan.root_processors, composite_plan.root_processors,
+            plan.root_processors,
+            composite_plan.root_processors,
         )
 
     query_alias_processors = plan.aliased_processors is not None
@@ -516,7 +531,8 @@ def test_composite_planner(
         assert len(plan.aliased_processors) == len(composite_plan.aliased_processors)
         for k in plan.aliased_processors:
             assert_subquery_processors_equality(
-                plan.aliased_processors[k], composite_plan.aliased_processors[k],
+                plan.aliased_processors[k],
+                composite_plan.aliased_processors[k],
             )
 
     def runner(
@@ -526,6 +542,9 @@ def test_composite_planner(
     ) -> QueryResult:
         report = query.equals(processed_query)
         assert report[0], f"Mismatch: {report[1]}"
-        return QueryResult({"data": []}, {"stats": {}, "sql": "", "experiments": {}},)
+        return QueryResult(
+            {"data": []},
+            {"stats": {}, "sql": "", "experiments": {}},
+        )
 
     CompositeExecutionPipeline(logical_query, HTTPRequestSettings(), runner).execute()

--- a/tests/pipeline/test_selector.py
+++ b/tests/pipeline/test_selector.py
@@ -16,7 +16,8 @@ def build_plan(table_name: str, storage_set: StorageSetKey) -> ClickhouseQueryPl
     return ClickhouseQueryPlan(
         Query(Table(table_name, ColumnSet([]))),
         SimpleQueryPlanExecutionStrategy(
-            get_cluster(storage_set), db_query_processors=[],
+            get_cluster(storage_set),
+            db_query_processors=[],
         ),
         storage_set,
         plan_query_processors=[],

--- a/tests/query/data_source/test_join.py
+++ b/tests/query/data_source/test_join.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.clickhouse.columns import UUID, Any, ColumnSet, String, UInt
 from snuba.datasets.entities import EntityKey
 from snuba.query import SelectedExpression

--- a/tests/query/formatters/test_query.py
+++ b/tests/query/formatters/test_query.py
@@ -33,10 +33,12 @@ columns = ColumnSet([("some_int", UInt(8, Modifiers(nullable=True)))])
 
 BASIC_JOIN = JoinClause(
     left_node=IndividualNode(
-        alias="ev", data_source=Entity(EntityKey.EVENTS, EVENTS_SCHEMA, None),
+        alias="ev",
+        data_source=Entity(EntityKey.EVENTS, EVENTS_SCHEMA, None),
     ),
     right_node=IndividualNode(
-        alias="gr", data_source=Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None),
+        alias="gr",
+        data_source=Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None),
     ),
     keys=[
         JoinCondition(
@@ -104,7 +106,11 @@ SIMPLE_FORMATTED = [
 
 
 TEST_JOIN = [
-    pytest.param(LOGICAL_QUERY, SIMPLE_FORMATTED, id="Simple logical query",),
+    pytest.param(
+        LOGICAL_QUERY,
+        SIMPLE_FORMATTED,
+        id="Simple logical query",
+    ),
     pytest.param(
         CompositeQuery(
             from_clause=LOGICAL_QUERY,
@@ -251,7 +257,8 @@ TEST_JOIN = [
 
 @pytest.mark.parametrize("query, formatted", TEST_JOIN)
 def test_query_formatter(
-    query: Union[ProcessableQuery, CompositeQuery[Entity]], formatted: TExpression,
+    query: Union[ProcessableQuery, CompositeQuery[Entity]],
+    formatted: TExpression,
 ) -> None:
     formatted_query = format_query(query)  # type: ignore
     assert formatted_query == formatted

--- a/tests/query/joins/join_structures.py
+++ b/tests/query/joins/join_structures.py
@@ -15,8 +15,8 @@ from snuba.query.expressions import Expression
 from snuba.query.logical import Query as LogicalQuery
 from tests.query.joins.equivalence_schema import (
     EVENTS_SCHEMA,
-    GROUPS_SCHEMA,
     GROUPS_ASSIGNEE,
+    GROUPS_SCHEMA,
 )
 
 TNode = TypeVar("TNode", bound=SimpleDataSource)

--- a/tests/query/joins/join_structures.py
+++ b/tests/query/joins/join_structures.py
@@ -96,7 +96,10 @@ def clickhouse_groups_node(
     condition: Optional[Expression] = None,
 ) -> IndividualNode[Table]:
     return build_clickhouse_node(
-        "gr", Table("groupedmessage_local", GROUPS_SCHEMA), selected_columns, condition,
+        "gr",
+        Table("groupedmessage_local", GROUPS_SCHEMA),
+        selected_columns,
+        condition,
     )
 
 
@@ -113,7 +116,8 @@ def clickhouse_assignees_node(
 
 
 def events_groups_join(
-    left: IndividualNode[TNode], right: IndividualNode[TNode],
+    left: IndividualNode[TNode],
+    right: IndividualNode[TNode],
 ) -> JoinClause[TNode]:
     return JoinClause(
         left_node=left,

--- a/tests/query/joins/test_branch_cutter.py
+++ b/tests/query/joins/test_branch_cutter.py
@@ -237,7 +237,10 @@ TEST_CASES = [
                 FunctionCall(
                     "_snuba_g",
                     "g",
-                    (Column("_snuba_col", "events", "column"), Literal(None, "val"),),
+                    (
+                        Column("_snuba_col", "events", "column"),
+                        Literal(None, "val"),
+                    ),
                 ),
                 Column("_snuba_col2", "groups", "column2"),
             ),
@@ -256,7 +259,10 @@ TEST_CASES = [
                     FunctionCall(
                         "_snuba_g",
                         "g",
-                        (Column("_snuba_col", None, "column"), Literal(None, "val"),),
+                        (
+                            Column("_snuba_col", None, "column"),
+                            Literal(None, "val"),
+                        ),
                     )
                 },
                 "groups": {Column("_snuba_col2", None, "column2")},
@@ -276,7 +282,10 @@ TEST_CASES = [
                     FunctionCall(
                         "_snuba_g",
                         "g",
-                        (Column("_snuba_col", None, "column"), Literal(None, "val"),),
+                        (
+                            Column("_snuba_col", None, "column"),
+                            Literal(None, "val"),
+                        ),
                     )
                 },
                 "groups": {Column("_snuba_col2", None, "column2")},
@@ -421,7 +430,10 @@ TEST_CASES = [
                     FunctionCall(
                         "_snuba_gen_1",
                         "g",
-                        (Column("_snuba_col", None, "column"), Literal(None, "val"),),
+                        (
+                            Column("_snuba_col", None, "column"),
+                            Literal(None, "val"),
+                        ),
                     )
                 },
                 "groups": {Column("_snuba_gen_2", None, "column2")},
@@ -441,7 +453,10 @@ TEST_CASES = [
                     FunctionCall(
                         "_snuba_gen_1",
                         "g",
-                        (Column("_snuba_col", None, "column"), Literal(None, "val"),),
+                        (
+                            Column("_snuba_col", None, "column"),
+                            Literal(None, "val"),
+                        ),
                     )
                 },
                 "groups": {Column("_snuba_gen_2", None, "column2")},
@@ -719,8 +734,16 @@ TEST_CASES = [
             ),
             cut_branches={
                 "events": {
-                    Column("_snuba_events.group_id", None, "group_id",),
-                    Column("_snuba_events.timestamp", None, "timestamp",),
+                    Column(
+                        "_snuba_events.group_id",
+                        None,
+                        "group_id",
+                    ),
+                    Column(
+                        "_snuba_events.timestamp",
+                        None,
+                        "timestamp",
+                    ),
                 }
             },
         ),

--- a/tests/query/joins/test_equivalence_adder.py
+++ b/tests/query/joins/test_equivalence_adder.py
@@ -1,6 +1,7 @@
 from functools import partial
 
 import pytest
+
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_IMPL
 from snuba.query import SelectedExpression

--- a/tests/query/joins/test_equivalence_adder.py
+++ b/tests/query/joins/test_equivalence_adder.py
@@ -219,7 +219,9 @@ TEST_REPLACEMENT = [
                     Literal(None, 1),
                 ),
                 binary_condition(
-                    ConditionFunctions.EQ, Column(None, "gr", "id"), Literal(None, 1),
+                    ConditionFunctions.EQ,
+                    Column(None, "gr", "id"),
+                    Literal(None, 1),
                 ),
             ]
         ),
@@ -232,7 +234,9 @@ TEST_REPLACEMENT = [
                     Literal(None, 1),
                 ),
                 binary_condition(
-                    ConditionFunctions.EQ, Column(None, "gr", "id"), Literal(None, 1),
+                    ConditionFunctions.EQ,
+                    Column(None, "gr", "id"),
+                    Literal(None, 1),
                 ),
                 binary_condition(
                     ConditionFunctions.EQ,

--- a/tests/query/joins/test_equivalences.py
+++ b/tests/query/joins/test_equivalences.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_IMPL
 from snuba.query.data_source.join import (

--- a/tests/query/joins/test_semi_join.py
+++ b/tests/query/joins/test_semi_join.py
@@ -1,6 +1,7 @@
 from typing import Mapping, Optional, cast
 
 import pytest
+
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.join import (

--- a/tests/query/joins/test_subqueries.py
+++ b/tests/query/joins/test_subqueries.py
@@ -38,10 +38,12 @@ from tests.query.joins.join_structures import (
 
 BASIC_JOIN = JoinClause(
     left_node=IndividualNode(
-        alias="ev", data_source=Entity(EntityKey.EVENTS, EVENTS_SCHEMA, None),
+        alias="ev",
+        data_source=Entity(EntityKey.EVENTS, EVENTS_SCHEMA, None),
     ),
     right_node=IndividualNode(
-        alias="gr", data_source=Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None),
+        alias="gr",
+        data_source=Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None),
     ),
     keys=[
         JoinCondition(
@@ -54,7 +56,10 @@ BASIC_JOIN = JoinClause(
 
 TEST_CASES = [
     pytest.param(
-        CompositeQuery(from_clause=BASIC_JOIN, selected_columns=[],),
+        CompositeQuery(
+            from_clause=BASIC_JOIN,
+            selected_columns=[],
+        ),
         CompositeQuery(
             from_clause=events_groups_join(
                 events_node(
@@ -105,7 +110,8 @@ TEST_CASES = [
                 groups_node(
                     [
                         SelectedExpression(
-                            "_snuba_group_id", Column("_snuba_group_id", None, "id"),
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "id"),
                         ),
                         SelectedExpression(
                             "_snuba_id", Column("_snuba_id", None, "id")
@@ -154,7 +160,8 @@ TEST_CASES = [
                 groups_node(
                     [
                         SelectedExpression(
-                            "_snuba_group_id", Column("_snuba_group_id", None, "id"),
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "id"),
                         ),
                         SelectedExpression(
                             "_snuba_id", Column("_snuba_id", None, "id")
@@ -218,7 +225,8 @@ TEST_CASES = [
                 groups_node(
                     [
                         SelectedExpression(
-                            "_snuba_group_id", Column("_snuba_group_id", None, "id"),
+                            "_snuba_group_id",
+                            Column("_snuba_group_id", None, "id"),
                         ),
                         SelectedExpression(
                             "_snuba_id", Column("_snuba_id", None, "id")
@@ -503,7 +511,8 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("original_query, processed_query", TEST_CASES)
 def test_subquery_generator(
-    original_query: CompositeQuery[Entity], processed_query: CompositeQuery[Entity],
+    original_query: CompositeQuery[Entity],
+    processed_query: CompositeQuery[Entity],
 ) -> None:
     ENTITY_IMPL[EntityKey.EVENTS] = Events()
     ENTITY_IMPL[EntityKey.GROUPEDMESSAGES] = GroupedMessage()

--- a/tests/query/joins/test_subqueries.py
+++ b/tests/query/joins/test_subqueries.py
@@ -1,6 +1,7 @@
 from typing import cast
 
 import pytest
+
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_IMPL
 from snuba.query import SelectedExpression

--- a/tests/query/parser/test_invalid_queries.py
+++ b/tests/query/parser/test_invalid_queries.py
@@ -16,7 +16,9 @@ test_cases = [
         id="Aggregation string cannot be parsed",
     ),
     pytest.param(
-        {"orderby": [[[[["column"]]]]]}, InvalidQueryError, id="Nonsensical order by",
+        {"orderby": [[[[["column"]]]]]},
+        InvalidQueryError,
+        id="Nonsensical order by",
     ),
     pytest.param(
         {"conditions": [["timestamp", "IS NOT NULL", "this makes no sense"]]},

--- a/tests/query/parser/test_query.py
+++ b/tests/query/parser/test_query.py
@@ -51,7 +51,10 @@ def with_required(condition: Optional[Expression] = None) -> Expression:
             FunctionCall(
                 None,
                 "equals",
-                (Column("_snuba_project_id", None, "project_id"), Literal(None, 1),),
+                (
+                    Column("_snuba_project_id", None, "project_id"),
+                    Literal(None, 1),
+                ),
             ),
         ),
     )
@@ -196,7 +199,10 @@ test_cases = [
                     FunctionCall(
                         None,
                         "tuple",
-                        (Literal(None, "dist1"), Literal(None, "dist2"),),
+                        (
+                            Literal(None, "dist1"),
+                            Literal(None, "dist2"),
+                        ),
                     ),
                 )
             ),
@@ -741,7 +747,8 @@ test_cases = [
                                                     (
                                                         Argument(None, "x"),
                                                         Literal(
-                                                            None, "ArithmeticException",
+                                                            None,
+                                                            "ArithmeticException",
                                                         ),
                                                     ),
                                                 ),
@@ -772,7 +779,8 @@ test_cases = [
                                                     (
                                                         Argument(None, "x"),
                                                         Literal(
-                                                            None, "RuntimeException",
+                                                            None,
+                                                            "RuntimeException",
                                                         ),
                                                     ),
                                                 ),
@@ -851,7 +859,8 @@ test_cases = [
                                                     (
                                                         Argument(None, "x"),
                                                         Literal(
-                                                            None, "ArithmeticException",
+                                                            None,
+                                                            "ArithmeticException",
                                                         ),
                                                     ),
                                                 ),
@@ -882,7 +891,8 @@ test_cases = [
                                                     (
                                                         Argument(None, "x"),
                                                         Literal(
-                                                            None, "RuntimeException",
+                                                            None,
+                                                            "RuntimeException",
                                                         ),
                                                     ),
                                                 ),
@@ -1129,10 +1139,12 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "group_id", Column("_snuba_group_id", None, "group_id"),
+                    "group_id",
+                    Column("_snuba_group_id", None, "group_id"),
                 ),
                 SelectedExpression(
-                    "group_id", Column("_snuba_group_id", None, "group_id"),
+                    "group_id",
+                    Column("_snuba_group_id", None, "group_id"),
                 ),
                 SelectedExpression(
                     "count()", FunctionCall("_snuba_count()", "count", tuple())

--- a/tests/query/parser/validation/test_functions.py
+++ b/tests/query/parser/validation/test_functions.py
@@ -57,14 +57,18 @@ test_cases = [
 test_expressions = [
     pytest.param(
         FunctionCall(
-            None, "f", (Column(alias=None, table_name=None, column_name="col"),),
+            None,
+            "f",
+            (Column(alias=None, table_name=None, column_name="col"),),
         ),
         True,
         id="Invalid function name",
     ),
     pytest.param(
         FunctionCall(
-            None, "count", (Column(alias=None, table_name=None, column_name="col"),),
+            None,
+            "count",
+            (Column(alias=None, table_name=None, column_name="col"),),
         ),
         False,
         id="Valid function name",

--- a/tests/query/processors/query_builders.py
+++ b/tests/query/processors/query_builders.py
@@ -1,10 +1,11 @@
-from snuba.clickhouse.columns import ColumnSet
-from snuba.query.data_source.simple import Table
 from typing import Optional, Sequence
+
+from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.clickhouse.translators.snuba.mappers import build_mapping_expr
 from snuba.query import SelectedExpression
 from snuba.query.conditions import binary_condition
+from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 
 

--- a/tests/query/processors/query_builders.py
+++ b/tests/query/processors/query_builders.py
@@ -41,8 +41,13 @@ def nested_expression(column: str, key: str) -> FunctionCall:
 
 
 def nested_condition(
-    column_name: str, key: str, operator: str, val: str,
+    column_name: str,
+    key: str,
+    operator: str,
+    val: str,
 ) -> Expression:
     return binary_condition(
-        operator, nested_expression(column_name, key), Literal(None, val),
+        operator,
+        nested_expression(column_name, key),
+        Literal(None, val),
     )

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -72,7 +72,11 @@ def test_apdex_format_expressions() -> None:
                             Literal(None, 2),
                         ),
                     ),
-                    FunctionCall(None, "count", (),),
+                    FunctionCall(
+                        None,
+                        "count",
+                        (),
+                    ),
                     "perf",
                 ),
             ),

--- a/tests/query/processors/test_array_has_optimizer.py
+++ b/tests/query/processors/test_array_has_optimizer.py
@@ -202,7 +202,8 @@ array_has_tests = [
 
 @pytest.mark.parametrize("query, expected_conditions", array_has_tests)
 def test_array_has_optimizer(
-    query: ClickhouseQuery, expected_conditions: Optional[Expression],
+    query: ClickhouseQuery,
+    expected_conditions: Optional[Expression],
 ) -> None:
     request_settings = HTTPRequestSettings()
     array_has_processor = ArrayHasOptimizer(["spans.op", "spans.group"])

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -56,7 +56,9 @@ tags_filter_tests = [
         build_query(
             selected_columns=[
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
             ],
         ),
@@ -67,13 +69,17 @@ tags_filter_tests = [
         build_query(
             selected_columns=[
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
             ],
             condition=binary_condition(
                 ConditionFunctions.EQ,
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
                 Literal(None, "tag"),
             ),
@@ -85,12 +91,16 @@ tags_filter_tests = [
         build_query(
             selected_columns=[
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
             ],
             condition=in_condition(
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
                 [Literal(None, "tag1"), Literal(None, "tag2")],
             ),
@@ -102,20 +112,26 @@ tags_filter_tests = [
         build_query(
             selected_columns=[
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
             ],
             condition=binary_condition(
                 ConditionFunctions.EQ,
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
                 Literal(None, "tag"),
             ),
             having=binary_condition(
                 ConditionFunctions.EQ,
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
                 Literal(None, "tag2"),
             ),
@@ -127,17 +143,23 @@ tags_filter_tests = [
         build_query(
             selected_columns=[
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
             ],
             condition=binary_condition(
                 BooleanFunctions.OR,
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
                 in_condition(
                     FunctionCall(
-                        "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                        "tags_key",
+                        "arrayJoin",
+                        (Column(None, None, "tags.key"),),
                     ),
                     [Literal(None, "tag1"), Literal(None, "tag2")],
                 ),
@@ -145,7 +167,9 @@ tags_filter_tests = [
             having=binary_condition(
                 ConditionFunctions.EQ,
                 FunctionCall(
-                    "tags_key", "arrayJoin", (Column(None, None, "tags.key"),),
+                    "tags_key",
+                    "arrayJoin",
+                    (Column(None, None, "tags.key"),),
                 ),
                 Literal(None, "tag"),
             ),
@@ -158,7 +182,8 @@ tags_filter_tests = [
 
 @pytest.mark.parametrize("query, expected_result", tags_filter_tests)
 def test_get_filtered_mapping_keys(
-    query: ClickhouseQuery, expected_result: Sequence[str],
+    query: ClickhouseQuery,
+    expected_result: Sequence[str],
 ) -> None:
     """
     Test the algorithm that identifies potential tag keys we can pre-filter
@@ -403,7 +428,8 @@ def parse_and_process(query_body: MutableMapping[str, Any]) -> ClickhouseQuery:
     ArrayJoinKeyValueOptimizer("tags").process_query(query, request.settings)
 
     query_plan = SingleStorageQueryPlanBuilder(
-        storage=storage, mappers=transaction_translator,
+        storage=storage,
+        mappers=transaction_translator,
     ).build_and_rank_plans(query, request.settings)[0]
 
     return query_plan.query
@@ -438,7 +464,8 @@ def test_formatting() -> None:
         arrayJoin(
             "snuba_all_tags",
             zip_columns(
-                Column(None, None, "tags.key"), Column(None, None, "tags.value"),
+                Column(None, None, "tags.key"),
+                Column(None, None, "tags.value"),
             ),
         ),
         Literal(None, 1),
@@ -453,7 +480,8 @@ def test_formatting() -> None:
             "snuba_all_tags",
             filter_key_values(
                 zip_columns(
-                    Column(None, None, "tags.key"), Column(None, None, "tags.value"),
+                    Column(None, None, "tags.key"),
+                    Column(None, None, "tags.value"),
                 ),
                 [Literal(None, "t1"), Literal(None, "t2")],
             ),

--- a/tests/query/processors/test_arrayjoin_spans_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_spans_optimizer.py
@@ -37,18 +37,30 @@ spans_groups = Column(None, None, "spans.group")
 
 spans_group_col = FunctionCall("spans_group", "arrayJoin", (spans_groups,))
 
-spans_op_group_col = FunctionCall(None, "tuple", (spans_op_col, spans_group_col),)
+spans_op_group_col = FunctionCall(
+    None,
+    "tuple",
+    (spans_op_col, spans_group_col),
+)
 
 spans_exclusive_time_col = FunctionCall(
-    "spans_exclusive_time", "arrayJoin", (Column(None, None, "spans.exclusive_time"),),
+    "spans_exclusive_time",
+    "arrayJoin",
+    (Column(None, None, "spans.exclusive_time"),),
 )
 
 spans_op_filter_tests = [
-    pytest.param(build_query(), set(), id="no op filter",),
+    pytest.param(
+        build_query(),
+        set(),
+        id="no op filter",
+    ),
     pytest.param(
         build_query(
             condition=binary_condition(
-                ConditionFunctions.EQ, spans_op_col, Literal(None, "db"),
+                ConditionFunctions.EQ,
+                spans_op_col,
+                Literal(None, "db"),
             ),
         ),
         {"db"},
@@ -57,7 +69,8 @@ spans_op_filter_tests = [
     pytest.param(
         build_query(
             condition=in_condition(
-                spans_op_col, [Literal(None, "db"), Literal(None, "http")],
+                spans_op_col,
+                [Literal(None, "db"), Literal(None, "http")],
             ),
         ),
         {"db", "http"},
@@ -65,8 +78,14 @@ spans_op_filter_tests = [
     ),
     pytest.param(
         build_query(
-            condition=in_condition(spans_op_col, [Literal(None, "db")],),
-            having=in_condition(spans_op_col, [Literal(None, "http")],),
+            condition=in_condition(
+                spans_op_col,
+                [Literal(None, "db")],
+            ),
+            having=in_condition(
+                spans_op_col,
+                [Literal(None, "http")],
+            ),
         ),
         {"db", "http"},
         id="conditions and having",
@@ -77,11 +96,13 @@ spans_op_filter_tests = [
                 BooleanFunctions.OR,
                 spans_op_col,
                 in_condition(
-                    spans_op_col, [Literal(None, "db"), Literal(None, "http")],
+                    spans_op_col,
+                    [Literal(None, "db"), Literal(None, "http")],
                 ),
             ),
             having=in_condition(
-                spans_op_col, [Literal(None, "db"), Literal(None, "http")],
+                spans_op_col,
+                [Literal(None, "db"), Literal(None, "http")],
             ),
         ),
         set(),
@@ -102,7 +123,11 @@ def test_get_single_column_filters(
 
 
 spans_op_group_tuple_filter_tests = [
-    pytest.param(build_query(), set(), id="no op+group filter",),
+    pytest.param(
+        build_query(),
+        set(),
+        id="no op+group filter",
+    ),
     pytest.param(
         build_query(
             condition=binary_condition(
@@ -327,14 +352,22 @@ def array_join_col(ops=None, groups=None, op_groups=None):
         cols = FunctionCall(
             None,
             "arrayFilter",
-            (Lambda(None, (argument_name,), combine_and_conditions(conditions)), cols,),
+            (
+                Lambda(None, (argument_name,), combine_and_conditions(conditions)),
+                cols,
+            ),
         )
 
     return arrayJoin("snuba_all_spans", cols)
 
 
 span_processor_tests = [
-    pytest.param(build_query(), [], None, id="no spans columns in select clause",),
+    pytest.param(
+        build_query(),
+        [],
+        None,
+        id="no spans columns in select clause",
+    ),
     pytest.param(
         build_query(
             selected_columns=[spans_op_col, spans_group_col, spans_exclusive_time_col]
@@ -361,7 +394,9 @@ span_processor_tests = [
         build_query(
             selected_columns=[spans_op_col, spans_group_col, spans_exclusive_time_col],
             condition=binary_condition(
-                ConditionFunctions.EQ, spans_op_col, Literal(None, "db"),
+                ConditionFunctions.EQ,
+                spans_op_col,
+                Literal(None, "db"),
             ),
         ),
         [
@@ -397,7 +432,8 @@ span_processor_tests = [
         build_query(
             selected_columns=[spans_op_col, spans_group_col, spans_exclusive_time_col],
             condition=in_condition(
-                spans_op_col, [Literal(None, "db"), Literal(None, "http")],
+                spans_op_col,
+                [Literal(None, "db"), Literal(None, "http")],
             ),
         ),
         [
@@ -442,7 +478,9 @@ span_processor_tests = [
         build_query(
             selected_columns=[spans_op_col, spans_group_col, spans_exclusive_time_col],
             condition=binary_condition(
-                ConditionFunctions.EQ, spans_group_col, Literal(None, "a" * 16),
+                ConditionFunctions.EQ,
+                spans_group_col,
+                Literal(None, "a" * 16),
             ),
         ),
         [
@@ -484,7 +522,8 @@ span_processor_tests = [
         build_query(
             selected_columns=[spans_op_col, spans_group_col, spans_exclusive_time_col],
             condition=in_condition(
-                spans_group_col, [Literal(None, "a" * 16), Literal(None, "b" * 16)],
+                spans_group_col,
+                [Literal(None, "a" * 16), Literal(None, "b" * 16)],
             ),
         ),
         [

--- a/tests/query/processors/test_custom_function.py
+++ b/tests/query/processors/test_custom_function.py
@@ -62,7 +62,10 @@ TEST_CASES = [
                     FunctionCall(
                         "my_func",
                         "f_call",
-                        (Literal(None, "literal1"), Column("param2", None, "param2"),),
+                        (
+                            Literal(None, "literal1"),
+                            Column("param2", None, "param2"),
+                        ),
                     ),
                 ),
             ],
@@ -147,7 +150,8 @@ def test_format_expressions(query: Query, expected_query: Query) -> None:
         "f_call",
         [("param1", ColType({String})), ("param2", ColType({UInt}))],
         partial_function(
-            "f_call_impl(param1, inner_call(param2), my_const)", [("my_const", 420)],
+            "f_call_impl(param1, inner_call(param2), my_const)",
+            [("my_const", 420)],
         ),
     )
     # We cannot just run == on the query objects. The content of the two
@@ -169,7 +173,9 @@ INVALID_QUERIES = [
                 SelectedExpression(
                     "my_func",
                     FunctionCall(
-                        "my_func", "f_call", (Column("param2", None, "param2"),),
+                        "my_func",
+                        "f_call",
+                        (Column("param2", None, "param2"),),
                     ),
                 ),
             ],

--- a/tests/query/processors/test_events_column_processor.py
+++ b/tests/query/processors/test_events_column_processor.py
@@ -28,10 +28,16 @@ def test_events_column_format_expressions() -> None:
                 FunctionCall(
                     "the_group_id",
                     "nullIf",
-                    (Column(None, None, "group_id"), Literal(None, 0),),
+                    (
+                        Column(None, None, "group_id"),
+                        Literal(None, 0),
+                    ),
                 ),
             ),
-            SelectedExpression("the_message", Column("the_message", None, "message"),),
+            SelectedExpression(
+                "the_message",
+                Column("the_message", None, "message"),
+            ),
         ],
     )
 

--- a/tests/query/processors/test_fixedstring_array_column_processor.py
+++ b/tests/query/processors/test_fixedstring_array_column_processor.py
@@ -2,20 +2,14 @@ import pytest
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+from snuba.clickhouse.query import Query
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
-from snuba.query.expressions import (
-    Column,
-    Expression,
-    FunctionCall,
-    Literal,
-)
-from snuba.clickhouse.query import Query
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.type_converters.fixedstring_array_column_processor import (
     FixedStringArrayColumnProcessor,
 )
 from snuba.request.request_settings import HTTPRequestSettings
-
 
 tests = [
     pytest.param(

--- a/tests/query/processors/test_fixedstring_array_column_processor.py
+++ b/tests/query/processors/test_fixedstring_array_column_processor.py
@@ -44,7 +44,9 @@ tests = [
 
 @pytest.mark.parametrize("unprocessed, expected, formatted_value", tests)
 def test_uuid_array_column_processor(
-    unprocessed: Expression, expected: Expression, formatted_value: str,
+    unprocessed: Expression,
+    expected: Expression,
+    formatted_value: str,
 ) -> None:
     unprocessed_query = Query(
         Table("transactions", ColumnSet([])),
@@ -61,7 +63,10 @@ def test_uuid_array_column_processor(
         unprocessed_query, HTTPRequestSettings()
     )
     assert unprocessed_query.get_selected_columns() == [
-        SelectedExpression("column2", Column(None, None, "column2"),)
+        SelectedExpression(
+            "column2",
+            Column(None, None, "column2"),
+        )
     ]
 
     assert expected_query.get_condition() == unprocessed_query.get_condition()

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -24,7 +24,12 @@ def test_handled_processor() -> None:
         selected_columns=[
             SelectedExpression(name=None, expression=Column(None, None, "id")),
             SelectedExpression(
-                "result", FunctionCall("result", "isHandled", tuple(),),
+                "result",
+                FunctionCall(
+                    "result",
+                    "isHandled",
+                    tuple(),
+                ),
             ),
         ],
     )
@@ -81,7 +86,11 @@ def test_handled_processor_invalid() -> None:
         selected_columns=[
             SelectedExpression(
                 "result",
-                FunctionCall("result", "isHandled", (Column(None, None, "type"),),),
+                FunctionCall(
+                    "result",
+                    "isHandled",
+                    (Column(None, None, "type"),),
+                ),
             ),
         ],
     )
@@ -99,7 +108,12 @@ def test_not_handled_processor() -> None:
         selected_columns=[
             SelectedExpression(name=None, expression=Column(None, None, "id")),
             SelectedExpression(
-                "result", FunctionCall("result", "notHandled", tuple(),),
+                "result",
+                FunctionCall(
+                    "result",
+                    "notHandled",
+                    tuple(),
+                ),
             ),
         ],
     )
@@ -157,7 +171,11 @@ def test_not_handled_processor_invalid() -> None:
         selected_columns=[
             SelectedExpression(
                 "result",
-                FunctionCall("result", "notHandled", (Column(None, None, "type"),),),
+                FunctionCall(
+                    "result",
+                    "notHandled",
+                    (Column(None, None, "type"),),
+                ),
             ),
         ],
     )

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -2,20 +2,15 @@ import pytest
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
-from snuba.query import SelectedExpression
-from snuba.query.expressions import Expression
-from snuba.query.conditions import (
-    binary_condition,
-    ConditionFunctions,
-)
-from snuba.query.data_source.simple import Table
-from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.clickhouse.query import Query
+from snuba.query import SelectedExpression
+from snuba.query.conditions import ConditionFunctions, binary_condition
+from snuba.query.data_source.simple import Table
+from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )
 from snuba.request.request_settings import HTTPRequestSettings
-
 
 tests = [
     pytest.param(

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -62,7 +62,13 @@ def test_hexint_column_processor(unprocessed: Expression, formatted_value: str) 
             FunctionCall(
                 None,
                 "lower",
-                (FunctionCall(None, "hex", (Column(None, None, "column1"),),),),
+                (
+                    FunctionCall(
+                        None,
+                        "hex",
+                        (Column(None, None, "column1"),),
+                    ),
+                ),
             ),
         )
     ]

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -33,7 +33,9 @@ test_data = [
         "table2",
         [
             binary_condition(
-                ConditionFunctions.EQ, Column("time", None, "time"), Literal(None, "1"),
+                ConditionFunctions.EQ,
+                Column("time", None, "time"),
+                Literal(None, "1"),
             ),
             binary_condition(
                 ConditionFunctions.EQ,
@@ -62,10 +64,14 @@ def test_mand_conditions(table: str, mand_conditions: List[FunctionCall]) -> Non
         binary_condition(
             BooleanFunctions.AND,
             binary_condition(
-                OPERATOR_TO_FUNCTION["="], Column("d", None, "d"), Literal(None, "1"),
+                OPERATOR_TO_FUNCTION["="],
+                Column("d", None, "d"),
+                Literal(None, "1"),
             ),
             binary_condition(
-                OPERATOR_TO_FUNCTION["="], Column("c", None, "c"), Literal(None, "3"),
+                OPERATOR_TO_FUNCTION["="],
+                Column("c", None, "c"),
+                Literal(None, "3"),
             ),
         ),
     )

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -2,6 +2,7 @@ import copy
 from typing import List
 
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
 from snuba.query.conditions import (

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.query.conditions import (
     BooleanFunctions,

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -189,7 +189,10 @@ TEST_CASES = [
 
 
 @pytest.mark.parametrize("query, expected_condition", TEST_CASES)
-def test_tags_hash_map(query: ClickhouseQuery, expected_condition: Expression,) -> None:
+def test_tags_hash_map(
+    query: ClickhouseQuery,
+    expected_condition: Expression,
+) -> None:
     set_config("tags_hash_map_enabled", 1)
     MappingOptimizer(
         column_name="tags",

--- a/tests/query/processors/test_mapping_optimizer_no_useless_conditions.py
+++ b/tests/query/processors/test_mapping_optimizer_no_useless_conditions.py
@@ -27,8 +27,15 @@ def tag_existence_expression(tag_name: str = "foo") -> FunctionCall:
                                 None,
                                 "indexOf",
                                 (
-                                    Column(None, None, "tags.key",),
-                                    Literal(None, tag_name,),
+                                    Column(
+                                        None,
+                                        None,
+                                        "tags.key",
+                                    ),
+                                    Literal(
+                                        None,
+                                        tag_name,
+                                    ),
                                 ),
                             ),
                         ),
@@ -84,7 +91,9 @@ def optimized_tag_expression(
         (
             Column(None, None, "_tags_hash_map"),
             FunctionCall(
-                None, "cityHash64", (Literal(None, f"{tag_name}={tag_value}"),),
+                None,
+                "cityHash64",
+                (Literal(None, f"{tag_name}={tag_value}"),),
             ),
         ),
     )
@@ -139,7 +148,10 @@ TEST_CASES = [
         ),
         build_query(
             selected_columns=[Column("count", None, "count")],
-            condition=and_exp(noop, or_exp(optimized_tag_expression(), noop),),
+            condition=and_exp(
+                noop,
+                or_exp(optimized_tag_expression(), noop),
+            ),
         ),
         id="useless condition nested in OR",
     ),
@@ -160,7 +172,8 @@ TEST_CASES = [
         build_query(
             selected_columns=[Column("count", None, "count")],
             condition=and_exp(
-                noop_or, and_exp(noop_or, and_exp(noop_or, optimized_tag_expression())),
+                noop_or,
+                and_exp(noop_or, and_exp(noop_or, optimized_tag_expression())),
             ),
         ),
         id="useless condition nested in AND",
@@ -230,7 +243,8 @@ TEST_CASES = [
 
 @pytest.mark.parametrize("input_query, expected_query", deepcopy(TEST_CASES))
 def test_recursive_useless_condition(
-    input_query: ClickhouseQuery, expected_query: ClickhouseQuery,
+    input_query: ClickhouseQuery,
+    expected_query: ClickhouseQuery,
 ) -> None:
     # copy the condition to the having condition so that we test both being
     # applied in one test
@@ -246,7 +260,8 @@ def test_recursive_useless_condition(
 
 @pytest.mark.parametrize("input_query, expected_query", deepcopy(TEST_CASES))
 def test_useless_has_condition(
-    input_query: ClickhouseQuery, expected_query: ClickhouseQuery,
+    input_query: ClickhouseQuery,
+    expected_query: ClickhouseQuery,
 ) -> None:
     from snuba.query.processors.empty_tag_condition_processor import (
         EmptyTagConditionProcessor,

--- a/tests/query/processors/test_mapping_promoter.py
+++ b/tests/query/processors/test_mapping_promoter.py
@@ -33,7 +33,10 @@ test_cases = [
                             FunctionCall(
                                 None,
                                 "indexOf",
-                                (Column(None, None, "tags.key"), Literal(None, "foo"),),
+                                (
+                                    Column(None, None, "tags.key"),
+                                    Literal(None, "foo"),
+                                ),
                             ),
                         ),
                     ),
@@ -53,7 +56,10 @@ test_cases = [
                             FunctionCall(
                                 None,
                                 "indexOf",
-                                (Column(None, None, "tags.key"), Literal(None, "foo"),),
+                                (
+                                    Column(None, None, "tags.key"),
+                                    Literal(None, "foo"),
+                                ),
                             ),
                         ),
                     ),

--- a/tests/query/processors/test_pattern_replacer.py
+++ b/tests/query/processors/test_pattern_replacer.py
@@ -1,4 +1,5 @@
 import pytest
+
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.entities import EntityKey
 from snuba.query import SelectedExpression

--- a/tests/query/processors/test_pattern_replacer.py
+++ b/tests/query/processors/test_pattern_replacer.py
@@ -67,7 +67,8 @@ test_data = [
 
 
 @pytest.mark.parametrize(
-    "unprocessed, expected", test_data,
+    "unprocessed, expected",
+    test_data,
 )
 def test_pattern_replacer_format_expressions(
     unprocessed: Query, expected: Query
@@ -75,10 +76,16 @@ def test_pattern_replacer_format_expressions(
     def transform(match: MatchResult, exp: Expression) -> Expression:
         assert isinstance(exp, Column)  # mypy
         return FunctionCall(
-            None, "nullIf", (Column(None, None, exp.column_name), Literal(None, ""),)
+            None,
+            "nullIf",
+            (
+                Column(None, None, exp.column_name),
+                Literal(None, ""),
+            ),
         )
 
     PatternReplacer(
-        Param("column", ColumnMatch(None, StringMatch("column1"))), transform,
+        Param("column", ColumnMatch(None, StringMatch("column1"))),
+        transform,
     ).process_query(unprocessed, HTTPRequestSettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -162,12 +162,18 @@ test_data = [
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["="],
-            (Column("_snuba_environment", None, "environment"), Literal(None, "abc"),),
+            (
+                Column("_snuba_environment", None, "environment"),
+                Literal(None, "abc"),
+            ),
         ),
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["="],
-            (Column("_snuba_project_id", None, "project_id"), Literal(None, 1),),
+            (
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 1),
+            ),
         ),
         True,
     ),
@@ -187,7 +193,9 @@ test_data = [
             OPERATOR_TO_FUNCTION["="],
             (
                 FunctionCall(
-                    None, "uniq", (Column("_snuba_environment", None, "environment"),),
+                    None,
+                    "uniq",
+                    (Column("_snuba_environment", None, "environment"),),
                 ),
                 Literal(None, "abc"),
             ),
@@ -195,7 +203,10 @@ test_data = [
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["="],
-            (Column("_snuba_project_id", None, "project_id"), Literal(None, 1),),
+            (
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 1),
+            ),
         ),
         False,
         id="Do not promote a column that is in a uniq function",
@@ -239,7 +250,10 @@ test_data = [
         FunctionCall(
             None,
             OPERATOR_TO_FUNCTION["="],
-            (Column("_snuba_project_id", None, "project_id"), Literal(None, 1),),
+            (
+                Column("_snuba_project_id", None, "project_id"),
+                Literal(None, 1),
+            ),
         ),
         False,
         id="Do not promote a column that is in a countIf function",

--- a/tests/query/processors/test_slice_of_map_optimizer.py
+++ b/tests/query/processors/test_slice_of_map_optimizer.py
@@ -2,20 +2,19 @@ import pytest
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+from snuba.clickhouse.query import Query
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import (
+    Argument,
     Column,
     Expression,
     FunctionCall,
-    Literal,
     Lambda,
-    Argument,
+    Literal,
 )
-from snuba.clickhouse.query import Query
 from snuba.query.processors.slice_of_map_optimizer import SliceOfMapOptimizer
 from snuba.request.request_settings import HTTPRequestSettings
-
 
 tests = [
     pytest.param(

--- a/tests/query/processors/test_slice_of_map_optimizer.py
+++ b/tests/query/processors/test_slice_of_map_optimizer.py
@@ -84,7 +84,9 @@ tests = [
 
 @pytest.mark.parametrize("unprocessed, expected, formatted_value", tests)
 def test_uuid_array_column_processor(
-    unprocessed: Expression, expected: Expression, formatted_value: str,
+    unprocessed: Expression,
+    expected: Expression,
+    formatted_value: str,
 ) -> None:
     unprocessed_query = Query(
         Table("transactions", ColumnSet([])),

--- a/tests/query/processors/test_timeseries_processor.py
+++ b/tests/query/processors/test_timeseries_processor.py
@@ -106,7 +106,9 @@ tests = [
         binary_condition(
             ConditionFunctions.GTE,
             FunctionCall(
-                None, "toStartOfDay", (Column("my_time", None, "finish_ts"),),
+                None,
+                "toStartOfDay",
+                (Column("my_time", None, "finish_ts"),),
             ),
             Literal(None, parse_datetime("2020-01-01T01:01:01.000000Z")),
         ),
@@ -140,7 +142,9 @@ tests = [
                         "intDiv",
                         (
                             FunctionCall(
-                                None, "toUInt32", (Column(None, None, "finish_ts"),),
+                                None,
+                                "toUInt32",
+                                (Column(None, None, "finish_ts"),),
                             ),
                             Literal(None, 1440),
                         ),
@@ -224,7 +228,9 @@ def test_invalid_datetime() -> None:
             ),
         ],
         condition=binary_condition(
-            ConditionFunctions.EQ, Column("my_time", None, "time"), Literal(None, ""),
+            ConditionFunctions.EQ,
+            Column("my_time", None, "time"),
+            Literal(None, ""),
         ),
     )
 

--- a/tests/query/processors/test_transaction_column_processor.py
+++ b/tests/query/processors/test_transaction_column_processor.py
@@ -35,7 +35,9 @@ def test_event_id_column_format_expressions() -> None:
                     "replaceAll",
                     (
                         FunctionCall(
-                            None, "toString", (Column(None, None, "event_id"),),
+                            None,
+                            "toString",
+                            (Column(None, None, "event_id"),),
                         ),
                         Literal(None, "-"),
                         Literal(None, ""),

--- a/tests/query/processors/test_type_condition_optimizer.py
+++ b/tests/query/processors/test_type_condition_optimizer.py
@@ -1,15 +1,15 @@
 from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
 from snuba.clickhouse.query import Query
+from snuba.datasets.storages.type_condition_optimizer import TypeConditionOptimizer
 from snuba.query.conditions import (
+    BooleanFunctions,
     ConditionFunctions,
     binary_condition,
-    BooleanFunctions,
 )
 from snuba.query.data_source.simple import Table
-from snuba.datasets.storages.type_condition_optimizer import TypeConditionOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
 from snuba.query.expressions import Column, Literal
-from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_type_condition_optimizer() -> None:

--- a/tests/query/processors/test_uuid_array_column_processor.py
+++ b/tests/query/processors/test_uuid_array_column_processor.py
@@ -1,24 +1,24 @@
-import pytest
 import uuid
+
+import pytest
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
+from snuba.clickhouse.query import Query
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import (
+    Argument,
     Column,
     Expression,
     FunctionCall,
-    Literal,
     Lambda,
-    Argument,
+    Literal,
 )
-from snuba.clickhouse.query import Query
 from snuba.query.processors.type_converters.uuid_array_column_processor import (
     UUIDArrayColumnProcessor,
 )
 from snuba.request.request_settings import HTTPRequestSettings
-
 
 tests = [
     pytest.param(

--- a/tests/query/processors/test_uuid_array_column_processor.py
+++ b/tests/query/processors/test_uuid_array_column_processor.py
@@ -53,7 +53,11 @@ tests = [
         FunctionCall(
             None,
             "arraySlice",
-            (Column(None, None, "column1"), Literal(None, 0), Literal(None, 2),),
+            (
+                Column(None, None, "column1"),
+                Literal(None, 0),
+                Literal(None, 2),
+            ),
         ),
         FunctionCall(
             None,
@@ -93,7 +97,9 @@ tests = [
 
 @pytest.mark.parametrize("unprocessed, expected, formatted_value", tests)
 def test_uuid_array_column_processor(
-    unprocessed: Expression, expected: Expression, formatted_value: str,
+    unprocessed: Expression,
+    expected: Expression,
+    formatted_value: str,
 ) -> None:
     unprocessed_query = Query(
         Table("transactions", ColumnSet([])),

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -120,7 +120,11 @@ tests = [
                 None,
                 "replaceAll",
                 (
-                    FunctionCall(None, "toString", (Column(None, None, "column1"),),),
+                    FunctionCall(
+                        None,
+                        "toString",
+                        (Column(None, None, "column1"),),
+                    ),
                     Literal(None, "-"),
                     Literal(None, ""),
                 ),
@@ -153,7 +157,9 @@ tests = [
                     "replaceAll",
                     (
                         FunctionCall(
-                            None, "toString", (Column(None, None, "column1"),),
+                            None,
+                            "toString",
+                            (Column(None, None, "column1"),),
                         ),
                         Literal(None, "-"),
                         Literal(None, ""),
@@ -168,7 +174,9 @@ tests = [
                     "replaceAll",
                     (
                         FunctionCall(
-                            None, "toString", (Column(None, None, "column1"),),
+                            None,
+                            "toString",
+                            (Column(None, None, "column1"),),
                         ),
                         Literal(None, "-"),
                         Literal(None, ""),
@@ -229,7 +237,9 @@ tests = [
 
 @pytest.mark.parametrize("unprocessed, expected, formatted_value", tests)
 def test_uuid_column_processor(
-    unprocessed: Expression, expected: Expression, formatted_value: str,
+    unprocessed: Expression,
+    expected: Expression,
+    formatted_value: str,
 ) -> None:
     unprocessed_query = Query(
         Table("transactions", ColumnSet([])),
@@ -252,7 +262,11 @@ def test_uuid_column_processor(
                 None,
                 "replaceAll",
                 (
-                    FunctionCall(None, "toString", (Column(None, None, "column2"),),),
+                    FunctionCall(
+                        None,
+                        "toString",
+                        (Column(None, None, "column2"),),
+                    ),
                     Literal(None, "-"),
                     Literal(None, ""),
                 ),

--- a/tests/query/snql/test_joins.py
+++ b/tests/query/snql/test_joins.py
@@ -1,6 +1,7 @@
-import pytest
 import uuid
 from typing import Sequence, Tuple, Union
+
+import pytest
 
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -13,7 +14,7 @@ from snuba.query.data_source.join import (
     JoinType,
 )
 from snuba.query.data_source.simple import Entity as QueryEntity
-from snuba.query.snql.joins import build_join_clause, RelationshipTuple
+from snuba.query.snql.joins import RelationshipTuple, build_join_clause
 
 ###################################
 ## Used to build expected result ##

--- a/tests/query/snql/test_joins.py
+++ b/tests/query/snql/test_joins.py
@@ -221,7 +221,10 @@ def test_joins(
         )
         relationships.append(
             RelationshipTuple(
-                node(lhs_alias, lhs), uuid.uuid4().hex, node(rhs_alias, rhs), data,
+                node(lhs_alias, lhs),
+                uuid.uuid4().hex,
+                node(rhs_alias, rhs),
+                data,
             )
         )
 

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -39,7 +39,9 @@ added_condition = build_cond("")
 required_condition = binary_condition(
     "and",
     binary_condition(
-        "equals", Column("_snuba_project_id", None, "project_id"), Literal(None, 1),
+        "equals",
+        Column("_snuba_project_id", None, "project_id"),
+        Literal(None, 1),
     ),
     binary_condition(
         "and",
@@ -106,7 +108,9 @@ test_cases = [
         f"MATCH (events SAMPLE 0.5) SELECT 4-5, c WHERE {added_condition}",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(), 0.5,
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
+                0.5,
             ),
             selected_columns=[
                 SelectedExpression(
@@ -337,7 +341,8 @@ test_cases = [
                     ),
                 ),
                 SelectedExpression(
-                    "count", FunctionCall("_snuba_count", "count", tuple()),
+                    "count",
+                    FunctionCall("_snuba_count", "count", tuple()),
                 ),
             ],
             groupby=[
@@ -490,10 +495,12 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "now", Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
+                    "now",
+                    Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
                 ),
                 SelectedExpression(
-                    "now", Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
+                    "now",
+                    Literal("_snuba_now", datetime.datetime(2020, 1, 1, 0, 0)),
                 ),
                 SelectedExpression(
                     "3*foo(c) AS foo",
@@ -540,7 +547,9 @@ test_cases = [
                     binary_condition(
                         "and",
                         binary_condition(
-                            "equals", Column("_snuba_c", None, "c"), Literal(None, 2),
+                            "equals",
+                            Column("_snuba_c", None, "c"),
+                            Literal(None, 2),
                         ),
                         binary_condition(
                             "and",
@@ -823,7 +832,8 @@ test_cases = [
                                                             (
                                                                 Literal(None, "Stack"),
                                                                 Literal(
-                                                                    None, "Arithmetic",
+                                                                    None,
+                                                                    "Arithmetic",
                                                                 ),
                                                             ),
                                                         ),
@@ -855,7 +865,8 @@ test_cases = [
                 left_node=IndividualNode(
                     "e",
                     QueryEntity(
-                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                        EntityKey.EVENTS,
+                        get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                 ),
                 right_node=IndividualNode(
@@ -940,7 +951,8 @@ test_cases = [
                 left_node=IndividualNode(
                     "e",
                     QueryEntity(
-                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                        EntityKey.EVENTS,
+                        get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                 ),
                 right_node=IndividualNode(
@@ -1330,7 +1342,8 @@ test_cases = [
         CompositeQuery(
             from_clause=LogicalQuery(
                 QueryEntity(
-                    EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                    EntityKey.EVENTS,
+                    get_entity(EntityKey.EVENTS).get_data_model(),
                 ),
                 selected_columns=[
                     SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -1369,7 +1382,8 @@ test_cases = [
             from_clause=CompositeQuery(
                 from_clause=LogicalQuery(
                     QueryEntity(
-                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                        EntityKey.EVENTS,
+                        get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                     selected_columns=[
                         SelectedExpression(
@@ -1470,10 +1484,12 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "tags_key", Column("_snuba_tags_key", None, "tags_key"),
+                    "tags_key",
+                    Column("_snuba_tags_key", None, "tags_key"),
                 ),
                 SelectedExpression(
-                    "count", FunctionCall("_snuba_count", "count", tuple()),
+                    "count",
+                    FunctionCall("_snuba_count", "count", tuple()),
                 ),
             ],
             groupby=[Column("_snuba_tags_key", None, "tags_key")],
@@ -1483,7 +1499,8 @@ test_cases = [
                     FunctionCall("_snuba_count", "count", tuple()),
                 ),
                 OrderBy(
-                    OrderByDirection.ASC, Column("_snuba_tags_key", None, "tags_key"),
+                    OrderByDirection.ASC,
+                    Column("_snuba_tags_key", None, "tags_key"),
                 ),
             ],
             limit=10,
@@ -1547,7 +1564,8 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "times_seen", FunctionCall("_snuba_times_seen", "count", tuple()),
+                    "times_seen",
+                    FunctionCall("_snuba_times_seen", "count", tuple()),
                 ),
             ],
             limit=1000,
@@ -1577,7 +1595,8 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "times_seen", FunctionCall("_snuba_times_seen", "count", tuple()),
+                    "times_seen",
+                    FunctionCall("_snuba_times_seen", "count", tuple()),
                 ),
             ],
             limit=1000,
@@ -1607,7 +1626,8 @@ test_cases = [
             ),
             selected_columns=[
                 SelectedExpression(
-                    "times_seen", FunctionCall("_snuba_times_seen", "count", tuple()),
+                    "times_seen",
+                    FunctionCall("_snuba_times_seen", "count", tuple()),
                 ),
             ],
             limit=1000,
@@ -1676,7 +1696,8 @@ test_cases = [
                     "tn", Column("_snuba_transaction_name", None, "transaction_name")
                 ),
                 SelectedExpression(
-                    "count", FunctionCall("_snuba_count", "count", tuple()),
+                    "count",
+                    FunctionCall("_snuba_count", "count", tuple()),
                 ),
             ],
             groupby=[Column("_snuba_transaction_name", None, "transaction_name")],

--- a/tests/query/snql/test_query_column_validation.py
+++ b/tests/query/snql/test_query_column_validation.py
@@ -36,7 +36,8 @@ time_validation_tests = [
         CompositeQuery(
             from_clause=LogicalQuery(
                 QueryEntity(
-                    EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                    EntityKey.EVENTS,
+                    get_entity(EntityKey.EVENTS).get_data_model(),
                 ),
                 selected_columns=[
                     SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -95,7 +96,8 @@ time_validation_tests = [
                 left_node=IndividualNode(
                     "e",
                     QueryEntity(
-                        EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                        EntityKey.EVENTS,
+                        get_entity(EntityKey.EVENTS).get_data_model(),
                     ),
                 ),
                 right_node=IndividualNode(
@@ -179,7 +181,8 @@ time_validation_tests = [
         AND timestamp=toDateTime('2021-01-01T00:00:00')""",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -208,7 +211,8 @@ time_validation_tests = [
         AND timestamp IN tuple(toDateTime('2021-01-01T00:00:00'))""",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -242,7 +246,8 @@ time_validation_tests = [
         AND timestamp < toDateTime('2021-01-02T00:30:00')""",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -280,7 +285,8 @@ time_validation_tests = [
         AND timestamp < toDateTime('2021-01-20T00:30:00')""",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -319,7 +325,8 @@ time_validation_tests = [
         AND timestamp < toDateTime('2021-01-03T00:30:00')""",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression("title", Column("_snuba_title", None, "title")),
@@ -366,7 +373,8 @@ time_validation_tests = [
         AND (timestamp < toDateTime('2021-01-02T00:30:00') OR timestamp < toDateTime('2021-01-02T00:30:00'))""",
         LogicalQuery(
             QueryEntity(
-                EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model(),
+                EntityKey.EVENTS,
+                get_entity(EntityKey.EVENTS).get_data_model(),
             ),
             selected_columns=[
                 SelectedExpression("title", Column("_snuba_title", None, "title")),

--- a/tests/query/test_conditions.py
+++ b/tests/query/test_conditions.py
@@ -76,7 +76,9 @@ def test_map_expressions_in_basic_condition() -> None:
     condition = condition.transform(replace_col)
 
     condition_b = binary_condition(
-        ConditionFunctions.EQ, FunctionCall(None, "f", (c3,)), c2,
+        ConditionFunctions.EQ,
+        FunctionCall(None, "f", (c3,)),
+        c2,
     )
     ret = list(condition)
     expected = [c3, FunctionCall(None, "f", (c3,)), c2, condition_b]
@@ -207,17 +209,25 @@ def test_is_x_condition_functions() -> None:
 
 def test_first_level_conditions() -> None:
     c1 = binary_condition(
-        ConditionFunctions.EQ, Column(None, "table1", "column1"), Literal(None, "test"),
+        ConditionFunctions.EQ,
+        Column(None, "table1", "column1"),
+        Literal(None, "test"),
     )
     c2 = binary_condition(
-        ConditionFunctions.EQ, Column(None, "table2", "column2"), Literal(None, "test"),
+        ConditionFunctions.EQ,
+        Column(None, "table2", "column2"),
+        Literal(None, "test"),
     )
     c3 = binary_condition(
-        ConditionFunctions.EQ, Column(None, "table3", "column3"), Literal(None, "test"),
+        ConditionFunctions.EQ,
+        Column(None, "table3", "column3"),
+        Literal(None, "test"),
     )
 
     cond = binary_condition(
-        BooleanFunctions.AND, binary_condition(BooleanFunctions.AND, c1, c2), c3,
+        BooleanFunctions.AND,
+        binary_condition(BooleanFunctions.AND, c1, c2),
+        c3,
     )
     assert get_first_level_and_conditions(cond) == [c1, c2, c3]
 
@@ -231,7 +241,9 @@ def test_first_level_conditions() -> None:
     assert get_first_level_and_conditions(cond) == [c1, c2, c3]
 
     cond = binary_condition(
-        BooleanFunctions.OR, binary_condition(BooleanFunctions.AND, c1, c2), c3,
+        BooleanFunctions.OR,
+        binary_condition(BooleanFunctions.AND, c1, c2),
+        c3,
     )
     assert get_first_level_or_conditions(cond) == [
         binary_condition(BooleanFunctions.AND, c1, c2),
@@ -253,7 +265,9 @@ def test_first_level_conditions() -> None:
 
 def test_binary_match() -> None:
     c1 = binary_condition(
-        ConditionFunctions.EQ, Column(None, "table1", "column1"), Literal(None, "test"),
+        ConditionFunctions.EQ,
+        Column(None, "table1", "column1"),
+        Literal(None, "test"),
     )
 
     lhs = ColumnPattern(String("table1"), String("column1"))

--- a/tests/query/test_expressions.py
+++ b/tests/query/test_expressions.py
@@ -207,7 +207,10 @@ TEST_CASES = [
     (Literal(None, "meowmeow"), "'meowmeow'"),
     (Literal(None, 123), "123"),
     (Literal(None, False), "False"),
-    (Literal(None, datetime(2020, 4, 20, 16, 20)), "datetime(2020-04-20T16:20:00)",),
+    (
+        Literal(None, datetime(2020, 4, 20, 16, 20)),
+        "datetime(2020-04-20T16:20:00)",
+    ),
     (Literal(None, datetime(2020, 4, 20, 16, 20).date()), "date(2020-04-20)"),
     (Literal(None, None), "None"),
     (

--- a/tests/query/test_matcher.py
+++ b/tests/query/test_matcher.py
@@ -24,7 +24,12 @@ from snuba.query.matchers import (
 )
 
 test_cases = [
-    ("Literal match", Literal(None), LiteralExpr("random_alias", 1), MatchResult(),),
+    (
+        "Literal match",
+        Literal(None),
+        LiteralExpr("random_alias", 1),
+        MatchResult(),
+    ),
     (
         "Literal match with none type",
         Literal(Any(type(None))),
@@ -64,7 +69,8 @@ test_cases = [
     (
         "Matches a column with all fields",
         Column(
-            Param("table_name", AnyOptionalString()), Param("column_name", Any(str)),
+            Param("table_name", AnyOptionalString()),
+            Param("column_name", Any(str)),
         ),
         ColumnExpr("alias", "table_name", "test_col"),
         MatchResult({"column_name": "test_col", "table_name": "table_name"}),
@@ -125,7 +131,11 @@ test_cases = [
     (
         "Does not match any Column",
         FunctionCall(None, (Param("p1", Any(ColumnExpr)),)),
-        FunctionCallExpr("irrelevant", "irrelevant", (LiteralExpr(None, "str"),),),
+        FunctionCallExpr(
+            "irrelevant",
+            "irrelevant",
+            (LiteralExpr(None, "str"),),
+        ),
         None,
     ),
     (
@@ -239,7 +249,9 @@ test_cases = [
             with_optionals=True,
         ),
         FunctionCallExpr(
-            "irrelevant", "irrelevant", (ColumnExpr(None, None, "c_name1"),),
+            "irrelevant",
+            "irrelevant",
+            (ColumnExpr(None, None, "c_name1"),),
         ),
         None,
     ),

--- a/tests/snapshots/test_postgres_snapshot.py
+++ b/tests/snapshots/test_postgres_snapshot.py
@@ -1,10 +1,10 @@
-from snuba.snapshots import (
+import pytest
+
+from snuba.snapshots import (  # NOQA
     ColumnConfig,
     DateFormatPrecision,
     DateTimeFormatterConfig,
-)  # NOQA
-import pytest
-
+)
 from snuba.snapshots.postgres_snapshot import PostgresSnapshot
 
 META_FILE = """

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -167,7 +167,8 @@ tests = [
 
 
 @pytest.mark.parametrize(
-    "vals", tests,
+    "vals",
+    tests,
 )
 def test_rate_limit_failures(vals: Tuple[int, int, int]) -> None:
     params = []

--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -103,5 +103,6 @@ class TestState:
 
 def test_safe_dumps():
     assert safe_dumps(ChainMap({"a": 1}, {"b": 2}), sort_keys=True,) == safe_dumps(
-        {"a": 1, "b": 2}, sort_keys=True,
+        {"a": 1, "b": 2},
+        sort_keys=True,
     )

--- a/tests/state/test_stateful_count_policy.py
+++ b/tests/state/test_stateful_count_policy.py
@@ -158,7 +158,8 @@ def test_stateful_count(
 
 
 def test_multiple_invalid_messages(
-    valid_message: Message[KafkaPayload], invalid_message: Message[KafkaPayload],
+    valid_message: Message[KafkaPayload],
+    invalid_message: Message[KafkaPayload],
 ) -> None:
     fake_batching_processor = FakeBatchingProcessingStep()
     count_policy = StatefulCountInvalidMessagePolicy(CONSUMER_GROUP_NAME, 5)

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -37,7 +37,8 @@ from tests.subscriptions.subscriptions_utils import create_entity_subscription
 
 
 def build_snql_subscription_data(
-    entity_key: EntityKey, organization: Optional[int] = None,
+    entity_key: EntityKey,
+    organization: Optional[int] = None,
 ) -> SubscriptionData:
 
     return SubscriptionData(
@@ -50,17 +51,37 @@ def build_snql_subscription_data(
 
 
 SNQL_CASES = [
-    pytest.param(build_snql_subscription_data, None, EntityKey.EVENTS, id="snql",),
-    pytest.param(build_snql_subscription_data, 1, EntityKey.SESSIONS, id="snql",),
     pytest.param(
-        build_snql_subscription_data, 1, EntityKey.METRICS_COUNTERS, id="snql",
+        build_snql_subscription_data,
+        None,
+        EntityKey.EVENTS,
+        id="snql",
     ),
-    pytest.param(build_snql_subscription_data, 1, EntityKey.METRICS_SETS, id="snql",),
+    pytest.param(
+        build_snql_subscription_data,
+        1,
+        EntityKey.SESSIONS,
+        id="snql",
+    ),
+    pytest.param(
+        build_snql_subscription_data,
+        1,
+        EntityKey.METRICS_COUNTERS,
+        id="snql",
+    ),
+    pytest.param(
+        build_snql_subscription_data,
+        1,
+        EntityKey.METRICS_SETS,
+        id="snql",
+    ),
 ]
 
 
 def assert_entity_subscription_on_subscription_class(
-    organization: Optional[int], subscription: SubscriptionData, entity_key: EntityKey,
+    organization: Optional[int],
+    subscription: SubscriptionData,
+    entity_key: EntityKey,
 ) -> None:
     subscription_cls = ENTITY_KEY_TO_SUBSCRIPTION_MAPPER[entity_key]
     if organization:

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -103,13 +103,19 @@ class TestBuildRequestBase:
         if exception is not None:
             with pytest.raises(exception):
                 request = subscription.build_request(
-                    self.dataset, datetime.utcnow(), 100, timer,
+                    self.dataset,
+                    datetime.utcnow(),
+                    100,
+                    timer,
                 )
                 parse_and_run_query(self.dataset, request, timer)
             return
 
         request = subscription.build_request(
-            self.dataset, datetime.utcnow(), 100, timer,
+            self.dataset,
+            datetime.utcnow(),
+            100,
+            timer,
         )
         result = parse_and_run_query(self.dataset, request, timer)
 

--- a/tests/subscriptions/test_entity_subscriptions.py
+++ b/tests/subscriptions/test_entity_subscriptions.py
@@ -16,7 +16,10 @@ from snuba.subscriptions.entity_subscription import (
 
 TESTS = [
     pytest.param(
-        EventsSubscription, {"data_dict": {}}, None, id="Events subscription",
+        EventsSubscription,
+        {"data_dict": {}},
+        None,
+        id="Events subscription",
     ),
     pytest.param(
         TransactionsSubscription,
@@ -69,7 +72,9 @@ TESTS_CONDITIONS_SNQL_METHOD = [
             binary_condition(
                 ConditionFunctions.LTE,
                 FunctionCall(
-                    None, "ifNull", (Column(None, None, "offset"), Literal(None, 0)),
+                    None,
+                    "ifNull",
+                    (Column(None, None, "offset"), Literal(None, 0)),
                 ),
                 Literal(None, 5),
             )
@@ -89,7 +94,9 @@ TESTS_CONDITIONS_SNQL_METHOD = [
             binary_condition(
                 ConditionFunctions.LTE,
                 FunctionCall(
-                    None, "ifNull", (Column(None, None, "offset"), Literal(None, 0)),
+                    None,
+                    "ifNull",
+                    (Column(None, None, "offset"), Literal(None, 0)),
                 ),
                 Literal(None, 5),
             )
@@ -107,7 +114,9 @@ TESTS_CONDITIONS_SNQL_METHOD = [
         SessionsSubscription(data_dict={"organization": 1}),
         [
             binary_condition(
-                ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 1),
+                ConditionFunctions.EQ,
+                Column(None, None, "org_id"),
+                Literal(None, 1),
             ),
         ],
         True,
@@ -117,7 +126,9 @@ TESTS_CONDITIONS_SNQL_METHOD = [
         MetricsCountersSubscription(data_dict={"organization": 1}),
         [
             binary_condition(
-                ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 1),
+                ConditionFunctions.EQ,
+                Column(None, None, "org_id"),
+                Literal(None, 1),
             ),
         ],
         True,
@@ -127,7 +138,9 @@ TESTS_CONDITIONS_SNQL_METHOD = [
         MetricsSetsSubscription(data_dict={"organization": 1}),
         [
             binary_condition(
-                ConditionFunctions.EQ, Column(None, None, "org_id"), Literal(None, 1),
+                ConditionFunctions.EQ,
+                Column(None, None, "org_id"),
+                Literal(None, 1),
             ),
         ],
         True,

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -338,7 +338,8 @@ def test_produce_result() -> None:
         1,
         SubscriptionTaskResult(
             ScheduledSubscriptionTask(
-                epoch, SubscriptionWithMetadata(EntityKey.EVENTS, subscription, 1),
+                epoch,
+                SubscriptionWithMetadata(EntityKey.EVENTS, subscription, 1),
             ),
             (request, result),
         ),

--- a/tests/subscriptions/test_scheduler.py
+++ b/tests/subscriptions/test_scheduler.py
@@ -58,7 +58,9 @@ class TestSubscriptionScheduler:
         tick = self.build_tick(start, end)
 
         store = RedisSubscriptionDataStore(
-            redis_client, self.entity_key, self.partition_id,
+            redis_client,
+            self.entity_key,
+            self.partition_id,
         )
         for subscription in subscriptions:
             store.create(subscription.identifier.uuid, subscription.data)

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -70,7 +70,12 @@ def test_tick_buffer_wait_slowest() -> None:
     next_step = mock.Mock()
 
     # Create strategy with 2 partitions
-    strategy = TickBuffer(SchedulingWatermarkMode.GLOBAL, 2, 10, next_step,)
+    strategy = TickBuffer(
+        SchedulingWatermarkMode.GLOBAL,
+        2,
+        10,
+        next_step,
+    )
 
     topic = Topic("messages")
     commit_log_partition = Partition(topic, 0)

--- a/tests/subscriptions/test_subscription.py
+++ b/tests/subscriptions/test_subscription.py
@@ -86,7 +86,9 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, self.entity_key, identifier.partition,
+                    redis_client,
+                    self.entity_key,
+                    identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -97,7 +99,8 @@ class TestSubscriptionCreator(BaseSubscriptionTest):
         creator = SubscriptionCreator(self.dataset, EntityKey.EVENTS)
         with raises(QueryException):
             creator.create(
-                subscription, self.timer,
+                subscription,
+                self.timer,
             )
 
     def test_invalid_aggregation(self) -> None:
@@ -184,7 +187,9 @@ class TestSessionsSubscriptionCreator:
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, EntityKey.SESSIONS, identifier.partition,
+                    redis_client,
+                    EntityKey.SESSIONS,
+                    identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -301,7 +306,9 @@ class TestMetricsCountersSubscriptionCreator:
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, entity_key, identifier.partition,
+                    redis_client,
+                    entity_key,
+                    identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -314,7 +321,8 @@ class TestMetricsCountersSubscriptionCreator:
         creator = SubscriptionCreator(self.dataset, EntityKey.METRICS_COUNTERS)
         with raises(InvalidQueryException):
             creator.create(
-                subscription, self.timer,
+                subscription,
+                self.timer,
             )
 
 
@@ -333,7 +341,9 @@ class TestSubscriptionDeleter(BaseSubscriptionTest):
             cast(
                 List[Tuple[UUID, SubscriptionData]],
                 RedisSubscriptionDataStore(
-                    redis_client, self.entity_key, identifier.partition,
+                    redis_client,
+                    self.entity_key,
+                    identifier.partition,
                 ).all(),
             )[0][1]
             == subscription
@@ -344,7 +354,9 @@ class TestSubscriptionDeleter(BaseSubscriptionTest):
         )
         assert (
             RedisSubscriptionDataStore(
-                redis_client, self.entity_key, identifier.partition,
+                redis_client,
+                self.entity_key,
+                identifier.partition,
             ).all()
             == []
         )

--- a/tests/subscriptions/test_verifier.py
+++ b/tests/subscriptions/test_verifier.py
@@ -59,7 +59,10 @@ def make_encoded_subscription_result(
             timestamp,
             SubscriptionWithMetadata(
                 EntityKey.EVENTS,
-                Subscription(subscription_identifier, subscription_data,),
+                Subscription(
+                    subscription_identifier,
+                    subscription_data,
+                ),
                 5,
             ),
         ),

--- a/tests/subscriptions/test_worker.py
+++ b/tests/subscriptions/test_worker.py
@@ -189,7 +189,8 @@ def test_subscription_worker(
     evaluations = 3
 
     subscription = Subscription(
-        SubscriptionIdentifier(PartitionId(0), uuid1()), subscription_data,
+        SubscriptionIdentifier(PartitionId(0), uuid1()),
+        subscription_data,
     )
 
     store = DummySubscriptionDataStore()
@@ -289,7 +290,8 @@ def test_subscription_worker_consistent() -> None:
     evaluations = 1
 
     subscription = Subscription(
-        SubscriptionIdentifier(PartitionId(0), uuid1()), subscription_data,
+        SubscriptionIdentifier(PartitionId(0), uuid1()),
+        subscription_data,
     )
 
     store = DummySubscriptionDataStore()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2235,7 +2235,9 @@ class TestCreateSubscriptionApi(BaseApiTest):
             len(
                 list(
                     RedisSubscriptionDataStore(
-                        redis_client, entity_key, partition,
+                        redis_client,
+                        entity_key,
+                        partition,
                     ).all()
                 )
             )
@@ -2346,7 +2348,9 @@ class TestDeleteSubscriptionApi(BaseApiTest):
             len(
                 list(
                     RedisSubscriptionDataStore(
-                        redis_client, entity_key, partition,
+                        redis_client,
+                        entity_key,
+                        partition,
                     ).all()
                 )
             )
@@ -2358,7 +2362,12 @@ class TestDeleteSubscriptionApi(BaseApiTest):
         )
         assert resp.status_code == 202, resp
         assert (
-            RedisSubscriptionDataStore(redis_client, entity_key, partition,).all() == []
+            RedisSubscriptionDataStore(
+                redis_client,
+                entity_key,
+                partition,
+            ).all()
+            == []
         )
 
     def test_invalid_dataset_and_entity_combination(self) -> None:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -51,7 +51,8 @@ test_data = [
 
 class TestCleanup:
     @pytest.mark.parametrize(
-        "storage_key, create_event_row_for_date", test_data,
+        "storage_key, create_event_row_for_date",
+        test_data,
     )
     @patch("snuba.cleanup.current_time")
     def test_main_cases(
@@ -167,7 +168,8 @@ class TestCleanup:
         )
 
     @pytest.mark.parametrize(
-        "storage_key, create_event_row_for_date", test_data,
+        "storage_key, create_event_row_for_date",
+        test_data,
     )
     @patch("snuba.cleanup.current_time")
     def test_midnight_error_case(

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -266,12 +266,24 @@ def test_multistorage_strategy_dead_letter_step(
     payloads = [
         KafkaPayload(
             None,
-            json.dumps((2, "insert", get_raw_event(),)).encode("utf8"),
+            json.dumps(
+                (
+                    2,
+                    "insert",
+                    get_raw_event(),
+                )
+            ).encode("utf8"),
             [("transaction_forwarder", "0".encode("utf8"))],
         ),
         KafkaPayload(
             None,
-            json.dumps((2, "insert", get_raw_transaction(),)).encode("utf8"),
+            json.dumps(
+                (
+                    2,
+                    "insert",
+                    get_raw_transaction(),
+                )
+            ).encode("utf8"),
             [("transaction_forwarder", "1".encode("utf8"))],
         ),
     ]
@@ -320,7 +332,11 @@ def test_dead_letter_step() -> None:
     # We only produce to dead letter topic if the payload is an insert
     # so payload of `None` shouldn't produce any futures
     none_message = Message(
-        Partition(Topic("topic"), 0), 0, (storage_key, None), datetime.now(), 1,
+        Partition(Topic("topic"), 0),
+        0,
+        (storage_key, None),
+        datetime.now(),
+        1,
     )
     dead_letter_step.submit(none_message)
     assert not dead_letter_step._DeadLetterStep__futures

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -47,7 +47,8 @@ class TestDiscoverApi(BaseApiTest):
         write_unprocessed_events(self.events_storage, [self.event])
 
         write_unprocessed_events(
-            get_writable_storage(StorageKey.TRANSACTIONS), [get_raw_transaction()],
+            get_writable_storage(StorageKey.TRANSACTIONS),
+            [get_raw_transaction()],
         )
 
     def test_raw_data(self) -> None:

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -253,7 +253,8 @@ class TestMetricsApiSets(BaseApiTest):
                 }
 
                 processed = processor.process_message(
-                    msg, KafkaMessageMetadata(0, 0, self.base_time),
+                    msg,
+                    KafkaMessageMetadata(0, 0, self.base_time),
                 )
                 if processed:
                     events.append(processed)
@@ -351,7 +352,8 @@ class TestMetricsApiDistributions(BaseApiTest):
                 }
 
                 processed = processor.process_message(
-                    msg, KafkaMessageMetadata(0, 0, self.base_time),
+                    msg,
+                    KafkaMessageMetadata(0, 0, self.base_time),
                 )
                 if processed:
                     events.append(processed)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -89,7 +89,8 @@ test_data = [
 
 class TestOptimize:
     @pytest.mark.parametrize(
-        "storage_key, create_event_row_for_date, parallel", test_data,
+        "storage_key, create_event_row_for_date, parallel",
+        test_data,
     )
     def test_optimize(
         self,
@@ -175,7 +176,11 @@ class TestOptimize:
     @pytest.mark.parametrize(
         "table,host,expected",
         [
-            ("errors_local", None, {"table": "errors_local"},),
+            (
+                "errors_local",
+                None,
+                {"table": "errors_local"},
+            ),
             (
                 "errors_local",
                 "some-hostname.domain.com",

--- a/tests/test_org_sessions_api.py
+++ b/tests/test_org_sessions_api.py
@@ -75,10 +75,12 @@ class TestOrgSessionsApi(BaseApiTest):
                 meta,
             ),
             processor.process_message(
-                {**template, "status": "exited", "quantity": 5}, meta,
+                {**template, "status": "exited", "quantity": 5},
+                meta,
             ),
             processor.process_message(
-                {**template, "status": "errored", "errors": 1, "quantity": 2}, meta,
+                {**template, "status": "errored", "errors": 1, "quantity": 2},
+                meta,
             ),
             processor.process_message(
                 {
@@ -110,7 +112,10 @@ class TestOrgSessionsApi(BaseApiTest):
             granularity=Granularity(3600),
         )
 
-        response = self.app.post("/sessions/snql", data=query.snuba(),)
+        response = self.app.post(
+            "/sessions/snql",
+            data=query.snuba(),
+        )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 2
@@ -139,7 +144,10 @@ class TestOrgSessionsApi(BaseApiTest):
             orderby=[OrderBy(Column("org_id"), Direction.ASC)],
         )
 
-        response = self.app.post("/sessions/snql", data=query.snuba(),)
+        response = self.app.post(
+            "/sessions/snql",
+            data=query.snuba(),
+        )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 3
@@ -150,8 +158,13 @@ class TestOrgSessionsApi(BaseApiTest):
         assert data["data"][2]["org_id"] == self.org_id2
         assert data["data"][2]["project_id"] == self.project_id3
 
-        query = query.set_orderby([OrderBy(Column("org_id"), Direction.DESC)],)
-        response = self.app.post("/sessions/snql", data=query.snuba(),)
+        query = query.set_orderby(
+            [OrderBy(Column("org_id"), Direction.DESC)],
+        )
+        response = self.app.post(
+            "/sessions/snql",
+            data=query.snuba(),
+        )
         data = json.loads(response.data)
         assert response.status_code == 200, response.data
         assert len(data["data"]) == 3

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -77,7 +77,10 @@ class TestOutcomesApi(BaseApiTest):
                 self.storage.get_table_writer()
                 .get_stream_loader()
                 .get_processor()
-                .process_message(message, KafkaMessageMetadata(0, 0, self.base_time),)
+                .process_message(
+                    message,
+                    KafkaMessageMetadata(0, 0, self.base_time),
+                )
             )
             if processed:
                 outcomes.append(processed)

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -35,7 +35,9 @@ class TestReplacer:
         self.storage = get_writable_storage(StorageKey.ERRORS)
 
         self.replacer = replacer.ReplacerWorker(
-            self.storage, CONSUMER_GROUP, DummyMetricsBackend(strict=True),
+            self.storage,
+            CONSUMER_GROUP,
+            DummyMetricsBackend(strict=True),
         )
 
         self.project_id = 1
@@ -298,7 +300,11 @@ class TestReplacer:
             flags.needs_final,
             flags.group_ids_to_exclude,
             flags.replacement_types,
-        ) == (True, set(), {ReplacementType.EXCLUDE_GROUPS},)
+        ) == (
+            True,
+            set(),
+            {ReplacementType.EXCLUDE_GROUPS},
+        )
 
         errors_replacer.set_project_needs_final(
             2, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
@@ -308,7 +314,11 @@ class TestReplacer:
             flags.needs_final,
             flags.group_ids_to_exclude,
             flags.replacement_types,
-        ) == (True, set(), {ReplacementType.EXCLUDE_GROUPS},)
+        ) == (
+            True,
+            set(),
+            {ReplacementType.EXCLUDE_GROUPS},
+        )
 
     def test_query_time_flags_groups(self) -> None:
         """
@@ -376,7 +386,11 @@ class TestReplacer:
             flags.needs_final,
             flags.group_ids_to_exclude,
             flags.replacement_types,
-        ) == (False, {1, 2}, {ReplacementType.EXCLUDE_GROUPS},)
+        ) == (
+            False,
+            {1, 2},
+            {ReplacementType.EXCLUDE_GROUPS},
+        )
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -161,10 +161,12 @@ class TestSessionsApi(BaseSessionsMockTest, BaseApiTest):
                 meta,
             ),
             processor.process_message(
-                {**template, "status": "exited", "quantity": 5}, meta,
+                {**template, "status": "exited", "quantity": 5},
+                meta,
             ),
             processor.process_message(
-                {**template, "status": "errored", "errors": 1, "quantity": 2}, meta,
+                {**template, "status": "errored", "errors": 1, "quantity": 2},
+                meta,
             ),
             processor.process_message(
                 {

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -38,7 +38,8 @@ class TestSnQLApi(BaseApiTest):
             minute=0, second=0, microsecond=0
         ) + timedelta(minutes=180)
         write_unprocessed_events(
-            get_writable_storage(StorageKey.TRANSACTIONS), [get_raw_transaction()],
+            get_writable_storage(StorageKey.TRANSACTIONS),
+            [get_raw_transaction()],
         )
 
     def test_simple_query(self) -> None:

--- a/tests/test_snql_sdk_api.py
+++ b/tests/test_snql_sdk_api.py
@@ -49,7 +49,8 @@ class TestSDKSnQLApi(BaseApiTest):
             minute=0, second=0, microsecond=0
         ) + timedelta(minutes=180)
         write_unprocessed_events(
-            get_writable_storage(StorageKey.TRANSACTIONS), [get_raw_transaction()],
+            get_writable_storage(StorageKey.TRANSACTIONS),
+            [get_raw_transaction()],
         )
 
     def test_simple_query(self) -> None:

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -27,8 +27,18 @@ def setup_function(function) -> None:
 
 
 split_specs = [
-    ("events", "event_id", "project_id", "timestamp",),
-    ("transactions", "event_id", "project_id", "finish_ts",),
+    (
+        "events",
+        "event_id",
+        "project_id",
+        "timestamp",
+    ),
+    (
+        "transactions",
+        "event_id",
+        "project_id",
+        "finish_ts",
+    ),
 ]
 
 
@@ -47,7 +57,9 @@ def test_no_split(
     )
 
     def do_query(
-        query: ClickhouseQuery, request_settings: RequestSettings, reader: Reader,
+        query: ClickhouseQuery,
+        request_settings: RequestSettings,
+        reader: Reader,
     ) -> QueryResult:
         assert query == query
         return QueryResult({}, {})
@@ -115,7 +127,9 @@ def test_col_split(
     second_query_data: Sequence[MutableMapping[str, Any]],
 ) -> None:
     def do_query(
-        query: ClickhouseQuery, request_settings: RequestSettings, reader: Reader,
+        query: ClickhouseQuery,
+        request_settings: RequestSettings,
+        reader: Reader,
     ) -> QueryResult:
         selected_col_names = [
             c.expression.column_name
@@ -344,7 +358,8 @@ def test_time_split_ast() -> None:
     found_timestamps = []
 
     def do_query(
-        query: ClickhouseQuery, request_settings: RequestSettings,
+        query: ClickhouseQuery,
+        request_settings: RequestSettings,
     ) -> QueryResult:
         from_date_ast, to_date_ast = get_time_range(query, "timestamp")
         assert from_date_ast is not None and isinstance(from_date_ast, datetime)

--- a/tests/utils/streams/test_kafka_consumer_with_commit_log.py
+++ b/tests/utils/streams/test_kafka_consumer_with_commit_log.py
@@ -69,6 +69,8 @@ def test_commit_log_consumer() -> None:
 
         assert commit_codec.decode(
             KafkaPayload(
-                commit_message.key(), commit_message.value(), commit_message.headers(),
+                commit_message.key(),
+                commit_message.value(),
+                commit_message.headers(),
             )
         ) == Commit("test", Partition(topic, 0), message.next_offset, now)

--- a/tests/utils/test_threaded_function_delegator.py
+++ b/tests/utils/test_threaded_function_delegator.py
@@ -28,7 +28,9 @@ def test() -> None:
     mock_callback = Mock(side_effect=callback_func)
 
     delegator = ThreadedFunctionDelegator[Any, int](
-        callables=callables, selector_func=selector_func, callback_func=mock_callback,
+        callables=callables,
+        selector_func=selector_func,
+        callback_func=mock_callback,
     )
 
     result = delegator.execute(5)

--- a/tests/web/test_count_columns.py
+++ b/tests/web/test_count_columns.py
@@ -43,7 +43,10 @@ SIMPLE_QUERY = ClickhouseQuery(
             "alias",
             FunctionCall("alias", "something", (Column(None, None, "event_id"),)),
         ),
-        SelectedExpression("group_id", Column(None, None, "group_id"),),
+        SelectedExpression(
+            "group_id",
+            Column(None, None, "group_id"),
+        ),
     ],
     array_join=None,
     condition=binary_condition(
@@ -61,7 +64,14 @@ SIMPLE_QUERY = ClickhouseQuery(
 )
 
 TEST_CASES = [
-    pytest.param(SIMPLE_QUERY, 3, {"errors_local"}, True, 0.1, id="Simple Query",),
+    pytest.param(
+        SIMPLE_QUERY,
+        3,
+        {"errors_local"},
+        True,
+        0.1,
+        id="Simple Query",
+    ),
     pytest.param(
         CompositeQuery(
             from_clause=SIMPLE_QUERY,
@@ -99,7 +109,8 @@ TEST_CASES = [
                     FunctionCall("alias", "something", (Column(None, "err", "alias"),)),
                 ),
                 SelectedExpression(
-                    "group_id", Column("group_id", "groups", "group_id"),
+                    "group_id",
+                    Column("group_id", "groups", "group_id"),
                 ),
                 SelectedExpression("message", Column("message", "groups", "message")),
             ],

--- a/tests/web/test_project_finder.py
+++ b/tests/web/test_project_finder.py
@@ -26,7 +26,10 @@ EVENTS_SCHEMA = EntityColumnSet(
 SIMPLE_QUERY = Query(
     Entity(EntityKey.EVENTS, EVENTS_SCHEMA),
     selected_columns=[
-        SelectedExpression("alias", Column("_snuba_project", None, "project_id"),)
+        SelectedExpression(
+            "alias",
+            Column("_snuba_project", None, "project_id"),
+        )
     ],
     array_join=None,
     condition=binary_condition(
@@ -37,7 +40,11 @@ SIMPLE_QUERY = Query(
 )
 
 TEST_CASES = [
-    pytest.param(SIMPLE_QUERY, {1, 2}, id="Simple Query",),
+    pytest.param(
+        SIMPLE_QUERY,
+        {1, 2},
+        id="Simple Query",
+    ),
     pytest.param(
         CompositeQuery(
             from_clause=SIMPLE_QUERY,
@@ -55,10 +62,12 @@ TEST_CASES = [
 
 
 @pytest.mark.parametrize(
-    "query, expected_proj", TEST_CASES,
+    "query, expected_proj",
+    TEST_CASES,
 )
 def test_count_columns(
-    query: Union[Query, CompositeQuery[Entity]], expected_proj: Set[int],
+    query: Union[Query, CompositeQuery[Entity]],
+    expected_proj: Set[int],
 ) -> None:
     project_finder = ProjectsFinder()
     assert project_finder.visit(query) == expected_proj


### PR DESCRIPTION
commits are split into atomic tasks -- it's recommended to view the reformat commits with [?w=1](https://youtu.be/qYJWBJvHqj0)

___

previously the check in CI was always silently passing due to `master` not being
available with `actions/checkout@v2`:

```
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```