### PR TITLE
Revert "feat(subscriptions): Temporarily run errors in global mode (#…

### DIFF
--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -42,8 +42,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,
-        # TODO: Temporarily running in Global mode for testing
-        subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
+        subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),

--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -108,8 +108,7 @@ storage = WritableTableStorage(
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,
-        # TODO: Temporarily running in Global mode for testing
-        subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
+        subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
     ),


### PR DESCRIPTION
…2616)"

This reverts commit 61598c2e394011a482d0d032fe117af7abb649f9.

Test is over, global mode results were almost identical to partition mode.
We can revert this change now.