### PR TITLE
ref(metrics/sessions): enforce retention days

### DIFF
--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -101,22 +101,21 @@ def extract_extra_contexts(
 
 
 def override_and_enforce_retention(
-    message: Mapping[str, Any], timestamp: Optional[datetime]
+    project_id: int, retention_days: Optional[int], timestamp: Optional[datetime]
 ) -> int:
     """
     Overriding retention with RETENTION_OVERRIDES is only
     used for events/transactions datasets.
     """
-    project_id = message["project_id"]
-    retention_days = settings.RETENTION_OVERRIDES.get(project_id)
-    if retention_days is None:
-        retention_days = int(
-            message.get("retention_days") or settings.DEFAULT_RETENTION_DAYS
-        )
+    if project_id:
+        retention_days = settings.RETENTION_OVERRIDES.get(project_id)
+
     return enforce_retention(retention_days, timestamp)
 
 
-def enforce_retention(retention_days: int, timestamp: Optional[datetime]) -> int:
+def enforce_retention(
+    retention_days: Optional[int], timestamp: Optional[datetime]
+) -> int:
     if retention_days is None:
         retention_days = settings.DEFAULT_RETENTION_DAYS
 

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -100,13 +100,25 @@ def extract_extra_contexts(
     return (context_keys, context_values)
 
 
-def enforce_retention(message: Mapping[str, Any], timestamp: Optional[datetime]) -> int:
+def override_and_enforce_retention(
+    message: Mapping[str, Any], timestamp: Optional[datetime]
+) -> int:
+    """
+    Overriding retention with RETENTION_OVERRIDES is only
+    used for events/transactions datasets.
+    """
     project_id = message["project_id"]
     retention_days = settings.RETENTION_OVERRIDES.get(project_id)
     if retention_days is None:
         retention_days = int(
             message.get("retention_days") or settings.DEFAULT_RETENTION_DAYS
         )
+    return enforce_retention(retention_days, timestamp)
+
+
+def enforce_retention(retention_days: int, timestamp: Optional[datetime]) -> int:
+    if retention_days is None:
+        retention_days = settings.DEFAULT_RETENTION_DAYS
 
     if settings.ENFORCE_RETENTION:
         retention_days = (

--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -108,7 +108,7 @@ def override_and_enforce_retention(
     used for events/transactions datasets.
     """
     if project_id:
-        retention_days = settings.RETENTION_OVERRIDES.get(project_id)
+        retention_days = settings.RETENTION_OVERRIDES.get(project_id) or retention_days
 
     return enforce_retention(retention_days, timestamp)
 

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -199,7 +199,8 @@ class EventsProcessorBase(MessageProcessor, ABC):
         extract_project_id(processed, event)
         self._extract_event_id(processed, event)
         processed["retention_days"] = override_and_enforce_retention(
-            event,
+            event["project_id"],
+            event.get("retention_days"),
             datetime.strptime(event["datetime"], settings.PAYLOAD_DATETIME_FORMAT),
         )
 

--- a/snuba/datasets/events_processor_base.py
+++ b/snuba/datasets/events_processor_base.py
@@ -8,10 +8,10 @@ from snuba import settings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.events_format import (
     EventTooOld,
-    enforce_retention,
     extract_extra_contexts,
     extract_extra_tags,
     extract_project_id,
+    override_and_enforce_retention,
 )
 from snuba.processor import (
     InsertBatch,
@@ -198,7 +198,7 @@ class EventsProcessorBase(MessageProcessor, ABC):
         processed: MutableMapping[str, Any] = {"deleted": 0}
         extract_project_id(processed, event)
         self._extract_event_id(processed, event)
-        processed["retention_days"] = enforce_retention(
+        processed["retention_days"] = override_and_enforce_retention(
             event,
             datetime.strptime(event["datetime"], settings.PAYLOAD_DATETIME_FORMAT),
         )

--- a/snuba/datasets/metrics_aggregate_processor.py
+++ b/snuba/datasets/metrics_aggregate_processor.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping, Optional, Sequence, Tuple
 
 from snuba import environment, settings
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.datasets.events_format import enforce_retention
+from snuba.datasets.events_format import EventTooOld, enforce_retention
 from snuba.processor import (
     AggregateInsertBatch,
     MessageProcessor,
@@ -79,6 +79,11 @@ class MetricsAggregateProcessor(MessageProcessor, ABC):
             assert isinstance(value, int)
             values.append(value)
 
+        try:
+            retention_days = enforce_retention(message, timestamp)
+        except EventTooOld:
+            return None
+
         processed = [
             {
                 "org_id": _literal(message["org_id"]),
@@ -95,7 +100,7 @@ class MetricsAggregateProcessor(MessageProcessor, ABC):
                 "tags.key": _array_literal(keys),
                 "tags.value": _array_literal(values),
                 **self._process_values(message),
-                "retention_days": _literal(enforce_retention(message, timestamp)),
+                "retention_days": _literal(retention_days),
                 "granularity": _literal(granularity),
             }
             for granularity in self.GRANULARITIES_SECONDS

--- a/snuba/datasets/metrics_aggregate_processor.py
+++ b/snuba/datasets/metrics_aggregate_processor.py
@@ -80,7 +80,7 @@ class MetricsAggregateProcessor(MessageProcessor, ABC):
             values.append(value)
 
         try:
-            retention_days = enforce_retention(message, timestamp)
+            retention_days = enforce_retention(message["retention_days"], timestamp)
         except EventTooOld:
             return None
 

--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -58,7 +58,7 @@ class MetricsBucketProcessor(MessageProcessor, ABC):
         )
 
         try:
-            retention_days = enforce_retention(message, timestamp)
+            retention_days = enforce_retention(message["retention_days"], timestamp)
         except EventTooOld:
             return None
 

--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -9,6 +9,7 @@ from snuba.datasets.metrics_aggregate_processor import (
     METRICS_COUNTERS_TYPE,
     METRICS_DISTRIBUTIONS_TYPE,
     METRICS_SET_TYPE,
+    enforce_retention_days,
 )
 from snuba.processor import (
     InsertBatch,
@@ -65,7 +66,7 @@ class MetricsBucketProcessor(MessageProcessor, ABC):
             "tags.value": values,
             **self._process_values(message),
             "materialization_version": mat_version,
-            "retention_days": message["retention_days"],
+            "retention_days": enforce_retention_days(message),
             "partition": metadata.partition,
             "offset": metadata.offset,
         }

--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, Optional
 
 from snuba import settings
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.datasets.events_format import enforce_retention
+from snuba.datasets.events_format import EventTooOld, enforce_retention
 from snuba.datasets.metrics_aggregate_processor import (
     METRICS_COUNTERS_TYPE,
     METRICS_DISTRIBUTIONS_TYPE,
@@ -57,6 +57,11 @@ class MetricsBucketProcessor(MessageProcessor, ABC):
             else settings.ENABLED_MATERIALIZATION_VERSION
         )
 
+        try:
+            retention_days = enforce_retention(message, timestamp)
+        except EventTooOld:
+            return None
+
         processed = {
             "org_id": message["org_id"],
             "project_id": message["project_id"],
@@ -66,7 +71,7 @@ class MetricsBucketProcessor(MessageProcessor, ABC):
             "tags.value": values,
             **self._process_values(message),
             "materialization_version": mat_version,
-            "retention_days": enforce_retention(message, timestamp),
+            "retention_days": retention_days,
             "partition": metadata.partition,
             "offset": metadata.offset,
         }

--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -5,11 +5,11 @@ from typing import Any, Mapping, Optional
 
 from snuba import settings
 from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.events_format import enforce_retention
 from snuba.datasets.metrics_aggregate_processor import (
     METRICS_COUNTERS_TYPE,
     METRICS_DISTRIBUTIONS_TYPE,
     METRICS_SET_TYPE,
-    enforce_retention_days,
 )
 from snuba.processor import (
     InsertBatch,
@@ -66,7 +66,7 @@ class MetricsBucketProcessor(MessageProcessor, ABC):
             "tags.value": values,
             **self._process_values(message),
             "materialization_version": mat_version,
-            "retention_days": enforce_retention_days(message),
+            "retention_days": enforce_retention(message, timestamp),
             "partition": metadata.partition,
             "offset": metadata.offset,
         }

--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Mapping, Optional
 
-from snuba import environment
+from snuba import environment, settings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.processor import (
     MAX_UINT32,
@@ -25,6 +25,18 @@ STATUS_MAPPING = {
 }
 
 metrics = MetricsWrapper(environment.metrics, "sessions.processor")
+
+
+def enforce_retention_days(message: Mapping[str, Any]) -> int:
+    retention_days: int = message["retention_days"]
+
+    if settings.ENFORCE_RETENTION:
+        retention_days = (
+            settings.LOWER_RETENTION_DAYS
+            if retention_days <= settings.LOWER_RETENTION_DAYS
+            else settings.DEFAULT_RETENTION_DAYS
+        )
+    return retention_days
 
 
 class SessionsProcessor(MessageProcessor):
@@ -67,7 +79,7 @@ class SessionsProcessor(MessageProcessor):
             "seq": message["seq"],
             "org_id": message["org_id"],
             "project_id": message["project_id"],
-            "retention_days": message["retention_days"],
+            "retention_days": enforce_retention_days(message),
             "duration": duration,
             "status": STATUS_MAPPING[message["status"]],
             "errors": errors,

--- a/snuba/datasets/sessions_processor.py
+++ b/snuba/datasets/sessions_processor.py
@@ -68,7 +68,7 @@ class SessionsProcessor(MessageProcessor):
             "seq": message["seq"],
             "org_id": message["org_id"],
             "project_id": message["project_id"],
-            "retention_days": enforce_retention(message, received),
+            "retention_days": enforce_retention(message["retention_days"], received),
             "duration": duration,
             "status": STATUS_MAPPING[message["status"]],
             "errors": errors,

--- a/snuba/datasets/spans_processor.py
+++ b/snuba/datasets/spans_processor.py
@@ -45,7 +45,9 @@ class SpansMessageProcessor(MessageProcessor):
             "project_id": event["project_id"],
             "transaction_id": str(uuid.UUID(event["event_id"])),
             "retention_days": override_and_enforce_retention(
-                event, datetime.utcfromtimestamp(data["timestamp"])
+                event["project_id"],
+                event.get("retention_days"),
+                datetime.utcfromtimestamp(data["timestamp"]),
             ),
             "transaction_span_id": int(transaction_ctx["span_id"], 16),
             "trace_id": str(uuid.UUID(transaction_ctx["trace_id"])),

--- a/snuba/datasets/spans_processor.py
+++ b/snuba/datasets/spans_processor.py
@@ -6,7 +6,10 @@ from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
 from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.datasets.events_format import enforce_retention, extract_extra_tags
+from snuba.datasets.events_format import (
+    extract_extra_tags,
+    override_and_enforce_retention,
+)
 from snuba.processor import (
     InsertBatch,
     MessageProcessor,
@@ -41,7 +44,7 @@ class SpansMessageProcessor(MessageProcessor):
             "deleted": 0,
             "project_id": event["project_id"],
             "transaction_id": str(uuid.UUID(event["event_id"])),
-            "retention_days": enforce_retention(
+            "retention_days": override_and_enforce_retention(
                 event, datetime.utcfromtimestamp(data["timestamp"])
             ),
             "transaction_span_id": int(transaction_ctx["span_id"], 16),

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -86,7 +86,9 @@ class TransactionsMessageProcessor(MessageProcessor):
             # rest of the codebase. We can be confident that clients are only
             # sending UTC dates.
             retention_days = override_and_enforce_retention(
-                event, datetime.utcfromtimestamp(data["timestamp"])
+                event["project_id"],
+                event.get("retention_days"),
+                datetime.utcfromtimestamp(data["timestamp"]),
             )
         except EventTooOld:
             return None

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -11,13 +11,13 @@ from snuba import environment, settings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.events_format import (
     EventTooOld,
-    enforce_retention,
     extract_base,
     extract_extra_contexts,
     extract_extra_tags,
     extract_http,
     extract_nested,
     extract_user,
+    override_and_enforce_retention,
 )
 from snuba.processor import (
     InsertBatch,
@@ -85,7 +85,7 @@ class TransactionsMessageProcessor(MessageProcessor):
             # We are purposely using a naive datetime here to work with the
             # rest of the codebase. We can be confident that clients are only
             # sending UTC dates.
-            retention_days = enforce_retention(
+            retention_days = override_and_enforce_retention(
                 event, datetime.utcfromtimestamp(data["timestamp"])
             )
         except EventTooOld:

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -34,7 +34,8 @@ SET_MESSAGE_SHARED = {
     "timestamp": 1619225296,
     "tags": {"10": 11, "20": 22, "30": 33},
     "value": [324234, 345345, 456456, 567567],
-    "retention_days": 30,
+    # test enforce retention days of 30
+    "retention_days": 22,
 }
 
 COUNTER_MESSAGE_SHARED = {
@@ -45,7 +46,8 @@ COUNTER_MESSAGE_SHARED = {
     "timestamp": 1619225296,
     "tags": {"10": 11, "20": 22, "30": 33},
     "value": 123.123,
-    "retention_days": 30,
+    # test enforce retention days of 30
+    "retention_days": 23,
 }
 
 DIST_VALUES = [324.12, 345.23, 4564.56, 567567]
@@ -57,7 +59,8 @@ DIST_MESSAGE_SHARED = {
     "timestamp": 1619225296,
     "tags": {"10": 11, "20": 22, "30": 33},
     "value": DIST_VALUES,
-    "retention_days": 30,
+    # test enforce retention days of 90
+    "retention_days": 50,
 }
 
 TEST_CASES_BUCKETS = [
@@ -117,7 +120,7 @@ TEST_CASES_BUCKETS = [
                 "tags.value": [11, 22, 33],
                 "values": [324.12, 345.23, 4564.56, 567567],
                 "materialization_version": MATERIALIZATION_VERSION,
-                "retention_days": 30,
+                "retention_days": 90,
                 "partition": 1,
                 "offset": 100,
             }
@@ -275,7 +278,7 @@ TEST_CASES_AGGREGATES = [
                         _array_literal([float(len(DIST_VALUES))]),
                     ),
                 ),
-                "retention_days": _literal(30),
+                "retention_days": _literal(90),
                 "granularity": _literal(granularity),
             }
             for granularity in MetricsAggregateProcessor.GRANULARITIES_SECONDS
@@ -408,7 +411,7 @@ TEST_CASES_POLYMORPHIC = [
                 "metric_type": "distribution",
                 "distribution_values": [324.12, 345.23, 4564.56, 567567],
                 "materialization_version": MATERIALIZATION_VERSION,
-                "retention_days": 30,
+                "retention_days": 90,
                 "partition": 1,
                 "offset": 100,
             }

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -27,7 +27,7 @@ from snuba.processor import AggregateInsertBatch, InsertBatch
 MATERIALIZATION_VERSION = 4
 
 timestamp = int(datetime.now(timezone.utc).timestamp())
-# I don't know why this is off by 7 hours
+# expects that test is run in utc local time
 expected_timestamp = datetime.fromtimestamp(timestamp)
 
 SET_MESSAGE_SHARED = {

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -28,7 +28,7 @@ MATERIALIZATION_VERSION = 4
 
 timestamp = int(datetime.now(timezone.utc).timestamp())
 # I don't know why this is off by 7 hours
-expected_timestamp = datetime.fromtimestamp(timestamp + 25200)
+expected_timestamp = datetime.fromtimestamp(timestamp)
 
 SET_MESSAGE_SHARED = {
     "org_id": 1,

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Mapping, Optional, Sequence
 from unittest.mock import patch
 
@@ -26,12 +26,16 @@ from snuba.processor import AggregateInsertBatch, InsertBatch
 
 MATERIALIZATION_VERSION = 4
 
+timestamp = int(datetime.now(timezone.utc).timestamp())
+# I don't know why this is off by 7 hours
+expected_timestamp = datetime.fromtimestamp(timestamp + 25200)
+
 SET_MESSAGE_SHARED = {
     "org_id": 1,
     "project_id": 2,
     "metric_id": 1232341,
     "type": "s",
-    "timestamp": 1619225296,
+    "timestamp": timestamp,
     "tags": {"10": 11, "20": 22, "30": 33},
     "value": [324234, 345345, 456456, 567567],
     # test enforce retention days of 30
@@ -43,7 +47,7 @@ COUNTER_MESSAGE_SHARED = {
     "project_id": 2,
     "metric_id": 1232341,
     "type": "c",
-    "timestamp": 1619225296,
+    "timestamp": timestamp,
     "tags": {"10": 11, "20": 22, "30": 33},
     "value": 123.123,
     # test enforce retention days of 30
@@ -56,7 +60,7 @@ DIST_MESSAGE_SHARED = {
     "project_id": 2,
     "metric_id": 1232341,
     "type": "d",
-    "timestamp": 1619225296,
+    "timestamp": timestamp,
     "tags": {"10": 11, "20": 22, "30": 33},
     "value": DIST_VALUES,
     # test enforce retention days of 90
@@ -71,7 +75,7 @@ TEST_CASES_BUCKETS = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
-                "timestamp": datetime(2021, 4, 24, 0, 48, 16),
+                "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
                 "set_values": [324234, 345345, 456456, 567567],
@@ -93,7 +97,7 @@ TEST_CASES_BUCKETS = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
-                "timestamp": datetime(2021, 4, 24, 0, 48, 16),
+                "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
                 "value": 123.123,
@@ -115,7 +119,7 @@ TEST_CASES_BUCKETS = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
-                "timestamp": datetime(2021, 4, 24, 0, 48, 16),
+                "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
                 "values": [324.12, 345.23, 4564.56, 567567],
@@ -168,7 +172,7 @@ def test_metrics_processor(
     )
 
 
-MOCK_TIME_BUCKET = datetime(2021, 4, 24, 0, 0, 0)
+MOCK_TIME_BUCKET = expected_timestamp
 TEST_CASES_AGGREGATES = [
     pytest.param(
         SET_MESSAGE_SHARED,
@@ -367,7 +371,7 @@ TEST_CASES_POLYMORPHIC = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
-                "timestamp": datetime(2021, 4, 24, 0, 48, 16),
+                "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
                 "metric_type": "set",
@@ -386,7 +390,7 @@ TEST_CASES_POLYMORPHIC = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
-                "timestamp": datetime(2021, 4, 24, 0, 48, 16),
+                "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
                 "metric_type": "counter",
@@ -405,7 +409,7 @@ TEST_CASES_POLYMORPHIC = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
-                "timestamp": datetime(2021, 4, 24, 0, 48, 16),
+                "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
                 "metric_type": "distribution",

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -151,3 +151,52 @@ class TestSessionProcessor:
             ],
             None,
         )
+
+    def test_retention_days(self) -> None:
+        timestamp = datetime.now(timezone.utc)
+        started = timestamp - timedelta(hours=1)
+
+        payload = {
+            "device_family": "iPhone12,3",
+            "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+            "duration": 1947.49,
+            "environment": "production",
+            "org_id": 1,
+            "os": "iOS",
+            "os_version": "13.3.1",
+            "project_id": 42,
+            "release": "sentry-test@1.0.0",
+            "retention_days": 120,
+            "seq": 42,
+            "errors": 0,
+            "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+            "started": started.timestamp(),
+            "status": "crashed",
+            "received": timestamp.timestamp(),
+        }
+
+        meta = KafkaMessageMetadata(
+            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+        )
+        assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
+            [
+                {
+                    "distinct_id": "b3ef3211-58a4-4b36-a9a1-5a55df0d9aaf",
+                    "quantity": 1,
+                    "duration": 1947490,
+                    "environment": "production",
+                    "org_id": 1,
+                    "project_id": 42,
+                    "release": "sentry-test@1.0.0",
+                    "retention_days": 90,
+                    "seq": 42,
+                    # abnormal counts as at least one error
+                    "errors": 1,
+                    "session_id": "8333339f-5675-4f89-a9a0-1c935255ab58",
+                    "started": started.replace(tzinfo=None),
+                    "status": 2,
+                    "received": timestamp.replace(tzinfo=None),
+                }
+            ],
+            None,
+        )


### PR DESCRIPTION
**context**:
Sessions and metrics don't have retention enforced anywhere in snuba and rely on the the payload of the session/metric event. This PR makes sure that sessions and metrics events have a retention of either `30` or `90` days.

**changes**
I've spilt out the override functionality of the existing `enforce_retention` that is used for events/transactions. Overriding retention days is something that can be set on a project level basis for events/transactions.

Sessions/metrics may want to have override functionality later on but currently we don't and we'd want those overrides to be independent from other datasets (events/transactions). 