### PR TITLE
chore(tiger): Log exceptions from tiger with warn level

### DIFF
--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -188,6 +188,7 @@ class BaseEventsEntity(Entity, ABC):
             },
             selector_func=v2_selector_function,
             split_rate_limiter=True,
+            ignore_secondary_exceptions=True,
             callback_func=comparison_callback,
         )
 

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -181,6 +181,7 @@ class BaseTransactionsEntity(Entity, ABC):
             },
             selector_func=v2_selector_function,
             split_rate_limiter=True,
+            ignore_secondary_exceptions=True,
             callback_func=comparison_callback,
         )
 

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -74,11 +74,13 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
         query_pipeline_builders: QueryPipelineBuilders,
         selector_func: SelectorFunc,
         split_rate_limiter: bool,
+        ignore_secondary_exceptions: bool,
         callback_func: Optional[CallbackFunc],
     ):
         self.__request = request
         self.__runner = runner
         self.__split_rate_limtier = split_rate_limiter
+        self.__ignore_secondary_exceptions = ignore_secondary_exceptions
         self.__query_pipeline_builders = query_pipeline_builders
 
         self.__selector_func = lambda query: selector_func(
@@ -130,6 +132,7 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
             },
             selector_func=self.__selector_func,
             callback_func=self.__callback_func,
+            ignore_secondary_exceptions=self.__ignore_secondary_exceptions,
         )
         assert isinstance(self.__request.query, LogicalQuery)
         return executor.execute(self.__request.query)
@@ -145,12 +148,14 @@ class PipelineDelegator(QueryPipelineBuilder[ClickhouseQueryPlan]):
         query_pipeline_builders: QueryPipelineBuilders,
         selector_func: SelectorFunc,
         split_rate_limiter: bool,
+        ignore_secondary_exceptions: bool,
         callback_func: Optional[CallbackFunc] = None,
     ) -> None:
         self.__query_pipeline_builders = query_pipeline_builders
         self.__selector_func = selector_func
         self.__callback_func = callback_func
         self.__split_rate_limiter = split_rate_limiter
+        self.__ignore_secondary_exceptions = ignore_secondary_exceptions
 
     def build_execution_pipeline(
         self, request: Request, runner: QueryRunner
@@ -161,6 +166,7 @@ class PipelineDelegator(QueryPipelineBuilder[ClickhouseQueryPlan]):
             query_pipeline_builders=self.__query_pipeline_builders,
             selector_func=self.__selector_func,
             split_rate_limiter=self.__split_rate_limiter,
+            ignore_secondary_exceptions=self.__ignore_secondary_exceptions,
             callback_func=self.__callback_func,
         )
 

--- a/snuba/utils/threaded_function_delegator.py
+++ b/snuba/utils/threaded_function_delegator.py
@@ -39,10 +39,12 @@ class ThreadedFunctionDelegator(Generic[TInput, TResult]):
         callback_func: Optional[
             Callable[[Optional[Result[TResult]], List[Result[TResult]]], None]
         ],
+        ignore_secondary_exceptions: bool = False,
     ) -> None:
         self.__callables = callables
         self.__selector_func = selector_func
         self.__callback_func = callback_func
+        self.__ignore_secondary_exceptions = ignore_secondary_exceptions
 
     def __execute_callable(self, function_id: str) -> Result[TResult]:
         start_time = time.time()
@@ -84,6 +86,9 @@ class ThreadedFunctionDelegator(Generic[TInput, TResult]):
                     if self.__callback_func is not None:
                         self.__callback_func(primary_result, other_results)
                 except Exception as error:
-                    logger.exception(error)
+                    if self.__ignore_secondary_exceptions:
+                        logger.warning(error)
+                    else:
+                        logger.exception(error)
 
             executor.submit(execute_callback)

--- a/tests/pipeline/test_pipeline_delegator.py
+++ b/tests/pipeline/test_pipeline_delegator.py
@@ -81,6 +81,7 @@ def test() -> None:
         },
         selector_func=lambda query, referrer: ("errors", ["errors_ro"]),
         split_rate_limiter=True,
+        ignore_secondary_exceptions=True,
         callback_func=mock_callback,
     )
 


### PR DESCRIPTION
In order to avoid impacting our SLO's while still trying to run the
production load we would like to change the exceptions from the tiger
cluster to warn level.