### PR TITLE
fix: Use `python3` for `.envrc` virtualenv creation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1091
 
 if [ ! -d .venv ]; then
-    python -m venv .venv
+    python3 -m venv .venv
     source .venv/bin/activate
     pip install --upgrade pip==21.1.3 wheel
     make develop


### PR DESCRIPTION
on the latest macos, `python` has been removed and is not
always a symlink to `python3`.

before this patch:

```console
$ direnv allow
direnv: loading ~/workspace/snuba/.envrc
./.envrc:5: python: command not found
./.envrc:6: .venv/bin/activate: No such file or directory
./.envrc:7: pip: command not found
pip install -e .
make: pip: No such file or directory
make: *** [install-python-dependencies] Error 1
```