### PR TITLE
feat(metrics): Add entity and storage to allow for cross-org metric counter queries

### DIFF
--- a/snuba/datasets/entities/__init__.py
+++ b/snuba/datasets/entities/__init__.py
@@ -14,6 +14,7 @@ class EntityKey(Enum):
     GROUPEDMESSAGES = "groupedmessage"
     METRICS_SETS = "metrics_sets"
     METRICS_COUNTERS = "metrics_counters"
+    ORG_METRICS_COUNTERS = "org_metrics_counters"
     METRICS_DISTRIBUTIONS = "metrics_distributions"
     OUTCOMES = "outcomes"
     OUTCOMES_RAW = "outcomes_raw"

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -31,6 +31,7 @@ def get_entity(name: EntityKey) -> Entity:
         MetricsCountersEntity,
         MetricsDistributionsEntity,
         MetricsSetsEntity,
+        OrgMetricsCountersEntity,
     )
     from snuba.datasets.entities.outcomes import OutcomesEntity
     from snuba.datasets.entities.outcomes_raw import OutcomesRawEntity
@@ -56,6 +57,7 @@ def get_entity(name: EntityKey) -> Entity:
         EntityKey.DISCOVER_EVENTS: DiscoverEventsEntity,
         EntityKey.METRICS_SETS: MetricsSetsEntity,
         EntityKey.METRICS_COUNTERS: MetricsCountersEntity,
+        EntityKey.ORG_METRICS_COUNTERS: OrgMetricsCountersEntity,
         EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
         EntityKey.PROFILES: ProfilesEntity,
         **(dev_entity_factories if settings.ENABLE_DEV_FEATURES else {}),

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -1,6 +1,6 @@
 from abc import ABC
 from dataclasses import dataclass
-from typing import Optional, Sequence, Tuple, Union
+from typing import List, Optional, Sequence, Tuple, Union
 
 from snuba.clickhouse.columns import (
     AggregateFunction,
@@ -50,6 +50,7 @@ from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import (
     EntityRequiredColumnValidator,
     GranularityValidator,
+    QueryValidator,
 )
 from snuba.request.request_settings import RequestSettings
 
@@ -91,7 +92,7 @@ class MetricsEntity(Entity, ABC):
         if writable_storage:
             storages.append(writable_storage)
 
-        validators = []
+        validators: List[QueryValidator] = []
         if not allow_cross_org:
             validators.append(EntityRequiredColumnValidator({"org_id", "project_id"}))
         validators.append(GranularityValidator(minimum=10))

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -82,7 +82,7 @@ class MetricsEntity(Entity, ABC):
         readable_storage_key: StorageKey,
         value_schema: Sequence[Column[SchemaModifiers]],
         mappers: TranslationMappers,
-        abstract_column_set: ColumnSet = None,
+        abstract_column_set: Optional[ColumnSet] = None,
         validators: Optional[Sequence[QueryValidator]] = None,
     ) -> None:
         writable_storage = (

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -177,13 +177,8 @@ class OrgMetricsCountersEntity(MetricsEntity):
             writable_storage_key=None,
             readable_storage_key=StorageKey.METRICS_COUNTERS,
             value_schema=[Column("value", AggregateFunction("sum", [Float(64)]))],
-            mappers=TranslationMappers(
-                functions=[
-                    FunctionNameMapper("sum", "sumMerge"),
-                    FunctionNameMapper("sumIf", "sumMergeIf"),
-                ],
-            ),
-            validators=[],
+            mappers=TranslationMappers(),
+            validators=[GranularityValidator(minimum=3600)],
         )
 
 

--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -17,4 +17,5 @@ class MetricsDataset(Dataset):
             get_entity(EntityKey.METRICS_COUNTERS),
             get_entity(EntityKey.METRICS_DISTRIBUTIONS),
             get_entity(EntityKey.METRICS_SETS),
+            get_entity(EntityKey.ORG_METRICS_COUNTERS),
         )

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -15,6 +15,7 @@ class StorageKey(Enum):
     GROUPEDMESSAGES = "groupedmessages"
     GROUPASSIGNEES = "groupassignees"
     METRICS_COUNTERS = "metrics_counters"
+    ORG_METRICS_COUNTERS = "org_metrics_counters"
     METRICS_DISTRIBUTIONS = "metrics_distributions"
     METRICS_SETS = "metrics_sets"
     METRICS_RAW = "metrics_raw"

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -16,6 +16,9 @@ from snuba.datasets.storages.metrics import (
     distributions_storage as metrics_distributions_storage,
 )
 from snuba.datasets.storages.metrics import (
+    org_counters_storage as metrics_org_counters_storage,
+)
+from snuba.datasets.storages.metrics import (
     polymorphic_bucket as metrics_polymorphic_storage,
 )
 from snuba.datasets.storages.metrics import sets_storage as metrics_sets_storage
@@ -83,6 +86,7 @@ DEV_NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {}
 METRICS_NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
     metrics_counters_storage.get_storage_key(): metrics_counters_storage,
     metrics_distributions_storage.get_storage_key(): metrics_distributions_storage,
+    metrics_org_counters_storage.get_storage_key(): metrics_org_counters_storage,
     metrics_sets_storage.get_storage_key(): metrics_sets_storage,
 }
 

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -144,15 +144,23 @@ counters_storage = WritableTableStorage(
 )
 
 org_counters_storage = ReadableTableStorage(
-    storage_key=StorageKey.METRICS_COUNTERS,
+    storage_key=StorageKey.ORG_METRICS_COUNTERS,
     storage_set_key=StorageSetKey.METRICS,
     schema=TableSchema(
         local_table_name="metrics_counters_v2_local",
         dist_table_name="metrics_counters_v2_dist",
         storage_set_key=StorageSetKey.METRICS,
-        columns=ColumnSet([*aggregated_columns]),
+        columns=ColumnSet(
+            [
+                Column("org_id", UInt(64)),
+                Column("project_id", UInt(64)),
+                Column("metric_id", UInt(64)),
+                Column("granularity", UInt(32)),
+                Column("timestamp", DateTime()),
+            ]
+        ),
     ),
-    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
+    query_processors=[TableRateLimit()],
 )
 
 

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -24,8 +24,8 @@ from snuba.datasets.metrics_aggregate_processor import (
     SetsAggregateProcessor,
 )
 from snuba.datasets.metrics_bucket_processor import PolymorphicMetricsProcessor
-from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
-from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema, WriteFormat
+from snuba.datasets.storage import ReadableTableStorage, WritableTableStorage
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
@@ -141,6 +141,23 @@ counters_storage = WritableTableStorage(
         dead_letter_queue_policy_closure=ignore_policy_closure,
     ),
     write_format=WriteFormat.VALUES,
+)
+
+org_counters_storage = ReadableTableStorage(
+    storage_key=StorageKey.METRICS_COUNTERS,
+    storage_set_key=StorageSetKey.METRICS,
+    schema=TableSchema(
+        local_table_name="metrics_counters_v2_local",
+        dist_table_name="metrics_counters_v2_dist",
+        storage_set_key=StorageSetKey.METRICS,
+        columns=ColumnSet(
+            [
+                *aggregated_columns,
+                Column("value", AggregateFunction("sum", [Float(64)])),
+            ]
+        ),
+    ),
+    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
 )
 
 

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -150,12 +150,7 @@ org_counters_storage = ReadableTableStorage(
         local_table_name="metrics_counters_v2_local",
         dist_table_name="metrics_counters_v2_dist",
         storage_set_key=StorageSetKey.METRICS,
-        columns=ColumnSet(
-            [
-                *aggregated_columns,
-                Column("value", AggregateFunction("sum", [Float(64)])),
-            ]
-        ),
+        columns=ColumnSet([*aggregated_columns]),
     ),
     query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
 )

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -200,6 +200,141 @@ class TestMetricsApiCounters(BaseApiTest):
         assert aggregation["total_seconds"] == 3600
 
 
+class TestOrgMetricsApiCounters(BaseApiTest):
+    @pytest.fixture
+    def test_app(self) -> Any:
+        return self.app
+
+    @pytest.fixture
+    def test_entity(self) -> Union[str, Tuple[str, str]]:
+        return "org_metrics_counters"
+
+    @pytest.fixture(autouse=True)
+    def setup_post(self, _build_snql_post_methods: Callable[[str], Any]) -> None:
+        self.post = _build_snql_post_methods
+
+    def setup_method(self, test_method: Any) -> None:
+        super().setup_method(test_method)
+
+        # values for test data
+        self.metric_id = 1001
+        self.org_projects = {101: [1, 2], 102: [3]}
+        self.seconds = 180 * 60
+
+        self.skew = timedelta(seconds=self.seconds)
+
+        self.base_time = datetime.utcnow().replace(
+            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+        )
+        self.storage = cast(
+            WritableTableStorage,
+            get_entity(EntityKey.METRICS_COUNTERS).get_writable_storage(),
+        )
+        self.generate_counters()
+
+    def teardown_method(self, test_method: Any) -> None:
+        teardown_common()
+
+    def generate_counters(self) -> None:
+        events = []
+        for n in range(self.seconds):
+            for org_id, project_ids in self.org_projects.items():
+                for project_id in project_ids:
+                    processed = (
+                        self.storage.get_table_writer()
+                        .get_stream_loader()
+                        .get_processor()
+                        .process_message(
+                            (
+                                {
+                                    "org_id": org_id,
+                                    "project_id": project_id,
+                                    "unit": "ms",
+                                    "type": METRICS_COUNTERS_TYPE,
+                                    "value": 1.0,
+                                    "tags": {},
+                                    "timestamp": self.base_time.timestamp() + n,
+                                    "metric_id": self.metric_id,
+                                    "retention_days": RETENTION_DAYS,
+                                }
+                            ),
+                            KafkaMessageMetadata(0, 0, self.base_time),
+                        )
+                    )
+                    if processed:
+                        events.append(processed)
+        write_processed_messages(self.storage, events)
+
+    def build_simple_query(
+        self,
+        metric_id: Optional[int] = None,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
+        granularity: Optional[int] = None,
+    ) -> str:
+        if not metric_id:
+            metric_id = self.metric_id
+        if not start_time:
+            start_time = (self.base_time - self.skew).isoformat()
+        if not end_time:
+            end_time = (self.base_time + self.skew).isoformat()
+        if not granularity:
+            granularity = 3600
+        query_str = f"""MATCH (org_metrics_counters)
+                    SELECT org_id, project_id BY org_id, project_id
+                    WHERE metric_id = {metric_id}
+                    AND timestamp >= toDateTime('{start_time}')
+                    AND timestamp < toDateTime('{end_time}')
+                    ORDER BY org_id ASC, project_id ASC
+                    GRANULARITY {granularity}
+                    """
+
+        return query_str
+
+    def test_retrieval_basic(self) -> None:
+        query_str = self.build_simple_query()
+        response = self.app.post(
+            SNQL_ROUTE, data=json.dumps({"query": query_str, "dataset": "metrics"})
+        )
+        data = json.loads(response.data)
+
+        assert response.status_code == 200
+        assert data["data"] == [
+            {"org_id": 101, "project_id": 1},
+            {"org_id": 101, "project_id": 2},
+            {"org_id": 102, "project_id": 3},
+        ]
+
+    def test_retrieval_counter_not_present(self) -> None:
+        ABSENT_METRIC_ID = 4096
+        query_str = self.build_simple_query(metric_id=ABSENT_METRIC_ID)
+        response = self.app.post(
+            SNQL_ROUTE, data=json.dumps({"query": query_str, "dataset": "metrics"})
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200
+        assert data["data"] == [], data
+
+    def test_retrieval_single_hour_at_hour_granularity(self) -> None:
+        query_str = self.build_simple_query(
+            start_time=timestamp_to_bucket(self.base_time, 3600).isoformat(),
+            end_time=(
+                timestamp_to_bucket(self.base_time, 3600) + timedelta(hours=1)
+            ).isoformat(),
+            granularity=3600,
+        )
+        response = self.app.post(
+            SNQL_ROUTE, data=json.dumps({"query": query_str, "dataset": "metrics"})
+        )
+        data = json.loads(response.data)
+        assert response.status_code == 200
+        assert data["data"] == [
+            {"org_id": 101, "project_id": 1},
+            {"org_id": 101, "project_id": 2},
+            {"org_id": 102, "project_id": 3},
+        ]
+
+
 class TestMetricsApiSets(BaseApiTest):
     @pytest.fixture
     def test_app(self) -> Any:


### PR DESCRIPTION
To support converting the release monitor in sentry over to metrics we want to be able to make
queries without having to specify org and project ids in the query. This pr adds in
`OrgMetricsCountersEntity` and `org_counters_storage` to allow us to do this.