### PR TITLE
Fix parse errors on tiger

### DIFF
--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -34,6 +34,7 @@ from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.slice_of_map_optimizer import SliceOfMapOptimizer
 from snuba.query.processors.table_rate_limit import TableRateLimit
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )
@@ -55,6 +56,7 @@ from snuba.utils.streams.topics import Topic
 # the new storage.
 query_processors = [
     UniqInSelectAndHavingProcessor(),
+    TupleUnaliaser(),
     PostReplacementConsistencyEnforcer(
         project_column="project_id", replacer_state_name=ReplacerState.ERRORS_V2,
     ),

--- a/snuba/datasets/storages/errors_v2_ro.py
+++ b/snuba/datasets/storages/errors_v2_ro.py
@@ -8,6 +8,9 @@ from snuba.datasets.storages.errors_common import (
     query_processors,
     query_splitters,
 )
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
+
+v2_query_processors = [*query_processors, TupleUnaliaser()]
 
 schema = TableSchema(
     columns=all_columns,
@@ -21,6 +24,6 @@ storage = ReadableTableStorage(
     storage_key=StorageKey.ERRORS_V2_RO,
     storage_set_key=StorageSetKey.ERRORS_V2_RO,
     schema=schema,
-    query_processors=query_processors,
+    query_processors=v2_query_processors,
     query_splitters=query_splitters,
 )

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -12,6 +12,7 @@ from snuba.datasets.storages.transactions_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -24,11 +25,14 @@ schema = WritableTableSchema(
     part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
+v2_query_processors = [*query_processors, TupleUnaliaser()]
+
+
 storage = WritableTableStorage(
     storage_key=StorageKey.TRANSACTIONS_V2,
     storage_set_key=StorageSetKey.TRANSACTIONS_V2,
     schema=schema,
-    query_processors=query_processors,
+    query_processors=v2_query_processors,
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),
         pre_filter=KafkaHeaderFilter("transaction_forwarder", "0"),

--- a/snuba/query/processors/tuple_unaliaser.py
+++ b/snuba/query/processors/tuple_unaliaser.py
@@ -1,0 +1,65 @@
+from dataclasses import replace
+
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.expressions import (
+    Argument,
+    Column,
+    CurriedFunctionCall,
+    Expression,
+    ExpressionVisitor,
+    FunctionCall,
+    Lambda,
+    Literal,
+    SubscriptableReference,
+)
+from snuba.request.request_settings import RequestSettings
+
+
+class _TupleUnaliasVisitor(ExpressionVisitor[Expression]):
+    def __init__(self) -> None:
+        # TODO: make level handling a context manager maybe
+        self.__level = 0
+
+    def visit_literal(self, exp: Literal) -> Expression:
+        return exp
+
+    def visit_column(self, exp: Column) -> Expression:
+        return exp
+
+    def visit_subscriptable_reference(self, exp: SubscriptableReference) -> Expression:
+        return exp
+
+    def visit_function_call(self, exp: FunctionCall) -> Expression:
+        self.__level += 1
+        transfomed_params = tuple([param.accept(self) for param in exp.parameters])
+        self.__level -= 1
+        if self.__level != 0 and exp.function_name == "tuple" and exp.alias is not None:
+            return replace(exp, alias=None, parameters=transfomed_params)
+        return replace(exp, parameters=transfomed_params)
+
+    def visit_curried_function_call(self, exp: CurriedFunctionCall) -> Expression:
+        self.__level += 1
+        transfomed_params = tuple([param.accept(self) for param in exp.parameters])
+        res = replace(
+            exp,
+            internal_function=exp.internal_function.accept(self),
+            parameters=transfomed_params,
+        )
+        self.__level -= 1
+        return res
+
+    def visit_lambda(self, exp: Lambda) -> Expression:
+        self.__level += 1
+        res = replace(exp, transformation=exp.transformation.accept(self))
+        self.__level -= 1
+        return res
+
+    def visit_argument(self, exp: Argument) -> Expression:
+        return exp
+
+
+class TupleUnaliaser(QueryProcessor):
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        visitor = _TupleUnaliasVisitor()
+        query.transform(visitor)

--- a/tests/query/processors/test_tuple_unaliaser.py
+++ b/tests/query/processors/test_tuple_unaliaser.py
@@ -2,8 +2,15 @@ from __future__ import annotations
 
 import pytest
 
+from snuba.query.dsl import identity as dsl_identity
 from snuba.query.dsl import literals_tuple, tupleElement
-from snuba.query.expressions import Expression, FunctionCall, Literal
+from snuba.query.expressions import (
+    CurriedFunctionCall,
+    Expression,
+    FunctionCall,
+    Lambda,
+    Literal,
+)
 from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.request.request_settings import HTTPRequestSettings
 from tests.query.processors.query_builders import build_query
@@ -17,27 +24,91 @@ def some_tuple(alias: str | None):
     return literals_tuple(alias, [Literal(None, "duration"), Literal(None, 300)])
 
 
-bad_alias = tupleElement(None, some_tuple(alias="doo"), Literal(None, 1))
+def identity(expression: Expression) -> Expression:
+    return dsl_identity(expression, None)
+
 
 TEST_QUERIES = [
     pytest.param(
         build_query(
             selected_columns=[
                 some_tuple(alias="foo"),
-                equals(bad_alias, Literal(None, 300)),
+                equals(
+                    tupleElement(None, some_tuple(alias="doo"), Literal(None, 1)),
+                    Literal(None, 300),
+                ),
             ]
         ),
         build_query(
             selected_columns=[
+                # top level tuple alias persists
                 some_tuple(alias="foo"),
                 equals(
+                    # alias of the tuple of internal function is removed (it is not useful)
                     tupleElement(None, some_tuple(alias=None), Literal(None, 1)),
                     Literal(None, 300),
                 ),
             ]
         ),
         id="simple happy path",
-    )
+    ),
+    pytest.param(
+        build_query(selected_columns=[Lambda(None, ("a",), some_tuple(alias="foo"))]),
+        build_query(selected_columns=[Lambda(None, ("a",), some_tuple(alias=None))]),
+        id="simple lambda",
+    ),
+    pytest.param(
+        build_query(
+            selected_columns=[
+                identity(
+                    identity(
+                        identity(
+                            equals(
+                                # alias of the tuple of internal function is removed (it is not useful)
+                                tupleElement(
+                                    None, some_tuple(alias="ayyy"), Literal(None, 1)
+                                ),
+                                Literal(None, 300),
+                            )
+                        )
+                    )
+                )
+            ]
+        ),
+        build_query(
+            selected_columns=[
+                identity(
+                    identity(
+                        identity(
+                            equals(
+                                # alias of the tuple of internal function is removed (it is not useful)
+                                tupleElement(
+                                    None, some_tuple(alias=None), Literal(None, 1)
+                                ),
+                                Literal(None, 300),
+                            )
+                        )
+                    )
+                )
+            ]
+        ),
+        id="Highly nested",
+    ),
+    pytest.param(
+        build_query(
+            selected_columns=[
+                CurriedFunctionCall(
+                    None, some_tuple(alias="foo"), (Literal(None, "4"),)
+                )
+            ]
+        ),
+        build_query(
+            selected_columns=[
+                CurriedFunctionCall(None, some_tuple(alias=None), (Literal(None, "4"),))
+            ]
+        ),
+        id="curried function",
+    ),
 ]
 
 
@@ -46,4 +117,3 @@ def test_tuple_unaliaser(input_query, expected_query):
     settings = HTTPRequestSettings()
     TupleUnaliaser().process_query(input_query, settings)
     assert input_query == expected_query
-    assert repr(input_query) == repr(expected_query)

--- a/tests/query/processors/test_tuple_unaliaser.py
+++ b/tests/query/processors/test_tuple_unaliaser.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from snuba.query.dsl import literals_tuple, tupleElement
+from snuba.query.expressions import Expression, FunctionCall, Literal
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
+from snuba.request.request_settings import HTTPRequestSettings
+from tests.query.processors.query_builders import build_query
+
+
+def equals(op1: Expression, op2: Expression, alias: str | None = None) -> FunctionCall:
+    return FunctionCall(alias, "eq", tuple([op1, op2]))
+
+
+def some_tuple(alias: str | None):
+    return literals_tuple(alias, [Literal(None, "duration"), Literal(None, 300)])
+
+
+bad_alias = tupleElement(None, some_tuple(alias="doo"), Literal(None, 1))
+
+TEST_QUERIES = [
+    pytest.param(
+        build_query(
+            selected_columns=[
+                some_tuple(alias="foo"),
+                equals(bad_alias, Literal(None, 300)),
+            ]
+        ),
+        build_query(
+            selected_columns=[
+                some_tuple(alias="foo"),
+                equals(
+                    tupleElement(None, some_tuple(alias=None), Literal(None, 1)),
+                    Literal(None, 300),
+                ),
+            ]
+        ),
+        id="simple happy path",
+    )
+]
+
+
+@pytest.mark.parametrize("input_query,expected_query", TEST_QUERIES)
+def test_tuple_unaliaser(input_query, expected_query):
+    settings = HTTPRequestSettings()
+    TupleUnaliaser().process_query(input_query, settings)
+    assert input_query == expected_query
+    assert repr(input_query) == repr(expected_query)


### PR DESCRIPTION
### Context
Due to a backwards incomaptibility issue in clickhouse from 20.8 -> 21.8, aliased tuples within functions sometimes cause parsing errors in certain conditions. Issue: https://github.com/ClickHouse/ClickHouse/issues/35625


Introduce a query processor removes the aliases of`tuple` function calls whenever they are nested within other expressions. This change depends on alias expansion earlier in the pipeline working. I verified to see that it does in fact work as expected and the test coverage is adequate, but there is some risk being taken on here

### Notes:

This will likely not solve all the issues related to queries on tiger but I would like to roll this out to see if this fixes the majority of them. I think it should. Here are queries that I tried on a local 21.8 distributed clickhouse to reproduce the issue. Table name does not matter.


Query | Fails? | Comments
-- | -- | --
SELECT equals(tupleElement(tuple('a', 10) AS x, 1), 'a') FROM all_hits_2 LIMIT 1 | ✅ | Nikhar’s original
SELECT equals(tupleElement(tuple('a', 10), 1), 'a') FROM all_hits_2 LIMIT 1 | ❌ | No aliasing of the tuple
SELECT equals(tuple('a', 10) AS x, tuple('a', 1) AS y) FROM all_hits_2 LIMIT 1 | ❌ | tuple aliased inside the equals function but not within tupleElement
SELECT untuple(tuple(tupleElement(tuple('a', 10, 1) AS xyz, 1), 'poo') AS y) AS x FROM all_hits_2 LIMIT 1 | ❌ | aliasing the tuple element inside the tupleElement function seems to be fine as well. Maybe it’s just equals?
SELECT equals(tuple(tupleElement(tuple('a', 10, 1) AS xyz, 1), 'poo'), tuple('a', 'b')) AS x FROM all_hits_2 LIMIT 1 | ✅ | equals is probably the culprit
SELECT equals(tuple(tupleElement(tuple('a', 10, 1), 1), 'poo') AS xyz, tuple('a', 'b')) AS x FROM all_hits_2 LIMIT 1 | ❌ | aliasing the tuple outside of tupleElement within equals works

I was not able to get a full end to end test from snql -> bad clickhouse sql. It was taking me way too long and I ended up in the guts of the query pipeline again. A a pragmatic tradeoff, I would like to deploy this processor and see how it behaves in production

### Rollout
This QueryProcessor can be turned on/off in the runtime config

To turn on:
`SET tuple_unaliaser_rollout 1.0`

To turn on for ten percent of queries:
`SET tuple_unaliaser_rollout 0.1`


To turn off:
`SET tuple_unaliaser_rollout 0`
or
`DELETE tuple_unaliaser_rollout`





