### PR TITLE
fix: Fix tagging of executor metrics

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -88,8 +88,6 @@ def subscriptions_executor(
     The subscription's executor consumes scheduled subscriptions from the scheduled
     subscription topic for that entity, executes the queries on ClickHouse and publishes
     results on the results topic.
-
-    It currently only supports executing subscriptions on a single dataset/entity.
     """
     setup_logging(log_level)
     setup_sentry()
@@ -97,7 +95,7 @@ def subscriptions_executor(
     metrics = MetricsWrapper(
         environment.metrics,
         "subscriptions.executor",
-        tags={"entity": ",".join(entity_names)},
+        tags={"dataset": dataset_name},
     )
 
     configure_metrics(StreamMetricsAdapter(metrics))


### PR DESCRIPTION
The comma in the entity list does not seem to be properly handled in
Datadog, just tag the dataset instead.




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
