### PR TITLE
feat: Upgrade black and click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 atomicwrites==1.1.5
 attrs==18.1.0
 blinker==1.4
-black==19.10b0
+black==22.3.0
 certifi==2018.4.16
 chardet==3.0.4
-click==7.1.2
+click==8.0.4
 clickhouse-driver==0.2.2
 colorama==0.3.9
 confluent-kafka==1.7.0

--- a/snuba/cli/config.py
+++ b/snuba/cli/config.py
@@ -33,7 +33,7 @@ def config() -> None:
 
 
 @config.command("get-all")
-@click.option("--format", type=click.Choice(FORMATS.keys()), default="human")
+@click.option("--format", type=click.Choice([*FORMATS.keys()]), default="human")
 def get_all(*, format: str) -> None:
     "Dump all runtime configuration."
 
@@ -42,7 +42,7 @@ def get_all(*, format: str) -> None:
 
 
 @config.command()
-@click.option("--format", type=click.Choice(FORMATS.keys()), default="human")
+@click.option("--format", type=click.Choice([*FORMATS.keys()]), default="human")
 @click.argument("key")
 def get(*, key: str, format: str) -> None:
     "Get a single key."

--- a/snuba/cli/subscriptions.py
+++ b/snuba/cli/subscriptions.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
     "--dataset",
     "dataset_name",
     default="events",
-    type=click.Choice(DATASET_NAMES),
+    type=click.Choice([*DATASET_NAMES]),
     help="The dataset to target",
 )
 @click.option(


### PR DESCRIPTION
The main motivation for this upgrade is to match the black version to the
one used in pre-commit. Previously they were different causing editor autoformatting
(e.g. the formatting applied on save in VSCode) to be different to autoformatting
applied in pre-commit.




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
