### PR TITLE
fix(subscriptions): Properly close producer

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -1,8 +1,8 @@
 import logging
 import signal
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import closing
-from typing import Any, Optional, Sequence
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional, Sequence
 
 import click
 from arroyo import configure_metrics
@@ -143,3 +143,11 @@ def subscriptions_executor(
 
     with closing(producer), executor:
         processor.run()
+
+
+@contextmanager
+def closing(producer: KafkaProducer) -> Iterator[Optional[KafkaProducer]]:
+    try:
+        yield producer
+    finally:
+        producer.close().result()

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -9,7 +9,7 @@ from typing import Callable, Deque, Mapping, MutableMapping, Optional, Sequence,
 import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
@@ -438,11 +438,3 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             self.__commit(
                 {message.partition: Position(message.offset, message.timestamp)}
             )
-
-        # Flush producer
-        if isinstance(self.__producer, KafkaProducer):
-            remaining = timeout - (time.time() - start) if timeout is not None else None
-            # TODO: This is just for testing. If it works expose a flush method on KafkaProducer
-            producer = self.__producer._KafkaProducer__producer  # type: ignore
-            messages = producer.flush(*[remaining] if remaining is not None else [])
-            logger.debug(f"{messages} executor messages pending delivery")

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -9,7 +9,7 @@ from typing import Callable, Deque, Mapping, MutableMapping, Optional, Sequence,
 import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
@@ -438,3 +438,11 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             self.__commit(
                 {message.partition: Position(message.offset, message.timestamp)}
             )
+
+        # Flush producer
+        if isinstance(self.__producer, KafkaProducer):
+            remaining = timeout - (time.time() - start) if timeout is not None else None
+            # TODO: This is just for testing. If it works expose a flush method on KafkaProducer
+            producer = self.__producer._KafkaProducer__producer  # type: ignore
+            messages = producer.flush(*[remaining] if remaining is not None else [])
+            logger.debug(f"{messages} executor messages pending delivery")


### PR DESCRIPTION
This is an attempt to fix an error we are seeing in the executor logs
about the producer terminating with unflushed messages still in queue.

Now we wait for the producer.close() future to finish when closing the producer.