### PR TITLE
fix(subscriptions): Close producer before executor

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -141,7 +141,7 @@ def subscriptions_executor(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with closing(producer), executor:
+    with executor, closing(producer):
         processor.run()
 
 


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/2644 did not really work. The producer
is still not being closed properly. Try closing it first before the executor.