### PR TITLE
fix(tests): Flakey DLQ policy test

### DIFF
--- a/tests/state/test_stateful_count_policy.py
+++ b/tests/state/test_stateful_count_policy.py
@@ -115,11 +115,10 @@ def test_count_short(
     processing_step: FakeProcessingStep,
 ) -> None:
     dlq_count_short: DeadLetterQueue[KafkaPayload] = DeadLetterQueue(
-        processing_step, StatefulCountInvalidMessagePolicy(CONSUMER_GROUP_NAME, 5, 1)
+        processing_step, StatefulCountInvalidMessagePolicy(CONSUMER_GROUP_NAME, 1, 1)
     )
     dlq_count_short.submit(valid_message)
-    for _ in range(5):
-        dlq_count_short.submit(invalid_message)
+    dlq_count_short.submit(invalid_message)
     with pytest.raises(InvalidMessages):
         dlq_count_short.submit(invalid_message)
     time.sleep(1)


### PR DESCRIPTION
### Overview
- Lyn encountered a `DID NOT RAISE` failure on a DLQ policy test
- This test ensures the policy ignores up to `n` invalid messages per second before raising an exception on the `n+1`st invalid message
- The flakeyness could be from the time bucket changing to the next second while the original `n` messages are being submitted, making the expected exception not raise since it's still under the limit
- Reduced `n` from 5 to 1 to reduce the window of possible time bucket change