### PR TITLE
fix(subscriptions): Flush producer on rebalance

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -9,7 +9,7 @@ from typing import Callable, Deque, Mapping, MutableMapping, Optional, Sequence,
 import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
@@ -438,3 +438,11 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             self.__commit(
                 {message.partition: Position(message.offset, message.timestamp)}
             )
+
+        # Flush producer
+        if isinstance(self.__producer, KafkaProducer):
+            remaining = timeout - (time.time() - start) if timeout is not None else None
+            # TODO: This is just for testing. If it works expose a flush method on KafkaProducer
+            producer = self.__producer._KafkaProducer__producer  # type: ignore
+            messages = producer.flush(*[remaining] if remaining is not None else [])
+            logger.debug(f"{messages} executor messages pending delivery")


### PR DESCRIPTION
Bringing this experiment back since https://github.com/getsentry/snuba/pull/2644
didn't work.

This is an attempt to fix an error we are seeing in the executor logs
about the producer terminating with unflushed messages still in queue.

Now we manually call flush() when the strategy is closed. For now this
is just a test - if it actually works, then we will update Arroyo to properly
expose the flush() method instead of relying on this hack.