### PR TITLE
fix: Separate testing metrics backend into a different class

### DIFF
--- a/snuba/util.py
+++ b/snuba/util.py
@@ -228,7 +228,11 @@ def create_metrics(
     host: Optional[str] = settings.DOGSTATSD_HOST
     port: Optional[int] = settings.DOGSTATSD_PORT
 
-    if host is None and port is None:
+    if settings.TESTING:
+        from snuba.utils.metrics.backends.testing import TestingMetricsBackend
+
+        return TestingMetricsBackend()
+    elif host is None and port is None:
         from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 
         return DummyMetricsBackend()

--- a/snuba/utils/metrics/backends/testing.py
+++ b/snuba/utils/metrics/backends/testing.py
@@ -1,16 +1,55 @@
 from __future__ import annotations
 
-from typing import Mapping, Optional, Union
+from dataclasses import dataclass
+from typing import List, Mapping, MutableMapping, Optional, Union
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.types import Tags
 
 
-class DummyMetricsBackend(MetricsBackend):
+@dataclass(frozen=True)
+class RecordedMetricCall:
+    value: int | float
+    tags: Tags
+
+
+RecordedMetricCalls = List[RecordedMetricCall]
+
+
+RECORDED_METRIC_CALLS: MutableMapping[
+    str, MutableMapping[str, List[RecordedMetricCall]]
+] = {}
+
+
+def record_metric_call(
+    mtype: str, name: str, value: int | float, tags: Optional[Tags]
+) -> None:
+    if mtype not in RECORDED_METRIC_CALLS:
+        RECORDED_METRIC_CALLS[mtype] = {}
+
+    if name not in RECORDED_METRIC_CALLS[mtype]:
+        RECORDED_METRIC_CALLS[mtype][name] = []
+
+    if tags is None:
+        tags = {}
+    RECORDED_METRIC_CALLS[mtype][name].append(RecordedMetricCall(value, tags))
+
+
+def clear_recorded_metric_calls() -> None:
+    global RECORDED_METRIC_CALLS
+    RECORDED_METRIC_CALLS = {}
+
+
+def get_recorded_metric_calls(mtype: str, name: str) -> RecordedMetricCalls | None:
     """
-    A metrics backend that does not record metrics. Intended for use during
-    development, or other environments where metrics support may not be
-    required.
+    Used in tests to determine if the metrics were called with the correct values
+    """
+    return RECORDED_METRIC_CALLS.get(mtype, dict()).get(name)
+
+
+class TestingMetricsBackend(MetricsBackend):
+    """
+    A metrics backend that records metrics locally, to be verified in tests.
     """
 
     def __init__(self, strict: bool = False):
@@ -28,6 +67,7 @@ class DummyMetricsBackend(MetricsBackend):
     def increment(
         self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
     ) -> None:
+        record_metric_call("increment", name, value, tags)
         if self.__strict:
             assert isinstance(name, str)
             assert isinstance(value, (int, float))
@@ -37,6 +77,7 @@ class DummyMetricsBackend(MetricsBackend):
     def gauge(
         self, name: str, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
+        record_metric_call("gauge", name, value, tags)
         if self.__strict:
             assert isinstance(name, str)
             assert isinstance(value, (int, float))
@@ -46,6 +87,7 @@ class DummyMetricsBackend(MetricsBackend):
     def timing(
         self, name: str, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
+        record_metric_call("timing", name, value, tags)
         if self.__strict:
             assert isinstance(name, str)
             assert isinstance(value, (int, float))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ def run_migrations() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def clear_recorded_metrics() -> Iterator[None]:
-    from snuba.utils.metrics.backends.dummy import clear_recorded_metric_calls
+    from snuba.utils.metrics.backends.testing import clear_recorded_metric_calls
 
     yield
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -11,7 +11,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.utils.metrics.backends.dummy import get_recorded_metric_calls
+from snuba.utils.metrics.backends.testing import get_recorded_metric_calls
 from tests.base import BaseApiTest
 from tests.fixtures import get_raw_event, get_raw_transaction
 from tests.helpers import write_unprocessed_events

--- a/tests/test_snql_sdk_api.py
+++ b/tests/test_snql_sdk_api.py
@@ -22,7 +22,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.utils.metrics.backends.dummy import get_recorded_metric_calls
+from snuba.utils.metrics.backends.testing import get_recorded_metric_calls
 from tests.base import BaseApiTest
 from tests.fixtures import get_raw_event, get_raw_transaction
 from tests.helpers import write_unprocessed_events


### PR DESCRIPTION
There are potentially users who don't want to set up Datadog for Snuba, who will
then be hit by a memory leak since the Dummy backend will record all metrics.

Create a separate Testing backend that is used specifically for tests, and
revert the Dummy backend to stop storing anything.
