### PR TITLE
ref(tiger): Allow increasing cache wait time for tiger

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -467,17 +467,6 @@ def execute_query_with_readthrough_caching(
         tags={"partition_id": reader.cache_partition_id or "default"},
     )
 
-    cache_wait_timeout: int = int(query_settings.get("max_execution_time", 30))
-    # Increase the cache wait timeout for tiger clusters to debug
-    # ExecutionTimeoutErrors
-    if reader.cache_partition_id and reader.cache_partition_id in {
-        "tiger_errors",
-        "tiger_transactions",
-    }:
-        tiger_wait_timeout_config = state.get_config("tiger-cache-wait-time")
-        if tiger_wait_timeout_config:
-            cache_wait_timeout = tiger_wait_timeout_config
-
     return cache_partition.get_readthrough(
         query_id,
         partial(
@@ -492,9 +481,29 @@ def execute_query_with_readthrough_caching(
             robust,
         ),
         record_cache_hit_type=record_cache_hit_type,
-        timeout=cache_wait_timeout,
+        timeout=_get_cache_wait_timeout(query_settings, reader),
         timer=timer,
     )
+
+
+def _get_cache_wait_timeout(query_settings: MutableMapping[str, Any], reader: Reader):
+    """
+    Helper function to determine how long a query should wait when doing
+    a readthrough caching.
+
+    The overrides are primarily used for debugging the ExecutionTimeoutError
+    raised by the readthrough caching system on the tigers cluster. When we
+    have root caused the problem we can remove the overrides.
+    """
+    cache_wait_timeout: int = int(query_settings.get("max_execution_time", 30))
+    if reader.cache_partition_id and reader.cache_partition_id in {
+        "tiger_errors",
+        "tiger_transactions",
+    }:
+        tiger_wait_timeout_config = state.get_config("tiger-cache-wait-time")
+        if tiger_wait_timeout_config:
+            cache_wait_timeout = tiger_wait_timeout_config
+    return cache_wait_timeout
 
 
 def raw_query(

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -486,7 +486,9 @@ def execute_query_with_readthrough_caching(
     )
 
 
-def _get_cache_wait_timeout(query_settings: MutableMapping[str, Any], reader: Reader):
+def _get_cache_wait_timeout(
+    query_settings: MutableMapping[str, Any], reader: Reader
+) -> int:
     """
     Helper function to determine how long a query should wait when doing
     a readthrough caching.

--- a/tests/web/test_cache_partitions.py
+++ b/tests/web/test_cache_partitions.py
@@ -1,5 +1,6 @@
+from snuba import state
 from snuba.clickhouse.native import ClickhousePool, NativeDriverReader
-from snuba.web.db_query import _get_cache_partition
+from snuba.web.db_query import _get_cache_partition, _get_cache_wait_timeout
 
 
 def test_cache_partition() -> None:
@@ -19,3 +20,22 @@ def test_cache_partition() -> None:
 
     assert id(nondefault_cache) == id(another_nondefault_cache)
     assert id(default_cache) != id(nondefault_cache)
+
+
+def test_cache_wait_timeout() -> None:
+    pool = ClickhousePool("localhost", 9000, "", "", "")
+    default_reader = NativeDriverReader(None, pool)
+    tiger_errors_reader = NativeDriverReader("tiger_errors", pool)
+    tiger_transactions_reader = NativeDriverReader("tiger_transactions", pool)
+
+    query_settings = {"max_execution_time": 30}
+    assert _get_cache_wait_timeout(query_settings, default_reader) == 30
+    assert _get_cache_wait_timeout(query_settings, tiger_errors_reader) == 30
+    assert _get_cache_wait_timeout(query_settings, tiger_transactions_reader) == 30
+
+    state.set_config("tiger-cache-wait-time", 60)
+    assert _get_cache_wait_timeout(query_settings, default_reader) == 30
+    assert _get_cache_wait_timeout(query_settings, tiger_errors_reader) == 60
+    assert _get_cache_wait_timeout(query_settings, tiger_transactions_reader) == 60
+
+    state.delete_config("tiger-cache-wait-time")


### PR DESCRIPTION
We are noticing an increase in ExecutionTimeoutError on the tiger
cluster. In order to debug what's happening, I would like the ability
to increase the cache wait timeout period for tiger clusters. The max
query execution time for a clickhouse query would be still 30 seconds.
But I would increase the wait timeout to see if the result gets
populated with some additional wait time.




<!-- Describe your PR here. -->

<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
