### PR TITLE
fix(tracing): don't set the readonly mode on the client side

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -45,7 +45,7 @@ class ClickhouseClientSettings(Enum):
     )
     OPTIMIZE = ClickhouseClientSettingsType({}, 10000)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
-    TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
+    TRACING = ClickhouseClientSettingsType({}, None)
     REPLACE = ClickhouseClientSettingsType(
         {
             # Replacing existing rows requires reconstructing the entire tuple for each


### PR DESCRIPTION
Currently the snuba-admin tool is broken for new hosts with the following error:

`An error occurred: DB::Exception: Cannot modify 'readonly' setting in readonly mode.`

From clickhouse:

```
SELECT *
FROM system.settings
WHERE name = 'readonly'
FORMAT Vertical

Query id: 4751d842-e00a-402c-9439-214afd1610d6

Row 1:
──────
name:        readonly
value:       2
changed:     1
IMPORTANT ------> description: 0 - everything is allowed. 1 - only read requests. 2 - only read requests, as well as changing settings, except for the 'readonly' setting.
min:         ᴺᵁᴸᴸ
max:         ᴺᵁᴸᴸ
readonly:    1
type:        UInt64
```
> 2 - only read requests, as well as changing settings, except for the 'readonly' setting.

Putting this setting into the client settings makes clickhouse interpret the query as changing the readonly setting (despite the fact that nothing is being changed. There is actually no need for us to pass this in the connection as the read only user can only issue read only queries