### PR TITLE
feat: Use Request from Snuba SDK

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,1 @@
-snuba-sdk==0.1.5
+snuba-sdk==1.0.0

--- a/tests/clickhouse/query_dsl/test_project_id.py
+++ b/tests/clickhouse/query_dsl/test_project_id.py
@@ -177,12 +177,12 @@ def test_find_projects(
     events = get_dataset("events")
     if expected_projects is None:
         with pytest.raises(ParsingException):
-            snql_query = json_to_snql(query_body, "events")
-            query, _ = parse_snql_query(str(snql_query), events)
+            snql_request = json_to_snql(query_body, "events")
+            query, _ = parse_snql_query(str(snql_request.query), events)
             identity_translate(query)
     else:
-        snql_query = json_to_snql(query_body, "events")
-        query, _ = parse_snql_query(str(snql_query), events)
+        snql_request = json_to_snql(query_body, "events")
+        query, _ = parse_snql_query(str(snql_request.query), events)
         query = identity_translate(query)
         project_ids_ast = get_object_ids_in_query_ast(query, "project_id")
         assert project_ids_ast == expected_projects

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def convert_legacy_to_snql() -> Callable[[str, str], str]:
     def convert(data: str, entity: str) -> str:
         legacy = json.loads(data)
         sdk_output = json_to_snql(legacy, entity)
-        return sdk_output.snuba()
+        return sdk_output.serialize()
 
     return convert
 

--- a/tests/datasets/test_discover.py
+++ b/tests/datasets/test_discover.py
@@ -167,7 +167,7 @@ def test_data_source(
     if not query_body.get("selected_columns"):
         query_body["selected_columns"] = ["project_id"]
 
-    snql_query = json_to_snql(query_body, "discover")
-    query, _ = parse_snql_query(str(snql_query), dataset)
+    snql_request = json_to_snql(query_body, "discover")
+    query, _ = parse_snql_query(str(snql_request.query), dataset)
 
     assert query.get_from_clause().key == expected_entity

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -195,9 +195,9 @@ def test_select_storage(
     query_body: MutableMapping[str, Any], is_subscription: bool, expected_table: str
 ) -> None:
     sessions = get_dataset("sessions")
-    snql_query = json_to_snql(query_body, "sessions")
-    query, snql_anonymized = parse_snql_query(str(snql_query), sessions)
-    query_body = json.loads(snql_query.snuba())
+    snql_request = json_to_snql(query_body, "sessions")
+    query, snql_anonymized = parse_snql_query(str(snql_request.query), sessions)
+    query_body = json.loads(snql_request.serialize())
     subscription_settings = (
         SubscriptionRequestSettings if is_subscription else HTTPRequestSettings
     )

--- a/tests/query/parser/test_invalid_queries.py
+++ b/tests/query/parser/test_invalid_queries.py
@@ -45,5 +45,5 @@ def test_failures(
 ) -> None:
     with pytest.raises(expected_exception):
         events = get_dataset("events")
-        snql_query = json_to_snql(query_body, "events")
-        parse_snql_query(str(snql_query), events)
+        snql_request = json_to_snql(query_body, "events")
+        parse_snql_query(str(snql_request.query), events)

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -408,9 +408,9 @@ test_data = [
 
 def parse_and_process(query_body: MutableMapping[str, Any]) -> ClickhouseQuery:
     dataset = get_dataset("transactions")
-    snql_query = json_to_snql(query_body, "transactions")
-    body = json.loads(snql_query.snuba())
-    query, snql_anonymized = parse_snql_query(str(snql_query), dataset)
+    snql_request = json_to_snql(query_body, "transactions")
+    body = json.loads(snql_request.serialize())
+    query, snql_anonymized = parse_snql_query(str(snql_request.query), dataset)
     request = Request(
         id="a",
         body=body,

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -282,8 +282,8 @@ def test_prewhere(
         ["timestamp", "<", "2021-01-02T00:00:00"],
         ["project_id", "=", 1],
     ]
-    snql_query = json_to_snql(query_body, "events")
-    query, _ = parse_snql_query(str(snql_query), events)
+    snql_request = json_to_snql(query_body, "events")
+    query, _ = parse_snql_query(str(snql_request.query), events)
     query = identity_translate(query)
     query.set_from_clause(Table("my_table", all_columns, final=final))
 

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -162,8 +162,8 @@ def test_get_all_columns_legacy() -> None:
         "groupby": [["format_eventid", ["event_id"]]],
     }
     events = get_dataset("events")
-    snql_query = json_to_snql(query_body, "events")
-    query, _ = parse_snql_query(str(snql_query), events)
+    snql_request = json_to_snql(query_body, "events")
+    query, _ = parse_snql_query(str(snql_request.query), events)
 
     assert query.get_all_ast_referenced_columns() == {
         Column("_snuba_column1", None, "column1"),
@@ -328,8 +328,8 @@ def test_alias_validation(
     query_body: MutableMapping[str, Any], expected_result: bool
 ) -> None:
     events = get_dataset("events")
-    snql_query = json_to_snql(query_body, "events")
-    query, _ = parse_snql_query(str(snql_query), events)
+    snql_request = json_to_snql(query_body, "events")
+    query, _ = parse_snql_query(str(snql_request.query), events)
     settings = HTTPRequestSettings()
     query_plan = (
         events.get_default_entity()

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -325,8 +325,8 @@ def test_col_split_conditions(
     id_column: str, project_column: str, timestamp_column: str, query, expected_result
 ) -> None:
     dataset = get_dataset("events")
-    snql_query = json_to_snql(query, "events")
-    query, _ = parse_snql_query(str(snql_query), dataset)
+    snql_request = json_to_snql(query, "events")
+    query, _ = parse_snql_query(str(snql_request.query), dataset)
     splitter = ColumnSplitQueryStrategy(id_column, project_column, timestamp_column)
 
     def do_query(


### PR DESCRIPTION
Use the Request object when building queries with the SDK.

Leaving this in a draft until the new version is released.