### PR TITLE
ref(freight): Remove metrics subscriptions executor from freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -47,8 +47,6 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: metrics-sets-subscriptions-scheduler
   - image: us.gcr.io/sentryio/snuba:{sha}
-    name: metrics-subscriptions-executor
-  - image: us.gcr.io/sentryio/snuba:{sha}
     name: cdc-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: cdc-groupassignee-consumer


### PR DESCRIPTION
We are seeing an `OffsetOutOfRange` error crashing the metrics subscription executor so removing it from freight for now so that it doesn't block other snuba deployments
