### PR TITLE
fix: Retry simultaneous query errors for non-robust queries

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -245,13 +245,16 @@ class ClickhousePool(object):
                         if attempts_remaining <= 0:
                             raise ClickhouseError(e.message, code=e.code) from e
 
+                        sleep_interval_seconds = state.get_config(
+                            "simultaneous_queries_sleep_seconds", None
+                        )
+                        if not sleep_interval_seconds:
+                            raise ClickhouseError(e.message, code=e.code) from e
+
                         attempts_remaining = min(
                             attempts_remaining, 1
                         )  # only retry once
 
-                        sleep_interval_seconds = state.get_config(
-                            "simultaneous_queries_sleep_seconds", 1
-                        )
                         assert sleep_interval_seconds is not None
                         # Linear backoff. Adds one second at each iteration.
                         time.sleep(sleep_interval_seconds)

--- a/tests/clickhouse/test_native.py
+++ b/tests/clickhouse/test_native.py
@@ -25,7 +25,7 @@ def test_transform_datetime() -> None:
     )
 
 
-def test_concurrency_limit() -> None:
+def test_robust_concurrency_limit() -> None:
     connection = mock.Mock()
     connection.execute.side_effect = ClickhouseError(
         "some error", extra_data={"code": 1}
@@ -48,6 +48,34 @@ def test_concurrency_limit() -> None:
     with pytest.raises(ClickhouseError):
         pool.execute_robust("SELECT something")
     assert connection.execute.call_count == 3, "Expected three attempts"
+
+
+class TestError(errors.Error):  # type: ignore
+    code = 1
+
+
+class TestConcurrentError(errors.Error):  # type: ignore
+    code = errors.ErrorCodes.TOO_MANY_SIMULTANEOUS_QUERIES
+
+
+def test_concurrency_limit() -> None:
+    connection = mock.Mock()
+    connection.execute.side_effect = TestError("some error")
+
+    pool = ClickhousePool("host", 100, "test", "test", "test")
+    pool.pool = queue.LifoQueue(1)
+    pool.pool.put(connection, block=False)
+
+    with pytest.raises(ClickhouseError):
+        pool.execute("SELECT something")
+    connection.execute.assert_called_once()
+
+    connection.reset_mock(side_effect=True)
+    connection.execute.side_effect = TestConcurrentError("some error")
+
+    with pytest.raises(ClickhouseError):
+        pool.execute("SELECT something")
+    assert connection.execute.call_count == 2, "Expected two attempts"
 
 
 TEST_DB_NAME = "test"

--- a/tests/clickhouse/test_native.py
+++ b/tests/clickhouse/test_native.py
@@ -62,6 +62,8 @@ def test_concurrency_limit() -> None:
     connection = mock.Mock()
     connection.execute.side_effect = TestError("some error")
 
+    state.set_config("simultaneous_queries_sleep_seconds", 0.5)
+
     pool = ClickhousePool("host", 100, "test", "test", "test")
     pool.pool = queue.LifoQueue(1)
     pool.pool.put(connection, block=False)


### PR DESCRIPTION
Retry simultaneous query errors for non-robust queries. This logic is very
similar to what happens with robust queries, but the errors will only be retried
once.

Context:
We sometimes see issues where a single storage node gets imbalanced incorrectly and receives a lot more traffic than it should. The reason for the imbalance is unclear, but we can retry those queries so they get run on a different node.