### PR TITLE
fix(docs): Update and clarify dev setup

### DIFF
--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -5,12 +5,18 @@ Snuba development environment
 This section explains how to run snuba from source and set up a development
 environment.
 
-In order to set up Clickhouse and Redis, please refer to :doc:`/getstarted`.
+In order to set up Clickhouse, Redis, and Kafka, please refer to :doc:`/getstarted`.
 
 Prerequisites
 -------------
 `pyenv <https://github.com/pyenv/pyenv#installation>`_ must be installed on your system.
 It is also assumed that you have completed the steps to set up the `sentry dev environment <https://develop.sentry.dev/environment/>`_.
+
+If you are using Homebrew and a M1 Mac, ensure the development packages you've installed with Homebrew are available
+by setting these environment variables::
+
+    export CPATH=/opt/homebrew/include
+    export LIBRARY_PATH=/opt/homebrew/lib
 
 Install / Run
 -------------

--- a/docs/source/getstarted.rst
+++ b/docs/source/getstarted.rst
@@ -13,8 +13,14 @@ Snuba assumes:
 1. A Clickhouse server endpoint at ``CLICKHOUSE_HOST`` (default ``localhost``).
 2. A redis instance running at ``REDIS_HOST`` (default ``localhost``). On port
    `6379`
+3. A Kafka cluster running at ``localhost`` on port `9092`.
 
-A quick way to get these services running is to set up sentry, then use::
+A quick way to get these services running is to set up sentry, and add the following line
+in ``~/.sentry/sentry.conf.py``::
+
+    SENTRY_EVENTSTREAM = "sentry.eventstream.kafka.KafkaEventStream"
+
+And then use::
 
     sentry devservices up --exclude=snuba
 


### PR DESCRIPTION
Fix two issues I got stuck on while setting up my environment:
* `make develop` failed because clang couldn't find libraries installed
with Homebrew.
* `make test` failed because Kafka wasn't running but the instructions
didn't describe how to run it.