### PR TITLE
Revert "ref(freight): Remove metrics subscriptions executor from freight"

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -47,6 +47,8 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: metrics-sets-subscriptions-scheduler
   - image: us.gcr.io/sentryio/snuba:{sha}
+    name: metrics-subscriptions-executor
+  - image: us.gcr.io/sentryio/snuba:{sha}
     name: cdc-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: cdc-groupassignee-consumer


### PR DESCRIPTION
Reverts getsentry/snuba#2662

Offsets were reset to latest in [OPS-1703](https://getsentry.atlassian.net/browse/OPS-1703).