### PR TITLE
fix(snql): Return 400 error code on queries with type errors

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -427,6 +427,16 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
         assert False, "unexpected fallthrough"
 
 
+# These codes are from:
+# https://github.com/ClickHouse/ClickHouse/blob/1c0b731ea6b86ce3bf7f88bd3ec27df7b218454d/src/Common/ErrorCodes.cpp
+ILLEGAL_TYPE_OF_ARGUMENT = 43
+TYPE_MISMATCH = 53
+CLICKHOUSE_TYPING_ERROR_CODES = {
+    ILLEGAL_TYPE_OF_ARGUMENT,
+    TYPE_MISMATCH,
+}
+
+
 @with_span()
 def dataset_query(
     dataset: Dataset, body: MutableMapping[str, Any], timer: Timer
@@ -471,6 +481,12 @@ def dataset_query(
                 exc_info=True,
             )
         elif isinstance(cause, ClickhouseError):
+            # Since the query validator doesn't have a typing system, queries containing type errors are run on
+            # Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem
+            # lies with the query, not Snuba.
+            if cause.code in CLICKHOUSE_TYPING_ERROR_CODES:
+                status = 400
+
             details = {
                 "type": "clickhouse",
                 "message": str(cause),

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -866,3 +866,47 @@ class TestSnQLApi(BaseApiTest):
         )
 
         assert response.status_code == 200
+
+    def test_clickhouse_type_mismatch_error(self) -> None:
+        """Test that snql queries that cause Clickhosue type errors have a 400 status code."""
+        response = self.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (discover_events)
+                    SELECT count()
+                    WHERE type != 'transaction' AND project_id = {self.project_id}
+                    AND timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    AND type IN array(1, 2, 3)
+                    LIMIT 1000""",
+                    "turbo": False,
+                    "consistent": True,
+                    "debug": True,
+                }
+            ),
+        )
+
+        assert b"DB::Exception: Type mismatch" in response.data
+        assert response.status_code == 400
+
+    def test_clickhouse_illegal_type_error(self) -> None:
+        response = self.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (discover_events)
+                    SELECT quantile(0.95)(type)
+                    WHERE type != 'transaction' AND project_id = {self.project_id}
+                    AND timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    LIMIT 1000""",
+                    "turbo": False,
+                    "consistent": True,
+                    "debug": True,
+                }
+            ),
+        )
+
+        assert b"DB::Exception: Illegal type" in response.data
+        assert response.status_code == 400


### PR DESCRIPTION
When queries fail with Clickhouse errors, return a 400 status code when
the Clickhouse error code indicates a type error in the query. This ensures
our SLOs are not impacted when users make mistakes in their queries.