### PR TITLE
feat(subscriptions): Add config to skip stale subscriptions in executor

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -125,6 +125,13 @@ def subscriptions_executor(
 
     executor = ThreadPoolExecutor(max_concurrent_queries)
 
+    # TODO: Consider removing and always passing via CLI.
+    # If a value provided via config, it overrides the one provided via CLI.
+    # This is so we can quickly change this in an emergency.
+    stale_threshold_seconds = state.get_config(
+        f"subscriptions_stale_threshold_sec_{dataset_name}", stale_threshold_seconds
+    )
+
     processor = build_executor_consumer(
         dataset_name,
         entity_names,


### PR DESCRIPTION
The CLI argument --stale-threshold-seconds can be overriden via config.