### PR TITLE
ref(dev-tooling): Enable commit tracking attempt II

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -1,7 +1,7 @@
-# sentry:
-#   organization: sentry
-#   project: snuba
-#   repository: getsentry/snuba
+sentry:
+  organization: sentry
+  project: snuba
+  repository: getsentry/snuba
 
 steps:
 - kind: KubernetesDeployment


### PR DESCRIPTION
**context**
Attempt II of https://github.com/getsentry/snuba/pull/2664. The first time around we ran into [this issue](https://sentry.io/organizations/sentry/issues/3252488041/?project=37617&query=is%3Aunresolved&statsPeriod=24h) but @joshuarli has since added the `SENTRY_API_TOKEN` to freight's env. 
