### PR TITLE
feat(subscriptions): Add logging for skipped subscriptions

### DIFF
--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -229,16 +229,17 @@ class SubscriptionWorker(
         max_validity_latency = state.get_config("subscriptions_max_latency_sec", 0)
         assert isinstance(max_validity_latency, int)
 
-        if max_validity_latency == 0:
-            tasks: Iterator[ScheduledSubscriptionTask] = self.__schedulers[
-                message.partition.index
-            ].find(tick)
-        else:
-            tasks = (
-                t
-                for t in self.__schedulers[message.partition.index].find(tick)
-                if datetime.timestamp(t.timestamp) > time.time() - max_validity_latency
+        if (
+            max_validity_latency != 0
+            and time.time() - datetime.timestamp(tick.timestamps.lower)
+            > max_validity_latency
+        ):
+            self.__metrics.increment(
+                "skipping_tick_subscriptions", tags={"dataset": self.__dataset_name}
             )
+            tasks: Iterator[ScheduledSubscriptionTask] = iter([])
+        else:
+            tasks = self.__schedulers[message.partition.index].find(tick)
 
         return [
             SubscriptionTaskResultFuture(


### PR DESCRIPTION
Log when subscriptions are skipped due to the `subscriptions_max_latency_sec`
override