### PR TITLE
chore(tiger): Raise a different timeout exception from tiger clusters

### DIFF
--- a/snuba/state/cache/abstract.py
+++ b/snuba/state/cache/abstract.py
@@ -15,6 +15,10 @@ class ExecutionTimeoutError(ExecutionError):
     pass
 
 
+class TigerExecutionTimeoutError(ExecutionError):
+    pass
+
+
 class Cache(Generic[TValue], ABC):
     @abstractmethod
     def get(self, key: str) -> Optional[TValue]:

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -9,7 +9,12 @@ from pkg_resources import resource_string
 from redis.exceptions import ResponseError
 from snuba.redis import RedisClientType
 from snuba.state import get_config
-from snuba.state.cache.abstract import Cache, ExecutionError, TValue
+from snuba.state.cache.abstract import (
+    Cache,
+    ExecutionError,
+    ExecutionTimeoutError,
+    TValue,
+)
 from snuba.utils.codecs import ExceptionAwareCodec
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.serializable_exception import SerializableException
@@ -29,7 +34,7 @@ class RedisCache(Cache[TValue]):
         prefix: str,
         codec: ExceptionAwareCodec[bytes, TValue],
         executor: ThreadPoolExecutor,
-        timeout_exception: Type[Exception],
+        timeout_exception: Optional[Type[Exception]] = ExecutionTimeoutError,
     ) -> None:
         self.__client = client
         self.__prefix = prefix

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -34,7 +34,7 @@ class RedisCache(Cache[TValue]):
         prefix: str,
         codec: ExceptionAwareCodec[bytes, TValue],
         executor: ThreadPoolExecutor,
-        timeout_exception: Optional[Type[Exception]] = ExecutionTimeoutError,
+        timeout_exception: Type[Exception] = ExecutionTimeoutError,
     ) -> None:
         self.__client = client
         self.__prefix = prefix

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -87,7 +87,6 @@ cache_partitions: MutableMapping[str, Cache[Result]] = {
         "snuba-query-cache:",
         ResultCacheCodec(),
         ThreadPoolExecutor(),
-        ExecutionTimeoutError,
     )
 }
 # This lock prevents us from initializing the cache twice. The cache is initialized
@@ -601,7 +600,10 @@ def raw_query(
                             errors.ErrorCodes.NETWORK_ERROR,
                         ):
                             sentry_sdk.set_tag("timeout", "network")
-                elif isinstance(cause, (TimeoutError, ExecutionTimeoutError)):
+                elif isinstance(
+                    cause,
+                    (TimeoutError, ExecutionTimeoutError, TigerExecutionTimeoutError),
+                ):
                     if scope.span:
                         sentry_sdk.set_tag("timeout", "cache_timeout")
 


### PR DESCRIPTION
### Context
When queries are run against the tiger cluster and the operation is performed via readthrough caching, we see a lot of ExecutionTimeoutErrors. This happens because uwsgi respawns the processes every 3 minutes. The respawn ensures that the requests sent to the processes have all returned their responses. So we don't see this issue with the primary queries. Unfortunately, there is no way to ask uwsgi to wait for queries being run in threads that need time to run. Those threads get killed mercilessly.

### Solution
Differentiate the exceptions being raised be queries from tiger cluster from regular production clusters. That way we can tune the alerts to ignore certain tiger exceptions.




<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
