### PR TITLE
fix(querylog): compress, allow larger messages on the querylog producer

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -315,13 +315,20 @@ def record_query(query_metadata: Mapping[str, Any]) -> None:
                 # the querylog payloads can get really large so we allow larger messages
                 # (double the default)
                 # The performance is not business critical and therefore we accept the tradeoffs
-                # in more bandwidth for more observability
+                # in more bandwidth for more observability/debugability
                 # for this to be meaningful, the following setting has to be matched on the broker:
                 # max.message.bytes=2097176
                 build_kafka_producer_configuration(
                     topic=None,
                     override_params={
-                        "compression.type": "zstd",
+                        # at time of writing (2022-05-09) lz4 was chosen because it
+                        # compresses quickly. If more compression is needed at the cost of
+                        # performance, zstd can be used instead. Recording the query
+                        # is part of the API request, therefore speed is important
+                        # perf-testing: https://indico.fnal.gov/event/16264/contributions/36466/attachments/22610/28037/Zstd__LZ4.pdf
+                        # by default a topic is configured to use whatever compression method the producer used
+                        # https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#topicconfigs_compression.type
+                        "compression.type": "lz4",
                         "max.request.size": 2097176,
                     },
                 )

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -312,14 +312,18 @@ def record_query(query_metadata: Mapping[str, Any]) -> None:
 
         if kfk is None:
             kfk = Producer(
-                # the querylog payloafs can get really large so we allow larger messages
+                # the querylog payloads can get really large so we allow larger messages
                 # (double the default)
                 # The performance is not business critical and therefore we accept the tradeoffs
                 # in more bandwidth for more observability
                 # for this to be meaningful, the following setting has to be matched on the broker:
                 # max.message.bytes=2097176
                 build_kafka_producer_configuration(
-                    topic=None, override_params={"max.request.size": 2097176}
+                    topic=None,
+                    override_params={
+                        "compression.type": "zstd",
+                        "max.request.size": 2097176,
+                    },
                 )
             )
 


### PR DESCRIPTION
Sometimes the message is too large for the querylog topic. Add compression to the producer and allow larger messages. There is also an ops ticket to allow larger messages on the broker 