### PR TITLE
feat(subscriptions): Debug producer shutdown

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -148,11 +148,14 @@ def subscriptions_executor(
 
     def handler(signum: int, frame: Any) -> None:
         # TODO: Temporary code for debugging executor shutdown
-        logging.getLogger().setLevel(logging.DEBUG)
+        logger = logging.getLogger()
+        logger.setLevel(logging.DEBUG)
 
         processor.signal_shutdown()
+        logger.debug("Flushing querylog producer")
         # Ensure the querylog producer is flushed
         state.flush_producer()
+        logger.debug("Flushed querylog producer")
 
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -328,7 +328,8 @@ def record_query(query_metadata: Mapping[str, Any]) -> None:
 def flush_producer() -> None:
     global kfk
     if kfk is not None:
-        kfk.flush()
+        messages_remaining = kfk.flush()
+        logger.debug(f"{messages_remaining} querylog messages pending delivery")
 
 
 def get_queries() -> Sequence[Mapping[str, Optional[Any]]]:

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -10,7 +10,7 @@ from typing import Callable, Deque, Mapping, MutableMapping, Optional, Sequence,
 import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Producer
-from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
@@ -484,3 +484,12 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             self.__commit(
                 {message.partition: Position(message.offset, message.timestamp)}
             )
+
+        # Flush producer
+        if isinstance(self.__producer, KafkaProducer):
+            remaining = timeout - (time.time() - start) if timeout is not None else None
+            # TODO: This is just for testing. If it works expose a flush method on KafkaProducer
+            producer = self.__producer._KafkaProducer__producer  # type: ignore
+            logger.debug("Flushing executor producer")
+            messages = producer.flush(*[remaining] if remaining is not None else [])
+            logger.debug(f"{messages} executor messages pending delivery")


### PR DESCRIPTION
We are *still* seeing an error in the logs that the producer was
being terminated with messages in queue. Add calls to flush() and
a bunch of logging to try and track this down.
