### PR TITLE
fix(tiger): Implement tupleElement function in snuba

### DIFF
--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -34,7 +34,7 @@ from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.slice_of_map_optimizer import SliceOfMapOptimizer
 from snuba.query.processors.table_rate_limit import TableRateLimit
-from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
+from snuba.query.processors.tuple_unaliaser import TupleElementer, TupleUnaliaser
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )
@@ -57,6 +57,7 @@ from snuba.utils.streams.topics import Topic
 query_processors = [
     UniqInSelectAndHavingProcessor(),
     TupleUnaliaser(),
+    TupleElementer(),
     PostReplacementConsistencyEnforcer(
         project_column="project_id",
         replacer_state_name=ReplacerState.ERRORS_V2,

--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -34,7 +34,8 @@ from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.slice_of_map_optimizer import SliceOfMapOptimizer
 from snuba.query.processors.table_rate_limit import TableRateLimit
-from snuba.query.processors.tuple_unaliaser import TupleElementer, TupleUnaliaser
+from snuba.query.processors.tuple_elementer import TupleElementer
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )

--- a/snuba/datasets/storages/errors_v2_ro.py
+++ b/snuba/datasets/storages/errors_v2_ro.py
@@ -8,9 +8,10 @@ from snuba.datasets.storages.errors_common import (
     query_processors,
     query_splitters,
 )
+from snuba.query.processors.tuple_elementer import TupleElementer
 from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 
-v2_query_processors = [*query_processors, TupleUnaliaser()]
+v2_query_processors = [*query_processors, TupleUnaliaser(), TupleElementer()]
 
 schema = TableSchema(
     columns=all_columns,

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -12,6 +12,7 @@ from snuba.datasets.storages.transactions_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
+from snuba.query.processors.tuple_elementer import TupleElementer
 from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
@@ -25,7 +26,7 @@ schema = WritableTableSchema(
     part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
-v2_query_processors = [*query_processors, TupleUnaliaser()]
+v2_query_processors = [*query_processors, TupleUnaliaser(), TupleElementer()]
 
 
 storage = WritableTableStorage(

--- a/snuba/query/processors/tuple_elementer.py
+++ b/snuba/query/processors/tuple_elementer.py
@@ -1,0 +1,115 @@
+import random
+from dataclasses import replace
+from typing import cast
+
+from snuba.utils.serializable_exception import SerializableException
+from snuba.clickhouse.processors import QueryProcessor
+from snuba.clickhouse.query import Query
+from snuba.query.expressions import (
+    Argument,
+    Column,
+    CurriedFunctionCall,
+    Expression,
+    ExpressionVisitor,
+    FunctionCall,
+    Lambda,
+    Literal,
+    SubscriptableReference,
+)
+from snuba.request.request_settings import RequestSettings
+from snuba.query.exceptions import InvalidQueryException
+from snuba.state import get_config
+
+
+def _validate_tupleElement_and_get_index(exp: FunctionCall):
+    element_index_exp = exp.parameters[1]
+    assert isinstance(element_index_exp, Literal)
+    assert isinstance(element_index_exp.value, int)
+    # clickhouse tuples are 1 -indexed, python tuples are not
+    element_index = element_index_exp.value - 1
+    assert (
+        isinstance(exp.parameters[0], FunctionCall)
+        and exp.parameters[0].function_name == "tuple"
+    )
+    return element_index
+
+
+class _TupleElementerVisitor(ExpressionVisitor[Expression]):
+    def __init__(self) -> None:
+        # TODO: make level handling a context manager maybe
+        self.__current_tuple = 0
+
+    def visit_literal(self, exp: Literal) -> Expression:
+        return exp
+
+    def visit_column(self, exp: Column) -> Expression:
+        return exp
+
+    def visit_subscriptable_reference(self, exp: SubscriptableReference) -> Expression:
+        return exp
+
+    def visit_function_call(self, exp: FunctionCall) -> Expression:
+        if exp.function_name == "tupleElement":
+            # the tupleElement function's last parameter must be a constant:
+            # https://clickhouse.com/docs/en/sql-reference/functions/tuple-functions#tupleelement
+
+            # TODO: throw proper validation exceptions
+            element_index_exp = exp.parameters[1]
+            assert isinstance(element_index_exp, Literal)
+            assert isinstance(element_index_exp.value, int)
+            # clickhouse tuples are 1 -indexed, python tuples are not
+            element_index = element_index_exp.value - 1
+            assert (
+                isinstance(exp.parameters[0], FunctionCall)
+                and exp.parameters[0].function_name == "tuple"
+            )
+            to_return = exp.parameters[0].parameters[element_index]
+            to_return.accept(self)
+            return to_return
+        transfomed_params = tuple([param.accept(self) for param in exp.parameters])
+        return replace(exp, parameters=transfomed_params)
+
+    def visit_curried_function_call(self, exp: CurriedFunctionCall) -> Expression:
+        transfomed_params = tuple([param.accept(self) for param in exp.parameters])
+        res = replace(
+            exp,
+            internal_function=exp.internal_function.accept(self),
+            parameters=transfomed_params,
+        )
+        return res
+
+    def visit_lambda(self, exp: Lambda) -> Expression:
+        res = replace(exp, transformation=exp.transformation.accept(self))
+        return res
+
+    def visit_argument(self, exp: Argument) -> Expression:
+        return exp
+
+
+class TupleElementer(QueryProcessor):
+    """Resolves the `tupleElement function in a query
+
+    e.g.: tupleElement(tuple("a", "b"), 1) -> "a"
+
+    Thie is a zero cost function in clickhouse that is resolved at AST
+    parse time. We do it on our end to avoid backwards incomaptibility issues
+
+    Due to a backwards incomaptibility issue in clickhouse from
+    20.8 -> 21.8, tupleElement calls cause parsing errors
+    parsing errors in certain conditions.
+    """
+
+    def should_run(self) -> bool:
+        try:
+            unaliaser_config_percentage = float(
+                cast(float, get_config("tuple_elementer_rollout", 0))
+            )
+            return random.random() < unaliaser_config_percentage
+        except ValueError:
+            return False
+
+    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+        if not self.should_run():
+            return None
+        visitor = _TupleElementerVisitor()
+        query.transform(visitor)

--- a/snuba/query/processors/tuple_elementer.py
+++ b/snuba/query/processors/tuple_elementer.py
@@ -20,19 +20,6 @@ from snuba.request.request_settings import RequestSettings
 from snuba.state import get_config
 
 
-def _validate_tupleElement_and_get_index(exp: FunctionCall):
-    element_index_exp = exp.parameters[1]
-    assert isinstance(element_index_exp, Literal)
-    assert isinstance(element_index_exp.value, int)
-    # clickhouse tuples are 1 -indexed, python tuples are not
-    element_index = element_index_exp.value - 1
-    assert (
-        isinstance(exp.parameters[0], FunctionCall)
-        and exp.parameters[0].function_name == "tuple"
-    )
-    return element_index
-
-
 class _TupleElementerVisitor(ExpressionVisitor[Expression]):
     def visit_literal(self, exp: Literal) -> Expression:
         return exp

--- a/tests/query/processors/test_backwards_compatibility_processors.py
+++ b/tests/query/processors/test_backwards_compatibility_processors.py
@@ -1,0 +1,70 @@
+"""This file tests the query processors introduced to facilitate backwards
+compatibility with between Clickhouse 21.8 and CLickhouse 20.7"""
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from snuba.query.dsl import literals_tuple, tupleElement
+from snuba.query.expressions import FunctionCall, Literal
+from snuba.query.processors.tuple_elementer import TupleElementer
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state import set_config
+from tests.query.processors.query_builders import build_query
+
+TEST_QUERIES = [
+    pytest.param(
+        build_query(
+            selected_columns=[
+                literals_tuple("foo", (Literal(None, "a"), Literal(None, "b"))),
+                FunctionCall(
+                    None,
+                    "equals",
+                    (
+                        tupleElement(
+                            None,
+                            literals_tuple(
+                                "doo", (Literal(None, "c"), Literal(None, "d"))
+                            ),
+                            Literal(None, 1),
+                        ),
+                        Literal(None, 300),
+                    ),
+                ),
+            ]
+        ),
+        build_query(
+            selected_columns=[
+                literals_tuple("foo", (Literal(None, "a"), Literal(None, "b"))),
+                FunctionCall(
+                    None,
+                    "equals",
+                    (
+                        Literal(None, "c"),
+                        Literal(None, 300),
+                    ),
+                ),
+            ]
+        ),
+        id="a tuple element and an unalias",
+    )
+]
+
+
+@pytest.mark.parametrize("input_query,expected_query", TEST_QUERIES)
+def test_processors(input_query, expected_query):
+    set_config("tuple_elementer_rollout", 1)
+    set_config("tuple_unaliaser_rollout", 1)
+
+    def test_processors(i_query, processors):
+        q_copy = deepcopy(i_query)
+        for p in processors:
+            p.process_query(q_copy, HTTPRequestSettings())
+        assert q_copy == expected_query
+
+    q_processors = [TupleElementer(), TupleUnaliaser()]
+    # order should not matter, the resulting query should be the same
+    test_processors(input_query, q_processors)
+    test_processors(input_query, reversed(q_processors))

--- a/tests/query/processors/test_tuple_elementer.py
+++ b/tests/query/processors/test_tuple_elementer.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import pytest
+
+from snuba.query.dsl import identity as dsl_identity
+from snuba.query.dsl import literals_tuple, tupleElement
+from snuba.query.expressions import (
+    CurriedFunctionCall,
+    Expression,
+    FunctionCall,
+    Lambda,
+    Literal,
+)
+from snuba.query.processors.tuple_elementer import TupleElementer
+from snuba.request.request_settings import HTTPRequestSettings
+from snuba.state import set_config
+from tests.query.processors.query_builders import build_query
+
+
+def equals(op1: Expression, op2: Expression, alias: str | None = None) -> FunctionCall:
+    return FunctionCall(alias, "eq", tuple([op1, op2]))
+
+
+def some_tuple(alias: str | None):
+    return literals_tuple(alias, [Literal(None, "duration"), Literal(None, 300)])
+
+
+def identity(expression: Expression) -> Expression:
+    return dsl_identity(expression, None)
+
+
+TEST_QUERIES = [
+    pytest.param(
+        build_query(
+            selected_columns=[
+                some_tuple(alias="foo"),
+                equals(
+                    tupleElement(None, some_tuple(alias="doo"), Literal(None, 1)),
+                    Literal(None, 300),
+                ),
+            ]
+        ),
+        build_query(
+            selected_columns=[
+                some_tuple(alias="foo"),
+                equals(
+                    Literal(None, "duration"),
+                    Literal(None, 300),
+                ),
+            ]
+        ),
+        id="simple happy path",
+    ),
+    pytest.param(
+        build_query(
+            selected_columns=[
+                identity(
+                    identity(
+                        identity(
+                            equals(
+                                tupleElement(
+                                    None, some_tuple(alias="ayyy"), Literal(None, 1)
+                                ),
+                                Literal(None, 300),
+                            )
+                        )
+                    )
+                )
+            ]
+        ),
+        build_query(
+            selected_columns=[
+                identity(
+                    identity(
+                        identity(
+                            equals(
+                                Literal(None, "duration"),
+                                Literal(None, 300),
+                            )
+                        )
+                    )
+                )
+            ]
+        ),
+        id="Highly nested",
+    )
+]
+
+
+@pytest.mark.parametrize("input_query,expected_query", TEST_QUERIES)
+def test_tuple_unaliaser(input_query, expected_query):
+    set_config("tuple_elementer_rollout", 1)
+    settings = HTTPRequestSettings()
+    TupleElementer().process_query(input_query, settings)
+    assert input_query == expected_query
+
+
+def test_killswitch():
+    p = TupleElementer()
+    assert not p.should_run()
+    set_config("tuple_elementer_rollout", 0)
+    assert not p.should_run()
+    set_config("tuple_elementer_rollout", 1)
+    assert p.should_run()
+
+
+def test_garbage_rollot():
+    p = TupleElementer()
+    set_config("tuple_elementer_rollout", "garbage")
+    assert not p.should_run()


### PR DESCRIPTION
### Context

The new clickhouse sometimes fails to parse queries that have a `tupleElement` function.  

Example:

```sql
 SELECT
 (
    toStartOfHour(finish_ts, 'Universal') AS _snuba_time
  ),
  countIf(
    lessOrEquals(
      multiIf(
        equals(tupleElement(tuple('duration', 300), 1), 'lcp'),
        (
          if(
            has(measurements.key, 'lcp'),
            arrayElement(
              measurements.value,
              indexOf(measurements.key, 'lcp')
            ),
            NULL
          ) AS ` _snuba_measurements [ lcp ] `
        ),
        (duration AS _snuba_duration)
      ),
      tupleElement(tuple('duration', 300), 2)
    )
  )
FROM
  transactions_dist PREWHERE equals((transaction_name AS _snuba_transaction), '/')
WHERE
  equals(('transaction' AS _snuba_type), 'transaction')
  AND greaterOrEquals(
    (finish_ts AS _snuba_finish_ts),
    toDateTime('2022-04-11T20:52:46', 'Universal')
  )
  AND less(
    _snuba_finish_ts,
    toDateTime('2022-04-25T20:52:46', 'Universal')
  )
  AND in((project_id AS _snuba_project_id), [ 5853067 ])
GROUP BY
  _snuba_time
ORDER BY
  _snuba_time ASC
LIMIT
  10000 OFFSET 0
  ```
  
  This fails with:
  ```
   Not found column countIf(lessOrEquals(multiIf(equals(tupleElement(tuple('duration', 300), 1), 'lcp'), 
   if(has(measurements.key, 'lcp'),
    arrayElement(measurements.value, indexOf(measurements.key, 'lcp')), NULL), duration), 
    tupleElement(tuple('duration', 300), 2))) in block. 
   ```
  
  Resolving the tupleElement fixes the issue:
  
  ```sql
  SELECT
  (
    toStartOfHour(finish_ts, 'Universal') AS _snuba_time
  ),
  countIf(
    lessOrEquals(
      multiIf(
        equals('duration', 'lcp'),
        (
          if(
            has(measurements.key, 'lcp'),
            arrayElement(
              measurements.value,
              indexOf(measurements.key, 'lcp')
            ),
            NULL
          ) AS ` _snuba_measurements [ lcp ] `
        ),
        (duration AS _snuba_duration)
      ),
      300
    )
  )
FROM
  transactions_dist PREWHERE equals((transaction_name AS _snuba_transaction), '/')
WHERE
  equals(('transaction' AS _snuba_type), 'transaction')
  AND greaterOrEquals(
    (finish_ts AS _snuba_finish_ts),
    toDateTime('2022-04-11T20:52:46', 'Universal')
  )
  AND less(
    _snuba_finish_ts,
    toDateTime('2022-04-25T20:52:46', 'Universal')
  )
  AND in((project_id AS _snuba_project_id), [ 5853067 ])
GROUP BY
  _snuba_time
ORDER BY
  _snuba_time ASC
LIMIT
  10000 OFFSET 0
  ```
  
  