### PR TITLE
ref: try building the arm64 image using linux builders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,16 +131,13 @@ jobs:
             docker push ghcr.io/getsentry/snuba-ci:latest
           fi
 
-  # For now, we cannot build linux/arm64 images on Linux hosts since
-  # |docker buildx ls| does not list arm64 as an option.
-  #
   # This step does not have a set timeout because it is very slow. This is due
   # because emulation required (this is running on an Intel host rather than an arm64 host)
   # and that many Python packages do not have arm wheels, thus, requirying to build them from source.
   # Upgrading Python package versions + giving access to a cache could improve things a lot
   snuba-arm64-image:
     name: "Docker Arm64 build"
-    runs-on: macos-11
+    runs-on: ubuntu-latest
     env:
       # `sentry devservices up snuba` picks up the `amd64` version of the image
       # For now, we will publish to a different name until we want to officially
@@ -157,13 +154,8 @@ jobs:
         # it can be used as a docker tag
         run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/} | tr / -)"
 
-      - name: Set up Docker
-        run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask docker
-          sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
-          open -a /Applications/Docker.app --args --unattended --accept-license
-          echo "We are waiting for Docker to be up and running. It can take over 2 minutes..."
-          while ! /Applications/Docker.app/Contents/Resources/bin/docker info &>/dev/null; do sleep 1; done
+      - name: enable arm64 building
+        run: docker run --rm --privileged tonistiigi/binfmt --install arm64
 
       - name: Registry login
         run: |


### PR DESCRIPTION
this drastically speeds up the arm64 image build

- a representative "before": **54 minutes** https://github.com/getsentry/snuba/runs/6378324183?check_suite_focus=true
- this PR: **25 minutes** https://github.com/getsentry/snuba/runs/6389113546?check_suite_focus=true

validation done:

I override the image in my `sentry` checkout, `make run-dependent-services` and then ran `pytest tests/snuba`

```diff
diff --git a/src/sentry/conf/server.py b/src/sentry/conf/server.py
index 63b3f4e2bc..6489ee9203 100644
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1931,7 +1931,7 @@ SENTRY_DEVSERVICES = {
         {
             "image": "getsentry/snuba:nightly" if not APPLE_ARM64
             # We cross-build arm64 images on GH's Apple Intel runners
-            else "ghcr.io/getsentry/snuba-arm64-dev:latest",
+            else "ghcr.io/getsentry/snuba-arm64-dev:refs-pull-2688-merge",
             "pull": True,
             "ports": {"1218/tcp": 1218},
             "command": ["devserver"],
```

I had issues with two tests hanging, though this appears to hang on master already for me: `tests/snuba/incidents/test_tasks.py` and `tests/snuba/snuba/test_query_subscription_consumer.py`

```
$ pytest tests/snuba -k 'not incidents and not test_query_subscription_consumer'

...

========= 1224 passed, 7 skipped, 5 deselected, 3 xfailed, 2 xpassed in 780.73s (0:13:00) ==========
...

