### PR TITLE
fix(querylog): use correct kafka config option

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -312,12 +312,6 @@ def record_query(query_metadata: Mapping[str, Any]) -> None:
 
         if kfk is None:
             kfk = Producer(
-                # the querylog payloads can get really large so we allow larger messages
-                # (double the default)
-                # The performance is not business critical and therefore we accept the tradeoffs
-                # in more bandwidth for more observability/debugability
-                # for this to be meaningful, the following setting has to be matched on the broker:
-                # max.message.bytes=2097176
                 build_kafka_producer_configuration(
                     topic=None,
                     override_params={
@@ -329,7 +323,13 @@ def record_query(query_metadata: Mapping[str, Any]) -> None:
                         # by default a topic is configured to use whatever compression method the producer used
                         # https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#topicconfigs_compression.type
                         "compression.type": "lz4",
-                        "max.request.size": 2097176,
+                        # the querylog payloads can get really large so we allow larger messages
+                        # (double the default)
+                        # The performance is not business critical and therefore we accept the tradeoffs
+                        # in more bandwidth for more observability/debugability
+                        # for this to be meaningful, the following setting has to be at least as large on the broker
+                        # max.message.bytes=2000000
+                        "max.message.bytes": 2000000,
                     },
                 )
             )


### PR DESCRIPTION
Lyn was right that `max.request.size` is not applicable for librdkafka producers, I read the wrong confluent docs