### PR TITLE
fix(querylog): fix the kafka config, add test for producer

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -87,7 +87,7 @@ REDIS_INIT_MAX_RETRIES = 3
 USE_RESULT_CACHE = True
 
 # Query Recording Options
-RECORD_QUERIES = True
+RECORD_QUERIES = False
 
 # Runtime Config Options
 CONFIG_MEMOIZE_TIMEOUT = 10

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -87,7 +87,7 @@ REDIS_INIT_MAX_RETRIES = 3
 USE_RESULT_CACHE = True
 
 # Query Recording Options
-RECORD_QUERIES = False
+RECORD_QUERIES = True
 
 # Runtime Config Options
 CONFIG_MEMOIZE_TIMEOUT = 10

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -50,7 +50,7 @@ max_query_duration_s = 60
 rate_lookback_s = 60
 
 
-def _kafka_producer():
+def _kafka_producer() -> Producer:
     global kfk
     if kfk is None:
         kfk = Producer(

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -50,6 +50,34 @@ max_query_duration_s = 60
 rate_lookback_s = 60
 
 
+def _kafka_producer():
+    global kfk
+    if kfk is None:
+        kfk = Producer(
+            build_kafka_producer_configuration(
+                topic=None,
+                override_params={
+                    # at time of writing (2022-05-09) lz4 was chosen because it
+                    # compresses quickly. If more compression is needed at the cost of
+                    # performance, zstd can be used instead. Recording the query
+                    # is part of the API request, therefore speed is important
+                    # perf-testing: https://indico.fnal.gov/event/16264/contributions/36466/attachments/22610/28037/Zstd__LZ4.pdf
+                    # by default a topic is configured to use whatever compression method the producer used
+                    # https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#topicconfigs_compression.type
+                    "compression.type": "lz4",
+                    # the querylog payloads can get really large so we allow larger messages
+                    # (double the default)
+                    # The performance is not business critical and therefore we accept the tradeoffs
+                    # in more bandwidth for more observability/debugability
+                    # for this to be meaningful, the following setting has to be at least as large on the broker
+                    # message.max.bytes=2000000
+                    "message.max.bytes": 2000000,
+                },
+            )
+        )
+    return kfk
+
+
 @dataclass(frozen=True)
 class MismatchedTypeException(Exception):
     key: str
@@ -302,40 +330,15 @@ def _record_query_delivery_callback(
 
 
 def record_query(query_metadata: Mapping[str, Any]) -> None:
-    global kfk
     max_redis_queries = 200
     try:
+        producer = _kafka_producer()
         data = safe_dumps(query_metadata)
         rds.pipeline(transaction=False).lpush(queries_list, data).ltrim(  # type: ignore
             queries_list, 0, max_redis_queries - 1
         ).execute()
-
-        if kfk is None:
-            kfk = Producer(
-                build_kafka_producer_configuration(
-                    topic=None,
-                    override_params={
-                        # at time of writing (2022-05-09) lz4 was chosen because it
-                        # compresses quickly. If more compression is needed at the cost of
-                        # performance, zstd can be used instead. Recording the query
-                        # is part of the API request, therefore speed is important
-                        # perf-testing: https://indico.fnal.gov/event/16264/contributions/36466/attachments/22610/28037/Zstd__LZ4.pdf
-                        # by default a topic is configured to use whatever compression method the producer used
-                        # https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#topicconfigs_compression.type
-                        "compression.type": "lz4",
-                        # the querylog payloads can get really large so we allow larger messages
-                        # (double the default)
-                        # The performance is not business critical and therefore we accept the tradeoffs
-                        # in more bandwidth for more observability/debugability
-                        # for this to be meaningful, the following setting has to be at least as large on the broker
-                        # max.message.bytes=2000000
-                        "max.message.bytes": 2000000,
-                    },
-                )
-            )
-
-        kfk.poll(0)  # trigger queued delivery callbacks
-        kfk.produce(
+        producer.poll(0)  # trigger queued delivery callbacks
+        producer.produce(
             settings.KAFKA_TOPIC_MAP.get(Topic.QUERYLOG.value, Topic.QUERYLOG.value),
             data.encode("utf-8"),
             on_delivery=_record_query_delivery_callback,

--- a/tests/state/test_record.py
+++ b/tests/state/test_record.py
@@ -1,0 +1,5 @@
+from snuba.state import _kafka_producer
+
+
+def test_get_producer():
+    assert _kafka_producer() is not None


### PR DESCRIPTION
* Use the correct kafka setting this time I promise
* Add a test to make sure the producer can actually be created. The test was able to reproduce the failure that happened in production.