### PR TITLE
feat(kafka): Extend KafkaMessageMetadata

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -607,7 +607,12 @@ def process_message(
     result = processor.process_message(
         rapidjson.loads(message.payload.value),
         KafkaMessageMetadata(
-            message.offset, message.partition.index, message.timestamp
+            offset=message.offset,
+            partition=message.partition.index,
+            timestamp=message.timestamp,
+            topic=message.partition.topic.name,
+            key=message.payload.key,
+            headers=message.payload.headers,
         ),
     )
 
@@ -651,7 +656,12 @@ def process_message_multistorage(
 ) -> MultistorageProcessedMessage:
     value = rapidjson.loads(message.payload.payload.value)
     metadata = KafkaMessageMetadata(
-        message.offset, message.partition.index, message.timestamp
+        offset=message.offset,
+        partition=message.partition.index,
+        timestamp=message.timestamp,
+        topic=message.partition.topic.name,
+        key=message.payload.payload.key,
+        headers=message.payload.payload.headers,
     )
 
     results: MutableSequence[
@@ -686,7 +696,12 @@ def process_message_multistorage_identical_storages(
     """
     value = rapidjson.loads(message.payload.payload.value)
     metadata = KafkaMessageMetadata(
-        message.offset, message.partition.index, message.timestamp
+        offset=message.offset,
+        partition=message.partition.index,
+        timestamp=message.timestamp,
+        topic=message.partition.topic.name,
+        key=message.payload.payload.key,
+        headers=message.payload.payload.headers,
     )
 
     intermediate_results: MutableMapping[

--- a/snuba/consumers/types.py
+++ b/snuba/consumers/types.py
@@ -1,8 +1,13 @@
 from datetime import datetime
-from typing import NamedTuple
+from typing import NamedTuple, Optional
+
+from arroyo.backends.kafka.consumer import Headers
 
 
 class KafkaMessageMetadata(NamedTuple):
     offset: int
     partition: int
     timestamp: datetime
+    topic: str
+    key: Optional[bytes]
+    headers: Headers

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -593,7 +593,12 @@ if application.debug or application.testing:
                 .process_message(
                     message,
                     KafkaMessageMetadata(
-                        offset=offset, partition=0, timestamp=datetime.utcnow()
+                        offset=offset,
+                        partition=0,
+                        timestamp=datetime.utcnow(),
+                        topic="topic",
+                        key=None,
+                        headers=[],
                     ),
                 )
             )

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -161,7 +161,12 @@ class TestGroupassignee:
         processor = GroupAssigneeProcessor("sentry_groupasignee")
 
         metadata = KafkaMessageMetadata(
-            offset=42, partition=0, timestamp=datetime(1970, 1, 1)
+            offset=42,
+            partition=0,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
 
         ret = processor.process_message(self.INSERT_MSG, metadata)

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -226,7 +226,12 @@ class TestGroupedMessage:
         processor = GroupedMessageProcessor("sentry_groupedmessage")
 
         metadata = KafkaMessageMetadata(
-            offset=42, partition=0, timestamp=datetime(1970, 1, 1)
+            offset=42,
+            partition=0,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
 
         ret = processor.process_message(self.INSERT_MSG, metadata)

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -335,7 +335,14 @@ def test_error_processor() -> None:
         "transaction_name": "",
     }
 
-    meta = KafkaMessageMetadata(offset=2, partition=1, timestamp=datetime(1970, 1, 1))
+    meta = KafkaMessageMetadata(
+        offset=2,
+        partition=1,
+        timestamp=datetime(1970, 1, 1),
+        topic="topic",
+        key=None,
+        headers=[],
+    )
     processor = ErrorsProcessor(
         {
             "environment": "environment",

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -147,7 +147,14 @@ def test_metrics_processor(
 ) -> None:
     settings.DISABLED_DATASETS = set()
 
-    meta = KafkaMessageMetadata(offset=100, partition=1, timestamp=datetime(1970, 1, 1))
+    meta = KafkaMessageMetadata(
+        offset=100,
+        partition=1,
+        timestamp=datetime(1970, 1, 1),
+        topic="topic",
+        key=None,
+        headers=[],
+    )
 
     expected_set_result = (
         InsertBatch(expected_set, None) if expected_set is not None else None
@@ -325,7 +332,14 @@ def test_metrics_aggregate_processor(
     settings.DISABLED_DATASETS = set()
     settings.WRITE_METRICS_AGG_DIRECTLY = True
 
-    meta = KafkaMessageMetadata(offset=100, partition=1, timestamp=datetime(1970, 1, 1))
+    meta = KafkaMessageMetadata(
+        offset=100,
+        partition=1,
+        timestamp=datetime(1970, 1, 1),
+        topic="topic",
+        key=None,
+        headers=[],
+    )
 
     expected_set_result = (
         AggregateInsertBatch(expected_set, None) if expected_set is not None else None
@@ -435,7 +449,14 @@ def test_metrics_polymorphic_processor(
 ) -> None:
     settings.DISABLED_DATASETS = set()
 
-    meta = KafkaMessageMetadata(offset=100, partition=1, timestamp=datetime(1970, 1, 1))
+    meta = KafkaMessageMetadata(
+        offset=100,
+        partition=1,
+        timestamp=datetime(1970, 1, 1),
+        topic="topic",
+        key=None,
+        headers=[],
+    )
     # test_time_bucketing tests the bucket function, parameterizing the output times here
     # would require repeating the code in the class we're testing
     with patch(

--- a/tests/datasets/test_processors_idempotency.py
+++ b/tests/datasets/test_processors_idempotency.py
@@ -33,7 +33,14 @@ def test_processors_of_multistorage_consumer_are_idempotent(
     Test that when the same message is provided to the processors, the result would be the same. That is the process
     message operation is idempotent.
     """
-    metadata = KafkaMessageMetadata(1000, 1, datetime.now())
+    metadata = KafkaMessageMetadata(
+        offset=1000,
+        partition=1,
+        timestamp=datetime.now(),
+        topic="",
+        key=None,
+        headers=[],
+    )
 
     result1 = processor.process_message(message, metadata)
     result2 = processor.process_message(message, metadata)

--- a/tests/datasets/test_profiles_processor.py
+++ b/tests/datasets/test_profiles_processor.py
@@ -49,7 +49,12 @@ class ProfileEvent:
 class TestProfilesProcessor:
     def test_missing_symbols(self) -> None:
         meta = KafkaMessageMetadata(
-            offset=1, partition=0, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=0,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         message = ProfileEvent(
             organization_id=123456789,
@@ -84,7 +89,12 @@ class TestProfilesProcessor:
 
     def test_process_message(self) -> None:
         meta = KafkaMessageMetadata(
-            offset=0, partition=0, timestamp=datetime(1970, 1, 1)
+            offset=0,
+            partition=0,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         message = ProfileEvent(
             organization_id=123456789,

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -94,7 +94,15 @@ def test_simple() -> None:
     )
 
     assert processor.process_message(
-        message, KafkaMessageMetadata(0, 0, datetime.now())
+        message,
+        KafkaMessageMetadata(
+            offset=0,
+            partition=0,
+            timestamp=datetime.now(),
+            topic="topic",
+            key=None,
+            headers=[],
+        ),
     ) == InsertBatch(
         [
             {
@@ -216,7 +224,15 @@ def test_missing_fields() -> None:
         )
 
         assert processor.process_message(
-            message, KafkaMessageMetadata(0, 0, datetime.now())
+            message,
+            KafkaMessageMetadata(
+                offset=0,
+                partition=0,
+                timestamp=datetime.now(),
+                topic="topic",
+                key=None,
+                headers=[],
+            ),
         ) == InsertBatch(
             [
                 {

--- a/tests/datasets/test_session_processor.py
+++ b/tests/datasets/test_session_processor.py
@@ -30,7 +30,12 @@ class TestSessionProcessor:
         }
 
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
             [
@@ -78,7 +83,12 @@ class TestSessionProcessor:
         }
 
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
             [
@@ -127,7 +137,12 @@ class TestSessionProcessor:
         }
 
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
             [
@@ -176,7 +191,12 @@ class TestSessionProcessor:
         }
 
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         assert SessionsProcessor().process_message(payload, meta) == InsertBatch(
             [

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -275,7 +275,12 @@ class TestTransactionsProcessor:
         payload[2]["data"]["type"] = "error"
 
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         processor = TransactionsMessageProcessor()
         assert processor.process_message(payload, meta) is None
@@ -311,7 +316,12 @@ class TestTransactionsProcessor:
         del payload[2]["data"]["contexts"]
 
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         processor = TransactionsMessageProcessor()
         assert processor.process_message(payload, meta) is None
@@ -346,7 +356,12 @@ class TestTransactionsProcessor:
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
         )
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         assert TransactionsMessageProcessor().process_message(
             message.serialize(), meta
@@ -384,7 +399,12 @@ class TestTransactionsProcessor:
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
         )
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
 
         payload = message.serialize()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -35,7 +35,15 @@ def write_unprocessed_events(
     processed_messages = []
     for i, event in enumerate(events):
         processed_message = processor.process_message(
-            (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
+            (2, "insert", event, {}),
+            KafkaMessageMetadata(
+                offset=i,
+                partition=0,
+                timestamp=datetime.now(),
+                topic="topic",
+                key=None,
+                headers=[],
+            ),
         )
         assert processed_message is not None
         processed_messages.append(processed_message)

--- a/tests/migrations/test_runner_individual.py
+++ b/tests/migrations/test_runner_individual.py
@@ -129,7 +129,14 @@ def generate_transactions() -> None:
             .get_processor()
             .process_message(
                 (2, "insert", raw_transaction),
-                KafkaMessageMetadata(0, 0, datetime.utcnow()),
+                KafkaMessageMetadata(
+                    offset=0,
+                    partition=0,
+                    timestamp=datetime.utcnow(),
+                    topic="topic",
+                    key=None,
+                    headers=[],
+                ),
             )
         )
         assert isinstance(processed, InsertBatch)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,7 +64,15 @@ class SimpleAPITest(BaseApiTest):
         processed_messages = []
         for i, event in enumerate(events):
             processed_message = processor.process_message(
-                (2, "insert", event, {}), KafkaMessageMetadata(i, 0, datetime.now())
+                (2, "insert", event, {}),
+                KafkaMessageMetadata(
+                    offset=i,
+                    partition=0,
+                    timestamp=datetime.now(),
+                    topic="topic",
+                    key=None,
+                    headers=[],
+                ),
             )
             assert processed_message is not None
             processed_messages.append(processed_message)

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -111,7 +111,14 @@ class TestMetricsApiCounters(BaseApiTest):
                                 "retention_days": RETENTION_DAYS,
                             }
                         ),
-                        KafkaMessageMetadata(0, 0, self.base_time),
+                        KafkaMessageMetadata(
+                            offset=0,
+                            partition=0,
+                            timestamp=self.base_time,
+                            topic="topic",
+                            key=None,
+                            headers=[],
+                        ),
                     )
                 )
                 if processed:
@@ -258,7 +265,14 @@ class TestOrgMetricsApiCounters(BaseApiTest):
                                     "retention_days": RETENTION_DAYS,
                                 }
                             ),
-                            KafkaMessageMetadata(0, 0, self.base_time),
+                            KafkaMessageMetadata(
+                                offset=0,
+                                partition=0,
+                                timestamp=self.base_time,
+                                topic="topic",
+                                key=None,
+                                headers=[],
+                            ),
                         )
                     )
                     if processed:
@@ -395,7 +409,14 @@ class TestMetricsApiSets(BaseApiTest):
 
                 processed = processor.process_message(
                     msg,
-                    KafkaMessageMetadata(0, 0, self.base_time),
+                    KafkaMessageMetadata(
+                        offset=0,
+                        partition=0,
+                        timestamp=self.base_time,
+                        topic="topic",
+                        key=None,
+                        headers=[],
+                    ),
                 )
                 if processed:
                     events.append(processed)
@@ -492,7 +513,14 @@ class TestMetricsApiDistributions(BaseApiTest):
 
                 processed = processor.process_message(
                     msg,
-                    KafkaMessageMetadata(0, 0, self.base_time),
+                    KafkaMessageMetadata(
+                        offset=0,
+                        partition=0,
+                        timestamp=self.base_time,
+                        topic="topic",
+                        key=None,
+                        headers=[],
+                    ),
                 )
                 if processed:
                     events.append(processed)

--- a/tests/test_org_sessions_api.py
+++ b/tests/test_org_sessions_api.py
@@ -46,7 +46,12 @@ class TestOrgSessionsApi(BaseApiTest):
     def generate_session_events(self, org_id: int, project_id: int) -> None:
         processor = self.storage.get_table_writer().get_stream_loader().get_processor()
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         distinct_id = uuid4().hex
         template = {

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -79,7 +79,14 @@ class TestOutcomesApi(BaseApiTest):
                 .get_processor()
                 .process_message(
                     message,
-                    KafkaMessageMetadata(0, 0, self.base_time),
+                    KafkaMessageMetadata(
+                        offset=0,
+                        partition=0,
+                        timestamp=self.base_time,
+                        topic="topic",
+                        key=None,
+                        headers=[],
+                    ),
                 )
             )
             if processed:

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -133,7 +133,12 @@ class TestLegacySessionsApi(BaseSessionsMockTest, BaseApiTest):
     def generate_session_events(self, project_id: int) -> None:
         processor = self.storage.get_table_writer().get_stream_loader().get_processor()
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         template = {
             "session_id": "00000000-0000-0000-0000-000000000000",
@@ -309,7 +314,12 @@ class TestSessionsApi(BaseSessionsMockTest, BaseApiTest):
     def generate_session_events(self, project_id: int) -> None:
         processor = self.storage.get_table_writer().get_stream_loader().get_processor()
         meta = KafkaMessageMetadata(
-            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+            offset=1,
+            partition=2,
+            timestamp=datetime(1970, 1, 1),
+            topic="topic",
+            key=None,
+            headers=[],
         )
         template = {
             "session_id": "00000000-0000-0000-0000-000000000000",

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -163,7 +163,14 @@ class TestTransactionsApi(BaseApiTest):
                                     },
                                 },
                             ),
-                            KafkaMessageMetadata(0, 0, self.base_time),
+                            KafkaMessageMetadata(
+                                offset=0,
+                                partition=0,
+                                timestamp=self.base_time,
+                                topic="topic",
+                                key=None,
+                                headers=[],
+                            ),
                         )
                     )
                     if processed:


### PR DESCRIPTION
### Overview
- Currently, `KafkaMessageMetadata` only contains a message timestamp, offset, and partition index
- It would be useful to also have the topic, and key+headers of the payload so eventually the `InvalidKafkaMessage` class in Arroyo introduced by DLQ changes could be used
- `MessageProcessor`s currently don't have enough data to use the appropriate invalid message class so only the `InvalidRawMessage` class (from Arroyo) is currently useful
- Eg. https://github.com/getsentry/snuba/pull/2614 Could have used `InvalidKafkaMessage` in order to produce more debug data to a dead-letter topic

### Changes
- Added extra fields to the metadata tuple
- Most of this PR is just updating tests to add the new fields to the tuple

### Notes
- Ideally, there should also be a way to figure out which consumer group a message was consumed/processed by, is there a way to do this?