### PR TITLE
fix(dlq): Metrics ignored messages should be Sentry Errors

### DIFF
--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -188,7 +188,7 @@ def _raise_invalid_message(message: Mapping[str, Any], reason: str) -> None:
             ]
         )
     else:
-        logger.warning(
+        logger.error(
             "Ignored an invalid message on Metrics! (Did not go to DLQ)",
             exc_info=True,
             extra={"message": message, "reason": reason},

--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -178,7 +178,7 @@ def _raise_invalid_message(message: Mapping[str, Any], reason: str) -> None:
     """
     Pass an invalid message to the DLQ by raising `InvalidMessages` exception.
     """
-    if state.get_config("ENABLE_METRICS_DLQ", False):
+    if state.get_config("enable_metrics_dlq", False):
         raise InvalidMessages(
             [
                 InvalidRawMessage(


### PR DESCRIPTION
### Overview
- Metrics DLQ is behind a runtime config right now
- Warns but should error if we encounter an invalid message and the DLQ is disabled