### PR TITLE
fix(tiger): don't call the explicit tuple function in clickhouse

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -137,6 +137,11 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
             # and work when they are passed as [1, 2, 3]
             return self._alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
 
+        if exp.function_name == "tuple":
+            # Some distributed queries fail when tuples are passed as tuple(1,2,3)
+            # and work when they are passed as (1, 2, 3)
+            return self._alias(f"({self.__visit_params(exp.parameters)})", exp.alias)
+
         elif exp.function_name == BooleanFunctions.AND:
             formatted = (c.accept(self) for c in get_first_level_and_conditions(exp))
             return " AND ".join(formatted)

--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -137,9 +137,11 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
             # and work when they are passed as [1, 2, 3]
             return self._alias(f"[{self.__visit_params(exp.parameters)}]", exp.alias)
 
-        if exp.function_name == "tuple":
+        if exp.function_name == "tuple" and len(exp.parameters) > 1:
             # Some distributed queries fail when tuples are passed as tuple(1,2,3)
             # and work when they are passed as (1, 2, 3)
+            # to be safe, only do this for when a tuple has more than one element otherwise clickhouse
+            # will interpret (1) -> 1 which will break things like 1 IN tuple(1)
             return self._alias(f"({self.__visit_params(exp.parameters)})", exp.alias)
 
         elif exp.function_name == BooleanFunctions.AND:

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -207,6 +207,15 @@ test_expressions = [
         "(f0(table1.param1) AS snubatagssomepii)",
         "(f0(table1.param1) AS snubatagssomepii)",
     ),
+    (
+        FunctionCall(
+            "some_tuple",
+            "tuple",
+            (Column(None, "table1", "param1"), Column(None, "table1", "param2")),
+        ),
+        "((table1.param1, table1.param2) AS some_tuple)",
+        "((table1.param1, table1.param2) AS some_tuple)",
+    ),
 ]
 
 

--- a/tests/clickhouse/test_formatter.py
+++ b/tests/clickhouse/test_formatter.py
@@ -216,6 +216,15 @@ test_expressions = [
         "((table1.param1, table1.param2) AS some_tuple)",
         "((table1.param1, table1.param2) AS some_tuple)",
     ),
+    (
+        FunctionCall(
+            "single_tuple",
+            "tuple",
+            (Column(None, "table1", "param1"),),
+        ),
+        "(tuple(table1.param1) AS single_tuple)",
+        "(tuple(table1.param1) AS single_tuple)",
+    ),
 ]
 
 

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -470,7 +470,7 @@ def test_formatting() -> None:
         ),
         Literal(None, 1),
     ).accept(ClickhouseExpressionFormatter()) == (
-        "(tupleElement((arrayJoin(arrayMap((x, y -> tuple(x, y)), "
+        "(tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), "
         "tags.key, tags.value)) AS snuba_all_tags), 1) AS tags_key)"
     )
 
@@ -489,8 +489,8 @@ def test_formatting() -> None:
         Literal(None, 1),
     ).accept(ClickhouseExpressionFormatter()) == (
         "(tupleElement((arrayJoin(arrayFilter((pair -> in("
-        "tupleElement(pair, 1), tuple('t1', 't2'))), "
-        "arrayMap((x, y -> tuple(x, y)), tags.key, tags.value))) AS snuba_all_tags), 1) AS tags_key)"
+        "tupleElement(pair, 1), ('t1', 't2'))), "
+        "arrayMap((x, y -> (x, y)), tags.key, tags.value))) AS snuba_all_tags), 1) AS tags_key)"
     )
 
 
@@ -518,10 +518,10 @@ def test_aliasing() -> None:
     )
 
     assert sql == (
-        "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> tuple(x, y)), "
+        "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), "
         "tags.key, tags.value)) AS snuba_all_tags), 2) AS _snuba_tags_value) "
         f"FROM {transactions_table_name} "
-        "WHERE in((tupleElement(snuba_all_tags, 1) AS _snuba_tags_key), tuple('t1', 't2')) "
+        "WHERE in((tupleElement(snuba_all_tags, 1) AS _snuba_tags_key), ('t1', 't2')) "
         "AND equals((project_id AS _snuba_project_id), 1) "
         "AND greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime('2021-01-01T00:00:00', 'Universal')) "
         "AND less(_snuba_finish_ts, toDateTime('2021-01-02T00:00:00', 'Universal')) "

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -30,7 +30,7 @@ tests = [
                 None, "tuple", (Literal(None, "a" * 16), Literal(None, "b" * 16))
             ),
         ),
-        "in(column1, tuple(12297829382473034410, 13527612320720337851))",
+        "in(column1, (12297829382473034410, 13527612320720337851))",
         id="in_operator",
     ),
     pytest.param(

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -91,8 +91,8 @@ tests = [
                 ),
             ),
         ),
-        "in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
-        id="in(column1, tuple('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
+        "in(column1, ('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
+        id="in(column1, ('a7d67cf7-9677-4551-a95b-e6543cacd459', 'a7d67cf7-9677-4551-a95b-e6543cacd45a'))",
     ),
     pytest.param(
         binary_condition(

--- a/tests/query/snql/test_snql_anonymizer.py
+++ b/tests/query/snql/test_snql_anonymizer.py
@@ -68,7 +68,7 @@ test_cases = [
         (
             "MATCH Entity(events) "
             "SELECT a, `b[c]` "
-            "WHERE in(project_id, tuple(-1337, -1337)) "
+            "WHERE in(project_id, (-1337, -1337)) "
             "AND greaterOrEquals(timestamp, toDateTime('$S')) "
             "AND less(timestamp, toDateTime('$S')) "
             "LIMIT 1000 OFFSET 0"
@@ -83,7 +83,7 @@ test_cases = [
             "MATCH Entity(events) "
             "SELECT (minus(-1337, -1337) AS `4-5`), (multiply(-1337, (foo(c) AS foo)) AS `3*foo(c) AS foo`), c "
             "WHERE equals((equals(arrayExists(a, '$S', '$S'), -1337) "
-            "OR equals(arrayAll(b, '$S', tuple('$S', '$S')), -1337)), -1337) "
+            "OR equals(arrayAll(b, '$S', ('$S', '$S')), -1337)), -1337) "
             "AND equals(project_id, -1337) "
             "AND greaterOrEquals(timestamp, toDateTime('$S')) "
             "AND less(timestamp, toDateTime('$S')) "

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -808,7 +808,7 @@ class TestApi(SimpleAPITest):
             ).data
         )
         assert (
-            "PREWHERE notEquals(positionCaseInsensitive((message AS _snuba_message), 'abc'), 0) AND in((project_id AS _snuba_project_id), tuple(1))"
+            "PREWHERE notEquals(positionCaseInsensitive((message AS _snuba_message), 'abc'), 0) AND in((project_id AS _snuba_project_id), (1))"
             in result["sql"]
         )
 
@@ -833,12 +833,8 @@ class TestApi(SimpleAPITest):
         )
 
         # make sure the conditions is in PREWHERE and nowhere else
-        assert (
-            "PREWHERE in((project_id AS _snuba_project_id), tuple(1))" in result["sql"]
-        )
-        assert (
-            result["sql"].count("in((project_id AS _snuba_project_id), tuple(1))") == 1
-        )
+        assert "PREWHERE in((project_id AS _snuba_project_id), (1))" in result["sql"]
+        assert result["sql"].count("in((project_id AS _snuba_project_id), (1))") == 1
 
     def test_aggregate(self) -> None:
         result = json.loads(
@@ -1322,7 +1318,7 @@ class TestApi(SimpleAPITest):
             ).data
         )
         formatted = sorted([f"'{t}'" for t in tags])
-        tag_phrase = f"in(tupleElement(pair, 1), tuple({', '.join(formatted)})"
+        tag_phrase = f"in(tupleElement(pair, 1), ({', '.join(formatted)})"
         assert tag_phrase in result["sql"]
 
     def test_unicode_condition(self) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -808,7 +808,7 @@ class TestApi(SimpleAPITest):
             ).data
         )
         assert (
-            "PREWHERE notEquals(positionCaseInsensitive((message AS _snuba_message), 'abc'), 0) AND in((project_id AS _snuba_project_id), (1))"
+            "PREWHERE notEquals(positionCaseInsensitive((message AS _snuba_message), 'abc'), 0) AND in((project_id AS _snuba_project_id), tuple(1))"
             in result["sql"]
         )
 
@@ -833,8 +833,12 @@ class TestApi(SimpleAPITest):
         )
 
         # make sure the conditions is in PREWHERE and nowhere else
-        assert "PREWHERE in((project_id AS _snuba_project_id), (1))" in result["sql"]
-        assert result["sql"].count("in((project_id AS _snuba_project_id), (1))") == 1
+        assert (
+            "PREWHERE in((project_id AS _snuba_project_id), tuple(1))" in result["sql"]
+        )
+        assert (
+            result["sql"].count("in((project_id AS _snuba_project_id), tuple(1))") == 1
+        )
 
     def test_aggregate(self) -> None:
         result = json.loads(


### PR DESCRIPTION
After drilling down enough, it seems like this is actually the cause of the bugs. I thought I tried it a week ago when @evanh told me to but I guess I didn't try it correctly. Either way this should actually fix the problems. It looks like we already had to implement a similar fix for arrays so this should be no different.