### PR TITLE
fix(subscriptions): Only flush the querylog producer when we are done producing

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -159,10 +159,6 @@ def subscriptions_executor(
         logger.setLevel(logging.DEBUG)
 
         processor.signal_shutdown()
-        logger.debug("Flushing querylog producer")
-        # Ensure the querylog producer is flushed
-        state.flush_producer()
-        logger.debug("Flushed querylog producer")
 
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -495,3 +495,8 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             logger.debug("Flushing executor producer")
             messages = producer.flush(*[remaining] if remaining is not None else [])
             logger.debug(f"{messages} executor messages pending delivery")
+
+        # Flush querylog producer
+        logger.debug("Flushing querylog producer")
+        state.flush_producer()
+        logger.debug("Flushed querylog producer")


### PR DESCRIPTION
Currently we are flushing the querylog producer before shutting the strategy,
however closing the strategy can result in some final query executions which
will produce more messages to the querylog. This changes moves it later
when we are finished producing to the querylog.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
