### PR TITLE
fix(api): Clickhouse Memory Limit Exceeded is a 400, not internal error

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -260,9 +260,6 @@ class ClickhousePool(object):
                         time.sleep(sleep_interval_seconds)
                         continue
 
-                    if e.code == errors.ErrorCodes.MEMORY_LIMIT_EXCEEDED:
-                        pass
-
                     raise ClickhouseError(e.message, code=e.code) from e
         finally:
             # Return finished connection to the appropriate connection pool

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -260,6 +260,9 @@ class ClickhousePool(object):
                         time.sleep(sleep_interval_seconds)
                         continue
 
+                    if e.code == errors.ErrorCodes.MEMORY_LIMIT_EXCEEDED:
+                        pass
+
                     raise ClickhouseError(e.message, code=e.code) from e
         finally:
             # Return finished connection to the appropriate connection pool

--- a/snuba/web/constants.py
+++ b/snuba/web/constants.py
@@ -1,0 +1,36 @@
+from snuba.clickhouse.errors import ClickhouseError
+
+### HTTP Status Codes ###
+INTERNAL_SERVER_ERROR = 500
+BAD_REQUEST = 400
+
+### ClickHouse Error Codes ###
+# https://github.com/ClickHouse/ClickHouse/blob/1c0b731ea6b86ce3bf7f88bd3ec27df7b218454d/src/Common/ErrorCodes.cpp
+ILLEGAL_TYPE_OF_ARGUMENT = 43
+TYPE_MISMATCH = 53
+
+# queries that can never return the amount of data requested by the user are not an internal error
+MEMORY_LIMIT_EXCEEDED = 241
+
+# Since the query validator doesn't have a typing system, queries containing type errors are run on
+# Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem
+# lies with the query, not Snuba.
+CLICKHOUSE_TYPING_ERROR_CODES = {
+    ILLEGAL_TYPE_OF_ARGUMENT,
+    TYPE_MISMATCH,
+}
+
+ACCEPTABLE_CLICKHOUSE_ERROR_CODES = {
+    *CLICKHOUSE_TYPING_ERROR_CODES,
+    MEMORY_LIMIT_EXCEEDED,
+}
+
+
+def get_http_status_for_clickhouse_error(cause: ClickhouseError) -> int:
+    """
+    ClickHouse Errors are generally internal errors, but sometimes they
+    are caused by bad Snuba requests.
+    """
+    if cause.code in ACCEPTABLE_CLICKHOUSE_ERROR_CODES:
+        return BAD_REQUEST
+    return INTERNAL_SERVER_ERROR

--- a/snuba/web/constants.py
+++ b/snuba/web/constants.py
@@ -1,3 +1,5 @@
+from clickhouse_driver.errors import ErrorCodes
+
 from snuba.clickhouse.errors import ClickhouseError
 
 ### HTTP Status Codes ###
@@ -5,24 +7,19 @@ INTERNAL_SERVER_ERROR = 500
 BAD_REQUEST = 400
 
 ### ClickHouse Error Codes ###
-# https://github.com/ClickHouse/ClickHouse/blob/1c0b731ea6b86ce3bf7f88bd3ec27df7b218454d/src/Common/ErrorCodes.cpp
-ILLEGAL_TYPE_OF_ARGUMENT = 43
-TYPE_MISMATCH = 53
-
-# queries that can never return the amount of data requested by the user are not an internal error
-MEMORY_LIMIT_EXCEEDED = 241
 
 # Since the query validator doesn't have a typing system, queries containing type errors are run on
 # Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem
 # lies with the query, not Snuba.
 CLICKHOUSE_TYPING_ERROR_CODES = {
-    ILLEGAL_TYPE_OF_ARGUMENT,
-    TYPE_MISMATCH,
+    ErrorCodes.ILLEGAL_TYPE_OF_ARGUMENT,
+    ErrorCodes.TYPE_MISMATCH,
 }
 
 ACCEPTABLE_CLICKHOUSE_ERROR_CODES = {
     *CLICKHOUSE_TYPING_ERROR_CODES,
-    MEMORY_LIMIT_EXCEEDED,
+    # queries that can never return the amount of data requested by the user are not an internal error
+    ErrorCodes.MEMORY_LIMIT_EXCEEDED,
 }
 
 

--- a/snuba/web/constants.py
+++ b/snuba/web/constants.py
@@ -1,12 +1,8 @@
+from http.client import BAD_REQUEST, INTERNAL_SERVER_ERROR
+
 from clickhouse_driver.errors import ErrorCodes
 
 from snuba.clickhouse.errors import ClickhouseError
-
-### HTTP Status Codes ###
-INTERNAL_SERVER_ERROR = 500
-BAD_REQUEST = 400
-
-### ClickHouse Error Codes ###
 
 # Since the query validator doesn't have a typing system, queries containing type errors are run on
 # Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -431,9 +431,21 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
 # https://github.com/ClickHouse/ClickHouse/blob/1c0b731ea6b86ce3bf7f88bd3ec27df7b218454d/src/Common/ErrorCodes.cpp
 ILLEGAL_TYPE_OF_ARGUMENT = 43
 TYPE_MISMATCH = 53
+
+# queries that can never return the amount of data requested by the user are not an internal error
+MEMORY_LIMIT_EXCEEDED = 241
+
+# Since the query validator doesn't have a typing system, queries containing type errors are run on
+# Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem
+# lies with the query, not Snuba.
 CLICKHOUSE_TYPING_ERROR_CODES = {
     ILLEGAL_TYPE_OF_ARGUMENT,
     TYPE_MISMATCH,
+}
+
+ACCEPTABLE_CLICKHOUSE_ERROR_CODES = {
+    *CLICKHOUSE_TYPING_ERROR_CODES,
+    MEMORY_LIMIT_EXCEEDED,
 }
 
 
@@ -481,12 +493,8 @@ def dataset_query(
                 exc_info=True,
             )
         elif isinstance(cause, ClickhouseError):
-            # Since the query validator doesn't have a typing system, queries containing type errors are run on
-            # Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem
-            # lies with the query, not Snuba.
-            if cause.code in CLICKHOUSE_TYPING_ERROR_CODES:
+            if cause.code in ACCEPTABLE_CLICKHOUSE_ERROR_CODES:
                 status = 400
-
             details = {
                 "type": "clickhouse",
                 "message": str(cause),

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -65,6 +65,7 @@ from snuba.util import with_span
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.web import QueryException, QueryTooLongException
+from snuba.web.constants import get_http_status_for_clickhouse_error
 from snuba.web.converters import DatasetConverter, EntityConverter
 from snuba.web.query import parse_and_run_query
 from snuba.writer import BatchWriterEncoderWrapper, WriterTableRow
@@ -427,28 +428,6 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
         assert False, "unexpected fallthrough"
 
 
-# These codes are from:
-# https://github.com/ClickHouse/ClickHouse/blob/1c0b731ea6b86ce3bf7f88bd3ec27df7b218454d/src/Common/ErrorCodes.cpp
-ILLEGAL_TYPE_OF_ARGUMENT = 43
-TYPE_MISMATCH = 53
-
-# queries that can never return the amount of data requested by the user are not an internal error
-MEMORY_LIMIT_EXCEEDED = 241
-
-# Since the query validator doesn't have a typing system, queries containing type errors are run on
-# Clickhouse and generate ClickhouseErrors. Return a 400 status code for such requests because the problem
-# lies with the query, not Snuba.
-CLICKHOUSE_TYPING_ERROR_CODES = {
-    ILLEGAL_TYPE_OF_ARGUMENT,
-    TYPE_MISMATCH,
-}
-
-ACCEPTABLE_CLICKHOUSE_ERROR_CODES = {
-    *CLICKHOUSE_TYPING_ERROR_CODES,
-    MEMORY_LIMIT_EXCEEDED,
-}
-
-
 @with_span()
 def dataset_query(
     dataset: Dataset, body: MutableMapping[str, Any], timer: Timer
@@ -493,8 +472,7 @@ def dataset_query(
                 exc_info=True,
             )
         elif isinstance(cause, ClickhouseError):
-            if cause.code in ACCEPTABLE_CLICKHOUSE_ERROR_CODES:
-                status = 400
+            status = get_http_status_for_clickhouse_error(cause)
             details = {
                 "type": "clickhouse",
                 "message": str(cause),


### PR DESCRIPTION
### Overview
- Return 400 for queries that can never return the amount of data requested by the user, this is not an internal error
- See [SNS-1333](https://getsentry.atlassian.net/browse/SNS-1333)

### Changes
- Added `MEMORY_LIMIT_EXCEEDED` to "Acceptable" Clickhouse errors