### PR TITLE
ref(subscriptions): Log commit log msg decode errors

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -127,6 +127,7 @@ class CommitLogTickConsumer(Consumer[Tick]):
         except Exception:
             logger.error(
                 f"Error decoding commit log message for followed group: {self.__followed_consumer_group}.",
+                extra={"payload": str(message.payload), "offset": message.offset},
                 exc_info=True,
             )
             return None

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -121,8 +121,15 @@ class CommitLogTickConsumer(Consumer[Tick]):
         if message is None:
             return None
 
-        commit = commit_codec.decode(message.payload)
-        assert commit.orig_message_ts is not None
+        try:
+            commit = commit_codec.decode(message.payload)
+            assert commit.orig_message_ts is not None
+        except Exception:
+            logger.error(
+                f"Error decoding commit log message for followed group: {self.__followed_consumer_group}.",
+                exc_info=True,
+            )
+            return None
 
         if commit.group != self.__followed_consumer_group:
             return None


### PR DESCRIPTION
**context:**
This should really not ever happen, BUT if for some reason we get a bad message from the commit log topic, the scheduler consumer will just crash. If this happens very frequently the consumer crashing might be okay since it would indicate something upstream is very wrong. However if it's only one (or even a couple messages) we may not want to disrupt the entire subscription processing pipeline

Instead, if we have a problem decoding the kafka payload, let's log the error and drop the message. 

**what's the impact?**
The scheduler consumer creates ticks based on intervals between these `Commit` messages that come from the commit log topic. Given the example messages below (assume all the same partition):

```
message 0 @ 12:00 
message 1 @ 12:01 
message 2 @ 12:02
```

Normally we would create a tick for `12:00-12:01` and then a tick for `12:01-12:02`. If message 1 was a bad message and we dropped it, we would instead have just one tick for `12:00-12:02`. 