### PR TITLE
fix(dlq): Backup logging overwrote message

### DIFF
--- a/snuba/datasets/metrics_bucket_processor.py
+++ b/snuba/datasets/metrics_bucket_processor.py
@@ -214,5 +214,5 @@ def _raise_invalid_message(message: Mapping[str, Any], reason: str) -> None:
         logger.error(
             "Ignored an invalid message on Metrics! (Did not go to DLQ)",
             exc_info=True,
-            extra={"message": message, "reason": reason},
+            extra={"original_message": message, "reason": reason},
         )


### PR DESCRIPTION
### Overview
- Logging with `message` as a key in the extra fields raises an error as `message` is a keyword already used by the logger

### Testing
- Tested with DLQ and with this logger to ensure both ways work