### PR TITLE
fix(dlq): Revert Produce policy to Ignore on Metrics

### DIFF
--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -1,10 +1,8 @@
 from typing import Sequence
 
-from arroyo import Topic as KafkaTopic
-from arroyo.backends.kafka import KafkaProducer
 from arroyo.processing.strategies.dead_letter_queue import (
     DeadLetterQueuePolicy,
-    ProduceInvalidMessagePolicy,
+    IgnoreInvalidMessagePolicy,
 )
 
 from snuba.clickhouse.columns import (
@@ -35,7 +33,6 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
 )
 from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.subscriptions.utils import SchedulingWatermarkMode
-from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.topics import Topic
 
 PRE_VALUE_COLUMNS: Sequence[Column[SchemaModifiers]] = [
@@ -54,14 +51,11 @@ POST_VALUE_COLUMNS: Sequence[Column[SchemaModifiers]] = [
 ]
 
 
-def produce_policy_closure() -> DeadLetterQueuePolicy:
+def ignore_policy_closure() -> DeadLetterQueuePolicy:
     """
-    Produce all bad messages to dead-letter topic.
+    Ignore all bad messages.
     """
-    return ProduceInvalidMessagePolicy(
-        KafkaProducer(build_kafka_producer_configuration(Topic.DEAD_LETTER_METRICS)),
-        KafkaTopic(Topic.DEAD_LETTER_METRICS.value),
-    )
+    return IgnoreInvalidMessagePolicy()
 
 
 polymorphic_bucket = WritableTableStorage(
@@ -90,7 +84,7 @@ polymorphic_bucket = WritableTableStorage(
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
         subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_METRICS,
         subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_METRICS,
-        dead_letter_queue_policy_closure=produce_policy_closure,
+        dead_letter_queue_policy_closure=ignore_policy_closure,
     ),
 )
 
@@ -124,7 +118,7 @@ sets_storage = WritableTableStorage(
     stream_loader=build_kafka_stream_loader_from_settings(
         SetsAggregateProcessor(),
         default_topic=Topic.METRICS,
-        dead_letter_queue_policy_closure=produce_policy_closure,
+        dead_letter_queue_policy_closure=ignore_policy_closure,
     ),
     write_format=WriteFormat.VALUES,
 )
@@ -147,7 +141,7 @@ counters_storage = WritableTableStorage(
     stream_loader=build_kafka_stream_loader_from_settings(
         CounterAggregateProcessor(),
         default_topic=Topic.METRICS,
-        dead_letter_queue_policy_closure=produce_policy_closure,
+        dead_letter_queue_policy_closure=ignore_policy_closure,
     ),
     write_format=WriteFormat.VALUES,
 )
@@ -201,7 +195,7 @@ distributions_storage = WritableTableStorage(
     stream_loader=build_kafka_stream_loader_from_settings(
         DistributionsAggregateProcessor(),
         default_topic=Topic.METRICS,
-        dead_letter_queue_policy_closure=produce_policy_closure,
+        dead_letter_queue_policy_closure=ignore_policy_closure,
     ),
     write_format=WriteFormat.VALUES,
 )


### PR DESCRIPTION
### Overview
- There is a bug in produce policy - we never close the producer
- Reverting to Ignore policy while we figure out how to approach closing/rebalancing producer when metrics consumer is closed/rebalanced