### PR TITLE
(chore): Update pytest and attrs deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 atomicwrites==1.1.5
-attrs==19.2.0
 blinker==1.4
 black==22.3.0
 certifi==2018.4.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 atomicwrites==1.1.5
-attrs==18.1.0
+attrs==19.2.0
 blinker==1.4
 black==22.3.0
 certifi==2018.4.16
@@ -31,7 +31,7 @@ packaging==17.1
 parsimonious==0.8.1
 py==1.10.0
 pyparsing==2.2.0
-pytest==6.1.2
+pytest==6.2.0
 pytest-cov==2.10.1
 pytest-watch==4.2.0
 pathtools==0.1.2


### PR DESCRIPTION
This isn't a huge deal but I wanted to be able to type the `caplog` used in some tests, but that is only available starting in [pytest version `6.2.0`](https://github.com/pytest-dev/pytest/releases/tag/6.2.0) where they add `_pytest.logging.LogCaptureFixture`. 

Additionally, when trying to upgrade `pytest` I ran into:

```
The conflict is caused by:
    snuba 22.6.0.dev0 depends on attrs==18.1.0
    jsonschema 3.0.1 depends on attrs>=17.4.0
    pytest 6.2.0 depends on attrs>=19.2.0
```

so I'm also upgrading `attrs` to `19.2.0`. From the [release notes](https://github.com/python-attrs/attrs/releases?page=1) it doesn't seem like there is a whole lot of difference between `18.1.0` and `19.2.0`. 

The only breaking change for moving to `pytest==6.2.0` is that they only support python 3.6+ (and we are using 3.8.13) 

