### PR TITLE
fix(tiger errors): Use v2 query processors

### DIFF
--- a/snuba/datasets/storages/errors_v2_ro.py
+++ b/snuba/datasets/storages/errors_v2_ro.py
@@ -5,13 +5,9 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.errors_common import (
     all_columns,
     mandatory_conditions,
-    query_processors,
     query_splitters,
 )
-from snuba.query.processors.tuple_elementer import TupleElementer
-from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
-
-v2_query_processors = [*query_processors, TupleUnaliaser(), TupleElementer()]
+from snuba.datasets.storages.errors_v2 import query_processors
 
 schema = TableSchema(
     columns=all_columns,
@@ -25,6 +21,6 @@ storage = ReadableTableStorage(
     storage_key=StorageKey.ERRORS_V2_RO,
     storage_set_key=StorageSetKey.ERRORS_V2_RO,
     schema=schema,
-    query_processors=v2_query_processors,
+    query_processors=query_processors,
     query_splitters=query_splitters,
 )


### PR DESCRIPTION
Fix a bug in the tiger errors ro storages to use the query processors
defined by the v2 entity.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
