### PR TITLE
Revert "ref: factor out gosu and use USER instead"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,21 @@ RUN set -ex; \
     ; \
     rm -rf /var/lib/apt/lists/*
 
+ENV GOSU_VERSION=1.12 \
+    GOSU_SHA256=0f25a21cf64e58078057adc78f38705163c1d564a959ff30a891c31917011a54
+
+RUN set -x \
+    && buildDeps=" \
+      wget \
+    " \
+    && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
+    && rm -rf /var/lib/apt/lists/* \
+    # grab gosu for easy step-down from root
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+    && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
+    && chmod +x /usr/local/bin/gosu \
+    && apt-get purge -y --auto-remove $buildDeps
+
 WORKDIR /usr/src/snuba
 
 ENV PIP_NO_CACHE_DIR=off \
@@ -66,13 +81,10 @@ ENV SNUBA_RELEASE=$SOURCE_COMMIT \
     UWSGI_STATS_PUSH=dogstatsd:127.0.0.1:8126 \
     UWSGI_DOGSTATSD_EXTRA_TAGS=service:snuba
 
-USER snuba
 EXPOSE 1218
 ENTRYPOINT [ "./docker_entrypoint.sh" ]
 CMD [ "api" ]
 
 FROM application AS testing
 
-USER 0
 RUN pip install -r requirements-test.txt
-USER snuba

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -29,8 +29,6 @@ services:
       REDIS_DB: 0
       DEFAULT_BROKERS: 'kafka:9092'
     entrypoint: python
-    # override the `snuba` user to write to the /.artifacts mount
-    user: root
   zookeeper:
     image: 'confluentinc/cp-zookeeper:5.1.2'
     environment:

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -12,6 +12,7 @@ help_return=$?
 
 if [[ "${help_return}" -eq 0 ]]; then
   set -- snuba "$@"
+  set gosu snuba "$@"
 else
   # Print the error message if it returns non-zero, to help with troubleshooting.
   printf "Error running snuba ${1} --help, passing command to exec directly."


### PR DESCRIPTION
Reverts getsentry/snuba#2696

This breaks the production deployment as some of the scripts rely on gosu to be present in the docker container