### PR TITLE
fix(rate_limit): Allow passing a suffix to table rate limit

### DIFF
--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -88,7 +88,7 @@ query_processors = [
         # merged together by the final.
         omit_if_final=["environment", "release", "group_id"],
     ),
-    TableRateLimit(),
+    TableRateLimit(suffix="errors_tiger"),
 ]
 
 schema = WritableTableSchema(

--- a/snuba/query/processors/table_rate_limit.py
+++ b/snuba/query/processors/table_rate_limit.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.request.request_settings import RequestSettings
@@ -11,12 +13,15 @@ class TableRateLimit(QueryProcessor):
     TODO: Do this at Cluster level instead.
     """
 
+    def __init__(self, suffix: Optional[str] = None) -> None:
+        self.__suffix = "_".join(["", suffix]) if suffix else ""
+
     def process_query(self, query: Query, request_settings: RequestSettings) -> None:
         table_name = query.get_from_clause().table_name
         (per_second, concurr) = get_configs(
             [
-                (f"table_per_second_limit_{table_name}", 1000),
-                (f"table_concurrent_limit_{table_name}", 1000),
+                (f"table_per_second_limit_{table_name}{self.__suffix}", 1000),
+                (f"table_concurrent_limit_{table_name}{self.__suffix}", 1000),
             ]
         )
 

--- a/tests/query/processors/test_table_rate_limit.py
+++ b/tests/query/processors/test_table_rate_limit.py
@@ -1,6 +1,7 @@
 import pytest
 
 from snuba.clickhouse.columns import ColumnSet
+from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.data_source.simple import Table
 from snuba.query.processors.table_rate_limit import TableRateLimit
@@ -10,6 +11,7 @@ from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitParameters
 
 test_data = [
     pytest.param(
+        TableRateLimit(),
         Query(
             Table("errors_local", ColumnSet([])), selected_columns=[], condition=None
         ),
@@ -23,6 +25,7 @@ test_data = [
         id="Set rate limiter on another table",
     ),
     pytest.param(
+        TableRateLimit(),
         Query(
             Table("errors_local", ColumnSet([])), selected_columns=[], condition=None
         ),
@@ -33,17 +36,34 @@ test_data = [
             per_second_limit=1000,
             concurrent_limit=50,
         ),
-        id="Set rate limiter on another table",
+        id="Set rate limiter on existing table",
+    ),
+    pytest.param(
+        TableRateLimit(suffix="errors_tiger"),
+        Query(
+            Table("errors_local", ColumnSet([])), selected_columns=[], condition=None
+        ),
+        "table_concurrent_limit_errors_local_errors_tiger",
+        RateLimitParameters(
+            rate_limit_name=TABLE_RATE_LIMIT_NAME,
+            bucket="errors_local",
+            per_second_limit=1000,
+            concurrent_limit=50,
+        ),
+        id="Set rate limiter on table with suffix",
     ),
 ]
 
 
-@pytest.mark.parametrize("query, limit_to_set, params", test_data)
+@pytest.mark.parametrize("processor, query, limit_to_set, params", test_data)
 def test_table_rate_limit(
-    query: Query, limit_to_set: str, params: RateLimitParameters
+    processor: QueryProcessor,
+    query: Query,
+    limit_to_set: str,
+    params: RateLimitParameters,
 ) -> None:
     set_config(limit_to_set, 50)
     request_settings = HTTPRequestSettings(consistent=True)
-    TableRateLimit().process_query(query, request_settings)
+    processor.process_query(query, request_settings)
     rate_limiters = request_settings.get_rate_limit_params()
     assert params in rate_limiters


### PR DESCRIPTION
In order to allow having separate configurations for table rate limiters
that work on the same table but are residing in different clusters,
allow passing a suffix to the TableRateLimiter. The errors tiger
query processors will use a TableRateLimiter with a suffix.
