### PR TITLE
ref: set an explicit uid/gid for the snuba user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,8 @@ RUN set -ex; \
 # so try not to do anything heavy beyond here.
 COPY . ./
 RUN set -ex; \
-    groupadd -r snuba; \
-    useradd -r -g snuba snuba; \
+    groupadd -r snuba --gid 1000; \
+    useradd -r -g snuba --uid 1000 snuba; \
     chown -R snuba:snuba ./; \
     pip install -e .; \
     snuba --help;


### PR DESCRIPTION
this will be used in conjunction with `runAsUser` / `runAsGroup` in the k8s metadata so `gosu` can be factored out (originally attempted in https://github.com/getsentry/snuba/pull/2696 but that had to be rolled back)


