### PR TITLE
build: Update sentry-relay to 0.8.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ python-rapidjson==1.4
 redis==2.10.6
 redis-py-cluster==1.3.5
 sentry-arroyo==0.0.19
-sentry-relay==0.8.11
+sentry-relay==0.8.12
 sentry-sdk==1.5.10
 simplejson==3.15.0
 urllib3==1.26.5


### PR DESCRIPTION

Update `sentry-relay` dependency to ver. 0.8.12