### PR TITLE
fix(rate limiter) Increase the default table per second rate limiter

### DIFF
--- a/snuba/query/processors/table_rate_limit.py
+++ b/snuba/query/processors/table_rate_limit.py
@@ -20,7 +20,7 @@ class TableRateLimit(QueryProcessor):
         table_name = query.get_from_clause().table_name
         (per_second, concurr) = get_configs(
             [
-                (f"table_per_second_limit_{table_name}{self.__suffix}", 1000),
+                (f"table_per_second_limit_{table_name}{self.__suffix}", 5000),
                 (f"table_concurrent_limit_{table_name}{self.__suffix}", 1000),
             ]
         )

--- a/tests/query/processors/test_table_rate_limit.py
+++ b/tests/query/processors/test_table_rate_limit.py
@@ -19,7 +19,7 @@ test_data = [
         RateLimitParameters(
             rate_limit_name=TABLE_RATE_LIMIT_NAME,
             bucket="errors_local",
-            per_second_limit=1000,
+            per_second_limit=5000,
             concurrent_limit=1000,
         ),
         id="Set rate limiter on another table",
@@ -33,7 +33,7 @@ test_data = [
         RateLimitParameters(
             rate_limit_name=TABLE_RATE_LIMIT_NAME,
             bucket="errors_local",
-            per_second_limit=1000,
+            per_second_limit=5000,
             concurrent_limit=50,
         ),
         id="Set rate limiter on existing table",
@@ -47,7 +47,7 @@ test_data = [
         RateLimitParameters(
             rate_limit_name=TABLE_RATE_LIMIT_NAME,
             bucket="errors_local",
-            per_second_limit=1000,
+            per_second_limit=5000,
             concurrent_limit=50,
         ),
         id="Set rate limiter on table with suffix",


### PR DESCRIPTION
The table rate limiter was designed with the idea of being a concurrent rate limiter in mind primarily. The per second rate limiter is only meaningful for specific projects/features. At a global level it is generally not very useful.

We are now hitting the default per second rate limiter at times on large clusters, which is kind of expected considering it was set only to 1000. 
This increases the default value so that we have more headroom. We could even remove the per second global rate limiter altogether but that requires a rate limiter refactoring