### PR TITLE
feat(subscriptions): Make --override-result-topic optional in executor

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -73,7 +73,6 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 @click.option(
     "--override-result-topic",
     type=str,
-    required=True,
     help="Override the result topic for testing",
 )
 # TODO: For testing alternate rebalancing strategies. To be eventually removed.
@@ -93,7 +92,7 @@ def subscriptions_executor(
     no_strict_offset_reset: bool,
     log_level: Optional[str],
     stale_threshold_seconds: Optional[int],
-    override_result_topic: str,
+    override_result_topic: Optional[str],
     cooperative_rebalancing: bool,
 ) -> None:
     """
@@ -119,7 +118,7 @@ def subscriptions_executor(
     storage = get_entity(entity_key).get_writable_storage()
     assert storage is not None
     stream_loader = storage.get_table_writer().get_stream_loader()
-    result_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
+    result_topic_spec = stream_loader.get_subscription_result_topic_spec()
     assert result_topic_spec is not None
 
     producer = KafkaProducer(

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -58,7 +58,7 @@ def build_executor_consumer(
     executor: ThreadPoolExecutor,
     stale_threshold_seconds: Optional[int],
     # TODO: Should be removed once testing is done
-    override_result_topic: str,
+    override_result_topic: Optional[str],
     cooperative_rebalancing: bool = False,
 ) -> StreamProcessor[KafkaPayload]:
     # Validate that a valid dataset/entity pair was passed in
@@ -132,6 +132,9 @@ def build_executor_consumer(
     if cooperative_rebalancing is True:
         consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
+    result_topic = override_result_topic or result_topic_spec.topic_name
+    assert result_topic is not None
+
     return StreamProcessor(
         KafkaConsumer(consumer_configuration),
         Topic(scheduled_topic_spec.topic_name),
@@ -143,7 +146,7 @@ def build_executor_consumer(
             producer,
             metrics,
             stale_threshold_seconds,
-            override_result_topic,
+            result_topic,
         ),
     )
 


### PR DESCRIPTION
This was being used during testing to ensure the executor wasn't producing
results to the real result topic. Now we are going to use the real topic from the
stream loader.

This is the first step towards removing it completely. Once we are no
longer passing this anywhere, it will be removed completely.