### PR TITLE
fix(rate-limits): Create copy of request settings

### DIFF
--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Optional, Sequence
 
 from snuba.request.request_settings import RequestSettings
@@ -25,7 +26,7 @@ class RateLimiterDelegate(RequestSettings):
 
     def __init__(self, prefix: str, delegate: RequestSettings):
         self.referrer = delegate.referrer
-        self.__delegate = delegate
+        self.__delegate = copy.deepcopy(delegate)
         self.__prefix = prefix
 
     def __append_prefix(self, rate_limiter: RateLimitParameters) -> RateLimitParameters:

--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -22,6 +22,12 @@ class RateLimiterDelegate(RequestSettings):
     Specifically the PipelineDelegator provides a RateLimiterDelegate to
     to each query pipeline so that the pipeline can use a separate
     rate limiter namespace without knowing about it.
+
+    A deepcopy of `delegate` is made to allow multiple concurrent execution
+    pipelines to not interfere with each other. The rate limit parameters
+    are stored in a list in the RequestSettings object. When the add_rate_limit
+    method is called from 2 concurrent execution pipelines they would add
+    the rate limits to the same list if a deepcopy is not created.
     """
 
     def __init__(self, prefix: str, delegate: RequestSettings):


### PR DESCRIPTION
The current implementation of RateLimiterDelegate uses the same
RequestSettings passed to it in the constructor. That causes a bug
since the original rate_limit_params of HTTPRequestSettings are stored
in a list. The same list gets used by both the threads processing the
query since add_rate_limit_params from both execution pipelines
adds the rate limit to the same list.

The end result of this is that instead of processing 3 sets of rate
limits (project, table, global), secondary queries are actually getting 6
sets of rate limits (all of the above multiplied by 2). This leads
to overcounting since a query run in a single execution pipeline
gets counted in both execution pipelines.

To fix this we use a deep copy of the RequestSettings.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
