### PR TITLE
feat(subscriptions): Remove support for sessions subscriptions

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -177,28 +177,6 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 ),
             ]
 
-    if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
-        daemons += [
-            (
-                "subscriptions-consumer-sessions",
-                [
-                    "snuba",
-                    "subscriptions",
-                    "--auto-offset-reset=latest",
-                    "--no-strict-offset-reset",
-                    "--log-level=debug",
-                    "--max-batch-size=1",
-                    "--consumer-group=snuba-sessions-subscriptions-consumers",
-                    "--dataset=sessions",
-                    "--commit-log-topic=snuba-sessions-commit-log",
-                    "--commit-log-group=sessions_group",
-                    "--delay-seconds=1",
-                    "--schedule-ttl=10",
-                    "--max-query-workers=1",
-                ],
-            )
-        ]
-
     if settings.ENABLE_PROFILES_CONSUMER:
         daemons += [
             (

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from snuba import settings
 from snuba.clickhouse.columns import (
     UUID,
     AggregateFunction,
@@ -23,7 +22,6 @@ from snuba.query.processors.conditions_enforcer import OrgIdEnforcer, ProjectIdE
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.table_rate_limit import TableRateLimit
 from snuba.request.request_settings import RequestSettings
-from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
 WRITE_LOCAL_TABLE_NAME = "sessions_raw_local"
@@ -115,21 +113,9 @@ class MinuteResolutionProcessor(QueryProcessor):
             )
 
 
-# The raw table we write onto, and that potentially we could
-# query.
-if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
-    kafka_stream_loader = build_kafka_stream_loader_from_settings(
-        processor=SessionsProcessor(),
-        default_topic=Topic.SESSIONS,
-        commit_log_topic=Topic.SESSIONS_COMMIT_LOG,
-        subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_SESSIONS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_SESSIONS,
-    )
-else:
-    kafka_stream_loader = build_kafka_stream_loader_from_settings(
-        processor=SessionsProcessor(), default_topic=Topic.SESSIONS
-    )
+kafka_stream_loader = build_kafka_stream_loader_from_settings(
+    processor=SessionsProcessor(), default_topic=Topic.SESSIONS
+)
 
 raw_storage = WritableTableStorage(
     storage_key=StorageKey.SESSIONS_RAW,

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -183,7 +183,6 @@ CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
 ENABLE_SENTRY_METRICS_DEV = os.environ.get("ENABLE_SENTRY_METRICS_DEV", False)
 
 # Metric Alerts Subscription Options
-ENABLE_SESSIONS_SUBSCRIPTIONS = os.environ.get("ENABLE_SESSIONS_SUBSCRIPTIONS", False)
 ENABLE_METRICS_SUBSCRIPTIONS = os.environ.get("ENABLE_METRICS_SUBSCRIPTIONS", False)
 
 # Subscriptions scheduler buffer size

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import Mapping
 
-from snuba import settings
-
 
 # These are the default topic names, they can be changed via settings
 class Topic(Enum):
@@ -15,15 +13,12 @@ class Topic(Enum):
     METRICS = "snuba-metrics"
     OUTCOMES = "outcomes"
     SESSIONS = "ingest-sessions"
-    SESSIONS_COMMIT_LOG = "snuba-sessions-commit-log"
     METRICS_COMMIT_LOG = "snuba-metrics-commit-log"
     SUBSCRIPTION_SCHEDULED_EVENTS = "scheduled-subscriptions-events"
     SUBSCRIPTION_SCHEDULED_TRANSACTIONS = "scheduled-subscriptions-transactions"
-    SUBSCRIPTION_SCHEDULED_SESSIONS = "scheduled-subscriptions-sessions"
     SUBSCRIPTION_SCHEDULED_METRICS = "scheduled-subscriptions-metrics"
     SUBSCRIPTION_RESULTS_EVENTS = "events-subscription-results"
     SUBSCRIPTION_RESULTS_TRANSACTIONS = "transactions-subscription-results"
-    SUBSCRIPTION_RESULTS_SESSIONS = "sessions-subscription-results"
     SUBSCRIPTION_RESULTS_METRICS = "metrics-subscription-results"
     QUERYLOG = "snuba-queries"
     PROFILES = "processed-profiles"
@@ -39,6 +34,4 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
         Topic.METRICS: {"message.timestamp.type": "LogAppendTime"},
         Topic.PROFILES: {"message.timestamp.type": "LogAppendTime"},
     }
-    if settings.ENABLE_SESSIONS_SUBSCRIPTIONS:
-        config.update({Topic.SESSIONS: {"message.timestamp.type": "LogAppendTime"}})
     return config.get(topic, {})


### PR DESCRIPTION
Removes the ENABLE_SESSIONS_SUBSCRIPTIONS flag.
The sessions consumer no longer has the option of writing a commit log.