### PR TITLE
feat(subscriptions): Record information about size of each tick buffer

### DIFF
--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -215,6 +215,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
             self.__partitions,
             self.__buffer_size,
             ForwardToExecutor(self.__schedulers, execute_step),
+            self.__metrics,
         )
 
 

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -342,4 +342,5 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
             self.__partitions,
             self.__buffer_size,
             ProvideCommitStrategy(self.__partitions, schedule_step, self.__metrics),
+            self.__metrics,
         )

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -204,6 +204,7 @@ class TickBuffer(ProcessingStrategy[Tick]):
         partitions: int,
         max_ticks_buffered_per_partition: Optional[int],
         next_step: ProcessingStrategy[Tick],
+        metrics: MetricsBackend,
     ) -> None:
         if mode == SchedulingWatermarkMode.GLOBAL:
             assert max_ticks_buffered_per_partition is not None
@@ -212,12 +213,15 @@ class TickBuffer(ProcessingStrategy[Tick]):
         self.__partitions = partitions
         self.__max_ticks_buffered_per_partition = max_ticks_buffered_per_partition
         self.__next_step = next_step
+        self.__metrics = metrics
 
         self.__buffers: Mapping[int, Deque[Message[Tick]]] = {
             index: deque() for index in range(self.__partitions)
         }
 
         self.__closed = False
+        self.__record_frequency_seconds = 180  # 3 minutes
+        self.__last_recorded_time: float = 0
 
     def poll(self) -> None:
         self.__next_step.poll()
@@ -250,6 +254,17 @@ class TickBuffer(ProcessingStrategy[Tick]):
             )
             self.__next_step.submit(self.__buffers[tick_partition].popleft())
             return
+
+        # Periodically record the legnth of each buffer
+        now = time.time()
+        if now - self.__last_recorded_time > self.__record_frequency_seconds:
+            for partition_index in self.__buffers:
+                self.__metrics.gauge(
+                    "TickBuffer.queue_size",
+                    len(self.__buffers[partition_index]),
+                    tags={"partition": str(partition_index)},
+                )
+            self.__last_recorded_time = now
 
         # If there are any empty buffers, we can't submit anything yet.
         # Otherwise if all the buffers have ticks then we look for the partition/s

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -37,10 +37,12 @@ from tests.backends.metrics import TestingMetricsBackend
 
 def test_tick_buffer_immediate() -> None:
     epoch = datetime(1970, 1, 1)
-
     next_step = mock.Mock()
+    metrics = TestingMetricsBackend()
 
-    strategy = TickBuffer(SchedulingWatermarkMode.PARTITION, 2, None, next_step)
+    strategy = TickBuffer(
+        SchedulingWatermarkMode.PARTITION, 2, None, next_step, metrics
+    )
 
     topic = Topic("messages")
     partition = Partition(topic, 0)
@@ -66,16 +68,11 @@ def test_tick_buffer_immediate() -> None:
 def test_tick_buffer_wait_slowest() -> None:
     epoch = datetime(1970, 1, 1)
     now = datetime.now()
-
     next_step = mock.Mock()
+    metrics = TestingMetricsBackend()
 
     # Create strategy with 2 partitions
-    strategy = TickBuffer(
-        SchedulingWatermarkMode.GLOBAL,
-        2,
-        10,
-        next_step,
-    )
+    strategy = TickBuffer(SchedulingWatermarkMode.GLOBAL, 2, 10, next_step, metrics)
 
     topic = Topic("messages")
     commit_log_partition = Partition(topic, 0)
@@ -325,14 +322,15 @@ def test_tick_buffer_with_commit_strategy_partition() -> None:
     now = datetime.now()
 
     metrics_backend = TestingMetricsBackend()
-
     next_step = mock.Mock()
+    metrics = TestingMetricsBackend()
 
     strategy = TickBuffer(
         SchedulingWatermarkMode.PARTITION,
         2,
         10,
         ProvideCommitStrategy(2, next_step, metrics_backend),
+        metrics,
     )
 
     topic = Topic("messages")
@@ -410,7 +408,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
     now = datetime.now()
 
     metrics_backend = TestingMetricsBackend()
-
     next_step = mock.Mock()
 
     strategy = TickBuffer(
@@ -418,6 +415,7 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
         2,
         10,
         ProvideCommitStrategy(2, next_step, metrics_backend),
+        metrics_backend,
     )
 
     topic = Topic("messages")
@@ -438,7 +436,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
     strategy.submit(message_0_0)
 
     assert next_step.submit.call_count == 0
-    assert metrics_backend.calls == []
 
     # Another message in partition 0, cannot submit yet
     message_0_1 = Message(
@@ -457,7 +454,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
     strategy.submit(message_0_1)
 
     assert next_step.submit.call_count == 0
-    assert metrics_backend.calls == []
 
     # Message in partition 1, submitted to next step since it has the earliest timestamp.
     # Does not commit since we have not submitted anything on the other partition yet.


### PR DESCRIPTION
We experienced an incident where some partitions heavily lagged
behind others. There was not a lot of visibility about the
contents of the TickBuffer and how long it was waiting for ticks
to be able to be submitted to the next step. This is important for
datasets that run in "global" mode, as subscriptions on those datasets
wait for all partitions to reach a timestamp before they can be executed.