### PR TITLE
fix(subscriptions): Commit the right offset in the scheduler and executor

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -337,7 +337,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
 
             # Periodically commit offsets if we haven't started rollout yet
             self.__commit_data[message.partition] = Position(
-                message.offset, message.timestamp
+                message.next_offset, message.timestamp
             )
 
             now = time.time()
@@ -446,7 +446,7 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             self.__queue.popleft()
 
             self.__commit_data[message.partition] = Position(
-                message.offset, message.timestamp
+                message.next_offset, message.timestamp
             )
         self.__throttled_commit()
 

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -133,7 +133,9 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
 
         # Keep track of the earliest partition based on its offset in the commit log topic.
         # This is used to determine the offset that we can safely commit.
-        earliest = message.offset
+        # The offset to be committed is the `next_offset`: 1 higher than the offset of
+        # the current message
+        earliest = message.next_offset
 
         for partition_message in self.__latest_messages_by_partition.values():
             if partition_message is None:


### PR DESCRIPTION
The offset to be committed should always be the *next_offset* - the minimum
offset of the next message to be processed (which is one higher than the
offset of the last successfully processed message). Previously we
were committing the offset of the current message which is one offset behind
what it should be.