### PR TITLE
feat(subscriptions): Remove --override-result-topic

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -64,17 +64,6 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     type=int,
     help="Skip execution if timestamp is beyond this threshold compared to the system time",
 )
-# This option allows us to reroute the produced subscription results to a different
-# topic temporarily while we are testing and running the old and new subscription
-# pipeline concurrently. It is currently (temporarily) required to reduce the chance
-# of inadvertently writing to the actual result topics while we are still validating
-# results and running the old subscriptions pipeline. Eventaully we can just get it
-# from stream_loader.get_subscription_result_topic_spec()
-@click.option(
-    "--override-result-topic",
-    type=str,
-    help="Override the result topic for testing",
-)
 # TODO: For testing alternate rebalancing strategies. To be eventually removed.
 @click.option(
     "--cooperative-rebalancing",
@@ -92,7 +81,6 @@ def subscriptions_executor(
     no_strict_offset_reset: bool,
     log_level: Optional[str],
     stale_threshold_seconds: Optional[int],
-    override_result_topic: Optional[str],
     cooperative_rebalancing: bool,
 ) -> None:
     """
@@ -148,7 +136,6 @@ def subscriptions_executor(
         metrics,
         executor,
         stale_threshold_seconds,
-        override_result_topic,
         cooperative_rebalancing,
     )
 

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -57,8 +57,6 @@ def build_executor_consumer(
     metrics: MetricsBackend,
     executor: ThreadPoolExecutor,
     stale_threshold_seconds: Optional[int],
-    # TODO: Should be removed once testing is done
-    override_result_topic: Optional[str],
     cooperative_rebalancing: bool = False,
 ) -> StreamProcessor[KafkaPayload]:
     # Validate that a valid dataset/entity pair was passed in
@@ -132,9 +130,6 @@ def build_executor_consumer(
     if cooperative_rebalancing is True:
         consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
-    result_topic = override_result_topic or result_topic_spec.topic_name
-    assert result_topic is not None
-
     return StreamProcessor(
         KafkaConsumer(consumer_configuration),
         Topic(scheduled_topic_spec.topic_name),
@@ -146,7 +141,7 @@ def build_executor_consumer(
             producer,
             metrics,
             stale_threshold_seconds,
-            result_topic,
+            result_topic_spec.topic_name,
         ),
     )
 


### PR DESCRIPTION
This was only used for testing to route results to test topics.
No longer needed.

Depends on:
- https://github.com/getsentry/snuba/pull/2731
- https://github.com/getsentry/ops/pull/4741




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
