### PR TITLE
ref(subscriptions): Executor created within strategy

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -1,6 +1,5 @@
 import logging
 import signal
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, Iterator, Optional, Sequence
 
@@ -114,8 +113,6 @@ def subscriptions_executor(
         )
     )
 
-    executor = ThreadPoolExecutor(max_concurrent_queries)
-
     # TODO: Consider removing and always passing via CLI.
     # If a value provided via config, it overrides the one provided via CLI.
     # This is so we can quickly change this in an emergency.
@@ -132,7 +129,6 @@ def subscriptions_executor(
         auto_offset_reset,
         not no_strict_offset_reset,
         metrics,
-        executor,
         stale_threshold_seconds,
         cooperative_rebalancing,
     )
@@ -147,7 +143,7 @@ def subscriptions_executor(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with executor, closing(producer), flush_querylog():
+    with closing(producer), flush_querylog():
         processor.run()
 
 

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -1,5 +1,4 @@
 import signal
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, Iterator, Optional, Sequence
 
@@ -115,8 +114,6 @@ def subscriptions_scheduler_executor(
         )
     )
 
-    executor = ThreadPoolExecutor(max_concurrent_queries)
-
     processor = build_scheduler_executor_consumer(
         dataset_name,
         entity_names,
@@ -129,7 +126,6 @@ def subscriptions_scheduler_executor(
         delay_seconds,
         stale_threshold_seconds,
         max_concurrent_queries,
-        executor,
         metrics,
     )
 
@@ -139,7 +135,7 @@ def subscriptions_scheduler_executor(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with executor, closing(producer), flush_querylog():
+    with closing(producer), flush_querylog():
         processor.run()
 
 

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from datetime import timedelta
 from typing import Callable, Mapping, NamedTuple, Optional, Sequence, cast
@@ -48,7 +47,6 @@ def build_scheduler_executor_consumer(
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
     max_concurrent_queries: int,
-    executor: ThreadPoolExecutor,
     metrics: MetricsBackend,
 ) -> StreamProcessor[Tick]:
     dataset = get_dataset(dataset_name)
@@ -97,7 +95,6 @@ def build_scheduler_executor_consumer(
     factory = CombinedSchedulerExecutorFactory(
         dataset,
         entity_names,
-        executor,
         partitions,
         max_concurrent_queries,
         producer,
@@ -132,7 +129,6 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         self,
         dataset: Dataset,
         entity_names: Sequence[str],
-        executor: ThreadPoolExecutor,
         partitions: int,
         max_concurrent_queries: int,
         producer: Producer[KafkaPayload],
@@ -176,7 +172,6 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         )
 
         self.__executor_factory = SubscriptionExecutorProcessingFactory(
-            executor,
             max_concurrent_queries,
             dataset,
             entity_names,

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -1,6 +1,5 @@
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from datetime import datetime, timedelta
 from unittest import mock
@@ -48,7 +47,6 @@ def test_combined_scheduler_and_executor() -> None:
     entity_names = ["events"]
     num_partitions = 2
     max_concurrent_queries = 2
-    executor = ThreadPoolExecutor(max_concurrent_queries)
     metrics = TestingMetricsBackend()
 
     commit = mock.Mock()
@@ -67,7 +65,6 @@ def test_combined_scheduler_and_executor() -> None:
         factory = CombinedSchedulerExecutorFactory(
             dataset,
             entity_names,
-            executor,
             num_partitions,
             max_concurrent_queries,
             producer,

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -1,7 +1,6 @@
 import json
 import time
 import uuid
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from typing import Iterator, Mapping, Optional
 from unittest import mock
@@ -115,7 +114,6 @@ def test_executor_consumer() -> None:
         auto_offset_reset,
         strict_offset_reset,
         TestingMetricsBackend(),
-        ThreadPoolExecutor(2),
         None,
     )
     for i in range(1, 5):
@@ -222,7 +220,6 @@ def test_execute_query_strategy() -> None:
     dataset = get_dataset("events")
     entity_names = ["events"]
     max_concurrent_queries = 2
-    executor = ThreadPoolExecutor(max_concurrent_queries)
     metrics = TestingMetricsBackend()
     next_step = mock.Mock()
     commit = mock.Mock()
@@ -230,7 +227,6 @@ def test_execute_query_strategy() -> None:
     strategy = ExecuteQuery(
         dataset,
         entity_names,
-        executor,
         max_concurrent_queries,
         None,
         metrics,
@@ -264,14 +260,11 @@ def test_too_many_concurrent_queries() -> None:
     state.set_config("executor_queue_size_factor", 1)
     dataset = get_dataset("events")
     entity_names = ["events"]
-    executor = ThreadPoolExecutor(2)
     metrics = TestingMetricsBackend()
     next_step = mock.Mock()
     commit = mock.Mock()
 
-    strategy = ExecuteQuery(
-        dataset, entity_names, executor, 4, None, metrics, next_step, commit
-    )
+    strategy = ExecuteQuery(dataset, entity_names, 4, None, metrics, next_step, commit)
 
     make_message = generate_message(EntityKey.EVENTS)
 
@@ -292,14 +285,11 @@ def test_skip_execution_for_entity() -> None:
     # Skips execution if the entity name is not on the list
     dataset = get_dataset("metrics")
     entity_names = ["metrics_sets"]
-    executor = ThreadPoolExecutor()
     metrics = TestingMetricsBackend()
     next_step = mock.Mock()
     commit = mock.Mock()
 
-    strategy = ExecuteQuery(
-        dataset, entity_names, executor, 4, None, metrics, next_step, commit
-    )
+    strategy = ExecuteQuery(dataset, entity_names, 4, None, metrics, next_step, commit)
 
     metrics_sets_message = next(generate_message(EntityKey.METRICS_SETS))
     strategy.submit(metrics_sets_message)
@@ -390,7 +380,6 @@ def test_execute_and_produce_result() -> None:
     state.set_config("subscription_mode_events", "new")
     dataset = get_dataset("events")
     entity_names = ["events"]
-    executor = ThreadPoolExecutor()
     max_concurrent_queries = 2
     metrics = TestingMetricsBackend()
 
@@ -408,7 +397,6 @@ def test_execute_and_produce_result() -> None:
     strategy = ExecuteQuery(
         dataset,
         entity_names,
-        executor,
         max_concurrent_queries,
         None,
         metrics,
@@ -438,7 +426,6 @@ def test_execute_and_produce_result() -> None:
 def test_skip_stale_message() -> None:
     dataset = get_dataset("events")
     entity_names = ["events"]
-    executor = ThreadPoolExecutor()
     max_concurrent_queries = 2
     metrics = TestingMetricsBackend()
 
@@ -458,7 +445,6 @@ def test_skip_stale_message() -> None:
     strategy = ExecuteQuery(
         dataset,
         entity_names,
-        executor,
         max_concurrent_queries,
         stale_threshold_seconds,
         metrics,


### PR DESCRIPTION
**context**
This is kind of a reverse and then some of: https://github.com/getsentry/snuba/pull/2364 but for different reasons. Some background on this PR:

The task I'm currently working on is auto scaling our snuba consumers, starting with the executors. We have auto scaling on some of snuba services, such as the api[^1], but not everything. Additionally, certain consumers, like the executors[^2] have args passed in that depend on the no. of replicas (which will no longer will be constant if we have auto scaling implemented).

**why replica dependent args not great?**
When an autoscaler kicks in, it adds new pods. The new pods will be aware of new number of replicas, whereas the currently running "old" pods will not. This would lead to different parameters for different pods, and those parameters might not be appropriate any longer (which might also be the case if we scaled down)

**Executors**
The executors depend on `max-concurrent-queries` being passed in which is calculated from the replicas:

```yaml
- --max-concurrent-queries
- "{{ (total_concurrent_queries / metrics_subscription_executor_replicas)|int }}"
```

We don't really want to restart every single pod each time the auto scaler kicks in just to update the `max_concurrent_queries` so we'd like `max_concurrent_queries` to be calculated within the executor itself. I have two options for how to do that, one with changes solely in snuba[^3] and one that would require arroyo changes[^4].

Both options however, would require that the executor be created within the `ExecuteQuery` strategy. 

[^1]: auto scaling example snuba api https://github.com/getsentry/ops/blob/5b33fe67830a8d9e36ea0a0b49a2371d4f9f93bd/k8s/services/snuba/_deployment.api.yaml#L17-L29
[^2]: metrics executor config https://github.com/getsentry/ops/blob/5b33fe67830a8d9e36ea0a0b49a2371d4f9f93bd/k8s/services/snuba/_deployment.metrics-subscriptions-executor.yaml#L59-L60
[^3]: https://github.com/getsentry/snuba/pull/2745
[^4]: https://github.com/getsentry/snuba/pull/2761