### PR TITLE
Revert "build(deps): bump parsimonious from 0.8.1 to 0.9.0 (#2753)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ mywsgi==1.0.3
 more-itertools==4.2.0
 mypy>=0.812,<0.900
 packaging==17.1
-parsimonious==0.9.0
+parsimonious==0.8.1
 py==1.10.0
 pyparsing==2.2.0
 pytest==6.2.0


### PR DESCRIPTION
This reverts commit 20598412d0cd0d7870fddf67227602c81c4f1304.

This caused a noticable regression in query performance.