### PR TITLE
Revert "ops(profiles) - remove profiles consumer from freight (#2549)"

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -37,6 +37,8 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-executor
   - image: us.gcr.io/sentryio/snuba:{sha}
+    name: profiles-consumer
+  - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: transactions-subscriptions-scheduler


### PR DESCRIPTION
This reverts commit 6cacf5c029b5a1a2b1364e8660dd6f89af4dc42f.

We need to deploy all consumers with Freight. Currently the profiles
consumer has to be periodically updated by ops manually. It's also
very easy to break the profiles consumer when we change
settings in Snuba as they get applied here against (potentially) very
old version of our codebase. This happened 2 weeks ago and ops
had to manually intervene to update the hash.
