### PR TITLE
feat(subscriptions): Improve filtering of stale subscriptions in scheduler

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -461,7 +461,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
 
         if (
             self.__stale_threshold_seconds is not None
-            and time.time() - datetime.timestamp(tick.timestamps.upper)
+            and time.time() - datetime.timestamp(tick.timestamps.lower)
             > self.__stale_threshold_seconds
         ):
             encoded_tasks = []

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -660,8 +660,7 @@ def test_produce_scheduled_subscription_message() -> None:
 
 def test_produce_stale_message() -> None:
     stale_threshold_seconds = 60
-    now = datetime.now().replace(second=0, microsecond=0)
-    # epoch = datetime(1970, 1, 1)
+    now = datetime.now()
     metrics_backend = TestingMetricsBackend()
     partition_index = 0
     entity_key = EntityKey.EVENTS
@@ -748,7 +747,7 @@ def test_produce_stale_message() -> None:
             Tick(
                 0,
                 offsets=Interval(3, 4),
-                timestamps=Interval(now - timedelta(minutes=1), now),
+                timestamps=Interval(now - timedelta(seconds=50), now),
             ),
             True,
         ),


### PR DESCRIPTION
During a multi-hour outage, the scheduler gets into the unusual state of having
ticks spanning multiple hours, for which a very large number of subscriptions
need to be scheduled (often exceeding the buffer size of 10,000 applied later
in the pipeline). This is likely to be a cause of the scheduler getting stuck.

If --stale-threshold-seconds is passed, we should use the lower bound of the tick
instead of the upper bound for comparison so that extremely large ticks that are
not able to be properly processed get discarded.