### PR TITLE
feat(subscriptions): Record librdkafka buffer size in scheduler

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timedelta
 from typing import Callable, Mapping, MutableMapping, NamedTuple, Optional, Sequence
 
+import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer, Producer
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
@@ -16,6 +17,7 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.redis import redis_client
+from snuba.state import get_config
 from snuba.subscriptions.data import PartitionId
 from snuba.subscriptions.scheduler import SubscriptionScheduler
 from snuba.subscriptions.scheduler_processing_strategy import (
@@ -271,15 +273,37 @@ class SchedulerBuilder:
         )
 
     def __build_tick_consumer(self) -> CommitLogTickConsumer:
+        consumer_configuration = build_kafka_consumer_configuration(
+            self.__commit_log_topic_spec.topic,
+            self.__consumer_group,
+            auto_offset_reset=self.__auto_offset_reset,
+            strict_offset_reset=self.__strict_offset_reset,
+        )
+
+        # Collect metrics from librdkafka if we have stats_collection_freq_ms set
+        # for the consumer group, or use the default.
+        stats_collection_frequency_ms = get_config(
+            f"stats_collection_freq_ms_{self.__consumer_group}",
+            get_config("stats_collection_freq_ms", 0),
+        )
+
+        if stats_collection_frequency_ms and stats_collection_frequency_ms > 0:
+
+            def stats_callback(stats_json: str) -> None:
+                stats = rapidjson.loads(stats_json)
+                self.__metrics.gauge(
+                    "librdkafka.total_queue_size", stats.get("replyq", 0)
+                )
+
+            consumer_configuration.update(
+                {
+                    "statistics.interval.ms": stats_collection_frequency_ms,
+                    "stats_cb": stats_callback,
+                }
+            )
+
         return CommitLogTickConsumer(
-            KafkaConsumer(
-                build_kafka_consumer_configuration(
-                    self.__commit_log_topic_spec.topic,
-                    self.__consumer_group,
-                    auto_offset_reset=self.__auto_offset_reset,
-                    strict_offset_reset=self.__strict_offset_reset,
-                ),
-            ),
+            KafkaConsumer(consumer_configuration),
             followed_consumer_group=self.__followed_consumer_group,
             time_shift=(
                 timedelta(seconds=self.__delay_seconds * -1)


### PR DESCRIPTION
We record this metric for most of our other consumers, we should bring it
over to the scheduler as well as it was a blind spot for us during
the outage when the scheduler got stuck.