### PR TITLE
ref(subscriptions): add SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV option

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -143,6 +143,100 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
         ),
     ]
 
+    if settings.SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV:
+        daemons += [
+            (
+                "subscriptions-scheduler-events",
+                [
+                    "snuba",
+                    "subscriptions-scheduler",
+                    "--entity=events",
+                    "--consumer-group=snuba-events-subscriptions-scheduler",
+                    "--followed-consumer-group=snuba-consumers",
+                    "--auto-offset-reset=latest",
+                    "--log-level=debug",
+                    "--delay-seconds=1",
+                    "--schedule-ttl=10",
+                ],
+            ),
+            (
+                "subscriptions-executor-events",
+                [
+                    "snuba",
+                    "subscriptions-executor",
+                    "--dataset=events",
+                    "--entity=events",
+                    "--consumer-group=snuba-events-subscription-executor",
+                    "--auto-offset-reset=latest",
+                    "--override-result-topic=events-subscription-results",
+                ],
+            ),
+            (
+                "subscriptions-scheduler-transactions",
+                [
+                    "snuba",
+                    "subscriptions-scheduler",
+                    "--entity=transactions",
+                    "--consumer-group=snuba-transactions-subscriptions-scheduler",
+                    "--followed-consumer-group=transactions_group",
+                    "--auto-offset-reset=latest",
+                    "--log-level=debug",
+                    "--delay-seconds=1",
+                    "--schedule-ttl=10",
+                ],
+            ),
+            (
+                "subscriptions-executor-transactions",
+                [
+                    "snuba",
+                    "subscriptions-executor",
+                    "--dataset=transactions",
+                    "--entity=transactions",
+                    "--consumer-group=snuba-transactions-subscription-executor",
+                    "--auto-offset-reset=latest",
+                    "--override-result-topic=transactions-subscription-results",
+                ],
+            ),
+        ]
+
+    else:
+        daemons += [
+            (
+                "subscriptions-scheduler-executor-events",
+                [
+                    "snuba",
+                    "subscriptions-scheduler-executor",
+                    "--dataset=events",
+                    "--entity=events",
+                    "--consumer-group=snuba-events-subscriptions-scheduler-executor",
+                    "--followed-consumer-group=snuba-consumers",
+                    "--auto-offset-reset=latest",
+                    "--no-strict-offset-reset",
+                    "--log-level=debug",
+                    "--delay-seconds=1",
+                    "--schedule-ttl=10",
+                    "--stale-threshold-seconds=900",
+                ],
+            ),
+            (
+                "subscriptions-scheduler-executor-transactions",
+                [
+                    "snuba",
+                    "subscriptions-scheduler-executor",
+                    "--dataset=transactions",
+                    "--entity=transactions",
+                    "--consumer-group=snuba-transactions-subscriptions-scheduler-executor",
+                    "--followed-consumer-group=transactions_group",
+                    "--auto-offset-reset=latest",
+                    "--no-strict-offset-reset",
+                    "--log-level=debug",
+                    "--delay-seconds=1",
+                    "--schedule-ttl=10",
+                    "--stale-threshold-seconds=900",
+                ],
+            ),
+        ]
+
     if settings.ENABLE_SENTRY_METRICS_DEV:
         daemons += [
             (
@@ -159,25 +253,70 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
             ),
         ]
         if settings.ENABLE_METRICS_SUBSCRIPTIONS:
-            daemons += [
-                (
-                    "subscriptions-scheduler-executor-metrics",
-                    [
-                        "snuba",
-                        "subscriptions-scheduler-executor",
-                        "--dataset=metrics",
-                        "--entity=metrics_sets",
-                        "--entity=metrics_counters",
-                        "--consumer-group=snuba-metrics-subscriptions-scheduler-executor",
-                        "--followed-consumer-group=snuba-metrics-consumers",
-                        "--auto-offset-reset=latest",
-                        "--no-strict-offset-reset",
-                        "--log-level=debug",
-                        "--delay-seconds=1",
-                        "--schedule-ttl=10",
-                    ],
-                ),
-            ]
+            if settings.SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV:
+                daemons += [
+                    (
+                        "subscriptions-scheduler-metrics-counters",
+                        [
+                            "snuba",
+                            "subscriptions-scheduler",
+                            "--entity=metrics_counters",
+                            "--consumer-group=snuba-metrics-subscriptions-scheduler",
+                            "--followed-consumer-group=snuba-metrics-consumers",
+                            "--auto-offset-reset=latest",
+                            "--log-level=debug",
+                            "--delay-seconds=1",
+                            "--schedule-ttl=10",
+                        ],
+                    ),
+                    (
+                        "subscriptions-scheduler-metrics-sets",
+                        [
+                            "snuba",
+                            "subscriptions-scheduler",
+                            "--entity=metrics_sets",
+                            "--consumer-group=snuba-metrics-subscriptions-scheduler",
+                            "--followed-consumer-group=snuba-metrics-consumers",
+                            "--auto-offset-reset=latest",
+                            "--log-level=debug",
+                            "--delay-seconds=1",
+                            "--schedule-ttl=10",
+                        ],
+                    ),
+                    (
+                        "subscriptions-executor-metrics",
+                        [
+                            "snuba",
+                            "subscriptions-executor",
+                            "--dataset=metrics",
+                            "--entity=metrics_counters",
+                            "--entity=metrics_sets",
+                            "--consumer-group=snuba-metrics-subscription-executor",
+                            "--auto-offset-reset=latest",
+                            "--override-result-topic=metrics-subscription-results",
+                        ],
+                    ),
+                ]
+            else:
+                daemons += [
+                    (
+                        "subscriptions-scheduler-executor-metrics",
+                        [
+                            "snuba",
+                            "subscriptions-scheduler-executor",
+                            "--dataset=metrics",
+                            "--entity=metrics_sets",
+                            "--entity=metrics_counters",
+                            "--consumer-group=snuba-metrics-subscriptions-scheduler-executor",
+                            "--followed-consumer-group=snuba-metrics-consumers",
+                            "--auto-offset-reset=latest",
+                            "--no-strict-offset-reset",
+                            "--log-level=debug",
+                            "--delay-seconds=1",
+                            "--schedule-ttl=10",
+                        ],
+                    ),
+                ]
 
     if settings.ENABLE_PROFILES_CONSUMER:
         daemons += [

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -185,6 +185,10 @@ ENABLE_SENTRY_METRICS_DEV = os.environ.get("ENABLE_SENTRY_METRICS_DEV", False)
 # Metric Alerts Subscription Options
 ENABLE_METRICS_SUBSCRIPTIONS = os.environ.get("ENABLE_METRICS_SUBSCRIPTIONS", False)
 
+SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV = os.environ.get(
+    "SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV", False
+)
+
 # Subscriptions scheduler buffer size
 SUBSCRIPTIONS_DEFAULT_BUFFER_SIZE = 10000
 SUBSCRIPTIONS_ENTITY_BUFFER_SIZE: Mapping[str, int] = {}  # (entity name, buffer size)


### PR DESCRIPTION
Consolidated the subscription scheduler and executor for dev was added in https://github.com/getsentry/snuba/pull/2666. Having this by default is great, but I wanted to make it easier for when developing on the subscriptions architecture that dev could resemble prod as much as possible. 