### PR TITLE
test: Fix flaky test

### DIFF
--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -659,7 +659,7 @@ def test_produce_scheduled_subscription_message() -> None:
 
 
 def test_produce_stale_message() -> None:
-    stale_threshold_seconds = 60
+    stale_threshold_seconds = 90
     now = datetime.now()
     metrics_backend = TestingMetricsBackend()
     partition_index = 0
@@ -719,7 +719,7 @@ def test_produce_stale_message() -> None:
                 0,
                 offsets=Interval(1, 3),
                 timestamps=Interval(
-                    now - timedelta(minutes=3), now - timedelta(seconds=59)
+                    now - timedelta(minutes=3), now - timedelta(seconds=60)
                 ),
             ),
             True,
@@ -747,7 +747,7 @@ def test_produce_stale_message() -> None:
             Tick(
                 0,
                 offsets=Interval(3, 4),
-                timestamps=Interval(now - timedelta(seconds=59), now),
+                timestamps=Interval(now - timedelta(seconds=60), now),
             ),
             True,
         ),

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -747,7 +747,7 @@ def test_produce_stale_message() -> None:
             Tick(
                 0,
                 offsets=Interval(3, 4),
-                timestamps=Interval(now - timedelta(seconds=50), now),
+                timestamps=Interval(now - timedelta(seconds=30), now),
             ),
             True,
         ),

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -1,4 +1,3 @@
-import time
 import uuid
 from collections import deque
 from concurrent.futures import Future
@@ -661,14 +660,14 @@ def test_produce_scheduled_subscription_message() -> None:
 
 def test_produce_stale_message() -> None:
     stale_threshold_seconds = 60
-    now = datetime.fromtimestamp(time.time())
+    now = datetime.now()
     metrics_backend = TestingMetricsBackend()
     partition_index = 0
     entity_key = EntityKey.EVENTS
     topic = Topic("scheduled-subscriptions-events")
     partition = Partition(topic, partition_index)
 
-    clock = TestingClock(now.timestamp())
+    clock = TestingClock()
     broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
     broker: Broker[KafkaPayload] = Broker(broker_storage, clock)
     broker.create_topic(topic, partitions=1)

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -710,7 +710,9 @@ def test_produce_stale_message() -> None:
         metrics_backend,
     )
 
-    # Produce a stale message
+    # Produce a stale message. Since the tick spans an interval of 60 seconds,
+    # the subscription will be executed once in this window (no matter what
+    # jitter gets applied to it)
     stale_message = Message(
         partition,
         1,

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -667,9 +667,8 @@ def test_produce_stale_message() -> None:
     topic = Topic("scheduled-subscriptions-events")
     partition = Partition(topic, partition_index)
 
-    clock = TestingClock()
     broker_storage: MemoryMessageStorage[KafkaPayload] = MemoryMessageStorage()
-    broker: Broker[KafkaPayload] = Broker(broker_storage, clock)
+    broker: Broker[KafkaPayload] = Broker(broker_storage)
     broker.create_topic(topic, partitions=1)
     producer = broker.get_producer()
 
@@ -747,7 +746,7 @@ def test_produce_stale_message() -> None:
             Tick(
                 0,
                 offsets=Interval(3, 4),
-                timestamps=Interval(now - timedelta(seconds=30), now),
+                timestamps=Interval(now - timedelta(seconds=50), now),
             ),
             True,
         ),

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -746,7 +746,7 @@ def test_produce_stale_message() -> None:
             Tick(
                 0,
                 offsets=Interval(3, 4),
-                timestamps=Interval(now - timedelta(seconds=50), now),
+                timestamps=Interval(now - timedelta(seconds=30), now),
             ),
             True,
         ),


### PR DESCRIPTION
This was flaky before since we were previously generating random subscription UUIDs and asserting they were executed within a 50 second window. Since the jitter spread things out over a minute this would fail roughly 10/60 of the time.