### PR TITLE
dev: Don't schedule stale subscriptions in dev

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -121,6 +121,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--log-level=debug",
                 "--delay-seconds=1",
                 "--schedule-ttl=10",
+                "--stale-threshold-seconds=900",
             ],
         ),
         (
@@ -137,6 +138,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--log-level=debug",
                 "--delay-seconds=1",
                 "--schedule-ttl=10",
+                "--stale-threshold-seconds=900",
             ],
         ),
     ]


### PR DESCRIPTION
The goal of this change is to match our dev environment configuration
more closely with prod (by skipping stale subscriptions beyond 15 minutes).