### PR TITLE
feat(metrics): create generic sets aggregate table + indices

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -31,6 +31,7 @@ class StorageSetKey(Enum):
     ERRORS_V2 = "errors_v2"
     ERRORS_V2_RO = "errors_v2_ro"
     PROFILES = "profiles"
+    GENERIC_METRICS_SETS = "generic_metrics_sets"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -32,6 +32,7 @@ class StorageKey(Enum):
     ERRORS_V2 = "errors_v2"
     PROFILES = "profiles"
     ERRORS_V2_RO = "errors_v2_ro"
+    GENERIC_METRICS_SETS = "generic_metrics_sets"
 
 
 IDENTICAL_STORAGES = frozenset(

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -29,8 +29,10 @@ aggregated_columns = [
     Column("granularity", UInt(32)),
     Column("timestamp", DateTime()),
     Column("retention_days", UInt(16)),
-    Column("tags", Nested([("key", UInt(64)), ("value", String())])),
-    Column("_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
+    Column("raw_tags", Nested([("key", UInt(64)), ("value", String())])),
+    Column("_raw_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
+    Column("indexed_tags", Nested([("key", UInt(64)), ("value", String())])),
+    Column("_indexed_tags_hash", Nested([("key", UInt(64)), ("value", UInt(64))])),
 ]
 
 sets_storage = ReadableTableStorage(
@@ -47,5 +49,9 @@ sets_storage = ReadableTableStorage(
             ]
         ),
     ),
-    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
+    query_processors=[
+        ArrayJoinKeyValueOptimizer("raw_tags"),
+        ArrayJoinKeyValueOptimizer("indexed_tags"),
+        TableRateLimit(),
+    ],
 )

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -1,0 +1,51 @@
+"""
+The storages defined in this file are for the generic metrics system,
+initially built to handle metrics-enhanced performance.
+"""
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Array,
+    Column,
+    ColumnSet,
+    DateTime,
+    Nested,
+    SchemaModifiers,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.schemas.tables import TableSchema
+from snuba.datasets.storage import ReadableTableStorage
+from snuba.datasets.storages import StorageKey
+from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
+    ArrayJoinKeyValueOptimizer,
+)
+from snuba.query.processors.table_rate_limit import TableRateLimit
+
+aggregated_columns = [
+    Column("org_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("metric_id", UInt(64)),
+    Column("granularity", UInt(32)),
+    Column("timestamp", DateTime()),
+    Column("retention_days", UInt(16)),
+    Column("tags", Nested([("key", UInt(64)), ("value", String())])),
+    Column("_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
+]
+
+sets_storage = ReadableTableStorage(
+    storage_key=StorageKey.GENERIC_METRICS_SETS,
+    storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
+    schema=TableSchema(
+        local_table_name="generic_metrics_sets_local",
+        dist_table_name="generic_metrics_sets_dist",
+        storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
+        columns=ColumnSet(
+            [
+                *aggregated_columns,
+                Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+            ]
+        ),
+    ),
+    query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
+)

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -24,7 +24,7 @@ from snuba.query.processors.table_rate_limit import TableRateLimit
 
 aggregated_columns = [
     Column("org_id", UInt(64)),
-    Column("use_case_id", String(SchemaModifiers(low_cardinality=True))),
+    Column("use_case_id", String()),
     Column("project_id", UInt(64)),
     Column("metric_id", UInt(64)),
     Column("granularity", UInt(8)),

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -30,9 +30,13 @@ aggregated_columns = [
     Column("granularity", UInt(8)),
     Column("timestamp", DateTime()),
     Column("retention_days", UInt(16)),
-    Column("raw_tags", Nested([("key", UInt(64)), ("value", String())])),
+    Column(
+        "tags",
+        Nested(
+            [("key", UInt(64)), ("indexed_value", UInt(64)), ("raw_value", String())]
+        ),
+    ),
     Column("_raw_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
-    Column("indexed_tags", Nested([("key", UInt(64)), ("value", String())])),
     Column("_indexed_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
 ]
 

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -24,15 +24,16 @@ from snuba.query.processors.table_rate_limit import TableRateLimit
 
 aggregated_columns = [
     Column("org_id", UInt(64)),
+    Column("use_case_id", String(SchemaModifiers(low_cardinality=True))),
     Column("project_id", UInt(64)),
     Column("metric_id", UInt(64)),
-    Column("granularity", UInt(32)),
+    Column("granularity", UInt(8)),
     Column("timestamp", DateTime()),
     Column("retention_days", UInt(16)),
     Column("raw_tags", Nested([("key", UInt(64)), ("value", String())])),
     Column("_raw_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
     Column("indexed_tags", Nested([("key", UInt(64)), ("value", String())])),
-    Column("_indexed_tags_hash", Nested([("key", UInt(64)), ("value", UInt(64))])),
+    Column("_indexed_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))),
 ]
 
 sets_storage = ReadableTableStorage(

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -55,8 +55,7 @@ sets_storage = ReadableTableStorage(
         ),
     ),
     query_processors=[
-        ArrayJoinKeyValueOptimizer("raw_tags"),
-        ArrayJoinKeyValueOptimizer("indexed_tags"),
+        ArrayJoinKeyValueOptimizer("tags"),
         TableRateLimit(),
     ],
 )

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -1,3 +1,6 @@
+"""
+The storages defined in this file are for release-health metrics.
+"""
 from typing import Sequence
 
 from arroyo import Topic as KafkaTopic

--- a/snuba/datasets/storages/tags_hash_map.py
+++ b/snuba/datasets/storages/tags_hash_map.py
@@ -11,18 +11,20 @@ TAGS_HASH_MAP_COLUMN = (
 )
 
 
-def hash_map_int_column_definition(column_name: str) -> str:
+def hash_map_int_column_definition(key_column_name: str, value_column_name: str) -> str:
     return (
         f"arrayMap((k, v) -> cityHash64(concat(toString(k), '=', toString(v))), "
-        f"{column_name}.key, {column_name}.value)"
+        f"{key_column_name}, {value_column_name})"
     )
 
 
-INT_TAGS_HASH_MAP_COLUMN = hash_map_int_column_definition("tags")
+INT_TAGS_HASH_MAP_COLUMN = hash_map_int_column_definition("tags.key", "tags.value")
 
 
-def hash_map_int_key_str_value_column_definition(tag_column_name: str) -> str:
+def hash_map_int_key_str_value_column_definition(
+    key_column_name: str, value_column_name: str
+) -> str:
     return (
         f"arrayMap((k, v) -> cityHash64(concat(toString(k), '=', v)), "
-        f"{tag_column_name}.key, {tag_column_name}.value)"
+        f"{key_column_name}, {value_column_name})"
     )

--- a/snuba/datasets/storages/tags_hash_map.py
+++ b/snuba/datasets/storages/tags_hash_map.py
@@ -11,7 +11,18 @@ TAGS_HASH_MAP_COLUMN = (
 )
 
 
-INT_TAGS_HASH_MAP_COLUMN = (
-    "arrayMap((k, v) -> cityHash64(concat(toString(k), '=', toString(v))), "
-    "tags.key, tags.value)"
-)
+def hash_map_int_column_definition(column_name: str) -> str:
+    return (
+        f"arrayMap((k, v) -> cityHash64(concat(toString(k), '=', toString(v))), "
+        f"{column_name}.key, {column_name}.value)"
+    )
+
+
+INT_TAGS_HASH_MAP_COLUMN = hash_map_int_column_definition("tags")
+
+
+def hash_map_int_key_str_value_column_definition(tag_column_name: str) -> str:
+    return (
+        f"arrayMap((k, v) -> cityHash64(concat(toString(k), '=', v)), "
+        f"{tag_column_name}.key, {tag_column_name}.value)"
+    )

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -17,6 +17,7 @@ class MigrationGroup(Enum):
     SESSIONS = "sessions"
     QUERYLOG = "querylog"
     PROFILES = "profiles"
+    GENERIC_METRICS = "generic_metrics"
 
 
 # Migration groups are mandatory by default, unless they are on this list
@@ -25,6 +26,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.SESSIONS,
     MigrationGroup.QUERYLOG,
     MigrationGroup.PROFILES,
+    MigrationGroup.GENERIC_METRICS,
 }
 
 
@@ -223,6 +225,14 @@ class ProfilesLoader(DirectoryLoader):
         return ["0001_profiles"]
 
 
+class GenericMetricsLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.migrations.snuba_migrations.generic_metrics")
+
+    def get_migrations(self) -> Sequence[str]:
+        return ["0001_sets_aggregate_table"]
+
+
 _REGISTERED_GROUPS = {
     MigrationGroup.SYSTEM: SystemLoader(),
     MigrationGroup.EVENTS: EventsLoader(),
@@ -233,6 +243,7 @@ _REGISTERED_GROUPS = {
     MigrationGroup.SESSIONS: SessionsLoader(),
     MigrationGroup.QUERYLOG: QuerylogLoader(),
     MigrationGroup.PROFILES: ProfilesLoader(),
+    MigrationGroup.GENERIC_METRICS: GenericMetricsLoader(),
 }
 
 

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -128,7 +128,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.GENERIC_METRICS_SETS,
                 table_name="generic_metric_sets_aggregated_dist",
                 engine=table_engines.Distributed(
-                    local_table_name=self.local_table_name
+                    local_table_name=self.local_table_name, sharding_key=None
                 ),
                 columns=self.columns,
             )

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -51,6 +51,7 @@ class Migration(migration.ClickhouseNodeMigration):
                         "raw_tags", Nested([("key", UInt(64)), ("value", String())])
                     ),
                     Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+                    Column("timeseries_id", UInt(64)),
                 ],
             ),
             operations.AddColumn(
@@ -130,7 +131,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="generic_metric_sets_aggregated_dist",
                 engine=table_engines.Distributed(
                     local_table_name=self.local_table_name,
-                    sharding_key="cityHash64(org_id,project_id,metric_id,granularity)",
+                    sharding_key="timeseries_id",
                 ),
                 columns=[],
             )

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -130,7 +130,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="generic_metric_sets_aggregated_dist",
                 engine=table_engines.Distributed(
                     local_table_name=self.local_table_name,
-                    sharding_key="TBD",
+                    sharding_key="cityHash64(org_id,project_id,metric_id,granularity)",
                 ),
                 columns=[],
             )

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -23,7 +23,6 @@ class Migration(migration.ClickhouseNodeMigration):
     granularity = "2048"
     local_table_name = "generic_metric_sets_local"
     columns: Sequence[Column[Modifiers]] = [
-        Column("use_case_id", String(Modifiers(low_cardinality=True))),
         Column("org_id", UInt(64)),
         Column("project_id", UInt(64)),
         Column("metric_id", UInt(64)),
@@ -41,7 +40,7 @@ class Migration(migration.ClickhouseNodeMigration):
             ),
         ),
         Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
-        Column("timeseries_id", UInt(64)),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
     ]
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
@@ -129,8 +128,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.GENERIC_METRICS_SETS,
                 table_name="generic_metric_sets_aggregated_dist",
                 engine=table_engines.Distributed(
-                    local_table_name=self.local_table_name,
-                    sharding_key="timeseries_id",
+                    local_table_name=self.local_table_name
                 ),
                 columns=self.columns,
             )

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -22,21 +22,21 @@ class Migration(migration.ClickhouseNodeMigration):
     blocking = False
     granularity = "2048"
     local_table_name = "generic_metric_sets_local"
+    columns: Sequence[Column[Modifiers]] = [
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime()),
+        Column("retention_days", UInt(16)),
+        Column("indexed_tags", Nested([("key", UInt(64)), ("value", UInt(64))])),
+        Column("raw_tags", Nested([("key", UInt(64)), ("value", String())])),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("timeseries_id", UInt(64)),
+    ]
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
-        self.columns = [
-            Column("use_case_id", String(Modifiers(low_cardinality=True))),
-            Column("org_id", UInt(64)),
-            Column("project_id", UInt(64)),
-            Column("metric_id", UInt(64)),
-            Column("granularity", UInt(8)),
-            Column("timestamp", DateTime()),
-            Column("retention_days", UInt(16)),
-            Column("indexed_tags", Nested([("key", UInt(64)), ("value", UInt(64))])),
-            Column("raw_tags", Nested([("key", UInt(64)), ("value", String())])),
-            Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
-            Column("timeseries_id", UInt(64)),
-        ]
         return [
             operations.CreateTable(
                 storage_set=StorageSetKey.GENERIC_METRICS_SETS,

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -1,0 +1,140 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Array,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import (
+    hash_map_int_column_definition,
+    hash_map_int_key_str_value_column_definition,
+)
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    granularity = "2048"
+    local_table_name = "generic_metric_sets_local"
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                engine=table_engines.AggregatingMergeTree(
+                    storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                    order_by="(org_id, project_id, metric_id, granularity, timestamp, indexed_tags.key, indexed_tags.value, raw_tags.key, retention_days)",
+                    primary_key="(org_id, project_id, metric_id, granularity, timestamp)",
+                    partition_by="(retention_days, toMonday(timestamp))",
+                    settings={"index_granularity": self.granularity},
+                    ttl="timestamp + toIntervalDay(retention_days)",
+                ),
+                columns=[
+                    Column("use_case_id", String(Modifiers(low_cardinality=True))),
+                    Column("org_id", UInt(64)),
+                    Column("project_id", UInt(64)),
+                    Column("metric_id", UInt(64)),
+                    Column("granularity", UInt(8)),
+                    Column("timestamp", DateTime()),
+                    Column("retention_days", UInt(16)),
+                    Column(
+                        "indexed_tags", Nested([("key", UInt(64)), ("value", UInt(64))])
+                    ),
+                    Column(
+                        "raw_tags", Nested([("key", UInt(64)), ("value", String())])
+                    ),
+                    Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+                ],
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                column=Column(
+                    "_indexed_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_column_definition("indexed_tags")
+                        ),
+                    ),
+                ),
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                column=Column(
+                    "_raw_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_key_str_value_column_definition(
+                                "raw_tags"
+                            )
+                        ),
+                    ),
+                ),
+            ),
+            operations.AddIndex(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                index_name="bf_indexed_tags_hash",
+                index_expression="_indexed_tags_hash",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+            operations.AddIndex(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                index_name="bf_indexed_tags_key_hash",
+                index_expression="indexed_tags.key",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+            operations.AddIndex(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                index_name="bf_raw_tags_hash",
+                index_expression="_raw_tags_hash",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+            operations.AddIndex(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                index_name="bf_raw_tags_key_hash",
+                index_expression="raw_tags.key",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name="generic_metric_sets_aggregated_dist",
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name,
+                    sharding_key="TBD",
+                ),
+                columns=[],
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [operations.DropTable()]

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -27,7 +27,7 @@ class Migration(migration.ClickhouseNodeMigration):
         Column("project_id", UInt(64)),
         Column("metric_id", UInt(64)),
         Column("granularity", UInt(8)),
-        Column("timestamp", DateTime()),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
         Column("retention_days", UInt(16)),
         Column(
             "tags",

--- a/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -137,4 +137,9 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return [operations.DropTable()]
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name="generic_metric_sets_aggregated_dist",
+            )
+        ]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -51,6 +51,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "errors_v2",
             "errors_v2_ro",
             "profiles",
+            "generic_metrics_sets",
         },
         "single_node": True,
     },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -24,6 +24,7 @@ CLUSTERS = [
             "errors_v2",
             "errors_v2_ro",
             "profiles",
+            "generic_metrics_sets",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",


### PR DESCRIPTION
## create generic_metrics_sets in ClickHouse
`generic_metrics_sets` is the first aggregate table I'm creating for the metrics-enhanced performance project (internal doc: https://www.notion.so/sentry/Metrics-Enhanced-Performance-Q2-SNS-Plan-79247be0ab134aae90269de0523c35f5). The goal with this approach is to create end-to-end functionality for sets (starting from the indexer ingestion in sentry, to writing to ClickHouse, and returning results via the query API) before implementing the other metric types (counters, distributions) and their processors.

Changes in this PR:
- new storage set key (for sets type only)
- new storage set (for sets type only)
- new migration group (will be shared with other "generic" metrics clusters)
- a migration to create the table

Next steps:
- create a raw table and materialized view for writing to `generic_metrics_sets`.
- create a processor and consumer in snuba for writing to the raw input table for `generic_metrics_sets`

Differences from old sets aggregate table:
- we are going to allow two modes of tag storage: (indexed key) -> (indexed value) and (indexed key) -> (raw value (string)). This means separate columns and indices.
- granularity is no longer delineated in seconds but will essentially be a constant so we can use a smaller storage format (e.g. 0=10s, 1=60s, 2=3600s, 3=86400s vs. having to store 86400 as the day value)
- a new `timeseries_id` column that lets us control sharding from within the python codebase.

Testing:
- ran local/dist migrations locally