### PR TITLE
chore(tiger): Move tiger errors start date

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -204,7 +204,7 @@ ENABLED_MATERIALIZATION_VERSION = 4
 ENABLE_PROFILES_CONSUMER = os.environ.get("ENABLE_PROFILES_CONSUMER", False)
 
 # Place the actual time we start ingesting on the new version.
-ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 2, 23, 0, 0, 0)
+ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 3, 23, 0, 0, 0)
 TRANSACTIONS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(
     2022, 2, 18, 0, 0, 0
 )


### PR DESCRIPTION
We want to see the impact 90 day queries have on the tiger clusters. In order to do that, lets move the start date by a months time so that 90 day queries are not run on the tiger clusters.
