### PR TITLE
feat(subscriptions): Allow scheduling watermark mode to be overridden

### DIFF
--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -72,9 +72,9 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 )
 @click.option("--log-level", help="Logging level to use.")
 @click.option(
-    "--override-partition-mode",
+    "--scheduling-mode",
     type=click.Choice(["partition", "global"]),
-    help="Skip scheduling if timestamp is beyond this threshold compared to the system time",
+    help="Overrides the partition scheduling mode associated with the dataset.",
 )
 def subscriptions_scheduler_executor(
     *,
@@ -89,10 +89,10 @@ def subscriptions_scheduler_executor(
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
     log_level: Optional[str],
-    # TODO: Temporarily overrides a partition mode.
+    # TODO: Temporarily overrides the scheduling mode.
     # Required for single tenant since some partitions may be empty.
     # To be removed once transactions is no longer semantically partitioned.
-    override_partition_mode: Optional[str],
+    scheduling_mode: Optional[str],
 ) -> None:
     """
     Combined subscriptions scheduler and executor. Alternative to the separate scheduler and executor processes.
@@ -141,8 +141,8 @@ def subscriptions_scheduler_executor(
         max_concurrent_queries,
         executor,
         metrics,
-        SchedulingWatermarkMode(override_partition_mode)
-        if override_partition_mode is not None
+        SchedulingWatermarkMode(scheduling_mode)
+        if scheduling_mode is not None
         else None,
     )
 

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -14,6 +14,7 @@ from snuba.environment import setup_logging, setup_sentry
 from snuba.subscriptions.combined_scheduler_executor import (
     build_scheduler_executor_consumer,
 )
+from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
@@ -70,6 +71,11 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Skip scheduling if timestamp is beyond this threshold compared to the system time",
 )
 @click.option("--log-level", help="Logging level to use.")
+@click.option(
+    "--override-partition-mode",
+    type=click.Choice(["partition", "global"]),
+    help="Skip scheduling if timestamp is beyond this threshold compared to the system time",
+)
 def subscriptions_scheduler_executor(
     *,
     dataset_name: str,
@@ -83,6 +89,10 @@ def subscriptions_scheduler_executor(
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
     log_level: Optional[str],
+    # TODO: Temporarily overrides a partition mode.
+    # Required for single tenant since some partitions may be empty.
+    # To be removed once transactions is no longer semantically partitioned.
+    override_partition_mode: Optional[str],
 ) -> None:
     """
     Combined subscriptions scheduler and executor. Alternative to the separate scheduler and executor processes.
@@ -131,6 +141,9 @@ def subscriptions_scheduler_executor(
         max_concurrent_queries,
         executor,
         metrics,
+        SchedulingWatermarkMode(override_partition_mode)
+        if override_partition_mode is not None
+        else None,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -142,7 +142,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         stale_threshold_seconds: Optional[int],
         result_topic: str,
         schedule_ttl: int,
-        override_partition_mode: Optional[SchedulingWatermarkMode],
+        override_partition_mode: Optional[SchedulingWatermarkMode] = None,
     ) -> None:
         # TODO: self.__partitions might not be the same for each entity
         self.__partitions = partitions

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -50,7 +50,7 @@ def build_scheduler_executor_consumer(
     max_concurrent_queries: int,
     executor: ThreadPoolExecutor,
     metrics: MetricsBackend,
-    override_partition_mode: Optional[SchedulingWatermarkMode],
+    scheduling_mode: Optional[SchedulingWatermarkMode],
 ) -> StreamProcessor[Tick]:
     dataset = get_dataset(dataset_name)
 
@@ -106,7 +106,7 @@ def build_scheduler_executor_consumer(
         stale_threshold_seconds,
         result_topic.topic_name,
         schedule_ttl,
-        override_partition_mode,
+        scheduling_mode,
     )
 
     return StreamProcessor(
@@ -142,7 +142,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         stale_threshold_seconds: Optional[int],
         result_topic: str,
         schedule_ttl: int,
-        override_partition_mode: Optional[SchedulingWatermarkMode] = None,
+        scheduling_mode: Optional[SchedulingWatermarkMode] = None,
     ) -> None:
         # TODO: self.__partitions might not be the same for each entity
         self.__partitions = partitions
@@ -189,8 +189,8 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
             result_topic,
         )
 
-        if override_partition_mode is not None:
-            self.__mode = override_partition_mode
+        if scheduling_mode is not None:
+            self.__mode = scheduling_mode
         else:
             modes = {
                 self._get_entity_watermark_mode(entity_key)


### PR DESCRIPTION
This is a temporary change that allows the scheduling watermark mode
to be overridden in the combined scheduler/executor. This is needed for
single tenant as we often have empty partitions there and empty partitions are
incompatible with "global" mode. Once transactions are no longer semantically
partitioned, this will not be necessary and this can be removed.
