### PR TITLE
feat: Don't pass next_offset to message

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -532,7 +532,6 @@ class MultistorageCollector(
                 message.offset,
                 payload,
                 message.timestamp,
-                message.next_offset,
             )
             self.__steps[storage_key].submit(writer_message)
 
@@ -545,7 +544,6 @@ class MultistorageCollector(
                 message.offset,
                 (storage_key, payload),
                 message.timestamp,
-                message.next_offset,
             )
 
             self.__messages[storage_key].append(other_message)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -276,7 +276,6 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
                         result_future.task, result_future.future.result()
                     ),
                     message.timestamp,
-                    message.next_offset,
                 )
             )
 
@@ -378,7 +377,6 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
                     message.offset,
                     subscription_task_result,
                     message.timestamp,
-                    message.next_offset,
                 )
             )
 

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -105,7 +105,6 @@ class ProvideCommitStrategy(ProcessingStrategy[Tick]):
                 message.offset,
                 CommittableTick(message.payload, offset_to_commit),
                 message.timestamp,
-                message.next_offset,
             )
         )
         if should_commit:

--- a/snuba/utils/streams/encoding.py
+++ b/snuba/utils/streams/encoding.py
@@ -36,7 +36,6 @@ class ProducerEncodingWrapper(Producer[TDecoded]):
                         message.offset,
                         payload,
                         message.timestamp,
-                        message.next_offset,
                     )
                 )
 

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -88,7 +88,6 @@ def test_combined_scheduler_and_executor() -> None:
                 timestamps=Interval(epoch, epoch + timedelta(seconds=60)),
             ),
             epoch,
-            5,
         )
         strategy.submit(message)
 

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -204,7 +204,6 @@ def test_tick_consumer(time_shift: Optional[timedelta]) -> None:
             time_shift
         ),
         epoch,
-        2,
     )
 
     assert consumer.tell() == {
@@ -219,7 +218,6 @@ def test_tick_consumer(time_shift: Optional[timedelta]) -> None:
             time_shift
         ),
         epoch,
-        3,
     )
 
     assert consumer.tell() == {
@@ -261,7 +259,6 @@ def test_tick_consumer(time_shift: Optional[timedelta]) -> None:
             time_shift
         ),
         epoch,
-        3,
     )
 
     assert consumer.tell() == {
@@ -327,7 +324,6 @@ def test_tick_consumer_non_monotonic() -> None:
                 timestamps=Interval(epoch, epoch + timedelta(seconds=1)),
             ),
             epoch + timedelta(seconds=1),
-            2,
         )
 
     clock.sleep(-1)
@@ -361,7 +357,6 @@ def test_tick_consumer_non_monotonic() -> None:
                 ),
             ),
             epoch + timedelta(seconds=2),
-            4,
         )
 
 

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -56,7 +56,6 @@ def test_tick_buffer_immediate() -> None:
             timestamps=Interval(epoch, epoch + timedelta(seconds=5)),
         ),
         epoch,
-        5,
     )
 
     strategy.submit(message)
@@ -87,7 +86,6 @@ def test_tick_buffer_wait_slowest() -> None:
             timestamps=Interval(epoch, epoch + timedelta(seconds=5)),
         ),
         now,
-        5,
     )
     strategy.submit(message_0_0)
 
@@ -105,7 +103,6 @@ def test_tick_buffer_wait_slowest() -> None:
             ),
         ),
         now,
-        6,
     )
     strategy.submit(message_0_1)
 
@@ -121,7 +118,6 @@ def test_tick_buffer_wait_slowest() -> None:
             timestamps=Interval(epoch, epoch + timedelta(seconds=4)),
         ),
         now,
-        7,
     )
     strategy.submit(message_1_0)
 
@@ -142,7 +138,6 @@ def test_tick_buffer_wait_slowest() -> None:
             ),
         ),
         now,
-        8,
     )
     strategy.submit(message_1_1)
 
@@ -168,7 +163,6 @@ def test_tick_buffer_wait_slowest() -> None:
             ),
         ),
         now,
-        8,
     )
     strategy.submit(message_1_2)
 
@@ -197,7 +191,6 @@ def test_tick_buffer_wait_slowest() -> None:
                 ),
             ),
             now + timedelta(seconds=i),
-            9 + i,
         )
         messages.append(message)
         strategy.submit(message)
@@ -214,7 +207,6 @@ def make_message_for_next_step(
         message.offset,
         CommittableTick(message.payload, offset_to_commit),
         message.timestamp,
-        message.next_offset,
     )
 
 
@@ -238,7 +230,6 @@ def test_provide_commit_strategy() -> None:
             ),
         ),
         epoch,
-        2,
     )
 
     strategy.submit(message_0_0)
@@ -260,7 +251,6 @@ def test_provide_commit_strategy() -> None:
             ),
         ),
         epoch,
-        3,
     )
 
     strategy.submit(message_1_0)
@@ -283,7 +273,6 @@ def test_provide_commit_strategy() -> None:
             ),
         ),
         epoch,
-        4,
     )
 
     strategy.submit(message_1_1)
@@ -307,7 +296,6 @@ def test_provide_commit_strategy() -> None:
             ),
         ),
         epoch,
-        5,
     )
 
     strategy.submit(message_0_1)
@@ -370,7 +358,6 @@ def test_tick_buffer_with_commit_strategy_partition() -> None:
             ),
         ),
         now,
-        6,
     )
     strategy.submit(message_1_0)
 
@@ -393,7 +380,6 @@ def test_tick_buffer_with_commit_strategy_partition() -> None:
             ),
         ),
         now,
-        7,
     )
     strategy.submit(message_0_1)
 
@@ -431,7 +417,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
             timestamps=Interval(epoch, epoch + timedelta(seconds=4)),
         ),
         now,
-        5,
     )
     strategy.submit(message_0_0)
 
@@ -449,7 +434,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
             ),
         ),
         now,
-        6,
     )
     strategy.submit(message_0_1)
 
@@ -466,7 +450,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
             timestamps=Interval(epoch, epoch + timedelta(seconds=3)),
         ),
         now,
-        7,
     )
     strategy.submit(message_1_0)
 
@@ -491,7 +474,6 @@ def test_tick_buffer_with_commit_strategy_global() -> None:
             ),
         ),
         now,
-        8,
     )
     strategy.submit(message_1_1)
 
@@ -524,7 +506,6 @@ def test_scheduled_subscription_queue() -> None:
             1,
         ),
         epoch,
-        2,
     )
 
     futures: Sequence[Future[Message[KafkaPayload]]] = [Future(), Future()]
@@ -622,7 +603,6 @@ def test_produce_scheduled_subscription_message() -> None:
             True,
         ),
         epoch,
-        2,
     )
 
     strategy.submit(message)
@@ -727,7 +707,6 @@ def test_produce_stale_message() -> None:
             True,
         ),
         now,
-        2,
     )
 
     strategy.submit(stale_message)
@@ -754,7 +733,6 @@ def test_produce_stale_message() -> None:
             True,
         ),
         now,
-        3,
     )
 
     strategy.submit(non_stale_message)

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -336,7 +336,6 @@ def test_dead_letter_step() -> None:
         0,
         (storage_key, None),
         datetime.now(),
-        1,
     )
     dead_letter_step.submit(none_message)
     assert not dead_letter_step._DeadLetterStep__futures
@@ -349,7 +348,6 @@ def test_dead_letter_step() -> None:
         1,
         (storage_key, insert_payload),
         datetime.now(),
-        2,
     )
     dead_letter_step.submit(insert_message)
     assert len(dead_letter_step._DeadLetterStep__futures) == 1


### PR DESCRIPTION
We shouldn't ever manually pass a next_offset to Message. This is
because next_offset must always equal to offset + 1, and this will
be properly applied as long as we don't pass anything. The
goal of this change is to remove the ability to pass invalid input into
a message.

In a future version of Arroyo, the ability to pass this at all
will be removed.