### PR TITLE
feat(metrics) - raw input table and materialized view for generic metrics sets

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -230,7 +230,7 @@ class GenericMetricsLoader(DirectoryLoader):
         super().__init__("snuba.migrations.snuba_migrations.generic_metrics")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_sets_aggregate_table"]
+        return ["0001_sets_aggregate_table", "0002_sets_raw_table"]
 
 
 _REGISTERED_GROUPS = {

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -230,7 +230,7 @@ class GenericMetricsLoader(DirectoryLoader):
         super().__init__("snuba.migrations.snuba_migrations.generic_metrics")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_sets_aggregate_table", "0002_sets_raw_table"]
+        return ["0001_sets_aggregate_table", "0002_sets_raw_table", "0003_sets_mv"]
 
 
 _REGISTERED_GROUPS = {

--- a/snuba/migrations/snuba_migrations/generic_metrics/0002_sets_raw_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0002_sets_raw_table.py
@@ -38,6 +38,8 @@ class Migration(migration.ClickhouseNodeMigration):
         Column("set_values", Array(UInt(64))),
         Column("count_value", Float(64)),
         Column("distribution_values", Array(Float(64))),
+        Column("metric_type", String(Modifiers(low_cardinality=True))),
+        Column("materialization_version", UInt(8)),
         Column("timeseries_id", UInt(32)),
     ]
 

--- a/snuba/migrations/snuba_migrations/generic_metrics/0002_sets_raw_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0002_sets_raw_table.py
@@ -1,0 +1,85 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    Array,
+    Column,
+    DateTime,
+    Float,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "generic_metric_sets_raw_local"
+    dist_table_name = "generic_metric_sets_raw_dist"
+    columns: Sequence[Column[Modifiers]] = [
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("timestamp", DateTime()),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("set_values", Array(UInt(64))),
+        Column("count_value", Float(64)),
+        Column("distribution_values", Array(Float(64))),
+        Column("timeseries_id", UInt(32)),
+    ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+                engine=table_engines.AggregatingMergeTree(
+                    storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                    order_by="(use_case_id, org_id, project_id, metric_id, timestamp)",
+                    partition_by="(toStartOfInterval(timestamp, toIntervalDay(3)))",
+                    ttl="timestamp + toIntervalDay(7)",
+                ),
+                columns=self.columns,
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.local_table_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name, sharding_key="timeseries_id"
+                ),
+                columns=self.columns,
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.dist_table_name,
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/generic_metrics/0003_sets_mv.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0003_sets_mv.py
@@ -1,0 +1,92 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_sets_aggregation_mv"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name="generic_metric_sets_local",
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin([0,1,2,3]) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(timestamp),
+                             multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                    retention_days,
+                    uniqCombined64State(arrayJoin(set_values)) as value
+                FROM generic_metric_sets_raw_local
+                WHERE materialization_version = 1
+                  AND metric_type = 'set'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.view_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []


### PR DESCRIPTION
Create an input table (with a schema that can be reused for other types) and materialized view for sets specifically. Tested that it works locally inserting rows in the raw table, and viewing the output

Note: The tags storage in the aggregate table is a little strange as raw_value or indexed_value is padded with non-meaningful data ('' or 0, respectively). We may want to consider a nullable flag or some more obvious placeholder

```
c66a319cda67 :) select tags.key,tags.indexed_value,tags.raw_value from generic_metric_sets_local;

SELECT 
    tags.key, 
    tags.indexed_value, 
    tags.raw_value
FROM generic_metric_sets_local

┌─tags.key─┬─tags.indexed_value─┬─tags.raw_value─┐
│ [1]      │ [2]                │ ['']           │
│ [1]      │ [2]                │ ['']           │
│ [1]      │ [2]                │ ['']           │
│ [1]      │ [2]                │ ['']           │
└──────────┴────────────────────┴────────────────┘
┌─tags.key─┬─tags.indexed_value─┬─tags.raw_value─┐
│ []       │ []                 │ []             │
│ []       │ []                 │ []             │
│ []       │ []                 │ []             │
│ []       │ []                 │ []             │
└──────────┴────────────────────┴────────────────┘
┌─tags.key─┬─tags.indexed_value─┬─tags.raw_value─┐
│ [1]      │ [0]                │ ['hello']      │
│ [1]      │ [0]                │ ['hello']      │
│ [1]      │ [0]                │ ['hello']      │
│ [1]      │ [0]                │ ['hello']      │
└──────────┴────────────────────┴────────────────┘
```