### PR TITLE
feat: Remove legacy events subscriptions consumer from Freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -31,8 +31,6 @@ steps:
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: outcomes-billing-consumer
   - image: us.gcr.io/sentryio/snuba:{sha}
-    name: events-subscriptions-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-scheduler
   - image: us.gcr.io/sentryio/snuba:{sha}
     name: events-subscriptions-executor


### PR DESCRIPTION
This has been replaced by the scheduler/executor and is no longer
serving any prod traffic