### PR TITLE
fix: Update to latest version of Redis (4.3.3)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -58,7 +58,7 @@ ignore_missing_imports = True
 [mypy-rapidjson]
 ignore_missing_imports = True
 
-[mypy-rediscluster.*]
+[mypy-redis.*]
 ignore_missing_imports = True
 
 [mypy-sentry_relay]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ MarkupSafe==1.1.1
 mywsgi==1.0.3
 more-itertools==4.2.0
 mypy>=0.812,<0.900
-packaging==17.1
+packaging==20.4
 parsimonious==0.8.1
 py==1.10.0
 pyparsing==2.2.0
@@ -39,8 +39,7 @@ progressbar2==3.53.1
 python-dateutil==2.7.3
 pytz==2018.4
 python-rapidjson==1.4
-redis==2.10.6
-redis-py-cluster==1.3.5
+redis==4.3.3
 sentry-arroyo==0.1.0
 sentry-relay==0.8.12
 sentry-sdk==1.5.10

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -25,8 +25,8 @@ from typing import (
 )
 
 import sentry_sdk
-from rediscluster.pipeline import StrictClusterPipeline
 
+from redis.cluster import ClusterPipeline as StrictClusterPipeline
 from snuba import environment, settings
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.clickhouse.columns import FlattenedColumn, Nullable, ReadOnly
@@ -192,15 +192,19 @@ def set_project_exclude_groups(
     )
     p = redis_client.pipeline()
 
-    group_id_data: Mapping[str, float] = {str(group_id): now for group_id in group_ids}
-    p.zadd(key, **group_id_data)
+    group_id_data: Mapping[str | bytes, bytes | float | int | str] = {
+        str(group_id): now for group_id in group_ids
+    }
+    p.zadd(key, group_id_data)
     # remove group id deletions that should have been merged by now
     p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
     p.expire(key, int(settings.REPLACER_KEY_TTL))
 
     # store the replacement type data
-    replacement_type_data: Mapping[str, float] = {replacement_type: now}
-    p.zadd(type_key, **replacement_type_data)
+    replacement_type_data: Mapping[str | bytes, bytes | float | int | str] = {
+        replacement_type: now
+    }
+    p.zadd(type_key, replacement_type_data)
     p.zremrangebyscore(type_key, -1, now - settings.REPLACER_KEY_TTL)
     p.expire(type_key, int(settings.REPLACER_KEY_TTL))
 

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -2,24 +2,22 @@ from __future__ import absolute_import
 
 import time
 from functools import wraps
-from typing import Any, Callable, Union
-
-from rediscluster import StrictRedisCluster
-from rediscluster.exceptions import RedisClusterException
+from typing import Any, Callable, Union, cast
 
 from redis.client import StrictRedis
+from redis.cluster import ClusterNode, NodesManager, RedisCluster, RedisClusterException
 from redis.exceptions import BusyLoadingError, ConnectionError
 from snuba import settings
 from snuba.utils.serializable_exception import SerializableException
 
-RedisClientType = Union[StrictRedis, StrictRedisCluster]
+RedisClientType = Union[StrictRedis, RedisCluster]
 
 
 class FailedClusterInitization(SerializableException):
     pass
 
 
-class RetryingStrictRedisCluster(StrictRedisCluster):  # type: ignore #  Missing type stubs in client lib
+class RetryingStrictRedisCluster(RedisCluster):  # type: ignore #  Missing type stubs in client lib
     """
     Execute a command with cluster reinitialization retry logic.
     Should a cluster respond with a ConnectionError or BusyLoadingError the
@@ -35,7 +33,10 @@ class RetryingStrictRedisCluster(StrictRedisCluster):  # type: ignore #  Missing
             BusyLoadingError,
             KeyError,  # see: https://github.com/Grokzen/redis-py-cluster/issues/287
         ):
-            self.connection_pool.nodes.reset()
+            # the code in the RedisCluster __init__ idiotically sets
+            # self.nodes_manager = None
+            # self.nodes_manager = NodesManager(...)
+            cast(NodesManager, self.nodes_manager).reset()
             return super(self.__class__, self).execute_command(*args, **kwargs)
 
 
@@ -77,8 +78,11 @@ def _initialize_redis_cluster() -> RedisClientType:
         startup_nodes = settings.REDIS_CLUSTER_STARTUP_NODES
         if startup_nodes is None:
             startup_nodes = [{"host": settings.REDIS_HOST, "port": settings.REDIS_PORT}]
+        startup_cluster_nodes = [
+            ClusterNode(n["host"], n["port"]) for n in startup_nodes
+        ]
         return RetryingStrictRedisCluster(
-            startup_nodes=startup_nodes,
+            startup_nodes=startup_cluster_nodes,
             socket_keepalive=True,
             password=settings.REDIS_PASSWORD,
             max_connections_per_node=True,

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -120,7 +120,7 @@ def rate_limit(
     """
 
     bucket = "{}{}".format(state.ratelimit_prefix, rate_limit_params.bucket)
-    query_id = uuid.uuid4()
+    query_id = str(uuid.uuid4())
 
     now = time.time()
     bypass_rate_limit, rate_history_s = state.get_configs(
@@ -168,8 +168,7 @@ def rate_limit(
     #                                   running concurrently; in this case 3)
     #              ^
     #              | current time
-
-    pipe.zadd(bucket, now + state.max_query_duration_s, query_id)  # type: ignore
+    pipe.zadd(bucket, {query_id: now + state.max_query_duration_s})
     if rate_limit_params.per_second_limit is None:
         pipe.exists("nosuchkey")  # no-op if we don't need per-second
     else:
@@ -248,7 +247,7 @@ def rate_limit(
         try:
             # return the query to its start time, if the query_id was actually added.
             if not rate_limited:
-                rds.zincrby(bucket, query_id, -float(state.max_query_duration_s))
+                rds.zincrby(bucket, -float(state.max_query_duration_s), query_id)
         except Exception as ex:
             logger.exception(ex)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2138,7 +2138,7 @@ class TestApi(SimpleAPITest):
 
     @patch("snuba.web.query._run_query_pipeline")
     def test_error_handler(self, pipeline_mock: MagicMock) -> None:
-        from rediscluster.utils import ClusterDownError
+        from redis.cluster import ClusterDownError
 
         pipeline_mock.side_effect = ClusterDownError("stuff")
         response = self.post(

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,5 +1,4 @@
-from rediscluster.exceptions import RedisClusterException
-
+from redis.exceptions import RedisClusterException  # type: ignore
 from snuba import redis
 
 

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 from datetime import datetime, timedelta
 from typing import Any, Mapping, MutableMapping, Sequence
@@ -244,7 +246,10 @@ class TestReplacer:
         group_id_data_asc: MutableMapping[str, float] = {"1": now.timestamp()}
         for exclude_groups_key, _ in exclude_groups_keys:
             group_id_data_asc["1"] += 10
-            p.zadd(exclude_groups_key, **group_id_data_asc)
+            to_insert: Mapping[str | bytes, bytes | int | float | str] = {
+                "1": group_id_data_asc["1"],
+            }  # typing error fix
+            p.zadd(exclude_groups_key, to_insert)
         p.execute()
         expected_time = now + timedelta(seconds=30)
         flags = ProjectsQueryFlags.load_from_redis(project_ids, ReplacerState.ERRORS)
@@ -262,7 +267,11 @@ class TestReplacer:
         for exclude_groups_key, _ in exclude_groups_keys:
             group_id_data_multiple["1"] -= 10
             group_id_data_multiple["2"] -= 10
-            p.zadd(exclude_groups_key, **group_id_data_multiple)
+            to_insert = {
+                "1": group_id_data_multiple["1"],
+                "2": group_id_data_multiple["2"],
+            }  # typing error fix
+            p.zadd(exclude_groups_key, to_insert)
         p.execute()
         expected_time = now
         flags = ProjectsQueryFlags.load_from_redis(project_ids, ReplacerState.ERRORS)

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -307,7 +307,7 @@ class TestSnQLApi(BaseApiTest):
 
     @patch("snuba.web.query._run_query_pipeline")
     def test_error_handler(self, pipeline_mock: MagicMock) -> None:
-        from rediscluster.utils import ClusterDownError
+        from redis.cluster import ClusterDownError
 
         hsh = "0" * 32
         group_id = int(hsh[:16], 16)


### PR DESCRIPTION
Our current version of Redis is EOL, so update to the latest. Dependabot only
updated to 4.1.3 but 4.3.3 contains fixes for things that were broken in the
version Dependabot wanted. redis-py-cluster has been added to the redis library
so we don't need to import it separately any more.