### PR TITLE
feat(replays): replays processor to ingest data into clickhouse

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -295,6 +295,19 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 ],
             ),
         ]
+    if settings.ENABLE_REPLAYS_CONSUMER:
+        daemons += [
+            (
+                "replays-consumer",
+                [
+                    "snuba",
+                    "consumer",
+                    "--auto-offset-reset=latest",
+                    "--log-level=debug",
+                    "--storage=replays",
+                ],
+            ),
+        ]
 
     manager = Manager()
     for name, cmd in daemons:

--- a/snuba/datasets/entities/__init__.py
+++ b/snuba/datasets/entities/__init__.py
@@ -24,3 +24,4 @@ class EntityKey(Enum):
     DISCOVER_TRANSACTIONS = "discover_transactions"
     DISCOVER_EVENTS = "discover_events"
     PROFILES = "profiles"
+    REPLAYS = "replays"

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -36,6 +36,7 @@ def get_entity(name: EntityKey) -> Entity:
     from snuba.datasets.entities.outcomes import OutcomesEntity
     from snuba.datasets.entities.outcomes_raw import OutcomesRawEntity
     from snuba.datasets.entities.profiles import ProfilesEntity
+    from snuba.datasets.entities.replays import ReplaysEntity
     from snuba.datasets.entities.sessions import OrgSessionsEntity, SessionsEntity
     from snuba.datasets.entities.transactions import TransactionsEntity
 
@@ -58,6 +59,7 @@ def get_entity(name: EntityKey) -> Entity:
         EntityKey.ORG_METRICS_COUNTERS: OrgMetricsCountersEntity,
         EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
         EntityKey.PROFILES: ProfilesEntity,
+        EntityKey.REPLAYS: ReplaysEntity,
         **(dev_entity_factories if settings.ENABLE_DEV_FEATURES else {}),
     }
 

--- a/snuba/datasets/entities/replays.py
+++ b/snuba/datasets/entities/replays.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import DateTime, UInt
+from snuba.datasets.entities.entity_data_model import EntityColumnSet
+from snuba.datasets.entity import Entity
+from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.replays import storage as replays_storage
+from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
+from snuba.query.processors import QueryProcessor
+from snuba.query.processors.basic_functions import BasicFunctionsProcessor
+from snuba.query.processors.object_id_rate_limiter import ProjectRateLimiterProcessor
+from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
+from snuba.query.validation.validators import (
+    ColumnValidationMode,
+    EntityRequiredColumnValidator,
+)
+from snuba.utils.schemas import Column
+
+replays_data_model = EntityColumnSet(
+    [Column("project_id", UInt(64)), Column("timestamp", DateTime())]
+)
+
+
+class ReplaysEntity(Entity):
+    def __init__(self) -> None:
+
+        writable_storage = get_writable_storage(StorageKey.REPLAYS)
+
+        super().__init__(
+            storages=[writable_storage],
+            query_pipeline_builder=SimplePipelineBuilder(
+                query_plan_builder=SingleStorageQueryPlanBuilder(
+                    storage=replays_storage
+                ),
+            ),
+            abstract_column_set=replays_data_model,
+            join_relationships={},
+            writable_storage=writable_storage,
+            validators=[EntityRequiredColumnValidator({"project_id"})],
+            required_time_column="timestamp",
+            validate_data_model=ColumnValidationMode.WARN,
+        )
+
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return [
+            BasicFunctionsProcessor(),
+            TimeSeriesProcessor({"time": "timestamp"}, ("timestamp",)),
+            ProjectRateLimiterProcessor(project_column="project_id"),
+        ]

--- a/snuba/datasets/replays.py
+++ b/snuba/datasets/replays.py
@@ -1,0 +1,11 @@
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+
+
+class ReplaysDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(default_entity=EntityKey.REPLAYS)
+
+    @classmethod
+    def is_experimental(cls) -> bool:
+        return True

--- a/snuba/datasets/replays_processor.py
+++ b/snuba/datasets/replays_processor.py
@@ -1,0 +1,174 @@
+import logging
+import uuid
+from datetime import datetime
+from typing import Any, Mapping, MutableMapping, Optional, Tuple
+
+from snuba import environment
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.events_format import (
+    EventTooOld,
+    enforce_retention,
+    extract_extra_tags,
+    extract_user,
+)
+from snuba.processor import (
+    InsertBatch,
+    MessageProcessor,
+    ProcessedMessage,
+    _as_dict_safe,
+    _ensure_valid_date,
+    _ensure_valid_ip,
+    _unicodify,
+)
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+logger = logging.getLogger(__name__)
+
+metrics = MetricsWrapper(environment.metrics, "replays.processor")
+from sentry_sdk import capture_exception
+
+EventDict = Mapping[Any, Any]
+RetentionDays = int
+
+
+class ReplaysProcessor(MessageProcessor):
+    PROMOTED_TAGS = {
+        "environment",
+        "sentry:release",
+        "sentry:user",
+        "sentry:dist",
+    }
+
+    def __extract_timestamp(self, field: int) -> datetime:
+        timestamp = _ensure_valid_date(datetime.utcfromtimestamp(field))
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+        return timestamp
+
+    def _structure_and_validate_message(
+        self, message: Mapping[Any, Any]
+    ) -> Optional[Tuple[EventDict, RetentionDays]]:
+
+        event = message
+        data = event["data"]
+
+        try:
+            # We are purposely using a naive datetime here to work with the
+            # rest of the codebase. We can be confident that clients are only
+            # sending UTC dates.
+            retention_days = enforce_retention(
+                message["retention_days"], datetime.utcfromtimestamp(data["timestamp"])
+            )
+        except EventTooOld:
+            return None
+
+        return event, retention_days
+
+    def _process_base_event_values(
+        self, processed: MutableMapping[str, Any], event_dict: EventDict
+    ) -> MutableMapping[str, Any]:
+
+        processed["replay_id"] = str(uuid.UUID(event_dict["replay_id"]))
+        processed["project_id"] = event_dict["project_id"]
+
+        processed["sequence_id"] = event_dict["sequence_id"]
+        processed["trace_ids"] = event_dict["trace_ids"]
+
+        processed["timestamp"] = self.__extract_timestamp(
+            event_dict["data"]["timestamp"],
+        )
+
+        processed["platform"] = _unicodify(event_dict["platform"])
+        return processed
+
+    def _process_tags(
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
+    ) -> None:
+
+        tags: Mapping[str, Any] = _as_dict_safe(event_dict["data"].get("tags", None))
+        processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
+        promoted_tags = {col: tags[col] for col in self.PROMOTED_TAGS if col in tags}
+        processed["release"] = promoted_tags.get(
+            "sentry:release",
+            event_dict.get("release"),
+        )
+        processed["environment"] = promoted_tags.get("environment")
+        processed["user"] = promoted_tags.get("sentry:user", "")
+        processed["dist"] = _unicodify(
+            promoted_tags.get("sentry:dist", event_dict["data"].get("dist")),
+        )
+
+    def _process_user(
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
+    ) -> None:
+
+        user_dict = (
+            event_dict["data"].get(
+                "user", event_dict["data"].get("sentry.interfaces.User", None)
+            )
+            or {}
+        )
+
+        user_data: MutableMapping[str, Any] = {}
+        extract_user(user_data, user_dict)
+        processed["user_name"] = user_data["username"]
+        processed["user_id"] = user_data["user_id"]
+        processed["user_email"] = user_data["email"]
+        ip_address = _ensure_valid_ip(user_data["ip_address"])
+        if ip_address:
+            if ip_address.version == 4:
+                processed["ip_address_v4"] = str(ip_address)
+            elif ip_address.version == 6:
+                processed["ip_address_v6"] = str(ip_address)
+
+    def _process_sdk_data(
+        self,
+        processed: MutableMapping[str, Any],
+        event_dict: EventDict,
+    ) -> None:
+        sdk = event_dict["data"].get("sdk", None) or {}
+        processed["sdk_name"] = _unicodify(sdk.get("name") or "")
+        processed["sdk_version"] = _unicodify(sdk.get("version") or "")
+
+        if processed["sdk_name"] == "":
+            metrics.increment("missing_sdk_name")
+        if processed["sdk_version"] == "":
+            metrics.increment("missing_sdk_version")
+
+    def process_message(
+        self, message: Mapping[Any, Any], metadata: KafkaMessageMetadata
+    ) -> Optional[ProcessedMessage]:
+        try:
+            event_dict, retention_days = self._structure_and_validate_message(
+                message
+            ) or (
+                None,
+                None,
+            )
+
+            if not event_dict:
+                return None
+            processed: MutableMapping[str, Any] = {
+                "retention_days": retention_days,
+            }
+            # The following helper functions should be able to be applied in any order.
+            # At time of writing, there are no reads of the values in the `processed`
+            # dictionary to inform values in other functions.
+            # Ideally we keep continue that rule
+            self._process_base_event_values(processed, event_dict)
+            self._process_tags(processed, event_dict)
+            self._process_sdk_data(processed, event_dict)
+            processed["partition"] = metadata.partition
+            processed["offset"] = metadata.offset
+
+            # the following operation modifies the event_dict and is therefore *not* order-independent
+            self._process_user(processed, event_dict)
+            return InsertBatch([processed], None)
+        except Exception as e:
+            metrics.increment("consumer_error")
+            capture_exception(e)
+            return None

--- a/snuba/datasets/storages/__init__.py
+++ b/snuba/datasets/storages/__init__.py
@@ -31,6 +31,7 @@ class StorageKey(Enum):
     TRANSACTIONS_V2 = "transactions_v2"
     ERRORS_V2 = "errors_v2"
     PROFILES = "profiles"
+    REPLAYS = "replays"
     ERRORS_V2_RO = "errors_v2_ro"
     GENERIC_METRICS_SETS = "generic_metrics_sets"
 

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -30,6 +30,7 @@ from snuba.datasets.storages.profiles import (
     writable_storage as profiles_writable_storage,
 )
 from snuba.datasets.storages.querylog import storage as querylog_storage
+from snuba.datasets.storages.replays import storage as replays_storage
 from snuba.datasets.storages.sessions import (
     materialized_storage as sessions_hourly_storage,
 )
@@ -74,6 +75,7 @@ WRITABLE_STORAGES: Mapping[StorageKey, WritableTableStorage] = {
             transactions_v2_storage,
             errors_v2_storage,
             profiles_writable_storage,
+            replays_storage,
         ]
     },
     **(DEV_WRITABLE_STORAGES if settings.ENABLE_DEV_FEATURES else {}),

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -1,0 +1,73 @@
+from snuba.clickhouse.columns import UUID, Array, ColumnSet, DateTime, IPv4, IPv6
+from snuba.clickhouse.columns import SchemaModifiers as Modifiers
+from snuba.clickhouse.columns import String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.replays_processor import ReplaysProcessor
+from snuba.datasets.schemas.tables import WritableTableSchema
+from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.storages import StorageKey
+from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
+from snuba.query.processors.conditions_enforcer import ProjectIdEnforcer
+from snuba.query.processors.table_rate_limit import TableRateLimit
+from snuba.utils.schemas import Nested
+from snuba.utils.streams.topics import Topic
+
+LOCAL_TABLE_NAME = "replays_local"
+DIST_TABLE_NAME = "replays_dist"
+
+columns = ColumnSet(
+    [
+        ("replay_id", UUID()),
+        ("sequence_id", UInt(16)),
+        ("timestamp", DateTime()),
+        (
+            "trace_ids",
+            Array(UUID()),
+        ),  # TODO: create bloom filter index / materialize column
+        ("title", String(Modifiers(readonly=True))),
+        ### common sentry event columns
+        ("project_id", UInt(64)),
+        # release/environment info
+        ("platform", String()),
+        ("environment", String(Modifiers(nullable=True))),
+        ("release", String(Modifiers(nullable=True))),
+        ("dist", String(Modifiers(nullable=True))),
+        ("ip_address_v4", IPv4(Modifiers(nullable=True))),
+        ("ip_address_v6", IPv6(Modifiers(nullable=True))),
+        # user columns
+        ("user", String()),
+        ("user_hash", UInt(64, Modifiers(readonly=True))),
+        ("user_id", String(Modifiers(nullable=True))),
+        ("user_name", String(Modifiers(nullable=True))),
+        ("user_email", String(Modifiers(nullable=True))),
+        # sdk info
+        ("sdk_name", String()),
+        ("sdk_version", String()),
+        ("tags", Nested([("key", String()), ("value", String())])),
+        # deletion info
+        ("retention_days", UInt(16)),
+        ("partition", UInt(16)),
+        ("offset", UInt(64)),
+    ]
+)
+
+schema = WritableTableSchema(
+    columns=columns,
+    local_table_name=LOCAL_TABLE_NAME,
+    dist_table_name=DIST_TABLE_NAME,
+    storage_set_key=StorageSetKey.REPLAYS,
+)
+
+# TODO: set up deadletter queue for bad messages.
+
+storage = WritableTableStorage(
+    storage_key=StorageKey.REPLAYS,
+    storage_set_key=StorageSetKey.REPLAYS,
+    schema=schema,
+    query_processors=[TableRateLimit()],
+    mandatory_condition_checkers=[ProjectIdEnforcer()],
+    stream_loader=build_kafka_stream_loader_from_settings(
+        processor=ReplaysProcessor(),
+        default_topic=Topic.REPLAYEVENTS,
+    ),
+)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -205,6 +205,9 @@ ENABLED_MATERIALIZATION_VERSION = 4
 # Enable profiles ingestion
 ENABLE_PROFILES_CONSUMER = os.environ.get("ENABLE_PROFILES_CONSUMER", False)
 
+# Enable replays ingestion
+ENABLE_REPLAYS_CONSUMER = os.environ.get("ENABLE_REPLAYS_CONSUMER", False)
+
 # Place the actual time we start ingesting on the new version.
 ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 3, 23, 0, 0, 0)
 TRANSACTIONS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -41,6 +41,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "metrics-subscription-results",
         "snuba-dead-letter-inserts",
         "processed-profiles",
+        "snuba-replay-events",
     }
 
     for key in locals["KAFKA_TOPIC_MAP"].keys():

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -22,6 +22,8 @@ class Topic(Enum):
     SUBSCRIPTION_RESULTS_METRICS = "metrics-subscription-results"
     QUERYLOG = "snuba-queries"
     PROFILES = "processed-profiles"
+    REPLAYEVENTS = "snuba-replay-events"
+
     DEAD_LETTER_QUEUE_INSERTS = "snuba-dead-letter-inserts"
     DEAD_LETTER_METRICS = "snuba-dead-letter-metrics"
     DEAD_LETTER_SESSIONS = "snuba-dead-letter-sessions"
@@ -33,5 +35,6 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
         Topic.TRANSACTIONS: {"message.timestamp.type": "LogAppendTime"},
         Topic.METRICS: {"message.timestamp.type": "LogAppendTime"},
         Topic.PROFILES: {"message.timestamp.type": "LogAppendTime"},
+        Topic.REPLAYEVENTS: {"message.timestamp.type": "LogAppendTime"},
     }
     return config.get(topic, {})

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.replays_processor import ReplaysProcessor
+from snuba.processor import InsertBatch
+
+
+@dataclass
+class ReplayEvent:
+    replay_id: str
+    sequence_id: int
+    trace_ids: list[str]
+    timestamp: float
+    platform: str
+    environment: str
+    release: str
+    dist: str
+    ipv4: str
+    ipv6: str | None
+    user_name: str
+    user_id: str
+    user_email: str
+    sdk_name: str
+    sdk_version: str
+    title: str
+
+    def serialize(self) -> Mapping[Any, Any]:
+        return {
+            "datetime": "2019-08-08T22:29:53.917000Z",
+            "organization_id": 1,
+            "platform": self.platform,
+            "project_id": 1,
+            "replay_id": self.replay_id,
+            "message": "/organizations/:orgId/issues/",
+            "retention_days": 23,
+            "sequence_id": self.sequence_id,
+            "trace_ids": self.trace_ids,
+            "data": {
+                "replay_id": self.replay_id,
+                "environment": self.environment,
+                "project_id": 1,
+                "release": self.release,
+                "dist": self.dist,
+                "sdk": {
+                    "version": self.sdk_version,
+                    "name": self.sdk_name,
+                    "packages": [{"version": "0.9.0", "name": "pypi:sentry-sdk"}],
+                },
+                "platform": self.platform,
+                "version": "7",
+                "location": "/organizations/:orgId/issues/",
+                "type": "replay_event",
+                "datetime": datetime.utcfromtimestamp(self.timestamp),
+                "timestamp": self.timestamp,
+                "tags": [
+                    ["sentry:release", self.release],
+                    ["sentry:user", self.user_id],
+                    ["environment", self.environment],
+                    ["we|r=d", "tag"],
+                ],
+                "user": {
+                    "username": self.user_name,
+                    "ip_address": self.ipv4 or self.ipv6,
+                    "id": self.user_id,
+                    "email": self.user_email,
+                    # "geo": self.geo,
+                },
+                "title": self.title,
+            },
+        }
+
+    def build_result(self, meta: KafkaMessageMetadata) -> Mapping[str, Any]:
+        ret = {
+            "project_id": 1,
+            "replay_id": str(uuid.UUID(self.replay_id)),
+            "sequence_id": self.sequence_id,
+            "trace_ids": self.trace_ids,
+            "timestamp": datetime.utcfromtimestamp(self.timestamp),
+            "platform": self.platform,
+            "environment": self.environment,
+            "release": self.release,
+            "dist": self.dist,
+            "user": self.user_id,
+            "user_id": self.user_id,
+            "user_name": self.user_name,
+            "user_email": self.user_email,
+            "tags.key": ["environment", "sentry:release", "sentry:user", "we|r=d"],
+            "tags.value": [self.environment, self.release, self.user_id, "tag"],
+            "sdk_name": "sentry.python",
+            "sdk_version": "0.9.0",
+            "retention_days": 30,
+            "offset": meta.offset,
+            "partition": meta.partition,
+        }
+
+        if self.ipv4:
+            ret["ip_address_v4"] = self.ipv4
+        else:
+            ret["ip_address_v6"] = self.ipv6
+        return ret
+
+
+class TestReplaysProcessor:
+    def test_process_message(self) -> None:
+        meta = KafkaMessageMetadata(
+            offset=0, partition=0, timestamp=datetime(1970, 1, 1)
+        )
+
+        message = ReplayEvent(
+            replay_id="e5e062bf2e1d4afd96fd2f90b6770431",
+            title="/organizations/:orgId/issues/",
+            trace_ids=[
+                "36e980a9-c602-4cde-9f5d-089f15b83b5f",
+                "8bea4461-d8b9-44f3-93c1-5a3cb1c4169a",
+            ],
+            sequence_id=0,
+            timestamp=datetime.now(tz=timezone.utc).timestamp(),
+            platform="python",
+            dist="",
+            user_name="me",
+            user_id="232",
+            user_email="test@test.com",
+            ipv4="127.0.0.1",
+            ipv6=None,
+            environment="prod",
+            release="34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a",
+            sdk_name="sentry.python",
+            sdk_version="0.9.0",
+        )
+
+        assert ReplaysProcessor().process_message(
+            message.serialize(), meta
+        ) == InsertBatch([message.build_result(meta)], None)


### PR DESCRIPTION
(re-open of #2683)

following up on https://github.com/getsentry/snuba/pull/2681, we add a processor to insert replay data rows into clickhouse.

common code has been copy/pasted from relevant consumers for things like tag/environment processing etc.

Will note that we'll be rapidly prototyping on top of this, so opting for quicker / more isolated changes (as opposed to e.g. refactoring to be more DRY for tag processing).