### PR TITLE
ref(attribution): Split RequestSettings into QuerySetings and attribution

### DIFF
--- a/snuba/attribution/attribution_info.py
+++ b/snuba/attribution/attribution_info.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from snuba.attribution import AppID
+
+
+@dataclass(frozen=True)
+class AttributionInfo:
+    """The settings for a attribution of a query + quota enforcement
+    should be immutable
+    """
+
+    app_id: AppID
+    referrer: str
+    team: str | None
+    feature: str | None
+    parent_api: str | None

--- a/snuba/clickhouse/processors.py
+++ b/snuba/clickhouse/processors.py
@@ -22,7 +22,7 @@ class QueryProcessor(ABC):
     """
 
     @abstractmethod
-    def process_query(self, query: Query, request_settings: QuerySettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # TODO: Consider making the Query immutable.
         raise NotImplementedError
 
@@ -40,6 +40,6 @@ class CompositeQueryProcessor(ABC):
 
     @abstractmethod
     def process_query(
-        self, query: CompositeQuery[Table], request_settings: QuerySettings
+        self, query: CompositeQuery[Table], query_settings: QuerySettings
     ) -> None:
         raise NotImplementedError

--- a/snuba/clickhouse/processors.py
+++ b/snuba/clickhouse/processors.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from snuba.clickhouse.query import Query
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class QueryProcessor(ABC):
@@ -22,7 +22,7 @@ class QueryProcessor(ABC):
     """
 
     @abstractmethod
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, request_settings: QuerySettings) -> None:
         # TODO: Consider making the Query immutable.
         raise NotImplementedError
 
@@ -40,6 +40,6 @@ class CompositeQueryProcessor(ABC):
 
     @abstractmethod
     def process_query(
-        self, query: CompositeQuery[Table], request_settings: RequestSettings
+        self, query: CompositeQuery[Table], request_settings: QuerySettings
     ) -> None:
         raise NotImplementedError

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -82,4 +82,6 @@ class DatasetQueryPipelineBuilder:
                 request, runner
             )
         else:
-            return CompositeExecutionPipeline(request.query, request.settings, runner)
+            return CompositeExecutionPipeline(
+                request.query, request.query_settings, runner
+            )

--- a/snuba/datasets/entities/clickhouse_upgrade.py
+++ b/snuba/datasets/entities/clickhouse_upgrade.py
@@ -21,8 +21,8 @@ from sentry_sdk import set_tag
 
 from snuba import environment, settings
 from snuba.query.logical import Query
+from snuba.query.query_settings import QuerySettings
 from snuba.reader import Row
-from snuba.request.request_settings import RequestSettings
 from snuba.state import get_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.threaded_function_delegator import Result
@@ -119,7 +119,7 @@ RowValues = Tuple[Union[int, float, bool], ...]
 
 def comparison_callback(
     _query: Query,
-    _settings: RequestSettings,
+    _settings: QuerySettings,
     referrer: str,
     primary_result: Optional[Result[QueryResult]],
     results: List[Result[QueryResult]],

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -36,8 +36,8 @@ from snuba.query.processors.object_id_rate_limiter import (
 from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
+from snuba.query.query_settings import QuerySettings
 from snuba.query.validation.validators import EntityRequiredColumnValidator
-from snuba.request.request_settings import RequestSettings
 
 event_translator = TranslationMappers(
     columns=[
@@ -103,11 +103,11 @@ class ErrorsQueryStorageSelector(QueryStorageSelector):
         self.__mappers = mappers
 
     def select_storage(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> StorageAndMappers:
         use_readonly_storage = (
             state.get_config("enable_events_readonly_table", False)
-            and not request_settings.get_consistent()
+            and not query_settings.get_consistent()
         )
 
         storage = (
@@ -123,9 +123,9 @@ class ErrorsV2QueryStorageSelector(QueryStorageSelector):
         self.__mappers = mappers
 
     def select_storage(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> StorageAndMappers:
-        use_readonly_storage = not request_settings.get_consistent()
+        use_readonly_storage = not query_settings.get_consistent()
 
         storage = (
             self.__errors_ro_table if use_readonly_storage else self.__errors_table

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -47,16 +47,16 @@ from snuba.query.processors.object_id_rate_limiter import (
 )
 from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
+from snuba.query.query_settings import QuerySettings
 from snuba.query.validation.validators import (
     EntityRequiredColumnValidator,
     GranularityValidator,
     QueryValidator,
 )
-from snuba.request.request_settings import RequestSettings
 
 
 class TagsTypeTransformer(QueryProcessor):
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_expression(exp: Expression) -> Expression:
             if not isinstance(exp, SubscriptableReference):
                 return exp

--- a/snuba/datasets/entities/sessions.py
+++ b/snuba/datasets/entities/sessions.py
@@ -40,11 +40,11 @@ from snuba.query.processors.timeseries_processor import (
     TimeSeriesProcessor,
     extract_granularity_from_query,
 )
+from snuba.query.query_settings import QuerySettings, SubscriptionQuerySettings
 from snuba.query.validation.validators import (
     ColumnValidationMode,
     EntityRequiredColumnValidator,
 )
-from snuba.request.request_settings import RequestSettings, SubscriptionRequestSettings
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "api.sessions")
@@ -221,10 +221,10 @@ class SessionsQueryStorageSelector(QueryStorageSelector):
         self.raw_storage = get_storage(StorageKey.SESSIONS_RAW)
 
     def select_storage(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> StorageAndMappers:
 
-        # If the passed in `request_settings` arg is an instance of `SubscriptionRequestSettings`,
+        # If the passed in `query_settings` arg is an instance of `SubscriptionQuerySettings`,
         # then it is a crash rate alert subscription, and hence we decide on whether to use the
         # materialized storage or the raw storage by examining the time_window.
         # If the `time_window` <=1h, then select the raw storage otherwise select materialized
@@ -232,7 +232,7 @@ class SessionsQueryStorageSelector(QueryStorageSelector):
         # NOTE: If we were to support other types of subscriptions over the sessions dataset that
         # do not follow this method used to identify which storage to use, we would need to
         # find a different way to distinguish them.
-        if isinstance(request_settings, SubscriptionRequestSettings):
+        if isinstance(query_settings, SubscriptionQuerySettings):
             from_date, to_date = get_time_range(query, "started")
             if from_date and to_date:
                 use_materialized_storage = to_date - from_date > timedelta(hours=1)

--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -41,8 +41,8 @@ from snuba.query.processors.performance_expressions import (
 from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
+from snuba.query.query_settings import QuerySettings
 from snuba.query.validation.validators import EntityRequiredColumnValidator
-from snuba.request.request_settings import RequestSettings
 
 transaction_translator = TranslationMappers(
     columns=[
@@ -110,10 +110,10 @@ class TransactionsQueryStorageSelector(QueryStorageSelector):
         self.__mappers = mappers
 
     def select_storage(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> StorageAndMappers:
         readonly_referrer = (
-            request_settings.referrer
+            query_settings.referrer
             in settings.TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS
         )
         use_readonly_storage = readonly_referrer or state.get_config(

--- a/snuba/datasets/plans/query_plan.py
+++ b/snuba/datasets/plans/query_plan.py
@@ -11,12 +11,12 @@ from snuba.query import Query as AbstractQuery
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.query_settings import QuerySettings
 from snuba.reader import Reader
-from snuba.request.request_settings import RequestSettings
 from snuba.web import QueryResult
 
 QueryRunner = Callable[
-    [Union[Query, CompositeQuery[Table]], RequestSettings, Reader], QueryResult
+    [Union[Query, CompositeQuery[Table]], QuerySettings, Reader], QueryResult
 ]
 
 TQuery = TypeVar("TQuery", bound=AbstractQuery)
@@ -160,7 +160,7 @@ class QueryPlanExecutionStrategy(ABC, Generic[TQuery]):
     def execute(
         self,
         query: TQuery,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         runner: QueryRunner,
     ) -> QueryResult:
         """
@@ -182,7 +182,7 @@ class ClickhouseQueryPlanBuilder(ABC):
 
     @abstractmethod
     def build_and_rank_plans(
-        self, query: LogicalQuery, request_settings: RequestSettings
+        self, query: LogicalQuery, query_settings: QuerySettings
     ) -> Sequence[ClickhouseQueryPlan]:
         """
         Returns all the valid plans for this query sorted in ranking
@@ -191,8 +191,8 @@ class ClickhouseQueryPlanBuilder(ABC):
         raise NotImplementedError
 
     def build_best_plan(
-        self, query: LogicalQuery, request_settings: RequestSettings
+        self, query: LogicalQuery, query_settings: QuerySettings
     ) -> ClickhouseQueryPlan:
-        plans = self.build_and_rank_plans(query, request_settings)
+        plans = self.build_and_rank_plans(query, query_settings)
         assert plans, "Query planner did not produce a plan"
         return plans[0]

--- a/snuba/datasets/plans/split_strategy.py
+++ b/snuba/datasets/plans/split_strategy.py
@@ -11,7 +11,7 @@ SplitQueryRunner = Callable[[Query, RequestSettings], QueryResult]
 class QuerySplitStrategy(ABC):
     """
     Implements a query split algorithm. It works in a similar way as a
-    QueryExecutionStrategy, it takes a query, request settings and a query runner
+    QueryExecutionStrategy, it takes a query, request.query_settings and a query runner
     and decides if it should split the query into more efficient parts.
     If it can split the query, it uses the SplitQueryRunner to execute every chunk,
     otherwise it returns None immediately.

--- a/snuba/datasets/plans/split_strategy.py
+++ b/snuba/datasets/plans/split_strategy.py
@@ -2,10 +2,10 @@ from abc import ABC, abstractmethod
 from typing import Callable, Optional
 
 from snuba.clickhouse.query import Query
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.web import QueryResult
 
-SplitQueryRunner = Callable[[Query, RequestSettings], QueryResult]
+SplitQueryRunner = Callable[[Query, QuerySettings], QueryResult]
 
 
 class QuerySplitStrategy(ABC):
@@ -31,7 +31,7 @@ class QuerySplitStrategy(ABC):
     def execute(
         self,
         query: Query,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         runner: SplitQueryRunner,
     ) -> Optional[QueryResult]:
         """

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -16,8 +16,8 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.table_storage import KafkaStreamLoader, TableWriter
 from snuba.query.expressions import Expression
 from snuba.query.logical import Query
+from snuba.query.query_settings import QuerySettings
 from snuba.replacers.replacer_processor import ReplacerProcessor
-from snuba.request.request_settings import RequestSettings
 
 
 class Storage(ABC):
@@ -211,6 +211,6 @@ class QueryStorageSelector(ABC):
 
     @abstractmethod
     def select_storage(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> StorageAndMappers:
         raise NotImplementedError

--- a/snuba/datasets/storages/events_bool_contexts.py
+++ b/snuba/datasets/storages/events_bool_contexts.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import Expression
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.matchers import Column, FunctionCall, Literal, Or, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class EventsPromotedBooleanContextsProcessor(QueryProcessor):
@@ -30,7 +30,7 @@ class EventsPromotedBooleanContextsProcessor(QueryProcessor):
     patch to the events storage for as long as it exists.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # We care only of promoted contexts, so we do not need to match
         # the original nested expression.
         matcher = FunctionCall(
@@ -80,7 +80,7 @@ class EventsBooleanContextsProcessor(QueryProcessor):
     from the errors and events storages.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         matcher = FunctionCall(
             String("arrayElement"),
             (

--- a/snuba/datasets/storages/group_id_column_processor.py
+++ b/snuba/datasets/storages/group_id_column_processor.py
@@ -1,11 +1,11 @@
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class GroupIdColumnProcessor(QueryProcessor):
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_column(exp: Expression) -> Expression:
             if isinstance(exp, Column):
                 if exp.column_name == "group_id":

--- a/snuba/datasets/storages/processors/consistency_enforcer.py
+++ b/snuba/datasets/storages/processors/consistency_enforcer.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class ConsistencyEnforcerProcessor(QueryProcessor):
@@ -14,5 +14,5 @@ class ConsistencyEnforcerProcessor(QueryProcessor):
     like the CDC tables.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         query.set_from_clause(replace(query.get_from_clause(), final=True))

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -21,7 +21,7 @@ from snuba.query.exceptions import ValidationException
 from snuba.query.processors.conditions_enforcer import OrgIdEnforcer, ProjectIdEnforcer
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.table_rate_limit import TableRateLimit
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.utils.streams.topics import Topic
 
 WRITE_LOCAL_TABLE_NAME = "sessions_raw_local"
@@ -103,7 +103,7 @@ materialized_view_schema = TableSchema(
 
 
 class MinuteResolutionProcessor(QueryProcessor):
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # NOTE: the product side is restricted to a 6h window, however it rounds
         # outwards, which extends the window to 7h.
         from_date, to_date = get_time_range(query, "started")

--- a/snuba/datasets/storages/type_condition_optimizer.py
+++ b/snuba/datasets/storages/type_condition_optimizer.py
@@ -3,7 +3,7 @@ from snuba.clickhouse.query import Query
 from snuba.query.expressions import Expression
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.matchers import Column, FunctionCall, Literal, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class TypeConditionOptimizer(QueryProcessor):
@@ -14,7 +14,7 @@ class TypeConditionOptimizer(QueryProcessor):
     required for compatibility with the events storage.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def replace_exp(exp: Expression) -> Expression:
             matcher = FunctionCall(
                 String("notEquals"),

--- a/snuba/datasets/storages/user_column_processor.py
+++ b/snuba/datasets/storages/user_column_processor.py
@@ -1,7 +1,7 @@
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class UserColumnProcessor(QueryProcessor):
@@ -11,7 +11,7 @@ class UserColumnProcessor(QueryProcessor):
     that it will be properly applied to the promoted sentry:user tag.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_column(exp: Expression) -> Expression:
             if isinstance(exp, Column):
                 if exp.column_name == "user":

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -91,7 +91,7 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
             partial(
                 callback_func,
                 self.__request.query,
-                self.__request.settings,
+                self.__request.query_settings,
                 self.__request.referrer,
             )
             if callback_func
@@ -107,7 +107,7 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
             """
             query = (
                 request.query
-                if _is_query_copying_disallowed(request.settings.referrer)
+                if _is_query_copying_disallowed(request.query_settings.referrer)
                 else copy.deepcopy(request.query)
             )
 
@@ -117,7 +117,7 @@ class MultipleConcurrentPipeline(QueryExecutionPipeline):
             return replace(
                 request,
                 query=query,
-                settings=RateLimiterDelegate(builder_id, request.settings),
+                query_settings=RateLimiterDelegate(builder_id, request.query_settings),
             )
 
         executor = ThreadedFunctionDelegator[LogicalQuery, QueryResult](

--- a/snuba/pipeline/pipeline_delegator.py
+++ b/snuba/pipeline/pipeline_delegator.py
@@ -12,8 +12,8 @@ from snuba.pipeline.query_pipeline import (
 )
 from snuba.pipeline.settings_delegator import RateLimiterDelegate
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.query_settings import QuerySettings
 from snuba.request import Request
-from snuba.request.request_settings import RequestSettings
 from snuba.state import get_config
 from snuba.utils.threaded_function_delegator import Result, ThreadedFunctionDelegator
 from snuba.web import QueryResult
@@ -24,7 +24,7 @@ QueryPipelineBuilders = Mapping[BuilderId, QueryPipelineBuilder[ClickhouseQueryP
 QueryResults = List[Result[QueryResult]]
 SelectorFunc = Callable[[LogicalQuery, str], Tuple[BuilderId, List[BuilderId]]]
 CallbackFunc = Callable[
-    [LogicalQuery, RequestSettings, str, Optional[Result[QueryResult]], QueryResults],
+    [LogicalQuery, QuerySettings, str, Optional[Result[QueryResult]], QueryResults],
     None,
 ]
 
@@ -171,7 +171,7 @@ class PipelineDelegator(QueryPipelineBuilder[ClickhouseQueryPlan]):
         )
 
     def build_planner(
-        self, query: LogicalQuery, settings: RequestSettings
+        self, query: LogicalQuery, settings: QuerySettings
     ) -> QueryPlanner[ClickhouseQueryPlan]:
         # For composite queries, we just build the primary pipeline / query plan;
         # running multiple concurrent composite queries is not currently supported.

--- a/snuba/pipeline/processors.py
+++ b/snuba/pipeline/processors.py
@@ -6,13 +6,13 @@ from snuba.clickhouse.processors import QueryProcessor
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.query.logical import Query as LogicalQuery
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 def _execute_clickhouse_processors(
     processors: Callable[[ClickhouseQueryPlan], Sequence[QueryProcessor]],
     query_plan: ClickhouseQueryPlan,
-    settings: RequestSettings,
+    settings: QuerySettings,
 ) -> None:
     """
     Executes the Clickhouse query processors for the query. These
@@ -32,7 +32,7 @@ def _execute_clickhouse_processors(
 
 def execute_plan_processors(
     query_plan: ClickhouseQueryPlan,
-    settings: RequestSettings,
+    settings: QuerySettings,
 ) -> None:
     """
     Executes the plan query processors but not the db ones (those
@@ -47,7 +47,7 @@ def execute_plan_processors(
 
 def execute_all_clickhouse_processors(
     query_plan: ClickhouseQueryPlan,
-    settings: RequestSettings,
+    settings: QuerySettings,
 ) -> None:
     """
     Executes all Clickhouse query processing including the plan processors
@@ -63,7 +63,7 @@ def execute_all_clickhouse_processors(
     )
 
 
-def execute_entity_processors(query: LogicalQuery, settings: RequestSettings) -> None:
+def execute_entity_processors(query: LogicalQuery, settings: QuerySettings) -> None:
     """
     Executes the entity query processors for the query. These are taken
     from the entity.

--- a/snuba/pipeline/query_pipeline.py
+++ b/snuba/pipeline/query_pipeline.py
@@ -17,7 +17,7 @@ TPlan = TypeVar("TPlan", bound=Union[ClickhouseQueryPlan, CompositeQueryPlan])
 class QueryPlanner(ABC, Generic[TPlan]):
     """
     A QueryPlanner contains a series of steps that, given a logical
-    query and request settings, executes all the logical query processing
+    query and request.query_settings, executes all the logical query processing
     translates the query and compiles a query plan that can be used
     to execute the query.
 

--- a/snuba/pipeline/query_pipeline.py
+++ b/snuba/pipeline/query_pipeline.py
@@ -7,8 +7,8 @@ from snuba.datasets.plans.query_plan import (
     QueryRunner,
 )
 from snuba.query.logical import Query
+from snuba.query.query_settings import QuerySettings
 from snuba.request import Request
-from snuba.request.request_settings import RequestSettings
 from snuba.web import QueryResult
 
 TPlan = TypeVar("TPlan", bound=Union[ClickhouseQueryPlan, CompositeQueryPlan])
@@ -73,6 +73,6 @@ class QueryPipelineBuilder(ABC, Generic[TPlan]):
 
     @abstractmethod
     def build_planner(
-        self, query: Query, settings: RequestSettings
+        self, query: Query, settings: QuerySettings
     ) -> QueryPlanner[ClickhouseQueryPlan]:
         raise NotImplementedError

--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -52,23 +52,11 @@ class RateLimiterDelegate(RequestSettings):
     def get_debug(self) -> bool:
         return self.__delegate.get_debug()
 
-    def get_parent_api(self) -> str:
-        return self.__delegate.get_parent_api()
-
     def get_dry_run(self) -> bool:
         return self.__delegate.get_dry_run()
 
     def get_legacy(self) -> bool:
         return self.__delegate.get_legacy()
-
-    def get_team(self) -> str:
-        return self.__delegate.get_team()
-
-    def get_feature(self) -> str:
-        return self.__delegate.get_feature()
-
-    def get_app_id(self) -> str:
-        return self.__delegate.get_app_id()
 
     def get_rate_limit_params(self) -> Sequence[RateLimitParameters]:
         return [

--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -1,12 +1,12 @@
 import copy
 from typing import Optional, Sequence
 
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state.quota import ResourceQuota
 from snuba.state.rate_limit import RateLimitParameters
 
 
-class RateLimiterDelegate(RequestSettings):
+class RateLimiterDelegate(QuerySettings):
     """
     When we run the pipeline delegator, we are running multiple queries
     at the same time. Generally they are duplicates.
@@ -30,7 +30,7 @@ class RateLimiterDelegate(RequestSettings):
     the rate limits to the same list if a deepcopy is not created.
     """
 
-    def __init__(self, prefix: str, delegate: RequestSettings):
+    def __init__(self, prefix: str, delegate: QuerySettings):
         self.referrer = delegate.referrer
         self.__delegate = copy.deepcopy(delegate)
         self.__prefix = prefix

--- a/snuba/pipeline/simple_pipeline.py
+++ b/snuba/pipeline/simple_pipeline.py
@@ -12,8 +12,8 @@ from snuba.pipeline.query_pipeline import (
     QueryPlanner,
 )
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.query_settings import QuerySettings
 from snuba.request import Request
-from snuba.request.request_settings import RequestSettings
 from snuba.web import QueryResult
 
 
@@ -31,7 +31,7 @@ class EntityQueryPlanner(QueryPlanner[ClickhouseQueryPlan]):
     def __init__(
         self,
         query: LogicalQuery,
-        settings: RequestSettings,
+        settings: QuerySettings,
         query_plan_builder: ClickhouseQueryPlanBuilder,
     ) -> None:
         self.__query = query
@@ -93,6 +93,6 @@ class SimplePipelineBuilder(QueryPipelineBuilder[ClickhouseQueryPlan]):
     def build_planner(
         self,
         query: LogicalQuery,
-        settings: RequestSettings,
+        settings: QuerySettings,
     ) -> EntityQueryPlanner:
         return EntityQueryPlanner(query, settings, self.__query_plan_builder)

--- a/snuba/pipeline/simple_pipeline.py
+++ b/snuba/pipeline/simple_pipeline.py
@@ -67,7 +67,7 @@ class SimpleExecutionPipeline(QueryExecutionPipeline):
         self.__query_planner = query_planner
 
     def execute(self) -> QueryResult:
-        settings = self.__request.settings
+        settings = self.__request.query_settings
         query_plan = self.__query_planner.build_best_plan()
         execute_plan_processors(query_plan, settings)
 
@@ -87,7 +87,7 @@ class SimplePipelineBuilder(QueryPipelineBuilder[ClickhouseQueryPlan]):
         return SimpleExecutionPipeline(
             request,
             runner,
-            self.build_planner(request.query, request.settings),
+            self.build_planner(request.query, request.query_settings),
         )
 
     def build_planner(

--- a/snuba/query/joins/semi_joins.py
+++ b/snuba/query/joins/semi_joins.py
@@ -13,7 +13,7 @@ from snuba.query.data_source.join import (
 )
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class SemiJoinOptimizer(CompositeQueryProcessor):
@@ -40,11 +40,11 @@ class SemiJoinOptimizer(CompositeQueryProcessor):
     """
 
     def process_query(
-        self, query: CompositeQuery[Table], request_settings: RequestSettings
+        self, query: CompositeQuery[Table], query_settings: QuerySettings
     ) -> None:
         from_clause = query.get_from_clause()
         if isinstance(from_clause, CompositeQuery):
-            self.process_query(from_clause, request_settings)
+            self.process_query(from_clause, query_settings)
             return
         elif isinstance(from_clause, ProcessableQuery):
             return

--- a/snuba/query/processors/__init__.py
+++ b/snuba/query/processors/__init__.py
@@ -7,7 +7,7 @@ from snuba.request.request_settings import RequestSettings
 class QueryProcessor(ABC):
     """
     A transformation applied to a Query. This depends on the query structure and
-    on the request settings. No additional context is provided.
+    on the request.query_settings. No additional context is provided.
     This transformation mutates the Query object in place.
 
     These processors tweak the query and are developed independently from each other,

--- a/snuba/query/processors/__init__.py
+++ b/snuba/query/processors/__init__.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from snuba.query.logical import Query
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class QueryProcessor(ABC):
@@ -21,7 +21,7 @@ class QueryProcessor(ABC):
     """
 
     @abstractmethod
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # TODO: Now the query is moved around through the Request object, which
         # is frozen (and it should be), thus the Query itself is mutable since
         # we cannot reassign it.

--- a/snuba/query/processors/array_has_optimizer.py
+++ b/snuba/query/processors/array_has_optimizer.py
@@ -13,7 +13,7 @@ from snuba.query.matchers import (
     Param,
     String,
 )
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 """
 This optimizer is necessary because SnQL does not permit conditions like
@@ -49,7 +49,7 @@ class ArrayHasOptimizer(QueryProcessor):
             ),
         )
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def replace_expression(expr: Expression) -> Expression:
             match = self.__array_has_pattern.match(expr)
 

--- a/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
+++ b/snuba/query/processors/arrayjoin_keyvalue_optimizer.py
@@ -18,7 +18,7 @@ from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.expressions import Lambda
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.matchers import Any, Column, FunctionCall, Literal, Or, Param, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 def key_column(col_name: str) -> str:
@@ -140,7 +140,7 @@ class ArrayJoinKeyValueOptimizer(QueryProcessor):
     def __init__(self, column_name: str) -> None:
         self.__column_name = column_name
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         arrayjoin_pattern = FunctionCall(
             String("arrayJoin"),
             (

--- a/snuba/query/processors/arrayjoin_optimizer.py
+++ b/snuba/query/processors/arrayjoin_optimizer.py
@@ -18,7 +18,7 @@ from snuba.query.matchers import Column, FunctionCall, Or, Param, String
 from snuba.query.processors.abstract_array_join_optimizer import (
     AbstractArrayJoinOptimizer,
 )
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class ArrayJoinOptimizer(AbstractArrayJoinOptimizer):
@@ -84,7 +84,7 @@ class ArrayJoinOptimizer(AbstractArrayJoinOptimizer):
 
         return alias
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         array_joins_in_query = self.__get_array_joins_in_query(query)
 
         tuple_alias = self.__get_unused_alias(query)

--- a/snuba/query/processors/basic_functions.py
+++ b/snuba/query/processors/basic_functions.py
@@ -8,7 +8,7 @@ from snuba.query.expressions import (
 )
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class BasicFunctionsProcessor(QueryProcessor):
@@ -18,7 +18,7 @@ class BasicFunctionsProcessor(QueryProcessor):
     This exists only to preserve the current Snuba syntax and only works on the new AST.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_functions(exp: Expression) -> Expression:
             if isinstance(exp, FunctionCall):
                 if exp.function_name == "uniq":

--- a/snuba/query/processors/bloom_filter_optimizer.py
+++ b/snuba/query/processors/bloom_filter_optimizer.py
@@ -10,11 +10,11 @@ from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.processors.abstract_array_join_optimizer import (
     AbstractArrayJoinOptimizer,
 )
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class BloomFilterOptimizer(AbstractArrayJoinOptimizer):
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         single_filtered, multiple_filtered = self.get_filtered_arrays(
             query, self.key_columns
         )

--- a/snuba/query/processors/conditions_enforcer.py
+++ b/snuba/query/processors/conditions_enforcer.py
@@ -14,7 +14,7 @@ from snuba.query.matchers import Column as ColumnPattern
 from snuba.query.matchers import FunctionCall as FunctionCallPattern
 from snuba.query.matchers import Literal as LiteralPattern
 from snuba.query.matchers import Or, Param, Pattern, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state import get_config
 
 logger = logging.getLogger(__name__)
@@ -83,7 +83,7 @@ class MandatoryConditionEnforcer(QueryProcessor):
     def __init__(self, condition_checkers: Sequence[ConditionChecker]) -> None:
         self.__condition_checkers = condition_checkers
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         missing_checkers = {checker for checker in self.__condition_checkers}
 
         def inspect_expression(condition: Expression) -> None:

--- a/snuba/query/processors/custom_function.py
+++ b/snuba/query/processors/custom_function.py
@@ -6,9 +6,9 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.parser.expressions import parse_clickhouse_function
 from snuba.query.processors import QueryProcessor
+from snuba.query.query_settings import QuerySettings
 from snuba.query.validation import InvalidFunctionCall
 from snuba.query.validation.signature import ParamType, SignatureValidator
-from snuba.request.request_settings import RequestSettings
 
 
 class InvalidCustomFunctionCall(InvalidExpressionException):
@@ -81,7 +81,7 @@ class CustomFunction(QueryProcessor):
         self.__body = body
         self.__validator = SignatureValidator(param_types)
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def apply_function(expression: Expression) -> Expression:
             if (
                 isinstance(expression, FunctionCall)

--- a/snuba/query/processors/empty_tag_condition_processor.py
+++ b/snuba/query/processors/empty_tag_condition_processor.py
@@ -11,7 +11,7 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.matchers import FunctionCall as FunctionCallPattern
 from snuba.query.matchers import Literal as LiteralPattern
 from snuba.query.matchers import String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 CONDITION_PATTERN = condition_pattern(
     {ConditionFunctions.EQ, ConditionFunctions.NEQ},
@@ -30,7 +30,7 @@ class EmptyTagConditionProcessor(QueryProcessor):
     the `has` function.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_condition(exp: Expression) -> Expression:
             result = CONDITION_PATTERN.match(exp)
             if result is not None:

--- a/snuba/query/processors/granularity_processor.py
+++ b/snuba/query/processors/granularity_processor.py
@@ -4,7 +4,7 @@ from snuba.query.exceptions import InvalidGranularityException
 from snuba.query.expressions import Column, Literal
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 #: Granularities for which a materialized view exist, in ascending order
 GRANULARITIES_AVAILABLE = (10, 60, 60 * 60, 24 * 60 * 60)
@@ -30,7 +30,7 @@ class GranularityProcessor(QueryProcessor):
             f"Granularity must be multiple of one of {GRANULARITIES_AVAILABLE}"
         )
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         granularity = self.__get_granularity(query)
         query.add_condition_to_ast(
             binary_condition(

--- a/snuba/query/processors/handled_functions.py
+++ b/snuba/query/processors/handled_functions.py
@@ -15,9 +15,9 @@ from snuba.query.expressions import (
 )
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
+from snuba.query.query_settings import QuerySettings
 from snuba.query.validation import InvalidFunctionCall
 from snuba.query.validation.signature import SignatureValidator
-from snuba.request.request_settings import RequestSettings
 
 
 class HandledFunctionsProcessor(QueryProcessor):
@@ -53,7 +53,7 @@ class HandledFunctionsProcessor(QueryProcessor):
                 should_report=False,
             ) from err
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_functions(exp: Expression) -> Expression:
             if isinstance(exp, FunctionCall):
                 if exp.function_name == "isHandled":

--- a/snuba/query/processors/mandatory_condition_applier.py
+++ b/snuba/query/processors/mandatory_condition_applier.py
@@ -1,7 +1,7 @@
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.conditions import combine_and_conditions
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class MandatoryConditionApplier(QueryProcessor):
@@ -11,7 +11,7 @@ class MandatoryConditionApplier(QueryProcessor):
     and applies them to the query.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
 
         mandatory_conditions = query.get_from_clause().mandatory_conditions
 

--- a/snuba/query/processors/mapping_optimizer.py
+++ b/snuba/query/processors/mapping_optimizer.py
@@ -25,7 +25,7 @@ from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.matchers import Any, AnyOptionalString
 from snuba.query.matchers import Column as ColumnMatcher
 from snuba.query.matchers import FunctionCall, Literal, Or, Param, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state import get_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
@@ -284,7 +284,7 @@ class MappingOptimizer(QueryProcessor):
         else:
             return clause, cond_class
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         if not get_config(self.__killswitch, 1):
             return
         condition, cond_class = self.__get_reduced_and_classified_query_clause(

--- a/snuba/query/processors/mapping_promoter.py
+++ b/snuba/query/processors/mapping_promoter.py
@@ -10,7 +10,7 @@ from snuba.clickhouse.translators.snuba.mappers import (
     mapping_pattern,
 )
 from snuba.query.expressions import Column, Expression, FunctionCall
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class SubscriptableMatch(NamedTuple):
@@ -90,7 +90,7 @@ class MappingColumnPromoter(QueryProcessor):
         self.__specs = mapping_specs
         self.__cast_to_string = cast_to_string
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_nested_column(exp: Expression) -> Expression:
             subscript = match_subscriptable_reference(exp)
             if subscript is None:

--- a/snuba/query/processors/null_column_caster.py
+++ b/snuba/query/processors/null_column_caster.py
@@ -6,7 +6,7 @@ from snuba.clickhouse.query import Query
 from snuba.datasets.storage import ReadableTableStorage
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.functions import AGGREGATION_FUNCTIONS
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 def _col_is_nullable(col: FlattenedColumn) -> bool:
@@ -83,7 +83,7 @@ class NullColumnCaster(QueryProcessor):
     def mismatched_null_columns(self) -> Dict[str, FlattenedColumn]:
         return self.__mismatched_null_columns
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def cast_column_to_nullable(exp: Expression) -> Expression:
             if isinstance(exp, Column):
                 if exp.column_name in self.mismatched_null_columns:

--- a/snuba/query/processors/object_id_rate_limiter.py
+++ b/snuba/query/processors/object_id_rate_limiter.py
@@ -3,7 +3,7 @@ from typing import Optional
 from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state import get_configs
 from snuba.state.rate_limit import (
     ORGANIZATION_RATE_LIMIT_NAME,
@@ -28,25 +28,25 @@ class ObjectIDRateLimiterProcessor(QueryProcessor):
         rate_limit_name: str,
         per_second_name: str,
         concurrent_name: str,
-        request_settings_field: Optional[str] = None,
+        query_settings_field: Optional[str] = None,
         default_limit: int = DEFAULT_LIMIT,
     ) -> None:
         self.object_column = object_column
         self.rate_limit_name = rate_limit_name
         self.per_second_name = per_second_name
         self.concurrent_name = concurrent_name
-        self.request_settings_field = request_settings_field
+        self.query_settings_field = query_settings_field
         self.default_limit = default_limit
 
-    def _is_already_applied(self, request_settings: RequestSettings) -> bool:
-        existing = request_settings.get_rate_limit_params()
+    def _is_already_applied(self, query_settings: QuerySettings) -> bool:
+        existing = query_settings.get_rate_limit_params()
         for ex in existing:
             if ex.rate_limit_name == self.rate_limit_name:
                 return True
         return False
 
     def get_object_id(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> Optional[str]:
         obj_ids = get_object_ids_in_query_ast(query, self.object_column)
         if not obj_ids:
@@ -54,37 +54,33 @@ class ObjectIDRateLimiterProcessor(QueryProcessor):
 
         # TODO: Add logic for multiple IDs
         obj_id = str(obj_ids.pop())
-        if self.request_settings_field is not None:
-            request_settings_field_val = getattr(
-                request_settings, self.request_settings_field, None
+        if self.query_settings_field is not None:
+            query_settings_field_val = getattr(
+                query_settings, self.query_settings_field, None
             )
-            if request_settings_field_val is not None:
-                obj_id = f"{obj_id}_{request_settings_field_val}"
+            if query_settings_field_val is not None:
+                obj_id = f"{obj_id}_{query_settings_field_val}"
         return str(obj_id)
 
-    def get_per_second_name(
-        self, query: Query, request_settings: RequestSettings
-    ) -> str:
+    def get_per_second_name(self, query: Query, query_settings: QuerySettings) -> str:
         return self.per_second_name
 
-    def get_concurrent_name(
-        self, query: Query, request_settings: RequestSettings
-    ) -> str:
+    def get_concurrent_name(self, query: Query, query_settings: QuerySettings) -> str:
         return self.concurrent_name
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # If the settings don't already have an object rate limit, add one
-        if self._is_already_applied(request_settings):
+        if self._is_already_applied(query_settings):
             return
-        per_second_name = self.get_per_second_name(query, request_settings)
-        concurrent_name = self.get_concurrent_name(query, request_settings)
+        per_second_name = self.get_per_second_name(query, query_settings)
+        concurrent_name = self.get_concurrent_name(query, query_settings)
         object_rate_limit, object_concurrent_limit = get_configs(
             [
                 (per_second_name, self.default_limit),
                 (concurrent_name, self.default_limit),
             ]
         )
-        obj_id = self.get_object_id(query, request_settings)
+        obj_id = self.get_object_id(query, query_settings)
         if obj_id is None:
             return
         # Specific objects can have their rate limits overridden
@@ -102,21 +98,21 @@ class ObjectIDRateLimiterProcessor(QueryProcessor):
             concurrent_limit=concurr,
         )
 
-        request_settings.add_rate_limit(rate_limit)
+        query_settings.add_rate_limit(rate_limit)
 
 
 class OnlyIfConfiguredRateLimitProcessor(ObjectIDRateLimiterProcessor):
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # If the settings don't already have an object rate limit, add one
-        per_second_name = self.get_per_second_name(query, request_settings)
-        concurrent_name = self.get_concurrent_name(query, request_settings)
+        per_second_name = self.get_per_second_name(query, query_settings)
+        concurrent_name = self.get_concurrent_name(query, query_settings)
 
-        if self._is_already_applied(request_settings):
+        if self._is_already_applied(query_settings):
             return
         object_rate_limit, object_concurrent_limit = get_configs(
             [(per_second_name, None), (concurrent_name, None)]
         )
-        obj_id = self.get_object_id(query, request_settings)
+        obj_id = self.get_object_id(query, query_settings)
         if obj_id is None:
             return
         # don't enforce any limit that isn't specified
@@ -137,7 +133,7 @@ class OnlyIfConfiguredRateLimitProcessor(ObjectIDRateLimiterProcessor):
             concurrent_limit=concurr,
         )
 
-        request_settings.add_rate_limit(rate_limit)
+        query_settings.add_rate_limit(rate_limit)
 
 
 class OrganizationRateLimiterProcessor(ObjectIDRateLimiterProcessor):
@@ -163,21 +159,17 @@ class ProjectReferrerRateLimiter(OnlyIfConfiguredRateLimitProcessor):
             PROJECT_REFERRER_RATE_LIMIT_NAME,
             "project_referrer_per_second_limit",
             "project_referrer_concurrent_limit",
-            request_settings_field="referrer",
+            query_settings_field="referrer",
         )
 
-    def get_concurrent_name(
-        self, query: Query, request_settings: RequestSettings
-    ) -> str:
-        return f"{self.concurrent_name}_{request_settings.referrer}"
+    def get_concurrent_name(self, query: Query, query_settings: QuerySettings) -> str:
+        return f"{self.concurrent_name}_{query_settings.referrer}"
 
-    def get_per_second_name(
-        self, query: Query, request_settings: RequestSettings
-    ) -> str:
-        return f"{self.per_second_name}_{request_settings.referrer}"
+    def get_per_second_name(self, query: Query, query_settings: QuerySettings) -> str:
+        return f"{self.per_second_name}_{query_settings.referrer}"
 
     def get_object_id(
-        self, query: Query, request_settings: RequestSettings
+        self, query: Query, query_settings: QuerySettings
     ) -> Optional[str]:
         obj_ids = get_object_ids_in_query_ast(query, self.object_column)
         if not obj_ids:
@@ -198,11 +190,11 @@ class ReferrerRateLimiterProcessor(OnlyIfConfiguredRateLimitProcessor):
             REFERRER_RATE_LIMIT_NAME,
             "referrer_per_second_limit",
             "referrer_concurrent_limit",
-            request_settings_field="referrer",
+            query_settings_field="referrer",
         )
 
-    def get_object_id(self, query: Query, request_settings: RequestSettings) -> str:
-        return request_settings.referrer
+    def get_object_id(self, query: Query, query_settings: QuerySettings) -> str:
+        return query_settings.referrer
 
 
 class ProjectRateLimiterProcessor(ObjectIDRateLimiterProcessor):

--- a/snuba/query/processors/pattern_replacer.py
+++ b/snuba/query/processors/pattern_replacer.py
@@ -5,7 +5,7 @@ from snuba.query.expressions import Expression
 from snuba.query.logical import Query
 from snuba.query.matchers import MatchResult, Pattern, TMatchedType
 from snuba.query.processors import QueryProcessor
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class PatternReplacer(QueryProcessor):
@@ -21,7 +21,7 @@ class PatternReplacer(QueryProcessor):
         self.__matcher = matcher
         self.__transformation_fn = transformation_fn
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def apply_matcher(expression: Expression) -> Expression:
             result = self.__matcher.match(expression)
             if result is not None:

--- a/snuba/query/processors/prewhere.py
+++ b/snuba/query/processors/prewhere.py
@@ -10,7 +10,7 @@ from snuba.query.conditions import (
     get_first_level_and_conditions,
 )
 from snuba.query.expressions import FunctionCall
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 ALLOWED_OPERATORS = [
@@ -50,7 +50,7 @@ class PrewhereProcessor(QueryProcessor):
         self.__omit_if_final = omit_if_final
         self.__max_prewhere_conditions: Optional[int] = max_prewhere_conditions
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         max_prewhere_conditions: int = (
             self.__max_prewhere_conditions or settings.MAX_PREWHERE_CONDITIONS
         )
@@ -73,7 +73,7 @@ class PrewhereProcessor(QueryProcessor):
             if col in prewhere_keys:
                 metrics.increment(
                     "uniq_col_in_prewhere_candidate",
-                    tags={"column": col, "referrer": request_settings.referrer},
+                    tags={"column": col, "referrer": query_settings.referrer},
                 )
 
         prewhere_keys = [key for key in prewhere_keys if key not in uniq_cols]

--- a/snuba/query/processors/slice_of_map_optimizer.py
+++ b/snuba/query/processors/slice_of_map_optimizer.py
@@ -1,7 +1,7 @@
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.expressions import Expression, FunctionCall
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class SliceOfMapOptimizer(QueryProcessor):
@@ -10,7 +10,7 @@ class SliceOfMapOptimizer(QueryProcessor):
     a pattern often produced by UUIDArrayColumnProcessor.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         query.transform_expressions(self._process_expressions)
 
     def _process_expressions(self, exp: Expression) -> Expression:

--- a/snuba/query/processors/table_rate_limit.py
+++ b/snuba/query/processors/table_rate_limit.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state import get_configs
 from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitParameters
 
@@ -16,7 +16,7 @@ class TableRateLimit(QueryProcessor):
     def __init__(self, suffix: Optional[str] = None) -> None:
         self.__suffix = "_".join(["", suffix]) if suffix else ""
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         table_name = query.get_from_clause().table_name
         (per_second, concurr) = get_configs(
             [
@@ -32,4 +32,4 @@ class TableRateLimit(QueryProcessor):
             concurrent_limit=concurr,
         )
 
-        request_settings.add_rate_limit(rate_limit)
+        query_settings.add_rate_limit(rate_limit)

--- a/snuba/query/processors/tags_expander.py
+++ b/snuba/query/processors/tags_expander.py
@@ -3,7 +3,7 @@ from dataclasses import replace
 from snuba.query.expressions import Column, Expression, FunctionCall
 from snuba.query.logical import Query
 from snuba.query.processors import QueryProcessor
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class TagsExpanderProcessor(QueryProcessor):
@@ -14,7 +14,7 @@ class TagsExpanderProcessor(QueryProcessor):
     valid column name.
     """
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_expression(exp: Expression) -> Expression:
             # This is intentionally not configurable in order to discourage creating
             # a special syntax for expressions that should be function calls.

--- a/snuba/query/processors/timeseries_processor.py
+++ b/snuba/query/processors/timeseries_processor.py
@@ -11,7 +11,7 @@ from snuba.query.matchers import FunctionCall as FunctionCallMatch
 from snuba.query.matchers import Literal as LiteralMatch
 from snuba.query.matchers import Or, Param, String
 from snuba.query.processors import QueryProcessor
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.util import parse_datetime
 
 
@@ -176,7 +176,7 @@ class TimeSeriesProcessor(QueryProcessor):
 
         return exp
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # Use time_group_columns to map the old column names to the new column names, and
         # map the time_group_columns into functions based on the query granularity.
         granularity = query.get_granularity()

--- a/snuba/query/processors/tuple_unaliaser.py
+++ b/snuba/query/processors/tuple_unaliaser.py
@@ -15,7 +15,7 @@ from snuba.query.expressions import (
     Literal,
     SubscriptableReference,
 )
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state import get_config
 
 
@@ -111,7 +111,7 @@ class TupleUnaliaser(QueryProcessor):
         except ValueError:
             return False
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         if not self.should_run():
             return None
         visitor = _TupleUnaliasVisitor()

--- a/snuba/query/processors/type_converters/__init__.py
+++ b/snuba/query/processors/type_converters/__init__.py
@@ -11,7 +11,7 @@ from snuba.query.matchers import Column as ColumnMatch
 from snuba.query.matchers import FunctionCall as FunctionCallMatch
 from snuba.query.matchers import Literal as LiteralMatch
 from snuba.query.matchers import Or, Param, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 class ColumnTypeError(ValidationException):
@@ -96,7 +96,7 @@ class BaseTypeConverter(QueryProcessor, ABC):
             ]
         )
 
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         query.transform_expressions(
             self._process_expressions, skip_transform_condition=True
         )

--- a/snuba/query/processors/uniq_in_select_and_having.py
+++ b/snuba/query/processors/uniq_in_select_and_having.py
@@ -15,7 +15,7 @@ from snuba.query.exceptions import InvalidQueryException
 from snuba.query.expressions import Expression, FunctionCall, NoopVisitor
 from snuba.query.matchers import FunctionCall as FunctionCallMatch
 from snuba.query.matchers import Param, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.state import get_config
 
 
@@ -39,7 +39,7 @@ class _ExpressionOrAliasMatcher(NoopVisitor):
 
 
 class UniqInSelectAndHavingProcessor(QueryProcessor):
-    def process_query(self, query: Query, request_settings: RequestSettings) -> None:
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         having_clause = query.get_having()
         if not having_clause:
             return None

--- a/snuba/query/schema.py
+++ b/snuba/query/schema.py
@@ -21,8 +21,6 @@ SNQL_QUERY_SCHEMA = {
     "properties": {
         "query": {"type": "string"},
         "dataset": {"type": "string"},
-        # Maps to the transaction name of the Sentry API call
-        "parent_api": {"type": "string", "default": "<unknown>"},
     },
     "additionalProperties": False,
 }

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -25,14 +25,12 @@ def _record_timer_metrics(
         tags={
             "status": query_metadata.status.value,
             "referrer": referrer,
-            "parent_api": request.settings.get_parent_api(),
             "final": final,
             "dataset": query_metadata.dataset,
         },
         mark_tags={
             "final": final,
             "referrer": referrer,
-            "parent_api": request.settings.get_parent_api(),
             "dataset": query_metadata.dataset,
         },
     )
@@ -42,7 +40,7 @@ def _record_attribution_metrics(
     request: Request, query_metadata: SnubaQueryMetadata, extra_data: Mapping[str, Any]
 ) -> None:
     attr_data = AttributionData(
-        app_id=request.app_id,
+        app_id=request.attribution_info.app_id,
         referrer=request.referrer,
         dataset=query_metadata.dataset,
         entity=query_metadata.entity,

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -113,11 +113,11 @@ class SnubaQueryMetadata:
         return {
             "request": {
                 "id": self.request.id,
-                "body": self.request.body,
+                "body": self.request.original_body,
                 "referrer": self.request.referrer,
-                "team": self.request.settings.get_team(),
-                "feature": self.request.settings.get_feature(),
-                "app_id": self.request.app_id.key,
+                "team": self.request.attribution_info.team,
+                "feature": self.request.attribution_info.feature,
+                "app_id": self.request.attribution_info.app_id.key,
             },
             "dataset": self.dataset,
             "entity": self.entity,

--- a/snuba/request/__init__.py
+++ b/snuba/request/__init__.py
@@ -3,22 +3,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Mapping, Union
 
-from snuba.attribution import AppID
+from snuba.attribution.attribution_info import AttributionInfo
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Entity
 from snuba.query.logical import Query
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 
 
 @dataclass(frozen=True)
 class Request:
     id: str
-    body: Mapping[str, Any]
+    original_body: Mapping[str, Any]
     query: Union[Query, CompositeQuery[Entity]]
-    app_id: AppID
+    query_settings: QuerySettings
+    attribution_info: AttributionInfo
+
+    # TODO: This should maybe not live on the request
     snql_anonymized: str
-    settings: RequestSettings  # settings provided by the request
 
     @property
     def referrer(self) -> str:
-        return self.settings.referrer
+        return self.attribution_info.referrer

--- a/snuba/state/quota.py
+++ b/snuba/state/quota.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 

--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -46,7 +46,7 @@ class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult
                     "version": 3,
                     "payload": {
                         "subscription_id": subscription_id,
-                        "request": {**request.body},
+                        "request": {**request.original_body},
                         "result": result,
                         "timestamp": value.task.timestamp.isoformat(),
                         "entity": entity.value,

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -32,9 +32,9 @@ from snuba.query.conditions import (
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.logical import Query
+from snuba.query.query_settings import SubscriptionQuerySettings
 from snuba.reader import Result
 from snuba.request import Request
-from snuba.request.request_settings import SubscriptionRequestSettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.subscriptions.entity_subscription import (
@@ -151,12 +151,12 @@ class SubscriptionData:
         metrics: Optional[MetricsBackend] = None,
         referrer: str = SUBSCRIPTION_REFERRER,
     ) -> Request:
-        schema = RequestSchema.build(SubscriptionRequestSettings)
+        schema = RequestSchema.build(SubscriptionQuerySettings)
 
         request = build_request(
             {"query": self.query},
             parse_snql_query,
-            SubscriptionRequestSettings,
+            SubscriptionQuerySettings,
             schema,
             dataset,
             timer,

--- a/snuba/subscriptions/worker.py
+++ b/snuba/subscriptions/worker.py
@@ -15,12 +15,11 @@ from arroyo.backends.abstract import Producer
 from arroyo.processing.strategies.batching import AbstractBatchWorker
 
 from snuba import state
-from snuba.attribution import get_app_id
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import get_dataset_name
+from snuba.query.query_settings import SubscriptionQuerySettings
 from snuba.reader import Result
 from snuba.request import Request
-from snuba.request.request_settings import SubscriptionRequestSettings
 from snuba.subscriptions.data import (
     ScheduledSubscriptionTask,
     SubscriptionScheduler,
@@ -98,18 +97,19 @@ class SubscriptionWorker(
         self, request: Request, timer: Timer, task: ScheduledSubscriptionTask
     ) -> Tuple[Request, Result]:
         with self.__concurrent_gauge:
-            is_consistent_query = request.settings.get_consistent()
+            is_consistent_query = request.query_settings.get_consistent()
 
             def run_consistent() -> Result:
                 request_copy = Request(
                     id=request.id,
-                    body=copy.deepcopy(request.body),
+                    # TODO: there should be no need to copy the original body after it has been parsed
+                    original_body=copy.deepcopy(request.original_body),
                     query=copy.deepcopy(request.query),
-                    app_id=get_app_id("default"),
                     snql_anonymized=request.snql_anonymized,
-                    settings=SubscriptionRequestSettings(
+                    query_settings=SubscriptionQuerySettings(
                         referrer=request.referrer, consistent=True
                     ),
+                    attribution_info=request.attribution_info,
                 )
 
                 return parse_and_run_query(
@@ -125,13 +125,14 @@ class SubscriptionWorker(
             def run_non_consistent() -> Result:
                 request_copy = Request(
                     id=request.id,
-                    body=copy.deepcopy(request.body),
+                    # TODO: there should be no need to copy the original body after it has been parsed
+                    original_body=copy.deepcopy(request.original_body),
                     query=copy.deepcopy(request.query),
-                    app_id=get_app_id("default"),
                     snql_anonymized=request.snql_anonymized,
-                    settings=SubscriptionRequestSettings(
+                    query_settings=SubscriptionQuerySettings(
                         referrer=request.referrer, consistent=False
                     ),
+                    attribution_info=request.attribution_info,
                 )
 
                 return parse_and_run_query(

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -25,6 +25,7 @@ from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
 from snuba.query.data_source.simple import Table
 from snuba.query.data_source.visitor import DataSourceVisitor
+from snuba.query.query_settings import QuerySettings
 from snuba.querylog.query_metadata import (
     ClickhouseQueryMetadata,
     QueryStatus,
@@ -32,7 +33,6 @@ from snuba.querylog.query_metadata import (
 )
 from snuba.reader import Reader, Result
 from snuba.redis import redis_client
-from snuba.request.request_settings import RequestSettings
 from snuba.state.cache.abstract import (
     Cache,
     ExecutionTimeoutError,
@@ -230,12 +230,12 @@ def execute_query(
     # file rely either entirely on clickhouse query or entirely on
     # the formatter.
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     formatted_query: FormattedQuery,
     reader: Reader,
     timer: Timer,
     stats: MutableMapping[str, Any],
-    query_settings: MutableMapping[str, Any],
+    clickhouse_query_settings: MutableMapping[str, Any],
     robust: bool,
 ) -> Result:
     """
@@ -248,20 +248,20 @@ def execute_query(
     column_counter = ReferencedColumnsCounter()
     column_counter.visit(clickhouse_query.get_from_clause())
     if column_counter.count_columns() > uc_max:
-        query_settings["use_uncompressed_cache"] = 0
+        clickhouse_query_settings["use_uncompressed_cache"] = 0
 
     # Force query to use the first shard replica, which
     # should have synchronously received any cluster writes
     # before this query is run.
-    consistent = request_settings.get_consistent()
+    consistent = query_settings.get_consistent()
     stats["consistent"] = consistent
     if consistent:
-        query_settings["load_balancing"] = "in_order"
-        query_settings["max_threads"] = 1
+        clickhouse_query_settings["load_balancing"] = "in_order"
+        clickhouse_query_settings["max_threads"] = 1
 
     result = reader.execute(
         formatted_query,
-        query_settings,
+        clickhouse_query_settings,
         with_totals=clickhouse_query.has_totals(),
         robust=robust,
     )
@@ -329,12 +329,12 @@ def _record_rate_limit_metrics(
 @with_span(op="db")
 def execute_query_with_rate_limits(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     formatted_query: FormattedQuery,
     reader: Reader,
     timer: Timer,
     stats: MutableMapping[str, Any],
-    query_settings: MutableMapping[str, Any],
+    clickhouse_query_settings: MutableMapping[str, Any],
     robust: bool,
 ) -> Result:
     # Global rate limiter is added at the end of the chain to be
@@ -342,11 +342,11 @@ def execute_query_with_rate_limits(
     # This allows us not to borrow capacity from the global quota
     # during the evaluation if one of the more specific limiters
     # (like the project rate limiter) rejects the query first.
-    request_settings.add_rate_limit(get_global_rate_limit_params())
+    query_settings.add_rate_limit(get_global_rate_limit_params())
     # XXX: We should consider moving this that it applies to the logical query,
     # not the physical query.
     with RateLimitAggregator(
-        request_settings.get_rate_limit_params()
+        query_settings.get_rate_limit_params()
     ) as rate_limit_stats_container:
         stats.update(rate_limit_stats_container.to_dict())
         timer.mark("rate_limit")
@@ -355,18 +355,18 @@ def execute_query_with_rate_limits(
             PROJECT_RATE_LIMIT_NAME
         )
 
-        thread_quota = request_settings.get_resource_quota()
+        thread_quota = query_settings.get_resource_quota()
         if (
-            ("max_threads" in query_settings or thread_quota is not None)
+            ("max_threads" in clickhouse_query_settings or thread_quota is not None)
             and project_rate_limit_stats is not None
             and project_rate_limit_stats.concurrent > 1
         ):
             maxt = (
-                query_settings["max_threads"]
+                clickhouse_query_settings["max_threads"]
                 if thread_quota is None
                 else thread_quota.max_threads
             )
-            query_settings["max_threads"] = max(
+            clickhouse_query_settings["max_threads"] = max(
                 1, maxt - project_rate_limit_stats.concurrent + 1
             )
 
@@ -374,12 +374,12 @@ def execute_query_with_rate_limits(
 
         return execute_query(
             clickhouse_query,
-            request_settings,
+            query_settings,
             formatted_query,
             reader,
             timer,
             stats,
-            query_settings,
+            clickhouse_query_settings,
             robust=robust,
         )
 
@@ -421,12 +421,12 @@ def _get_cache_partition(reader: Reader) -> Cache[Result]:
 @with_span(op="db")
 def execute_query_with_caching(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     formatted_query: FormattedQuery,
     reader: Reader,
     timer: Timer,
     stats: MutableMapping[str, Any],
-    query_settings: MutableMapping[str, Any],
+    clickhouse_query_settings: MutableMapping[str, Any],
     robust: bool,
 ) -> Result:
     # XXX: ``uncompressed_cache_max_cols`` is used to control both the result
@@ -444,7 +444,7 @@ def execute_query_with_caching(
     execute = partial(
         execute_query_with_rate_limits,
         clickhouse_query,
-        request_settings,
+        query_settings,
         formatted_query,
         reader,
         timer,
@@ -455,7 +455,7 @@ def execute_query_with_caching(
 
     with sentry_sdk.start_span(description="execute", op="db") as span:
         key = get_query_cache_key(formatted_query)
-        query_settings["query_id"] = key
+        clickhouse_query_settings["query_id"] = key
         if use_cache:
             cache_partition = _get_cache_partition(reader)
             result = cache_partition.get(key)
@@ -477,16 +477,16 @@ def execute_query_with_caching(
 @with_span(op="db")
 def execute_query_with_readthrough_caching(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     formatted_query: FormattedQuery,
     reader: Reader,
     timer: Timer,
     stats: MutableMapping[str, Any],
-    query_settings: MutableMapping[str, Any],
+    clickhouse_query_settings: MutableMapping[str, Any],
     robust: bool,
 ) -> Result:
     query_id = get_query_cache_key(formatted_query)
-    query_settings["query_id"] = query_id
+    clickhouse_query_settings["query_id"] = query_id
 
     span = Hub.current.scope.span
     if span:
@@ -516,7 +516,7 @@ def execute_query_with_readthrough_caching(
         partial(
             execute_query_with_rate_limits,
             clickhouse_query,
-            request_settings,
+            query_settings,
             formatted_query,
             reader,
             timer,
@@ -525,7 +525,7 @@ def execute_query_with_readthrough_caching(
             robust,
         ),
         record_cache_hit_type=record_cache_hit_type,
-        timeout=_get_cache_wait_timeout(query_settings, reader),
+        timeout=_get_cache_wait_timeout(clickhouse_query_settings, reader),
         timer=timer,
     )
 
@@ -558,7 +558,7 @@ def raw_query(
     # file rely either entirely on clickhouse query or entirely on
     # the formatter.
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     formatted_query: FormattedQuery,
     reader: Reader,
     timer: Timer,
@@ -604,7 +604,7 @@ def raw_query(
     try:
         result = execute_query_strategy(
             clickhouse_query,
-            request_settings,
+            query_settings,
             formatted_query,
             reader,
             timer,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -449,7 +449,7 @@ def execute_query_with_caching(
         reader,
         timer,
         stats,
-        query_settings,
+        clickhouse_query_settings,
         robust=robust,
     )
 
@@ -521,7 +521,7 @@ def execute_query_with_readthrough_caching(
             reader,
             timer,
             stats,
-            query_settings,
+            clickhouse_query_settings,
             robust,
         ),
         record_cache_hit_type=record_cache_hit_type,
@@ -574,7 +574,7 @@ def raw_query(
     query. If this function ends up depending on the dataset, something is wrong.
     """
     all_confs = state.get_all_configs()
-    query_settings: MutableMapping[str, Any] = {
+    clickhouse_query_settings: MutableMapping[str, Any] = {
         k.split("/", 1)[1]: v
         for k, v in all_confs.items()
         if k.startswith("query_settings/")
@@ -591,7 +591,7 @@ def raw_query(
         timer,
         stats,
         query_metadata,
-        query_settings,
+        clickhouse_query_settings,
         trace_id,
     )
 
@@ -609,7 +609,7 @@ def raw_query(
             reader,
             timer,
             stats,
-            query_settings,
+            clickhouse_query_settings,
             robust=robust,
         )
     except Exception as cause:

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -147,7 +147,7 @@ def parse_and_run_query(
             concurrent_queries_gauge=concurrent_queries_gauge,
         )
         _set_query_final(request, result.extra)
-        if not request.settings.get_dry_run():
+        if not request.query_settings.get_dry_run():
             record_query(request, timer, query_metadata, result.extra)
     except QueryException as error:
         _set_query_final(request, error.extra)
@@ -183,12 +183,12 @@ def _run_query_pipeline(
     - Providing the newly built Query, processors to be run for each DB query and a QueryRunner
       to the QueryExecutionStrategy to actually run the DB Query.
     """
-    if not request.settings.get_turbo() and SampleClauseFinder().visit(
+    if not request.query_settings.get_turbo() and SampleClauseFinder().visit(
         request.query.get_from_clause()
     ):
         metrics.increment("sample_without_turbo", tags={"referrer": request.referrer})
 
-    if request.settings.get_dry_run():
+    if request.query_settings.get_dry_run():
         query_runner = _dry_run_query_runner
     else:
         query_runner = partial(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -26,11 +26,11 @@ from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
 from snuba.query.data_source.simple import Entity, Table
 from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.logical import Query as LogicalQuery
+from snuba.query.query_settings import QuerySettings
 from snuba.querylog import record_query
 from snuba.querylog.query_metadata import SnubaQueryMetadata
 from snuba.reader import Reader
 from snuba.request import Request
-from snuba.request.request_settings import RequestSettings
 from snuba.util import with_span
 from snuba.utils.metrics.gauge import Gauge
 from snuba.utils.metrics.timer import Timer
@@ -209,7 +209,7 @@ def _run_query_pipeline(
 
 def _dry_run_query_runner(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     reader: Reader,
 ) -> QueryResult:
     with sentry_sdk.start_span(description="dryrun_create_query", op="db") as span:
@@ -233,7 +233,7 @@ def _run_and_apply_column_names(
     robust: bool,
     concurrent_queries_gauge: Optional[Gauge],
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     reader: Reader,
 ) -> QueryResult:
     """
@@ -250,7 +250,7 @@ def _run_and_apply_column_names(
         query_metadata,
         referrer,
         clickhouse_query,
-        request_settings,
+        query_settings,
         reader,
         robust,
         concurrent_queries_gauge,
@@ -283,7 +283,7 @@ def _format_storage_query_and_run(
     query_metadata: SnubaQueryMetadata,
     referrer: str,
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
     reader: Reader,
     robust: bool,
     concurrent_queries_gauge: Optional[Gauge] = None,
@@ -296,7 +296,7 @@ def _format_storage_query_and_run(
     visitor.visit(from_clause)
     table_names = ",".join(sorted(visitor.get_tables()))
     with sentry_sdk.start_span(description="create_query", op="db") as span:
-        _apply_turbo_sampling_if_needed(clickhouse_query, request_settings)
+        _apply_turbo_sampling_if_needed(clickhouse_query, query_settings)
 
         formatted_query = format_query(clickhouse_query)
         query_size_bytes = len(formatted_query.get_sql().encode("utf-8"))
@@ -333,7 +333,7 @@ def _format_storage_query_and_run(
         def execute() -> QueryResult:
             return raw_query(
                 clickhouse_query,
-                request_settings,
+                query_settings,
                 formatted_query,
                 reader,
                 timer,
@@ -371,7 +371,7 @@ def get_query_size_group(query_size_bytes: int) -> str:
 
 def _apply_turbo_sampling_if_needed(
     clickhouse_query: Union[Query, CompositeQuery[Table]],
-    request_settings: RequestSettings,
+    query_settings: QuerySettings,
 ) -> None:
     """
     TODO: Remove this method entirely and move the sampling logic
@@ -379,7 +379,7 @@ def _apply_turbo_sampling_if_needed(
     """
     if isinstance(clickhouse_query, Query):
         if (
-            request_settings.get_turbo()
+            query_settings.get_turbo()
             and not clickhouse_query.get_from_clause().sampling_rate
         ):
             clickhouse_query.set_from_clause(

--- a/snuba/web/split.py
+++ b/snuba/web/split.py
@@ -24,7 +24,7 @@ from snuba.query.expressions import Expression
 from snuba.query.expressions import FunctionCall as FunctionCallExpr
 from snuba.query.expressions import Literal as LiteralExpr
 from snuba.query.matchers import AnyExpression, Column, FunctionCall, Or, Param, String
-from snuba.request.request_settings import RequestSettings
+from snuba.query.query_settings import QuerySettings
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.web import QueryResult
 
@@ -84,7 +84,7 @@ class TimeSplitQueryStrategy(QuerySplitStrategy):
     def execute(
         self,
         query: Query,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         runner: SplitQueryRunner,
     ) -> Optional[QueryResult]:
         """
@@ -149,7 +149,7 @@ class TimeSplitQueryStrategy(QuerySplitStrategy):
             # At every iteration we only append the "data" key from the results returned by
             # the runner. The "extra" key is only populated at the first iteration of the
             # loop and never changed.
-            result = runner(split_query, request_settings)
+            result = runner(split_query, query_settings)
 
             if overall_result is None:
                 overall_result = result
@@ -209,7 +209,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
     def execute(
         self,
         query: Query,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         runner: SplitQueryRunner,
     ) -> Optional[QueryResult]:
         """
@@ -304,7 +304,7 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
                 metrics.increment("column_splitter.orderby_has_a_function")
                 return None
 
-        result = runner(minimal_query, request_settings)
+        result = runner(minimal_query, query_settings)
         del minimal_query
 
         if not result.result["data"]:
@@ -362,4 +362,4 @@ class ColumnSplitQueryStrategy(QuerySplitStrategy):
             ),
         )
 
-        return runner(query, request_settings)
+        return runner(query, query_settings)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -506,7 +506,7 @@ def dataset_query(
 
     payload: MutableMapping[str, Any] = {**result.result, "timing": timer.for_json()}
 
-    if settings.STATS_IN_RESPONSE or request.settings.get_debug():
+    if settings.STATS_IN_RESPONSE or request.query_settings.get_debug():
         payload.update(result.extra)
 
     return Response(json.dumps(payload), 200, {"Content-Type": "application/json"})

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -50,9 +50,9 @@ from snuba.datasets.factory import (
 )
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.query.exceptions import InvalidQueryException
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.redis import redis_client
 from snuba.request.exceptions import InvalidJsonRequestException, JsonDecodeException
-from snuba.request.request_settings import HTTPRequestSettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.state import MismatchedTypeException
@@ -422,7 +422,7 @@ def unqualified_query_view(*, timer: Timer) -> WerkzeugResponse:
 @util.time_request("query")
 def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response, str]:
     if http_request.method == "GET":
-        schema = RequestSchema.build(HTTPRequestSettings)
+        schema = RequestSchema.build(HTTPQuerySettings)
         return render_template(
             "query.html",
             query_template=json.dumps(schema.generate_template(), indent=4),
@@ -455,10 +455,10 @@ def dataset_query(
             metrics.timing("post.shutdown.query.delay", diff, tags=tags)
 
     with sentry_sdk.start_span(description="build_schema", op="validate"):
-        schema = RequestSchema.build(HTTPRequestSettings)
+        schema = RequestSchema.build(HTTPQuerySettings)
 
     request = build_request(
-        body, parse_snql_query, HTTPRequestSettings, schema, dataset, timer, referrer
+        body, parse_snql_query, HTTPQuerySettings, schema, dataset, timer, referrer
     )
 
     try:

--- a/tests/clickhouse/query_dsl/test_time_range.py
+++ b/tests/clickhouse/query_dsl/test_time_range.py
@@ -4,8 +4,8 @@ from snuba.clickhouse.query_dsl.accessors import get_time_range
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.translator.query import identity_translate
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query
-from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_get_time_range() -> None:
@@ -27,7 +27,7 @@ def test_get_time_range() -> None:
     processors = events.get_default_entity().get_query_processors()
     for processor in processors:
         if isinstance(processor, TimeSeriesProcessor):
-            processor.process_query(query, HTTPRequestSettings())
+            processor.process_query(query, HTTPQuerySettings())
 
     from_date_ast, to_date_ast = get_time_range(identity_translate(query), "timestamp")
     assert (

--- a/tests/datasets/entities/test_tags_transformer.py
+++ b/tests/datasets/entities/test_tags_transformer.py
@@ -5,7 +5,7 @@ from snuba.query import SelectedExpression
 from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Column, Literal, SubscriptableReference
 from snuba.query.logical import Query
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def build_query(tag_key: Literal) -> Query:
@@ -24,7 +24,7 @@ def build_query(tag_key: Literal) -> Query:
 
 def test_transformer() -> None:
     query = build_query(Literal(None, "10"))
-    TagsTypeTransformer().process_query(query, HTTPRequestSettings())
+    TagsTypeTransformer().process_query(query, HTTPQuerySettings())
 
     assert query.get_selected_columns()[0].expression == SubscriptableReference(
         "_snuba_tags[10]", Column(None, None, "tags"), Literal(None, 10)
@@ -34,5 +34,5 @@ def test_transformer() -> None:
 def test_broken_query() -> None:
     with pytest.raises(InvalidExpressionException):
         TagsTypeTransformer().process_query(
-            build_query(Literal(None, "asdasd")), HTTPRequestSettings()
+            build_query(Literal(None, "asdasd")), HTTPQuerySettings()
         )

--- a/tests/datasets/test_context_promotion.py
+++ b/tests/datasets/test_context_promotion.py
@@ -11,8 +11,8 @@ from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal, NoopVisitor
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.utils.metrics.timer import Timer
@@ -72,12 +72,12 @@ def test_span_id_promotion(entity: Entity, expected_table_name: str) -> None:
 
     dataset = get_dataset(dataset_name)
 
-    schema = RequestSchema.build(HTTPRequestSettings)
+    schema = RequestSchema.build(HTTPQuerySettings)
 
     request = build_request(
         query_body,
         parse_snql_query,
-        HTTPRequestSettings,
+        HTTPQuerySettings,
         schema,
         dataset,
         Timer(name="bloop"),
@@ -87,7 +87,7 @@ def test_span_id_promotion(entity: Entity, expected_table_name: str) -> None:
 
     def query_verifier(
         query: Union[Query, CompositeQuery[Table]],
-        settings: RequestSettings,
+        settings: QuerySettings,
         reader: Reader,
     ) -> QueryResult:
         assert isinstance(query, Query)

--- a/tests/datasets/test_events.py
+++ b/tests/datasets/test_events.py
@@ -11,7 +11,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.query.data_source.simple import Entity
 from snuba.query.logical import Query
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from tests.fixtures import get_raw_event
 from tests.helpers import write_unprocessed_events
 
@@ -61,13 +61,13 @@ def test_storage_selector() -> None:
     storage_selector = ErrorsQueryStorageSelector(mappers=errors_translators)
     assert (
         storage_selector.select_storage(
-            query, HTTPRequestSettings(consistent=False)
+            query, HTTPQuerySettings(consistent=False)
         ).storage
         == storage_ro
     )
     assert (
         storage_selector.select_storage(
-            query, HTTPRequestSettings(consistent=True)
+            query, HTTPQuerySettings(consistent=True)
         ).storage
         == storage
     )

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -1,12 +1,13 @@
 from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.query import Query
 from snuba.datasets.factory import get_dataset
 from snuba.query import SelectedExpression
 from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.query.snql.parser import parse_snql_query
 from snuba.reader import Reader
 from snuba.request import Request
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
 
@@ -28,15 +29,15 @@ def test_events_processing() -> None:
     query, snql_anonymized = parse_snql_query(query_body["query"], events_dataset)
     request = Request(
         id="",
-        body=query_body,
+        original_body=query_body,
         query=query,
-        app_id=get_app_id("default"),
         snql_anonymized=snql_anonymized,
-        settings=HTTPRequestSettings(referrer=""),
+        query_settings=HTTPQuerySettings(referrer=""),
+        attribution_info=AttributionInfo(get_app_id("blah"), "blah", None, None, None),
     )
 
     def query_runner(
-        query: Query, settings: RequestSettings, reader: Reader
+        query: Query, settings: QuerySettings, reader: Reader
     ) -> QueryResult:
         assert query.get_selected_columns() == [
             SelectedExpression(

--- a/tests/datasets/test_metrics_processing.py
+++ b/tests/datasets/test_metrics_processing.py
@@ -5,6 +5,7 @@ import pytest
 
 from snuba import settings
 from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.query import Expression, Query
 from snuba.clusters import cluster
 from snuba.datasets import factory
@@ -16,10 +17,10 @@ from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.query.snql.parser import parse_snql_query
 from snuba.reader import Reader
 from snuba.request import Request
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
 TEST_CASES = [
@@ -247,16 +248,16 @@ def test_metrics_processing(
 
     request = Request(
         id="",
-        body=query_body,
+        original_body=query_body,
         query=query,
-        app_id=get_app_id("default"),
         snql_anonymized="",
-        settings=HTTPRequestSettings(referrer=""),
+        query_settings=HTTPQuerySettings(referrer=""),
+        attribution_info=AttributionInfo(get_app_id("blah"), "blah", None, None, None),
     )
 
     def query_runner(
         query: Union[Query, CompositeQuery[Table]],
-        settings: RequestSettings,
+        settings: QuerySettings,
         reader: Reader,
     ) -> QueryResult:
         assert query.get_selected_columns() == [

--- a/tests/datasets/test_nullable_field_casting.py
+++ b/tests/datasets/test_nullable_field_casting.py
@@ -10,8 +10,8 @@ from snuba.datasets.factory import get_dataset
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal, StringifyVisitor
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.utils.metrics.timer import Timer
@@ -51,12 +51,12 @@ def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> Non
 
     dataset = get_dataset(dataset_name)
 
-    schema = RequestSchema.build(HTTPRequestSettings)
+    schema = RequestSchema.build(HTTPQuerySettings)
 
     request = build_request(
         query_body,
         parse_snql_query,
-        HTTPRequestSettings,
+        HTTPQuerySettings,
         schema,
         dataset,
         Timer(name="bloop"),
@@ -66,7 +66,7 @@ def test_nullable_field_casting(entity: Entity, expected_table_name: str) -> Non
 
     def query_verifier(
         query: Union[Query, CompositeQuery[Table]],
-        settings: RequestSettings,
+        settings: QuerySettings,
         reader: Reader,
     ) -> QueryResult:
         # The only reason this extends StringifyVisitor is because it has all the other

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 
 from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -11,6 +12,7 @@ from snuba.datasets.storages.factory import get_writable_storage
 from snuba.processor import InsertBatch
 from snuba.query.data_source.simple import Entity
 from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.querylog.query_metadata import (
     ClickhouseQueryMetadata,
     ClickhouseQueryProfile,
@@ -19,7 +21,6 @@ from snuba.querylog.query_metadata import (
     SnubaQueryMetadata,
 )
 from snuba.request import Request
-from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.clock import TestingClock
 from snuba.utils.metrics.timer import Timer
 
@@ -39,12 +40,14 @@ def test_simple() -> None:
     )
 
     request = Request(
-        uuid.UUID("a" * 32).hex,
-        request_body,
-        query,
-        get_app_id("default"),
-        "",
-        HTTPRequestSettings(referrer="search"),
+        id=uuid.UUID("a" * 32).hex,
+        original_body=request_body,
+        query=query,
+        snql_anonymized="",
+        query_settings=HTTPQuerySettings(referrer="search"),
+        attribution_info=AttributionInfo(
+            get_app_id("default"), "search", None, None, None
+        ),
     )
 
     time = TestingClock()
@@ -150,12 +153,14 @@ def test_missing_fields() -> None:
     )
 
     request = Request(
-        uuid.UUID("a" * 32).hex,
-        request_body,
-        query,
-        get_app_id("default"),
-        "",
-        HTTPRequestSettings(referrer="search"),
+        id=uuid.UUID("a" * 32).hex,
+        original_body=request_body,
+        query=query,
+        snql_anonymized="",
+        query_settings=HTTPQuerySettings(referrer="search"),
+        attribution_info=AttributionInfo(
+            get_app_id("default"), "search", None, None, None
+        ),
     )
 
     time = TestingClock()

--- a/tests/datasets/test_tags_hashmap.py
+++ b/tests/datasets/test_tags_hashmap.py
@@ -3,8 +3,8 @@ from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.query.expressions import Column, FunctionCall, NoopVisitor
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.utils.metrics.timer import Timer
@@ -36,12 +36,12 @@ def test_tags_hashmap_optimization() -> None:
 
     dataset = get_dataset(dataset_name)
 
-    schema = RequestSchema.build(HTTPRequestSettings)
+    schema = RequestSchema.build(HTTPQuerySettings)
 
     request = build_request(
         query_body,
         parse_snql_query,
-        HTTPRequestSettings,
+        HTTPQuerySettings,
         schema,
         dataset,
         Timer(name="bloop"),
@@ -49,7 +49,7 @@ def test_tags_hashmap_optimization() -> None:
     )
     # --------------------------------------------------------------------
 
-    def query_verifier(query: Query, settings: RequestSettings, reader: Reader) -> None:
+    def query_verifier(query: Query, settings: QuerySettings, reader: Reader) -> None:
         class ConditionVisitor(NoopVisitor):
             def __init__(self) -> None:
                 self.found_hashmap_condition = False

--- a/tests/datasets/test_transactions.py
+++ b/tests/datasets/test_transactions.py
@@ -9,7 +9,7 @@ from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_storage
 from snuba.query.data_source.simple import Entity
 from snuba.query.logical import Query
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 RO_REFERRER = "RO_REFERRER"
 RW_REFERRER = "RW_REFERRER"
@@ -25,13 +25,13 @@ def test_storage_selector_global_config() -> None:
     query = Query(Entity(EntityKey.TRANSACTIONS, ColumnSet([])), selected_columns=[])
 
     assert (
-        STORAGE_SELECTOR.select_storage(query, HTTPRequestSettings()).storage
+        STORAGE_SELECTOR.select_storage(query, HTTPQuerySettings()).storage
         == STORAGE_RO
     )
 
     state.set_config("enable_transactions_readonly_table", False)
     assert (
-        STORAGE_SELECTOR.select_storage(query, HTTPRequestSettings()).storage == STORAGE
+        STORAGE_SELECTOR.select_storage(query, HTTPQuerySettings()).storage == STORAGE
     )
 
 
@@ -42,13 +42,13 @@ def test_storage_selector_query_settings() -> None:
 
     assert (
         STORAGE_SELECTOR.select_storage(
-            query, HTTPRequestSettings(referrer=RO_REFERRER)
+            query, HTTPQuerySettings(referrer=RO_REFERRER)
         ).storage
         == STORAGE_RO
     )
     assert (
         STORAGE_SELECTOR.select_storage(
-            query, HTTPRequestSettings(referrer=RW_REFERRER)
+            query, HTTPQuerySettings(referrer=RW_REFERRER)
         ).storage
         == STORAGE
     )

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -44,8 +44,8 @@ from snuba.query.expressions import (
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.processors.conditions_enforcer import MandatoryConditionEnforcer
 from snuba.query.processors.mandatory_condition_applier import MandatoryConditionApplier
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.reader import Reader
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 
 events_ent = Entity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model())
@@ -502,7 +502,7 @@ def test_composite_planner(
         ]
 
     plan = CompositeQueryPlanner(
-        deepcopy(logical_query), HTTPRequestSettings()
+        deepcopy(logical_query), HTTPQuerySettings()
     ).build_best_plan()
     report = plan.query.equals(composite_plan.query)
     assert report[0], f"Mismatch: {report[1]}"
@@ -537,7 +537,7 @@ def test_composite_planner(
 
     def runner(
         query: Union[ClickhouseQuery, CompositeQuery[Table]],
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         reader: Reader,
     ) -> QueryResult:
         report = query.equals(processed_query)
@@ -547,4 +547,4 @@ def test_composite_planner(
             {"stats": {}, "sql": "", "experiments": {}},
         )
 
-    CompositeExecutionPipeline(logical_query, HTTPRequestSettings(), runner).execute()
+    CompositeExecutionPipeline(logical_query, HTTPQuerySettings(), runner).execute()

--- a/tests/pipeline/test_settings_delegator.py
+++ b/tests/pipeline/test_settings_delegator.py
@@ -3,15 +3,12 @@ from typing import Sequence, Type, Union
 import pytest
 
 from snuba.pipeline.settings_delegator import RateLimiterDelegate
-from snuba.request.request_settings import (
-    HTTPRequestSettings,
-    SubscriptionRequestSettings,
-)
+from snuba.query.query_settings import HTTPQuerySettings, SubscriptionQuerySettings
 from snuba.state.rate_limit import RateLimitParameters
 
 test_cases = [
     pytest.param(
-        HTTPRequestSettings,
+        HTTPQuerySettings,
         [
             RateLimitParameters(
                 rate_limit_name="rate_name",
@@ -28,21 +25,20 @@ test_cases = [
         ],
         id="HTTP Request Settings",
     ),
-    pytest.param(SubscriptionRequestSettings, [], id="Subscriptions request settings"),
+    pytest.param(
+        SubscriptionQuerySettings, [], id="Subscriptions request.query_settings"
+    ),
 ]
 
 
 @pytest.mark.parametrize("settings_class, expected_rate_limiters", test_cases)
 def test_delegate(
-    settings_class: Type[Union[HTTPRequestSettings, SubscriptionRequestSettings]],
+    settings_class: Type[Union[HTTPQuerySettings, SubscriptionQuerySettings]],
     expected_rate_limiters: Sequence[RateLimitParameters],
 ) -> None:
     settings = settings_class(
         referrer="test",
         consistent=False,
-        parent_api="parent",
-        team="team",
-        feature="feature",
     )
 
     settings.add_rate_limit(

--- a/tests/query/joins/test_semi_join.py
+++ b/tests/query/joins/test_semi_join.py
@@ -14,7 +14,7 @@ from snuba.query.data_source.join import (
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column
 from snuba.query.joins.semi_joins import SemiJoinOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from tests.query.joins.join_structures import (
     clickhouse_assignees_node,
     clickhouse_events_node,
@@ -239,7 +239,7 @@ def test_subquery_generator(
         if isinstance(clause.left_node, JoinClause):
             assert_transformation(clause.left_node, expected)
 
-    SemiJoinOptimizer().process_query(query, HTTPRequestSettings())
+    SemiJoinOptimizer().process_query(query, HTTPQuerySettings())
     assert_transformation(
         cast(JoinClause[Table], query.get_from_clause()), expected_semi_join
     )

--- a/tests/query/processors/test_apdex.py
+++ b/tests/query/processors/test_apdex.py
@@ -12,7 +12,7 @@ from snuba.query.dsl import divide, multiply, plus
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.performance_expressions import apdex_processor
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_apdex_format_expressions() -> None:
@@ -83,7 +83,7 @@ def test_apdex_format_expressions() -> None:
         ],
     )
 
-    apdex_processor().process_query(unprocessed, HTTPRequestSettings())
+    apdex_processor().process_query(unprocessed, HTTPQuerySettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
     ret = unprocessed.get_selected_columns()[1].expression.accept(

--- a/tests/query/processors/test_array_has_optimizer.py
+++ b/tests/query/processors/test_array_has_optimizer.py
@@ -6,7 +6,7 @@ from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.query.conditions import combine_and_conditions
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.array_has_optimizer import ArrayHasOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from tests.query.processors.query_builders import build_query
 
 spans_ops = Column(None, None, "spans.op")
@@ -205,7 +205,7 @@ def test_array_has_optimizer(
     query: ClickhouseQuery,
     expected_conditions: Optional[Expression],
 ) -> None:
-    request_settings = HTTPRequestSettings()
+    query_settings = HTTPQuerySettings()
     array_has_processor = ArrayHasOptimizer(["spans.op", "spans.group"])
-    array_has_processor.process_query(query, request_settings)
+    array_has_processor.process_query(query, query_settings)
     assert query.get_condition() == expected_conditions

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -6,6 +6,7 @@ import pytest
 from snuba_sdk.legacy import json_to_snql
 
 from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.formatter.expression import ClickhouseExpressionFormatter
 from snuba.clickhouse.formatter.query import format_query
 from snuba.clickhouse.query import Query as ClickhouseQuery
@@ -30,9 +31,9 @@ from snuba.query.processors.arrayjoin_keyvalue_optimizer import (
     get_filtered_mapping_keys,
     zip_columns,
 )
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query
 from snuba.request import Request
-from snuba.request.request_settings import HTTPRequestSettings
 
 
 def build_query(
@@ -413,24 +414,24 @@ def parse_and_process(query_body: MutableMapping[str, Any]) -> ClickhouseQuery:
     query, snql_anonymized = parse_snql_query(str(snql_query), dataset)
     request = Request(
         id="a",
-        body=body,
+        original_body=body,
         query=query,
-        app_id=get_app_id("default"),
         snql_anonymized=snql_anonymized,
-        settings=HTTPRequestSettings(referrer="r"),
+        query_settings=HTTPQuerySettings(referrer="r"),
+        attribution_info=AttributionInfo(get_app_id("blah"), "blah", None, None, None),
     )
     entity = get_entity(query.get_from_clause().key)
     storage = entity.get_writable_storage()
     assert storage is not None
     for p in entity.get_query_processors():
-        p.process_query(query, request.settings)
+        p.process_query(query, request.query_settings)
 
-    ArrayJoinKeyValueOptimizer("tags").process_query(query, request.settings)
+    ArrayJoinKeyValueOptimizer("tags").process_query(query, request.query_settings)
 
     query_plan = SingleStorageQueryPlanBuilder(
         storage=storage,
         mappers=transaction_translator,
-    ).build_and_rank_plans(query, request.settings)[0]
+    ).build_and_rank_plans(query, request.query_settings)[0]
 
     return query_plan.query
 

--- a/tests/query/processors/test_arrayjoin_spans_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_spans_optimizer.py
@@ -26,7 +26,7 @@ from snuba.query.processors.abstract_array_join_optimizer import (
 )
 from snuba.query.processors.arrayjoin_optimizer import ArrayJoinOptimizer
 from snuba.query.processors.bloom_filter_optimizer import BloomFilterOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from tests.query.processors.query_builders import build_query
 
 spans_ops = Column(None, None, "spans.op")
@@ -757,14 +757,14 @@ def test_spans_processor(
     expected_selected_columns: List[SelectedExpression],
     expected_conditions: Optional[Expression],
 ) -> None:
-    request_settings = HTTPRequestSettings()
+    query_settings = HTTPQuerySettings()
     bloom_filter_processor = BloomFilterOptimizer(
         "spans", ["op", "group"], ["exclusive_time"]
     )
-    bloom_filter_processor.process_query(query, request_settings)
+    bloom_filter_processor.process_query(query, query_settings)
     array_join_processor = ArrayJoinOptimizer(
         "spans", ["op", "group"], ["exclusive_time"]
     )
-    array_join_processor.process_query(query, request_settings)
+    array_join_processor.process_query(query, query_settings)
     assert query.get_selected_columns() == expected_selected_columns
     assert query.get_condition() == expected_conditions

--- a/tests/query/processors/test_bool_context.py
+++ b/tests/query/processors/test_bool_context.py
@@ -12,7 +12,7 @@ from snuba.query.data_source.simple import Table
 from snuba.query.dsl import literals_tuple
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_events_promoted_boolean_context() -> None:
@@ -74,7 +74,7 @@ def test_events_promoted_boolean_context() -> None:
         ],
     )
 
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     MappingColumnPromoter(
         {"contexts": {"device.charging": "device_charging"}}, cast_to_string=True
     ).process_query(query, settings)
@@ -149,7 +149,7 @@ def test_events_boolean_context() -> None:
         ],
     )
 
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     EventsBooleanContextsProcessor().process_query(query, settings)
 
     assert query.get_selected_columns() == expected.get_selected_columns()

--- a/tests/query/processors/test_custom_function.py
+++ b/tests/query/processors/test_custom_function.py
@@ -13,8 +13,8 @@ from snuba.query.processors.custom_function import (
     partial_function,
     simple_function,
 )
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.validation.signature import Column as ColType
-from snuba.request.request_settings import HTTPRequestSettings
 
 QUERY_ENTITY = QueryEntity(
     EntityKey.EVENTS,
@@ -156,7 +156,7 @@ def test_format_expressions(query: Query, expected_query: Query) -> None:
     )
     # We cannot just run == on the query objects. The content of the two
     # objects is different, being one the AST and the ont the AST + raw body
-    processor.process_query(query, HTTPRequestSettings())
+    processor.process_query(query, HTTPQuerySettings())
     assert query.get_selected_columns() == expected_query.get_selected_columns()
     assert query.get_groupby() == expected_query.get_groupby()
     assert query.get_condition() == expected_query.get_condition()
@@ -212,4 +212,4 @@ def test_invalid_call(query: Query) -> None:
         simple_function("f_call_impl(param1, inner_call(param2))"),
     )
     with pytest.raises(InvalidCustomFunctionCall):
-        processor.process_query(query, HTTPRequestSettings())
+        processor.process_query(query, HTTPQuerySettings())

--- a/tests/query/processors/test_empty_tag_condition_processor.py
+++ b/tests/query/processors/test_empty_tag_condition_processor.py
@@ -6,7 +6,7 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.empty_tag_condition_processor import (
     EmptyTagConditionProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from tests.query.processors.query_builders import build_query
 
 test_data = [
@@ -156,7 +156,7 @@ test_data = [
 
 @pytest.mark.parametrize("query, expected", test_data)  # type: ignore
 def test_empty_tag_condition(query: Query, expected: Expression) -> None:
-    request_settings = HTTPRequestSettings()
+    query_settings = HTTPQuerySettings()
     processor = EmptyTagConditionProcessor()
-    processor.process_query(query, request_settings)
+    processor.process_query(query, query_settings)
     assert query.get_condition() == expected

--- a/tests/query/processors/test_events_column_processor.py
+++ b/tests/query/processors/test_events_column_processor.py
@@ -5,7 +5,7 @@ from snuba.datasets.storages.group_id_column_processor import GroupIdColumnProce
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_events_column_format_expressions() -> None:
@@ -41,7 +41,7 @@ def test_events_column_format_expressions() -> None:
         ],
     )
 
-    GroupIdColumnProcessor().process_query(unprocessed, HTTPRequestSettings())
+    GroupIdColumnProcessor().process_query(unprocessed, HTTPQuerySettings())
     assert expected_query.get_selected_columns() == unprocessed.get_selected_columns()
 
     expected = (

--- a/tests/query/processors/test_failure_rate.py
+++ b/tests/query/processors/test_failure_rate.py
@@ -12,7 +12,7 @@ from snuba.query.dsl import count, divide
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.performance_expressions import failure_rate_processor
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_failure_rate_format_expressions() -> None:
@@ -53,7 +53,7 @@ def test_failure_rate_format_expressions() -> None:
         ],
     )
 
-    failure_rate_processor().process_query(unprocessed, HTTPRequestSettings())
+    failure_rate_processor().process_query(unprocessed, HTTPQuerySettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
     ret = unprocessed.get_selected_columns()[1].expression.accept(

--- a/tests/query/processors/test_fixedstring_array_column_processor.py
+++ b/tests/query/processors/test_fixedstring_array_column_processor.py
@@ -9,7 +9,7 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.type_converters.fixedstring_array_column_processor import (
     FixedStringArrayColumnProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 tests = [
     pytest.param(
@@ -60,7 +60,7 @@ def test_uuid_array_column_processor(
     )
 
     FixedStringArrayColumnProcessor(set(["column1", "column2"]), 32).process_query(
-        unprocessed_query, HTTPRequestSettings()
+        unprocessed_query, HTTPQuerySettings()
     )
     assert unprocessed_query.get_selected_columns() == [
         SelectedExpression(

--- a/tests/query/processors/test_functions_processor.py
+++ b/tests/query/processors/test_functions_processor.py
@@ -9,7 +9,7 @@ from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, CurriedFunctionCall, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.basic_functions import BasicFunctionsProcessor
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 test_data = [
     (
@@ -201,7 +201,7 @@ test_data = [
 @pytest.mark.parametrize("pre_format, expected_query", test_data)
 def test_format_expressions(pre_format: Query, expected_query: Query) -> None:
     copy = deepcopy(pre_format)
-    BasicFunctionsProcessor().process_query(copy, HTTPRequestSettings())
+    BasicFunctionsProcessor().process_query(copy, HTTPQuerySettings())
     assert copy.get_selected_columns() == expected_query.get_selected_columns()
     assert copy.get_groupby() == expected_query.get_groupby()
     assert copy.get_condition() == expected_query.get_condition()

--- a/tests/query/processors/test_granularity_processor.py
+++ b/tests/query/processors/test_granularity_processor.py
@@ -16,7 +16,7 @@ from snuba.query.exceptions import InvalidGranularityException
 from snuba.query.expressions import Column, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.granularity_processor import GranularityProcessor
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 @pytest.mark.parametrize(
@@ -61,7 +61,7 @@ def test_granularity_added(
     )
 
     try:
-        GranularityProcessor().process_query(query, HTTPRequestSettings())
+        GranularityProcessor().process_query(query, HTTPQuerySettings())
     except InvalidGranularityException:
         assert query_granularity is None
     else:

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -14,7 +14,7 @@ from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Argument, Column, FunctionCall, Lambda, Literal
 from snuba.query.logical import Query
 from snuba.query.processors import handled_functions
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_handled_processor() -> None:
@@ -68,7 +68,7 @@ def test_handled_processor() -> None:
     processor = handled_functions.HandledFunctionsProcessor(
         "exception_stacks.mechanism_handled"
     )
-    processor.process_query(unprocessed, HTTPRequestSettings())
+    processor.process_query(unprocessed, HTTPQuerySettings())
 
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
@@ -98,7 +98,7 @@ def test_handled_processor_invalid() -> None:
         "exception_stacks.mechanism_handled",
     )
     with pytest.raises(InvalidExpressionException):
-        processor.process_query(unprocessed, HTTPRequestSettings())
+        processor.process_query(unprocessed, HTTPQuerySettings())
 
 
 def test_not_handled_processor() -> None:
@@ -152,7 +152,7 @@ def test_not_handled_processor() -> None:
     processor = handled_functions.HandledFunctionsProcessor(
         "exception_stacks.mechanism_handled",
     )
-    processor.process_query(unprocessed, HTTPRequestSettings())
+    processor.process_query(unprocessed, HTTPQuerySettings())
 
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
@@ -183,4 +183,4 @@ def test_not_handled_processor_invalid() -> None:
         "exception_stacks.mechanism_handled",
     )
     with pytest.raises(InvalidExpressionException):
-        processor.process_query(unprocessed, HTTPRequestSettings())
+        processor.process_query(unprocessed, HTTPQuerySettings())

--- a/tests/query/processors/test_hexint_column_processor.py
+++ b/tests/query/processors/test_hexint_column_processor.py
@@ -10,7 +10,7 @@ from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntColumnProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 tests = [
     pytest.param(
@@ -54,7 +54,7 @@ def test_hexint_column_processor(unprocessed: Expression, formatted_value: str) 
     )
 
     HexIntColumnProcessor(set(["column1"])).process_query(
-        unprocessed_query, HTTPRequestSettings()
+        unprocessed_query, HTTPQuerySettings()
     )
     assert unprocessed_query.get_selected_columns() == [
         SelectedExpression(

--- a/tests/query/processors/test_mandatory_condition_applier.py
+++ b/tests/query/processors/test_mandatory_condition_applier.py
@@ -15,7 +15,7 @@ from snuba.query.conditions import (
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.mandatory_condition_applier import MandatoryConditionApplier
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 test_data = [
     pytest.param(
@@ -78,9 +78,9 @@ def test_mand_conditions(table: str, mand_conditions: List[FunctionCall]) -> Non
 
     query_ast_copy = copy.deepcopy(query)
 
-    request_settings = HTTPRequestSettings(consistent=True)
+    query_settings = HTTPQuerySettings(consistent=True)
     processor = MandatoryConditionApplier()
-    processor.process_query(query, request_settings)
+    processor.process_query(query, query_settings)
 
     query_ast_copy.add_condition_to_ast(combine_and_conditions(mand_conditions))
 

--- a/tests/query/processors/test_mandatory_condition_enforcer.py
+++ b/tests/query/processors/test_mandatory_condition_enforcer.py
@@ -18,7 +18,7 @@ from snuba.query.processors.conditions_enforcer import (
     OrgIdEnforcer,
     ProjectIdEnforcer,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state import set_config
 
 test_data = [
@@ -156,10 +156,10 @@ def test_condition_enforcer(
     query: Query, valid: bool, org_id_enforcer: OrgIdEnforcer
 ) -> None:
     set_config("mandatory_condition_enforce", 1)
-    request_settings = HTTPRequestSettings(consistent=True)
+    query_settings = HTTPQuerySettings(consistent=True)
     processor = MandatoryConditionEnforcer([org_id_enforcer, ProjectIdEnforcer()])
     if valid:
-        processor.process_query(query, request_settings)
+        processor.process_query(query, query_settings)
     else:
         with pytest.raises(AssertionError):
-            processor.process_query(query, request_settings)
+            processor.process_query(query, query_settings)

--- a/tests/query/processors/test_mapping_optimizer.py
+++ b/tests/query/processors/test_mapping_optimizer.py
@@ -8,7 +8,7 @@ from snuba.query.conditions import (
 )
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state import set_config
 from tests.query.processors.query_builders import (
     build_query,
@@ -198,6 +198,6 @@ def test_tags_hash_map(
         column_name="tags",
         hash_map_name="_tags_hash_map",
         killswitch="tags_hash_map_enabled",
-    ).process_query(query, HTTPRequestSettings())
+    ).process_query(query, HTTPQuerySettings())
 
     assert query.get_condition() == expected_condition

--- a/tests/query/processors/test_mapping_optimizer_no_useless_conditions.py
+++ b/tests/query/processors/test_mapping_optimizer_no_useless_conditions.py
@@ -5,7 +5,7 @@ import pytest
 from snuba.clickhouse.query import Query as ClickhouseQuery
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.mapping_optimizer import MappingOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from tests.query.processors.query_builders import build_query
 
 
@@ -254,7 +254,7 @@ def test_recursive_useless_condition(
         column_name="tags",
         hash_map_name="_tags_hash_map",
         killswitch="tags_hash_map_enabled",
-    ).process_query(input_query, HTTPRequestSettings())
+    ).process_query(input_query, HTTPQuerySettings())
     assert input_query == expected_query
 
 
@@ -269,14 +269,14 @@ def test_useless_has_condition(
 
     # change the existence expression to be a has(tags, 'my_tag') expression for boh queries
     # this allows reuse of the previous test cases
-    EmptyTagConditionProcessor().process_query(input_query, HTTPRequestSettings())
-    EmptyTagConditionProcessor().process_query(expected_query, HTTPRequestSettings())
+    EmptyTagConditionProcessor().process_query(input_query, HTTPQuerySettings())
+    EmptyTagConditionProcessor().process_query(expected_query, HTTPQuerySettings())
 
     MappingOptimizer(
         column_name="tags",
         hash_map_name="_tags_hash_map",
         killswitch="tags_hash_map_enabled",
-    ).process_query(input_query, HTTPRequestSettings())
+    ).process_query(input_query, HTTPQuerySettings())
     assert input_query == expected_query
 
 
@@ -331,5 +331,5 @@ def test_having_special_case(
         column_name="tags",
         hash_map_name="_tags_hash_map",
         killswitch="tags_hash_map_enabled",
-    ).process_query(input_query, HTTPRequestSettings())
+    ).process_query(input_query, HTTPQuerySettings())
     assert input_query == expected_query

--- a/tests/query/processors/test_mapping_promoter.py
+++ b/tests/query/processors/test_mapping_promoter.py
@@ -8,7 +8,7 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 columns = ColumnSet(
     [
@@ -110,7 +110,7 @@ def test_format_expressions(
     name: str, query: ClickhouseQuery, expected_query: ClickhouseQuery
 ) -> None:
     MappingColumnPromoter({"tags": {"promoted_tag": "promoted"}}).process_query(
-        query, HTTPRequestSettings()
+        query, HTTPQuerySettings()
     )
 
     assert query.get_selected_columns() == expected_query.get_selected_columns()

--- a/tests/query/processors/test_null_column_caster.py
+++ b/tests/query/processors/test_null_column_caster.py
@@ -14,7 +14,7 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.null_column_caster import NullColumnCaster
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 columns1 = ColumnSet(
     [
@@ -213,5 +213,5 @@ def test_caster(input_q, expected_q):
         NullColumnCaster([Storage1, Storage2]),
     ):
         input_query = deepcopy(input_q)
-        caster.process_query(input_query, HTTPRequestSettings())
+        caster.process_query(input_query, HTTPQuerySettings())
         assert input_query == expected_q

--- a/tests/query/processors/test_org_rate_limiter.py
+++ b/tests/query/processors/test_org_rate_limiter.py
@@ -11,7 +11,7 @@ from snuba.query.logical import Query
 from snuba.query.processors.object_id_rate_limiter import (
     OrganizationRateLimiterProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state.rate_limit import ORGANIZATION_RATE_LIMIT_NAME
 
 tests = [
@@ -69,7 +69,7 @@ def test_org_rate_limit_processor(unprocessed: Expression, org_id: int) -> None:
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
         condition=unprocessed,
     )
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
 
     num_before = len(settings.get_rate_limit_params())
     OrganizationRateLimiterProcessor("org_id").process_query(query, settings)
@@ -90,7 +90,7 @@ def test_org_rate_limit_processor_overridden(
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
         condition=unprocessed,
     )
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     state.set_config(f"org_per_second_limit_{org_id}", 5)
     state.set_config(f"org_concurrent_limit_{org_id}", 10)
 

--- a/tests/query/processors/test_pattern_replacer.py
+++ b/tests/query/processors/test_pattern_replacer.py
@@ -10,7 +10,7 @@ from snuba.query.matchers import Column as ColumnMatch
 from snuba.query.matchers import MatchResult, Param
 from snuba.query.matchers import String as StringMatch
 from snuba.query.processors.pattern_replacer import PatternReplacer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 test_data = [
     pytest.param(
@@ -87,5 +87,5 @@ def test_pattern_replacer_format_expressions(
     PatternReplacer(
         Param("column", ColumnMatch(None, StringMatch("column1"))),
         transform,
-    ).process_query(unprocessed, HTTPRequestSettings())
+    ).process_query(unprocessed, HTTPQuerySettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()

--- a/tests/query/processors/test_prewhere.py
+++ b/tests/query/processors/test_prewhere.py
@@ -16,8 +16,8 @@ from snuba.query.conditions import (
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.processors.prewhere import PrewhereProcessor
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query
-from snuba.request.request_settings import HTTPRequestSettings
 
 test_data = [
     (
@@ -287,9 +287,9 @@ def test_prewhere(
     query = identity_translate(query)
     query.set_from_clause(Table("my_table", all_columns, final=final))
 
-    request_settings = HTTPRequestSettings()
+    query_settings = HTTPQuerySettings()
     processor = PrewhereProcessor(keys, omit_if_final=omit_if_final_keys)
-    processor.process_query(query, request_settings)
+    processor.process_query(query, query_settings)
 
     # HACK until we migrate these tests to SnQL
     def verify_expressions(top_level: Expression, expected: Expression) -> bool:

--- a/tests/query/processors/test_project_rate_limiter.py
+++ b/tests/query/processors/test_project_rate_limiter.py
@@ -9,7 +9,7 @@ from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.object_id_rate_limiter import ProjectRateLimiterProcessor
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state.rate_limit import PROJECT_RATE_LIMIT_NAME
 
 tests = [
@@ -67,7 +67,7 @@ def test_project_rate_limit_processor(unprocessed: Expression, project_id: int) 
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
         condition=unprocessed,
     )
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
 
     num_before = len(settings.get_rate_limit_params())
     ProjectRateLimiterProcessor("project_id").process_query(query, settings)
@@ -88,7 +88,7 @@ def test_project_rate_limit_processor_overridden(
         selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
         condition=unprocessed,
     )
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     state.set_config(f"project_per_second_limit_{project_id}", 5)
     state.set_config(f"project_concurrent_limit_{project_id}", 10)
 

--- a/tests/query/processors/test_project_referrer_rate_limiter.py
+++ b/tests/query/processors/test_project_referrer_rate_limiter.py
@@ -9,7 +9,7 @@ from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.object_id_rate_limiter import ProjectReferrerRateLimiter
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state.rate_limit import PROJECT_REFERRER_RATE_LIMIT_NAME
 
 tests = [
@@ -35,7 +35,7 @@ def test_referrer_unspecified_project(unprocessed: Expression, project_id: int) 
     state.set_config("project_referrer_per_second_limit_abusive_delivery", 1000)
     state.set_config("project_referrer_concurrent_limit_abusive_delivery", 1000)
     referrer = "abusive_delivery"
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     settings.referrer = referrer
 
     num_before = len(settings.get_rate_limit_params())
@@ -58,7 +58,7 @@ def test_referrer_specified_project(unprocessed: Expression, project_id: int) ->
     state.set_config("project_referrer_per_second_limit_abusive_delivery_1", 10)
     state.set_config("project_referrer_concurrent_limit_abusive_delivery_1", 10)
     referrer = "abusive_delivery"
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     settings.referrer = referrer
 
     num_before = len(settings.get_rate_limit_params())
@@ -82,7 +82,7 @@ def test_referrer_rate_limit_processor_no_config(
     )
     # don't configure it, rate limit shouldn't fire
     referrer = "abusive_delivery"
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     settings.referrer = referrer
 
     num_before = len(settings.get_rate_limit_params())

--- a/tests/query/processors/test_quota.py
+++ b/tests/query/processors/test_quota.py
@@ -15,7 +15,7 @@ from snuba.query.processors.quota_processor import (
     REFERRER_PROJECT_CONFIG,
     ResourceQuotaProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state.quota import ResourceQuota
 
 tests = [
@@ -69,7 +69,7 @@ def test_apply_quota(
             Literal(None, 1),
         ),
     )
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     settings.referrer = referrer
 
     ResourceQuotaProcessor("project_id").process_query(query, settings)

--- a/tests/query/processors/test_referrer_rate_limiter.py
+++ b/tests/query/processors/test_referrer_rate_limiter.py
@@ -7,7 +7,7 @@ from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.processors.object_id_rate_limiter import ReferrerRateLimiterProcessor
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state.rate_limit import REFERRER_RATE_LIMIT_NAME
 
 conditions = [
@@ -48,7 +48,7 @@ queries = [
 
 def test_project_rate_limit_processor() -> None:
 
-    settings = HTTPRequestSettings(referrer="foo")
+    settings = HTTPQuerySettings(referrer="foo")
 
     num_before = len(settings.get_rate_limit_params())
     for query in queries:
@@ -59,7 +59,7 @@ def test_project_rate_limit_processor() -> None:
 
 def test_project_rate_limit_processor_overridden() -> None:
     referrer_name = "foo"
-    settings = HTTPRequestSettings(referrer="foo")
+    settings = HTTPQuerySettings(referrer="foo")
     state.set_config(f"referrer_per_second_limit_{referrer_name}", 5)
     state.set_config(f"referrer_concurrent_limit_{referrer_name}", 10)
 
@@ -76,7 +76,7 @@ def test_project_rate_limit_processor_overridden() -> None:
 
 def test_project_rate_limit_processor_overridden_only_one() -> None:
     referrer_name = "foo"
-    settings = HTTPRequestSettings(referrer="foo")
+    settings = HTTPQuerySettings(referrer="foo")
     state.set_config(f"referrer_concurrent_limit_{referrer_name}", 10)
 
     num_before = len(settings.get_rate_limit_params())

--- a/tests/query/processors/test_slice_of_map_optimizer.py
+++ b/tests/query/processors/test_slice_of_map_optimizer.py
@@ -14,7 +14,7 @@ from snuba.query.expressions import (
     Literal,
 )
 from snuba.query.processors.slice_of_map_optimizer import SliceOfMapOptimizer
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 tests = [
     pytest.param(
@@ -99,7 +99,7 @@ def test_uuid_array_column_processor(
         condition=expected,
     )
 
-    SliceOfMapOptimizer().process_query(unprocessed_query, HTTPRequestSettings())
+    SliceOfMapOptimizer().process_query(unprocessed_query, HTTPQuerySettings())
 
     assert expected_query.get_condition() == unprocessed_query.get_condition()
     condition = unprocessed_query.get_condition()

--- a/tests/query/processors/test_table_rate_limit.py
+++ b/tests/query/processors/test_table_rate_limit.py
@@ -5,7 +5,7 @@ from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
 from snuba.query.data_source.simple import Table
 from snuba.query.processors.table_rate_limit import TableRateLimit
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state import set_config
 from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitParameters
 
@@ -63,7 +63,7 @@ def test_table_rate_limit(
     params: RateLimitParameters,
 ) -> None:
     set_config(limit_to_set, 50)
-    request_settings = HTTPRequestSettings(consistent=True)
-    processor.process_query(query, request_settings)
-    rate_limiters = request_settings.get_rate_limit_params()
+    query_settings = HTTPQuerySettings(consistent=True)
+    processor.process_query(query, query_settings)
+    rate_limiters = query_settings.get_rate_limit_params()
     assert params in rate_limiters

--- a/tests/query/processors/test_tags_expander.py
+++ b/tests/query/processors/test_tags_expander.py
@@ -8,8 +8,8 @@ from snuba.query.conditions import (
 )
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.tags_expander import TagsExpanderProcessor
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query
-from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_tags_expander() -> None:
@@ -27,8 +27,8 @@ def test_tags_expander() -> None:
     query, _ = parse_snql_query(query_body, events)
 
     processor = TagsExpanderProcessor()
-    request_settings = HTTPRequestSettings()
-    processor.process_query(query, request_settings)
+    query_settings = HTTPQuerySettings()
+    processor.process_query(query, query_settings)
 
     assert query.get_selected_columns() == [
         SelectedExpression(

--- a/tests/query/processors/test_timeseries_processor.py
+++ b/tests/query/processors/test_timeseries_processor.py
@@ -21,7 +21,7 @@ from snuba.query.processors.timeseries_processor import (
     TimeSeriesProcessor,
     extract_granularity_from_query,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.util import parse_datetime
 
 tests = [
@@ -201,7 +201,7 @@ def test_timeseries_format_expressions(
     processors = entity.get_query_processors()
     for processor in processors:
         if isinstance(processor, TimeSeriesProcessor):
-            processor.process_query(unprocessed, HTTPRequestSettings())
+            processor.process_query(unprocessed, HTTPQuerySettings())
 
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
     assert expected.get_condition() == unprocessed.get_condition()
@@ -239,4 +239,4 @@ def test_invalid_datetime() -> None:
     for processor in processors:
         if isinstance(processor, TimeSeriesProcessor):
             with pytest.raises(InvalidQueryException):
-                processor.process_query(unprocessed, HTTPRequestSettings())
+                processor.process_query(unprocessed, HTTPQuerySettings())

--- a/tests/query/processors/test_transaction_column_processor.py
+++ b/tests/query/processors/test_transaction_column_processor.py
@@ -7,7 +7,7 @@ from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_event_id_column_format_expressions() -> None:
@@ -47,7 +47,7 @@ def test_event_id_column_format_expressions() -> None:
         ],
     )
 
-    UUIDColumnProcessor({"event_id"}).process_query(unprocessed, HTTPRequestSettings())
+    UUIDColumnProcessor({"event_id"}).process_query(unprocessed, HTTPQuerySettings())
     assert expected.get_selected_columns() == unprocessed.get_selected_columns()
 
     formatted = unprocessed.get_selected_columns()[1].expression.accept(

--- a/tests/query/processors/test_tuple_unaliaser.py
+++ b/tests/query/processors/test_tuple_unaliaser.py
@@ -12,7 +12,7 @@ from snuba.query.expressions import (
     Literal,
 )
 from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state import set_config
 from tests.query.processors.query_builders import build_query
 
@@ -116,7 +116,7 @@ TEST_QUERIES = [
 @pytest.mark.parametrize("input_query,expected_query", TEST_QUERIES)
 def test_tuple_unaliaser(input_query, expected_query):
     set_config("tuple_unaliaser_rollout", 1)
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     TupleUnaliaser().process_query(input_query, settings)
     assert input_query == expected_query
 

--- a/tests/query/processors/test_type_condition_optimizer.py
+++ b/tests/query/processors/test_type_condition_optimizer.py
@@ -9,7 +9,7 @@ from snuba.query.conditions import (
 )
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, Literal
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 
 def test_type_condition_optimizer() -> None:
@@ -33,7 +33,7 @@ def test_type_condition_optimizer() -> None:
         Table("errors", ColumnSet([])),
         condition=binary_condition(BooleanFunctions.AND, Literal(None, 1), cond1),
     )
-    TypeConditionOptimizer().process_query(unprocessed_query, HTTPRequestSettings())
+    TypeConditionOptimizer().process_query(unprocessed_query, HTTPQuerySettings())
 
     assert expected_query.get_condition() == unprocessed_query.get_condition()
     condition = unprocessed_query.get_condition()

--- a/tests/query/processors/test_uniq_in_select_and_having.py
+++ b/tests/query/processors/test_uniq_in_select_and_having.py
@@ -8,7 +8,7 @@ from snuba.query.processors.uniq_in_select_and_having import (
     MismatchedAggregationException,
     UniqInSelectAndHavingProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.state import set_config
 from tests.query.processors.query_builders import build_query
 
@@ -83,15 +83,13 @@ VALID_QUERY_CASES = [
 def test_invalid_uniq_queries(input_query: ClickhouseQuery) -> None:
     set_config("throw_on_uniq_select_and_having", True)
     with pytest.raises(MismatchedAggregationException):
-        UniqInSelectAndHavingProcessor().process_query(
-            input_query, HTTPRequestSettings()
-        )
+        UniqInSelectAndHavingProcessor().process_query(input_query, HTTPQuerySettings())
 
 
 @pytest.mark.parametrize("input_query", deepcopy(VALID_QUERY_CASES))
 def test_valid_uniq_queries(input_query: ClickhouseQuery) -> None:
     set_config("throw_on_uniq_select_and_having", True)
     og_query = deepcopy(input_query)
-    UniqInSelectAndHavingProcessor().process_query(input_query, HTTPRequestSettings())
+    UniqInSelectAndHavingProcessor().process_query(input_query, HTTPQuerySettings())
     # query should not change
     assert og_query == input_query

--- a/tests/query/processors/test_uuid_array_column_processor.py
+++ b/tests/query/processors/test_uuid_array_column_processor.py
@@ -18,7 +18,7 @@ from snuba.query.expressions import (
 from snuba.query.processors.type_converters.uuid_array_column_processor import (
     UUIDArrayColumnProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 tests = [
     pytest.param(
@@ -113,7 +113,7 @@ def test_uuid_array_column_processor(
     )
 
     UUIDArrayColumnProcessor(set(["column1", "column2"])).process_query(
-        unprocessed_query, HTTPRequestSettings()
+        unprocessed_query, HTTPQuerySettings()
     )
     assert unprocessed_query.get_selected_columns() == [
         SelectedExpression(

--- a/tests/query/processors/test_uuid_column_processor.py
+++ b/tests/query/processors/test_uuid_column_processor.py
@@ -17,7 +17,7 @@ from snuba.query.processors.type_converters import ColumnTypeError
 from snuba.query.processors.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 
 tests = [
     pytest.param(
@@ -253,7 +253,7 @@ def test_uuid_column_processor(
     )
 
     UUIDColumnProcessor(set(["column1", "column2"])).process_query(
-        unprocessed_query, HTTPRequestSettings()
+        unprocessed_query, HTTPQuerySettings()
     )
     assert unprocessed_query.get_selected_columns() == [
         SelectedExpression(
@@ -311,5 +311,5 @@ def test_invalid_uuid(unprocessed: Expression) -> None:
 
     with pytest.raises(ColumnTypeError):
         UUIDColumnProcessor(set(["column1", "column2"])).process_query(
-            unprocessed_query, HTTPRequestSettings()
+            unprocessed_query, HTTPQuerySettings()
         )

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -17,8 +17,8 @@ from snuba.query.expressions import (
     Literal,
     SubscriptableReference,
 )
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query, parse_snql_query_initial
-from snuba.request.request_settings import HTTPRequestSettings
 
 
 def test_iterate_over_query() -> None:
@@ -330,7 +330,7 @@ def test_alias_validation(
     events = get_dataset("events")
     snql_query = json_to_snql(query_body, "events")
     query, _ = parse_snql_query(str(snql_query), events)
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     query_plan = (
         events.get_default_entity()
         .get_query_pipeline_builder()

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -15,7 +15,7 @@ from snuba.query.conditions import (
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
-from snuba.request.request_settings import HTTPRequestSettings
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
 from snuba.utils.metrics.timer import Timer
@@ -63,12 +63,12 @@ TESTS = [
 def test_build_request(body: MutableMapping[str, Any], condition: Expression) -> None:
     dataset = get_dataset("events")
     entity = dataset.get_default_entity()
-    schema = RequestSchema.build(HTTPRequestSettings)
+    schema = RequestSchema.build(HTTPQuerySettings)
 
     request = build_request(
         body,
         parse_snql_query,
-        HTTPRequestSettings,
+        HTTPQuerySettings,
         schema,
         dataset,
         Timer("test"),

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -93,6 +93,6 @@ def test_build_request(body: MutableMapping[str, Any], condition: Expression) ->
     )
 
     assert request.referrer == "my_request"
-    assert dict(request.body) == body
+    assert dict(request.original_body) == body
     status, differences = request.query.equals(expected_query)
     assert status == True, f"Query mismatch: {differences}"

--- a/tests/request/test_schema.py
+++ b/tests/request/test_schema.py
@@ -1,0 +1,34 @@
+from snuba.query.query_settings import HTTPQuerySettings
+from snuba.request.schema import RequestSchema
+
+
+def test_split_request() -> None:
+    payload = {
+        "turbo": False,
+        "consistent": False,
+        "debug": False,
+        "dry_run": False,
+        "legacy": False,
+        "team": "sns",
+        "feature": "attribution",
+        "app_id": "foobar",
+        "query": """MATCH (something) dontcare""",
+    }
+    schema = RequestSchema.build(HTTPQuerySettings)
+    parts = schema.validate(payload)
+    assert set(parts.query_settings.keys()) == {
+        "turbo",
+        "consistent",
+        "debug",
+        "dry_run",
+        "legacy",
+        "referrer",
+    }
+    assert set(parts.attribution_info.keys()) == {
+        "team",
+        "feature",
+        "app_id",
+        "parent_api",
+        "referrer",
+    }
+    assert set(parts.query.keys()) == {"query"}

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -183,7 +183,7 @@ def test_subscription_task_result_encoder() -> None:
     assert payload["subscription_id"] == str(
         task_result.task.task.subscription.identifier
     )
-    assert payload["request"] == request.body
+    assert payload["request"] == request.original_body
     assert payload["result"] == result
     assert payload["timestamp"] == task_result.task.timestamp.isoformat()
     assert payload["entity"] == EntityKey.EVENTS.value
@@ -264,7 +264,7 @@ def test_metrics_subscription_task_result_encoder(
     assert payload["subscription_id"] == str(
         task_result.task.task.subscription.identifier
     )
-    assert payload["request"] == request.body
+    assert payload["request"] == request.original_body
     assert payload["result"] == result
     assert payload["timestamp"] == task_result.task.timestamp.isoformat()
     assert payload["entity"] == entity_key.value

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -16,9 +16,9 @@ from snuba.datasets.plans.translator.query import identity_translate
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.query.snql.parser import parse_snql_query
 from snuba.reader import Reader
-from snuba.request.request_settings import HTTPRequestSettings, RequestSettings
 from snuba.web import QueryResult
 from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
@@ -59,7 +59,7 @@ def test_no_split(
 
     def do_query(
         query: ClickhouseQuery,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         reader: Reader,
     ) -> QueryResult:
         assert query == query
@@ -78,7 +78,7 @@ def test_no_split(
         ],
     )
 
-    strategy.execute(query, HTTPRequestSettings(), do_query)
+    strategy.execute(query, HTTPQuerySettings(), do_query)
 
 
 def test_set_limit_on_split_query():
@@ -175,7 +175,7 @@ def test_col_split(
 ) -> None:
     def do_query(
         query: ClickhouseQuery,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
         reader: Reader,
     ) -> QueryResult:
         selected_col_names = [
@@ -211,7 +211,7 @@ def test_col_split(
         ],
     )
 
-    strategy.execute(query, HTTPRequestSettings(), do_query)
+    strategy.execute(query, HTTPQuerySettings(), do_query)
 
 
 column_set = ColumnSet(
@@ -377,7 +377,7 @@ def test_col_split_conditions(
     splitter = ColumnSplitQueryStrategy(id_column, project_column, timestamp_column)
 
     def do_query(
-        query: ClickhouseQuery, request_settings: RequestSettings = None
+        query: ClickhouseQuery, query_settings: QuerySettings = None
     ) -> QueryResult:
         return QueryResult(
             {
@@ -393,7 +393,7 @@ def test_col_split_conditions(
         )
 
     assert (
-        splitter.execute(query, HTTPRequestSettings(), do_query) is not None
+        splitter.execute(query, HTTPQuerySettings(), do_query) is not None
     ) == expected_result
 
 
@@ -406,7 +406,7 @@ def test_time_split_ast() -> None:
 
     def do_query(
         query: ClickhouseQuery,
-        request_settings: RequestSettings,
+        query_settings: QuerySettings,
     ) -> QueryResult:
         from_date_ast, to_date_ast = get_time_range(query, "timestamp")
         assert from_date_ast is not None and isinstance(from_date_ast, datetime)
@@ -428,7 +428,7 @@ def test_time_split_ast() -> None:
 
     query, _ = parse_snql_query(body, get_dataset("events"))
     entity = get_entity(query.get_from_clause().key)
-    settings = HTTPRequestSettings()
+    settings = HTTPQuerySettings()
     for p in entity.get_query_processors():
         p.process_query(query, settings)
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -94,9 +94,7 @@ def test_set_limit_on_split_query():
 
     query_run_count = 0
 
-    def do_query(
-        query: ClickhouseQuery, request_settings: RequestSettings
-    ) -> QueryResult:
+    def do_query(query: ClickhouseQuery, query_settings: QuerySettings) -> QueryResult:
         nonlocal query_run_count
         query_run_count += 1
         if query_run_count == 1:
@@ -125,7 +123,7 @@ def test_set_limit_on_split_query():
         id_column="event_id",
         project_column="project_id",
         timestamp_column="timestamp",
-    ).execute(query, HTTPRequestSettings(), do_query)
+    ).execute(query, HTTPQuerySettings(), do_query)
     assert query_run_count == 2
 
 

--- a/tests/web/test_transform_names.py
+++ b/tests/web/test_transform_names.py
@@ -13,9 +13,9 @@ from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.logical import Query
+from snuba.query.query_settings import HTTPQuerySettings
 from snuba.reader import Column as MetaColumn
 from snuba.request import Request
-from snuba.request.request_settings import HTTPRequestSettings
 from snuba.utils.metrics.timer import Timer
 from snuba.web.query import parse_and_run_query
 from tests.helpers import write_unprocessed_events
@@ -72,7 +72,7 @@ def test_transform_column_names() -> None:
             ),
         ],
     )
-    query_settings = HTTPRequestSettings(referrer="asd")
+    query_settings = HTTPQuerySettings(referrer="asd")
 
     dataset = get_dataset("events")
     timer = Timer("test")

--- a/tests/web/test_transform_names.py
+++ b/tests/web/test_transform_names.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from snuba import settings
 from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.events_processor_base import InsertEvent
@@ -80,11 +81,13 @@ def test_transform_column_names() -> None:
         dataset,
         Request(
             id="asd",
-            body={},
+            original_body={},
             query=query,
-            app_id=get_app_id("default"),
             snql_anonymized="",
-            settings=query_settings,
+            query_settings=query_settings,
+            attribution_info=AttributionInfo(
+                get_app_id("blah"), "blah", None, None, None
+            ),
         ),
         timer,
     )


### PR DESCRIPTION
This PR is step one of an effort to decouple attribution of queries from the settings passed to the query pipeline. 

The main changes are in `snuba/request/validation.py` and `snuba/request/schema.py` The rest of this PR is just renaming `RequestSettings` to `QuerySettings` 

### Could this be split up into multiple PRs?
Not really, I gave it a shot however as soon as `RequestSettings` no longer exists, you can't even run a test in this repo, therefore unfortunately I have to to this in one shot.  The commits are split into two: logic, and rename. 