### PR TITLE
enforce retention_days is int type

### DIFF
--- a/snuba/datasets/events_format.py
+++ b/snuba/datasets/events_format.py
@@ -116,7 +116,7 @@ def override_and_enforce_retention(
 def enforce_retention(
     retention_days: Optional[int], timestamp: Optional[datetime]
 ) -> int:
-    if retention_days is None:
+    if not isinstance(retention_days, int):
         retention_days = settings.DEFAULT_RETENTION_DAYS
 
     if settings.ENFORCE_RETENTION:


### PR DESCRIPTION
If the `retention_days` provided is not an int we will just use the `DEFAULT_RETENTION_DAYS`. Should fix https://github.com/getsentry/snuba/issues/2780. 
