### PR TITLE
fix: Update various dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ atomicwrites==1.1.5
 blinker==1.4
 black==22.3.0
 certifi==2018.4.16
-chardet==3.0.4
+chardet==4.0.0
 click==8.0.4
 clickhouse-driver==0.2.4
 colorama==0.3.9
@@ -11,7 +11,7 @@ coverage==5.0
 datadog==0.21.0
 deprecation==2.0.3
 docopt==0.6.2
-flake8==3.7.8
+flake8==4.0.1
 Flask==1.0.2
 future==0.18.2
 honcho==1.0.1
@@ -29,13 +29,13 @@ mypy>=0.812,<0.900
 packaging==20.4
 parsimonious==0.8.1
 py==1.10.0
-pyparsing==2.2.0
+pyparsing==3.0.9
 pytest==6.2.0
 pytest-cov==2.10.1
 pytest-watch==4.2.0
 pathtools==0.1.2
 pluggy==0.13.0
-progressbar2==3.53.1
+progressbar2==4.0.0
 python-dateutil==2.7.3
 pytz==2018.4
 python-rapidjson==1.4


### PR DESCRIPTION
bump flake8 from 3.7.8 to 4.0.1
bump progressbar2 from 3.53.1 to 4.0.0
bump chardet from 3.0.4 to 4.0.0
bump pyparsing from 2.2.0 to 3.0.9

These are copied from dependabot PRs:
https://github.com/getsentry/snuba/pull/2751
https://github.com/getsentry/snuba/pull/2752
https://github.com/getsentry/snuba/pull/2812
https://github.com/getsentry/snuba/pull/2811