### PR TITLE
ref(subscriptions): Add total_concurrent_queries cli arg

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -38,11 +38,19 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     default="snuba-subscription-executor",
     help="Consumer group used for consuming the scheduled subscription topic/s.",
 )
+# TODO: Once we are using the --total-concurrent-queries to calculate the max
+# concurrent queries we can remove this cli arg.
 @click.option(
     "--max-concurrent-queries",
     default=20,
     type=int,
-    help="Max concurrent ClickHouse queries",
+    help="Max concurrent ClickHouse queries.",
+)
+@click.option(
+    "--total-concurrent-queries",
+    default=64,
+    type=int,
+    help="Total max number of concurrent queries for all replicas. Used to calculate max_concurrent_queries.",
 )
 @click.option(
     "--auto-offset-reset",
@@ -74,6 +82,7 @@ def subscriptions_executor(
     entity_names: Sequence[str],
     consumer_group: str,
     max_concurrent_queries: int,
+    total_concurrent_queries: int,
     auto_offset_reset: str,
     no_strict_offset_reset: bool,
     log_level: Optional[str],
@@ -126,6 +135,7 @@ def subscriptions_executor(
         consumer_group,
         producer,
         max_concurrent_queries,
+        total_concurrent_queries,
         auto_offset_reset,
         not no_strict_offset_reset,
         metrics,

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -45,11 +45,19 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     required=True,
     help="Name of the consumer group to follow",
 )
+# TODO: Once we are using the --total-concurrent-queries to calculate the max
+# concurrent queries we can remove this cli arg.
 @click.option(
     "--max-concurrent-queries",
     default=20,
     type=int,
     help="Max concurrent ClickHouse queries",
+)
+@click.option(
+    "--total-concurrent-queries",
+    default=64,
+    type=int,
+    help="Total max number of concurrent queries for all replicas. Used to calculate max_concurrent_queries.",
 )
 @click.option(
     "--auto-offset-reset",
@@ -82,6 +90,7 @@ def subscriptions_scheduler_executor(
     consumer_group: str,
     followed_consumer_group: str,
     max_concurrent_queries: int,
+    total_concurrent_queries: int,
     auto_offset_reset: str,
     no_strict_offset_reset: bool,
     schedule_ttl: int,
@@ -136,6 +145,7 @@ def subscriptions_scheduler_executor(
         delay_seconds,
         stale_threshold_seconds,
         max_concurrent_queries,
+        total_concurrent_queries,
         metrics,
         SchedulingWatermarkMode(scheduling_mode)
         if scheduling_mode is not None

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -47,6 +47,7 @@ def build_scheduler_executor_consumer(
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
     max_concurrent_queries: int,
+    total_concurrent_queries: int,
     metrics: MetricsBackend,
     scheduling_mode: Optional[SchedulingWatermarkMode],
 ) -> StreamProcessor[Tick]:
@@ -98,6 +99,7 @@ def build_scheduler_executor_consumer(
         entity_names,
         partitions,
         max_concurrent_queries,
+        total_concurrent_queries,
         producer,
         metrics,
         stale_threshold_seconds,
@@ -133,6 +135,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         entity_names: Sequence[str],
         partitions: int,
         max_concurrent_queries: int,
+        total_concurrent_queries: int,
         producer: Producer[KafkaPayload],
         metrics: MetricsBackend,
         stale_threshold_seconds: Optional[int],
@@ -176,6 +179,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
 
         self.__executor_factory = SubscriptionExecutorProcessingFactory(
             max_concurrent_queries,
+            total_concurrent_queries,
             dataset,
             entity_names,
             producer,

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -52,6 +52,7 @@ def build_executor_consumer(
     consumer_group: str,
     producer: Producer[KafkaPayload],
     max_concurrent_queries: int,
+    total_concurrent_queries: int,
     auto_offset_reset: str,
     strict_offset_reset: Optional[bool],
     metrics: MetricsBackend,
@@ -134,6 +135,7 @@ def build_executor_consumer(
         Topic(scheduled_topic_spec.topic_name),
         SubscriptionExecutorProcessingFactory(
             max_concurrent_queries,
+            total_concurrent_queries,
             dataset,
             entity_names,
             producer,
@@ -148,6 +150,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
     def __init__(
         self,
         max_concurrent_queries: int,
+        total_concurrent_queries: int,
         dataset: Dataset,
         entity_names: Sequence[str],
         producer: Producer[KafkaPayload],
@@ -156,6 +159,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
         result_topic: str,
     ) -> None:
         self.__max_concurrent_queries = max_concurrent_queries
+        self.__total_concurrent_queries = total_concurrent_queries
         self.__dataset = dataset
         self.__entity_names = entity_names
         self.__producer = producer
@@ -170,6 +174,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
             self.__dataset,
             self.__entity_names,
             self.__max_concurrent_queries,
+            self.__total_concurrent_queries,
             self.__stale_threshold_seconds,
             self.__metrics,
             ProduceResult(self.__producer, self.__result_topic, commit),
@@ -188,6 +193,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
         dataset: Dataset,
         entity_names: Sequence[str],
         max_concurrent_queries: int,
+        total_concurrent_queries: int,
         stale_threshold_seconds: Optional[int],
         metrics: MetricsBackend,
         next_step: ProcessingStrategy[SubscriptionTaskResult],
@@ -199,6 +205,7 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
         self.__dataset = dataset
         self.__entity_names = set(entity_names)
         self.__max_concurrent_queries = max_concurrent_queries
+        self.__total_concurrent_queries = total_concurrent_queries
         self.__executor = ThreadPoolExecutor(self.__max_concurrent_queries)
         self.__stale_threshold_seconds = stale_threshold_seconds
         self.__metrics = metrics

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -47,6 +47,7 @@ def test_combined_scheduler_and_executor() -> None:
     entity_names = ["events"]
     num_partitions = 2
     max_concurrent_queries = 2
+    total_concurrent_queries = 2
     metrics = TestingMetricsBackend()
 
     commit = mock.Mock()
@@ -67,6 +68,7 @@ def test_combined_scheduler_and_executor() -> None:
             entity_names,
             num_partitions,
             max_concurrent_queries,
+            total_concurrent_queries,
             producer,
             metrics,
             stale_threshold_seconds,

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -111,6 +111,7 @@ def test_executor_consumer() -> None:
         consumer_group,
         result_producer,
         2,
+        2,
         auto_offset_reset,
         strict_offset_reset,
         TestingMetricsBackend(),
@@ -220,6 +221,7 @@ def test_execute_query_strategy() -> None:
     dataset = get_dataset("events")
     entity_names = ["events"]
     max_concurrent_queries = 2
+    total_concurrent_queries = 2
     metrics = TestingMetricsBackend()
     next_step = mock.Mock()
     commit = mock.Mock()
@@ -228,6 +230,7 @@ def test_execute_query_strategy() -> None:
         dataset,
         entity_names,
         max_concurrent_queries,
+        total_concurrent_queries,
         None,
         metrics,
         next_step,
@@ -264,7 +267,18 @@ def test_too_many_concurrent_queries() -> None:
     next_step = mock.Mock()
     commit = mock.Mock()
 
-    strategy = ExecuteQuery(dataset, entity_names, 4, None, metrics, next_step, commit)
+    total_concurrent_queries = 4
+
+    strategy = ExecuteQuery(
+        dataset,
+        entity_names,
+        4,
+        total_concurrent_queries,
+        None,
+        metrics,
+        next_step,
+        commit,
+    )
 
     make_message = generate_message(EntityKey.EVENTS)
 
@@ -289,7 +303,18 @@ def test_skip_execution_for_entity() -> None:
     next_step = mock.Mock()
     commit = mock.Mock()
 
-    strategy = ExecuteQuery(dataset, entity_names, 4, None, metrics, next_step, commit)
+    total_concurrent_queries = 4
+
+    strategy = ExecuteQuery(
+        dataset,
+        entity_names,
+        4,
+        total_concurrent_queries,
+        None,
+        metrics,
+        next_step,
+        commit,
+    )
 
     metrics_sets_message = next(generate_message(EntityKey.METRICS_SETS))
     strategy.submit(metrics_sets_message)
@@ -380,6 +405,7 @@ def test_execute_and_produce_result() -> None:
     dataset = get_dataset("events")
     entity_names = ["events"]
     max_concurrent_queries = 2
+    total_concurrent_queries = 2
     metrics = TestingMetricsBackend()
 
     scheduled_topic = Topic("scheduled-subscriptions-events")
@@ -397,6 +423,7 @@ def test_execute_and_produce_result() -> None:
         dataset,
         entity_names,
         max_concurrent_queries,
+        total_concurrent_queries,
         None,
         metrics,
         ProduceResult(producer, result_topic.name, commit),
@@ -426,6 +453,7 @@ def test_skip_stale_message() -> None:
     dataset = get_dataset("events")
     entity_names = ["events"]
     max_concurrent_queries = 2
+    total_concurrent_queries = 2
     metrics = TestingMetricsBackend()
 
     scheduled_topic = Topic("scheduled-subscriptions-events")
@@ -445,6 +473,7 @@ def test_skip_stale_message() -> None:
         dataset,
         entity_names,
         max_concurrent_queries,
+        total_concurrent_queries,
         stale_threshold_seconds,
         metrics,
         ProduceResult(producer, result_topic.name, commit),


### PR DESCRIPTION
**context**:
We've been working on a solution to helping our snuba consumers scale automatically. There is some detailed context about that in https://github.com/getsentry/snuba/pull/2762. For the executors specifically we want `max_concurrent_queries` to be calculated dynamically.

We need three numbers to do that:
1. **total concurrent queries**
    * This PR adds this arg be passed in through the cli with the default of `64`. `64` is the `total_concurrent_queries` set in the ops repo for all of the executors aside from [the metrics executor](https://github.com/getsentry/ops/blob/master/k8s/services/snuba/_deployment.metrics-subscriptions-executor.yaml#L10) which is `24`.
1. **total no. partitions**
    * This can be gathered from `TOPIC_PARTITION_COUNTS` but we want to make sure those are set correctly in ops
1. **current partitions for the given strategy**
    * Arroyo has been updated to allow partitions to be passed through to the strategy factory. This work was done in https://github.com/getsentry/arroyo/pull/75. 


The work of putting this all together will be done in https://github.com/getsentry/snuba/pull/2761.