### PR TITLE
feat: Print the ClickHouse host, port and version if invalid version

### DIFF
--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -52,5 +52,5 @@ def check_clickhouse(clickhouse: ClickhousePool) -> None:
     ver = ver.replace(".testingarm", "")
     if version.parse(ver) < version.parse(CLICKHOUSE_SERVER_MIN_VERSION):
         raise InvalidClickhouseVersion(
-            f"Snuba requires Clickhouse version {CLICKHOUSE_SERVER_MIN_VERSION}"
+            f"Snuba requires Clickhouse version {CLICKHOUSE_SERVER_MIN_VERSION} ({clickhouse.host}:{clickhouse.port} - {ver})"
         )


### PR DESCRIPTION
It can be hard to tell which ClickHouse node/cluster is invalid, print the host, port and version if
an invalid version is encountered.