### PR TITLE
fix: Remove redis check for dbsize

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2059,10 +2059,6 @@ class TestApi(SimpleAPITest):
         result = json.loads(self.post(json.dumps(query)).data)
         assert result["data"] == []
 
-        # make sure redis has _something_ before we go about dropping all the keys in it
-        time.sleep(1)
-        assert self.redis_db_size() > 0
-
         storage = get_writable_storage(StorageKey.ERRORS)
         clickhouse = storage.get_cluster().get_query_connection(
             ClickhouseClientSettings.QUERY


### PR DESCRIPTION
The new version of Redis doesn't return the dbsize the same way as the old one, which causes this test to flake.

Remove it for now and debug the flake later.