### PR TITLE
fix(admin): make get local table name resilient to bad clickhouse configs

### DIFF
--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -18,9 +18,12 @@ Storage = TypedDict(
 
 
 def _get_local_table_name(storage_key: StorageKey) -> str:
-    schema = get_storage(storage_key).get_schema()
-    assert isinstance(schema, TableSchema)
-    return schema.get_table_name()
+    try:
+        schema = get_storage(storage_key).get_schema()
+        assert isinstance(schema, TableSchema)
+        return schema.get_table_name()
+    except UndefinedClickhouseCluster:
+        return "badcluster"
 
 
 def _get_local_nodes(storage_key: StorageKey) -> Sequence[Node]:


### PR DESCRIPTION
Currently this breaks the admin page when an experimental cluster is not properly configured. Make it so that only the bad cluster config is affected