### PR TITLE
fix: Dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: "npm"
     directory: "/snuba/admin"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      open-pull-requests-limit: 10
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      open-pull-requests-limit: 50


### PR DESCRIPTION
Change dependabot to find things on Sunday so the PRs are ready to go on Monday.
Also change the limit to allow it to open PRs for everything at once.