### PR TITLE
fix(replays): correct initial migration

### DIFF
--- a/snuba/migrations/snuba_migrations/replays/0001_replays.py
+++ b/snuba/migrations/snuba_migrations/replays/0001_replays.py
@@ -21,7 +21,9 @@ raw_columns: Sequence[Column[Modifiers]] = [
     Column("trace_ids", Array(UUID())),
     Column(
         "_trace_ids_hashed",
-        UInt(64, Modifiers(materialized="arrayMap(t -> cityHash64(t), trace_ids)")),
+        Array(
+            UInt(64), Modifiers(materialized="arrayMap(t -> cityHash64(t), trace_ids)")
+        ),
     ),
     Column("title", String()),
     ### columns used by other sentry events


### PR DESCRIPTION
the materialized trace_ids column needs to be an array. there is no data in this table, will simply drop and re-create. 