### PR TITLE
make generic sets granularities configurable from raw table

### DIFF
--- a/snuba/migrations/snuba_migrations/generic_metrics/0002_sets_raw_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0002_sets_raw_table.py
@@ -41,6 +41,7 @@ class Migration(migration.ClickhouseNodeMigration):
         Column("metric_type", String(Modifiers(low_cardinality=True))),
         Column("materialization_version", UInt(8)),
         Column("timeseries_id", UInt(32)),
+        Column("granularities", Array(UInt(8))),
         Column("partition", UInt(16)),
         Column("offset", UInt(64)),
     ]

--- a/snuba/migrations/snuba_migrations/generic_metrics/0003_sets_mv.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0003_sets_mv.py
@@ -50,13 +50,13 @@ class Migration(migration.ClickhouseNodeMigration):
                     org_id,
                     project_id,
                     metric_id,
-                    arrayJoin([0,1,2,3]) as granularity,
+                    arrayJoin(granularities) as granularity,
                     tags.key,
                     tags.indexed_value,
                     tags.raw_value,
                     toDateTime(multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
                       intDiv(toUnixTimestamp(timestamp),
-                             multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                        multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
                     retention_days,
                     uniqCombined64State(arrayJoin(set_values)) as value
                 FROM generic_metric_sets_raw_local


### PR DESCRIPTION
Filippo suggested this could make us a little more flexible for different use cases (some alerts may want 10s granularity, other reporting functions may never care about <1d).

These migrations can be modified because the production DB was wiped