### PR TITLE
db(metrics): migrations to update generic sets schema

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -242,7 +242,13 @@ class GenericMetricsLoader(DirectoryLoader):
         super().__init__("snuba.migrations.snuba_migrations.generic_metrics")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_sets_aggregate_table", "0002_sets_raw_table", "0003_sets_mv"]
+        return [
+            "0001_sets_aggregate_table",
+            "0002_sets_raw_table",
+            "0003_sets_mv",
+            "0004_sets_raw_add_granularities",
+            "0005_sets_replace_mv",
+        ]
 
 
 _REGISTERED_GROUPS = {

--- a/snuba/migrations/snuba_migrations/generic_metrics/0004_sets_raw_add_granularities.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0004_sets_raw_add_granularities.py
@@ -1,0 +1,48 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.utils.schemas import Array, Column, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    table_name = "generic_metric_sets_raw_local"
+    new_column: Column[MigrationModifiers] = Column("granularities", Array(UInt(8)))
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.table_name,
+                column=self.new_column,
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.table_name,
+                column_name=self.new_column.name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.table_name,
+                column=self.new_column,
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.table_name,
+                column_name=self.new_column.name,
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/generic_metrics/0005_sets_replace_mv.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0005_sets_replace_mv.py
@@ -1,0 +1,96 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_sets_aggregation_mv"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.view_name,
+            ),
+            operations.CreateMaterializedView(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name="generic_metric_sets_local",
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(timestamp),
+                             multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                    retention_days,
+                    uniqCombined64State(arrayJoin(set_values)) as value
+                FROM generic_metric_sets_raw_local
+                WHERE materialization_version = 1
+                  AND metric_type = 'set'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.view_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []


### PR DESCRIPTION
Allow for custom granularities to be entered in the raw table and expanded in the materialized view