### PR TITLE
feat(consumers): Experimental Consumers

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -208,6 +208,9 @@ ENABLE_PROFILES_CONSUMER = os.environ.get("ENABLE_PROFILES_CONSUMER", False)
 # Enable replays ingestion
 ENABLE_REPLAYS_CONSUMER = os.environ.get("ENABLE_REPLAYS_CONSUMER", False)
 
+# Used to tag consumers as experimental to avoid them crash looping in production
+EXPERIMENTAL_CONSUMER_GROUPS: Set[str] = set()
+
 # Place the actual time we start ingesting on the new version.
 ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 3, 23, 0, 0, 0)
 TRANSACTIONS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(


### PR DESCRIPTION
### Overview
- We want the ability to mark a consumer as experimental so new consumers can crash on deploy without blocking the entire deploy
- By default, the k8s health check that blocks the deploy if a consumer crashes is just a simple check of whether or not the container is still running
- We need the consumer to be able to crash without the container itself restarting

### Changes
- Wrapped the entire `snuba consumer` CLI command with a try/except that just starts an infinite loop to keep the process from crashing
- Introduced setting which can contain consumer groups to be marked experimental - in turn marking the consumers experimental

### Tests
- Tested locally, marking a consumer group experimental and starting a broken consumer will log but not kill the process