### PR TITLE
experiment(consumers): Add logic to enable an experimental consumer deploy test

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -186,6 +186,11 @@ def consumer(
         signal.signal(signal.SIGINT, handler)
         signal.signal(signal.SIGTERM, handler)
 
+        # TODO: Remove block after experimental consumer deploy test
+        if consumer_group == "experimental-consumers":
+            logger.info("Breaking experimental consumer...")
+            raise Exception("Testing broken consumer fallback logic")
+
         consumer.run()
 
     except Exception:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -209,7 +209,8 @@ ENABLE_PROFILES_CONSUMER = os.environ.get("ENABLE_PROFILES_CONSUMER", False)
 ENABLE_REPLAYS_CONSUMER = os.environ.get("ENABLE_REPLAYS_CONSUMER", False)
 
 # Used to tag consumers as experimental to avoid them crash looping in production
-EXPERIMENTAL_CONSUMER_GROUPS: Set[str] = set()
+# TODO: Revert value to an empty set after experimental consumer deploy test
+EXPERIMENTAL_CONSUMER_GROUPS: Set[str] = {"experimental-consumers"}
 
 # Place the actual time we start ingesting on the new version.
 ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 3, 23, 0, 0, 0)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -208,6 +208,9 @@ ENABLE_PROFILES_CONSUMER = os.environ.get("ENABLE_PROFILES_CONSUMER", False)
 # Enable replays ingestion
 ENABLE_REPLAYS_CONSUMER = os.environ.get("ENABLE_REPLAYS_CONSUMER", False)
 
+# Used to tag consumers as experimental to avoid them crash looping in production
+EXPERIMENTAL_CONSUMER_GROUPS: Set[str] = set()
+
 # Place the actual time we start ingesting on the new version.
 ERRORS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(2022, 3, 23, 0, 0, 0)
 TRANSACTIONS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(


### PR DESCRIPTION
### Overview
- When #2878 is merged, we should be able to mark consumers experimental via a Snuba setting
- This PR is meant to test this logic by adding an experimental consumer group called `experimental-consumers` to the setting and then attempt to crash any consumer under this group
- The try/except logic around the CLI should catch this and not block the deploy of the rest of the consumers