### PR TITLE
ref(subscriptions): Add partition_count for executors

### DIFF
--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -180,6 +180,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         self.__executor_factory = SubscriptionExecutorProcessingFactory(
             max_concurrent_queries,
             total_concurrent_queries,
+            self.__partitions,
             dataset,
             entity_names,
             producer,


### PR DESCRIPTION
**context**
As per comment: https://github.com/getsentry/snuba/pull/2761#pullrequestreview-1017852897, we cannot hardcode `64` as the number of partitions across all consumers since that is not the case. 

The executors consume from the `scheduled-subscriptions-*` topics. So in order for this PR to pass the correct number of partitions, we'd need to add the following to the production settings `TOPIC_PARTITION_COUNTS`:

```
{
    "scheduled-subscriptions-events": 32,
    "scheduled-subscriptions-transactions": 32,
    "scheduled-subscriptions-metrics": 16,
}
```