### PR TITLE
ref(consumers): Add get_partition_count

### DIFF
--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -8,8 +8,7 @@ from snuba.utils.streams.configuration_builder import get_default_kafka_configur
 from snuba.utils.streams.topics import Topic
 
 
-def get_partition_count_from_kafka_admin(topic: Topic, logger: Logger) -> int:
-
+def get_partition_count(topic: Topic, logger: Logger) -> int:
     override_params = {
         # Default is 60s, do we need that long?
         "socket.timeout.ms": 2000,

--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -1,0 +1,52 @@
+import time
+from logging import Logger
+
+from confluent_kafka import KafkaException
+from confluent_kafka.admin import AdminClient
+
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
+from snuba.utils.streams.topics import Topic
+
+
+def get_partition_count_from_kafka_admin(topic: Topic, logger: Logger) -> int:
+
+    override_params = {
+        # Default is 60s, do we need that long?
+        "socket.timeout.ms": 2000,
+    }
+    attempts = 0
+    while True:
+        try:
+            logger.info("Attempting to connect to Kafka (attempt %d)...", attempts)
+            client = AdminClient(
+                get_default_kafka_configuration(
+                    topic=topic, override_params=override_params
+                )
+            )
+            cluster_metadata = client.list_topics(topic=topic.value, timeout=1.0)
+            break
+        except KafkaException as err:
+            logger.debug(
+                "Connection to Kafka failed (attempt %d)", attempts, exc_info=err
+            )
+            attempts += 1
+            # How many attempts is too many?
+            if attempts == 3:
+                raise
+            time.sleep(1)
+
+    try:
+        logger.info(f"Getting topic metadata for {topic.value}...")
+        topic_metadata = cluster_metadata.topics[topic.value]
+    except KeyError:
+        logger.info(f"No topic found for: {topic.value}")
+
+    if topic_metadata.error:
+        # (TODO) handle if there is a topic error, value is KafkaError object
+        # although not sure if this is necessary give the KafkaException
+        # handling above.
+        pass
+
+    total_partition_count = len(topic_metadata.partitions.keys())
+    logger.info(f"Total of {total_partition_count} partition(s) for {topic.value}.")
+    return total_partition_count

--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -22,6 +22,7 @@ def get_partition_count(topic: Topic, timeout: float = 2.0) -> int:
             client = AdminClient(get_default_kafka_configuration(topic=topic))
             cluster_metadata = client.list_topics(timeout=timeout)
             logger.info(f"Checking topic metadata for {topic.value}...")
+            logger.debug(f"All topics: {t for t in cluster_metadata.topics.keys()}")
             topic_metadata = cluster_metadata.topics.get(topic.value)
             break
         except KafkaException as err:

--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -36,7 +36,7 @@ def get_partition_count(topic: Topic, timeout: float = 2.0) -> int:
 
     if not topic_metadata:
         raise TopicNotFound(
-            f"Topic {topic.value} was not found in topics: {cluster_metadata.topics.keys()}"
+            f"Topic metadata {topic.value} was not found in topics: {cluster_metadata.topics.keys()}"
         )
 
     if topic_metadata.error is not None:

--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -22,7 +22,6 @@ def get_partition_count(topic: Topic, timeout: float = 2.0) -> int:
             client = AdminClient(get_default_kafka_configuration(topic=topic))
             cluster_metadata = client.list_topics(timeout=timeout)
             logger.info(f"Checking topic metadata for {topic.value}...")
-            logger.debug(f"All topics: {t for t in cluster_metadata.topics.keys()}")
             topic_metadata = cluster_metadata.topics.get(topic.value)
             break
         except KafkaException as err:
@@ -36,7 +35,9 @@ def get_partition_count(topic: Topic, timeout: float = 2.0) -> int:
             time.sleep(1)
 
     if not topic_metadata:
-        raise TopicNotFound(f"Topic {topic.value} was not found.")
+        raise TopicNotFound(
+            f"Topic {topic.value} was not found in topics: {cluster_metadata.topics.keys()}"
+        )
 
     if topic_metadata.error is not None:
         raise KafkaException(topic_metadata.error)

--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -24,6 +24,8 @@ def get_partition_count(topic: Topic) -> int:
             logger.info("Attempting to connect to Kafka (attempt %d)...", attempts)
             client = AdminClient(get_default_kafka_configuration(topic=topic))
             cluster_metadata = client.list_topics(timeout=2.0)
+            logger.info(f"Checking topic metadata for {topic.value}...")
+            topic_metadata = cluster_metadata.topics.get(topic.value)
             break
         except KafkaException as err:
             logger.debug(
@@ -34,9 +36,6 @@ def get_partition_count(topic: Topic) -> int:
             if attempts == 3:
                 raise
             time.sleep(1)
-
-    logger.info(f"Checking topic metadata for {topic.value}...")
-    topic_metadata = cluster_metadata.topics.get(topic.value)
 
     if not topic_metadata:
         raise InvalidTopicName(f"Topic {topic.value} was not found.")

--- a/snuba/consumers/utils.py
+++ b/snuba/consumers/utils.py
@@ -28,7 +28,7 @@ def get_partition_count(topic: Topic) -> int:
                     topic=topic, override_params=override_params
                 )
             )
-            cluster_metadata = client.list_topics(topic=topic.value, timeout=1.0)
+            cluster_metadata = client.list_topics(topic=topic.value, timeout=2.0)
             break
         except KafkaException as err:
             logger.debug(
@@ -42,14 +42,12 @@ def get_partition_count(topic: Topic) -> int:
 
     logger.info(f"Checking topic metadata for {topic.value}...")
     topic_metadata = cluster_metadata.topics.get(topic.value)
+
     if not topic_metadata:
         raise InvalidTopicName(f"Topic {topic.value} was not found")
 
-    if topic_metadata.error:
-        # (TODO) handle if there is a topic error, value is KafkaError object
-        # although not sure if this is necessary give the KafkaException
-        # handling above.
-        pass
+    if topic_metadata.error is not None:
+        raise KafkaException(topic_metadata.error)
 
     total_partition_count = len(topic_metadata.partitions.keys())
     logger.info(f"Total of {total_partition_count} partition(s) for {topic.value}.")

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -108,7 +108,7 @@ def build_executor_consumer(
     )
 
     try:
-        partition_count = get_partition_count(scheduled_topic_spec.topic, logger)
+        partition_count = get_partition_count(scheduled_topic_spec.topic)
     except Exception:
         logger.error("partition count unavailable..", exc_info=True)
         partition_count = 0

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -17,6 +17,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
 from arroyo.types import Position
 
 from snuba import state
+from snuba.consumers.utils import get_partition_count_from_kafka_admin
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
@@ -104,6 +105,22 @@ def build_executor_consumer(
         consumer_group,
         auto_offset_reset=auto_offset_reset,
         strict_offset_reset=strict_offset_reset,
+    )
+
+    try:
+        partition_count = get_partition_count_from_kafka_admin(
+            scheduled_topic_spec.topic, logger
+        )
+    except Exception:
+        logger.error("partition count unavailable..", exc_info=True)
+        partition_count = 0
+
+    # XXX: for now verify that the partition_counts are correct for
+    # the executors.
+    metrics.gauge(
+        "executor.partition_count",
+        partition_count,
+        tags={"topic": scheduled_topic_spec.topic_name},
     )
 
     # Collect metrics from librdkafka if we have stats_collection_freq_ms set

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -17,7 +17,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
 from arroyo.types import Position
 
 from snuba import state
-from snuba.consumers.utils import get_partition_count_from_kafka_admin
+from snuba.consumers.utils import get_partition_count
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
@@ -108,9 +108,7 @@ def build_executor_consumer(
     )
 
     try:
-        partition_count = get_partition_count_from_kafka_admin(
-            scheduled_topic_spec.topic, logger
-        )
+        partition_count = get_partition_count(scheduled_topic_spec.topic, logger)
     except Exception:
         logger.error("partition count unavailable..", exc_info=True)
         partition_count = 0

--- a/tests/consumers/test_utils.py
+++ b/tests/consumers/test_utils.py
@@ -1,11 +1,8 @@
-from unittest.mock import Mock, patch
-
 import pytest
 from confluent_kafka import KafkaException
-from confluent_kafka.admin import ClusterMetadata
 
 from snuba import settings
-from snuba.consumers.utils import TopicNotFound, get_partition_count
+from snuba.consumers.utils import get_partition_count
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.utils.streams.topics import Topic
@@ -22,13 +19,6 @@ def test_get_partition_count() -> None:
     assert scheduled_topic_spec is not None
 
     assert get_partition_count(scheduled_topic_spec.topic) == 1
-
-
-@patch("snuba.consumers.utils.AdminClient.list_topics")
-def test_topic_not_found(mock_fn: Mock) -> None:
-    mock_fn.return_value = ClusterMetadata()
-    with pytest.raises(TopicNotFound):
-        get_partition_count(Topic.TRANSACTIONS)
 
 
 def test_invalid_broker_config() -> None:

--- a/tests/consumers/test_utils.py
+++ b/tests/consumers/test_utils.py
@@ -12,7 +12,7 @@ from snuba.utils.streams.topics import Topic
 
 
 def test_get_partition_count() -> None:
-    entity = get_entity(EntityKey("transactions"))
+    entity = get_entity(EntityKey("events"))
     storage = entity.get_writable_storage()
 
     assert storage is not None

--- a/tests/consumers/test_utils.py
+++ b/tests/consumers/test_utils.py
@@ -2,17 +2,22 @@ from unittest.mock import Mock, patch
 
 import pytest
 from confluent_kafka import KafkaException
-from confluent_kafka.admin import ClusterMetadata
+from confluent_kafka.admin import AdminClient, ClusterMetadata
 
 from snuba import settings
 from snuba.consumers.utils import TopicNotFound, get_partition_count
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.utils.manage_topics import create_topics
+from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
 from snuba.utils.streams.topics import Topic
 
 
 def test_get_partition_count() -> None:
-    entity = get_entity(EntityKey("events"))
+    admin_client = AdminClient(get_default_kafka_configuration())
+    create_topics(admin_client, [Topic.SUBSCRIPTION_SCHEDULED_TRANSACTIONS])
+
+    entity = get_entity(EntityKey("transactions"))
     storage = entity.get_writable_storage()
 
     assert storage is not None

--- a/tests/consumers/test_utils.py
+++ b/tests/consumers/test_utils.py
@@ -1,0 +1,39 @@
+import pytest
+from confluent_kafka import KafkaException
+
+from snuba import settings
+from snuba.consumers.utils import InvalidTopicName, get_partition_count
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.utils.streams.topics import Topic
+
+
+def test_get_partition_count() -> None:
+    entity = get_entity(EntityKey("transactions"))
+    storage = entity.get_writable_storage()
+
+    assert storage is not None
+    stream_loader = storage.get_table_writer().get_stream_loader()
+
+    scheduled_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
+    assert scheduled_topic_spec is not None
+
+    assert get_partition_count(scheduled_topic_spec.topic) == 1
+
+
+def test_invalid_topic() -> None:
+    with pytest.raises(InvalidTopicName):
+        get_partition_count("blah")  # type: ignore
+
+    with pytest.raises(InvalidTopicName):
+        get_partition_count(None)  # type: ignore
+
+
+def test_invalid_broker_config() -> None:
+    settings.KAFKA_BROKER_CONFIG = {
+        "transactions": {
+            "bootstrap.servers": "invalid.broker:9092",
+        }
+    }
+    with pytest.raises(KafkaException):
+        assert get_partition_count(Topic.TRANSACTIONS)


### PR DESCRIPTION
**context**
Okay so for the last piece of https://github.com/getsentry/snuba/pull/2761, we need to get the total partition count to use in our calculation for the max_concurrent_queries.

As stated in this comment https://github.com/getsentry/snuba/pull/2761#discussion_r905614595, there are a couple ways to go about this:

1. Keep track of the total number of partitions per topic in settings (implemented in https://github.com/getsentry/snuba/pull/2885)
2. Use the kafka admin api to get the number of partitions (as is implemented in this PR)

For this PR I was thinking that I would just log the metrics for `partition_count` to verify this works, but also to see what the impact of making these requests to the kafka admin is. I'm assuming it shouldn't be too much of an impact since this would only be when the consumers are starting up. If this ends up being a reasonable approach I'll modify https://github.com/getsentry/snuba/pull/2761 to use `get_partition_count` and pass through the result to the strategy
