### PR TITLE
feat(metrics): add snuba-generic-metrics to topics for validation

### DIFF
--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -42,6 +42,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "snuba-dead-letter-inserts",
         "processed-profiles",
         "snuba-replay-events",
+        "snuba-generic-metrics",
     }
 
     for key in locals["KAFKA_TOPIC_MAP"].keys():


### PR DESCRIPTION
This is necessary for https://github.com/getsentry/ops/pull/4910/files to deploy.

The first attempt to deploy that errored out with this log:
```
│ Traceback (most recent call last):                                                                                                                                                                                 
│   File "/usr/local/bin/snuba", line 33, in <module>                                                                                                                                                                
│     sys.exit(load_entry_point('snuba', 'console_scripts', 'snuba')())                                                                                                                                              
│   File "/usr/local/bin/snuba", line 25, in importlib_load_entry_point                                                                                                                                              
│     return next(matches).load()                                                                                                                                                                                    
│   File "/usr/local/lib/python3.8/importlib/metadata.py", line 77, in load                                                                                                                                          
│     module = import_module(match.group('module'))                                                                                                                                                                  
│   File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module                                                                                                                                
│     return _bootstrap._gcd_import(name[level:], package, level)                                                                                                                                                    
│   File "<frozen importlib._bootstrap>", line 1014, in _gcd_import                                                                                                                                                  
│   File "<frozen importlib._bootstrap>", line 991, in _find_and_load                                                                                                                                                
│   File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked                                                                                                                                       
│   File "<frozen importlib._bootstrap>", line 671, in _load_unlocked                                                                                                                                                
│   File "<frozen importlib._bootstrap_external>", line 843, in exec_module                                                                                                                                          
│   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed                                                                                                                                     
│   File "/usr/src/snuba/snuba/cli/__init__.py", line 21, in <module>                                                                                                                                                
│     module = __import__(module_name, globals(), locals(), ["__name__"])                                                                                                                                            
│   File "/usr/src/snuba/snuba/cli/admin.py", line 6, in <module>                                                                                                                                                    
│     from snuba.environment import setup_logging                                                                                                                                                                    
│   File "/usr/src/snuba/snuba/environment.py", line 13, in <module>                                                                                                                                                 
│     from snuba import settings                                                                                                                                                                                     
│   File "/usr/src/snuba/snuba/settings/__init__.py", line 260, in <module>                                                                                                                                          
│     validate_settings(locals())                                                                                                                                                                                    
│   File "/usr/src/snuba/snuba/settings/validation.py", line 53, in validate_settings                                                                                                                                
│     raise ValueError(f"Invalid topic value {key}")                                                                                                                                                                 
│ ValueError: Invalid topic value snuba-generic-metrics
```