### PR TITLE
fix(metrics): handle 64-bit ints

### DIFF
--- a/snuba/datasets/generic_metrics_processor.py
+++ b/snuba/datasets/generic_metrics_processor.py
@@ -45,10 +45,10 @@ class GenericMetricsBucketProcessor(MessageProcessor, ABC):
 
         buffer = bytearray()
         for field in [org_id, project_id, metric_id]:
-            buffer.extend(field.to_bytes(length=4, byteorder="little"))
+            buffer.extend(field.to_bytes(length=8, byteorder="little"))
         for (key, value) in sorted_tag_items:
             buffer.extend(bytes(key, "utf-8"))
-            buffer.extend(value.to_bytes(length=4, byteorder="little"))
+            buffer.extend(value.to_bytes(length=8, byteorder="little"))
 
         return buffer
 


### PR DESCRIPTION
On our last attempt to deploy this consumer, we found that some 64-bit ints from sentry were causing overflow. Sentry issue link: https://sentry.io/organizations/sentry/issues/3385584245/events/fe6a45136d3f461a97ce8f02271d2b2e/?project=300688

Verified that this works on the MAX_VALUE in https://github.com/getsentry/sentry/blob/cf018ef83b999b5287d1fde7ea523d56d09a228d/src/sentry/db/models/fields/bounded.py#L66

```
>>> x = 9223372036854775807
>>> x.to_bytes(length=8,byteorder='little')
b'\xff\xff\xff\xff\xff\xff\xff\x7f'
>>> x.to_bytes(length=4,byteorder='little')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OverflowError: int too big to convert
```

After making this change, I took a message that caused one of the sentry errors and ran it through my local environment, and it successfully wrote to clickhouse