### PR TITLE
fix(metrics): add granularities column to dist table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -258,6 +258,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0003_sets_mv",
             "0004_sets_raw_add_granularities",
             "0005_sets_replace_mv",
+            "0006_sets_raw_add_granularities_dist_table",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/generic_metrics/0006_sets_raw_add_granularities_dist_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0006_sets_raw_add_granularities_dist_table.py
@@ -1,0 +1,36 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.utils.schemas import Array, Column, UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    table_name = "generic_metric_sets_raw_dist"
+    new_column: Column[MigrationModifiers] = Column("granularities", Array(UInt(8)))
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.table_name,
+                column=self.new_column,
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
+                table_name=self.table_name,
+                column_name=self.new_column.name,
+            )
+        ]


### PR DESCRIPTION
There was a mistake in https://github.com/getsentry/snuba/pull/2875 that created a column twice on the raw table but not on the dist table.

This new migration aims to fix that.