### PR TITLE
feat(metrics): expose generic_metrics dataset, generic_metrics_sets entity, add e2e test

### DIFF
--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -27,6 +27,7 @@ def get_entity(name: EntityKey) -> Entity:
         DiscoverTransactionsEntity,
     )
     from snuba.datasets.entities.events import EventsEntity
+    from snuba.datasets.entities.generic_metrics import GenericMetricsSetsEntity
     from snuba.datasets.entities.metrics import (
         MetricsCountersEntity,
         MetricsDistributionsEntity,
@@ -60,6 +61,7 @@ def get_entity(name: EntityKey) -> Entity:
         EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
         EntityKey.PROFILES: ProfilesEntity,
         EntityKey.REPLAYS: ReplaysEntity,
+        EntityKey.GENERIC_METRICS_SETS: GenericMetricsSetsEntity,
         **(dev_entity_factories if settings.ENABLE_DEV_FEATURES else {}),
     }
 

--- a/snuba/datasets/entities/generic_metrics.py
+++ b/snuba/datasets/entities/generic_metrics.py
@@ -1,0 +1,63 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    ColumnSet,
+    DateTime,
+    Nested,
+    UInt,
+)
+from snuba.clickhouse.translators.snuba.mappers import (
+    FunctionNameMapper,
+    SubscriptableMapper,
+)
+from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
+from snuba.datasets.entity import Entity
+from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.storages.generic_metrics import sets_bucket_storage, sets_storage
+from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
+from snuba.query.processors import QueryProcessor
+from snuba.query.validation.validators import EntityRequiredColumnValidator
+
+
+class GenericMetricsSetsEntity(Entity):
+    READABLE_STORAGE = sets_storage
+    WRITABLE_STORAGE = sets_bucket_storage
+
+    def __init__(self) -> None:
+        super().__init__(
+            storages=[sets_bucket_storage, sets_storage],
+            query_pipeline_builder=SimplePipelineBuilder(
+                query_plan_builder=SingleStorageQueryPlanBuilder(
+                    self.READABLE_STORAGE,
+                    mappers=TranslationMappers(
+                        subscriptables=[
+                            SubscriptableMapper(None, "tags", None, "tags"),
+                        ],
+                        functions=[
+                            FunctionNameMapper("uniq", "uniqCombined64Merge"),
+                            FunctionNameMapper("uniqIf", "uniqCombined64MergeIf"),
+                        ],
+                    ),
+                )
+            ),
+            abstract_column_set=ColumnSet(
+                [
+                    Column("org_id", UInt(64)),
+                    Column("project_id", UInt(64)),
+                    Column("metric_id", UInt(64)),
+                    Column("timestamp", DateTime()),
+                    Column("bucketed_time", DateTime()),
+                    Column("tags", Nested([("key", UInt(64)), ("value", UInt(64))])),
+                    Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+                ]
+            ),
+            join_relationships={},
+            writable_storage=self.WRITABLE_STORAGE,
+            validators=[EntityRequiredColumnValidator({"org_id", "project_id"})],
+            required_time_column="timestamp",
+        )
+
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return []

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -21,6 +21,7 @@ DATASET_NAMES: Set[str] = {
     "sessions",
     "transactions",
     "profiles",
+    "generic_metrics",
     *(DEV_DATASET_NAMES if settings.ENABLE_DEV_FEATURES else set()),
 }
 
@@ -44,6 +45,7 @@ def get_dataset(name: str) -> Dataset:
     from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
     from snuba.datasets.discover import DiscoverDataset
     from snuba.datasets.events import EventsDataset
+    from snuba.datasets.generic_metrics import GenericMetricsDataset
     from snuba.datasets.metrics import MetricsDataset
     from snuba.datasets.outcomes import OutcomesDataset
     from snuba.datasets.outcomes_raw import OutcomesRawDataset
@@ -62,6 +64,7 @@ def get_dataset(name: str) -> Dataset:
         "sessions": SessionsDataset,
         "transactions": TransactionsDataset,
         "profiles": ProfilesDataset,
+        "generic_metrics": GenericMetricsDataset,
     }
 
     try:

--- a/snuba/datasets/generic_metrics.py
+++ b/snuba/datasets/generic_metrics.py
@@ -1,0 +1,16 @@
+from typing import Sequence
+
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
+
+DEFAULT_GRANULARITY = 60
+
+
+class GenericMetricsDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(default_entity=EntityKey.GENERIC_METRICS_SETS)
+
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [get_entity(EntityKey.GENERIC_METRICS_SETS)]

--- a/snuba/datasets/generic_metrics_processor.py
+++ b/snuba/datasets/generic_metrics_processor.py
@@ -45,10 +45,10 @@ class GenericMetricsBucketProcessor(MessageProcessor, ABC):
 
         buffer = bytearray()
         for field in [org_id, project_id, metric_id]:
-            buffer.extend(field.to_bytes(length=4, byteorder="little"))
+            buffer.extend(field.to_bytes(length=8, byteorder="little"))
         for (key, value) in sorted_tag_items:
             buffer.extend(bytes(key, "utf-8"))
-            buffer.extend(value.to_bytes(length=4, byteorder="little"))
+            buffer.extend(value.to_bytes(length=8, byteorder="little"))
 
         return buffer
 

--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 
 class InputType(Enum):
@@ -24,6 +24,7 @@ def is_set_message(message: Mapping[str, Any]) -> bool:
 
 def values_for_set_message(message: Mapping[str, Any]) -> Mapping[str, Any]:
     values = message["value"]
+    assert isinstance(values, Iterable), "expected iterable of values for set"
     for value in values:
         assert isinstance(value, int), f"{ILLEGAL_VALUE_IN_SET} {INT_EXPECTED}: {value}"
     return {"metric_type": OutputType.SET.value, "set_values": values}

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -12,6 +12,9 @@ from snuba.datasets.storages.errors_v2_ro import storage as errors_v2_ro_storage
 from snuba.datasets.storages.generic_metrics import (
     sets_bucket_storage as generic_metrics_sets_bucket_storage,
 )
+from snuba.datasets.storages.generic_metrics import (
+    sets_storage as gen_metrics_sets_aggregate_storage,
+)
 from snuba.datasets.storages.groupassignees import storage as groupassignees_storage
 from snuba.datasets.storages.groupedmessages import storage as groupedmessages_storage
 from snuba.datasets.storages.metrics import counters_storage as metrics_counters_storage
@@ -92,6 +95,7 @@ METRICS_NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {
     metrics_distributions_storage.get_storage_key(): metrics_distributions_storage,
     metrics_org_counters_storage.get_storage_key(): metrics_org_counters_storage,
     metrics_sets_storage.get_storage_key(): metrics_sets_storage,
+    gen_metrics_sets_aggregate_storage.get_storage_key(): gen_metrics_sets_aggregate_storage,
 }
 
 NON_WRITABLE_STORAGES: Mapping[StorageKey, ReadableTableStorage] = {

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -62,7 +62,6 @@ aggregated_columns: Sequence[Column[SchemaModifiers]] = [
             [("key", UInt(64)), ("indexed_value", UInt(64)), ("raw_value", String())]
         ),
     ),
-    Column("timeseries_id", UInt(32)),
 ]
 
 sets_storage = ReadableTableStorage(
@@ -104,6 +103,7 @@ sets_bucket_storage = WritableTableStorage(
                 Column("count_value", Float(64)),
                 Column("set_values", Array(UInt(64))),
                 Column("distribution_values", Array(Float(64))),
+                Column("timeseries_id", UInt(32)),
             ]
         ),
         local_table_name="generic_metric_sets_raw_local",

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -69,7 +69,7 @@ sets_storage = ReadableTableStorage(
     storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
     schema=TableSchema(
         local_table_name="generic_metric_sets_local",
-        dist_table_name="generic_metric_sets_dist",
+        dist_table_name="generic_metric_sets_aggregated_dist",
         storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
         columns=ColumnSet(
             [

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -69,8 +69,8 @@ sets_storage = ReadableTableStorage(
     storage_key=StorageKey.GENERIC_METRICS_SETS,
     storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
     schema=TableSchema(
-        local_table_name="generic_metrics_sets_local",
-        dist_table_name="generic_metrics_sets_dist",
+        local_table_name="generic_metric_sets_local",
+        dist_table_name="generic_metric_sets_dist",
         storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
         columns=ColumnSet(
             [

--- a/tests/test_generic_metrics_api.py
+++ b/tests/test_generic_metrics_api.py
@@ -136,4 +136,4 @@ class TestGenericMetricsApiSets(BaseApiTest):
 
         assert response.status_code == 200
         assert len(data["data"]) == 1, data
-        assert data["data"]["unique_values"] == self.unique_values
+        assert data["data"][0]["unique_values"] == self.unique_values

--- a/tests/test_generic_metrics_api.py
+++ b/tests/test_generic_metrics_api.py
@@ -31,7 +31,7 @@ class TestGenericMetricsApiSets(BaseApiTest):
 
     @pytest.fixture
     def test_entity(self) -> Union[str, Tuple[str, str]]:
-        return "metrics_counters"
+        return "generic_metrics_sets"
 
     @pytest.fixture(autouse=True)
     def setup_post(self, _build_snql_post_methods: Callable[[str], Any]) -> None:

--- a/tests/test_generic_metrics_api.py
+++ b/tests/test_generic_metrics_api.py
@@ -122,7 +122,7 @@ class TestGenericMetricsApiSets(BaseApiTest):
         query_str = f"""MATCH (generic_metrics_sets)
                     SELECT uniq(value) AS unique_values BY project_id, org_id
                     WHERE org_id = {self.org_id}
-                    AND project_id = 1
+                    AND project_id = {self.project_id}
                     AND metric_id = {self.metric_id}
                     AND timestamp >= toDateTime('{self.start_time}')
                     AND timestamp < toDateTime('{self.end_time}')
@@ -133,8 +133,6 @@ class TestGenericMetricsApiSets(BaseApiTest):
             data=json.dumps({"query": query_str, "dataset": "generic_metrics"}),
         )
         data = json.loads(response.data)
-        print(query_str)
-        print(response)
 
         assert response.status_code == 200
         assert len(data["data"]) == 1, data

--- a/tests/test_generic_metrics_api.py
+++ b/tests/test_generic_metrics_api.py
@@ -1,0 +1,116 @@
+from datetime import datetime, timedelta
+from typing import Any, Callable, Tuple, Union
+
+import pytest
+import pytz
+
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.metrics_messages import InputType
+
+# from snuba.datasets.entities import EntityKey
+# from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.storages.generic_metrics import sets_bucket_storage
+from tests.base import BaseApiTest
+from tests.helpers import write_processed_messages
+
+RETENTION_DAYS = 90
+
+
+def utc_yesterday_12_15() -> datetime:
+    return (datetime.utcnow() - timedelta(days=1)).replace(
+        hour=12, minute=15, second=0, microsecond=0, tzinfo=pytz.utc
+    )
+
+
+class TestGenericMetricsApiSets(BaseApiTest):
+    placeholder_counter = 0
+
+    @pytest.fixture
+    def test_app(self) -> Any:
+        return self.app
+
+    @pytest.fixture
+    def test_entity(self) -> Union[str, Tuple[str, str]]:
+        return "metrics_counters"
+
+    @pytest.fixture(autouse=True)
+    def setup_post(self, _build_snql_post_methods: Callable[[str], Any]) -> None:
+        self.post = _build_snql_post_methods
+
+    def placeholder(self) -> str:
+        self.placeholder_counter += 1
+        return "placeholder{:04d}".format(self.placeholder_counter)
+
+    def setup_method(self, test_method: Any) -> None:
+        super().setup_method(test_method)
+
+        self.write_storage = sets_bucket_storage
+        self.count = 10
+        self.org_id = 1
+        self.project_id = 2
+        self.metric_id = 3
+        self.base_time = utc_yesterday_12_15()
+        self.default_tags = {
+            "65546": 65536,
+            "9223372036854776010": 65593,
+            "9223372036854776016": 109333,
+            "9223372036854776020": 65616,
+            "9223372036854776021": 9223372036854776027,
+            "9223372036854776022": 65539,
+            "9223372036854776023": 65555,
+            "9223372036854776026": 9223372036854776031,
+        }
+        self.mapping_meta = {
+            "c": {
+                "65536": self.placeholder(),
+                "65539": self.placeholder(),
+                "65546": self.placeholder(),
+                "65555": self.placeholder(),
+                "65593": self.placeholder(),
+                "65616": self.placeholder(),
+                "109333": self.placeholder(),
+            },
+            "h": {
+                "9223372036854775908": self.placeholder(),
+                "9223372036854776010": self.placeholder(),
+                "9223372036854776016": self.placeholder(),
+                "9223372036854776020": self.placeholder(),
+                "9223372036854776021": self.placeholder(),
+                "9223372036854776022": self.placeholder(),
+                "9223372036854776023": self.placeholder(),
+                "9223372036854776026": self.placeholder(),
+                "9223372036854776027": self.placeholder(),
+                "9223372036854776031": self.placeholder(),
+            },
+        }
+        self.set_values = [50, 100, 150]
+        self.use_case_id = "performance"
+        self.generate_sets()
+
+    def generate_sets(self) -> None:
+        rows = [
+            self.write_storage.get_table_writer()
+            .get_stream_loader()
+            .get_processor()
+            .process_message(
+                {
+                    "org_id": self.org_id,
+                    "project_id": self.project_id,
+                    "unit": "ms",
+                    "type": InputType.SET.value,
+                    "value": self.set_values,
+                    "timestamp": self.base_time.timestamp() + n,
+                    "tags": self.default_tags,
+                    "metric_id": self.metric_id,
+                    "retention_days": RETENTION_DAYS,
+                    "mapping_meta": self.mapping_meta,
+                    "use_case_id": self.use_case_id,
+                },
+                KafkaMessageMetadata(0, 0, self.base_time),
+            )
+            for n in range(self.count)
+        ]
+        write_processed_messages(self.write_storage, [row for row in rows if row])
+
+    def test_who_cares(self) -> None:
+        pass


### PR DESCRIPTION
I wanted to make sure we didn't have regressions in terms of metrics_sets consumption, which required adding an e2e test, which itself required exposing the metrics_sets dataset. 

The `GENERIC_METRICS_SETS` entity is not ready for prod traffic, but I didn't want to blow up the scope of this PR. If people prefer, I can increase the scope of this PR

Next steps:
1. getting proper granularity processing and validation on queries
1. adding rate limiting for queries
1. proper array join optimizations (specifically because tags now have raw and indexed values)

I think this can be used by clients once next steps are complete