### PR TITLE
feat(mep): add generic_metric_distributions tables

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -34,6 +34,7 @@ class StorageSetKey(Enum):
     FUNCTIONS = "functions"
     REPLAYS = "replays"
     GENERIC_METRICS_SETS = "generic_metrics_sets"
+    GENERIC_METRICS_DISTRIBUTIONS = "generic_metrics_distributions"
 
 
 # Storage sets enabled only when development features are enabled.

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -49,7 +49,7 @@ def produce_policy_creator() -> DeadLetterQueuePolicy:
     )
 
 
-aggregated_columns: Sequence[Column[SchemaModifiers]] = [
+common_columns: Sequence[Column[SchemaModifiers]] = [
     Column("org_id", UInt(64)),
     Column("use_case_id", String()),
     Column("project_id", UInt(64)),
@@ -62,6 +62,13 @@ aggregated_columns: Sequence[Column[SchemaModifiers]] = [
             [("key", UInt(64)), ("indexed_value", UInt(64)), ("raw_value", String())]
         ),
     ),
+]
+
+bucket_columns: Sequence[Column[SchemaModifiers]] = [
+    Column("granularities", Array(UInt(8))),
+    Column("count_value", Float(64)),
+    Column("set_values", Array(UInt(64))),
+    Column("distribution_values", Array(Float(64))),
     Column("timeseries_id", UInt(32)),
 ]
 
@@ -74,7 +81,7 @@ sets_storage = ReadableTableStorage(
         storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
         columns=ColumnSet(
             [
-                *aggregated_columns,
+                *common_columns,
                 Column(
                     "_raw_tags_hash", Array(UInt(64), SchemaModifiers(readonly=True))
                 ),
@@ -97,15 +104,7 @@ sets_bucket_storage = WritableTableStorage(
     storage_key=StorageKey.GENERIC_METRICS_SETS_RAW,
     storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,
     schema=WritableTableSchema(
-        columns=ColumnSet(
-            [
-                *aggregated_columns,
-                Column("granularities", Array(UInt(8))),
-                Column("count_value", Float(64)),
-                Column("set_values", Array(UInt(64))),
-                Column("distribution_values", Array(Float(64))),
-            ]
-        ),
+        columns=ColumnSet([*common_columns, *bucket_columns]),
         local_table_name="generic_metric_sets_raw_local",
         dist_table_name="generic_metric_sets_raw_dist",
         storage_set_key=StorageSetKey.GENERIC_METRICS_SETS,

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -259,6 +259,9 @@ class GenericMetricsLoader(DirectoryLoader):
             "0004_sets_raw_add_granularities",
             "0005_sets_replace_mv",
             "0006_sets_raw_add_granularities_dist_table",
+            "0007_distributions_aggregate_table",
+            "0008_distributions_raw_table",
+            "0009_distributions_mv",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/generic_metrics/0007_distributions_aggregate_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0007_distributions_aggregate_table.py
@@ -1,0 +1,155 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Array,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import (
+    hash_map_int_column_definition,
+    hash_map_int_key_str_value_column_definition,
+)
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.utils.schemas import Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    granularity = "2048"
+    local_table_name = "generic_metric_distributions_aggregated_local"
+    dist_table_name = "generic_metric_distributions_aggregated_dist"
+    columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+        Column(
+            "percentiles",
+            AggregateFunction("quantiles(0.5, 0.75, 0.9, 0.95, 0.99)", [Float(64)]),
+        ),
+        Column("min", AggregateFunction("min", [Float(64)])),
+        Column("max", AggregateFunction("max", [Float(64)])),
+        Column("avg", AggregateFunction("avg", [Float(64)])),
+        Column("sum", AggregateFunction("sum", [Float(64)])),
+        Column("count", AggregateFunction("count", [Float(64)])),
+        Column("histogram_buckets", AggregateFunction("histogram(250)", [Float(64)])),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                engine=table_engines.AggregatingMergeTree(
+                    storage_set=self.storage_set_key,
+                    order_by="(org_id, project_id, metric_id, granularity, timestamp, tags.key, tags.indexed_value, tags.raw_value, retention_days, use_case_id)",
+                    primary_key="(org_id, project_id, metric_id, granularity, timestamp)",
+                    partition_by="(retention_days, toMonday(timestamp))",
+                    settings={"index_granularity": self.granularity},
+                    ttl="timestamp + toIntervalDay(retention_days)",
+                ),
+                columns=self.columns,
+            ),
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                column=Column(
+                    "_indexed_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_column_definition(
+                                "tags.key", "tags.indexed_value"
+                            )
+                        ),
+                    ),
+                ),
+            ),
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                column=Column(
+                    "_raw_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_key_str_value_column_definition(
+                                "tags.key", "tags.raw_value"
+                            )
+                        ),
+                    ),
+                ),
+            ),
+            operations.AddIndex(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                index_name="bf_indexed_tags_hash",
+                index_expression="_indexed_tags_hash",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+            operations.AddIndex(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                index_name="bf_raw_tags_hash",
+                index_expression="_raw_tags_hash",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+            operations.AddIndex(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                index_name="bf_tags_key_hash",
+                index_expression="tags.key",
+                index_type="bloom_filter()",
+                granularity=1,
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name, sharding_key=None
+                ),
+                columns=self.columns,
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/generic_metrics/0008_distributions_raw_table.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0008_distributions_raw_table.py
@@ -1,0 +1,92 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    Array,
+    Column,
+    DateTime,
+    Float,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    local_table_name = "generic_metric_distributions_raw_local"
+    dist_table_name = "generic_metric_distributions_raw_dist"
+    columns: Sequence[Column[Modifiers]] = [
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("timestamp", DateTime()),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("set_values", Array(UInt(64))),
+        Column("count_value", Float(64)),
+        Column("distribution_values", Array(Float(64))),
+        Column("metric_type", String(Modifiers(low_cardinality=True))),
+        Column("materialization_version", UInt(8)),
+        Column("timeseries_id", UInt(32)),
+        Column("partition", UInt(16)),
+        Column("offset", UInt(64)),
+        Column("granularities", Array(UInt(8))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+                engine=table_engines.MergeTree(
+                    storage_set=self.storage_set_key,
+                    order_by="(use_case_id, org_id, project_id, metric_id, timestamp)",
+                    partition_by="(toStartOfInterval(timestamp, toIntervalDay(3)))",
+                    ttl="timestamp + toIntervalDay(7)",
+                ),
+                columns=self.columns,
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.local_table_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                engine=table_engines.Distributed(
+                    local_table_name=self.local_table_name,
+                    sharding_key="cityHash64(timeseries_id)",
+                ),
+                columns=self.columns,
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/generic_metrics/0009_distributions_mv.py
+++ b/snuba/migrations/snuba_migrations/generic_metrics/0009_distributions_mv.py
@@ -1,0 +1,99 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_distributions_aggregation_mv"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name="generic_metric_distributions_aggregated_local",
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(timestamp),
+                             multiIf(granularity=0,10,granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                    retention_days,
+                    quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)((arrayJoin(distribution_values) AS values_rows)) as percentiles,
+                    minState(values_rows) as min,
+                    maxState(values_rows) as max,
+                    avgState(values_rows) as avg,
+                    sumState(values_rows) as sum,
+                    countState(values_rows) as count,
+                    histogramState(250)(values_rows) as histogram_buckets
+                FROM generic_metric_distributions_raw_local
+                WHERE materialization_version = 1
+                  AND metric_type = 'distribution'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -54,6 +54,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "functions",
             "replays",
             "generic_metrics_sets",
+            "generic_metrics_distributions",
         },
         "single_node": True,
     },


### PR DESCRIPTION
This creates all the tables for the distributions part of the pipeline:

```
c66a319cda67 :) insert into generic_metric_distributions_raw_local 
:-] (use_case_id,org_id,project_id,metric_id,timestamp,retention_days,tags.key,tags.raw_value,distribution_values,metric_type,materialization_version,granularities) 
:-] values 
:-] ('none',1,1,1,now(),90,[1],['hello'],[1.0,2.0,3.0],'distribution',1,[2,3])

INSERT INTO generic_metric_distributions_raw_local (use_case_id, org_id, project_id, metric_id, timestamp, retention_days, tags.key, tags.raw_value, distribution_values, metric_type, materialization_version, granularities) VALUES

Ok.

1 rows in set. Elapsed: 0.033 sec. 

c66a319cda67 :) select quantilesMerge(0.99)(percentiles), sumMerge(sum), avgMerge(avg), maxMerge(max), minMerge(min) from generic_metric_distributions_aggregated_local where org_id=1 and project_id=1 and metric_id=1;

SELECT 
    quantilesMerge(0.99)(percentiles), 
    sumMerge(sum), 
    avgMerge(avg), 
    maxMerge(max), 
    minMerge(min)
FROM generic_metric_distributions_aggregated_local
WHERE (org_id = 1) AND (project_id = 1) AND (metric_id = 1)

┌─quantilesMerge(0.99)(percentiles)─┬─sumMerge(sum)─┬─avgMerge(avg)─┬─maxMerge(max)─┬─minMerge(min)─┐
│ [3]                               │            12 │             2 │             3 │             1 │
└───────────────────────────────────┴───────────────┴───────────────┴───────────────┴───────────────┘

1 rows in set. Elapsed: 0.012 sec. 

```