### PR TITLE
experiment(consumers): Experimental Consumers Freight Config

### DIFF
--- a/.freight.experimental.yml
+++ b/.freight.experimental.yml
@@ -12,11 +12,3 @@ steps:
         name: generic-metrics-sets-consumer
       - image: us.gcr.io/sentryio/snuba:{sha}
         name: generic-metrics-distributions-consumer
-  - kind: KubernetesCronJob
-    selector:
-      label_selector: service=snuba
-    containers:
-      - image: us.gcr.io/sentryio/snuba:{sha}
-        name: cleanup
-      - image: us.gcr.io/sentryio/snuba:{sha}
-        name: optimize


### PR DESCRIPTION
### Overview
- I'm working on extending Freight to support multiple config files per repo 
    - https://github.com/getsentry/freight/pull/303
- Each config file will require a separate Freight app to deploy
- I've added a new config file to act as a placeholder for "experimental" consumers
- Ideally, this config file is picked up by some `Snuba-experimental` freight app while the original freight config is run by the existing Snuba freight app
- I've just added the new generic metrics consumers into this config for now to test that this setup works
