### PR TITLE
fix(profiling): Disable vertical merge algorithm

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -236,7 +236,10 @@ class ProfilesLoader(DirectoryLoader):
         super().__init__("snuba.migrations.snuba_migrations.profiles")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_profiles"]
+        return [
+            "0001_profiles",
+            "0002_disable_vertical_merge_algorithm",
+        ]
 
 
 class FunctionsLoader(DirectoryLoader):

--- a/snuba/migrations/snuba_migrations/profiles/0002_disable_vertical_merge_algorithm.py
+++ b/snuba/migrations/snuba_migrations/profiles/0002_disable_vertical_merge_algorithm.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Use the horizontal merge algorithm
+    """
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.RunSql(
+                storage_set=StorageSetKey.PROFILES,
+                statement=(
+                    "ALTER TABLE profiles_local MODIFY SETTINGS enable_vertical_merge_algorithm=0"
+                ),
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []


### PR DESCRIPTION
Since our `profile` column is so big, we have merge issues. Switching horizontal merges helps with this issue.