### PR TITLE
Add emergency replacement bypass

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -1132,6 +1132,13 @@ def process_delete_tag(
     use_promoted_prewhere: bool,
     schema: WritableTableSchema,
 ) -> Optional[Replacement]:
+    # bypass logic
+    project_id = message.data["project_id"]
+    bypass_project = get_config("tag_replacement_bypass")
+    if bypass_project and bypass_project == project_id:
+        logger.error("Skipping tag replacement")
+        return None
+
     tag = message.data["tag"]
     if not tag:
         return None


### PR DESCRIPTION
This is meant to allow us skip replacements in case the replacer is overwhelmed and process them over time.