### PR TITLE
remove atomicwrites from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-atomicwrites==1.4.0
 blinker==1.4
 black==22.3.0
 certifi==2022.6.15


### PR DESCRIPTION
It seems @untitaker marked it as unmaintained: https://github.com/untitaker/python-atomicwrites/commit/d18328460520e18b4f197297f962d4444c5889b6

which appears to break the build (https://github.com/getsentry/snuba/runs/7257404301?check_suite_focus=true)

and I don't believe we're actually using it