### PR TITLE
ref: Fix TypedDict import

### DIFF
--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -1,23 +1,16 @@
 from itertools import groupby
-from typing import TYPE_CHECKING, Mapping, MutableSequence, Optional, Tuple
+from typing import Mapping, MutableSequence, Optional, Tuple, TypedDict
 
 from snuba.utils.clock import Clock, SystemClock
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.types import Tags
 
-if TYPE_CHECKING:
-    from mypy_extensions import TypedDict
 
-    class TimerData(TypedDict):
-        timestamp: int
-        duration_ms: int
-        marks_ms: Mapping[str, int]
-        tags: Tags
-
-else:
-    from typing import Any
-
-    TimerData = Mapping[Any, Any]
+class TimerData(TypedDict):
+    timestamp: int
+    duration_ms: int
+    marks_ms: Mapping[str, int]
+    tags: Tags
 
 
 class Timer:

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, NamedTuple
-
-from mypy_extensions import TypedDict
+from typing import Any, Mapping, NamedTuple, TypedDict
 
 from snuba.reader import Column, Result, Row, transform_rows
 from snuba.utils.serializable_exception import SerializableException


### PR DESCRIPTION
Now we are on Python 3.8 TypedDict is properly supported. We no longer
need to import from mypy_extensions.