### PR TITLE
feat(mep): fix header filter error

### DIFF
--- a/snuba/datasets/message_filters.py
+++ b/snuba/datasets/message_filters.py
@@ -47,6 +47,28 @@ class KafkaHeaderFilter(StreamMessageFilter[KafkaPayload]):
 
 
 @dataclass
+class KafkaHeaderSelectFilter(StreamMessageFilter[KafkaPayload]):
+    """
+    A filter over messages coming from a stream which matches whether the given message
+    has the provided header key and if it matches the provided header value. If there is
+    a match, the message gets processed. (This is the inverse of KafkaHeaderFilter)
+    """
+
+    header_key: str
+    header_value: str
+
+    def should_drop(self, message: Message[KafkaPayload]) -> bool:
+        for key, value in message.payload.headers:
+            if key != self.header_key:
+                continue
+
+            str_value = value.decode("utf-8")
+            return False if str_value == self.header_value else True
+
+        return True
+
+
+@dataclass
 class KafkaHeaderFilterWithBypass(KafkaHeaderFilter):
     """
     A special case filter which is similar to KafkaHeaderFilter but allows a message to

--- a/snuba/datasets/message_filters.py
+++ b/snuba/datasets/message_filters.py
@@ -63,7 +63,7 @@ class KafkaHeaderSelectFilter(StreamMessageFilter[KafkaPayload]):
                 continue
 
             str_value = value.decode("utf-8")
-            return False if str_value == self.header_value else True
+            return str_value != self.header_value
 
         return True
 

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -28,7 +28,7 @@ from snuba.datasets.generic_metrics_processor import (
     GenericDistributionsMetricsProcessor,
     GenericSetsMetricsProcessor,
 )
-from snuba.datasets.message_filters import KafkaHeaderFilter
+from snuba.datasets.message_filters import KafkaHeaderSelectFilter
 from snuba.datasets.metrics_messages import InputType
 from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
 from snuba.datasets.storage import ReadableTableStorage, WritableTableStorage
@@ -122,7 +122,7 @@ sets_bucket_storage = WritableTableStorage(
         default_topic=Topic.GENERIC_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
         commit_log_topic=Topic.GENERIC_METRICS_SETS_COMMIT_LOG,
-        pre_filter=KafkaHeaderFilter("metric_type", InputType.SET.value),
+        pre_filter=KafkaHeaderSelectFilter("metric_type", InputType.SET.value),
     ),
 )
 
@@ -172,6 +172,6 @@ distributions_bucket_storage = WritableTableStorage(
         default_topic=Topic.GENERIC_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
         commit_log_topic=Topic.GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG,
-        pre_filter=KafkaHeaderFilter("metric_type", InputType.DISTRIBUTION.value),
+        pre_filter=KafkaHeaderSelectFilter("metric_type", InputType.DISTRIBUTION.value),
     ),
 )

--- a/tests/datasets/test_message_filters.py
+++ b/tests/datasets/test_message_filters.py
@@ -7,11 +7,13 @@ from arroyo.backends.kafka import KafkaPayload
 from snuba.datasets.message_filters import (
     KafkaHeaderFilter,
     KafkaHeaderFilterWithBypass,
+    KafkaHeaderSelectFilter,
 )
 
 test_data = [
     pytest.param(
         KafkaHeaderFilter("should_drop", "1"),
+        KafkaHeaderSelectFilter("should_drop", "1"),
         Message(
             Partition(Topic("random"), 1),
             1,
@@ -23,6 +25,7 @@ test_data = [
     ),
     pytest.param(
         KafkaHeaderFilter("should_drop", "0"),
+        KafkaHeaderSelectFilter("should_drop", "0"),
         Message(
             Partition(Topic("random"), 1),
             1,
@@ -34,6 +37,7 @@ test_data = [
     ),
     pytest.param(
         KafkaHeaderFilter("should_drop", "1"),
+        KafkaHeaderSelectFilter("should_drop", "1"),
         Message(
             Partition(Topic("random"), 1),
             1,
@@ -46,13 +50,17 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize("header_filter, message, expected_result", test_data)
+@pytest.mark.parametrize(
+    "header_filter, select_filter, message, expected_drop_result", test_data
+)
 def test_kafka_filter_header_should_drop(
     header_filter: KafkaHeaderFilter,
+    select_filter: KafkaHeaderSelectFilter,
     message: Message[KafkaPayload],
-    expected_result: bool,
+    expected_drop_result: bool,
 ) -> None:
-    assert header_filter.should_drop(message) == expected_result
+    assert header_filter.should_drop(message) == expected_drop_result
+    assert select_filter.should_drop(message) == (not expected_drop_result)
 
 
 def test_kafka_filter_header_with_bypass() -> None:


### PR DESCRIPTION
I mistakenly thought that the `KafkaHeaderFilter` was passing matches but it was actually dropping them, so we were dropping all MEP messages (which is fine, it's pre-prod).

This fixes the issue