### PR TITLE
dev(generic-metrics) run generic-metrics consumers in dev

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -215,6 +215,30 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     "--consumer-group=snuba-metrics-consumers",
                 ],
             ),
+            (
+                "generic-metrics-distributions-consumer",
+                [
+                    "snuba",
+                    "consumer",
+                    "--storage=generic_metrics_distributions_raw",
+                    "--auto-offset-reset=latest",
+                    "--no-strict-offset-reset",
+                    "--log-level=debug",
+                    "--consumer-group=snuba-gen-metrics-distributions-consumers",
+                ],
+            ),
+            (
+                "generic-metrics-sets-consumer",
+                [
+                    "snuba",
+                    "consumer",
+                    "--storage=generic_metrics_sets_raw",
+                    "--auto-offset-reset=latest",
+                    "--no-strict-offset-reset",
+                    "--log-level=debug",
+                    "--consumer-group=snuba-gen-metrics-sets-consumers",
+                ],
+            ),
         ]
         if settings.ENABLE_METRICS_SUBSCRIPTIONS:
             if settings.SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV:


### PR DESCRIPTION
this enables developers to automatically run generic metrics consumers for testing metrics-enhanced performance locally