### PR TITLE
feat: Add a str default to JSON encoding

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -64,7 +64,7 @@ metrics = MetricsWrapper(environment.metrics, "db_query")
 
 class ResultCacheCodec(ExceptionAwareCodec[bytes, Result]):
     def encode(self, value: Result) -> bytes:
-        return cast(str, rapidjson.dumps(value)).encode("utf-8")
+        return cast(str, rapidjson.dumps(value, default=str)).encode("utf-8")
 
     def decode(self, value: bytes) -> Result:
         ret = rapidjson.loads(value)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -508,7 +508,9 @@ def dataset_query(
     if settings.STATS_IN_RESPONSE or request.query_settings.get_debug():
         payload.update(result.extra)
 
-    return Response(json.dumps(payload), 200, {"Content-Type": "application/json"})
+    return Response(
+        json.dumps(payload, default=str), 200, {"Content-Type": "application/json"}
+    )
 
 
 @application.errorhandler(InvalidSubscriptionError)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -10,6 +10,7 @@ from snuba import settings
 from snuba.datasets.events_processor_base import InsertEvent
 
 PROJECT_ID = 70156
+ORG_ID = 1123
 
 
 def get_raw_event() -> InsertEvent:
@@ -268,6 +269,63 @@ def get_raw_transaction(span_id: str | None = None) -> Mapping[str, Any]:
                     "exclusive_time": 1.2,
                 }
             ],
+        },
+    }
+
+
+def get_replay_event(replay_id: str | None = None) -> Mapping[str, Any]:
+    replay_id = (
+        replay_id if replay_id else str(uuid.UUID("e5e062bf2e1d4afd96fd2f90b6770431"))
+    )
+    now = (
+        datetime.utcnow()
+        .replace(minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+        .timestamp()
+    )
+
+    return {
+        "datetime": now,
+        "organization_id": ORG_ID,
+        "platform": "python",
+        "project_id": PROJECT_ID,
+        "replay_id": replay_id,
+        "message": "/organizations/:orgId/issues/",
+        "retention_days": 23,
+        "sequence_id": 0,
+        "trace_ids": [
+            "36e980a9-c602-4cde-9f5d-089f15b83b5f",
+            "8bea4461-d8b9-44f3-93c1-5a3cb1c4169a",
+        ],
+        "data": {
+            "replay_id": replay_id,
+            "environment": "prod",
+            "project_id": PROJECT_ID,
+            "release": "34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a",
+            "dist": "",
+            "sdk": {
+                "version": "0.9.0",
+                "name": "sentry.python",
+                "packages": [{"version": "0.9.0", "name": "pypi:sentry-sdk"}],
+            },
+            "platform": "python",
+            "version": "7",
+            "location": "/organizations/:orgId/issues/",
+            "type": "replay_event",
+            "datetime": now,
+            "timestamp": now,
+            "tags": [
+                ["sentry:release", "34a554c14b68285d8a8eb6c5c4c56dfc1db9a83a"],
+                ["sentry:user", "232"],
+                ["environment", "prod"],
+                ["we|r=d", "tag"],
+            ],
+            "user": {
+                "username": "me",
+                "ip_address": "127.0.0.1",
+                "id": "232",
+                "email": "test@test.com",
+            },
+            "title": "/organizations/:orgId/issues/",
         },
     }
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -41,3 +41,20 @@ def write_unprocessed_events(
         processed_messages.append(processed_message)
 
     write_processed_messages(storage, processed_messages)
+
+
+def write_raw_unprocessed_events(
+    storage: WritableStorage, events: Sequence[Union[InsertEvent, Mapping[str, Any]]]
+) -> None:
+
+    processor = storage.get_table_writer().get_stream_loader().get_processor()
+
+    processed_messages = []
+    for i, event in enumerate(events):
+        processed_message = processor.process_message(
+            event, KafkaMessageMetadata(i, 0, datetime.now())
+        )
+        assert processed_message is not None
+        processed_messages.append(processed_message)
+
+    write_processed_messages(storage, processed_messages)

--- a/tests/test_replays_api.py
+++ b/tests/test_replays_api.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import datetime, timedelta
+from typing import Any, Callable
+
+import simplejson as json
+
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from tests.base import BaseApiTest
+from tests.fixtures import get_replay_event
+from tests.helpers import write_raw_unprocessed_events
+
+
+class TestReplaysApi(BaseApiTest):
+    def post(self, url: str, data: str) -> Any:
+        return self.app.post(url, data=data, headers={"referer": "test"})
+
+    def setup_method(self, test_method: Callable[..., Any]) -> None:
+        super().setup_method(test_method)
+        self.replay_id = uuid.UUID("7400045b-25c4-43b8-8591-4600aa83ad05")
+        self.event = get_replay_event(replay_id=str(self.replay_id))
+        self.project_id = self.event["project_id"]
+        self.org_id = self.event["organization_id"]
+        self.skew = timedelta(minutes=180)
+        self.base_time = datetime.utcnow().replace(
+            minute=0, second=0, microsecond=0
+        ) - timedelta(minutes=180)
+        replays_storage = get_entity(EntityKey.REPLAYS).get_writable_storage()
+        assert replays_storage is not None
+        write_raw_unprocessed_events(replays_storage, [self.event])
+        self.next_time = datetime.utcnow().replace(
+            minute=0, second=0, microsecond=0
+        ) + timedelta(minutes=180)
+
+    def test_default_json_encoder(self) -> None:
+        response = self.post(
+            "/replays/snql",
+            data=json.dumps(
+                {
+                    "query": f"""
+                    MATCH (replays)
+                    SELECT replay_id, ip_address_v4, groupUniqArrayArray(trace_ids) AS `trace_ids`
+                    BY replay_id, ip_address_v4
+                    WHERE project_id = {self.project_id}
+                    AND timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    LIMIT 10 OFFSET 0
+                    """,
+                    "debug": True,
+                }
+            ),
+        )
+
+        data = json.loads(response.data)
+        assert response.status_code == 200, data
+
+        assert data["data"] == [
+            {
+                "replay_id": "7400045b-25c4-43b8-8591-4600aa83ad05",
+                "ip_address_v4": "127.0.0.1",
+                "trace_ids": [
+                    "8bea4461-d8b9-44f3-93c1-5a3cb1c4169a",
+                    "36e980a9-c602-4cde-9f5d-089f15b83b5f",
+                ],
+            }
+        ]


### PR DESCRIPTION
There are some types of data (IP addresses, UUIDs) that are converted to
classes in the result (ipaddress.IPv4Address, uuid.UUID). These classes are not
JSON serializable, so would throw an exception when encoded into the cache or
returned in the JSON response. Instead, automatically encode them as strings.

Context:
In previous datasets (errors, transactions) that had these types of columns
there are mappers and query processors that transform the query so that
Clickhouse returns a string instead of the class. With newer datasets like
replays they do not have these processors. Instead of forcing new datasets to
have these processors, or to wrap all calls with `toString`, we will
automatically JSON encode these results as strings.