### PR TITLE
fix(optimize): Make optimize queries non retryable

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -285,6 +285,7 @@ class ClickhousePool(object):
         types_check: bool = False,
         columnar: bool = False,
         capture_trace: bool = False,
+        retryable: bool = True,
     ) -> ClickhouseResult:
         """
         Execute a clickhouse query with a bit more tenacity. Make more retry
@@ -295,7 +296,7 @@ class ClickhousePool(object):
         query successfully or else quit altogether. Note that each retry in this
         loop will be doubled by the retry in execute()
         """
-        total_attempts = 3
+        total_attempts = 3 if retryable else 1
         attempts_remaining = total_attempts
 
         while True:

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -136,6 +136,7 @@ class ClickhousePool(object):
         types_check: bool = False,
         columnar: bool = False,
         capture_trace: bool = False,
+        retryable: bool = True,
     ) -> ClickhouseResult:
         """
         Execute a clickhouse query with a single quick retry in case of
@@ -150,7 +151,11 @@ class ClickhousePool(object):
         try:
             conn = self.pool.get(block=True)
 
-            attempts_remaining = 3 + (1 if self.fallback_pool_enabled() else 0)
+            if retryable:
+                attempts_remaining = 3 + (1 if self.fallback_pool_enabled() else 0)
+            else:
+                attempts_remaining = 1
+
             while attempts_remaining > 0:
                 attempts_remaining -= 1
                 # Lazily create connection instances

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -45,7 +45,7 @@ class ClickhouseClientSettings(Enum):
     MIGRATE = ClickhouseClientSettingsType(
         {"load_balancing": "in_order", "replication_alter_partitions_sync": 2}, 10000
     )
-    OPTIMIZE = ClickhouseClientSettingsType({}, 10000)
+    OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
     TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -226,7 +226,7 @@ def optimize_partitions(
         query = (query_template % args).strip()
         logger.info(f"Optimizing partition: {part.name}")
         start = time.time()
-        clickhouse.execute(query)
+        clickhouse.execute(query, retryable=False)
         metrics.timing(
             "optimized_part",
             time.time() - start,

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -219,6 +219,7 @@ TRANSACTIONS_UPGRADE_BEGINING_OF_TIME: Optional[datetime] = datetime(
 MAX_ROWS_TO_CHECK_FOR_SIMILARITY = 1000
 
 OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
+OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:

--- a/tests/clusters/fake_cluster.py
+++ b/tests/clusters/fake_cluster.py
@@ -28,6 +28,7 @@ class FakeClickhousePool(ClickhousePool):
         types_check: bool = False,
         columnar: bool = False,
         capture_trace: bool = False,
+        retryable: bool = True,
     ) -> ClickhouseResult:
         self.__queries.append(query)
         return ClickhouseResult([[1]])
@@ -51,6 +52,7 @@ class FakeFailingClickhousePool(FakeClickhousePool):
         types_check: bool = False,
         columnar: bool = False,
         capture_trace: bool = False,
+        retryable: bool = True,
     ) -> ClickhouseResult:
         raise ServerExplodedException("The server exploded")
 


### PR DESCRIPTION
Firing an optimize query causes a merge operation. This operation runs
in the background. So even if an error is raised(which is socket timeout
exception caused because optimize queries take longer to execute), it
does not indicate a failure in running the query. The cost of re executing
the query is huge. Hence we add an option to specify whether a query should
be retried or not. For optimize queries, we make them non-retryable.

Also increased the timeout value for the optimize queries to 4 hours
since we are seeing the socket timeout exception happen regularly
during beginning of the week.
