### PR TITLE
fix(tiger): Tiger clusters do not require different limits

### DIFF
--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -86,7 +86,7 @@ query_processors = [
         # merged together by the final.
         omit_if_final=["environment", "release", "group_id"],
     ),
-    TableRateLimit(suffix="errors_tiger"),
+    TableRateLimit(),
 ]
 
 schema = WritableTableSchema(


### PR DESCRIPTION
Tiger error clusters don't require different table rate limits. Use the same rate limits as prod cluster.
