### PR TITLE
feat: Add app_id to snuba timer query metrics

### DIFF
--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -20,6 +20,7 @@ def _record_timer_metrics(
 ) -> None:
     final = str(request.query.get_final())
     referrer = request.referrer or "none"
+    app_id = request.attribution_info.app_id.key or "none"
     timer.send_metrics_to(
         metrics,
         tags={
@@ -27,6 +28,7 @@ def _record_timer_metrics(
             "referrer": referrer,
             "final": final,
             "dataset": query_metadata.dataset,
+            "app_id": app_id,
         },
         mark_tags={
             "final": final,

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -621,6 +621,31 @@ class TestSnQLApi(BaseApiTest):
         assert metric_calls[0].tags["entity"] == "events"
         assert metric_calls[0].tags["table"].startswith("errors")
 
+    def test_timing_metrics_tags(self) -> None:
+        response = self.post(
+            "/events/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (events)
+                    SELECT count() AS count
+                    WHERE timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    AND project_id IN tuple({self.project_id})
+                    """,
+                    "app_id": "something-good",
+                }
+            ),
+        )
+        assert response.status_code == 200
+        metric_calls = get_recorded_metric_calls("timing", "api.query")
+        assert metric_calls is not None
+        assert len(metric_calls) == 1
+        assert metric_calls[0].tags["status"] == "success"
+        assert metric_calls[0].tags["referrer"] == "test"
+        assert metric_calls[0].tags["final"] == "False"
+        assert metric_calls[0].tags["dataset"] == "events"
+        assert metric_calls[0].tags["app_id"] == "something-good"
+
     def test_arbitrary_app_id_attribution(self) -> None:
         response = self.post(
             "/events/snql",


### PR DESCRIPTION
To help better monitor query performance of the Snuba API, we want to add
the app_id tag to timer query metrics in order to add an extra dimension
to filtering.
