### PR TITLE
fix(optimize): Sort partitions each time when getting schedule

### DIFF
--- a/tests/test_optimize_scheduler.py
+++ b/tests/test_optimize_scheduler.py
@@ -140,10 +140,22 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
     [
         pytest.param(
             1,
-            ["(90,'2022-03-28')", "(90,'2022-03-21')"],
+            [
+                "(90,'2022-06-13')",
+                "(90,'2022-06-08')",
+                "(90,'2022-06-20')",
+                "(90,'2022-06-27')",
+            ],
             last_midnight + timedelta(minutes=30),
             OptimizationSchedule(
-                [["(90,'2022-03-28')", "(90,'2022-03-21')"]],
+                [
+                    [
+                        "(90,'2022-06-27')",
+                        "(90,'2022-06-20')",
+                        "(90,'2022-06-13')",
+                        "(90,'2022-06-08')",
+                    ]
+                ],
                 last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME,
             ),
             id="non parallel",


### PR DESCRIPTION
One of the reasons the optimize jobs are timing out is that there can be overlaps between the TTL merge and optimize merge. When this happens, the other merge is blocked with a reason along the following lines
`Not executing log_entry <x> of type MERGE_PARTS because part <y> is not ready yet`

TTL merges work with the partition which is 13 weeks old. If we order the partitions to optimize in such a manner that the 13 week old partition is merged in the end, we decrease the likelihood of overlaps happening and optimize jobs timing out
