### PR TITLE
fix(optimize): Remove exception from optimize_partitions

### DIFF
--- a/snuba/optimize_scheduler.py
+++ b/snuba/optimize_scheduler.py
@@ -95,7 +95,10 @@ class OptimizeScheduler:
         """
         current_time = datetime.now()
         if current_time >= self.__full_job_end_time:
-            raise OptimizedSchedulerTimeout("Optimize job cutoff time exceeded")
+            raise OptimizedSchedulerTimeout(
+                f"Optimize job cutoff time exceeded "
+                f"{self.__full_job_end_time}. Abandoning"
+            )
 
         if self.__parallel == 1:
             return OptimizationSchedule(

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -9,12 +9,7 @@ from snuba import optimize, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storages import StorageKey
 from snuba.datasets.storages.factory import get_writable_storage
-from snuba.optimize import (
-    JobTimeoutException,
-    _get_metrics_tags,
-    optimize_partition_runner,
-    optimize_partitions,
-)
+from snuba.optimize import _get_metrics_tags, optimize_partition_runner
 from snuba.optimize_scheduler import OptimizedSchedulerTimeout, OptimizeScheduler
 from snuba.optimize_tracker import OptimizedPartitionTracker
 from snuba.processor import InsertBatch
@@ -252,17 +247,6 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     dummy_partition = "(90,'2022-03-28')"
     tracker.update_all_partitions([dummy_partition])
     scheduler = OptimizeScheduler(2)
-
-    with pytest.raises(JobTimeoutException):
-        optimize_partitions(
-            clickhouse=clickhouse_pool,
-            database=database,
-            table=table,
-            partitions=[dummy_partition],
-            cutoff_time=datetime.now(),
-            tracker=tracker,
-            clickhouse_host="some-hostname.domain.com",
-        )
 
     with freeze_time(
         last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(minutes=15)


### PR DESCRIPTION
The `optimize_partitions` api is primarily called from `optimize_partition_runner` from the cron job to control the execution based on different schedules When a timeout is provided to the api, it means that the current schedule can run only till the provided timeout.

Because `optimize_partitions` is run in a threaded context, it is not easy to capture its exception it raises since by the time join is called on the thread, the threads stack trace is already gone.

What is important for us is that the optimize job raise an exception when OPTIMIZE_JOB_CUTOFF_TIME is reached. Which it does in OptimizeScheduler's get_next_schedule. The code is here https://github.com/getsentry/snuba/blob/master/snuba/optimize_scheduler.py#L96-L98. We don't care about transitions between different schedules. 