### PR TITLE
fix(ci): increase cloud build timeout 10m->15m

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -76,7 +76,7 @@ steps:
           docker-compose logs;
           exit $test_return;
         fi
-    timeout: 600s
+    timeout: 900s
   - name: "gcr.io/cloud-builders/docker"
     id: docker-push
     waitFor:


### PR DESCRIPTION
We were seeing cloud build failures pretty regularly -- in an example log, the e2e tests finished but the container was still not shut down at 10 minutes. Since this doesn't happen every time I bet the timeout is just too low for "cleanup"

In the logs of a couple runs:
```
Finished Step #4 - "e2e-test"
ERROR
ERROR: build step 4 "gcr.io/sentryio/docker-compose" failed: context deadline exceeded
```