### PR TITLE
[wip] config(redis): redis isolation by use case

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -38,7 +38,8 @@ from snuba.datasets.events_processor_base import (
 )
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.processor import InvalidMessageType, _hashify
-from snuba.redis import redis_client
+from snuba.redis import get_redis_client
+from snuba.redis_multi.configuration import ClusterFunction
 from snuba.replacers.replacer_processor import Replacement as ReplacementBase
 from snuba.replacers.replacer_processor import (
     ReplacementMessage,
@@ -57,6 +58,8 @@ In theory this will be needed only during the events to errors migration.
 
 logger = logging.getLogger(__name__)
 metrics = MetricsWrapper(environment.metrics, "errors.replacer")
+
+redis_client = get_redis_client(ClusterFunction.REPLACEMENT_STORAGE)
 
 
 @dataclass(frozen=True)

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -111,7 +111,6 @@ def _build_cluster_client(
             ClusterNode(host=node.host, port=node.port)
             for node in connection_descriptor
         ],
-        db=connection_descriptor[0].db,
         password=connection_descriptor[0].password,
         max_connections_per_node=True,
     )

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -151,4 +151,7 @@ def get_redis_client(func: ClusterFunction) -> RedisClientType:
     return _EXISTING_CLIENTS_BY_FUNCTION[func]
 
 
+# TODO This no-function-specified redis client should be deprecated but
+# until we actually have separate clusters we can leave it in so we don't
+# have to blow everything up in one PR.
 redis_client: RedisClientType = get_redis_client(ClusterFunction.CACHE)

--- a/snuba/redis_multi/configuration.py
+++ b/snuba/redis_multi/configuration.py
@@ -1,0 +1,19 @@
+from enum import Enum
+from typing import NamedTuple, Optional, Sequence, Union
+
+
+class NodeDescriptor(NamedTuple):
+    host: str
+    port: int
+    db: int
+    password: Optional[str]
+
+
+ConnectionDescriptor = Union[NodeDescriptor, Sequence[NodeDescriptor]]
+
+
+class ClusterFunction(Enum):
+    CACHE = 0
+    RATE_LIMITING = 1
+    SUBSCRIPTION_STORAGE = 2
+    REPLACEMENT_STORAGE = 3

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -94,7 +94,7 @@ REDIS_DB = int(os.environ.get("REDIS_DB", 1))
 REDIS_INIT_MAX_RETRIES = 3
 
 # Set self-hosted users up with the default setup where everything is
-# on one redis. Users who want to multiplex to multiple customers should
+# on one redis. Users who want to multiplex to multiple clusters should
 # fill in the values of REDIS_CLUSTER_MAP with lists of NodeDescriptor[s]
 REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
     REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -93,7 +93,9 @@ REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
 REDIS_DB = int(os.environ.get("REDIS_DB", 1))
 REDIS_INIT_MAX_RETRIES = 3
 
-# Use different redis clusters for different functions
+# Set self-hosted users up with the default setup where everything is
+# on one redis. Users who want to multiplex to multiple customers should
+# fill in the values of REDIS_CLUSTER_MAP with lists of NodeDescriptor[s]
 REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
     REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD
 )

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -2,6 +2,11 @@ import os
 from datetime import datetime, timedelta
 from typing import Any, Mapping, MutableMapping, Optional, Sequence, Set
 
+from snuba.redis_multi.configuration import (
+    ClusterFunction,
+    ConnectionDescriptor,
+    NodeDescriptor,
+)
 from snuba.settings.validation import validate_settings
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
@@ -87,6 +92,17 @@ REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
 REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
 REDIS_DB = int(os.environ.get("REDIS_DB", 1))
 REDIS_INIT_MAX_RETRIES = 3
+
+# Use different redis clusters for different functions
+REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
+    REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD
+)
+REDIS_CLUSTER_MAP: Mapping[ClusterFunction, ConnectionDescriptor] = {
+    ClusterFunction.CACHE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.RATE_LIMITING: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.REPLACEMENT_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.SUBSCRIPTION_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+}
 
 USE_RESULT_CACHE = True
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -84,8 +84,6 @@ CLICKHOUSE_TRACE_USER = os.environ.get("CLICKHOUSE_TRACE_USER", "default")
 CLICKHOUSE_TRACE_PASSWORD = os.environ.get("CLICKHOUSE_TRACE_PASS", "")
 
 # Redis Options
-USE_REDIS_CLUSTER = os.environ.get("USE_REDIS_CLUSTER", "0") != "0"
-
 REDIS_CLUSTER_STARTUP_NODES = None
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -83,6 +83,8 @@ CLICKHOUSE_READONLY_PASSWORD = os.environ.get("CLICKHOUSE_READONLY_PASS", "")
 CLICKHOUSE_TRACE_USER = os.environ.get("CLICKHOUSE_TRACE_USER", "default")
 CLICKHOUSE_TRACE_PASSWORD = os.environ.get("CLICKHOUSE_TRACE_PASS", "")
 
+USE_REDIS_CLUSTER = os.environ.get("USE_REDIS_CLUSTER", "0") != "0"
+
 # Redis Options
 REDIS_CLUSTER_STARTUP_NODES = None
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")

--- a/snuba/settings/settings_docker.py
+++ b/snuba/settings/settings_docker.py
@@ -1,11 +1,4 @@
 import os
-from typing import Mapping
-
-from snuba.redis_multi.configuration import (
-    ClusterFunction,
-    ConnectionDescriptor,
-    NodeDescriptor,
-)
 
 env = os.environ.get
 
@@ -23,13 +16,3 @@ DOGSTATSD_HOST = env("DOGSTATSD_HOST")
 DOGSTATSD_PORT = env("DOGSTATSD_PORT")
 
 SENTRY_DSN = env("SENTRY_DSN")
-
-REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
-    REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD
-)
-REDIS_CLUSTER_MAP: Mapping[ClusterFunction, ConnectionDescriptor] = {
-    ClusterFunction.CACHE: REDIS_SINGLE_NODE_DESCRIPTOR,
-    ClusterFunction.RATE_LIMITING: REDIS_SINGLE_NODE_DESCRIPTOR,
-    ClusterFunction.REPLACEMENT_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
-    ClusterFunction.SUBSCRIPTION_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
-}

--- a/snuba/settings/settings_docker.py
+++ b/snuba/settings/settings_docker.py
@@ -1,4 +1,11 @@
 import os
+from typing import Mapping
+
+from snuba.redis_multi.configuration import (
+    ClusterFunction,
+    ConnectionDescriptor,
+    NodeDescriptor,
+)
 
 env = os.environ.get
 
@@ -10,10 +17,19 @@ REDIS_HOST = env("REDIS_HOST", "localhost")
 REDIS_PORT = int(env("REDIS_PORT", 6379))
 REDIS_PASSWORD = env("REDIS_PASSWORD")
 REDIS_DB = int(env("REDIS_DB", 1))
-USE_REDIS_CLUSTER = False
 
 # Dogstatsd Options
 DOGSTATSD_HOST = env("DOGSTATSD_HOST")
 DOGSTATSD_PORT = env("DOGSTATSD_PORT")
 
 SENTRY_DSN = env("SENTRY_DSN")
+
+REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
+    REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD
+)
+REDIS_CLUSTER_MAP: Mapping[ClusterFunction, ConnectionDescriptor] = {
+    ClusterFunction.CACHE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.RATE_LIMITING: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.REPLACEMENT_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.SUBSCRIPTION_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+}

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -1,6 +1,13 @@
 import os
 from datetime import timedelta
-from typing import Set
+from typing import Mapping, Set
+
+from snuba.redis_multi.configuration import (
+    ClusterFunction,
+    ConnectionDescriptor,
+    NodeDescriptor,
+)
+from snuba.settings import REDIS_HOST, REDIS_PASSWORD, REDIS_PORT
 
 TESTING = True
 
@@ -30,3 +37,13 @@ ENFORCE_RETENTION = True
 
 # Ignore optimize job cut off time for tests
 OPTIMIZE_JOB_CUTOFF_TIME = timedelta(days=1)
+
+REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
+    REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD
+)
+REDIS_CLUSTER_MAP: Mapping[ClusterFunction, ConnectionDescriptor] = {
+    ClusterFunction.CACHE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.RATE_LIMITING: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.REPLACEMENT_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    ClusterFunction.SUBSCRIPTION_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+}

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -11,7 +11,7 @@ from snuba.settings import REDIS_HOST, REDIS_PASSWORD, REDIS_PORT
 
 TESTING = True
 
-REDIS_DB = 2
+REDIS_DB = int(os.environ.get("REDIS_DB", 2))
 STATS_IN_RESPONSE = True
 CONFIG_MEMOIZE_TIMEOUT = 0
 

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -7,7 +7,7 @@ from snuba.redis_multi.configuration import (
     ConnectionDescriptor,
     NodeDescriptor,
 )
-from snuba.settings import REDIS_HOST, REDIS_PASSWORD, REDIS_PORT
+from snuba.settings import REDIS_HOST, REDIS_PASSWORD, REDIS_PORT, USE_REDIS_CLUSTER
 
 TESTING = True
 
@@ -41,9 +41,18 @@ OPTIMIZE_JOB_CUTOFF_TIME = timedelta(days=1)
 REDIS_SINGLE_NODE_DESCRIPTOR = NodeDescriptor(
     REDIS_HOST, REDIS_PORT, REDIS_DB, REDIS_PASSWORD
 )
-REDIS_CLUSTER_MAP: Mapping[ClusterFunction, ConnectionDescriptor] = {
-    ClusterFunction.CACHE: REDIS_SINGLE_NODE_DESCRIPTOR,
-    ClusterFunction.RATE_LIMITING: REDIS_SINGLE_NODE_DESCRIPTOR,
-    ClusterFunction.REPLACEMENT_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
-    ClusterFunction.SUBSCRIPTION_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
-}
+REDIS_CLUSTER_MAP: Mapping[ClusterFunction, ConnectionDescriptor] = (
+    {
+        ClusterFunction.CACHE: (REDIS_SINGLE_NODE_DESCRIPTOR,),
+        ClusterFunction.RATE_LIMITING: (REDIS_SINGLE_NODE_DESCRIPTOR,),
+        ClusterFunction.REPLACEMENT_STORAGE: (REDIS_SINGLE_NODE_DESCRIPTOR,),
+        ClusterFunction.SUBSCRIPTION_STORAGE: (REDIS_SINGLE_NODE_DESCRIPTOR,),
+    }
+    if USE_REDIS_CLUSTER
+    else {
+        ClusterFunction.CACHE: REDIS_SINGLE_NODE_DESCRIPTOR,
+        ClusterFunction.RATE_LIMITING: REDIS_SINGLE_NODE_DESCRIPTOR,
+        ClusterFunction.REPLACEMENT_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+        ClusterFunction.SUBSCRIPTION_STORAGE: REDIS_SINGLE_NODE_DESCRIPTOR,
+    }
+)

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,12 +1,13 @@
 from redis.exceptions import RedisClusterException  # type: ignore
 from snuba import redis
+from snuba.redis_multi.configuration import ConnectionDescriptor, NodeDescriptor
 
 
 def test_retry_init() -> None:
     fails_left = 2
 
     @redis._retry(2)
-    def my_bad_function() -> int:
+    def my_bad_function(connection_descriptor: ConnectionDescriptor) -> int:
         nonlocal fails_left
         fails_left -= 1
         if fails_left > 0:
@@ -15,4 +16,4 @@ def test_retry_init() -> None:
             )
         return 1
 
-    assert my_bad_function() == 1
+    assert my_bad_function(NodeDescriptor("localhost", 1234, 1, None)) == 1


### PR DESCRIPTION
Will probably do some cleanup before even a preliminary review but I'll use this PR to see what people think of this approach

I know that the separate `redis_multi` package is weird and would be addressed before merge. Basically I was just trying to avoid a circular import between `settings` importing `redis` to see the new setting types and vice-versa