### PR TITLE
feat(profiling): Add timeseries processor for profiles entity

### DIFF
--- a/snuba/datasets/entities/profiles.py
+++ b/snuba/datasets/entities/profiles.py
@@ -18,6 +18,7 @@ from snuba.query.processors.object_id_rate_limiter import (
     ReferrerRateLimiterProcessor,
 )
 from snuba.query.processors.quota_processor import ResourceQuotaProcessor
+from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import EntityRequiredColumnValidator
 
 profile_columns = EntityColumnSet(
@@ -74,4 +75,5 @@ class ProfilesEntity(Entity, ABC):
             ProjectReferrerRateLimiter("project_id"),
             ProjectRateLimiterProcessor(project_column="project_id"),
             ResourceQuotaProcessor("project_id"),
+            TimeSeriesProcessor({"time": "received"}, ("received",)),
         ]


### PR DESCRIPTION
We want to generate some timeseries on the profiles. The timeseries processor
will allow us to use the granularity clause in snql.