### PR TITLE
feat(query): Mechanism to override query settings

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -420,9 +420,15 @@ transform_column_types = build_result_transformer(
 
 class NativeDriverReader(Reader):
     def __init__(
-        self, cache_partition_id: Optional[str], client: ClickhousePool
+        self,
+        cache_partition_id: Optional[str],
+        client: ClickhousePool,
+        query_settings_prefix: Optional[str],
     ) -> None:
-        super().__init__(cache_partition_id=cache_partition_id)
+        super().__init__(
+            cache_partition_id=cache_partition_id,
+            query_settings_prefix=query_settings_prefix,
+        )
         self.__client = client
 
     def __transform_result(self, result: ClickhouseResult, with_totals: bool) -> Result:

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -207,6 +207,7 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         cluster_name: Optional[str] = None,
         distributed_cluster_name: Optional[str] = None,
         cache_partition_id: Optional[str] = None,
+        query_settings_prefix: Optional[str] = None,
     ):
         super().__init__(storage_sets)
         self.__host = host
@@ -222,6 +223,7 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         self.__reader: Optional[Reader] = None
         self.__connection_cache = connection_cache
         self.__cache_partition_id = cache_partition_id
+        self.__query_settings_prefix = query_settings_prefix
 
     def __str__(self) -> str:
         return str(self.__query_node)
@@ -265,6 +267,7 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
             self.__reader = NativeDriverReader(
                 cache_partition_id=self.__cache_partition_id,
                 client=self.get_query_connection(ClickhouseClientSettings.QUERY),
+                query_settings_prefix=self.__query_settings_prefix,
             )
         return self.__reader
 
@@ -362,6 +365,7 @@ CLUSTERS = [
         if "distributed_cluster_name" in cluster
         else None,
         cache_partition_id=cluster.get("cache_partition_id"),
+        query_settings_prefix=cluster.get("query_settings_prefix"),
     )
     for cluster in settings.CLUSTERS
 ]

--- a/snuba/reader.py
+++ b/snuba/reader.py
@@ -117,8 +117,11 @@ def build_result_transformer(
 
 
 class Reader(ABC):
-    def __init__(self, cache_partition_id: Optional[str]) -> None:
+    def __init__(
+        self, cache_partition_id: Optional[str], query_settings_prefix: Optional[str]
+    ) -> None:
         self.__cache_partition_id = cache_partition_id
+        self.__query_settings_prefix = query_settings_prefix
 
     @abstractmethod
     def execute(
@@ -144,3 +147,9 @@ class Reader(ABC):
         should go away.
         """
         return self.__cache_partition_id
+
+    def get_query_settings_prefix(self) -> Optional[str]:
+        """
+        Return the query settings prefix if there is one.
+        """
+        return self.__query_settings_prefix

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -553,7 +553,7 @@ def _get_cache_wait_timeout(
 
 
 def _get_query_settings_from_config(
-    cache_partition: Optional[str],
+    override_prefix: Optional[str],
 ) -> MutableMapping[str, Any]:
     """
     Helper function to get the query settings from the config.
@@ -572,13 +572,10 @@ def _get_query_settings_from_config(
         if k.startswith("query_settings/")
     }
 
-    if not cache_partition or cache_partition == DEFAULT_CACHE_PARTITION_ID:
-        return clickhouse_query_settings
-
-    # Populate the query settings with the cache partitions overrides
-    for k, v in all_confs.items():
-        if k.startswith(f"{cache_partition}/query_settings/"):
-            clickhouse_query_settings[k.split("/", 2)[2]] = v
+    if override_prefix:
+        for k, v in all_confs.items():
+            if k.startswith(f"{override_prefix}/query_settings/"):
+                clickhouse_query_settings[k.split("/", 2)[2]] = v
 
     return clickhouse_query_settings
 
@@ -605,7 +602,7 @@ def raw_query(
     query. If this function ends up depending on the dataset, something is wrong.
     """
     clickhouse_query_settings = _get_query_settings_from_config(
-        reader.cache_partition_id
+        reader.get_query_settings_prefix()
     )
 
     timer.mark("get_configs")

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -552,6 +552,37 @@ def _get_cache_wait_timeout(
     return cache_wait_timeout
 
 
+def _get_query_settings_from_config(
+    cache_partition: Optional[str],
+) -> MutableMapping[str, Any]:
+    """
+    Helper function to get the query settings from the config.
+
+    #TODO: Make this configurable by entity/dataset. Since we want to use
+    #      different settings across different clusters belonging to the
+    #      same entity/dataset, using cache_partition right now. This is
+    #      not ideal but it works for now.
+    """
+    all_confs = state.get_all_configs()
+
+    # Populate the query settings with the default values
+    clickhouse_query_settings: MutableMapping[str, Any] = {
+        k.split("/", 1)[1]: v
+        for k, v in all_confs.items()
+        if k.startswith("query_settings/")
+    }
+
+    if not cache_partition or cache_partition == DEFAULT_CACHE_PARTITION_ID:
+        return clickhouse_query_settings
+
+    # Populate the query settings with the cache partitions overrides
+    for k, v in all_confs.items():
+        if k.startswith(f"{cache_partition}/query_settings/"):
+            clickhouse_query_settings[k.split("/", 2)[2]] = v
+
+    return clickhouse_query_settings
+
+
 def raw_query(
     # TODO: Passing the whole clickhouse query here is needed as long
     # as the execute method depends on it. Otherwise we can make this
@@ -573,12 +604,9 @@ def raw_query(
     This function is not supposed to depend on anything higher level than the clickhouse
     query. If this function ends up depending on the dataset, something is wrong.
     """
-    all_confs = state.get_all_configs()
-    clickhouse_query_settings: MutableMapping[str, Any] = {
-        k.split("/", 1)[1]: v
-        for k, v in all_confs.items()
-        if k.startswith("query_settings/")
-    }
+    clickhouse_query_settings = _get_query_settings_from_config(
+        reader.cache_partition_id
+    )
 
     timer.mark("get_configs")
 

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -75,6 +75,7 @@ FULL_CONFIG = [
         "cluster_name": "clickhouse_hosts",
         "distributed_cluster_name": "dist_hosts",
         "cache_partition_id": "host_2_cache",
+        "query_settings_prefix": "transactions_v2",
     },
 ]
 
@@ -107,6 +108,17 @@ def test_cache_partition() -> None:
     get_storage(
         StorageKey("errors")
     ).get_cluster().get_reader().cache_partition_id is None
+
+
+@patch("snuba.settings.CLUSTERS", FULL_CONFIG)
+def test_query_settings_prefix() -> None:
+    get_storage(
+        StorageKey("transactions")
+    ).get_cluster().get_reader().get_query_settings_prefix() == "transactions_v2"
+
+    get_storage(
+        StorageKey("errors")
+    ).get_cluster().get_reader().get_query_settings_prefix() is None
 
 
 @patch("snuba.settings.CLUSTERS", FULL_CONFIG)

--- a/tests/web/test_cache_partitions.py
+++ b/tests/web/test_cache_partitions.py
@@ -5,16 +5,16 @@ from snuba.web.db_query import _get_cache_partition, _get_cache_wait_timeout
 
 def test_cache_partition() -> None:
     pool = ClickhousePool("localhost", 9000, "", "", "")
-    reader1 = NativeDriverReader(None, pool)
-    reader2 = NativeDriverReader(None, pool)
+    reader1 = NativeDriverReader(None, pool, None)
+    reader2 = NativeDriverReader(None, pool, None)
 
     default_cache = _get_cache_partition(reader1)
     another_default_cache = _get_cache_partition(reader2)
 
     assert id(default_cache) == id(another_default_cache)
 
-    reader3 = NativeDriverReader("non_default", pool)
-    reader4 = NativeDriverReader("non_default", pool)
+    reader3 = NativeDriverReader("non_default", pool, None)
+    reader4 = NativeDriverReader("non_default", pool, None)
     nondefault_cache = _get_cache_partition(reader3)
     another_nondefault_cache = _get_cache_partition(reader4)
 
@@ -24,9 +24,9 @@ def test_cache_partition() -> None:
 
 def test_cache_wait_timeout() -> None:
     pool = ClickhousePool("localhost", 9000, "", "", "")
-    default_reader = NativeDriverReader(None, pool)
-    tiger_errors_reader = NativeDriverReader("tiger_errors", pool)
-    tiger_transactions_reader = NativeDriverReader("tiger_transactions", pool)
+    default_reader = NativeDriverReader(None, pool, None)
+    tiger_errors_reader = NativeDriverReader("tiger_errors", pool, None)
+    tiger_transactions_reader = NativeDriverReader("tiger_transactions", pool, None)
 
     query_settings = {"max_execution_time": 30}
     assert _get_cache_wait_timeout(query_settings, default_reader) == 30

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -1,5 +1,4 @@
-from collections import Mapping
-from typing import Any, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
 
 import pytest
 

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -1,0 +1,61 @@
+from collections import Mapping
+from typing import Any, MutableMapping, Optional
+
+import pytest
+
+from snuba import state
+from snuba.web.db_query import _get_query_settings_from_config
+
+test_data = [
+    pytest.param(
+        {
+            "query_settings/max_threads": 10,
+            "query_settings/merge_tree_max_rows_to_use_cache": 50000,
+            "some-cache-partition/query_settings/max_threads": 5,
+        },
+        {
+            "max_threads": 10,
+            "merge_tree_max_rows_to_use_cache": 50000,
+        },
+        None,
+        id="no override when cache partition empty",
+    ),
+    pytest.param(
+        {
+            "query_settings/max_threads": 10,
+            "query_settings/merge_tree_max_rows_to_use_cache": 50000,
+            "some-cache-partition/query_settings/max_threads": 5,
+        },
+        {
+            "max_threads": 10,
+            "merge_tree_max_rows_to_use_cache": 50000,
+        },
+        "other-cache-partition",
+        id="no override for different cache partition",
+    ),
+    pytest.param(
+        {
+            "query_settings/max_threads": 10,
+            "query_settings/merge_tree_max_rows_to_use_cache": 50000,
+            "some-cache-partition/query_settings/max_threads": 5,
+            "some-cache-partition/query_settings/merge_tree_max_rows_to_use_cache": 100000,
+        },
+        {
+            "max_threads": 5,
+            "merge_tree_max_rows_to_use_cache": 100000,
+        },
+        "some-cache-partition",
+        id="override for same cache partition",
+    ),
+]
+
+
+@pytest.mark.parametrize("query_config,expected,cache_partition", test_data)
+def test_query_settings_from_config(
+    query_config: Mapping[str, Any],
+    expected: MutableMapping[str, Any],
+    cache_partition: Optional[str],
+) -> None:
+    for k, v in query_config.items():
+        state.set_config(k, v)
+    assert _get_query_settings_from_config(cache_partition) == expected

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -10,51 +10,53 @@ test_data = [
         {
             "query_settings/max_threads": 10,
             "query_settings/merge_tree_max_rows_to_use_cache": 50000,
-            "some-cache-partition/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/merge_tree_max_rows_to_use_cache": 100000,
         },
         {
             "max_threads": 10,
             "merge_tree_max_rows_to_use_cache": 50000,
         },
         None,
-        id="no override when cache partition empty",
+        id="no override when query settings prefix empty",
     ),
     pytest.param(
         {
             "query_settings/max_threads": 10,
             "query_settings/merge_tree_max_rows_to_use_cache": 50000,
-            "some-cache-partition/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/merge_tree_max_rows_to_use_cache": 100000,
         },
         {
             "max_threads": 10,
             "merge_tree_max_rows_to_use_cache": 50000,
         },
-        "other-cache-partition",
-        id="no override for different cache partition",
+        "other-query-prefix",
+        id="no override for different query prefix",
     ),
     pytest.param(
         {
             "query_settings/max_threads": 10,
             "query_settings/merge_tree_max_rows_to_use_cache": 50000,
-            "some-cache-partition/query_settings/max_threads": 5,
-            "some-cache-partition/query_settings/merge_tree_max_rows_to_use_cache": 100000,
+            "some-query-prefix/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/merge_tree_max_rows_to_use_cache": 100000,
         },
         {
             "max_threads": 5,
             "merge_tree_max_rows_to_use_cache": 100000,
         },
-        "some-cache-partition",
-        id="override for same cache partition",
+        "some-query-prefix",
+        id="override for same query prefix",
     ),
 ]
 
 
-@pytest.mark.parametrize("query_config,expected,cache_partition", test_data)
+@pytest.mark.parametrize("query_config,expected,query_prefix", test_data)
 def test_query_settings_from_config(
     query_config: Mapping[str, Any],
     expected: MutableMapping[str, Any],
-    cache_partition: Optional[str],
+    query_prefix: Optional[str],
 ) -> None:
     for k, v in query_config.items():
         state.set_config(k, v)
-    assert _get_query_settings_from_config(cache_partition) == expected
+    assert _get_query_settings_from_config(query_prefix) == expected


### PR DESCRIPTION
Added a mechanism to override the query settings that are fetched from runtime config. This is to allow different query settings on the errors cluster.

The current mechanism provides a way of overriding using cache partitions which is necessary because prod and tiger cluster use the same entity.
