### PR TITLE
ref(replays): adjust original schema

### DIFF
--- a/snuba/datasets/replays_processor.py
+++ b/snuba/datasets/replays_processor.py
@@ -71,7 +71,7 @@ class ReplaysProcessor(MessageProcessor):
         processed["replay_id"] = str(uuid.UUID(event_dict["replay_id"]))
         processed["project_id"] = event_dict["project_id"]
 
-        processed["sequence_id"] = event_dict["sequence_id"]
+        processed["segment_id"] = event_dict["segment_id"]
         processed["trace_ids"] = event_dict["trace_ids"]
 
         processed["timestamp"] = self.__extract_timestamp(

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -18,6 +18,7 @@ DIST_TABLE_NAME = "replays_dist"
 columns = ColumnSet(
     [
         ("replay_id", UUID()),
+        ("event_hash", UInt(64)),
         ("segment_id", UInt(16, Modifiers(nullable=True))),
         ("timestamp", DateTime()),
         (
@@ -37,7 +38,6 @@ columns = ColumnSet(
         ("ip_address_v6", IPv6(Modifiers(nullable=True))),
         # user columns
         ("user", String()),
-        ("user_hash", UInt(64, Modifiers(readonly=True))),
         ("user_id", String(Modifiers(nullable=True))),
         ("user_name", String(Modifiers(nullable=True))),
         ("user_email", String(Modifiers(nullable=True))),

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -18,7 +18,7 @@ DIST_TABLE_NAME = "replays_dist"
 columns = ColumnSet(
     [
         ("replay_id", UUID()),
-        ("event_hash", UInt(64)),
+        ("event_hash", UUID()),
         ("segment_id", UInt(16, Modifiers(nullable=True))),
         ("timestamp", DateTime()),
         (

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -18,7 +18,7 @@ DIST_TABLE_NAME = "replays_dist"
 columns = ColumnSet(
     [
         ("replay_id", UUID()),
-        ("segment_id", UInt(16)),
+        ("segment_id", UInt(16, Modifiers(nullable=True))),
         ("timestamp", DateTime()),
         (
             "trace_ids",

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -18,7 +18,7 @@ DIST_TABLE_NAME = "replays_dist"
 columns = ColumnSet(
     [
         ("replay_id", UUID()),
-        ("sequence_id", UInt(16)),
+        ("segment_id", UInt(16)),
         ("timestamp", DateTime()),
         (
             "trace_ids",

--- a/snuba/migrations/snuba_migrations/replays/0001_replays.py
+++ b/snuba/migrations/snuba_migrations/replays/0001_replays.py
@@ -99,7 +99,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=raw_columns,
                 engine=table_engines.Distributed(
                     local_table_name="replays_local",
-                    sharding_key="cityHash64(toString(replay_id))",
+                    sharding_key="cityHash64(replay_id)",
                 ),
             ),
         ]

--- a/snuba/migrations/snuba_migrations/replays/0001_replays.py
+++ b/snuba/migrations/snuba_migrations/replays/0001_replays.py
@@ -65,7 +65,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=raw_columns,
                 engine=table_engines.ReplacingMergeTree(
                     storage_set=StorageSetKey.REPLAYS,
-                    order_by="(project_id, toStartOfDay(timestamp), cityHash64(replay_id), timestamp)",
+                    order_by="(project_id, toStartOfDay(timestamp), cityHash64(replay_id))",
                     partition_by="(retention_days, toMonday(timestamp))",
                     settings={"index_granularity": "8192"},
                     ttl="timestamp + toIntervalDay(retention_days)",

--- a/snuba/migrations/snuba_migrations/replays/0001_replays.py
+++ b/snuba/migrations/snuba_migrations/replays/0001_replays.py
@@ -18,7 +18,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 raw_columns: Sequence[Column[Modifiers]] = [
     Column("replay_id", UUID()),  # the id of the encompassing replay
     Column(
-        "event_hash", UInt(64)
+        "event_hash", UUID()
     ),  # a hash that individually identifies a unique update within the replay
     Column("segment_id", UInt(16, Modifiers(nullable=True))),
     Column("trace_ids", Array(UUID())),

--- a/snuba/migrations/snuba_migrations/replays/0001_replays.py
+++ b/snuba/migrations/snuba_migrations/replays/0001_replays.py
@@ -17,7 +17,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 raw_columns: Sequence[Column[Modifiers]] = [
     Column("replay_id", UUID()),
-    Column("sequence_id", UInt(16)),
+    Column("segment_id", UInt(16, Modifiers(nullable=True))),
     Column("trace_ids", Array(UUID())),
     Column(
         "_trace_ids_hashed",
@@ -38,8 +38,8 @@ raw_columns: Sequence[Column[Modifiers]] = [
     Column("ip_address_v4", IPv4(Modifiers(nullable=True))),
     Column("ip_address_v6", IPv6(Modifiers(nullable=True))),
     # user columns
-    Column("user", String()),
-    Column("user_hash", UInt(64)),
+    Column("user", String(Modifiers(default="''"))),
+    Column("user_hash", UInt(64, Modifiers(materialized="cityHash64(user)"))),
     Column("user_id", String(Modifiers(nullable=True))),
     Column("user_name", String(Modifiers(nullable=True))),
     Column("user_email", String(Modifiers(nullable=True))),
@@ -65,7 +65,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=raw_columns,
                 engine=table_engines.ReplacingMergeTree(
                     storage_set=StorageSetKey.REPLAYS,
-                    order_by="(project_id, toStartOfDay(timestamp), cityHash64(replay_id), sequence_id)",
+                    order_by="(project_id, toStartOfDay(timestamp), cityHash64(replay_id), timestamp)",
                     partition_by="(retention_days, toMonday(timestamp))",
                     settings={"index_granularity": "8192"},
                     ttl="timestamp + toIntervalDay(retention_days)",

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -13,7 +13,7 @@ from snuba.processor import InsertBatch
 @dataclass
 class ReplayEvent:
     replay_id: str
-    sequence_id: int
+    segment_id: int
     trace_ids: list[str]
     timestamp: float
     platform: str
@@ -38,7 +38,7 @@ class ReplayEvent:
             "replay_id": self.replay_id,
             "message": "/organizations/:orgId/issues/",
             "retention_days": 23,
-            "sequence_id": self.sequence_id,
+            "segment_id": self.segment_id,
             "trace_ids": self.trace_ids,
             "data": {
                 "replay_id": self.replay_id,
@@ -78,7 +78,7 @@ class ReplayEvent:
         ret = {
             "project_id": 1,
             "replay_id": str(uuid.UUID(self.replay_id)),
-            "sequence_id": self.sequence_id,
+            "segment_id": self.segment_id,
             "trace_ids": self.trace_ids,
             "timestamp": datetime.utcfromtimestamp(self.timestamp),
             "platform": self.platform,
@@ -118,7 +118,7 @@ class TestReplaysProcessor:
                 "36e980a9-c602-4cde-9f5d-089f15b83b5f",
                 "8bea4461-d8b9-44f3-93c1-5a3cb1c4169a",
             ],
-            sequence_id=0,
+            segment_id=0,
             timestamp=datetime.now(tz=timezone.utc).timestamp(),
             platform="python",
             dist="",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -291,7 +291,7 @@ def get_replay_event(replay_id: str | None = None) -> Mapping[str, Any]:
         "replay_id": replay_id,
         "message": "/organizations/:orgId/issues/",
         "retention_days": 23,
-        "sequence_id": 0,
+        "segment_id": 0,
         "trace_ids": [
             "36e980a9-c602-4cde-9f5d-089f15b83b5f",
             "8bea4461-d8b9-44f3-93c1-5a3cb1c4169a",


### PR DESCRIPTION
- sequence_id 
    - remove from the sorting key, and replace with timestamp
    - make nullable (so that way we can receive out-of-bands updates)
    - rename to segment_id (sequence_id is kind of ambiguous)
- add default empty string for the user field
- add the materialized function for user_hash (missed this when copying the schema from txs, etc.)

We have received no production traffic so no problem with simply rerunning the initial migration, and Colton and I are the only developers who have run the migration locally and we can handle re-running.

