### PR TITLE
feat(replays): Alter url column to allow null

### DIFF
--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -25,7 +25,7 @@ columns = ColumnSet(
             Array(UUID()),
         ),  # TODO: create bloom filter index / materialize column
         ("title", String(Modifiers(readonly=True))),
-        ("url", String()),
+        ("url", String(Modifiers(nullable=True))),
         ### common sentry event columns
         ("project_id", UInt(64)),
         # release/environment info

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -170,6 +170,7 @@ class ReplaysLoader(DirectoryLoader):
         return [
             "0001_replays",
             "0002_add_url",
+            "0003_alter_url_allow_null",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/replays/0003_alter_url_allow_null.py
+++ b/snuba/migrations/snuba_migrations/replays/0003_alter_url_allow_null.py
@@ -23,7 +23,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.REPLAYS,
                 table_name="replays_local",
-                column=Column("url", String(Modifiers(nullable=False))),
+                column=Column("url", String(Modifiers(nullable=False, default=""))),
             )
         ]
 
@@ -41,6 +41,6 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.REPLAYS,
                 table_name="replays_dist",
-                column=Column("url", String(Modifiers(nullable=False))),
+                column=Column("url", String(Modifiers(nullable=False, default=""))),
             )
         ]

--- a/snuba/migrations/snuba_migrations/replays/0003_alter_url_allow_null.py
+++ b/snuba/migrations/snuba_migrations/replays/0003_alter_url_allow_null.py
@@ -1,0 +1,46 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.REPLAYS,
+                table_name="replays_local",
+                column=Column("url", String(Modifiers(nullable=True))),
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.REPLAYS,
+                table_name="replays_local",
+                column=Column("url", String(Modifiers(nullable=False))),
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.REPLAYS,
+                table_name="replays_dist",
+                column=Column("url", String(Modifiers(nullable=True))),
+            )
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=StorageSetKey.REPLAYS,
+                table_name="replays_dist",
+                column=Column("url", String(Modifiers(nullable=False))),
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/replays/0003_alter_url_allow_null.py
+++ b/snuba/migrations/snuba_migrations/replays/0003_alter_url_allow_null.py
@@ -23,7 +23,7 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.REPLAYS,
                 table_name="replays_local",
-                column=Column("url", String(Modifiers(nullable=False, default=""))),
+                column=Column("url", String(Modifiers(nullable=False, default="''"))),
             )
         ]
 
@@ -41,6 +41,6 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.ModifyColumn(
                 storage_set=StorageSetKey.REPLAYS,
                 table_name="replays_dist",
-                column=Column("url", String(Modifiers(nullable=False, default=""))),
+                column=Column("url", String(Modifiers(nullable=False, default="''"))),
             )
         ]


### PR DESCRIPTION
The `url` column should have allowed null in the original migration.