### PR TITLE
config(mep): add rate limiter to entities

### DIFF
--- a/snuba/datasets/entities/generic_metrics.py
+++ b/snuba/datasets/entities/generic_metrics.py
@@ -35,6 +35,13 @@ from snuba.query.processors.granularity_processor import (
     PERFORMANCE_GRANULARITIES,
     MappedGranularityProcessor,
 )
+from snuba.query.processors.object_id_rate_limiter import (
+    OrganizationRateLimiterProcessor,
+    ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
+)
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
 from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
 from snuba.query.validation.validators import (
     EntityRequiredColumnValidator,
@@ -110,6 +117,11 @@ class GenericMetricsEntity(Entity, ABC):
                 default_granularity_enum=DEFAULT_MAPPED_GRANULARITY_ENUM,
             ),
             TimeSeriesProcessor({"bucketed_time": "timestamp"}, ("timestamp",)),
+            ReferrerRateLimiterProcessor(),
+            OrganizationRateLimiterProcessor(org_column="org_id"),
+            ProjectReferrerRateLimiter("project_id"),
+            ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
         ]
 
 


### PR DESCRIPTION
For safety purposes, rate limit requests by project_id/org_id