### PR TITLE
feat(migrations): Add source column to transactions

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -126,6 +126,7 @@ class TransactionsLoader(DirectoryLoader):
             "0012_transactions_add_spans",
             "0013_transactions_reduce_spans_exclusive_time",
             "0014_transactions_remove_flattened_columns",
+            "0015_transactions_add_source_column",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -23,7 +23,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name=table_name,
                 column=Column(
-                    "transactions_source",
+                    "transaction_source",
                     String(Modifiers(nullable=True, low_cardinality=True)),
                 ),
                 after="title",

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -35,7 +35,7 @@ class Migration(migration.ClickhouseNodeMigration):
     ) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropColumn(
-                StorageSetKey.TRANSACTIONS, table_name, "transactions_source"
+                StorageSetKey.TRANSACTIONS, table_name, "transaction_source"
             ),
         ]
 

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -8,7 +8,9 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 class Migration(migration.ClickhouseNodeMigration):
     """
-    Add source column required for ...
+    The source column is required to query for transaction events
+    in the transaction summary when the transaction name has been
+    redacted in metrics.
     """
 
     blocking = False

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -21,12 +21,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name=table_name,
                 column=Column(
-                    "source",
-                    String(
-                        Modifiers(
-                            low_cardinality=True, materialized="transaction_source"
-                        )
-                    ),
+                    "transactions_source",
+                    String(Modifiers(nullable=True, low_cardinality=True)),
                 ),
                 after="title",
             ),
@@ -36,7 +32,9 @@ class Migration(migration.ClickhouseNodeMigration):
         self, table_name: str
     ) -> Sequence[operations.SqlOperation]:
         return [
-            operations.DropColumn(StorageSetKey.TRANSACTIONS, table_name, "source"),
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, table_name, "transactions_source"
+            ),
         ]
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -23,7 +23,9 @@ class Migration(migration.ClickhouseNodeMigration):
                 column=Column(
                     "source",
                     String(
-                        Modifiers(low_cardinality=True, materialized="'transaction'")
+                        Modifiers(
+                            low_cardinality=True, materialized="transaction_source"
+                        )
                     ),
                 ),
                 after="title",

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -1,0 +1,50 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Add source column required for ...
+    """
+
+    blocking = False
+
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name=table_name,
+                column=Column(
+                    "source",
+                    String(
+                        Modifiers(low_cardinality=True, materialized="'transaction'")
+                    ),
+                ),
+                after="title",
+            ),
+        ]
+
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(StorageSetKey.TRANSACTIONS, table_name, "source"),
+        ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("transactions_local")
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("transactions_local")
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("transactions_dist")
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("transactions_dist")

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -24,7 +24,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name=table_name,
                 column=Column(
                     "transaction_source",
-                    String(Modifiers(nullable=True, low_cardinality=True)),
+                    String(Modifiers(low_cardinality=True)),
                 ),
                 after="title",
             ),


### PR DESCRIPTION
Add new column `source` to transactions group.

PR based on [Snuba migrations field guide](https://github.com/getsentry/snuba/blob/master/MIGRATIONS.md).

Processor implementation lives in https://github.com/getsentry/snuba/pull/2985