### PR TITLE
feat(profiling): add architecture column to profiles_local table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -240,6 +240,7 @@ class ProfilesLoader(DirectoryLoader):
         return [
             "0001_profiles",
             "0002_disable_vertical_merge_algorithm",
+            "0003_add_device_architecture",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
+++ b/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
@@ -16,7 +16,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="profiles_local",
                 column=Column(
                     "architecture",
-                    String(Modifiers(low_cardinality=True, nullable=True)),
+                    String(Modifiers(low_cardinality=True, default="'unknown'")),
                 ),
                 after="device_os_version",
             )

--- a/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
+++ b/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
@@ -1,0 +1,38 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_local",
+                column=Column(
+                    "architecture",
+                    String(Modifiers(low_cardinality=True, nullable=True)),
+                ),
+                after="device_os_version",
+            )
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_local",
+                column_name="architecture",
+            )
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
+++ b/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
@@ -32,7 +32,23 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_dist",
+                column=Column(
+                    "architecture",
+                    String(Modifiers(low_cardinality=True, default="'unknown'")),
+                ),
+                after="device_os_version",
+            )
+        ]
 
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.PROFILES,
+                table_name="profiles_dist",
+                column_name="architecture",
+            )
+        ]

--- a/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
+++ b/snuba/migrations/snuba_migrations/profiles/0003_add_device_architecture.py
@@ -24,7 +24,7 @@ class Migration(migration.ClickhouseNodeMigration):
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
         return [
-            operations.DropTable(
+            operations.DropColumn(
                 storage_set=StorageSetKey.PROFILES,
                 table_name="profiles_local",
                 column_name="architecture",


### PR DESCRIPTION
This PR adds a new `architecture` column to the `profiles_local` table.

`architecture` is a string describing the architecture of the CPU that is used in the device that collected the specific profile.
