### PR TITLE
feat(transactions): Start processing `transaction_source` in transactions_processor.py

### DIFF
--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -97,6 +97,7 @@ columns = ColumnSet(
         ("type", String(Modifiers(readonly=True))),
         ("message", String(Modifiers(readonly=True))),
         ("title", String(Modifiers(readonly=True))),
+        ("transaction_source", String()),
         ("timestamp", DateTime(Modifiers(readonly=True))),
     ]
 )

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -110,6 +110,9 @@ class TransactionsMessageProcessor(MessageProcessor):
         processed["transaction_name"] = _unicodify(
             event_dict["data"].get("transaction") or ""
         )
+        processed["transaction_source"] = _unicodify(
+            event_dict["data"].get("transaction_info", {}).get("source") or ""
+        )
         processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
             event_dict["data"]["start_timestamp"],
         )

--- a/snuba/datasets/transactions_processor.py
+++ b/snuba/datasets/transactions_processor.py
@@ -111,7 +111,7 @@ class TransactionsMessageProcessor(MessageProcessor):
             event_dict["data"].get("transaction") or ""
         )
         processed["transaction_source"] = _unicodify(
-            event_dict["data"].get("transaction_info", {}).get("source") or ""
+            (event_dict["data"].get("transaction_info") or {}).get("source") or ""
         )
         processed["start_ts"], processed["start_ms"] = self.__extract_timestamp(
             event_dict["data"]["start_timestamp"],

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -23,22 +23,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name=table_name,
                 column=Column(
-<<<<<<< HEAD
                     "transaction_source",
                     String(Modifiers(low_cardinality=True)),
-||||||| parent of 253c718c (fixup!)
-                    "source",
-                    String(
-                        Modifiers(low_cardinality=True, materialized="'transaction'")
-                    ),
-=======
-                    "source",
-                    String(
-                        Modifiers(
-                            low_cardinality=True, materialized="transaction_source"
-                        )
-                    ),
->>>>>>> 253c718c (fixup!)
                 ),
                 after="title",
             ),

--- a/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -23,8 +23,22 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.TRANSACTIONS,
                 table_name=table_name,
                 column=Column(
+<<<<<<< HEAD
                     "transaction_source",
                     String(Modifiers(low_cardinality=True)),
+||||||| parent of 253c718c (fixup!)
+                    "source",
+                    String(
+                        Modifiers(low_cardinality=True, materialized="'transaction'")
+                    ),
+=======
+                    "source",
+                    String(
+                        Modifiers(
+                            low_cardinality=True, materialized="transaction_source"
+                        )
+                    ),
+>>>>>>> 253c718c (fixup!)
                 ),
                 after="title",
             ),

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -34,6 +34,7 @@ class TransactionEvent:
     http_referer: Optional[str]
     geo: Mapping[str, str]
     status: str
+    transaction_source: Optional[str]
 
     def serialize(self) -> Tuple[int, str, Mapping[str, Any]]:
         return (
@@ -54,6 +55,7 @@ class TransactionEvent:
                     "project_id": 1,
                     "release": self.release,
                     "dist": self.dist,
+                    "transaction_info": {"source": "url"},
                     "grouping_config": {
                         "enhancements": "eJybzDhxY05qemJypZWRgaGlroGxrqHRBABbEwcC",
                         "id": "legacy:2019-03-12",
@@ -179,6 +181,7 @@ class TransactionEvent:
             "transaction_name": self.transaction_name,
             "transaction_op": self.op,
             "transaction_status": 1 if self.status == "cancelled" else 2,
+            "transaction_source": "url",
             "start_ts": start_timestamp,
             "start_ms": int(start_timestamp.microsecond / 1000),
             "finish_ts": finish_timestamp,
@@ -269,6 +272,7 @@ class TestTransactionsProcessor:
             http_method="POST",
             http_referer="tagstore.something",
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
+            transaction_source="url",
         )
         payload = message.serialize()
         # Force an invalid event
@@ -305,6 +309,7 @@ class TestTransactionsProcessor:
             http_method="POST",
             http_referer="tagstore.something",
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
+            transaction_source="url",
         )
         payload = message.serialize()
         # Force an invalid event
@@ -344,6 +349,7 @@ class TestTransactionsProcessor:
             http_method="POST",
             http_referer="tagstore.something",
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
+            transaction_source="url",
         )
         meta = KafkaMessageMetadata(
             offset=1, partition=2, timestamp=datetime(1970, 1, 1)
@@ -382,6 +388,7 @@ class TestTransactionsProcessor:
             http_method="POST",
             http_referer="tagstore.something",
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
+            transaction_source="url",
         )
         meta = KafkaMessageMetadata(
             offset=1, partition=2, timestamp=datetime(1970, 1, 1)


### PR DESCRIPTION
Start processing new transaction annotation:

```
{ "transaction_info": {"source": "url"} }
```

https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations

and storing  it using new column `transaction_source` from https://github.com/getsentry/snuba/pull/2982

**PLEASE DON'T MERGE** until https://github.com/getsentry/snuba/pull/2982

resolves [TET-270]

[TET-270]: https://getsentry.atlassian.net/browse/TET-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ