### PR TITLE
ref(replays): add new topic to validation prior to consumer change

### DIFF
--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -30,6 +30,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "snuba-metrics",
         "outcomes",
         "ingest-sessions",
+        "ingest-replay-events",
         "snuba-queries",
         "scheduled-subscriptions-events",
         "scheduled-subscriptions-transactions",


### PR DESCRIPTION
- adds a new topic to validation.py, so we can deploy snuba with the new topic configured on the ops side.

After that, we can deploy the consumer to listen to the topic. https://github.com/getsentry/snuba/pull/2978