### PR TITLE
feat: Sort raw sql fields and conditions [Experiment]

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -145,11 +145,17 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
             return self._alias(f"({self.__visit_params(exp.parameters)})", exp.alias)
 
         elif exp.function_name == BooleanFunctions.AND:
-            formatted = (c.accept(self) for c in get_first_level_and_conditions(exp))
+            current_level = get_first_level_and_conditions(exp)
+            if self._parsing_context.sort_fields and isinstance(current_level, list):
+                current_level.sort()
+            formatted = (c.accept(self) for c in current_level)
             return " AND ".join(formatted)
 
         elif exp.function_name == BooleanFunctions.OR:
-            formatted = (c.accept(self) for c in get_first_level_or_conditions(exp))
+            current_level = get_first_level_or_conditions(exp)
+            if self._parsing_context.sort_fields and isinstance(current_level, list):
+                current_level.sort()
+            formatted = (c.accept(self) for c in current_level)
             return f"({' OR '.join(formatted)})"
 
         ret = f"{escape_identifier(exp.function_name)}({self.__visit_params(exp.parameters)})"

--- a/snuba/query/__init__.py
+++ b/snuba/query/__init__.py
@@ -55,6 +55,16 @@ class SelectedExpression:
     name: Optional[str]
     expression: Expression
 
+    def __gt__(self, other: SelectedExpression) -> bool:
+        if isinstance(self.expression, Column) and isinstance(other.expression, Column):
+            return self.expression > other.expression
+        return True
+
+    def __lt__(self, other: SelectedExpression) -> bool:
+        if isinstance(self.expression, Column) and isinstance(other.expression, Column):
+            return self.expression < other.expression
+        return True
+
 
 TExp = TypeVar("TExp", bound=Expression)
 

--- a/snuba/query/parsing.py
+++ b/snuba/query/parsing.py
@@ -8,8 +8,9 @@ class ParsingContext:
     alias cache).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, sort_fields: bool = False) -> None:
         self.__alias_cache: List[str] = []
+        self.sort_fields = sort_fields
 
     def add_alias(self, alias: str) -> None:
         self.__alias_cache.append(alias)

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -50,6 +50,16 @@ logger = logging.getLogger("snuba.query")
 metrics = MetricsWrapper(environment.metrics, "api")
 
 MAX_QUERY_SIZE_BYTES = 256 * 1024  # 256 KiB by default
+EXCLUDED_REFERRERS_FROM_FIELDS_SORTING = {
+    "subsciptions_executor",
+    "tsdb-modelid:4",
+    "outcomes.timeseries",
+    "tsdb-modelid:300",
+    "tasks.process_projects_with_sessions.session_count",
+    "tsdb-modelid:100",
+    "api.group-events",
+    "tagstore.get_release_tags",
+}
 
 
 class SampleClauseFinder(DataSourceVisitor[bool, Entity], JoinVisitor[bool, Entity]):
@@ -300,6 +310,13 @@ def _format_storage_query_and_run(
         _apply_turbo_sampling_if_needed(clickhouse_query, query_settings)
 
         formatted_query = format_query(clickhouse_query)
+        formatted_query_sorted = None
+
+        # Build formatted query with sorted fields and expressions
+        if referrer not in EXCLUDED_REFERRERS_FROM_FIELDS_SORTING:
+            formatted_query_sorted = format_query(clickhouse_query, sort_fields=True)
+
+        # do modular hash algorithm
         formatted_sql = formatted_query.get_sql()
         query_size_bytes = len(formatted_sql.encode("utf-8"))
         span.set_data(
@@ -339,6 +356,7 @@ def _format_storage_query_and_run(
                 clickhouse_query,
                 query_settings,
                 formatted_query,
+                formatted_query_sorted,
                 reader,
                 timer,
                 query_metadata,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -316,7 +316,6 @@ def _format_storage_query_and_run(
         if referrer not in EXCLUDED_REFERRERS_FROM_FIELDS_SORTING:
             formatted_query_sorted = format_query(clickhouse_query, sort_fields=True)
 
-        # do modular hash algorithm
         formatted_sql = formatted_query.get_sql()
         query_size_bytes = len(formatted_sql.encode("utf-8"))
         span.set_data(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -59,6 +59,7 @@ EXCLUDED_REFERRERS_FROM_FIELDS_SORTING = {
     "tsdb-modelid:100",
     "api.group-events",
     "tagstore.get_release_tags",
+    "group.unhandled-flag",
 }
 
 

--- a/tests/clickhouse/test_query_format.py
+++ b/tests/clickhouse/test_query_format.py
@@ -617,6 +617,45 @@ sorted_test_cases = [
             selected_columns=[
                 SelectedExpression("c2", Column("c2", None, "column2")),
                 SelectedExpression("c1", Column("c1", None, "column1")),
+            ],
+            condition=binary_condition(
+                "and",
+                lhs=binary_condition(
+                    ConditionFunctions.EQ,
+                    lhs=Column("c2", None, "column2"),
+                    rhs=Literal(None, "2"),
+                ),
+                rhs=binary_condition(
+                    ConditionFunctions.EQ,
+                    lhs=Column("c1", None, "column1"),
+                    rhs=Literal(None, "1"),
+                ),
+            ),
+        ),
+        [
+            "SELECT (column1 AS c1), (column2 AS c2)",
+            ["FROM", "my_table"],
+            ("WHERE equals(c1, '1') AND equals(c2, '2')"),
+        ],
+        (
+            "SELECT (column1 AS c1), (column2 AS c2) "
+            "FROM my_table "
+            "WHERE equals(c1, '1') AND equals(c2, '2')"
+        ),
+        (
+            "SELECT (column1 AS c1), (column2 AS c2) "
+            "FROM my_table "
+            "WHERE equals(c1, '$S') AND equals(c2, '$S')"
+        ),
+        id="query_simple_sort_columns_and_conditions",
+    ),
+    pytest.param(
+        Query(
+            Table("my_table", ColumnSet([])),
+            selected_columns=[
+                SelectedExpression("c2", Column("c2", None, "column2")),
+                SelectedExpression("c1", Column("c1", None, "column1")),
+                SelectedExpression("c3", Column("c4", None, "column4")),
                 SelectedExpression("c3", Column("c3", None, "column3")),
             ],
             condition=binary_condition(
@@ -626,50 +665,128 @@ sorted_test_cases = [
                     binary_condition(
                         ConditionFunctions.EQ,
                         lhs=Column("c3", None, "column3"),
-                        rhs=Literal(None, "abcd"),
+                        rhs=Literal(None, "3"),
                     ),
                     binary_condition(
                         ConditionFunctions.EQ,
                         lhs=Column("c2", None, "column2"),
-                        rhs=Literal(None, "efgh"),
+                        rhs=Literal(None, "2"),
                     ),
                 ),
                 binary_condition(
                     BooleanFunctions.OR,
                     binary_condition(
                         ConditionFunctions.EQ,
-                        lhs=Column(None, None, "c1"),
-                        rhs=Literal(None, "ijkl"),
+                        lhs=Column("c1", None, "column1"),
+                        rhs=Literal(None, "1"),
                     ),
                     binary_condition(
                         ConditionFunctions.EQ,
-                        lhs=Column(None, None, "c4"),
-                        rhs=Literal(None, "mnop"),
+                        lhs=Column("c4", None, "column4"),
+                        rhs=Literal(None, "4"),
                     ),
                 ),
             ),
         ),
         [
-            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3)",
+            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3), (column4 AS c4)",
             ["FROM", "my_table"],
             (
-                "WHERE (equals(c3, 'abcd') AND (equals(c1, 'ijkl') OR "
-                "equals(c2, 'efgh')) OR equals(c4, 'mnop'))"
+                "WHERE (equals(c1, '1') OR equals(c4, '4')) AND "
+                "(equals(c2, '2') OR equals(c3, '3'))"
             ),
         ],
         (
-            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3) "
+            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3), (column4 AS c4) "
             "FROM my_table "
-            "WHERE (equals(c3, 'abcd') AND (equals(c1, 'ijkl') OR "
-            "equals(c2, 'efgh')) OR equals(c4, 'mnop'))"
+            "WHERE (equals(c1, '1') OR equals(c4, '4')) AND "
+            "(equals(c2, '2') OR equals(c3, '3'))"
         ),
         (
-            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3) "
+            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3), (column4 AS c4) "
             "FROM my_table "
-            "WHERE (equals(c3, '$S') AND (equals(c1, '$S') OR "
-            "equals(c2, '$S')) OR equals(c4, '$S'))"
+            "WHERE (equals(c1, '$S') OR equals(c4, '$S')) AND "
+            "(equals(c2, '$S') OR equals(c3, '$S'))"
         ),
-        id="query_complex_condition",
+        id="query_nested_condition",
+    ),
+    pytest.param(
+        Query(
+            Table("my_table", ColumnSet([])),
+            selected_columns=[
+                SelectedExpression("c2", Column("c2", None, "column2")),
+                SelectedExpression("c1", Column("c1", None, "column1")),
+                SelectedExpression("c3", Column("c4", None, "column4")),
+                SelectedExpression("c3", Column("c3", None, "column3")),
+                SelectedExpression("c5", Column("c5", None, "column5")),
+            ],
+            condition=binary_condition(
+                BooleanFunctions.AND,
+                lhs=binary_condition(
+                    BooleanFunctions.OR,
+                    lhs=binary_condition(
+                        BooleanFunctions.OR,
+                        lhs=binary_condition(
+                            ConditionFunctions.EQ,
+                            lhs=Column("c4", None, "column4"),
+                            rhs=Literal(None, "4"),
+                        ),
+                        rhs=binary_condition(
+                            ConditionFunctions.EQ,
+                            lhs=Column("c3", None, "column3"),
+                            rhs=Literal(None, "3"),
+                        ),
+                    ),
+                    rhs=binary_condition(
+                        ConditionFunctions.EQ,
+                        lhs=Column("c5", None, "column5"),
+                        rhs=Literal(None, "5"),
+                    ),
+                ),
+                rhs=binary_condition(
+                    BooleanFunctions.OR,
+                    lhs=binary_condition(
+                        BooleanFunctions.OR,
+                        lhs=binary_condition(
+                            ConditionFunctions.EQ,
+                            lhs=Column("c3", None, "column3"),
+                            rhs=Literal(None, "3"),
+                        ),
+                        rhs=binary_condition(
+                            ConditionFunctions.EQ,
+                            lhs=Column("c2", None, "column2"),
+                            rhs=Literal(None, "2"),
+                        ),
+                    ),
+                    rhs=binary_condition(
+                        ConditionFunctions.EQ,
+                        lhs=Column("c1", None, "column1"),
+                        rhs=Literal(None, "1"),
+                    ),
+                ),
+            ),
+        ),
+        [
+            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3), (column4 AS c4), (column5 AS c5)",
+            ["FROM", "my_table"],
+            (
+                "WHERE (equals(c1, '1') OR equals(c2, '2') OR equals(c3, '3')) AND "
+                "(equals(c3, '3') OR equals(c4, '4') OR equals(c5, '5'))"
+            ),
+        ],
+        (
+            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3), (column4 AS c4), (column5 AS c5) "
+            "FROM my_table "
+            "WHERE (equals(c1, '1') OR equals(c2, '2') OR equals(c3, '3')) AND "
+            "(equals(c3, '3') OR equals(c4, '4') OR equals(c5, '5'))"
+        ),
+        (
+            "SELECT (column1 AS c1), (column2 AS c2), (column3 AS c3), (column4 AS c4), (column5 AS c5) "
+            "FROM my_table "
+            "WHERE (equals(c1, '$S') OR equals(c2, '$S') OR equals(c3, '$S')) AND "
+            "(equals(c3, '$S') OR equals(c4, '$S') OR equals(c5, '$S'))"
+        ),
+        id="query_double_nested_condition",
     ),
 ]
 


### PR DESCRIPTION
Context:
To help improve the frequency of raw sql cache hits, this PR is
responsible for sorting column fields and expression conditions in raw
SQL queries. Note: this code should not interferer with the current 
operations of Snuba query caching. This is an experiment to investigate 
the consistency of the natural ordering of columns and conditions.

Test Plan:
* Provide functionality for sorting, and select a certain percentage
  (defined in runtime config) of raw queries to be part of the
  experiment.
* Exclude queries from an explicit set of referrers to avoid
  some computational overhead.
* Record metrics of cache hits of sorted and unsorted queries.
* Determine whether or not sorting should be implemented for all queries.

Sorting is *only* to expressions simple Columns in SELECT clause and conditionals (or nested) in the WHERE clause
