### PR TITLE
fix(config): Add comment identifying experimental consumers

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -4,77 +4,78 @@ sentry:
   repository: getsentry/snuba
 
 steps:
-- kind: KubernetesDeployment
-  selector:
-    label_selector: service=snuba
-  containers:
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: api
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: errors-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: errors-replacer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: errors-tiger-replacer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: replacer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: transactions-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: sessions-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: outcomes-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: loadbalancer-outcomes-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: outcomes-billing-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: events-subscriptions-scheduler
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: events-subscriptions-executor
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: profiles-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: transactions-subscriptions-scheduler
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: transactions-subscriptions-executor
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: metrics-counters-subscriptions-scheduler
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: metrics-sets-subscriptions-scheduler
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: metrics-subscriptions-executor
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: cdc-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: cdc-groupassignee-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: querylog-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: snuba-admin
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: metrics-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: generic-metrics-sets-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: generic-metrics-distributions-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: loadtest-errors-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: loadtest-sessions-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: loadtest-transactions-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: loadtest-outcomes-consumer
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: loadtest-loadbalancer-outcomes-consumer
-- kind: KubernetesCronJob
-  selector:
-    label_selector: service=snuba
-  containers:
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: cleanup
-  - image: us.gcr.io/sentryio/snuba:{sha}
-    name: optimize
+  - kind: KubernetesDeployment
+    selector:
+      label_selector: service=snuba
+    containers:
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: api
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: errors-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: errors-replacer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: errors-tiger-replacer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: replacer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: transactions-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: sessions-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: outcomes-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: loadbalancer-outcomes-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: outcomes-billing-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: events-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: events-subscriptions-executor
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: transactions-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: transactions-subscriptions-executor
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: metrics-counters-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: metrics-sets-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: metrics-subscriptions-executor
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: cdc-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: cdc-groupassignee-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: querylog-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: snuba-admin
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: metrics-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-sets-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-distributions-consumer
+      # Consumers below this line are considered experimental (ie not present in .freight.stable.yml)
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: loadtest-errors-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: loadtest-sessions-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: loadtest-transactions-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: loadtest-outcomes-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: loadtest-loadbalancer-outcomes-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: profiles-consumer
+  - kind: KubernetesCronJob
+    selector:
+      label_selector: service=snuba
+    containers:
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: cleanup
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: optimize


### PR DESCRIPTION
- There is no way to know whether a consumer is experimental without diffing the two config files.
- Added a comment identifying split between stable and experimental consumers in the config