### PR TITLE
fix(replays): add old topic back in validation

### DIFF
--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -48,6 +48,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "snuba-attribution",
         "profiles-call-tree",
         "ingest-replay-events",
+        "snuba-replay-events",
         "snuba-generic-metrics",
         "snuba-generic-metrics-sets-commit-log",
         "snuba-generic-metrics-distributions-commit-log",


### PR DESCRIPTION
adds back in the validation for the old topic, until i can have ops remove it from the production configuration.