### PR TITLE
feat(optimize): Add jitter to optimize thread start time

### DIFF
--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -231,6 +231,9 @@ def optimize_partition_runner(
                         schedule.cutoff_time,
                         tracker,
                         clickhouse_host,
+                        schedule.start_time_jitter_minutes[i]
+                        if schedule.start_time_jitter_minutes
+                        else None,
                     ),
                 )
             )
@@ -258,11 +261,19 @@ def optimize_partitions(
     cutoff_time: Optional[datetime] = None,
     tracker: Optional[OptimizedPartitionTracker] = None,
     clickhouse_host: Optional[str] = None,
+    start_jitter: Optional[int] = None,
 ) -> None:
     query_template = """\
         OPTIMIZE TABLE %(database)s.%(table)s
         PARTITION %(partition)s FINAL
     """
+
+    if start_jitter is not None:
+        logger.info(
+            f"{threading.current_thread().name}: Jittering start time by"
+            f" {start_jitter} minutes"
+        )
+        time.sleep(start_jitter * 60)
 
     for partition in partitions:
         if cutoff_time is not None and datetime.now() > cutoff_time:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -231,6 +231,9 @@ PARALLEL_OPTIMIZE_JOB_END_TIME = timedelta(hours=9)
 OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
 OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 
+# Maximum jitter to add to the scheduling of threads of an optimize job
+OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30
+
 
 def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     """Load settings from the path provided in the SNUBA_SETTINGS environment

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -30,3 +30,5 @@ ENFORCE_RETENTION = True
 
 # Ignore optimize job cut off time for tests
 OPTIMIZE_JOB_CUTOFF_TIME = timedelta(days=1)
+
+OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 0


### PR DESCRIPTION
With parallel optimizations, one observation made is that the load
gets higher during the end of merge. This could potentially be
because theres a lot of IOPS we do during the end of the merge.
With parallel merges, it can get exacerbated because there's a
burst of higher IOPS happening during the end of the merge.

Have added a mechanism where we add a jitter to the starting of
parallel optimize threads to avoid those bursts.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
