### PR TITLE
build: Bump confluent kafka to 1.8.2 everywhere

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ black==22.3.0
 blinker==1.4
 click==8.1.3
 clickhouse-driver==0.2.4
-confluent-kafka==1.7.0
+confluent-kafka==1.8.2
 datadog==0.44.0
 flake8==4.0.1
 Flask==2.1.2
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.1
 redis==4.3.4
-sentry-arroyo==1.0.0
+sentry-arroyo==1.0.1
 sentry-relay==0.8.12
 sentry-sdk==1.7.0
 simplejson==3.17.6


### PR DESCRIPTION
This is the version that includes the fix for None header values crashing the Python
interpreter which we encountered in Sentry.