### PR TITLE
fix(upgrade): Check finish_ts for transactions upgrade

### DIFF
--- a/snuba/datasets/entities/transactions.py
+++ b/snuba/datasets/entities/transactions.py
@@ -133,8 +133,13 @@ def v2_selector_function(query: Query, referrer: str) -> Tuple[str, List[str]]:
     ):
         return ("transactions_v1", [])
 
-    range = get_time_range(query, "timestamp")
-    if range[0] is None or range[0] < settings.TRANSACTIONS_UPGRADE_BEGINING_OF_TIME:
+    time_range = get_time_range(query, "timestamp")
+    if time_range == (None, None):
+        time_range = get_time_range(query, "finish_ts")
+    if (
+        time_range[0] is None
+        or time_range[0] < settings.TRANSACTIONS_UPGRADE_BEGINING_OF_TIME
+    ):
         return ("transactions_v1", [])
 
     mapping = {

--- a/tests/datasets/test_upgrade_selector_transactions.py
+++ b/tests/datasets/test_upgrade_selector_transactions.py
@@ -73,6 +73,30 @@ TESTS = [
         ("transactions_v2", ["transactions_v1"]),
         id="In range, run both and trust the second.",
     ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, None, "finish_ts"),
+            Literal(None, datetime(2022, 1, 1, 0, 0, 0)),
+        ),
+        datetime(2021, 1, 1, 0, 0, 0),
+        1.0,
+        0.0,
+        ("transactions_v1", ["transactions_v2"]),
+        id="Using finish_ts in range, run both.",
+    ),
+    pytest.param(
+        binary_condition(
+            ConditionFunctions.GTE,
+            Column(None, None, "finish_ts"),
+            Literal(None, datetime(2022, 1, 1, 0, 0, 0)),
+        ),
+        datetime(2021, 1, 1, 0, 0, 0),
+        1.0,
+        1.0,
+        ("transactions_v2", ["transactions_v1"]),
+        id="Using finsh_ts in range, run both and trust the second.",
+    ),
 ]
 
 


### PR DESCRIPTION
The subscription queries use finish_ts in queries instead of timestamp. Added code to selector function to look at both timestamp and finish_ts columns to determine rollout.

Tested locally end to end to verify that transactions use the new cluster when appropriate paramaters are set.