### PR TITLE
chore(replays): add replays consumer to .freight.yaml

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -71,6 +71,8 @@ steps:
         name: loadtest-loadbalancer-outcomes-consumer
       - image: us.gcr.io/sentryio/snuba:{sha}
         name: profiles-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: replays-consumer
   - kind: KubernetesCronJob
     selector:
       label_selector: service=snuba


### PR DESCRIPTION
- the replays consumer should be good to go on freight now. The kafka topic has been added, and we're ready to deploy.
- i've confirmed the name of the consumer in the ops repo, `replays-consumer`, is correct.