### PR TITLE
ci(migrations): Print backward migration in the PR

### DIFF
--- a/scripts/ddl-changes.py
+++ b/scripts/ddl-changes.py
@@ -35,12 +35,21 @@ def _main() -> None:
             migration_filename = os.path.basename(line)
             migration_group = MigrationGroup(os.path.basename(os.path.dirname(line)))
             migration_id, _ = os.path.splitext(migration_filename)
-
             runner = Runner()
             migration_key = MigrationKey(migration_group, migration_id)
-            print(f"-- migration {migration_group.value} : {migration_id}")
+            print(f"-- forward migration {migration_group.value} :" f" {migration_id}")
             runner.run_migration(migration_key, dry_run=True)
-            print(f"-- end migration {migration_group.value} : {migration_id}")
+            print(
+                f"-- end forward migration {migration_group.value} :" f" {migration_id}"
+            )
+
+            migration_key = MigrationKey(migration_group, migration_id)
+            print(f"-- backward migration {migration_group.value} :" f" {migration_id}")
+            runner.reverse_migration(migration_key, dry_run=True)
+            print(
+                f"-- end backward migration {migration_group.value} :"
+                f" {migration_id}"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/ddl-changes.py
+++ b/scripts/ddl-changes.py
@@ -43,6 +43,7 @@ def _main() -> None:
                 f"-- end forward migration {migration_group.value} :" f" {migration_id}"
             )
 
+            print("\n\n\n")
             migration_key = MigrationKey(migration_group, migration_id)
             print(f"-- backward migration {migration_group.value} :" f" {migration_id}")
             runner.reverse_migration(migration_key, dry_run=True)


### PR DESCRIPTION
When applying a migration I would like to add backward migrations as well in the PR since it is handy to have it just in case its needed

Tested it locally using an existing PR

```
-- start migrations

-- forward migration transactions : 0015_transactions_add_source_column
Local operations:
ALTER TABLE transactions_local ADD COLUMN IF NOT EXISTS transaction_source LowCardinality(String) AFTER title;


Dist operations:
ALTER TABLE transactions_dist ADD COLUMN IF NOT EXISTS transaction_source LowCardinality(String) AFTER title;
-- end forward migration transactions : 0015_transactions_add_source_column
-- backward migration transactions : 0015_transactions_add_source_column
Local operations:
ALTER TABLE transactions_local DROP COLUMN IF EXISTS transaction_source;


Dist operations:
ALTER TABLE transactions_dist DROP COLUMN IF EXISTS transaction_source;
-- end backward migration transactions : 0015_transactions_add_source_column
```