### PR TITLE
(deps): revert update to datadog version 0.44.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ blinker==1.4
 click==8.1.3
 clickhouse-driver==0.2.4
 confluent-kafka==1.8.2
-datadog==0.44.0
+datadog==0.21.0
 flake8==4.0.1
 Flask==2.1.2
 future==0.18.2

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -241,7 +241,7 @@ def create_metrics(
             f"DOGSTATSD_HOST and DOGSTATSD_PORT should both be None or not None. Found DOGSTATSD_HOST: {host}, DOGSTATSD_PORT: {port} instead."
         )
 
-    from datadog.dogstatsd.base import DogStatsd
+    from datadog import DogStatsd
 
     from snuba.utils.metrics.backends.datadog import DatadogMetricsBackend
 

--- a/snuba/utils/metrics/backends/datadog.py
+++ b/snuba/utils/metrics/backends/datadog.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import threading
-from typing import Callable, Mapping, Optional, Union
+from typing import Callable, Mapping, Optional, Sequence, Union
 
-from datadog.dogstatsd.base import DogStatsd
+from datadog import DogStatsd
 
 from snuba.utils.metrics.backends.abstract import MetricsBackend
 from snuba.utils.metrics.types import Tags
@@ -38,11 +38,9 @@ class DatadogMetricsBackend(MetricsBackend):
             client = self.__thread_state.client
         except AttributeError:
             client = self.__thread_state.client = self.__client_factory()
-
-        assert isinstance(client, DogStatsd)  # for typing
         return client
 
-    def __normalize_tags(self, tags: Optional[Tags]) -> Optional[list[str]]:
+    def __normalize_tags(self, tags: Optional[Tags]) -> Optional[Sequence[str]]:
         if tags is None:
             return None
         else:


### PR DESCRIPTION
This reverts https://github.com/getsentry/snuba/pull/2887, in an effort to see if this is the cause of [SNUBA-2WK](https://sentry.io/organizations/sentry/issues/3386195934/?project=300688)