### PR TITLE
ref(rollout): Remove config option of tuple unaliaser

### DIFF
--- a/snuba/query/processors/tuple_unaliaser.py
+++ b/snuba/query/processors/tuple_unaliaser.py
@@ -1,6 +1,4 @@
-import random
 from dataclasses import replace
-from typing import cast
 
 from snuba.clickhouse.processors import QueryProcessor
 from snuba.clickhouse.query import Query
@@ -16,7 +14,6 @@ from snuba.query.expressions import (
     SubscriptableReference,
 )
 from snuba.query.query_settings import QuerySettings
-from snuba.state import get_config
 
 
 class _TupleUnaliasVisitor(ExpressionVisitor[Expression]):
@@ -102,17 +99,6 @@ class TupleUnaliaser(QueryProcessor):
         executing the query
     """
 
-    def should_run(self) -> bool:
-        try:
-            unaliaser_config_percentage = float(
-                cast(float, get_config("tuple_unaliaser_rollout", 0))
-            )
-            return random.random() < unaliaser_config_percentage
-        except ValueError:
-            return False
-
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        if not self.should_run():
-            return None
         visitor = _TupleUnaliasVisitor()
         query.transform(visitor)

--- a/tests/query/processors/test_tuple_unaliaser.py
+++ b/tests/query/processors/test_tuple_unaliaser.py
@@ -119,18 +119,3 @@ def test_tuple_unaliaser(input_query, expected_query):
     settings = HTTPQuerySettings()
     TupleUnaliaser().process_query(input_query, settings)
     assert input_query == expected_query
-
-
-def test_killswitch():
-    p = TupleUnaliaser()
-    assert not p.should_run()
-    set_config("tuple_unaliaser_rollout", 0)
-    assert not p.should_run()
-    set_config("tuple_unaliaser_rollout", 1)
-    assert p.should_run()
-
-
-def test_garbage_rollot():
-    p = TupleUnaliaser()
-    set_config("tuple_unaliaser_rollout", "garbage")
-    assert not p.should_run()


### PR DESCRIPTION
We don't need the knob of controlling whether to use tuple_unaliaser
anymore.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
