### PR TITLE
feat(rollout): Make transaction query processors same

### DIFF
--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -25,6 +25,7 @@ from snuba.query.processors.mapping_optimizer import MappingOptimizer
 from snuba.query.processors.mapping_promoter import MappingColumnPromoter
 from snuba.query.processors.prewhere import PrewhereProcessor
 from snuba.query.processors.table_rate_limit import TableRateLimit
+from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.query.processors.type_converters.hexint_column_processor import (
     HexIntArrayColumnProcessor,
     HexIntColumnProcessor,
@@ -133,6 +134,7 @@ query_processors = [
         ["event_id", "trace_id", "span_id", "transaction_name", "transaction", "title"]
     ),
     TableRateLimit(),
+    TupleUnaliaser(),
 ]
 
 query_splitters = [TimeSplitQueryStrategy(timestamp_col="finish_ts")]

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -12,7 +12,6 @@ from snuba.datasets.storages.transactions_common import (
 )
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.datasets.transactions_processor import TransactionsMessageProcessor
-from snuba.query.processors.tuple_unaliaser import TupleUnaliaser
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -25,14 +24,11 @@ schema = WritableTableSchema(
     part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
-v2_query_processors = [*query_processors, TupleUnaliaser()]
-
-
 storage = WritableTableStorage(
     storage_key=StorageKey.TRANSACTIONS_V2,
     storage_set_key=StorageSetKey.TRANSACTIONS_V2,
     schema=schema,
-    query_processors=v2_query_processors,
+    query_processors=query_processors,
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),
         pre_filter=KafkaHeaderFilter("transaction_forwarder", "0"),


### PR DESCRIPTION
In order to map the transactions dataset to the transactions-tiger
cluster and make it seamless, have the same set of query processors
run for both.

Verified locally that applying the query processor on 20.7 cluster
does not have a negative impact
