### PR TITLE
config(mep): add generic metrics schedulers/executors to freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -58,6 +58,14 @@ steps:
         name: generic-metrics-sets-consumer
       - image: us.gcr.io/sentryio/snuba:{sha}
         name: generic-metrics-distributions-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-sets-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-distributions-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-sets-subscriptions-executor
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-distributions-subscriptions-executor
       # Consumers below this line are considered experimental (ie not present in .freight.stable.yml)
       - image: us.gcr.io/sentryio/snuba:{sha}
         name: loadtest-errors-consumer


### PR DESCRIPTION
These are deployed in prod but we want freight to deploy them automatically