### PR TITLE
config(mep): add schedulers/executors to snuba-stable freight

### DIFF
--- a/.freight.stable.yml
+++ b/.freight.stable.yml
@@ -58,6 +58,14 @@ steps:
         name: metrics-sets-subscriptions-scheduler
       - image: us.gcr.io/sentryio/snuba:{sha}
         name: metrics-subscriptions-executor
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-sets-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-distributions-subscriptions-scheduler
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-sets-subscriptions-executor
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: generic-metrics-distributions-subscriptions-executor
   - kind: KubernetesCronJob
     selector:
       label_selector: service=snuba


### PR DESCRIPTION
ready for stable since https://github.com/getsentry/snuba/pull/3014 deployed successfully