### PR TITLE
fix(admin): Fix deletion of configs with `/` in them

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -248,7 +248,7 @@ def all_config_descriptions() -> Response:
     )
 
 
-@application.route("/configs/<config_key>", methods=["PUT", "DELETE"])
+@application.route("/configs/<path:config_key>", methods=["PUT", "DELETE"])
 def config(config_key: str) -> Response:
     if request.method == "DELETE":
         user = request.headers.get(USER_HEADER_KEY)


### PR DESCRIPTION
The query_settings are configured with forward slashes in them. In
order for flask route's to recognize them correctly we need to specify
them explicitly as path which can have forward slashes.
