### PR TITLE
config(ds): get rid of existing logic to move to dynamic sampling

### DIFF
--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import logging
 import os
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -24,10 +24,6 @@ def setup_logging(level: Optional[str] = None) -> None:
     )
 
 
-def traces_sampler(sampling_context: Mapping[str, Any]) -> Any:
-    return sampling_context["parent_sampled"] or False
-
-
 def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
@@ -38,7 +34,7 @@ def setup_sentry() -> None:
             RedisIntegration(),
         ],
         release=os.getenv("SNUBA_RELEASE"),
-        traces_sampler=traces_sampler,
+        traces_sample_rate=0,
     )
 
 

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -34,7 +34,7 @@ def setup_sentry() -> None:
             RedisIntegration(),
         ],
         release=os.getenv("SNUBA_RELEASE"),
-        traces_sample_rate=0,
+        traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
     )
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -98,6 +98,7 @@ CONFIG_MEMOIZE_TIMEOUT = 10
 
 # Sentry Options
 SENTRY_DSN = None
+SENTRY_TRACE_SAMPLE_RATE = 0
 
 # Snuba Admin Options
 SLACK_API_TOKEN = os.environ.get("SLACK_API_TOKEN")


### PR DESCRIPTION
According to @untitaker `parent_sampled` is already a special case in the python SDK (see internal slack thread https://sentry.slack.com/archives/C02N6582ZFA/p1659476660850549?thread_ts=1659473664.627579&cid=C02N6582ZFA for more info) and traces with this context set will never be rejected, even with a sample rate of 0.

We'd like to start testing service-side sampling, and this would unblock us from that.

This should be deployed with an eye on our sentry project to make sure that our assumption is correct