### PR TITLE
fix(discover): add missing transaction_source to TRANSACTIONS_COLUMNS

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -249,6 +249,7 @@ TRANSACTIONS_COLUMNS = ColumnSet(
         ("transaction_hash", UInt(64, Modifiers(nullable=True))),
         ("transaction_op", String(Modifiers(nullable=True))),
         ("transaction_status", UInt(8, Modifiers(nullable=True))),
+        ("transaction_source", String(Modifiers(nullable=True))),
         ("duration", UInt(32, Modifiers(nullable=True))),
         ("measurements", Nested([("key", String()), ("value", Float(64))])),
         ("span_op_breakdowns", Nested([("key", String()), ("value", Float(64))])),


### PR DESCRIPTION
After working on https://github.com/getsentry/sentry/pull/37295, 
@wmak suggested to add `transaction_source` to `TRANSACTIONS_COLUMNS` so 
we can query it from discover with this patch:
```diff
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -466,8 +466,7 @@ class Columns(Enum):
         group_name=None,
         event_name=None,
         transaction_name="transaction_source",
-        # Only available in transactions, pretend like its a tag so we dont error and just null instead
-        discover_name="tags[transaction_source]",
+        discover_name="transaction_source",
         alias="transaction.source",
     )
```
