### PR TITLE
build: Bump sentry-python to 1.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pytz==2022.1
 redis==4.3.4
 sentry-arroyo==1.0.1
 sentry-relay==0.8.12
-sentry-sdk==1.7.0
+sentry-sdk==1.9.0
 simplejson==3.17.6
 urllib3==1.26.10
 uWSGI==2.0.20


### PR DESCRIPTION
Our current version sentry-python doesn't have transaction source
fixes. So we need to bump it to start sending correct transaction source
from snuba.
