### PR TITLE
feat(replays): Add urls, user_agent, and replay_start_timestamp fields and processor

### DIFF
--- a/snuba/datasets/replays_processor.py
+++ b/snuba/datasets/replays_processor.py
@@ -36,6 +36,9 @@ RetentionDays = int
 
 # A sane upper bound of 1000 was chosen for error_ids. If you know better, change it.
 ERROR_IDS_LIMIT = 1000
+# A sane upper bound of 1000 was chosen for urls. If you know better, change it.
+URLS_LIMIT = 1000
+
 USER_FIELDS_PRECEDENCE = ("user_id", "username", "email", "ip_address")
 
 
@@ -68,7 +71,7 @@ class ReplaysProcessor(MessageProcessor):
         processed["replay_start_timestamp"] = self.__extract_started_at(
             replay_event.get("replay_start_timestamp"),
         )
-        processed["urls"] = replay_event.get("urls", [])
+        processed["urls"] = replay_event.get("urls", [])[:URLS_LIMIT]
         processed["release"] = replay_event.get("release")
         processed["environment"] = replay_event.get("environment")
         processed["dist"] = replay_event.get("dist")

--- a/snuba/datasets/replays_processor.py
+++ b/snuba/datasets/replays_processor.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from datetime import datetime
 from hashlib import md5
-from typing import Any, List, Mapping, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
 
 import rapidjson
 
@@ -59,7 +61,7 @@ class ReplaysProcessor(MessageProcessor):
         else:
             raise TypeError("Missing data for replay_start_timestamp column.")
 
-    def __extract_urls(self, replay_event: ReplayEventDict) -> List[str]:
+    def __extract_urls(self, replay_event: ReplayEventDict) -> list[str]:
         if "url" in replay_event:
             # Backwards compat for non-public, pre-alpha javascript SDK.
             return self.__extract_url(replay_event)
@@ -71,7 +73,7 @@ class ReplaysProcessor(MessageProcessor):
             # Malformed event catch all.
             return []
 
-    def __extract_url(self, replay_event: ReplayEventDict) -> List[str]:
+    def __extract_url(self, replay_event: ReplayEventDict) -> list[str]:
         request = replay_event.get("request", {})
         if not isinstance(request, dict):
             return []

--- a/snuba/datasets/replays_processor.py
+++ b/snuba/datasets/replays_processor.py
@@ -46,16 +46,15 @@ class ReplaysProcessor(MessageProcessor):
             timestamp = datetime.utcnow()
         return timestamp
 
-    def _get_url(self, replay_event: ReplayEventDict) -> Optional[str]:
-        request = replay_event.get("request", {})
-        if not isinstance(request, dict):
+    def __extract_started_at(self, started_at: Optional[int]) -> Optional[datetime]:
+        if started_at is None:
             return None
 
-        url = request.get("url")
-        if url is None:
-            return None
+        timestamp = _ensure_valid_date(datetime.utcfromtimestamp(started_at))
+        if timestamp:
+            return timestamp
         else:
-            return str(url)
+            raise TypeError("Missing data for replay_start_timestamp column.")
 
     def _process_base_replay_event_values(
         self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict
@@ -66,10 +65,13 @@ class ReplaysProcessor(MessageProcessor):
         processed["timestamp"] = self.__extract_timestamp(
             replay_event["timestamp"],
         )
+        processed["replay_start_timestamp"] = self.__extract_started_at(
+            replay_event.get("replay_start_timestamp"),
+        )
+        processed["urls"] = replay_event.get("urls", [])
         processed["release"] = replay_event.get("release")
         processed["environment"] = replay_event.get("environment")
         processed["dist"] = replay_event.get("dist")
-        processed["url"] = self._get_url(replay_event)
         processed["platform"] = _unicodify(replay_event["platform"])
 
         error_ids = replay_event.get("error_ids") or []
@@ -117,6 +119,19 @@ class ReplaysProcessor(MessageProcessor):
                 processed["ip_address_v6"] = str(ip_address)
 
         self._add_user_column(processed, user_data)
+
+    def _process_request_headers(
+        self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict
+    ) -> None:
+        request = replay_event.get("request", {})
+        if not isinstance(request, dict):
+            return None
+
+        headers = request.get("headers", {})
+        if not isinstance(headers, dict):
+            return None
+
+        processed["user_agent"] = headers.get("User-Agent")
 
     def _process_sdk(
         self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict
@@ -173,6 +188,7 @@ class ReplaysProcessor(MessageProcessor):
             # # the following operation modifies the event_dict and is therefore *not* order-independent
             self._process_user(processed, replay_event)
             self._process_event_hash(processed, replay_event)
+            self._process_request_headers(processed, replay_event)
             return InsertBatch([processed], None)
         except Exception as e:
             metrics.increment("consumer_error")

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -39,6 +39,7 @@ columns = ColumnSet(
             Array(UUID()),
         ),
         ("title", String(Modifiers(readonly=True))),
+        ("url", String()),
         ("urls", Array(String())),
         ### common sentry event columns
         ("project_id", UInt(64)),

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -29,6 +29,7 @@ columns = ColumnSet(
         ("event_hash", UUID()),
         ("segment_id", UInt(16, Modifiers(nullable=True))),
         ("timestamp", DateTime()),
+        ("replay_start_timestamp", DateTime(Modifiers(nullable=True))),
         (
             "trace_ids",
             Array(UUID()),
@@ -38,7 +39,7 @@ columns = ColumnSet(
             Array(UUID()),
         ),
         ("title", String(Modifiers(readonly=True))),
-        ("url", String(Modifiers(nullable=True))),
+        ("urls", Array(String())),
         ### common sentry event columns
         ("project_id", UInt(64)),
         # release/environment info
@@ -50,6 +51,7 @@ columns = ColumnSet(
         ("ip_address_v6", IPv6(Modifiers(nullable=True))),
         # user columns
         ("user", String()),
+        ("user_agent", String(Modifiers(nullable=True))),
         ("user_id", String(Modifiers(nullable=True))),
         ("user_name", String(Modifiers(nullable=True))),
         ("user_email", String(Modifiers(nullable=True))),

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -52,10 +52,20 @@ columns = ColumnSet(
         ("ip_address_v6", IPv6(Modifiers(nullable=True))),
         # user columns
         ("user", String()),
-        ("user_agent", String(Modifiers(nullable=True))),
         ("user_id", String(Modifiers(nullable=True))),
         ("user_name", String(Modifiers(nullable=True))),
         ("user_email", String(Modifiers(nullable=True))),
+        # OS
+        ("os_name", String(Modifiers(nullable=True))),
+        ("os_version", String(Modifiers(nullable=True))),
+        # Browser
+        ("browser_name", String(Modifiers(nullable=True))),
+        ("browser_version", String(Modifiers(nullable=True))),
+        # Device
+        ("device_name", String(Modifiers(nullable=True))),
+        ("device_brand", String(Modifiers(nullable=True))),
+        ("device_family", String(Modifiers(nullable=True))),
+        ("device_model", String(Modifiers(nullable=True))),
         # sdk info
         ("sdk_name", String()),
         ("sdk_version", String()),

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -39,7 +39,7 @@ columns = ColumnSet(
             Array(UUID()),
         ),
         ("title", String(Modifiers(readonly=True))),
-        ("url", String()),
+        ("url", String(Modifiers(nullable=True))),
         ("urls", Array(String())),
         ### common sentry event columns
         ("project_id", UInt(64)),

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -19,14 +19,16 @@ class ReplayEvent:
     segment_id: int
     trace_ids: list[str]
     error_ids: list[str]
+    urls: list[str]
     timestamp: float
+    replay_start_timestamp: float | None
     platform: str
     environment: str
     release: str
     dist: str
-    url: str | None
     ipv4: str | None
     ipv6: str | None
+    user_agent: str | None
     user_name: str | None
     user_id: str | None
     user_email: str | None
@@ -49,11 +51,13 @@ class ReplayEvent:
                             "replay_id": self.replay_id,
                             "segment_id": self.segment_id,
                             "tags": {"customtag": "is_set", "transaction": self.title},
+                            "urls": self.urls,
                             "trace_ids": self.trace_ids,
                             "error_ids": self.error_ids,
                             "dist": self.dist,
                             "platform": self.platform,
                             "timestamp": self.timestamp,
+                            "replay_start_timestamp": self.replay_start_timestamp,
                             "environment": self.environment,
                             "release": self.release,
                             "user": {
@@ -74,10 +78,8 @@ class ReplayEvent:
                                 }
                             },
                             "request": {
-                                "url": self.url,
-                                "headers": {
-                                    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
-                                },
+                                "url": "Doesn't matter not ingested.",
+                                "headers": {"User-Agent": self.user_agent},
                             },
                             "extra": {},
                         }
@@ -113,12 +115,18 @@ class ReplayEvent:
             "error_ids": self.error_ids,
             "trace_ids": self.trace_ids,
             "timestamp": datetime.utcfromtimestamp(self.timestamp),
+            "replay_start_timestamp": datetime.utcfromtimestamp(
+                self.replay_start_timestamp
+            )
+            if self.replay_start_timestamp
+            else None,
             "platform": self.platform,
             "environment": self.environment,
             "release": self.release,
             "dist": self.dist,
-            "url": self.url,
+            "urls": self.urls,
             "user_id": self.user_id,
+            "user_agent": self.user_agent,
             "user_name": self.user_name,
             "user_email": self.user_email,
             "tags.key": ["customtag"],
@@ -127,7 +135,6 @@ class ReplayEvent:
             "sdk_name": "sentry.python",
             "sdk_version": "0.9.0",
             "retention_days": 30,
-            # "url": "http://localhost:3000/", # commented out until we have the url field
             "offset": meta.offset,
             "partition": meta.partition,
         }
@@ -159,9 +166,11 @@ class TestReplaysProcessor:
             ],
             segment_id=0,
             timestamp=datetime.now(tz=timezone.utc).timestamp(),
+            replay_start_timestamp=datetime.now(tz=timezone.utc).timestamp(),
             platform="python",
             dist="",
-            url="http://localhost:8001",
+            urls=["http://localhost:8001"],
+            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
             user_name="me",
             user_id="232",
             user_email="test@test.com",
@@ -188,9 +197,11 @@ class TestReplaysProcessor:
             trace_ids=[],
             segment_id=0,
             timestamp=datetime.now(tz=timezone.utc).timestamp(),
+            replay_start_timestamp=None,
             platform="python",
             dist="",
-            url=None,
+            urls=[],
+            user_agent=None,
             user_name=None,
             user_id=None,
             user_email=None,

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -28,64 +28,81 @@ class ReplayEvent:
     dist: str
     ipv4: str | None
     ipv6: str | None
-    user_agent: str | None
     user_name: str | None
     user_id: str | None
     user_email: str | None
+    os_name: str | None
+    os_version: str | None
+    browser_name: str | None
+    browser_version: str | None
+    device_name: str | None
+    device_brand: str | None
+    device_family: str | None
+    device_model: str | None
     sdk_name: str
     sdk_version: str
     title: str | None
 
     def serialize(self) -> Mapping[Any, Any]:
+        replay_event = {
+            "type": "replay_event",
+            "replay_id": self.replay_id,
+            "segment_id": self.segment_id,
+            "tags": {"customtag": "is_set", "transaction": self.title},
+            "urls": self.urls,
+            "trace_ids": self.trace_ids,
+            "error_ids": self.error_ids,
+            "dist": self.dist,
+            "platform": self.platform,
+            "timestamp": self.timestamp,
+            "replay_start_timestamp": self.replay_start_timestamp,
+            "environment": self.environment,
+            "release": self.release,
+            "user": {
+                "id": self.user_id,
+                "username": self.user_name,
+                "email": self.user_email,
+                "ip_address": self.ipv4,
+            },
+            "sdk": {
+                "name": self.sdk_name,
+                "version": self.sdk_version,
+            },
+            "contexts": {
+                "trace": {
+                    "op": "pageload",
+                    "span_id": "affa5649681a1eeb",
+                    "trace_id": "23eda6cd4b174ef8a51f0096df3bfdd1",
+                },
+                "os": {
+                    "name": self.os_name,
+                    "version": self.os_version,
+                },
+                "browser": {
+                    "name": self.browser_name,
+                    "version": self.browser_version,
+                },
+                "device": {
+                    "name": self.device_name,
+                    "brand": self.device_brand,
+                    "family": self.device_family,
+                    "model": self.device_model,
+                },
+            },
+            "request": {
+                "url": "Doesn't matter not ingested.",
+                "headers": {"User-Agent": "not used"},
+            },
+            "extra": {},
+        }
+
         return {
             "type": "replay_event",
             "start_time": self.timestamp,
             "replay_id": self.replay_id,
             "project_id": 1,
             "retention_days": 30,
-            "payload": list(
-                bytes(
-                    json.dumps(
-                        {
-                            "type": "replay_event",
-                            "replay_id": self.replay_id,
-                            "segment_id": self.segment_id,
-                            "tags": {"customtag": "is_set", "transaction": self.title},
-                            "urls": self.urls,
-                            "trace_ids": self.trace_ids,
-                            "error_ids": self.error_ids,
-                            "dist": self.dist,
-                            "platform": self.platform,
-                            "timestamp": self.timestamp,
-                            "replay_start_timestamp": self.replay_start_timestamp,
-                            "environment": self.environment,
-                            "release": self.release,
-                            "user": {
-                                "id": self.user_id,
-                                "username": self.user_name,
-                                "email": self.user_email,
-                                "ip_address": self.ipv4,
-                            },
-                            "sdk": {
-                                "name": self.sdk_name,
-                                "version": self.sdk_version,
-                            },
-                            "contexts": {
-                                "trace": {
-                                    "op": "pageload",
-                                    "span_id": "affa5649681a1eeb",
-                                    "trace_id": "23eda6cd4b174ef8a51f0096df3bfdd1",
-                                }
-                            },
-                            "request": {
-                                "url": "Doesn't matter not ingested.",
-                                "headers": {"User-Agent": self.user_agent},
-                            },
-                            "extra": {},
-                        }
-                    ).encode()
-                )
-            ),
+            "payload": list(bytes(json.dumps(replay_event).encode())),
         }
 
     def _user_field(self) -> str | None:
@@ -126,9 +143,16 @@ class ReplayEvent:
             "dist": self.dist,
             "urls": self.urls,
             "user_id": self.user_id,
-            "user_agent": self.user_agent,
             "user_name": self.user_name,
             "user_email": self.user_email,
+            "os_name": self.os_name,
+            "os_version": self.os_version,
+            "browser_name": self.browser_name,
+            "browser_version": self.browser_version,
+            "device_name": self.device_name,
+            "device_brand": self.device_brand,
+            "device_family": self.device_family,
+            "device_model": self.device_model,
             "tags.key": ["customtag"],
             "tags.value": ["is_set"],
             "title": self.title,
@@ -170,10 +194,17 @@ class TestReplaysProcessor:
             platform="python",
             dist="",
             urls=["http://localhost:8001"],
-            user_agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36",
             user_name="me",
             user_id="232",
             user_email="test@test.com",
+            os_name="iOS",
+            os_version="16.2",
+            browser_name="Chrome",
+            browser_version="103.0.38",
+            device_name="iPhone 11",
+            device_brand="Apple",
+            device_family="iPhone",
+            device_model="iPhone",
             ipv4="127.0.0.1",
             ipv6=None,
             environment="prod",
@@ -201,7 +232,14 @@ class TestReplaysProcessor:
             platform="python",
             dist="",
             urls=[],
-            user_agent=None,
+            os_name=None,
+            os_version=None,
+            browser_name=None,
+            browser_version=None,
+            device_name=None,
+            device_brand=None,
+            device_family=None,
+            device_model=None,
             user_name=None,
             user_id=None,
             user_email=None,


### PR DESCRIPTION
Depends on: https://github.com/getsentry/snuba/pull/3021

- Add `urls`, `user_agent`, and `replay_start_timestamp` columns.
- Removes `url` column.
- Removes old url processor.