### PR TITLE
fix(replacements): Limit size of excluded groups set [INC-190]

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -215,7 +215,9 @@ def set_project_exclude_groups(
     p.execute()
 
 
-def truncate_group_id_replacement_set(p: StrictClusterPipeline, key: str, now: float) -> None:
+def truncate_group_id_replacement_set(
+    p: StrictClusterPipeline, key: str, now: float
+) -> None:
     # remove group id deletions that should have been merged by now
     p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
 

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -213,7 +213,7 @@ def set_project_exclude_groups(
     p.execute()
 
 
-def truncate_group_id_replacement_set(p, key, now):
+def truncate_group_id_replacement_set(p: Any, key: str, now: float) -> None:
     # remove group id deletions that should have been merged by now
     p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
     # remove group id deletions that exceed the maximum number of deletions

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -175,6 +175,7 @@ def set_project_exclude_groups(
     state_name: Optional[ReplacerState],
     #  replacement type is just for metrics, not necessary for functionality
     replacement_type: ReplacementType,
+    now: Optional[float] = None,
 ) -> None:
     """
     This method is called when a replacement comes in. For a specific project, record
@@ -186,7 +187,8 @@ def set_project_exclude_groups(
 
     Add replacement type for this replacement.
     """
-    now = time.time()
+    if now is None:
+        now = time.time()
     key, type_key = ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
         project_id, state_name
     )

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -215,7 +215,7 @@ def set_project_exclude_groups(
     p.execute()
 
 
-def truncate_group_id_replacement_set(p: Any, key: str, now: float) -> None:
+def truncate_group_id_replacement_set(p: StrictClusterPipeline, key: str, now: float) -> None:
     # remove group id deletions that should have been merged by now
     p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
 

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -175,7 +175,6 @@ def set_project_exclude_groups(
     state_name: Optional[ReplacerState],
     #  replacement type is just for metrics, not necessary for functionality
     replacement_type: ReplacementType,
-    now: Optional[float] = None,
 ) -> None:
     """
     This method is called when a replacement comes in. For a specific project, record
@@ -187,8 +186,7 @@ def set_project_exclude_groups(
 
     Add replacement type for this replacement.
     """
-    if now is None:
-        now = time.time()
+    now = time.time()
     key, type_key = ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
         project_id, state_name
     )

--- a/snuba/datasets/storages/processors/replaced_groups.py
+++ b/snuba/datasets/storages/processors/replaced_groups.py
@@ -97,7 +97,10 @@ class PostReplacementConsistencyEnforcer(QueryProcessor):
             groups_to_exclude = self._groups_to_exclude(
                 query, flags.group_ids_to_exclude
             )
-            if len(groups_to_exclude) > max_group_ids_exclude:
+            if (
+                len(flags.group_ids_to_exclude) > 2 * max_group_ids_exclude
+                or len(groups_to_exclude) > max_group_ids_exclude
+            ):
                 tags["cause"] = "max_groups"
                 metrics.increment(
                     name=FINAL_METRIC,

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -419,7 +419,7 @@ class TestReplacer:
 
         flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
         # Assert that most recent groups are preserved
-        assert flags.group_ids_to_exclude == {9, 8, 7, 6, 5}
+        assert flags.group_ids_to_exclude == {9, 8, 7, 6, 5, 4}
 
         project_id = 5
 
@@ -433,7 +433,7 @@ class TestReplacer:
 
         flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
         # All groups were excluded at the same time, so their order is not deterministic
-        assert len(flags.group_ids_to_exclude) == 5
+        assert len(flags.group_ids_to_exclude) == 6
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -403,37 +403,37 @@ class TestReplacer:
             {ReplacementType.EXCLUDE_GROUPS},
         )
 
-    @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2)
-    def test_query_time_flags_bounded_size(self) -> None:
-        redis_client.flushdb()
-        project_id = 4
-        now = datetime.now()
-        for i in range(10):
-            with freeze_time(now + timedelta(seconds=i)):
-                errors_replacer.set_project_exclude_groups(
-                    project_id,
-                    [i],
-                    ReplacerState.ERRORS,
-                    ReplacementType.EXCLUDE_GROUPS,
-                )
+    # @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2)
+    # def test_query_time_flags_bounded_size(self) -> None:
+    #     redis_client.flushdb()
+    #     project_id = 4
+    #     now = datetime.now()
+    #     for i in range(10):
+    #         with freeze_time(now + timedelta(seconds=i)):
+    #             errors_replacer.set_project_exclude_groups(
+    #                 project_id,
+    #                 [i],
+    #                 ReplacerState.ERRORS,
+    #                 ReplacementType.EXCLUDE_GROUPS,
+    #             )
 
-        flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
-        # Assert that most recent groups are preserved
-        assert flags.group_ids_to_exclude == {9, 8, 7, 6, 5}
+    #     flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
+    #     # Assert that most recent groups are preserved
+    #     assert flags.group_ids_to_exclude == {9, 8, 7, 6, 5}
 
-        project_id = 5
+    #     project_id = 5
 
-        errors_replacer.set_project_exclude_groups(
-            project_id,
-            list(range(10)),
-            ReplacerState.ERRORS,
-            ReplacementType.EXCLUDE_GROUPS,
-        )
+    #     errors_replacer.set_project_exclude_groups(
+    #         project_id,
+    #         list(range(10)),
+    #         ReplacerState.ERRORS,
+    #         ReplacementType.EXCLUDE_GROUPS,
+    #     )
 
-        flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
-        # All groups were excluded at the same time, so their order is not deterministic
-        # 2 * REPLACER_MAX_GROUP_IDS_TO_EXCLUDE + 1
-        assert len(flags.group_ids_to_exclude) == 5
+    #     flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
+    #     # All groups were excluded at the same time, so their order is not deterministic
+    #     # 2 * REPLACER_MAX_GROUP_IDS_TO_EXCLUDE + 1
+    #     assert len(flags.group_ids_to_exclude) == 5
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -406,7 +406,7 @@ class TestReplacer:
     # @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2)
     def test_query_time_flags_bounded_size(self) -> None:
         redis_client.flushdb()
-        project_id = 4
+        project_id = 256
         now = datetime.now()
         with mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2):
             for i in range(10):

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import time
 from datetime import datetime, timedelta
 from typing import Any, Mapping, MutableMapping, Sequence
 from unittest import mock
@@ -24,9 +25,6 @@ from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from tests.fixtures import get_raw_event
 from tests.helpers import write_unprocessed_events
-
-# from freezegun import freeze_time
-
 
 CONSUMER_GROUP = "consumer_group"
 
@@ -407,20 +405,16 @@ class TestReplacer:
 
     @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2)
     def test_query_time_flags_bounded_size(self) -> None:
-        import time
-
         redis_client.flushdb()
         project_id = 256
-        # now = datetime.now()
         for i in range(10):
-            # with freeze_time(now + timedelta(seconds=i)):
             errors_replacer.set_project_exclude_groups(
                 project_id,
                 [i],
                 ReplacerState.ERRORS,
                 ReplacementType.EXCLUDE_GROUPS,
             )
-            time.sleep(2)
+            time.sleep(1.1)  # Hack because freezegun was breaking unrelated tests
 
         flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
         # Assert that most recent groups are preserved

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -403,7 +403,7 @@ class TestReplacer:
             {ReplacementType.EXCLUDE_GROUPS},
         )
 
-    @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 5)
+    @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 2)
     def test_query_time_flags_bounded_size(self) -> None:
         redis_client.flushdb()
         project_id = 4
@@ -419,7 +419,7 @@ class TestReplacer:
 
         flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
         # Assert that most recent groups are preserved
-        assert flags.group_ids_to_exclude == {9, 8, 7, 6, 5, 4}
+        assert flags.group_ids_to_exclude == {9, 8, 7, 6, 5}
 
         project_id = 5
 
@@ -433,7 +433,8 @@ class TestReplacer:
 
         flags = ProjectsQueryFlags.load_from_redis([project_id], ReplacerState.ERRORS)
         # All groups were excluded at the same time, so their order is not deterministic
-        assert len(flags.group_ids_to_exclude) == 6
+        # 2 * REPLACER_MAX_GROUP_IDS_TO_EXCLUDE + 1
+        assert len(flags.group_ids_to_exclude) == 5
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from datetime import datetime, timedelta
 from typing import Any, Mapping, MutableMapping, Sequence
+from unittest import mock
 
 import pytz
 import simplejson as json
@@ -401,10 +402,10 @@ class TestReplacer:
             {ReplacementType.EXCLUDE_GROUPS},
         )
 
-    def test_query_time_flags_bounded_size(self, monkeypatch) -> None:
+    @mock.patch.object(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 5)
+    def test_query_time_flags_bounded_size(self) -> None:
         redis_client.flushdb()
         project_id = 4
-        monkeypatch.setattr(settings, "REPLACER_MAX_GROUP_IDS_TO_EXCLUDE", 5)
         for i in range(10):
             errors_replacer.set_project_exclude_groups(
                 project_id, [i], ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import importlib
 from datetime import datetime, timedelta
 from typing import Any, Mapping, MutableMapping, Sequence
-from unittest import mock
 
 import pytz
 import simplejson as json
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
-from freezegun import freeze_time
 
 from snuba import replacer, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
@@ -25,6 +23,12 @@ from snuba.settings import PAYLOAD_DATETIME_FORMAT
 from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 from tests.fixtures import get_raw_event
 from tests.helpers import write_unprocessed_events
+
+# from unittest import mock
+
+
+# from freezegun import freeze_time
+
 
 CONSUMER_GROUP = "consumer_group"
 


### PR DESCRIPTION
This is an insufficient fix for correctness, it mainly ensures the redis
set does not grow unbounded.

The redis set should be trimmed to the most recent groups. I have **not** thought through the product implications of doing that (we should automatically fallback to FINAL), but it seems better to me than manually denylisting projects over the weekend.