### PR TITLE
SNS-1570-rely-on-the-entity-enum-in-the-subscriptions-scheduler-cli-command

### DIFF
--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -24,16 +24,7 @@ logger = logging.getLogger(__name__)
     "--entity",
     "entity_name",
     required=True,
-    type=click.Choice(
-        [
-            "events",
-            "transactions",
-            "metrics_sets",
-            "metrics_counters",
-            "generic_metrics_sets",
-            "generic_metrics_distributions",
-        ]
-    ),
+    type=click.Choice([entity_key.value for entity_key in EntityKey]),
     help="The entity to target",
 )
 @click.option(


### PR DESCRIPTION

Uses the entity enum for the list of options in entity enum name CLI choice option. Addressing this https://getsentry.atlassian.net/browse/SNS-1570
