### PR TITLE
config(datasets) - create a PluggableEntity class

### DIFF
--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+from snuba.clickhouse.columns import Column
+from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
+from snuba.datasets.entities.entity_data_model import EntityColumnSet
+from snuba.datasets.entity import Entity
+from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
+from snuba.datasets.plans.single_storage import SingleStorageQueryPlanBuilder
+from snuba.datasets.storage import ReadableTableStorage, Storage, WritableTableStorage
+from snuba.pipeline.query_pipeline import QueryPipelineBuilder
+from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
+from snuba.query.data_source.join import JoinRelationship
+from snuba.query.processors import QueryProcessor
+from snuba.query.validation import FunctionCallValidator
+from snuba.query.validation.validators import QueryValidator
+from snuba.utils.schemas import SchemaModifiers
+
+
+@dataclass
+class PluggableEntity(Entity):
+    """
+    PluggableEntity is a version of Entity that is designed to be populated by
+    static YAML-based configuration files. It is intentionally less flexible
+    than Entity. See the documentation of Entity for explanation about how
+    overridden methods are supposed to behave.
+
+    At the time of writing, it makes certain assumptions, specifically that
+    the query pipeline builder will map all queries to a single storage, the
+    provided readable storage.
+    """
+
+    query_processors: Sequence[QueryProcessor]
+    columns: Sequence[Column[SchemaModifiers]]
+    readable_storage: ReadableTableStorage
+    validators: Sequence[QueryValidator]
+    translation_mappers: TranslationMappers
+    writeable_storage: Optional[WritableTableStorage] = None
+    join_relationships: Mapping[str, JoinRelationship] = {}
+    function_call_validators: Mapping[str, FunctionCallValidator] = {}
+
+    def get_query_processors(self) -> Sequence[QueryProcessor]:
+        return self.query_processors
+
+    def get_data_model(self) -> EntityColumnSet:
+        return EntityColumnSet(self.columns)
+
+    def get_join_relationship(self, relationship: str) -> Optional[JoinRelationship]:
+        return self.join_relationships.get(relationship)
+
+    def get_all_join_relationships(self) -> Mapping[str, JoinRelationship]:
+        return self.join_relationships
+
+    def get_query_pipeline_builder(self) -> QueryPipelineBuilder[ClickhouseQueryPlan]:
+        return SimplePipelineBuilder(
+            query_plan_builder=SingleStorageQueryPlanBuilder(
+                storage=self.readable_storage, mappers=self.translation_mappers
+            )
+        )
+
+    def get_all_storages(self) -> Sequence[Storage]:
+        return (
+            [self.readable_storage]
+            if not self.writeable_storage
+            else [self.readable_storage, self.writeable_storage]
+        )
+
+    def get_function_call_validators(self) -> Mapping[str, FunctionCallValidator]:
+        return self.function_call_validators
+
+    def get_validators(self) -> Sequence[QueryValidator]:
+        return self.validators
+
+    def get_writable_storage(self) -> Optional[WritableTableStorage]:
+        return self.writeable_storage

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Mapping, Optional, Sequence
 
 from snuba.clickhouse.columns import Column
@@ -36,8 +36,10 @@ class PluggableEntity(Entity):
     validators: Sequence[QueryValidator]
     translation_mappers: TranslationMappers
     writeable_storage: Optional[WritableTableStorage] = None
-    join_relationships: Mapping[str, JoinRelationship] = {}
-    function_call_validators: Mapping[str, FunctionCallValidator] = {}
+    join_relationships: Mapping[str, JoinRelationship] = field(default_factory=dict)
+    function_call_validators: Mapping[str, FunctionCallValidator] = field(
+        default_factory=dict
+    )
 
     def get_query_processors(self) -> Sequence[QueryProcessor]:
         return self.query_processors

--- a/tests/datasets/entities/test_pluggable_entity.py
+++ b/tests/datasets/entities/test_pluggable_entity.py
@@ -1,0 +1,163 @@
+from datetime import datetime, timedelta
+from functools import partial
+from typing import MutableMapping
+
+import pytest
+import pytz
+
+from snuba.attribution import get_app_id
+from snuba.attribution.attribution_info import AttributionInfo
+from snuba.clickhouse.translators.snuba.mappers import (
+    FunctionNameMapper,
+    SubscriptableMapper,
+)
+from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
+from snuba.datasets.entities.generic_metrics import GenericMetricsSetsEntity
+from snuba.datasets.entities.metrics import TagsTypeTransformer
+from snuba.datasets.factory import get_dataset
+from snuba.datasets.pluggable_entity import PluggableEntity
+from snuba.datasets.storages.generic_metrics import sets_storage
+from snuba.query import Query
+from snuba.query.processors.granularity_processor import (
+    DEFAULT_MAPPED_GRANULARITY_ENUM,
+    PERFORMANCE_GRANULARITIES,
+    MappedGranularityProcessor,
+)
+from snuba.query.processors.object_id_rate_limiter import (
+    OrganizationRateLimiterProcessor,
+    ProjectRateLimiterProcessor,
+    ProjectReferrerRateLimiter,
+    ReferrerRateLimiterProcessor,
+)
+from snuba.query.processors.quota_processor import ResourceQuotaProcessor
+from snuba.query.processors.timeseries_processor import TimeSeriesProcessor
+from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
+from snuba.query.snql.parser import parse_snql_query
+from snuba.reader import Reader
+from snuba.request import Request
+from snuba.utils.schemas import AggregateFunction
+from snuba.utils.schemas import Column as SchemaColumn
+from snuba.utils.schemas import DateTime, Nested, UInt
+from snuba.web import QueryResult
+
+
+@pytest.fixture
+def start_time() -> datetime:
+    return (datetime.utcnow() - timedelta(days=1)).replace(
+        hour=12, minute=15, second=0, microsecond=0, tzinfo=pytz.utc
+    )
+
+
+@pytest.fixture
+def end_time(start_time: datetime) -> datetime:
+    return start_time + timedelta(minutes=10)
+
+
+def test_generic_metrics_sets_vs_pluggable_similar_behavior(
+    start_time: datetime, end_time: datetime
+) -> None:
+    query_body = {
+        "query": f"""
+            MATCH (generic_metrics_sets)
+            SELECT uniq(value) AS unique_values BY project_id, org_id
+            WHERE org_id = 1
+            AND project_id = 2
+            AND metric_id = 3
+            AND tags['a'] = 4
+            AND timestamp >= toDateTime('{start_time}')
+            AND timestamp < toDateTime('{end_time}')
+            GRANULARITY 60
+        """,
+        "dataset": "generic_metrics",
+    }
+
+    generic_metrics_dataset = get_dataset("generic_metrics")
+
+    query, snql_anonymized = parse_snql_query(
+        query_body["query"], generic_metrics_dataset
+    )
+
+    request = Request(
+        id="",
+        original_body=query_body,
+        query=query,
+        snql_anonymized=snql_anonymized,
+        query_settings=HTTPQuerySettings(referrer=""),
+        attribution_info=AttributionInfo(get_app_id("blah"), "blah", None, None, None),
+    )
+
+    sets_entity: GenericMetricsSetsEntity = GenericMetricsSetsEntity()
+    pluggable_sets_entity: PluggableEntity = PluggableEntity(
+        readable_storage=sets_storage,
+        query_processors=[
+            TagsTypeTransformer(),
+            MappedGranularityProcessor(
+                accepted_granularities=PERFORMANCE_GRANULARITIES,
+                default_granularity_enum=DEFAULT_MAPPED_GRANULARITY_ENUM,
+            ),
+            TimeSeriesProcessor({"bucketed_time": "timestamp"}, ("timestamp",)),
+            ReferrerRateLimiterProcessor(),
+            OrganizationRateLimiterProcessor(org_column="org_id"),
+            ProjectReferrerRateLimiter("project_id"),
+            ProjectRateLimiterProcessor(project_column="project_id"),
+            ResourceQuotaProcessor("project_id"),
+        ],
+        columns=[
+            SchemaColumn("org_id", UInt(64)),
+            SchemaColumn("project_id", UInt(64)),
+            SchemaColumn("metric_id", UInt(64)),
+            SchemaColumn("timestamp", DateTime()),
+            SchemaColumn("bucketed_time", DateTime()),
+            SchemaColumn("tags", Nested([("key", UInt(64)), ("value", UInt(64))])),
+            SchemaColumn("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        ],
+        translation_mappers=TranslationMappers(
+            subscriptables=[
+                SubscriptableMapper(
+                    from_column_table=None,
+                    from_column_name="tags_raw",
+                    to_nested_col_table=None,
+                    to_nested_col_name="tags",
+                    value_subcolumn_name="raw_value",
+                ),
+                SubscriptableMapper(
+                    from_column_table=None,
+                    from_column_name="tags",
+                    to_nested_col_table=None,
+                    to_nested_col_name="tags",
+                    value_subcolumn_name="indexed_value",
+                ),
+            ],
+            functions=[
+                FunctionNameMapper("uniq", "uniqCombined64Merge"),
+                FunctionNameMapper("uniqIf", "uniqCombined64MergeIf"),
+            ],
+        ),
+        validators=[],
+    )
+
+    RESULT_MAP: MutableMapping[str, Query] = {}
+
+    def query_runner(
+        query: Query, settings: QuerySettings, reader: Reader, output_name: str
+    ) -> QueryResult:
+        RESULT_MAP[output_name] = query
+        return QueryResult({}, {})
+
+    sets_entity.get_query_pipeline_builder().build_execution_pipeline(
+        request=request, runner=partial(query_runner, output_name="existing")
+    ).execute()
+
+    pluggable_sets_entity.get_query_pipeline_builder().build_execution_pipeline(
+        request=request, runner=partial(query_runner, output_name="pluggable")
+    ).execute()
+
+    assert (
+        RESULT_MAP["existing"].get_granularity()
+        == RESULT_MAP["pluggable"].get_granularity()
+    )
+
+    assert (
+        RESULT_MAP["existing"].get_selected_columns()
+        == RESULT_MAP["pluggable"].get_selected_columns()
+    )

--- a/tests/datasets/entities/test_pluggable_entity.py
+++ b/tests/datasets/entities/test_pluggable_entity.py
@@ -121,7 +121,7 @@ def build_request(query_body: Mapping[str, str]) -> Request:
     return request
 
 
-def test_generic_metrics_sets_vs_pluggable_similar_behavior(
+def test_generic_metrics_sets_vs_pluggable_similar_pipeline_behavior(
     start_time: datetime, end_time: datetime, pluggable_sets_entity: PluggableEntity
 ) -> None:
     query_body = {


### PR DESCRIPTION
The goal of this new class is to provide a less flexible version of Entity that will not be subclassed but will be instantiated based on contents of YAML config files.

Once this and https://github.com/getsentry/snuba/pull/3046 are merged, we can make some changes to dynamically populate entities from YAML that fit certain characteristics (single storage plan, a limited set of query processors/mappers/etc.)

This should look somewhat similar to https://github.com/getsentry/snuba/pull/3037/files when done though that's obviously not complete