### PR TITLE
ref(MDC): cleanup dataset factory, formalize factory pattern

### DIFF
--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -7,11 +7,11 @@ from snuba.utils.serializable_exception import SerializableException
 
 
 class _DatasetFactory(ConfigComponentFactory[Dataset, str]):
-    def __init__(self):
+    def __init__(self) -> None:
         self._dataset_map: MutableMapping[str, Dataset] = {}
         self._name_map: MutableMapping[Type[Dataset], str] = {}
 
-    def initialize(self):
+    def initialize(self) -> None:
         from snuba.datasets.cdc.groupassignee import GroupAssigneeDataset
         from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
         from snuba.datasets.discover import DiscoverDataset
@@ -75,7 +75,7 @@ class InvalidDatasetError(SerializableException):
 _DS_FACTORY = None
 
 
-def _ds_factory():
+def _ds_factory() -> _DatasetFactory:
     global _DS_FACTORY
     if _DS_FACTORY is None:
         _DS_FACTORY = _DatasetFactory()

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -1,93 +1,96 @@
-from typing import Callable, MutableMapping, Sequence, Set
+from typing import Generator, MutableMapping, Sequence, Type
 
-from snuba import settings
 from snuba.datasets.dataset import Dataset
 from snuba.util import with_span
+from snuba.utils.config_component_factory import ConfigComponentFactory
 from snuba.utils.serializable_exception import SerializableException
 
-DATASETS_IMPL: MutableMapping[str, Dataset] = {}
-DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
 
-DEV_DATASET_NAMES: Set[str] = set()
+class _DatasetFactory(ConfigComponentFactory[Dataset, str]):
+    def __init__(self):
+        self._dataset_map: MutableMapping[str, Dataset] = {}
+        self._name_map: MutableMapping[Type[Dataset], str] = {}
 
-DATASET_NAMES: Set[str] = {
-    "discover",
-    "events",
-    "groupassignee",
-    "groupedmessage",
-    "metrics",
-    "outcomes",
-    "outcomes_raw",
-    "sessions",
-    "transactions",
-    "profiles",
-    "functions",
-    "generic_metrics",
-    "replays",
-    *(DEV_DATASET_NAMES if settings.ENABLE_DEV_FEATURES else set()),
-}
+    def initialize(self):
+        from snuba.datasets.cdc.groupassignee import GroupAssigneeDataset
+        from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
+        from snuba.datasets.discover import DiscoverDataset
+        from snuba.datasets.events import EventsDataset
+        from snuba.datasets.functions import FunctionsDataset
+        from snuba.datasets.generic_metrics import GenericMetricsDataset
+        from snuba.datasets.metrics import MetricsDataset
+        from snuba.datasets.outcomes import OutcomesDataset
+        from snuba.datasets.outcomes_raw import OutcomesRawDataset
+        from snuba.datasets.profiles import ProfilesDataset
+        from snuba.datasets.replays import ReplaysDataset
+        from snuba.datasets.sessions import SessionsDataset
+        from snuba.datasets.transactions import TransactionsDataset
+
+        self._dataset_map.update(
+            {
+                "discover": DiscoverDataset(),
+                "events": EventsDataset(),
+                "groupassignee": GroupAssigneeDataset(),
+                "groupedmessage": GroupedMessageDataset(),
+                "metrics": MetricsDataset(),
+                "outcomes": OutcomesDataset(),
+                "outcomes_raw": OutcomesRawDataset(),
+                "sessions": SessionsDataset(),
+                "transactions": TransactionsDataset(),
+                "profiles": ProfilesDataset(),
+                "functions": FunctionsDataset(),
+                "generic_metrics": GenericMetricsDataset(),
+                "replays": ReplaysDataset(),
+            }
+        )
+        # TODO: load the yaml datasets here
+
+        self._name_map = {v.__class__: k for k, v in self._dataset_map.items()}
+
+    def iter_all(self) -> Generator[Dataset, None, None]:
+        for dset in self._dataset_map.values():
+            yield dset
+
+    def all_names(self) -> Sequence[str]:
+        return list(self._dataset_map.keys())
+
+    def get(self, name: str) -> Dataset:
+        try:
+            return self._dataset_map[name]
+        except KeyError as error:
+            raise InvalidDatasetError(f"dataset {name!r} does not exist") from error
+
+    def get_dataset_name(self, dataset: Dataset) -> str:
+        # TODO: THis is dumb, the name should just be a property on the dataset
+        try:
+            return self._name_map[dataset.__class__]
+        except KeyError as error:
+            raise InvalidDatasetError(f"dataset {dataset} has no name") from error
 
 
 class InvalidDatasetError(SerializableException):
     """Exception raised on invalid dataset access."""
 
 
+_DS_FACTORY = None
+
+
+def _ds_factory():
+    global _DS_FACTORY
+    if _DS_FACTORY is None:
+        _DS_FACTORY = _DatasetFactory()
+        _DS_FACTORY.initialize()
+    return _DS_FACTORY
+
+
 @with_span()
 def get_dataset(name: str) -> Dataset:
-    if name in DATASETS_IMPL:
-        return DATASETS_IMPL[name]
-
-    if name in settings.DISABLED_DATASETS:
-        raise InvalidDatasetError(f"dataset {name!r} is disabled in this environment")
-
-    if name not in DATASET_NAMES:
-        raise InvalidDatasetError(f"dataset {name!r} is not available")
-
-    from snuba.datasets.cdc.groupassignee import GroupAssigneeDataset
-    from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
-    from snuba.datasets.discover import DiscoverDataset
-    from snuba.datasets.events import EventsDataset
-    from snuba.datasets.functions import FunctionsDataset
-    from snuba.datasets.generic_metrics import GenericMetricsDataset
-    from snuba.datasets.metrics import MetricsDataset
-    from snuba.datasets.outcomes import OutcomesDataset
-    from snuba.datasets.outcomes_raw import OutcomesRawDataset
-    from snuba.datasets.profiles import ProfilesDataset
-    from snuba.datasets.replays import ReplaysDataset
-    from snuba.datasets.sessions import SessionsDataset
-    from snuba.datasets.transactions import TransactionsDataset
-
-    dataset_factories: MutableMapping[str, Callable[[], Dataset]] = {
-        "discover": DiscoverDataset,
-        "events": EventsDataset,
-        "groupassignee": GroupAssigneeDataset,
-        "groupedmessage": GroupedMessageDataset,
-        "metrics": MetricsDataset,
-        "outcomes": OutcomesDataset,
-        "outcomes_raw": OutcomesRawDataset,
-        "sessions": SessionsDataset,
-        "transactions": TransactionsDataset,
-        "profiles": ProfilesDataset,
-        "functions": FunctionsDataset,
-        "generic_metrics": GenericMetricsDataset,
-        "replays": ReplaysDataset,
-    }
-
-    try:
-        dataset = DATASETS_IMPL[name] = dataset_factories[name]()
-        DATASETS_NAME_LOOKUP[dataset] = name
-    except KeyError as error:
-        raise InvalidDatasetError(f"dataset {name!r} does not exist") from error
-
-    return dataset
+    return _ds_factory().get(name)
 
 
 def get_dataset_name(dataset: Dataset) -> str:
-    try:
-        return DATASETS_NAME_LOOKUP[dataset]
-    except KeyError as error:
-        raise InvalidDatasetError("Dataset name not specified") from error
+    return _ds_factory().get_dataset_name(dataset)
 
 
 def get_enabled_dataset_names() -> Sequence[str]:
-    return [name for name in DATASET_NAMES if name not in settings.DISABLED_DATASETS]
+    return _ds_factory().all_names()

--- a/snuba/utils/config_component_factory.py
+++ b/snuba/utils/config_component_factory.py
@@ -5,7 +5,7 @@ KeyType = TypeVar("KeyType")
 
 
 class ConfigComponentFactory(Generic[T, KeyType]):
-    def initialize(self, **kwargs) -> None:
+    def initialize(self) -> None:
         raise NotImplementedError
 
     def iter_all(self) -> Generator[T, None, None]:

--- a/snuba/utils/config_component_factory.py
+++ b/snuba/utils/config_component_factory.py
@@ -1,0 +1,15 @@
+from typing import Generator, Generic, TypeVar
+
+T = TypeVar("T")
+KeyType = TypeVar("KeyType")
+
+
+class ConfigComponentFactory(Generic[T, KeyType]):
+    def initialize(self, **kwargs) -> None:
+        raise NotImplementedError
+
+    def iter_all(self) -> Generator[T, None, None]:
+        raise NotImplementedError
+
+    def get(self, name: KeyType) -> T:
+        raise NotImplementedError

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -244,7 +244,7 @@ def test_convert_SnQL_to_SQL_invalid_dataset(admin_api: FlaskClient) -> None:
     )
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["error"]["message"] == "dataset '' is not available"
+    assert data["error"]["message"] == "dataset '' does not exist"
 
 
 def test_convert_SnQL_to_SQL_invalid_query(admin_api: FlaskClient) -> None:

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -1,5 +1,9 @@
+import pytest
+
+from snuba import settings
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.factory import (
+    InvalidDatasetError,
     get_dataset,
     get_dataset_name,
     get_enabled_dataset_names,
@@ -25,6 +29,20 @@ def test_get_dataset():
         factory_ds = get_dataset(ds_name)
         assert isinstance(factory_ds, Dataset)
         assert get_dataset_name(factory_ds) == ds_name
+
+
+@pytest.fixture(scope="function")
+def disable_datasets():
+    og_disabled = settings.DISABLED_DATASETS
+    settings.DISABLED_DATASETS = ["events"]
+    yield
+    settings.DISABLED_DATASETS = og_disabled
+
+
+def test_disabled(disable_datasets):
+    assert "events" not in get_enabled_dataset_names()
+    with pytest.raises(InvalidDatasetError):
+        get_dataset("events")
 
 
 def test_all_names():

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -1,0 +1,47 @@
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.factory import (
+    get_dataset,
+    get_dataset_name,
+    get_enabled_dataset_names,
+)
+
+
+def test_get_dataset():
+    for ds_name in [
+        "discover",
+        "events",
+        "groupassignee",
+        "groupedmessage",
+        "metrics",
+        "outcomes",
+        "outcomes_raw",
+        "sessions",
+        "transactions",
+        "profiles",
+        "functions",
+        "generic_metrics",
+        "replays",
+    ]:
+        factory_ds = get_dataset(ds_name)
+        assert isinstance(factory_ds, Dataset)
+        assert get_dataset_name(factory_ds) == ds_name
+
+
+def test_all_names():
+    assert set(get_enabled_dataset_names()) == set(
+        [
+            "discover",
+            "events",
+            "groupassignee",
+            "groupedmessage",
+            "metrics",
+            "outcomes",
+            "outcomes_raw",
+            "sessions",
+            "transactions",
+            "profiles",
+            "functions",
+            "generic_metrics",
+            "replays",
+        ]
+    )


### PR DESCRIPTION
YAML datasets and python datasets will need to coexist for some time in production. 
The factory functions are the gateway to accessing datasets.

In order to make the transition easier, a few things were refactored in the dataset factory:

1. One container for all global state in the factory (down from four)
2. Only one list of dataset names maintained
3. remove complicated mapping/caching logic
4. Remove unused `DISABLED_DATASETS` feature


This PR also introduces the ConfigComponentFactory class that I would like to use for all other ConfigComponents (Datasets, Entities, Storages, QueryProcessors) to make the loading and merging of ConfigComponents have a uniform, predictable interface.