### PR TITLE
ref(MDC): cleanup dataset factory, formalize factory pattern [updated]

### DIFF
--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -1,93 +1,106 @@
-from typing import Callable, MutableMapping, Sequence, Set
+from typing import Generator, MutableMapping, Sequence, Type
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
 from snuba.util import with_span
+from snuba.utils.config_component_factory import ConfigComponentFactory
 from snuba.utils.serializable_exception import SerializableException
 
-DATASETS_IMPL: MutableMapping[str, Dataset] = {}
-DATASETS_NAME_LOOKUP: MutableMapping[Dataset, str] = {}
 
-DEV_DATASET_NAMES: Set[str] = set()
+class _DatasetFactory(ConfigComponentFactory[Dataset, str]):
+    def __init__(self) -> None:
+        self._dataset_map: MutableMapping[str, Dataset] = {}
+        self._name_map: MutableMapping[Type[Dataset], str] = {}
+        self.__initialize()
 
-DATASET_NAMES: Set[str] = {
-    "discover",
-    "events",
-    "groupassignee",
-    "groupedmessage",
-    "metrics",
-    "outcomes",
-    "outcomes_raw",
-    "sessions",
-    "transactions",
-    "profiles",
-    "functions",
-    "generic_metrics",
-    "replays",
-    *(DEV_DATASET_NAMES if settings.ENABLE_DEV_FEATURES else set()),
-}
+    def __initialize(self) -> None:
+        from snuba.datasets.cdc.groupassignee import GroupAssigneeDataset
+        from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
+        from snuba.datasets.discover import DiscoverDataset
+        from snuba.datasets.events import EventsDataset
+        from snuba.datasets.functions import FunctionsDataset
+        from snuba.datasets.generic_metrics import GenericMetricsDataset
+        from snuba.datasets.metrics import MetricsDataset
+        from snuba.datasets.outcomes import OutcomesDataset
+        from snuba.datasets.outcomes_raw import OutcomesRawDataset
+        from snuba.datasets.profiles import ProfilesDataset
+        from snuba.datasets.replays import ReplaysDataset
+        from snuba.datasets.sessions import SessionsDataset
+        from snuba.datasets.transactions import TransactionsDataset
+
+        self._dataset_map.update(
+            {
+                "discover": DiscoverDataset(),
+                "events": EventsDataset(),
+                "groupassignee": GroupAssigneeDataset(),
+                "groupedmessage": GroupedMessageDataset(),
+                "metrics": MetricsDataset(),
+                "outcomes": OutcomesDataset(),
+                "outcomes_raw": OutcomesRawDataset(),
+                "sessions": SessionsDataset(),
+                "transactions": TransactionsDataset(),
+                "profiles": ProfilesDataset(),
+                "functions": FunctionsDataset(),
+                "generic_metrics": GenericMetricsDataset(),
+                "replays": ReplaysDataset(),
+            }
+        )
+        # TODO: load the yaml datasets here
+
+        self._name_map = {v.__class__: k for k, v in self._dataset_map.items()}
+
+    def iter_all(self) -> Generator[Dataset, None, None]:
+        for dset in self._dataset_map.values():
+            yield dset
+
+    def all_names(self) -> Sequence[str]:
+        return [
+            name
+            for name in self._dataset_map.keys()
+            if name not in settings.DISABLED_DATASETS
+        ]
+
+    def get(self, name: str) -> Dataset:
+        if name in settings.DISABLED_DATASETS:
+            raise InvalidDatasetError(
+                f"dataset {name!r} is disabled in this environment"
+            )
+        try:
+            return self._dataset_map[name]
+        except KeyError as error:
+            raise InvalidDatasetError(f"dataset {name!r} does not exist") from error
+
+    def get_dataset_name(self, dataset: Dataset) -> str:
+        # TODO: This is dumb, the name should just be a property on the dataset
+        try:
+            return self._name_map[dataset.__class__]
+        except KeyError as error:
+            raise InvalidDatasetError(f"dataset {dataset} has no name") from error
 
 
 class InvalidDatasetError(SerializableException):
     """Exception raised on invalid dataset access."""
 
 
+_DS_FACTORY = None
+
+
+def _ds_factory() -> _DatasetFactory:
+    # This function can be acessed by many threads at once. It is okay if more than one thread recreates the same object.
+    global _DS_FACTORY
+    if _DS_FACTORY is None:
+        _DS_FACTORY = _DatasetFactory()
+    return _DS_FACTORY
+
+
 @with_span()
 def get_dataset(name: str) -> Dataset:
-    if name in DATASETS_IMPL:
-        return DATASETS_IMPL[name]
-
-    if name in settings.DISABLED_DATASETS:
-        raise InvalidDatasetError(f"dataset {name!r} is disabled in this environment")
-
-    if name not in DATASET_NAMES:
-        raise InvalidDatasetError(f"dataset {name!r} is not available")
-
-    from snuba.datasets.cdc.groupassignee import GroupAssigneeDataset
-    from snuba.datasets.cdc.groupedmessage import GroupedMessageDataset
-    from snuba.datasets.discover import DiscoverDataset
-    from snuba.datasets.events import EventsDataset
-    from snuba.datasets.functions import FunctionsDataset
-    from snuba.datasets.generic_metrics import GenericMetricsDataset
-    from snuba.datasets.metrics import MetricsDataset
-    from snuba.datasets.outcomes import OutcomesDataset
-    from snuba.datasets.outcomes_raw import OutcomesRawDataset
-    from snuba.datasets.profiles import ProfilesDataset
-    from snuba.datasets.replays import ReplaysDataset
-    from snuba.datasets.sessions import SessionsDataset
-    from snuba.datasets.transactions import TransactionsDataset
-
-    dataset_factories: MutableMapping[str, Callable[[], Dataset]] = {
-        "discover": DiscoverDataset,
-        "events": EventsDataset,
-        "groupassignee": GroupAssigneeDataset,
-        "groupedmessage": GroupedMessageDataset,
-        "metrics": MetricsDataset,
-        "outcomes": OutcomesDataset,
-        "outcomes_raw": OutcomesRawDataset,
-        "sessions": SessionsDataset,
-        "transactions": TransactionsDataset,
-        "profiles": ProfilesDataset,
-        "functions": FunctionsDataset,
-        "generic_metrics": GenericMetricsDataset,
-        "replays": ReplaysDataset,
-    }
-
-    try:
-        dataset = DATASETS_IMPL[name] = dataset_factories[name]()
-        DATASETS_NAME_LOOKUP[dataset] = name
-    except KeyError as error:
-        raise InvalidDatasetError(f"dataset {name!r} does not exist") from error
-
-    return dataset
+    return _ds_factory().get(name)
 
 
 def get_dataset_name(dataset: Dataset) -> str:
-    try:
-        return DATASETS_NAME_LOOKUP[dataset]
-    except KeyError as error:
-        raise InvalidDatasetError("Dataset name not specified") from error
+    return _ds_factory().get_dataset_name(dataset)
 
 
 def get_enabled_dataset_names() -> Sequence[str]:
-    return [name for name in DATASET_NAMES if name not in settings.DISABLED_DATASETS]
+    return _ds_factory().all_names()

--- a/snuba/utils/config_component_factory.py
+++ b/snuba/utils/config_component_factory.py
@@ -1,0 +1,12 @@
+from typing import Generator, Generic, TypeVar
+
+T = TypeVar("T")
+KeyType = TypeVar("KeyType")
+
+
+class ConfigComponentFactory(Generic[T, KeyType]):
+    def iter_all(self) -> Generator[T, None, None]:
+        raise NotImplementedError
+
+    def get(self, name: KeyType) -> T:
+        raise NotImplementedError

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -244,7 +244,7 @@ def test_convert_SnQL_to_SQL_invalid_dataset(admin_api: FlaskClient) -> None:
     )
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["error"]["message"] == "dataset '' is not available"
+    assert data["error"]["message"] == "dataset '' does not exist"
 
 
 def test_convert_SnQL_to_SQL_invalid_query(admin_api: FlaskClient) -> None:

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -1,0 +1,101 @@
+import threading
+from typing import Any, Iterator
+
+import pytest
+
+from snuba import settings
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.factory import (
+    InvalidDatasetError,
+    get_dataset,
+    get_dataset_name,
+    get_enabled_dataset_names,
+)
+
+
+def test_get_dataset() -> None:
+    for ds_name in [
+        "discover",
+        "events",
+        "groupassignee",
+        "groupedmessage",
+        "metrics",
+        "outcomes",
+        "outcomes_raw",
+        "sessions",
+        "transactions",
+        "profiles",
+        "functions",
+        "generic_metrics",
+        "replays",
+    ]:
+        factory_ds = get_dataset(ds_name)
+        assert isinstance(factory_ds, Dataset)
+        assert get_dataset_name(factory_ds) == ds_name
+
+
+def test_get_dataset_multithreaded_collision() -> None:
+    class GetDatasetThread(threading.Thread):
+        def test_get_dataset_threaded(self) -> None:
+            ds_name = "events"
+            factory_ds = get_dataset(ds_name)
+            assert isinstance(factory_ds, Dataset)
+            assert get_dataset_name(factory_ds) == ds_name
+
+        def run(self) -> None:
+            self.exception = None
+            try:
+                self.test_get_dataset_threaded()
+            except Exception as e:
+                self.exception = e
+
+        def join(self, *args: Any, **kwargs: Any) -> None:
+            threading.Thread.join(self)
+            if self.exception:
+                raise self.exception
+
+    threads = []
+    for _ in range(10):
+        thread = GetDatasetThread()
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        try:
+            thread.join()
+        except Exception as error:
+            raise error
+
+
+@pytest.fixture(scope="function")
+def disable_datasets() -> Iterator[None]:
+    og_disabled = settings.DISABLED_DATASETS
+    settings.DISABLED_DATASETS = set(["events"])
+    yield
+    settings.DISABLED_DATASETS = og_disabled
+
+
+def test_disabled(disable_datasets: Iterator[None]) -> None:
+    assert "events" not in get_enabled_dataset_names()
+    with pytest.raises(InvalidDatasetError):
+        get_dataset("events")
+
+
+def test_all_names() -> None:
+    assert set(get_enabled_dataset_names()) == set(
+        [
+            "discover",
+            "events",
+            "groupassignee",
+            "groupedmessage",
+            "metrics",
+            "outcomes",
+            "outcomes_raw",
+            "sessions",
+            "transactions",
+            "profiles",
+            "functions",
+            "generic_metrics",
+            "replays",
+        ]
+    )


### PR DESCRIPTION
See the original reverted PR here: https://github.com/getsentry/snuba/commit/46566686b32be90f1d95ce1eed633e70cdbcf5ab

@volokluev initial hypothesis of multiple threads accessing incomplete states of the dataset factory map was tested and verified. This PR includes an additional change for moving the initialization of the dataset mapping to the constructor of _DatasetFactory. This ensures the dataset factory object either contains the full map or is None. Test was added accordingly
