### PR TITLE
feat(transactions): Add group_ids column to transactions

### DIFF
--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -100,6 +100,7 @@ columns = ColumnSet(
         ("title", String(Modifiers(readonly=True))),
         ("transaction_source", String()),
         ("timestamp", DateTime(Modifiers(readonly=True))),
+        ("group_ids", Array(UUID())),
     ]
 )
 

--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -100,7 +100,7 @@ columns = ColumnSet(
         ("title", String(Modifiers(readonly=True))),
         ("transaction_source", String()),
         ("timestamp", DateTime(Modifiers(readonly=True))),
-        ("group_ids", Array(UUID())),
+        ("group_ids", Array(UInt(64))),
     ]
 )
 

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -127,6 +127,7 @@ class TransactionsLoader(DirectoryLoader):
             "0013_transactions_reduce_spans_exclusive_time",
             "0014_transactions_remove_flattened_columns",
             "0015_transactions_add_source_column",
+            "0016_transactions_add_group_ids_column",
         ]
 
 

--- a/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
@@ -1,40 +1,8 @@
-from typing import List, Sequence, Tuple
+from typing import Sequence
 
 from snuba.clickhouse.columns import Array, Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
-from snuba.migrations.columns import MigrationModifiers as Modifiers
-
-new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
-    (Column("group_ids", Array(UInt(64))), "timestamp"),
-    (
-        Column(
-            "_group_ids_hashed",
-            Array(
-                UInt(64),
-                Modifiers(materialized="arrayMap(t -> cityHash64(t), group_ids)"),
-            ),
-        ),
-        "group_ids",
-    ),
-]
-
-new_indexes: List[operations.SqlOperation] = [
-    operations.AddIndex(
-        storage_set=StorageSetKey.TRANSACTIONS,
-        table_name="transactions_local",
-        index_name="bf_group_ids_hashed",
-        index_expression="_group_ids_hashed",
-        index_type="bloom_filter()",
-        granularity=1,
-    )
-]
-
-drop_indexes: List[operations.SqlOperation] = [
-    operations.DropIndex(
-        StorageSetKey.TRANSACTIONS, "transactions_local", "bf_group_ids_hashed"
-    )
-]
 
 
 class Migration(migration.ClickhouseNodeMigration):
@@ -45,42 +13,33 @@ class Migration(migration.ClickhouseNodeMigration):
 
     blocking = False
 
-    def forwards_local(self) -> Sequence[operations.SqlOperation]:
-        new_column_ops: List[operations.SqlOperation] = [
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
             operations.AddColumn(
                 storage_set=StorageSetKey.TRANSACTIONS,
-                table_name="transactions_local",
-                column=column,
-                after=after,
+                table_name=table_name,
+                column=Column("group_ids", Array(UInt(64))),
+                after="timestamp",
             )
-            for column, after in new_columns
         ]
-        return new_column_ops + new_indexes
+
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(StorageSetKey.TRANSACTIONS, table_name, "group_ids")
+        ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("transactions_local")
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
-        drop_column_ops: List[operations.SqlOperation] = [
-            operations.DropColumn(
-                StorageSetKey.TRANSACTIONS, "transactions_local", column.name
-            )
-            for column, _ in reversed(new_columns)
-        ]
-        return drop_indexes + drop_column_ops
+        return self.__backwards_migrations("transactions_local")
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return [
-            operations.AddColumn(
-                storage_set=StorageSetKey.TRANSACTIONS,
-                table_name="transactions_dist",
-                column=column,
-                after=after,
-            )
-            for column, after in new_columns
-        ]
+        return self.__forward_migrations("transactions_dist")
 
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return [
-            operations.DropColumn(
-                StorageSetKey.TRANSACTIONS, "transactions_dist", column.name
-            )
-            for column, _ in reversed(new_columns)
-        ]
+        return self.__backwards_migrations("transactions_dist")

--- a/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
@@ -1,0 +1,86 @@
+from typing import Sequence, Tuple, List
+
+from snuba.clickhouse.columns import Column, UUID, Array, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
+    (Column("group_ids", Array(UUID())), "timestamp"),
+    (
+        Column(
+            "_group_ids_hashed",
+            Array(
+                UInt(64),
+                Modifiers(materialized="arrayMap(t -> cityHash64(t), group_ids)"),
+            ),
+        ),
+        "group_ids",
+    ),
+]
+
+new_indexes: List[operations.SqlOperation] = [
+    operations.AddIndex(
+        storage_set=StorageSetKey.TRANSACTIONS,
+        table_name="transactions_local",
+        index_name="bf_group_ids_hashed",
+        index_expression="_group_ids_hashed",
+        index_type="bloom_filter()",
+        granularity=1,
+    )
+]
+
+drop_indexes: List[operations.SqlOperation] = [
+    operations.DropIndex(
+        StorageSetKey.TRANSACTIONS, "transactions_local", "bf_group_ids_hashed"
+    )
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    The group ids column is required to query for transaction events
+    with the same performance issue.
+    """
+
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        new_column_ops: List[operations.SqlOperation] = [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_local",
+                column=column,
+                after=after,
+            )
+            for column, after in new_columns
+        ]
+        return new_column_ops + new_indexes
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        drop_column_ops: List[operations.SqlOperation] = [
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, "transactions_local", column.name
+            )
+            for column, _ in reversed(new_columns)
+        ]
+        return drop_indexes + drop_column_ops
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name="transactions_dist",
+                column=column,
+                after=after,
+            )
+            for column, after in new_columns
+        ]
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.TRANSACTIONS, "transactions_dist", column.name
+            )
+            for column, _ in reversed(new_columns)
+        ]

--- a/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
@@ -1,6 +1,6 @@
-from typing import Sequence, Tuple, List
+from typing import List, Sequence, Tuple
 
-from snuba.clickhouse.columns import Column, UUID, Array, UInt
+from snuba.clickhouse.columns import UUID, Array, Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
@@ -1,6 +1,6 @@
 from typing import List, Sequence, Tuple
 
-from snuba.clickhouse.columns import UUID, Array, Column, UInt
+from snuba.clickhouse.columns import Array, Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers

--- a/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
+++ b/snuba/migrations/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
-    (Column("group_ids", Array(UUID())), "timestamp"),
+    (Column("group_ids", Array(UInt(64))), "timestamp"),
     (
         Column(
             "_group_ids_hashed",


### PR DESCRIPTION
To link transactions to their associated groups, this PR adds a new array column to transactions table. `group_ids` would contain at most 10 group ids.
I will follow up with changes to the transactions processor once the column is in prod.

Fixes WOR-2086