### PR TITLE
ref(MDC): Create Entity Factory Pattern

### DIFF
--- a/bin/mocks/mock-subscriptions
+++ b/bin/mocks/mock-subscriptions
@@ -3,7 +3,7 @@ import argparse
 import random
 from datetime import timedelta
 
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
+from snuba.datasets.entities.factory import get_entity_name
 from snuba.datasets.factory import get_dataset
 from snuba.redis import redis_client
 from snuba.subscriptions.data import PartitionId, SubscriptionData
@@ -36,7 +36,7 @@ parsed = parser.parse_args()
 dataset_name = parsed.dataset
 dataset = get_dataset(dataset_name)
 entity = dataset.get_default_entity()
-entity_key = ENTITY_NAME_LOOKUP[entity]
+entity_key = get_entity_name(entity)
 storage = entity.get_writable_storage()
 assert storage is not None
 stream_loader = storage.get_table_writer().get_stream_loader()

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -1,83 +1,118 @@
-from typing import Callable, MutableMapping
-
-from snuba import settings
+from typing import Generator, MutableMapping, Sequence, Type
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
 from snuba.datasets.table_storage import TableWriter
+from snuba.utils.config_component_factory import ConfigComponentFactory
 from snuba.utils.serializable_exception import SerializableException
+
+
+class _EntityFactory(ConfigComponentFactory[Entity, EntityKey]):
+    def __init__(self) -> None:
+        self._entity_map: MutableMapping[EntityKey, Entity] = {}
+        self._name_map: MutableMapping[Type[Entity], EntityKey] = {}
+        self.__initialize()
+
+    def __initialize(self) -> None:
+        from snuba.datasets.cdc.groupassignee_entity import GroupAssigneeEntity
+        from snuba.datasets.cdc.groupedmessage_entity import GroupedMessageEntity
+        from snuba.datasets.entities.discover import (
+            DiscoverEntity,
+            DiscoverEventsEntity,
+            DiscoverTransactionsEntity,
+        )
+        from snuba.datasets.entities.events import EventsEntity
+        from snuba.datasets.entities.functions import FunctionsEntity
+        from snuba.datasets.entities.generic_metrics import (
+            GenericMetricsDistributionsEntity,
+            GenericMetricsSetsEntity,
+        )
+        from snuba.datasets.entities.metrics import (
+            MetricsCountersEntity,
+            MetricsDistributionsEntity,
+            MetricsSetsEntity,
+            OrgMetricsCountersEntity,
+        )
+        from snuba.datasets.entities.outcomes import OutcomesEntity
+        from snuba.datasets.entities.outcomes_raw import OutcomesRawEntity
+        from snuba.datasets.entities.profiles import ProfilesEntity
+        from snuba.datasets.entities.replays import ReplaysEntity
+        from snuba.datasets.entities.sessions import OrgSessionsEntity, SessionsEntity
+        from snuba.datasets.entities.transactions import TransactionsEntity
+
+        self._entity_map.update(
+            {
+                EntityKey.DISCOVER: DiscoverEntity(),
+                EntityKey.EVENTS: EventsEntity(),
+                EntityKey.GROUPASSIGNEE: GroupAssigneeEntity(),
+                EntityKey.GROUPEDMESSAGES: GroupedMessageEntity(),
+                EntityKey.OUTCOMES: OutcomesEntity(),
+                EntityKey.OUTCOMES_RAW: OutcomesRawEntity(),
+                EntityKey.SESSIONS: SessionsEntity(),
+                EntityKey.ORG_SESSIONS: OrgSessionsEntity(),
+                EntityKey.TRANSACTIONS: TransactionsEntity(),
+                EntityKey.DISCOVER_TRANSACTIONS: DiscoverTransactionsEntity(),
+                EntityKey.DISCOVER_EVENTS: DiscoverEventsEntity(),
+                EntityKey.METRICS_SETS: MetricsSetsEntity(),
+                EntityKey.METRICS_COUNTERS: MetricsCountersEntity(),
+                EntityKey.ORG_METRICS_COUNTERS: OrgMetricsCountersEntity(),
+                EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity(),
+                EntityKey.PROFILES: ProfilesEntity(),
+                EntityKey.FUNCTIONS: FunctionsEntity(),
+                EntityKey.REPLAYS: ReplaysEntity(),
+                EntityKey.GENERIC_METRICS_SETS: GenericMetricsSetsEntity(),
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS: GenericMetricsDistributionsEntity(),
+            }
+        )
+
+        # TODO: load the yaml entities here
+
+        self._name_map = {v.__class__: k for k, v in self._entity_map.items()}
+
+    def iter_all(self) -> Generator[Entity, None, None]:
+        for ent in self._entity_map.values():
+            yield ent
+
+    def all_names(self) -> Sequence[EntityKey]:
+        return [name for name in self._entity_map.keys()]
+
+    def get(self, name: EntityKey) -> Entity:
+        try:
+            return self._entity_map[name]
+        except KeyError as error:
+            raise InvalidEntityError(f"entity {name!r} does not exist") from error
+
+    def get_entity_name(self, entity: Entity) -> EntityKey:
+        # TODO: This is dumb, the name should just be a property on the entity
+        try:
+            return self._name_map[entity.__class__]
+        except KeyError as error:
+            raise InvalidEntityError(f"entity {entity} has no name") from error
 
 
 class InvalidEntityError(SerializableException):
     """Exception raised on invalid entity access."""
 
 
-ENTITY_IMPL: MutableMapping[EntityKey, Entity] = {}
-ENTITY_NAME_LOOKUP: MutableMapping[Entity, EntityKey] = {}
+_ENT_FACTORY = None
+
+
+def _ent_factory() -> _EntityFactory:
+    global _ENT_FACTORY
+    if _ENT_FACTORY is None:
+        _ENT_FACTORY = _EntityFactory()
+    return _ENT_FACTORY
 
 
 def get_entity(name: EntityKey) -> Entity:
-    if name in ENTITY_IMPL:
-        return ENTITY_IMPL[name]
+    return _ent_factory().get(name)
 
-    from snuba.datasets.cdc.groupassignee_entity import GroupAssigneeEntity
-    from snuba.datasets.cdc.groupedmessage_entity import GroupedMessageEntity
-    from snuba.datasets.entities.discover import (
-        DiscoverEntity,
-        DiscoverEventsEntity,
-        DiscoverTransactionsEntity,
-    )
-    from snuba.datasets.entities.events import EventsEntity
-    from snuba.datasets.entities.functions import FunctionsEntity
-    from snuba.datasets.entities.generic_metrics import (
-        GenericMetricsDistributionsEntity,
-        GenericMetricsSetsEntity,
-    )
-    from snuba.datasets.entities.metrics import (
-        MetricsCountersEntity,
-        MetricsDistributionsEntity,
-        MetricsSetsEntity,
-        OrgMetricsCountersEntity,
-    )
-    from snuba.datasets.entities.outcomes import OutcomesEntity
-    from snuba.datasets.entities.outcomes_raw import OutcomesRawEntity
-    from snuba.datasets.entities.profiles import ProfilesEntity
-    from snuba.datasets.entities.replays import ReplaysEntity
-    from snuba.datasets.entities.sessions import OrgSessionsEntity, SessionsEntity
-    from snuba.datasets.entities.transactions import TransactionsEntity
 
-    dev_entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {}
+def get_entity_name(entity: Entity) -> EntityKey:
+    return _ent_factory().get_entity_name(entity)
 
-    entity_factories: MutableMapping[EntityKey, Callable[[], Entity]] = {
-        EntityKey.DISCOVER: DiscoverEntity,
-        EntityKey.EVENTS: EventsEntity,
-        EntityKey.GROUPASSIGNEE: GroupAssigneeEntity,
-        EntityKey.GROUPEDMESSAGES: GroupedMessageEntity,
-        EntityKey.OUTCOMES: OutcomesEntity,
-        EntityKey.OUTCOMES_RAW: OutcomesRawEntity,
-        EntityKey.SESSIONS: SessionsEntity,
-        EntityKey.ORG_SESSIONS: OrgSessionsEntity,
-        EntityKey.TRANSACTIONS: TransactionsEntity,
-        EntityKey.DISCOVER_TRANSACTIONS: DiscoverTransactionsEntity,
-        EntityKey.DISCOVER_EVENTS: DiscoverEventsEntity,
-        EntityKey.METRICS_SETS: MetricsSetsEntity,
-        EntityKey.METRICS_COUNTERS: MetricsCountersEntity,
-        EntityKey.ORG_METRICS_COUNTERS: OrgMetricsCountersEntity,
-        EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
-        EntityKey.PROFILES: ProfilesEntity,
-        EntityKey.FUNCTIONS: FunctionsEntity,
-        EntityKey.REPLAYS: ReplaysEntity,
-        EntityKey.GENERIC_METRICS_SETS: GenericMetricsSetsEntity,
-        EntityKey.GENERIC_METRICS_DISTRIBUTIONS: GenericMetricsDistributionsEntity,
-        **(dev_entity_factories if settings.ENABLE_DEV_FEATURES else {}),
-    }
 
-    try:
-        entity = ENTITY_IMPL[name] = entity_factories[name]()
-        ENTITY_NAME_LOOKUP[entity] = name
-    except KeyError as error:
-        raise InvalidEntityError(f"entity {name!r} does not exist") from error
-
-    return entity
+def get_all_entity_names() -> Sequence[EntityKey]:
+    return _ent_factory().all_names()
 
 
 def enforce_table_writer(entity: Entity) -> TableWriter:
@@ -85,5 +120,15 @@ def enforce_table_writer(entity: Entity) -> TableWriter:
 
     assert (
         writable_storage is not None
-    ), f"Entity {ENTITY_NAME_LOOKUP[entity]} does not have a writable storage."
+    ), f"Entity {_ent_factory().get_entity_name(entity)} does not have a writable storage."
     return writable_storage.get_table_writer()
+
+
+def reset_entity_factory() -> None:
+    global _ENT_FACTORY
+    _ENT_FACTORY = _EntityFactory()
+
+
+# Used by test cases to store FakeEntity. The reset_entity_factory() should be used after override.
+def override_entity_map(name: EntityKey, entity: Entity) -> None:
+    _ent_factory()._entity_map[name] = entity

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -1,4 +1,5 @@
 from typing import Generator, MutableMapping, Sequence, Type
+
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
 from snuba.datasets.table_storage import TableWriter

--- a/snuba/datasets/factory.py
+++ b/snuba/datasets/factory.py
@@ -104,3 +104,8 @@ def get_dataset_name(dataset: Dataset) -> str:
 
 def get_enabled_dataset_names() -> Sequence[str]:
     return _ds_factory().all_names()
+
+
+def reset_dataset_factory() -> None:
+    global _DS_FACTORY
+    _DS_FACTORY = _DatasetFactory()

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -21,7 +21,7 @@ from snuba import state
 from snuba.consumers.utils import get_partition_count
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
+from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.reader import Result
@@ -86,7 +86,7 @@ def build_executor_consumer(
     # Validate that a valid dataset/entity pair was passed in
     dataset = get_dataset(dataset_name)
     dataset_entity_names = [
-        ENTITY_NAME_LOOKUP[e].value for e in dataset.get_all_entities()
+        get_entity_name(e).value for e in dataset.get_all_entities()
     ]
 
     # Only entities in the same dataset with the same scheduled and result topics

--- a/snuba/web/converters.py
+++ b/snuba/web/converters.py
@@ -2,7 +2,7 @@ from werkzeug.routing import BaseConverter
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
+from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.entity import Entity
 from snuba.datasets.factory import get_dataset, get_dataset_name
 
@@ -20,4 +20,4 @@ class EntityConverter(BaseConverter):
         return get_entity(EntityKey(value))
 
     def to_url(self, value: Entity) -> str:
-        return ENTITY_NAME_LOOKUP[value].value
+        return get_entity_name(value).value

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -40,7 +40,7 @@ from snuba.clickhouse.http import JSONRowEncoder
 from snuba.clusters.cluster import ClickhouseClientSettings, ConnectionId
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
+from snuba.datasets.entities.factory import get_entity_name
 from snuba.datasets.entity import Entity
 from snuba.datasets.factory import (
     InvalidDatasetError,
@@ -530,7 +530,7 @@ def create_subscription(*, dataset: Dataset, timer: Timer, entity: Entity) -> Re
         raise InvalidSubscriptionError(
             "Invalid subscription dataset and entity combination"
         )
-    entity_key = ENTITY_NAME_LOOKUP[entity]
+    entity_key = get_entity_name(entity)
     subscription = SubscriptionDataCodec(entity_key).decode(http_request.data)
     identifier = SubscriptionCreator(dataset, entity_key).create(subscription, timer)
 
@@ -553,7 +553,7 @@ def delete_subscription(
         raise InvalidSubscriptionError(
             "Invalid subscription dataset and entity combination"
         )
-    entity_key = ENTITY_NAME_LOOKUP[entity]
+    entity_key = get_entity_name(entity)
     SubscriptionDeleter(entity_key, PartitionId(partition)).delete(UUID(key))
     metrics.increment("subscription_deleted", tags={"entity": entity_key.value})
 

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -13,7 +13,6 @@ from snuba.datasets.factory import (
 )
 
 
-# This test should be the first to ensure dataset factory module is has fresh set of objects
 def test_get_dataset_multithreaded_collision() -> None:
     class GetDatasetThread(threading.Thread):
         def test_get_dataset_threaded(self) -> None:
@@ -35,7 +34,7 @@ def test_get_dataset_multithreaded_collision() -> None:
                 raise self.exception
 
     threads = []
-    for _ in range(10):
+    for _ in range(5):
         thread = GetDatasetThread()
         threads.append(thread)
         thread.start()

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -13,27 +13,7 @@ from snuba.datasets.factory import (
 )
 
 
-def test_get_dataset() -> None:
-    for ds_name in [
-        "discover",
-        "events",
-        "groupassignee",
-        "groupedmessage",
-        "metrics",
-        "outcomes",
-        "outcomes_raw",
-        "sessions",
-        "transactions",
-        "profiles",
-        "functions",
-        "generic_metrics",
-        "replays",
-    ]:
-        factory_ds = get_dataset(ds_name)
-        assert isinstance(factory_ds, Dataset)
-        assert get_dataset_name(factory_ds) == ds_name
-
-
+# This test should be the first to ensure dataset factory module is has fresh set of objects
 def test_get_dataset_multithreaded_collision() -> None:
     class GetDatasetThread(threading.Thread):
         def test_get_dataset_threaded(self) -> None:
@@ -65,6 +45,27 @@ def test_get_dataset_multithreaded_collision() -> None:
             thread.join()
         except Exception as error:
             raise error
+
+
+def test_get_dataset() -> None:
+    for ds_name in [
+        "discover",
+        "events",
+        "groupassignee",
+        "groupedmessage",
+        "metrics",
+        "outcomes",
+        "outcomes_raw",
+        "sessions",
+        "transactions",
+        "profiles",
+        "functions",
+        "generic_metrics",
+        "replays",
+    ]:
+        factory_ds = get_dataset(ds_name)
+        assert isinstance(factory_ds, Dataset)
+        assert get_dataset_name(factory_ds) == ds_name
 
 
 @pytest.fixture(scope="function")

--- a/tests/datasets/test_entity_factory.py
+++ b/tests/datasets/test_entity_factory.py
@@ -1,0 +1,77 @@
+import threading
+from typing import Any
+
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import (
+    get_all_entity_names,
+    get_entity,
+    get_entity_name,
+)
+from snuba.datasets.entity import Entity
+
+ENTITY_KEYS = [
+    EntityKey.DISCOVER,
+    EntityKey.EVENTS,
+    EntityKey.GROUPASSIGNEE,
+    EntityKey.GROUPEDMESSAGES,
+    EntityKey.OUTCOMES,
+    EntityKey.OUTCOMES_RAW,
+    EntityKey.SESSIONS,
+    EntityKey.ORG_SESSIONS,
+    EntityKey.TRANSACTIONS,
+    EntityKey.DISCOVER_TRANSACTIONS,
+    EntityKey.DISCOVER_EVENTS,
+    EntityKey.METRICS_SETS,
+    EntityKey.METRICS_COUNTERS,
+    EntityKey.ORG_METRICS_COUNTERS,
+    EntityKey.METRICS_DISTRIBUTIONS,
+    EntityKey.PROFILES,
+    EntityKey.FUNCTIONS,
+    EntityKey.REPLAYS,
+    EntityKey.GENERIC_METRICS_SETS,
+    EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
+]
+
+# This test should be the first to ensure dataset factory module is has fresh set of objects
+def test_get_entity_multithreaded_collision() -> None:
+    class GetEntityThread(threading.Thread):
+        def test_get_entity_threaded(self) -> None:
+            ent_name = EntityKey.EVENTS
+            entity = get_entity(ent_name)
+            assert isinstance(entity, Entity)
+            assert get_entity_name(entity) == ent_name
+
+        def run(self) -> None:
+            self.exception = None
+            try:
+                self.test_get_entity_threaded()
+            except Exception as e:
+                self.exception = e
+
+        def join(self, *args: Any, **kwargs: Any) -> None:
+            threading.Thread.join(self)
+            if self.exception:
+                raise self.exception
+
+    threads = []
+    for _ in range(10):
+        thread = GetEntityThread()
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        try:
+            thread.join()
+        except Exception as error:
+            raise error
+
+
+def test_get_entity() -> None:
+    for ent_name in ENTITY_KEYS:
+        entity = get_entity(ent_name)
+        assert isinstance(entity, Entity)
+        assert get_entity_name(entity) == ent_name
+
+
+def test_all_names() -> None:
+    assert set(get_all_entity_names()) == set(ENTITY_KEYS)

--- a/tests/query/joins/test_equivalence_adder.py
+++ b/tests/query/joins/test_equivalence_adder.py
@@ -3,7 +3,7 @@ from functools import partial
 import pytest
 
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import ENTITY_IMPL
+from snuba.datasets.entities.factory import override_entity_map, reset_entity_factory
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import (
@@ -263,8 +263,8 @@ def test_add_equivalent_condition(
     join_clause: JoinClause[EntitySource],
     expected_expr: Expression,
 ) -> None:
-    ENTITY_IMPL[EntityKey.EVENTS] = Events()
-    ENTITY_IMPL[EntityKey.GROUPEDMESSAGES] = GroupedMessage()
+    override_entity_map(EntityKey.EVENTS, Events())
+    override_entity_map(EntityKey.GROUPEDMESSAGES, GroupedMessage())
 
     query = CompositeQuery(
         from_clause=join_clause,
@@ -278,4 +278,4 @@ def test_add_equivalent_condition(
     add_equivalent_conditions(query)
     assert query.get_condition() == expected_expr
 
-    ENTITY_IMPL.clear()
+    reset_entity_factory()

--- a/tests/query/joins/test_equivalences.py
+++ b/tests/query/joins/test_equivalences.py
@@ -1,7 +1,7 @@
 import pytest
 
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import ENTITY_IMPL
+from snuba.datasets.entities.factory import override_entity_map, reset_entity_factory
 from snuba.query.data_source.join import (
     IndividualNode,
     JoinClause,
@@ -179,10 +179,10 @@ TEST_CASES = [
 def test_find_equivalences(
     join: JoinClause[EntitySource], graph: EquivalenceGraph
 ) -> None:
-    ENTITY_IMPL[EntityKey.EVENTS] = Events()
-    ENTITY_IMPL[EntityKey.GROUPEDMESSAGES] = GroupedMessage()
-    ENTITY_IMPL[EntityKey.GROUPASSIGNEE] = GroupAssignee()
+    override_entity_map(EntityKey.EVENTS, Events())
+    override_entity_map(EntityKey.GROUPEDMESSAGES, GroupedMessage())
+    override_entity_map(EntityKey.GROUPASSIGNEE, GroupAssignee())
 
     assert get_equivalent_columns(join) == graph
 
-    ENTITY_IMPL.clear()
+    reset_entity_factory()

--- a/tests/query/joins/test_subqueries.py
+++ b/tests/query/joins/test_subqueries.py
@@ -3,7 +3,7 @@ from typing import cast
 import pytest
 
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import ENTITY_IMPL
+from snuba.datasets.entities.factory import override_entity_map, reset_entity_factory
 from snuba.query import SelectedExpression
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import (
@@ -514,9 +514,9 @@ def test_subquery_generator(
     original_query: CompositeQuery[Entity],
     processed_query: CompositeQuery[Entity],
 ) -> None:
-    ENTITY_IMPL[EntityKey.EVENTS] = Events()
-    ENTITY_IMPL[EntityKey.GROUPEDMESSAGES] = GroupedMessage()
-    ENTITY_IMPL[EntityKey.GROUPASSIGNEE] = GroupAssignee()
+    override_entity_map(EntityKey.EVENTS, Events())
+    override_entity_map(EntityKey.GROUPEDMESSAGES, GroupedMessage())
+    override_entity_map(EntityKey.GROUPASSIGNEE, GroupAssignee())
 
     generate_subqueries(original_query)
 
@@ -535,4 +535,4 @@ def test_subquery_generator(
 
     report = original_query.equals(processed_query)
     assert report[0], f"Failed equality: {report[1]}"
-    ENTITY_IMPL.clear()
+    reset_entity_factory()

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime, timedelta
 
 from snuba import settings
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP
+from snuba.datasets.entities.factory import get_entity_name
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
@@ -18,7 +18,7 @@ class BaseSubscriptionTest:
         self.platforms = ["a", "b"]
         self.minutes = 20
         self.dataset = get_dataset("events")
-        self.entity_key = ENTITY_NAME_LOOKUP[self.dataset.get_default_entity()]
+        self.entity_key = get_entity_name(self.dataset.get_default_entity())
 
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ from snuba import settings, state
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.entities import EntityKey
-from snuba.datasets.entities.factory import ENTITY_NAME_LOOKUP, get_entity
+from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.events_processor_base import InsertEvent, ReplacementType
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages import StorageKey
@@ -2341,7 +2341,7 @@ class TestDeleteSubscriptionApi(BaseApiTest):
         subscription_id = data["subscription_id"]
         partition = subscription_id.split("/", 1)[0]
 
-        entity_key = ENTITY_NAME_LOOKUP[self.dataset.get_default_entity()]
+        entity_key = get_entity_name(self.dataset.get_default_entity())
 
         assert (
             len(


### PR DESCRIPTION
Similar to dataset factory in https://github.com/getsentry/snuba/pull/3060, both YAML and Python defined entities will need to coexist. This entity factory pattern helps clean up the old method of initializing and accessing entities. 

This PR is responsible for the following:
1. One central container for all entities to live in (both yaml and python defined) 
2. Remove complicated mapping/caching logic
3. Remove unused `dev_entity_factories`

This PR is *not* responsible for the following:
1. Removing the EntityEnum (the entity factory still requires the full list of enums)
2. Dynamic importing of entities (each entity remains hard-coded in factory)

Additionally, the multithreaded tests for accessing the dataset factory was moved to the top of the test file to ensure test is ran with fresh objects imported from factory module.