### PR TITLE
feat(admin):  allow show command to system queries SNS-1625

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -62,12 +62,32 @@ DESCRIBE_QUERY_RE = re.compile(
     re.VERBOSE,
 )
 
+SHOW_QUERY_RE = re.compile(
+    r"""
+        ^ # Start
+        (SHOW|show)
+        \s
+        [\w\s]+
+        ;? # Optional semicolon
+        $ # End
+    """,
+    re.VERBOSE,
+)
+
 
 def is_query_select(sql_query: str) -> bool:
     """
     Simple validation to ensure query is a select command
     """
     match = SYSTEM_QUERY_RE.match(sql_query)
+    return True if match else False
+
+
+def is_query_show(sql_query: str) -> bool:
+    """
+    Simple validation to ensure query is a show command
+    """
+    match = SHOW_QUERY_RE.match(sql_query)
     return True if match else False
 
 
@@ -85,6 +105,8 @@ def run_system_query_on_host_with_sql(
     if is_query_select(system_query_sql):
         validate_system_query(system_query_sql)
     elif is_query_describe(system_query_sql):
+        pass
+    elif is_query_show(system_query_sql):
         pass
     else:
         raise InvalidCustomQuery("Query is invalid")


### PR DESCRIPTION
This will allow [`SHOW` commands ](https://clickhouse.com/docs/en/sql-reference/statements/show/) in system queries on snuba admin. Show queries do not reveal customer data and are safe, read-only. Addresses JIRA https://getsentry.atlassian.net/browse/SNS-1625. 

Reviewers, please confirm that the Regex is safe. Right now, it is `SHOW [\w\s\]+$` so theoretically an adversary could insert arbitrary subqueries with the `[\w\s\]` matching. We can probably come up with a more complex regex to skip matching any unsafe subqueries but I'm not sure if its worth the work given that the admin threat model is targeted towards accidental mistakes rather than adversarial attacks. 




