### PR TITLE
fix QueryException not being instantiated properly

### DIFF
--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -22,7 +22,7 @@ class QueryException(SerializableException):
     """
 
     @classmethod
-    def from_args(cls, extra: QueryExtraData):
+    def from_args(cls, extra: QueryExtraData) -> "QueryException":
         return cls(extra=cast(JsonSerializable, extra))
 
     @property

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Mapping, NamedTuple, TypedDict
+from typing import Any, Mapping, NamedTuple, TypedDict, cast
 
 from snuba.reader import Column, Result, Row, transform_rows
-from snuba.utils.serializable_exception import SerializableException
+from snuba.utils.serializable_exception import JsonSerializable, SerializableException
 
 
 class QueryExtraData(TypedDict):
@@ -21,8 +21,16 @@ class QueryException(SerializableException):
     the cause of the exception.
     """
 
-    def __init__(self, extra: QueryExtraData):
-        self.extra = extra
+    @classmethod
+    def from_args(cls, extra: QueryExtraData):
+        return cls(extra=cast(JsonSerializable, extra))
+
+    @property
+    def extra(self) -> QueryExtraData:
+        extra = self.extra_data.get("extra", None)
+        if not extra:
+            return QueryExtraData(stats={}, sql="noquery", experiments={})
+        return cast(QueryExtraData, extra)
 
 
 class QueryTooLongException(SerializableException):

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -737,7 +737,7 @@ def raw_query(
 
                 logger.exception("Error running query: %s\n%s", sql, cause)
             stats = update_with_status(QueryStatus.ERROR, error_code=error_code)
-        raise QueryException(
+        raise QueryException.from_args(
             {
                 "stats": stats,
                 "sql": sql,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -336,7 +336,7 @@ def _format_storage_query_and_run(
     }
 
     if query_size_bytes > MAX_QUERY_SIZE_BYTES:
-        raise QueryException(
+        raise QueryException.from_args(
             extra=QueryExtraData(
                 stats=stats,
                 sql=formatted_sql,

--- a/tests/web/test_query_exception.py
+++ b/tests/web/test_query_exception.py
@@ -1,0 +1,10 @@
+import json
+
+from snuba.web import QueryException
+
+
+def test_printable():
+    e = QueryException.from_args({"stats": {}, "sql": "fdsfsdaf", "experiments": {}})
+    assert isinstance(repr(e), str)
+    assert isinstance(e.extra, dict)
+    json.dumps(e.to_dict())

--- a/tests/web/test_query_exception.py
+++ b/tests/web/test_query_exception.py
@@ -1,10 +1,13 @@
 import json
 
+from snuba.utils.serializable_exception import SerializableException
 from snuba.web import QueryException
 
 
-def test_printable():
+def test_printable() -> None:
     e = QueryException.from_args({"stats": {}, "sql": "fdsfsdaf", "experiments": {}})
     assert isinstance(repr(e), str)
     assert isinstance(e.extra, dict)
-    json.dumps(e.to_dict())
+    json_exc = json.dumps(e.to_dict())
+    dict_exc = json.loads(json_exc)
+    assert isinstance(SerializableException.from_dict(dict_exc), QueryException)


### PR DESCRIPTION
This happened in the metrics executor logs when the logger tried to print the exception

AttributeError: 'QueryException' object has no attribute 'message'

This is because this exception is not defined properly. This is documented behavior
https://github.com/getsentry/snuba/blob/master/snuba/utils/serializable_exception.py#L90-L94

This will also most likely fix the double raising of exceptions issues in sentry 