### PR TITLE
fix(typing) - fix entity_builder to account for mypy updates

### DIFF
--- a/snuba/datasets/configuration/entity_builder.py
+++ b/snuba/datasets/configuration/entity_builder.py
@@ -79,7 +79,7 @@ def _build_entity_validators(
     config_validators: list[dict[str, Any]]
 ) -> Sequence[QueryValidator]:
     return [
-        _VALIDATOR_MAPPING[qv_config["validator"]](**qv_config["args"])  # type: ignore
+        _VALIDATOR_MAPPING[qv_config["validator"]](**qv_config["args"])
         for qv_config in config_validators
     ]
 
@@ -88,7 +88,7 @@ def _build_entity_query_processors(
     config_query_processors: list[dict[str, Any]],
 ) -> Sequence[QueryProcessor]:
     return [
-        _QP_MAPPING[config_qp["processor"]](  # type: ignore
+        _QP_MAPPING[config_qp["processor"]](
             **(config_qp["args"] if config_qp.get("args") else {})
         )
         for config_qp in config_query_processors
@@ -99,11 +99,11 @@ def _build_entity_translation_mappers(
     config_translation_mappers: dict[str, Any],
 ) -> TranslationMappers:
     function_mappers: list[FunctionCallMapper] = [
-        _FUNCTION_MAPPER_MAPPING[fm_config["mapper"]](**fm_config["args"])  # type: ignore
+        _FUNCTION_MAPPER_MAPPING[fm_config["mapper"]](**fm_config["args"])
         for fm_config in config_translation_mappers["functions"]
     ]
     subscriptable_mappers: list[SubscriptableReferenceMapper] = [
-        _SUB_MAPPER_MAPPING[sub_config["mapper"]](**sub_config["args"])  # type: ignore
+        _SUB_MAPPER_MAPPING[sub_config["mapper"]](**sub_config["args"])
         for sub_config in config_translation_mappers["subscriptables"]
     ]
     return TranslationMappers(


### PR DESCRIPTION
mypy was updated on master while my feature branch for https://github.com/getsentry/snuba/pull/3063 was out.

The version of mypy on my feature branch did type checking on variant constructor arguments -- this one apparently doesn't and complains about `type: ignore` (from before):

```
➜  snuba git:(master) ✗ make backend-typing 
mypy snuba tests --strict --config-file mypy.ini --exclude 'tests/datasets|tests/query|tests/state|tests/snapshots|tests/clickhouse|tests/test_split.py|tests/test_consumer.py'

snuba/datasets/configuration/entity_builder.py:82: error: Unused "type: ignore" comment
snuba/datasets/configuration/entity_builder.py:91: error: Unused "type: ignore" comment
snuba/datasets/configuration/entity_builder.py:102: error: Unused "type: ignore" comment
snuba/datasets/configuration/entity_builder.py:106: error: Unused "type: ignore" comment
```