### PR TITLE
feat: Add initial documentation for Dataset configuration

### DIFF
--- a/docs/source/configuration/dataset.rst
+++ b/docs/source/configuration/dataset.rst
@@ -1,0 +1,10 @@
+Dataset
+========
+
+A Dataset is a container of components necessary to ingest and read data from Clickhouse.
+
+Fields
+---------
+
+name : string
+    The name of the Dataset.

--- a/docs/source/configuration/intro.rst
+++ b/docs/source/configuration/intro.rst
@@ -1,0 +1,5 @@
+=====================
+Dataset Configuration
+=====================
+
+Snuba Datasets are defined through YAML configuration files. These are then loaded and validated by the Snuba application.

--- a/docs/source/configuration/overview.rst
+++ b/docs/source/configuration/overview.rst
@@ -1,0 +1,9 @@
+.. include:: intro.rst
+
+Contents:
+---------
+
+.. toctree::
+   :maxdepth: 1
+
+   dataset

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Contents:
    architecture/overview
    architecture/datamodel
    architecture/queryprocessing
+   configuration/overview
    query/overview
    language/snql
    migrations/modes


### PR DESCRIPTION
Add some quick placeholder files for Dataset configuration. Any new components
should have a new file created (`entity.rst`) and then add that file name to
`overview.rst` so it gets indexed in the ToC.