### PR TITLE
ref(subscriptions): Remove max_concurrent_queries cli arg

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -49,14 +49,6 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     default="snuba-subscription-executor",
     help="Consumer group used for consuming the scheduled subscription topic/s.",
 )
-# TODO: Once we are using the --total-concurrent-queries to calculate the max
-# concurrent queries we can remove this cli arg.
-@click.option(
-    "--max-concurrent-queries",
-    default=20,
-    type=int,
-    help="Max concurrent ClickHouse queries.",
-)
 @click.option(
     "--total-concurrent-queries",
     default=64,
@@ -92,7 +84,6 @@ def subscriptions_executor(
     dataset_name: str,
     entity_names: Sequence[str],
     consumer_group: str,
-    max_concurrent_queries: int,
     total_concurrent_queries: int,
     auto_offset_reset: str,
     no_strict_offset_reset: bool,
@@ -145,7 +136,6 @@ def subscriptions_executor(
         entity_names,
         consumer_group,
         producer,
-        max_concurrent_queries,
         total_concurrent_queries,
         auto_offset_reset,
         not no_strict_offset_reset,

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -46,14 +46,6 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     required=True,
     help="Name of the consumer group to follow",
 )
-# TODO: Once we are using the --total-concurrent-queries to calculate the max
-# concurrent queries we can remove this cli arg.
-@click.option(
-    "--max-concurrent-queries",
-    default=20,
-    type=int,
-    help="Max concurrent ClickHouse queries",
-)
 @click.option(
     "--total-concurrent-queries",
     default=64,
@@ -90,7 +82,6 @@ def subscriptions_scheduler_executor(
     entity_names: Sequence[str],
     consumer_group: str,
     followed_consumer_group: str,
-    max_concurrent_queries: int,
     total_concurrent_queries: int,
     auto_offset_reset: str,
     no_strict_offset_reset: bool,
@@ -145,7 +136,6 @@ def subscriptions_scheduler_executor(
         schedule_ttl,
         delay_seconds,
         stale_threshold_seconds,
-        max_concurrent_queries,
         total_concurrent_queries,
         metrics,
         SchedulingWatermarkMode(scheduling_mode)

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -46,7 +46,6 @@ def build_scheduler_executor_consumer(
     schedule_ttl: int,
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
-    max_concurrent_queries: int,
     total_concurrent_queries: int,
     metrics: MetricsBackend,
     scheduling_mode: Optional[SchedulingWatermarkMode],
@@ -98,7 +97,6 @@ def build_scheduler_executor_consumer(
         dataset,
         entity_names,
         partitions,
-        max_concurrent_queries,
         total_concurrent_queries,
         producer,
         metrics,
@@ -134,7 +132,6 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         dataset: Dataset,
         entity_names: Sequence[str],
         partitions: int,
-        max_concurrent_queries: int,
         total_concurrent_queries: int,
         producer: Producer[KafkaPayload],
         metrics: MetricsBackend,
@@ -178,7 +175,6 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         )
 
         self.__executor_factory = SubscriptionExecutorProcessingFactory(
-            max_concurrent_queries,
             total_concurrent_queries,
             # total_partition_count should always be 1 when using the combined executor/scheduler
             1,

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -55,7 +55,6 @@ def test_combined_scheduler_and_executor() -> None:
             dataset=get_dataset("events"),
             entity_names=["events"],
             partitions=1,
-            max_concurrent_queries=2,
             total_concurrent_queries=2,
             producer=producer,
             metrics=TestingMetricsBackend(),

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -111,7 +111,6 @@ def test_executor_consumer() -> None:
         consumer_group,
         result_producer,
         2,
-        2,
         auto_offset_reset,
         strict_offset_reset,
         TestingMetricsBackend(),


### PR DESCRIPTION
**context:**
This is a follow up of the completion of https://github.com/getsentry/snuba/pull/2761. Now that the executors are using the calculated max concurrent queries in production, we can get rid of the cli arg. 

https://github.com/getsentry/ops/pull/5172 must be merged first so that we can safely remove the cli without there being a reference to it in the ops repo.
