### PR TITLE
make the cause the str of a SerializableException if there isn't one

### DIFF
--- a/snuba/utils/serializable_exception.py
+++ b/snuba/utils/serializable_exception.py
@@ -165,3 +165,11 @@ class SerializableException(Exception):
 
     def __repr__(self) -> str:
         return cast(str, rapidjson.dumps(self.to_dict(), indent=2))
+
+    def __str__(self) -> str:
+        if self.message:
+            return self.message
+        elif self.__cause__:
+            return str(self.__cause__)
+        else:
+            return repr(self)


### PR DESCRIPTION


<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
