### PR TITLE
make the QueryException's message go through to sentry

### DIFF
--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -22,8 +22,8 @@ class QueryException(SerializableException):
     """
 
     @classmethod
-    def from_args(cls, extra: QueryExtraData) -> "QueryException":
-        return cls(extra=cast(JsonSerializable, extra))
+    def from_args(cls, message: str, extra: QueryExtraData) -> "QueryException":
+        return cls(message=message, extra=cast(JsonSerializable, extra))
 
     @property
     def extra(self) -> QueryExtraData:

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -738,11 +738,14 @@ def raw_query(
                 logger.exception("Error running query: %s\n%s", sql, cause)
             stats = update_with_status(QueryStatus.ERROR, error_code=error_code)
         raise QueryException.from_args(
+            # This exception needs to have the message of the cause in it for sentry
+            # to pick it up properly
+            str(cause),
             {
                 "stats": stats,
                 "sql": sql,
                 "experiments": clickhouse_query.get_experiments(),
-            }
+            },
         ) from cause
     else:
         stats = update_with_status(QueryStatus.SUCCESS, result["profile"])

--- a/tests/web/test_query_exception.py
+++ b/tests/web/test_query_exception.py
@@ -5,7 +5,10 @@ from snuba.web import QueryException
 
 
 def test_printable() -> None:
-    e = QueryException.from_args({"stats": {}, "sql": "fdsfsdaf", "experiments": {}})
+    e = QueryException.from_args(
+        "the cause was coming from inside the house!",
+        {"stats": {}, "sql": "fdsfsdaf", "experiments": {}},
+    )
     assert isinstance(repr(e), str)
     assert isinstance(e.extra, dict)
     json_exc = json.dumps(e.to_dict())


### PR DESCRIPTION
If the message field is not set on the SerializableException, then there will be no message in sentry. This change makes sure that where we raise a QueryException, we put the message we want in there (since QueryException is a catchall for many exceptions)