### PR TITLE
ref: publish a multiarch application image to ghcr

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,52 @@
+on:
+  pull_request:
+  push:
+    branches: [master]
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    env:
+      IMG_CACHE: ghcr.io/getsentry/snuba:${{ matrix.arch }}-latest
+      IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
+    steps:
+    - uses: actions/checkout@v3
+    - run: docker run --rm --privileged tonistiigi/binfmt --install arm64
+      if: matrix.arch == 'arm64'
+    - name: build
+      run: |
+        set -euxo pipefail
+        args=()
+        if docker pull -q "$IMG_CACHE"; then
+          args+=(--cache-from "$IMG_CACHE")
+        fi
+        docker buildx build \
+            "${args[@]}" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --platform linux/${{ matrix.arch }} \
+            --tag "$IMG_VERSIONED" \
+            --target application \
+            .
+        docker tag "$IMG_VERSIONED" "$IMG_CACHE"
+    - name: push
+      run: |
+        set -euxo pipefail
+        docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+        docker push "$IMG_VERSIONED"
+        docker push "$IMG_CACHE"
+      if: github.event_name != 'pull_request'
+
+  multiarch:
+    if: github.event_name != 'pull_request'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        set -euxo pipefail
+        docker login --username '${{ github.actor }}' --password '${{ secrets.GITHUB_TOKEN }}' ghcr.io
+        docker manifest create ghcr.io/getsentry/snuba:latest \
+          ghcr.io/getsentry/snuba:arm64-latest \
+          ghcr.io/getsentry/snuba:amd64-latest
+        docker manifest push ghcr.io/getsentry/snuba:latest


### PR DESCRIPTION
I'll leave the other image for now -- but I plan to use this to replace both the `arm64-dev` and the dockerhub image in `sentry` ci