### PR TITLE
ref: use internal pypi for prebuilt packages

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,7 +4,7 @@
 if [ ! -d .venv ]; then
     python3 -m venv .venv
     source .venv/bin/activate
-    pip install --upgrade pip==21.1.3 wheel
+    pip install $(grep ^-- requirements.txt) --upgrade pip==22.2.2 wheel==0.37.1
     make develop
 else
     source .venv/bin/activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,6 @@
 ARG PYTHON_VERSION=3.8.13
 FROM python:${PYTHON_VERSION}-slim-bullseye AS application
 
-# these are required all the way through, and removing them will cause bad things
-RUN set -ex; \
-    apt-get update; \
-    apt-get install --no-install-recommends -y \
-        libexpat1 \
-        liblz4-1 \
-        libpcre3 \
-    ; \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /usr/src/snuba
 
 ENV PIP_NO_CACHE_DIR=off \
@@ -30,9 +20,6 @@ RUN set -ex; \
     '; \
     apt-get update; \
     apt-get install -y $buildDeps --no-install-recommends; \
-    # Since there's no confluent-kafka wheel for aarch64, remove when there is
-    [ $(uname -m) = "aarch64" ] && apt-get install -y librdkafka-dev --no-install-recommends; \
-    \
     pip install -r requirements.txt; \
     \
     mkdir /tmp/uwsgi-dogstatsd; \

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ backend-typing:
 
 install-python-dependencies:
 	pip uninstall -qqy uwsgi  # pip doesn't do well with swapping drop-ins
-	pip install -e .
-	pip install -r requirements-test.txt
+	pip install `grep ^-- requirements.txt` -e .
+	pip install `grep ^-- requirements.txt` -r requirements-test.txt
 
 snubadocs:
 	pip install -U -r ./docs-requirements.txt

--- a/docs/source/contributing/environment.rst
+++ b/docs/source/contributing/environment.rst
@@ -31,7 +31,7 @@ These commands set up the Python virtual environment::
     make pyenv-setup
     python -m venv .venv
     source .venv/bin/activate
-    pip install --upgrade pip==21.1.3
+    pip install --upgrade pip==22.2.2
     make develop
 
 These commands start the Snuba api, which is capable of processing queries::

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,5 @@
+--index-url https://pypi.devinfra.sentry.io/simple
+
 snuba-sdk==1.0.1
 freezegun==1.2.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,10 @@
+--index-url https://pypi.devinfra.sentry.io/simple
+
 black==22.6.0
 blinker==1.5
 click==8.1.3
 clickhouse-driver==0.2.4
-confluent-kafka==1.8.2
+confluent-kafka==1.9.2
 datadog==0.21.0
 flake8==5.0.4
 Flask==2.2.2
@@ -20,7 +22,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
-sentry-arroyo==1.0.1
+sentry-arroyo==1.0.4
 sentry-relay==0.8.13
 sentry-sdk==1.9.4
 simplejson==3.17.6

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,9 @@ VERSION = "22.9.0.dev0"
 
 def get_requirements() -> Sequence[str]:
     with open("requirements.txt") as fp:
-        return [x.strip() for x in fp.read().split("\n") if not x.startswith("#")]
+        return [
+            x.strip() for x in fp.read().split("\n") if not x.startswith(("#", "--"))
+        ]
 
 
 setup(


### PR DESCRIPTION
this changes from using public pypi to using our "internal" (but publicly accessible) pypi

the main advantage is on the 4 supported platforms (linux, macos) x (x86_64, arm64) all python dependencies are prebuilt and will not need to be built from source

pypi packages are sourced from https://github.com/getsentry/pypi 