### PR TITLE
feat(MDC): Generic Metrics Dataset loaded from Config

### DIFF
--- a/snuba/datasets/configuration/dataset_builder.py
+++ b/snuba/datasets/configuration/dataset_builder.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from snuba.datasets.configuration.json_schema import V1_READABLE_STORAGE_SCHEMA
+from snuba.datasets.configuration.loader import load_configuration_data
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.pluggable_dataset import PluggableDataset
+
+# TODO: Use a real dataset validation schema
+DATASET_VALIDATION_SCHEMAS = {"dataset": V1_READABLE_STORAGE_SCHEMA}
+
+
+def build_dataset(config_file_path: str) -> Dataset:
+    config = load_configuration_data(config_file_path, DATASET_VALIDATION_SCHEMAS)
+    return PluggableDataset(
+        name=config["name"],
+        is_experimental=bool(config["is_experimental"]),
+        default_entity=EntityKey(config["entities"]["default"]),
+        all_entities=[EntityKey(key) for key in config["entities"]["all"]],
+    )

--- a/snuba/datasets/configuration/dataset_builder.py
+++ b/snuba/datasets/configuration/dataset_builder.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from snuba.datasets.configuration.json_schema import V1_READABLE_STORAGE_SCHEMA
+from snuba.datasets.configuration.json_schema import V1_DATASET_SCHEMA
 from snuba.datasets.configuration.loader import load_configuration_data
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.pluggable_dataset import PluggableDataset
 
-# TODO: Use a real dataset validation schema
-DATASET_VALIDATION_SCHEMAS = {"dataset": V1_READABLE_STORAGE_SCHEMA}
+DATASET_VALIDATION_SCHEMAS = {"dataset": V1_DATASET_SCHEMA}
 
 
 def build_dataset(config_file_path: str) -> PluggableDataset:

--- a/snuba/datasets/configuration/dataset_builder.py
+++ b/snuba/datasets/configuration/dataset_builder.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from snuba.datasets.configuration.json_schema import V1_READABLE_STORAGE_SCHEMA
 from snuba.datasets.configuration.loader import load_configuration_data
-from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.pluggable_dataset import PluggableDataset
 
@@ -10,7 +9,7 @@ from snuba.datasets.pluggable_dataset import PluggableDataset
 DATASET_VALIDATION_SCHEMAS = {"dataset": V1_READABLE_STORAGE_SCHEMA}
 
 
-def build_dataset(config_file_path: str) -> Dataset:
+def build_dataset(config_file_path: str) -> PluggableDataset:
     config = load_configuration_data(config_file_path, DATASET_VALIDATION_SCHEMAS)
     return PluggableDataset(
         name=config["name"],

--- a/snuba/datasets/configuration/dataset_builder.py
+++ b/snuba/datasets/configuration/dataset_builder.py
@@ -8,7 +8,7 @@ from snuba.datasets.pluggable_dataset import PluggableDataset
 DATASET_VALIDATION_SCHEMAS = {"dataset": V1_DATASET_SCHEMA}
 
 
-def build_dataset(config_file_path: str) -> PluggableDataset:
+def build_dataset_from_config(config_file_path: str) -> PluggableDataset:
     config = load_configuration_data(config_file_path, DATASET_VALIDATION_SCHEMAS)
     return PluggableDataset(
         name=config["name"],

--- a/snuba/datasets/configuration/generic_metrics/dataset.yaml
+++ b/snuba/datasets/configuration/generic_metrics/dataset.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: dataset
-name: generic-metrics
+name: generic_metrics
 
 is_experimental: false
 

--- a/snuba/datasets/configuration/generic_metrics/dataset.yaml
+++ b/snuba/datasets/configuration/generic_metrics/dataset.yaml
@@ -1,0 +1,9 @@
+version: v1
+kind: dataset
+name: generic-metrics
+
+is_experimental: false
+
+entities:
+  default: generic_metrics_sets
+  all: [generic_metrics_sets, generic_metrics_distributions]

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -121,8 +121,6 @@ STORAGE_SCHEMA = {
 
 STORAGE_QUERY_PROCESSORS_SCHEMA = TYPE_STRING_ARRAY
 
-KIND_SCHEMA = {"enum": ["writable_storage", "readable_storage", "entity"]}
-
 ENTITY_QUERY_PROCESSOR = {
     "type": "object",
     "properties": {

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from typing import Any
 
 TYPE_STRING = {"type": "string"}
+TYPE_STRING_ARRAY = {"type": "array", "items": TYPE_STRING}
 TYPE_NULLABLE_STRING = {"type": ["string", "null"]}
 
 FUNCTION_CALL_SCHEMA = {
     "type": "object",
     "properties": {
         "type": TYPE_STRING,
-        "args": {"type": "array", "items": TYPE_STRING},
+        "args": TYPE_STRING_ARRAY,
     },
 }
 
@@ -33,7 +34,7 @@ STREAM_LOADER_SCHEMA = {
 def make_column_schema(
     column_type: dict[str, Any], args: dict[str, Any]
 ) -> dict[str, Any]:
-    args["properties"]["schema_modifiers"] = {"type": "array", "items": TYPE_STRING}
+    args["properties"]["schema_modifiers"] = TYPE_STRING_ARRAY
     return {
         "type": "object",
         "properties": {
@@ -118,7 +119,7 @@ STORAGE_SCHEMA = {
     "properties": {"key": TYPE_STRING, "set_key": TYPE_STRING},
 }
 
-STORAGE_QUERY_PROCESSORS_SCHEMA = {"type": "array", "items": TYPE_STRING}
+STORAGE_QUERY_PROCESSORS_SCHEMA = TYPE_STRING_ARRAY
 
 KIND_SCHEMA = {"enum": ["writable_storage", "readable_storage", "entity"]}
 
@@ -212,4 +213,18 @@ V1_ENTITY_SCHEMA = {
         "validators",
         "required_time_column",
     ],
+}
+
+V1_DATASET_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "version": {"const": "v1"},
+        "kind": {"const": "dataset"},
+        "name": TYPE_STRING,
+        "is_experimental": {"type": "boolean"},
+        "entities": {
+            "type": "object",
+            "properties": {"default": TYPE_STRING, "all": TYPE_STRING_ARRAY},
+        },
+    },
 }

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -43,8 +43,7 @@ class Dataset:
     def __init__(self, *, default_entity: EntityKey) -> None:
         self.__default_entity = default_entity
 
-    @classmethod
-    def is_experimental(cls) -> bool:
+    def is_experimental(self) -> bool:
         """Marks the dataset as experimental. Healthchecks failing on this
         dataset:
             * do not block deploys

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -119,6 +119,13 @@ def _ent_factory() -> _EntityFactory:
     return _ENT_FACTORY
 
 
+def initialize_entity_factory() -> None:
+    """
+    Used to load entities on initialization of datasets.
+    """
+    _ent_factory()
+
+
 def get_entity(name: EntityKey) -> Entity:
     return _ent_factory().get(name)
 

--- a/snuba/datasets/pluggable_dataset.py
+++ b/snuba/datasets/pluggable_dataset.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
+
+
+class PluggableDataset(Dataset):
+    """
+    PluggableDataset is a version of Dataset that is designed to be populated by
+    static YAML-based configuration files. It is intentionally less flexible
+    than Dataset. See the documentation of Dataset for explanation about how
+    overridden methods are supposed to behave.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        default_entity: EntityKey,
+        all_entities: list[EntityKey] | None,
+        is_experimental: bool | None,
+    ) -> None:
+        super().__init__(default_entity=default_entity)
+        self.__all_entities = [
+            get_entity(entity_key) for entity_key in (all_entities or [default_entity])
+        ]
+        self.name = name
+        self.__is_experimental = is_experimental or False
+
+    def is_experimental(self) -> bool:
+        return self.__is_experimental
+
+    def get_all_entities(self) -> list[Entity]:
+        return self.__all_entities
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, PluggableDataset) and self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -240,8 +240,12 @@ OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30
 
-# File path glob for storage configs
-STORAGE_CONFIG_FILES_GLOB = f"{Path(__file__).parent.parent.as_posix()}/datasets/configuration/**/storages/*.yaml"
+# Configuration directory settings
+CONFIG_FILES_PATH = f"{Path(__file__).parent.parent.as_posix()}/datasets/configuration"
+
+# File path glob for configs
+STORAGE_CONFIG_FILES_GLOB = f"{CONFIG_FILES_PATH}/**/storages/*.yaml"
+DATASET_CONFIG_FILES_GLOB = f"{CONFIG_FILES_PATH}/**/dataset.yaml"
 
 PREFER_PLUGGABLE_ENTITIES = False
 

--- a/tests/datasets/configuration/test_dataset_loader.py
+++ b/tests/datasets/configuration/test_dataset_loader.py
@@ -1,0 +1,18 @@
+from snuba.datasets.factory import get_config_built_datasets
+from snuba.datasets.generic_metrics import GenericMetricsDataset
+
+
+def test_build_entity_from_config_matches_python_definition() -> None:
+    py_dataset = GenericMetricsDataset()
+    config_dataset = get_config_built_datasets()["generic_metrics"]
+
+    for py_entity, config_entity in zip(
+        config_dataset.get_all_entities(), py_dataset.get_all_entities()
+    ):
+        assert py_entity.__class__ == config_entity.__class__
+
+    assert (
+        config_dataset.get_default_entity().__class__
+        == py_dataset.get_default_entity().__class__
+    )
+    assert config_dataset.is_experimental() == py_dataset.is_experimental()


### PR DESCRIPTION
### Overview
- Generic Metrics Dataset is loaded from a config file
- Added minimal `PluggableDataset` which can be extended as we config more complicated datasets
- Added validation for Dataset config
- New dataset configs will be automatically picked up

### Notes
- Any dataset config file should be named `dataset.yaml` and placed as follows to be automatically picked up
    - `snuba/datasets/configuration/<dataset_name>/dataset.yaml`