### PR TITLE
fix(mdc): use entity name for mapping when type is not sufficient

### DIFF
--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -4,6 +4,7 @@ from snuba import settings
 from snuba.datasets.configuration.entity_builder import build_entity_from_config
 from snuba.datasets.entities import EntityKey
 from snuba.datasets.entity import Entity
+from snuba.datasets.pluggable_entity import PluggableEntity
 from snuba.datasets.storages.factory import initialize_storage_factory
 from snuba.datasets.table_storage import TableWriter
 from snuba.utils.config_component_factory import ConfigComponentFactory
@@ -98,8 +99,10 @@ class _EntityFactory(ConfigComponentFactory[Entity, EntityKey]):
             raise InvalidEntityError(f"entity {name!r} does not exist") from error
 
     def get_entity_name(self, entity: Entity) -> EntityKey:
-        # TODO: This is dumb, the name should just be a property on the entity
         try:
+            if isinstance(entity, PluggableEntity):
+                return EntityKey(entity.name)
+            # TODO: Destroy all non-PluggableEntity Entities
             return self._name_map[entity.__class__]
         except KeyError as error:
             raise InvalidEntityError(f"entity {entity} has no name") from error


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-1656

Mix of latest changes broke the subscriptions executor for generic_metrics_sets (see https://sentry.io/organizations/sentry/issues/3552496714/)

Reproduced the issue locally and observed that this fixes it