### PR TITLE
ref(EntityKey): Rename GROUPEDMESSAGES to GROUPEDMESSAGE

### DIFF
--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -4,4 +4,4 @@ from snuba.datasets.entities import EntityKey
 
 class GroupedMessageDataset(Dataset):
     def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.GROUPEDMESSAGES)
+        super().__init__(default_entity=EntityKey.GROUPEDMESSAGE)

--- a/snuba/datasets/entities/__init__.py
+++ b/snuba/datasets/entities/__init__.py
@@ -10,8 +10,7 @@ class EntityKey(Enum):
     EVENTS = "events"
     GROUPS = "groups"
     GROUPASSIGNEE = "groupassignee"
-    # TODO: This has an S on the end in solidarity with storages, but it's got to go
-    GROUPEDMESSAGES = "groupedmessage"
+    GROUPEDMESSAGE = "groupedmessage"
     METRICS_SETS = "metrics_sets"
     METRICS_COUNTERS = "metrics_counters"
     ORG_METRICS_COUNTERS = "org_metrics_counters"

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -201,7 +201,7 @@ class BaseEventsEntity(Entity, ABC):
             abstract_column_set=columns,
             join_relationships={
                 "grouped": JoinRelationship(
-                    rhs_entity=EntityKey.GROUPEDMESSAGES,
+                    rhs_entity=EntityKey.GROUPEDMESSAGE,
                     columns=[("project_id", "project_id"), ("group_id", "id")],
                     join_type=JoinType.INNER,
                     equivalences=[],

--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -55,7 +55,7 @@ class _EntityFactory(ConfigComponentFactory[Entity, EntityKey]):
                 EntityKey.DISCOVER: DiscoverEntity(),
                 EntityKey.EVENTS: EventsEntity(),
                 EntityKey.GROUPASSIGNEE: GroupAssigneeEntity(),
-                EntityKey.GROUPEDMESSAGES: GroupedMessageEntity(),
+                EntityKey.GROUPEDMESSAGE: GroupedMessageEntity(),
                 EntityKey.OUTCOMES: OutcomesEntity(),
                 EntityKey.OUTCOMES_RAW: OutcomesRawEntity(),
                 EntityKey.SESSIONS: SessionsEntity(),

--- a/tests/datasets/test_cdc_events.py
+++ b/tests/datasets/test_cdc_events.py
@@ -79,7 +79,7 @@ class TestCdcEvents(BaseApiTest):
             }
         ]
 
-        groups_storage = get_entity(EntityKey.GROUPEDMESSAGES).get_writable_storage()
+        groups_storage = get_entity(EntityKey.GROUPEDMESSAGE).get_writable_storage()
         groups_storage.get_table_writer().get_batch_writer(
             metrics=DummyMetricsBackend(strict=True)
         ).write([json.dumps(group).encode("utf-8") for group in groups])

--- a/tests/datasets/test_entity_factory.py
+++ b/tests/datasets/test_entity_factory.py
@@ -11,7 +11,7 @@ ENTITY_KEYS = [
     EntityKey.DISCOVER,
     EntityKey.EVENTS,
     EntityKey.GROUPASSIGNEE,
-    EntityKey.GROUPEDMESSAGES,
+    EntityKey.GROUPEDMESSAGE,
     EntityKey.OUTCOMES,
     EntityKey.OUTCOMES_RAW,
     EntityKey.SESSIONS,

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -64,7 +64,7 @@ events_table = Table(
 )
 
 groups_ent = Entity(
-    EntityKey.GROUPEDMESSAGES, get_entity(EntityKey.GROUPEDMESSAGES).get_data_model()
+    EntityKey.GROUPEDMESSAGE, get_entity(EntityKey.GROUPEDMESSAGE).get_data_model()
 )
 groups_storage = get_storage(StorageKey.GROUPEDMESSAGES)
 groups_schema = groups_storage.get_schema()

--- a/tests/query/data_source/test_join.py
+++ b/tests/query/data_source/test_join.py
@@ -35,7 +35,7 @@ def test_simple_join() -> None:
     e = Entity(key=EntityKey.EVENTS, schema=ERRORS_SCHEMA)
     node_err = IndividualNode(alias="err", data_source=e)
 
-    g = Entity(key=EntityKey.GROUPEDMESSAGES, schema=GROUPS_SCHEMA)
+    g = Entity(key=EntityKey.GROUPEDMESSAGE, schema=GROUPS_SCHEMA)
     node_group = IndividualNode(alias="groups", data_source=g)
 
     join = JoinClause(
@@ -77,7 +77,7 @@ def test_complex_joins() -> None:
     e = Entity(key=EntityKey.EVENTS, schema=ERRORS_SCHEMA)
     node_err = IndividualNode(alias="err", data_source=e)
 
-    g = Entity(key=EntityKey.GROUPEDMESSAGES, schema=GROUPS_SCHEMA)
+    g = Entity(key=EntityKey.GROUPEDMESSAGE, schema=GROUPS_SCHEMA)
     node_group = IndividualNode(alias="groups", data_source=g)
 
     a = Entity(key=EntityKey.GROUPASSIGNEE, schema=GROUPS_ASSIGNEE)

--- a/tests/query/formatters/test_query.py
+++ b/tests/query/formatters/test_query.py
@@ -38,7 +38,7 @@ BASIC_JOIN = JoinClause(
     ),
     right_node=IndividualNode(
         alias="gr",
-        data_source=Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None),
+        data_source=Entity(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA, None),
     ),
     keys=[
         JoinCondition(

--- a/tests/query/joins/equivalence_schema.py
+++ b/tests/query/joins/equivalence_schema.py
@@ -50,7 +50,7 @@ class Events(FakeEntity):
             abstract_column_set=EVENTS_SCHEMA,
             join_relationships={
                 "grouped": JoinRelationship(
-                    rhs_entity=EntityKey.GROUPEDMESSAGES,
+                    rhs_entity=EntityKey.GROUPEDMESSAGE,
                     columns=[("group_id", "id")],
                     join_type=JoinType.INNER,
                     equivalences=[ColumnEquivalence("project_id", "project_id")],

--- a/tests/query/joins/join_structures.py
+++ b/tests/query/joins/join_structures.py
@@ -53,7 +53,7 @@ def groups_node(
 ) -> IndividualNode[Entity]:
     return build_node(
         "gr",
-        Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA),
+        Entity(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA),
         selected_columns,
         condition,
     )

--- a/tests/query/joins/test_equivalence_adder.py
+++ b/tests/query/joins/test_equivalence_adder.py
@@ -53,7 +53,7 @@ def test_classify_and_replace() -> None:
 
 ENTITY_GROUP_JOIN = JoinClause(
     IndividualNode("ev", EntitySource(EntityKey.EVENTS, EVENTS_SCHEMA, None)),
-    IndividualNode("gr", EntitySource(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None)),
+    IndividualNode("gr", EntitySource(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA, None)),
     [
         JoinCondition(
             JoinConditionExpression("ev", "group_id"),
@@ -264,7 +264,7 @@ def test_add_equivalent_condition(
     expected_expr: Expression,
 ) -> None:
     override_entity_map(EntityKey.EVENTS, Events())
-    override_entity_map(EntityKey.GROUPEDMESSAGES, GroupedMessage())
+    override_entity_map(EntityKey.GROUPEDMESSAGE, GroupedMessage())
 
     query = CompositeQuery(
         from_clause=join_clause,

--- a/tests/query/joins/test_equivalences.py
+++ b/tests/query/joins/test_equivalences.py
@@ -29,7 +29,7 @@ TEST_CASES = [
         JoinClause(
             IndividualNode("ev", EntitySource(EntityKey.EVENTS, EVENTS_SCHEMA, None)),
             IndividualNode(
-                "gr", EntitySource(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None)
+                "gr", EntitySource(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA, None)
             ),
             [
                 JoinCondition(
@@ -42,15 +42,15 @@ TEST_CASES = [
         ),
         {
             QualifiedCol(EntityKey.EVENTS, "group_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"): {
                 QualifiedCol(EntityKey.EVENTS, "group_id"),
             },
             QualifiedCol(EntityKey.EVENTS, "project_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"): {
                 QualifiedCol(EntityKey.EVENTS, "project_id"),
             },
         },
@@ -75,7 +75,7 @@ TEST_CASES = [
                 None,
             ),
             IndividualNode(
-                "gr", EntitySource(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None)
+                "gr", EntitySource(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA, None)
             ),
             [
                 JoinCondition(
@@ -88,27 +88,27 @@ TEST_CASES = [
         ),
         {
             QualifiedCol(EntityKey.EVENTS, "group_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"),
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "group_id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"): {
                 QualifiedCol(EntityKey.EVENTS, "group_id"),
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "group_id"),
             },
             QualifiedCol(EntityKey.GROUPASSIGNEE, "group_id"): {
                 QualifiedCol(EntityKey.EVENTS, "group_id"),
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"),
             },
             QualifiedCol(EntityKey.EVENTS, "project_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"),
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "project_id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"): {
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "project_id"),
                 QualifiedCol(EntityKey.EVENTS, "project_id"),
             },
             QualifiedCol(EntityKey.GROUPASSIGNEE, "project_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"),
                 QualifiedCol(EntityKey.EVENTS, "project_id"),
             },
         },
@@ -121,7 +121,7 @@ TEST_CASES = [
                     "ev", EntitySource(EntityKey.EVENTS, EVENTS_SCHEMA, None)
                 ),
                 IndividualNode(
-                    "gr", EntitySource(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None)
+                    "gr", EntitySource(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA, None)
                 ),
                 [
                     JoinCondition(
@@ -146,27 +146,27 @@ TEST_CASES = [
         ),
         {
             QualifiedCol(EntityKey.EVENTS, "group_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "id"): {
                 QualifiedCol(EntityKey.EVENTS, "group_id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "user_id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "user_id"): {
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "user_id"),
             },
             QualifiedCol(EntityKey.GROUPASSIGNEE, "user_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "user_id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "user_id"),
             },
             QualifiedCol(EntityKey.EVENTS, "project_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"),
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "project_id"),
             },
-            QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"): {
+            QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"): {
                 QualifiedCol(EntityKey.GROUPASSIGNEE, "project_id"),
                 QualifiedCol(EntityKey.EVENTS, "project_id"),
             },
             QualifiedCol(EntityKey.GROUPASSIGNEE, "project_id"): {
-                QualifiedCol(EntityKey.GROUPEDMESSAGES, "project_id"),
+                QualifiedCol(EntityKey.GROUPEDMESSAGE, "project_id"),
                 QualifiedCol(EntityKey.EVENTS, "project_id"),
             },
         },
@@ -180,7 +180,7 @@ def test_find_equivalences(
     join: JoinClause[EntitySource], graph: EquivalenceGraph
 ) -> None:
     override_entity_map(EntityKey.EVENTS, Events())
-    override_entity_map(EntityKey.GROUPEDMESSAGES, GroupedMessage())
+    override_entity_map(EntityKey.GROUPEDMESSAGE, GroupedMessage())
     override_entity_map(EntityKey.GROUPASSIGNEE, GroupAssignee())
 
     assert get_equivalent_columns(join) == graph

--- a/tests/query/joins/test_subqueries.py
+++ b/tests/query/joins/test_subqueries.py
@@ -43,7 +43,7 @@ BASIC_JOIN = JoinClause(
     ),
     right_node=IndividualNode(
         alias="gr",
-        data_source=Entity(EntityKey.GROUPEDMESSAGES, GROUPS_SCHEMA, None),
+        data_source=Entity(EntityKey.GROUPEDMESSAGE, GROUPS_SCHEMA, None),
     ),
     keys=[
         JoinCondition(
@@ -515,7 +515,7 @@ def test_subquery_generator(
     processed_query: CompositeQuery[Entity],
 ) -> None:
     override_entity_map(EntityKey.EVENTS, Events())
-    override_entity_map(EntityKey.GROUPEDMESSAGES, GroupedMessage())
+    override_entity_map(EntityKey.GROUPEDMESSAGE, GroupedMessage())
     override_entity_map(EntityKey.GROUPASSIGNEE, GroupAssignee())
 
     generate_subqueries(original_query)

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -98,7 +98,7 @@ def test_failures(query_body: str, message: str) -> None:
     mapping = {
         "contains": (EntityKey.TRANSACTIONS, "event_id"),
         "assigned": (EntityKey.GROUPASSIGNEE, "group_id"),
-        "bookmark": (EntityKey.GROUPEDMESSAGES, "first_release_id"),
+        "bookmark": (EntityKey.GROUPEDMESSAGE, "first_release_id"),
         "activity": (EntityKey.SESSIONS, "org_id"),
     }
 

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -1175,8 +1175,8 @@ test_cases = [
                         right_node=IndividualNode(
                             "gm",
                             QueryEntity(
-                                EntityKey.GROUPEDMESSAGES,
-                                get_entity(EntityKey.GROUPEDMESSAGES).get_data_model(),
+                                EntityKey.GROUPEDMESSAGE,
+                                get_entity(EntityKey.GROUPEDMESSAGE).get_data_model(),
                             ),
                         ),
                         keys=[
@@ -1961,7 +1961,7 @@ def test_format_expressions(query_body: str, expected_query: LogicalQuery) -> No
     mapping = {
         "contains": (EntityKey.TRANSACTIONS, "event_id"),
         "assigned": (EntityKey.GROUPASSIGNEE, "group_id"),
-        "bookmark": (EntityKey.GROUPEDMESSAGES, "first_release_id"),
+        "bookmark": (EntityKey.GROUPEDMESSAGE, "first_release_id"),
         "activity": (EntityKey.SESSIONS, "org_id"),
     }
 

--- a/tests/query/snql/test_snql_anonymizer.py
+++ b/tests/query/snql/test_snql_anonymizer.py
@@ -156,7 +156,7 @@ def test_format_expressions(query_body: str, expected_snql_anonymized: str) -> N
     mapping = {
         "contains": (EntityKey.TRANSACTIONS, "event_id"),
         "assigned": (EntityKey.GROUPASSIGNEE, "group_id"),
-        "bookmark": (EntityKey.GROUPEDMESSAGES, "first_release_id"),
+        "bookmark": (EntityKey.GROUPEDMESSAGE, "first_release_id"),
         "activity": (EntityKey.SESSIONS, "org_id"),
     }
 

--- a/tests/query/test_nested.py
+++ b/tests/query/test_nested.py
@@ -63,7 +63,7 @@ def test_join_query() -> None:
 
     groups_query = LogicalQuery(
         Entity(
-            EntityKey.GROUPEDMESSAGES,
+            EntityKey.GROUPEDMESSAGE,
             ColumnSet([("id", UInt(32)), ("message", String())]),
         ),
         selected_columns=[


### PR DESCRIPTION
### Overview
🤮 `EntityKey.GROUPEDMESSAGES` 💩 

😎 `EntityKey.GROUPEDMESSAGE` 🥇 

### Notes
- This is necessary to clean up `EntityKey` and unblock #3109 