### PR TITLE
config(redis) set reinitialize_steps from settings

### DIFF
--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -86,6 +86,7 @@ def _initialize_redis_cluster() -> RedisClientType:
             socket_keepalive=True,
             password=settings.REDIS_PASSWORD,
             max_connections_per_node=True,
+            reinitialize_steps=settings.REDIS_REINITIALIZE_STEPS,
         )
     else:
         return StrictRedis(

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -88,6 +88,7 @@ REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
 REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
 REDIS_DB = int(os.environ.get("REDIS_DB", 1))
 REDIS_INIT_MAX_RETRIES = 3
+REDIS_REINITIALIZE_STEPS = 10
 
 USE_RESULT_CACHE = True
 


### PR DESCRIPTION
Add an option to reduce `reinitialize_steps` from settings for Redis cluster failover handling. I think it's probably best to leave it the same for self-hosted.