### PR TITLE
fix(settings): Remove requirement of CDC and events to be on same cluster

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -45,7 +45,7 @@ DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset()
 # Joins can be performed across storage sets in the same group.
 JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
     {
-        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC}),
+        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO}),
         frozenset({StorageSetKey.ERRORS_V2, StorageSetKey.ERRORS_V2_RO}),
     }
 )

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -45,7 +45,7 @@ DEV_STORAGE_SETS: FrozenSet[StorageSetKey] = frozenset()
 # Joins can be performed across storage sets in the same group.
 JOINABLE_STORAGE_SETS: FrozenSet[FrozenSet[StorageSetKey]] = frozenset(
     {
-        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO}),
+        frozenset({StorageSetKey.EVENTS, StorageSetKey.EVENTS_RO, StorageSetKey.CDC}),
         frozenset({StorageSetKey.ERRORS_V2, StorageSetKey.ERRORS_V2_RO}),
     }
 )

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -71,7 +71,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
             raise ValueError(f"Invalid topic value {key}")
 
     # Validate cluster configuration
-    from snuba.clusters.storage_sets import JOINABLE_STORAGE_SETS, StorageSetKey
+    from snuba.clusters.storage_sets import StorageSetKey
 
     storage_set_to_cluster: MutableMapping[StorageSetKey, Any] = {}
 
@@ -83,23 +83,3 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
                 # We allow definition of storage_sets in configuration files
                 # that are not defined in StorageSetKey.
                 pass
-
-    for group in JOINABLE_STORAGE_SETS:
-        clusters = [storage_set_to_cluster[storage_set] for storage_set in group]
-
-        first = clusters[0]
-        for cluster in clusters[1:]:
-            if first != cluster:
-                for property in [
-                    "host",
-                    "port",
-                    "user",
-                    "password",
-                    "database",
-                    "http_port",
-                    "single_node",
-                    "distributed_cluster_name",
-                ]:
-                    assert first.get(property) == cluster.get(
-                        property
-                    ), f"Invalid property: {property}"


### PR DESCRIPTION
In order to swap the mapping of dataset to clusters for events and errors_v2, we would need to get rid of the validation since CDC datasets are not defined in the tiger clusters.