### PR TITLE
ref(arroyo): Fix arroyo imports

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -6,10 +6,10 @@ import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer, Producer
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.commit import CommitCodec
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
-from arroyo.synchronized import commit_codec
 from arroyo.types import Position
 
 from snuba import settings
@@ -32,6 +32,8 @@ from snuba.utils.streams.configuration_builder import build_kafka_consumer_confi
 from snuba.utils.types import Interval, InvalidRangeError
 
 logger = logging.getLogger(__name__)
+
+commit_codec = CommitCodec()
 
 
 class MessageDetails(NamedTuple):

--- a/snuba/utils/streams/kafka_consumer_with_commit_log.py
+++ b/snuba/utils/streams/kafka_consumer_with_commit_log.py
@@ -2,12 +2,14 @@ from typing import Any, Mapping, Optional
 
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
-from arroyo.synchronized import Commit, commit_codec
+from arroyo.commit import Commit, CommitCodec
 from arroyo.types import Position
 from arroyo.utils.retries import RetryPolicy
 from confluent_kafka import KafkaError
 from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentProducer
+
+commit_codec = CommitCodec()
 
 
 class KafkaConsumerWithCommitLog(KafkaConsumer):


### PR DESCRIPTION
The arroyo.synchronized module is deprecated and will be removed. Import the commit codec from arroyo.commit instead.