### PR TITLE
fix(self-hosted): Skip user prompt for dogfood self-hosted changes

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,6 +52,7 @@ steps:
       - |
         mkdir self-hosted && cd self-hosted
         curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
+        echo 'no' > .reporterrors
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
   - name: "gcr.io/$PROJECT_ID/docker-compose"
     id: e2e-test


### PR DESCRIPTION
Add a .reporterrors file with "no" in the self-hosted directory when running e2e tests to avoid the user prompt. 
