### PR TITLE
fix(migrations): Remove dist operations

### DIFF
--- a/snuba/snuba_migrations/generic_metrics/0004_sets_raw_add_granularities.py
+++ b/snuba/snuba_migrations/generic_metrics/0004_sets_raw_add_granularities.py
@@ -30,19 +30,7 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return [
-            operations.AddColumn(
-                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
-                table_name=self.table_name,
-                column=self.new_column,
-            )
-        ]
+        return []
 
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return [
-            operations.DropColumn(
-                storage_set=StorageSetKey.GENERIC_METRICS_SETS,
-                table_name=self.table_name,
-                column_name=self.new_column.name,
-            )
-        ]
+        return []


### PR DESCRIPTION
**context:**

Normally we wouldn't update migrations in place, but the fix to the migration won't affect the state. The migration `0004_sets_add_raw_granularities` was already wrong and there is a follow up migration https://github.com/getsentry/snuba/pull/2892 that fixes it for the prod configuration.

In prod right now for generic metrics we have the local and dist tables on the same node. When trying to run these migrations in different kinds of configurations such as the local and dist tables separated, you'll run into the following error:

```
clickhouse_driver.errors.ServerException: Code: 60.
DB::Exception: Table default.generic_metric_sets_raw_local doesn't exist..
```
since we are trying to add a column to a node that doesn't have that table. So to fix this, we move the operation on the dist tables since that logic is added in the above mentioned PR with the correct table (the dist table).

