### PR TITLE
feat(mdc): Add pre-commit check for config validation and additionalProperties to schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
           key: cache-epoch-1|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Setup pre-commit
         run: make setup-git
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make install-python-dependencies
       - uses: getsentry/paths-filter@v2
         id: files
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,5 +37,12 @@ repos:
     hooks:
       - id: no-commit-to-branch
         args: ['--branch', 'master']
+  - repo: local
+    hooks:
+      - id: validate-configs-syntax
+        name: validate-configs-syntax
+        entry: python3 ./snuba/validate_configs.py
+        language: system
+        pass_filenames: false
 default_language_version:
   python: python3.8

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -178,7 +178,6 @@ V1_WRITABLE_STORAGE_SCHEMA = {
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
         "stream_loader": STREAM_LOADER_SCHEMA,
     },
-    "additionalProperties": False,
 }
 
 
@@ -192,7 +191,6 @@ V1_READABLE_STORAGE_SCHEMA = {
         "schema": SCHEMA_SCHEMA,
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
     },
-    "additionalProperties": False,
 }
 
 V1_ENTITY_SCHEMA = {
@@ -219,7 +217,6 @@ V1_ENTITY_SCHEMA = {
         "validators",
         "required_time_column",
     ],
-    "additionalProperties": False,
 }
 
 V1_DATASET_SCHEMA = {
@@ -234,7 +231,6 @@ V1_DATASET_SCHEMA = {
             "properties": {"default": TYPE_STRING, "all": TYPE_STRING_ARRAY},
         },
     },
-    "additionalProperties": False,
 }
 
 V1_ENTITY_SUBSCIPTION_SCHEMA = {
@@ -251,7 +247,6 @@ V1_ENTITY_SUBSCIPTION_SCHEMA = {
         "kind",
         "name",
     ],
-    "additionalProperties": False,
 }
 
 
@@ -268,7 +263,6 @@ V1_MIGRATION_GROUP_SCHEMA = {
         },
     },
     "required": ["name", "migrations"],
-    "additionalProperties": False,
 }
 
 V1_ALL_SCHEMAS = {

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -178,6 +178,7 @@ V1_WRITABLE_STORAGE_SCHEMA = {
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
         "stream_loader": STREAM_LOADER_SCHEMA,
     },
+    "additionalProperties": False,
 }
 
 
@@ -191,6 +192,7 @@ V1_READABLE_STORAGE_SCHEMA = {
         "schema": SCHEMA_SCHEMA,
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
     },
+    "additionalProperties": False,
 }
 
 V1_ENTITY_SCHEMA = {
@@ -217,6 +219,7 @@ V1_ENTITY_SCHEMA = {
         "validators",
         "required_time_column",
     ],
+    "additionalProperties": False,
 }
 
 V1_DATASET_SCHEMA = {
@@ -231,6 +234,7 @@ V1_DATASET_SCHEMA = {
             "properties": {"default": TYPE_STRING, "all": TYPE_STRING_ARRAY},
         },
     },
+    "additionalProperties": False,
 }
 
 V1_ENTITY_SUBSCIPTION_SCHEMA = {
@@ -247,6 +251,7 @@ V1_ENTITY_SUBSCIPTION_SCHEMA = {
         "kind",
         "name",
     ],
+    "additionalProperties": False,
 }
 
 
@@ -263,6 +268,7 @@ V1_MIGRATION_GROUP_SCHEMA = {
         },
     },
     "required": ["name", "migrations"],
+    "additionalProperties": False,
 }
 
 V1_ALL_SCHEMAS = {


### PR DESCRIPTION
This PR is responsible for the following:
* Added component config validation pre-commit hook. The python file `snuba/validate_configs.py` was used over the `check-jsonchema` CLI because that only supports `.json` files as an input argument. Our schemas are `.py`. Also note, print statements are not forwarded to stdout in pre-commit hook unless the test fails. 
* `additionalProperties` were added to each full schema to ensure that no arbitrary keys are defined in config. Schema will not validate if a user inputs a key that is not present in `properties`.