### PR TITLE
feat(mdc): Remove default entity from base Dataset class

### DIFF
--- a/bin/mocks/mock-subscriptions
+++ b/bin/mocks/mock-subscriptions
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 import argparse
 import random
-from datetime import timedelta
 
-from snuba.datasets.entities.factory import get_entity_name
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.entity_subscriptions.factory import get_entity_subscription
 from snuba.datasets.factory import get_dataset
 from snuba.redis import redis_client
@@ -31,12 +31,21 @@ parser.add_argument(
     choices=["events"],
     default="events",
 )
+parser.add_argument(
+    "--entity",
+    type=str,
+    help="Entity for subscriptions",
+    dest="entity",
+    choices=["events"],
+    default="events",
+)
 parsed = parser.parse_args()
 
 dataset_name = parsed.dataset
 dataset = get_dataset(dataset_name)
-entity = dataset.get_default_entity()
-entity_key = get_entity_name(entity)
+entity_str = parsed.entity
+entity_key = EntityKey(entity_str)
+entity = get_entity(entity_key)
 storage = entity.get_writable_storage()
 assert storage is not None
 stream_loader = storage.get_table_writer().get_stream_loader()
@@ -52,8 +61,8 @@ for _ in range(parsed.number):
     subscription_data = SubscriptionData(
         query=f"MATCH ({entity_key.value}) SELECT count() AS count WHERE project_id = {project_id}",
         project_id=project_id,
-        time_window=timedelta(minutes=1),
-        resolution=timedelta(minutes=1),
+        time_window_sec=60,
+        resolution_sec=60,
         entity_subscription=entity_subscription,
     )
 

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,9 +1,6 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class GroupAssigneeDataset(Dataset):
@@ -15,7 +12,9 @@ class GroupAssigneeDataset(Dataset):
     there is no issue in fixing the name.
     """
 
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.GROUPASSIGNEE),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.GROUPASSIGNEE),
+            ]
+        )

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,5 +1,9 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class GroupAssigneeDataset(Dataset):
@@ -11,5 +15,7 @@ class GroupAssigneeDataset(Dataset):
     there is no issue in fixing the name.
     """
 
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.GROUPASSIGNEE)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.GROUPASSIGNEE),
+        ]

--- a/snuba/datasets/cdc/groupassignee.py
+++ b/snuba/datasets/cdc/groupassignee.py
@@ -1,6 +1,5 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class GroupAssigneeDataset(Dataset):
@@ -15,6 +14,6 @@ class GroupAssigneeDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.GROUPASSIGNEE),
+                EntityKey.GROUPASSIGNEE,
             ]
         )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,12 +1,11 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class GroupedMessageDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.GROUPEDMESSAGE),
+                EntityKey.GROUPEDMESSAGE,
             ]
         )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,13 +1,12 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class GroupedMessageDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.GROUPEDMESSAGE),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.GROUPEDMESSAGE),
+            ]
+        )

--- a/snuba/datasets/cdc/groupedmessage.py
+++ b/snuba/datasets/cdc/groupedmessage.py
@@ -1,7 +1,13 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class GroupedMessageDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.GROUPEDMESSAGE)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.GROUPEDMESSAGE),
+        ]

--- a/snuba/datasets/configuration/dataset_builder.py
+++ b/snuba/datasets/configuration/dataset_builder.py
@@ -12,7 +12,6 @@ def build_dataset_from_config(config_file_path: str) -> PluggableDataset:
     config = load_configuration_data(config_file_path, DATASET_VALIDATION_SCHEMAS)
     return PluggableDataset(
         name=config["name"],
-        is_experimental=bool(config["is_experimental"]),
-        default_entity=EntityKey(config["entities"]["default"]),
         all_entities=[EntityKey(key) for key in config["entities"]["all"]],
+        is_experimental=bool(config["is_experimental"]),
     )

--- a/snuba/datasets/configuration/generic_metrics/dataset.yaml
+++ b/snuba/datasets/configuration/generic_metrics/dataset.yaml
@@ -5,5 +5,4 @@ name: generic_metrics
 is_experimental: false
 
 entities:
-  default: generic_metrics_sets
   all: [generic_metrics_sets, generic_metrics_distributions]

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -273,8 +273,9 @@ V1_DATASET_SCHEMA = {
         "is_experimental": {"type": "boolean"},
         "entities": {
             "type": "object",
-            "properties": {"default": TYPE_STRING, "all": TYPE_STRING_ARRAY},
+            "properties": {"all": TYPE_STRING_ARRAY},
             "additionalProperties": False,
+            "required": ["all"],
         },
     },
     "required": [

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
+from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.entity import Entity
 from snuba.datasets.plans.query_plan import QueryRunner
@@ -39,7 +40,7 @@ class Dataset:
     manipulate the lower layer objects.
     """
 
-    def __init__(self, *, all_entities: Sequence[Entity]) -> None:
+    def __init__(self, *, all_entities: Sequence[EntityKey]) -> None:
         self.__all_entities = all_entities
 
     def is_experimental(self) -> bool:
@@ -52,7 +53,7 @@ class Dataset:
         return False
 
     def get_all_entities(self) -> Sequence[Entity]:
-        return self.__all_entities
+        return [get_entity(entity_key) for entity_key in self.__all_entities]
 
     def get_query_pipeline_builder(self) -> DatasetQueryPipelineBuilder:
         return DatasetQueryPipelineBuilder()

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import Sequence
 
-from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.entity import Entity
 from snuba.datasets.plans.query_plan import QueryRunner
@@ -40,9 +40,6 @@ class Dataset:
     manipulate the lower layer objects.
     """
 
-    def __init__(self, *, default_entity: EntityKey) -> None:
-        self.__default_entity = default_entity
-
     def is_experimental(self) -> bool:
         """Marks the dataset as experimental. Healthchecks failing on this
         dataset:
@@ -52,15 +49,9 @@ class Dataset:
         """
         return False
 
-    # TODO: Remove once entity selection moves to Sentry
-    def select_entity(self, query: Query) -> EntityKey:
-        return self.__default_entity
-
-    def get_default_entity(self) -> Entity:
-        return get_entity(self.__default_entity)
-
+    @abstractmethod
     def get_all_entities(self) -> Sequence[Entity]:
-        return [self.get_default_entity()]
+        return []
 
     def get_query_pipeline_builder(self) -> DatasetQueryPipelineBuilder:
         return DatasetQueryPipelineBuilder()

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from abc import abstractmethod
 from typing import Sequence
 
 from snuba.datasets.entities.factory import get_entity
@@ -40,6 +39,9 @@ class Dataset:
     manipulate the lower layer objects.
     """
 
+    def __init__(self, *, all_entities: Sequence[Entity]) -> None:
+        self.__all_entities = all_entities
+
     def is_experimental(self) -> bool:
         """Marks the dataset as experimental. Healthchecks failing on this
         dataset:
@@ -49,9 +51,8 @@ class Dataset:
         """
         return False
 
-    @abstractmethod
     def get_all_entities(self) -> Sequence[Entity]:
-        return []
+        return self.__all_entities
 
     def get_query_pipeline_builder(self) -> DatasetQueryPipelineBuilder:
         return DatasetQueryPipelineBuilder()

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -1,10 +1,13 @@
 import logging
+from typing import Sequence
 
 from snuba import environment
 from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.discover import EVENTS_COLUMNS, TRANSACTIONS_COLUMNS
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 from snuba.query.conditions import (
     BINARY_OPERATORS,
     ConditionFunctions,
@@ -26,9 +29,6 @@ EVENTS_AND_TRANSACTIONS = EntityKey.DISCOVER
 
 
 class DiscoverDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.DISCOVER)
-
     # XXX: This is temporary code that will eventually need to be ported to Sentry
     # since SnQL will require an entity to always be specified by the user.
     def select_entity(self, query: Query) -> EntityKey:
@@ -39,6 +39,13 @@ class DiscoverDataset(Dataset):
         track_bad_query(query, selected_entity, EVENTS_COLUMNS, TRANSACTIONS_COLUMNS)
 
         return selected_entity
+
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.DISCOVER),
+            get_entity(EntityKey.DISCOVER_EVENTS),
+            get_entity(EntityKey.DISCOVER_TRANSACTIONS),
+        ]
 
 
 metrics = MetricsWrapper(environment.metrics, "api.discover")

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -5,7 +5,6 @@ from snuba.clickhouse.columns import ColumnSet
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.discover import EVENTS_COLUMNS, TRANSACTIONS_COLUMNS
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 from snuba.query.conditions import (
     BINARY_OPERATORS,
     ConditionFunctions,
@@ -30,9 +29,9 @@ class DiscoverDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.DISCOVER),
-                get_entity(EntityKey.DISCOVER_EVENTS),
-                get_entity(EntityKey.DISCOVER_TRANSACTIONS),
+                EntityKey.DISCOVER,
+                EntityKey.DISCOVER_EVENTS,
+                EntityKey.DISCOVER_TRANSACTIONS,
             ]
         )
 

--- a/snuba/datasets/discover.py
+++ b/snuba/datasets/discover.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Sequence
 
 from snuba import environment
 from snuba.clickhouse.columns import ColumnSet
@@ -7,7 +6,6 @@ from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.discover import EVENTS_COLUMNS, TRANSACTIONS_COLUMNS
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 from snuba.query.conditions import (
     BINARY_OPERATORS,
     ConditionFunctions,
@@ -29,6 +27,15 @@ EVENTS_AND_TRANSACTIONS = EntityKey.DISCOVER
 
 
 class DiscoverDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.DISCOVER),
+                get_entity(EntityKey.DISCOVER_EVENTS),
+                get_entity(EntityKey.DISCOVER_TRANSACTIONS),
+            ]
+        )
+
     # XXX: This is temporary code that will eventually need to be ported to Sentry
     # since SnQL will require an entity to always be specified by the user.
     def select_entity(self, query: Query) -> EntityKey:
@@ -39,13 +46,6 @@ class DiscoverDataset(Dataset):
         track_bad_query(query, selected_entity, EVENTS_COLUMNS, TRANSACTIONS_COLUMNS)
 
         return selected_entity
-
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.DISCOVER),
-            get_entity(EntityKey.DISCOVER_EVENTS),
-            get_entity(EntityKey.DISCOVER_TRANSACTIONS),
-        ]
 
 
 metrics = MetricsWrapper(environment.metrics, "api.discover")

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,12 +1,11 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class EventsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.EVENTS),
+                EntityKey.EVENTS,
             ]
         )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,13 +1,12 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class EventsDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.EVENTS),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.EVENTS),
+            ]
+        )

--- a/snuba/datasets/events.py
+++ b/snuba/datasets/events.py
@@ -1,7 +1,13 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class EventsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.EVENTS)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.EVENTS),
+        ]

--- a/snuba/datasets/functions.py
+++ b/snuba/datasets/functions.py
@@ -1,17 +1,16 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class FunctionsDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.FUNCTIONS),
+            ]
+        )
+
     @classmethod
     def is_experimental(cls) -> bool:
         return True
-
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.FUNCTIONS),
-        ]

--- a/snuba/datasets/functions.py
+++ b/snuba/datasets/functions.py
@@ -1,13 +1,12 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class FunctionsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.FUNCTIONS),
+                EntityKey.FUNCTIONS,
             ]
         )
 

--- a/snuba/datasets/functions.py
+++ b/snuba/datasets/functions.py
@@ -1,11 +1,17 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class FunctionsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.FUNCTIONS)
-
     @classmethod
     def is_experimental(cls) -> bool:
         return True
+
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.FUNCTIONS),
+        ]

--- a/snuba/datasets/generic_metrics.py
+++ b/snuba/datasets/generic_metrics.py
@@ -9,9 +9,6 @@ DEFAULT_GRANULARITY = 60
 
 
 class GenericMetricsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.GENERIC_METRICS_SETS)
-
     def get_all_entities(self) -> Sequence[Entity]:
         return [
             get_entity(EntityKey.GENERIC_METRICS_SETS),

--- a/snuba/datasets/generic_metrics.py
+++ b/snuba/datasets/generic_metrics.py
@@ -1,16 +1,15 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 DEFAULT_GRANULARITY = 60
 
 
 class GenericMetricsDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.GENERIC_METRICS_SETS),
-            get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.GENERIC_METRICS_SETS),
+                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS),
+            ]
+        )

--- a/snuba/datasets/generic_metrics.py
+++ b/snuba/datasets/generic_metrics.py
@@ -1,6 +1,5 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 DEFAULT_GRANULARITY = 60
 
@@ -9,7 +8,7 @@ class GenericMetricsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.GENERIC_METRICS_SETS),
-                get_entity(EntityKey.GENERIC_METRICS_DISTRIBUTIONS),
+                EntityKey.GENERIC_METRICS_SETS,
+                EntityKey.GENERIC_METRICS_DISTRIBUTIONS,
             ]
         )

--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -7,13 +7,10 @@ from snuba.datasets.entity import Entity
 
 
 class MetricsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.METRICS_SETS)
-
     def get_all_entities(self) -> Sequence[Entity]:
-        return (
+        return [
             get_entity(EntityKey.METRICS_COUNTERS),
             get_entity(EntityKey.METRICS_DISTRIBUTIONS),
             get_entity(EntityKey.METRICS_SETS),
             get_entity(EntityKey.ORG_METRICS_COUNTERS),
-        )
+        ]

--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -1,16 +1,15 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class MetricsDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.METRICS_COUNTERS),
-            get_entity(EntityKey.METRICS_DISTRIBUTIONS),
-            get_entity(EntityKey.METRICS_SETS),
-            get_entity(EntityKey.ORG_METRICS_COUNTERS),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.METRICS_COUNTERS),
+                get_entity(EntityKey.METRICS_DISTRIBUTIONS),
+                get_entity(EntityKey.METRICS_SETS),
+                get_entity(EntityKey.ORG_METRICS_COUNTERS),
+            ]
+        )

--- a/snuba/datasets/metrics.py
+++ b/snuba/datasets/metrics.py
@@ -1,15 +1,14 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class MetricsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.METRICS_COUNTERS),
-                get_entity(EntityKey.METRICS_DISTRIBUTIONS),
-                get_entity(EntityKey.METRICS_SETS),
-                get_entity(EntityKey.ORG_METRICS_COUNTERS),
+                EntityKey.METRICS_COUNTERS,
+                EntityKey.METRICS_DISTRIBUTIONS,
+                EntityKey.METRICS_SETS,
+                EntityKey.ORG_METRICS_COUNTERS,
             ]
         )

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,6 +1,5 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class OutcomesDataset(Dataset):
@@ -11,6 +10,6 @@ class OutcomesDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.OUTCOMES),
+                EntityKey.OUTCOMES,
             ]
         )

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,5 +1,9 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class OutcomesDataset(Dataset):
@@ -7,5 +11,7 @@ class OutcomesDataset(Dataset):
     Tracks event ingestion outcomes in Sentry.
     """
 
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.OUTCOMES)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.OUTCOMES),
+        ]

--- a/snuba/datasets/outcomes.py
+++ b/snuba/datasets/outcomes.py
@@ -1,9 +1,6 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class OutcomesDataset(Dataset):
@@ -11,7 +8,9 @@ class OutcomesDataset(Dataset):
     Tracks event ingestion outcomes in Sentry.
     """
 
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.OUTCOMES),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.OUTCOMES),
+            ]
+        )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,5 +1,9 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class OutcomesRawDataset(Dataset):
@@ -7,5 +11,7 @@ class OutcomesRawDataset(Dataset):
     Tracks event ingestion outcomes in Sentry.
     """
 
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.OUTCOMES_RAW)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.OUTCOMES_RAW),
+        ]

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,9 +1,6 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class OutcomesRawDataset(Dataset):
@@ -11,7 +8,9 @@ class OutcomesRawDataset(Dataset):
     Tracks event ingestion outcomes in Sentry.
     """
 
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.OUTCOMES_RAW),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.OUTCOMES_RAW),
+            ]
+        )

--- a/snuba/datasets/outcomes_raw.py
+++ b/snuba/datasets/outcomes_raw.py
@@ -1,6 +1,5 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class OutcomesRawDataset(Dataset):
@@ -11,6 +10,6 @@ class OutcomesRawDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.OUTCOMES_RAW),
+                EntityKey.OUTCOMES_RAW,
             ]
         )

--- a/snuba/datasets/pluggable_dataset.py
+++ b/snuba/datasets/pluggable_dataset.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class PluggableDataset(Dataset):
@@ -22,9 +21,7 @@ class PluggableDataset(Dataset):
         all_entities: list[EntityKey],
         is_experimental: bool | None,
     ) -> None:
-        super().__init__(
-            all_entities=[get_entity(entity_key) for entity_key in all_entities]
-        )
+        super().__init__(all_entities=all_entities)
         self.name = name
         self.__is_experimental = is_experimental or False
 

--- a/snuba/datasets/pluggable_dataset.py
+++ b/snuba/datasets/pluggable_dataset.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from typing import Any
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class PluggableDataset(Dataset):
@@ -23,15 +22,14 @@ class PluggableDataset(Dataset):
         all_entities: list[EntityKey],
         is_experimental: bool | None,
     ) -> None:
-        self.__all_entities = [get_entity(entity_key) for entity_key in all_entities]
+        super().__init__(
+            all_entities=[get_entity(entity_key) for entity_key in all_entities]
+        )
         self.name = name
         self.__is_experimental = is_experimental or False
 
     def is_experimental(self) -> bool:
         return self.__is_experimental
-
-    def get_all_entities(self) -> Sequence[Entity]:
-        return self.__all_entities
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, PluggableDataset) and self.name == other.name

--- a/snuba/datasets/pluggable_dataset.py
+++ b/snuba/datasets/pluggable_dataset.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Sequence
 
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
@@ -20,21 +20,17 @@ class PluggableDataset(Dataset):
         self,
         *,
         name: str,
-        default_entity: EntityKey,
-        all_entities: list[EntityKey] | None,
+        all_entities: list[EntityKey],
         is_experimental: bool | None,
     ) -> None:
-        super().__init__(default_entity=default_entity)
-        self.__all_entities = [
-            get_entity(entity_key) for entity_key in (all_entities or [default_entity])
-        ]
+        self.__all_entities = [get_entity(entity_key) for entity_key in all_entities]
         self.name = name
         self.__is_experimental = is_experimental or False
 
     def is_experimental(self) -> bool:
         return self.__is_experimental
 
-    def get_all_entities(self) -> list[Entity]:
+    def get_all_entities(self) -> Sequence[Entity]:
         return self.__all_entities
 
     def __eq__(self, other: Any) -> bool:

--- a/snuba/datasets/profiles.py
+++ b/snuba/datasets/profiles.py
@@ -1,12 +1,11 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class ProfilesDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.PROFILES),
+                EntityKey.PROFILES,
             ]
         )

--- a/snuba/datasets/profiles.py
+++ b/snuba/datasets/profiles.py
@@ -1,7 +1,13 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class ProfilesDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.PROFILES)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.PROFILES),
+        ]

--- a/snuba/datasets/profiles.py
+++ b/snuba/datasets/profiles.py
@@ -1,13 +1,12 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class ProfilesDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.PROFILES),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.PROFILES),
+            ]
+        )

--- a/snuba/datasets/replays.py
+++ b/snuba/datasets/replays.py
@@ -1,17 +1,16 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class ReplaysDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.REPLAYS),
+            ]
+        )
+
     @classmethod
     def is_experimental(cls) -> bool:
         return True
-
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.REPLAYS),
-        ]

--- a/snuba/datasets/replays.py
+++ b/snuba/datasets/replays.py
@@ -1,11 +1,17 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class ReplaysDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.REPLAYS)
-
     @classmethod
     def is_experimental(cls) -> bool:
         return True
+
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.REPLAYS),
+        ]

--- a/snuba/datasets/replays.py
+++ b/snuba/datasets/replays.py
@@ -1,13 +1,12 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class ReplaysDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.REPLAYS),
+                EntityKey.REPLAYS,
             ]
         )
 

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,7 +1,13 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class SessionsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.SESSIONS)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.SESSIONS),
+        ]

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,13 +1,12 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class SessionsDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.SESSIONS),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.SESSIONS),
+            ]
+        )

--- a/snuba/datasets/sessions.py
+++ b/snuba/datasets/sessions.py
@@ -1,12 +1,11 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class SessionsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.SESSIONS),
+                EntityKey.SESSIONS,
             ]
         )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,12 +1,11 @@
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity
 
 
 class TransactionsDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(
             all_entities=[
-                get_entity(EntityKey.TRANSACTIONS),
+                EntityKey.TRANSACTIONS,
             ]
         )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,13 +1,12 @@
-from typing import Sequence
-
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.entity import Entity
 
 
 class TransactionsDataset(Dataset):
-    def get_all_entities(self) -> Sequence[Entity]:
-        return [
-            get_entity(EntityKey.TRANSACTIONS),
-        ]
+    def __init__(self) -> None:
+        super().__init__(
+            all_entities=[
+                get_entity(EntityKey.TRANSACTIONS),
+            ]
+        )

--- a/snuba/datasets/transactions.py
+++ b/snuba/datasets/transactions.py
@@ -1,7 +1,13 @@
+from typing import Sequence
+
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.entity import Entity
 
 
 class TransactionsDataset(Dataset):
-    def __init__(self) -> None:
-        super().__init__(default_entity=EntityKey.TRANSACTIONS)
+    def get_all_entities(self) -> Sequence[Entity]:
+        return [
+            get_entity(EntityKey.TRANSACTIONS),
+        ]

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -27,6 +27,7 @@ from snuba import state
 from snuba.clickhouse.columns import Array
 from snuba.clickhouse.query_dsl.accessors import get_time_range_expressions
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.discover import DiscoverDataset
 from snuba.datasets.entities.entity_data_model import EntityColumnSet
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
@@ -1380,6 +1381,7 @@ def _select_entity_for_dataset(
             # so only do this selection in that case. If someone wants the "discover" entity specifically
             # then their query will have to only use fields from that entity.
             if query_entity.key == EntityKey.DISCOVER:
+                assert isinstance(dataset, DiscoverDataset)
                 selected_entity_key = dataset.select_entity(query)
                 selected_entity = get_entity(selected_entity_key)
                 query_entity = QueryEntity(

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -604,16 +604,14 @@ if application.debug or application.testing:
 
         return ("ok", 200, {"Content-Type": "text/plain"})
 
-    @application.route("/tests/<dataset:dataset>/insert", methods=["POST"])
-    def write(*, dataset: Dataset) -> RespTuple:
-        return _write_to_entity(entity=dataset.get_default_entity())
-
     @application.route("/tests/entities/<entity:entity>/insert", methods=["POST"])
     def write_to_entity(*, entity: EntityType) -> RespTuple:
         return _write_to_entity(entity=entity)
 
-    @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])
-    def eventstream(*, dataset: Dataset) -> RespTuple:
+    @application.route(
+        "/tests/<dataset:dataset>/<entity:entity>/eventstream", methods=["POST"]
+    )
+    def eventstream(*, dataset: Dataset, entity: Entity) -> RespTuple:
         record = json.loads(http_request.data)
 
         version = record[0]
@@ -629,7 +627,7 @@ if application.debug or application.testing:
 
         type_ = record[1]
 
-        storage = dataset.get_default_entity().get_writable_storage()
+        storage = entity.get_writable_storage()
         assert storage is not None
 
         if type_ == "insert":

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -619,63 +619,7 @@ if application.debug or application.testing:
     @application.route("/tests/<dataset:dataset>/eventstream", methods=["POST"])
     def eventstream_v1(*, dataset: Dataset) -> RespTuple:
         # This endpoint is only used by sentry, this will be deprecated after https://github.com/getsentry/sentry/pull/38877 is merged
-        record = json.loads(http_request.data)
-
-        version = record[0]
-        if version != 2:
-            raise RuntimeError("Unsupported protocol version: %s" % record)
-
-        message: Message[KafkaPayload] = Message(
-            Partition(Topic("topic"), 0),
-            0,
-            KafkaPayload(None, http_request.data, []),
-            datetime.now(),
-        )
-
-        type_ = record[1]
-
-        all_entities = dataset.get_all_entities()
-        assert len(all_entities) > 0
-        entity = all_entities[
-            0
-        ]  # Tests which use this endpoint only send the events or transactions dataset which only have 1 entity
-        storage = entity.get_writable_storage()
-        assert storage is not None
-
-        if type_ == "insert":
-            from arroyo.processing.strategies.streaming import (
-                KafkaConsumerStrategyFactory,
-            )
-
-            from snuba.consumers.consumer import build_batch_writer, process_message
-
-            table_writer = storage.get_table_writer()
-            stream_loader = table_writer.get_stream_loader()
-            strategy = KafkaConsumerStrategyFactory(
-                stream_loader.get_pre_filter(),
-                functools.partial(
-                    process_message, stream_loader.get_processor(), "consumer_grouup"
-                ),
-                build_batch_writer(table_writer, metrics=metrics),
-                max_batch_size=1,
-                max_batch_time=1.0,
-                processes=None,
-                input_block_size=None,
-                output_block_size=None,
-            ).create_with_partitions(lambda offsets: None, {})
-            strategy.submit(message)
-            strategy.close()
-            strategy.join()
-        else:
-            from snuba.replacer import ReplacerWorker
-
-            worker = ReplacerWorker(storage, "consumer_group", metrics=metrics)
-            processed = worker.process_message(message)
-            if processed is not None:
-                batch = [processed]
-                worker.flush_batch(batch)
-
-        return ("ok", 200, {"Content-Type": "text/plain"})
+        return eventstream(entity=dataset.get_all_entities()[0])
 
     @application.route("/tests/<entity:entity>/eventstream", methods=["POST"])
     def eventstream(*, entity: Entity) -> RespTuple:

--- a/tests/clickhouse/query_dsl/test_time_range.py
+++ b/tests/clickhouse/query_dsl/test_time_range.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
 from snuba.clickhouse.query_dsl.accessors import get_time_range
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.translator.query import identity_translate
 from snuba.query.processors.logical.timeseries_processor import TimeSeriesProcessor
@@ -23,8 +25,9 @@ def test_get_time_range() -> None:
         """
 
     events = get_dataset("events")
+    entity = get_entity(EntityKey.EVENTS)
     query, _ = parse_snql_query(body, events)
-    processors = events.get_default_entity().get_query_processors()
+    processors = entity.get_query_processors()
     for processor in processors:
         if isinstance(processor, TimeSeriesProcessor):
             processor.process_query(query, HTTPQuerySettings())

--- a/tests/datasets/configuration/test_dataset_loader.py
+++ b/tests/datasets/configuration/test_dataset_loader.py
@@ -11,8 +11,4 @@ def test_build_entity_from_config_matches_python_definition() -> None:
     ):
         assert py_entity.__class__ == config_entity.__class__
 
-    assert (
-        config_dataset.get_default_entity().__class__
-        == py_dataset.get_default_entity().__class__
-    )
     assert config_dataset.is_experimental() == py_dataset.is_experimental()

--- a/tests/datasets/test_events_processing.py
+++ b/tests/datasets/test_events_processing.py
@@ -1,6 +1,8 @@
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.query import Query
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.query import SelectedExpression
 from snuba.query.expressions import Column, FunctionCall, Literal
@@ -24,7 +26,7 @@ def test_events_processing() -> None:
     }
 
     events_dataset = get_dataset("events")
-    events_entity = events_dataset.get_default_entity()
+    events_entity = get_entity(EntityKey.EVENTS)
 
     query, snql_anonymized = parse_snql_query(query_body["query"], events_dataset)
     request = Request(

--- a/tests/datasets/test_sessions_processing.py
+++ b/tests/datasets/test_sessions_processing.py
@@ -6,6 +6,8 @@ from snuba_sdk.legacy import json_to_snql
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.query import Query
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages.sessions import raw_schema, read_schema
 from snuba.query import SelectedExpression
@@ -35,6 +37,8 @@ def test_sessions_processing() -> None:
     }
 
     sessions = get_dataset("sessions")
+    sessions_entity = get_entity(EntityKey.SESSIONS)
+
     query, snql_anonymized = parse_snql_query(query_body["query"], sessions)
     request = Request(
         id="a",
@@ -90,7 +94,7 @@ def test_sessions_processing() -> None:
         ]
         return QueryResult({}, {})
 
-    sessions.get_default_entity().get_query_pipeline_builder().build_execution_pipeline(
+    sessions_entity.get_query_pipeline_builder().build_execution_pipeline(
         request, query_runner
     ).execute()
 
@@ -195,6 +199,7 @@ def test_select_storage(
     query_body: MutableMapping[str, Any], is_subscription: bool, expected_table: str
 ) -> None:
     sessions = get_dataset("sessions")
+    sessions_entity = get_entity(EntityKey.SESSIONS)
     request = json_to_snql(query_body, "sessions")
     request.validate()
     query, snql_anonymized = parse_snql_query(str(request.query), sessions)
@@ -219,6 +224,6 @@ def test_select_storage(
         assert query.get_from_clause().table_name == expected_table
         return QueryResult({}, {})
 
-    sessions.get_default_entity().get_query_pipeline_builder().build_execution_pipeline(
+    sessions_entity.get_query_pipeline_builder().build_execution_pipeline(
         request, query_runner
     ).execute()

--- a/tests/query/test_query_ast.py
+++ b/tests/query/test_query_ast.py
@@ -5,6 +5,8 @@ from snuba_sdk.legacy import json_to_snql
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.pipeline.processors import execute_all_clickhouse_processors
 from snuba.query import OrderBy, OrderByDirection, SelectedExpression
@@ -343,14 +345,13 @@ def test_alias_validation(
     query_body: MutableMapping[str, Any], expected_result: bool
 ) -> None:
     events = get_dataset("events")
+    events_entity = get_entity(EntityKey.EVENTS)
     request = json_to_snql(query_body, "events")
     request.validate()
     query, _ = parse_snql_query(str(request.query), events)
     settings = HTTPQuerySettings()
     query_plan = (
-        events.get_default_entity()
-        .get_query_pipeline_builder()
-        .build_planner(query, settings)
+        events_entity.get_query_pipeline_builder().build_planner(query, settings)
     ).build_best_plan()
     execute_all_clickhouse_processors(query_plan, settings)
 

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -4,6 +4,7 @@ from typing import Any, MutableMapping
 import pytest
 
 from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.query import SelectedExpression
 from snuba.query.conditions import (
@@ -62,7 +63,7 @@ TESTS = [
 @pytest.mark.parametrize("body, condition", TESTS)
 def test_build_request(body: MutableMapping[str, Any], condition: Expression) -> None:
     dataset = get_dataset("events")
-    entity = dataset.get_default_entity()
+    entity = get_entity(EntityKey.EVENTS)
     schema = RequestSchema.build(HTTPQuerySettings)
 
     request = build_request(

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -3,7 +3,8 @@ import uuid
 from datetime import datetime, timedelta
 
 from snuba import settings
-from snuba.datasets.entities.factory import get_entity_name
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.entity_subscriptions.entity_subscription import EntitySubscription
 from snuba.datasets.events_processor_base import InsertEvent
 from snuba.datasets.factory import get_dataset
@@ -18,7 +19,8 @@ class BaseSubscriptionTest:
         self.platforms = ["a", "b"]
         self.minutes = 20
         self.dataset = get_dataset("events")
-        self.entity_key = get_entity_name(self.dataset.get_default_entity())
+        self.entity = get_entity(EntityKey.EVENTS)
+        self.entity_key = get_entity_name(self.entity)
 
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0

--- a/tests/subscriptions/entity_subscriptions/test_pluggable_entity_subscription.py
+++ b/tests/subscriptions/entity_subscriptions/test_pluggable_entity_subscription.py
@@ -3,7 +3,8 @@ from uuid import UUID
 
 import pytest
 
-from snuba.datasets.entities.factory import get_entity_name
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity, get_entity_name
 from snuba.datasets.entity_subscriptions.entity_subscription import (
     EntitySubscription,
     GenericMetricsSetsSubscription,
@@ -19,7 +20,7 @@ from snuba.subscriptions.subscription import SubscriptionCreator
 from snuba.utils.metrics.timer import Timer
 
 dataset = get_dataset("generic_metrics")
-entity = dataset.get_default_entity()
+entity = get_entity(EntityKey.GENERIC_METRICS_SETS)
 entity_key = get_entity_name(entity)
 storage = entity.get_writable_storage()
 assert storage is not None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2026,9 +2026,7 @@ class TestApi(SimpleAPITest):
                 "data": {"received": time.mktime(self.base_time.timetuple())},
             },
         )
-        response = self.app.post(
-            "/tests/events/events/eventstream", data=json.dumps(event)
-        )
+        response = self.app.post("/tests/events/eventstream", data=json.dumps(event))
         assert response.status_code == 200
 
         query = {
@@ -2057,9 +2055,7 @@ class TestApi(SimpleAPITest):
                 ),
             },
         )
-        response = self.app.post(
-            "/tests/events/events/eventstream", data=json.dumps(event)
-        )
+        response = self.app.post("/tests/events/eventstream", data=json.dumps(event))
         assert response.status_code == 200
 
         result = json.loads(self.post(json.dumps(query)).data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ from snuba import settings, state
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.factory import get_entity, get_entity_name
+from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.events_processor_base import InsertEvent, ReplacementType
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages.errors import storage as errors_storage
@@ -2026,7 +2026,9 @@ class TestApi(SimpleAPITest):
                 "data": {"received": time.mktime(self.base_time.timetuple())},
             },
         )
-        response = self.app.post("/tests/events/eventstream", data=json.dumps(event))
+        response = self.app.post(
+            "/tests/events/events/eventstream", data=json.dumps(event)
+        )
         assert response.status_code == 200
 
         query = {
@@ -2055,7 +2057,9 @@ class TestApi(SimpleAPITest):
                 ),
             },
         )
-        response = self.app.post("/tests/events/eventstream", data=json.dumps(event))
+        response = self.app.post(
+            "/tests/events/events/eventstream", data=json.dumps(event)
+        )
         assert response.status_code == 200
 
         result = json.loads(self.post(json.dumps(query)).data)
@@ -2341,7 +2345,7 @@ class TestDeleteSubscriptionApi(BaseApiTest):
         subscription_id = data["subscription_id"]
         partition = subscription_id.split("/", 1)[0]
 
-        entity_key = get_entity_name(self.dataset.get_default_entity())
+        entity_key = EntityKey.EVENTS
 
         assert (
             len(

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -2,7 +2,6 @@ from typing import Sequence
 from unittest import mock
 
 from snuba.datasets.dataset import Dataset
-from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.events import EventsDataset
 from snuba.web.views import check_clickhouse
 
@@ -22,9 +21,6 @@ class ExperimentalDataset(Dataset):
     def is_experimental(cls) -> bool:
         return True
 
-    def get_default_entity(self) -> BadEntity:
-        return BadEntity()
-
     def get_all_entities(self) -> Sequence[BadEntity]:
         return [BadEntity()]
 
@@ -34,9 +30,6 @@ class BadDataset(Dataset):
     def is_experimental(cls) -> bool:
         return False
 
-    def get_default_entity(self) -> BadEntity:
-        return BadEntity()
-
     def get_all_entities(self) -> Sequence[BadEntity]:
         return [BadEntity()]
 
@@ -44,8 +37,8 @@ class BadDataset(Dataset):
 def fake_get_dataset(name: str) -> Dataset:
     return {
         "events": EventsDataset(),
-        "experimental": ExperimentalDataset(default_entity=EntityKey.PROFILES),
-        "bad": BadDataset(default_entity=EntityKey.TRANSACTIONS),
+        "experimental": ExperimentalDataset(),
+        "bad": BadDataset(),
     }[name]
 
 

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -17,6 +17,9 @@ class BadEntity(mock.MagicMock):
 
 
 class ExperimentalDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(all_entities=[])
+
     @classmethod
     def is_experimental(cls) -> bool:
         return True
@@ -26,6 +29,9 @@ class ExperimentalDataset(Dataset):
 
 
 class BadDataset(Dataset):
+    def __init__(self) -> None:
+        super().__init__(all_entities=[])
+
     @classmethod
     def is_experimental(cls) -> bool:
         return False


### PR DESCRIPTION
Now that all queries sent to Snuba specify an Entity, we want to remove the legacy `default_entity` attribute in a Dataset.

This PR is responsible for the following:
* Removed `default_entity` from base Dataset class and its get method.
* Enforced jsonschema to require configs to specify entities `all` sub-property.
* Added `all_entities` attribute to dataset base class and pass entity keys to child initialization
* Removed all `get_default_entity` occurrences in tests and added support where needed
* Creation of new testing eventstream and insert endpoints to remove `default_entity` and dataset parameter altogether. Plan to re-route to new endpoints are specified here: https://github.com/getsentry/sentry/pull/38877