### PR TITLE
feat(gen-metrics): Accept strings as tag values

### DIFF
--- a/snuba/datasets/generic_metrics_processor.py
+++ b/snuba/datasets/generic_metrics_processor.py
@@ -109,6 +109,7 @@ class GenericMetricsBucketProcessor(MessageProcessor, ABC):
         tags = message["tags"]
         version = message.get("version", 1)
         assert isinstance(tags, Mapping), "Invalid tags type"
+        raw_values_index = self._get_raw_values_index(message)
 
         sorted_tag_items = sorted(tags.items())
         for key, value in sorted_tag_items:
@@ -118,14 +119,11 @@ class GenericMetricsBucketProcessor(MessageProcessor, ABC):
             if version == 1:
                 assert isinstance(value, int), "Tag value invalid"
                 indexed_values.append(value)
+                raw_values.append(raw_values_index.get(str(value), ""))
             elif version == 2:
                 assert isinstance(value, str), "Tag value invalid"
                 indexed_values.append(0)
                 raw_values.append(value)
-
-        if version == 1:
-            raw_values_index = self._get_raw_values_index(message)
-            raw_values = [raw_values_index.get(str(v), "") for v in indexed_values]
 
         processed = {
             "use_case_id": message["use_case_id"],

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -50,16 +50,6 @@ MAPPING_META_TAG_VALUES_STRINGS = {
     },
 }
 
-MAPPING_META_TAG_VALUES_MIXED_STRINGS_INTS = {
-    "c": {
-        "10": "tag-1",
-        "20": "tag-2",
-        "22": "value-2",
-        "30": "tag-3",
-    },
-    "d": {"33": "value-3"},
-}
-
 SET_MESSAGE_SHARED = {
     "use_case_id": "release-health",
     "org_id": 1,

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -75,6 +75,7 @@ SET_MESSAGE_SHARED = {
 }
 
 SET_MESSAGE_TAG_VALUES_STRINGS = {
+    "version": 2,
     "use_case_id": "release-health",
     "org_id": 1,
     "project_id": 2,
@@ -86,20 +87,6 @@ SET_MESSAGE_TAG_VALUES_STRINGS = {
     # test enforce retention days of 30
     "retention_days": 22,
     "mapping_meta": MAPPING_META_TAG_VALUES_STRINGS,
-}
-
-SET_MESSAGE_TAG_VALUES_MIXED_STRINGS_INTS = {
-    "use_case_id": "release-health",
-    "org_id": 1,
-    "project_id": 2,
-    "metric_id": 1232341,
-    "type": "s",
-    "timestamp": timestamp,
-    "tags": {"10": "value-1", "20": 22, "30": 33},
-    "value": [324234, 345345, 456456, 567567],
-    # test enforce retention days of 30
-    "retention_days": 22,
-    "mapping_meta": MAPPING_META_TAG_VALUES_MIXED_STRINGS_INTS,
 }
 
 COUNTER_MESSAGE_SHARED = {
@@ -560,28 +547,6 @@ TEST_CASES_GENERIC = [
             }
         ],
         id="all tag values strings",
-    ),
-    pytest.param(
-        SET_MESSAGE_TAG_VALUES_MIXED_STRINGS_INTS,
-        [
-            {
-                "use_case_id": "release-health",
-                "org_id": 1,
-                "project_id": 2,
-                "metric_id": 1232341,
-                "timestamp": expected_timestamp,
-                "tags.key": [10, 20, 30],
-                "tags.indexed_value": [0, 22, 33],
-                "tags.raw_value": ["value-1", "value-2", "value-3"],
-                "metric_type": "set",
-                "set_values": [324234, 345345, 456456, 567567],
-                "materialization_version": 1,
-                "timeseries_id": ANY,
-                "retention_days": 30,
-                "granularities": [1, 2, 3],
-            }
-        ],
-        id="mixed tag values",
     ),
 ]
 

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -42,6 +42,24 @@ MAPPING_META_COMMON = {
     "d": {"33": "value-3"},
 }
 
+MAPPING_META_TAG_VALUES_STRINGS = {
+    "c": {
+        "10": "tag-1",
+        "20": "tag-2",
+        "30": "tag-3",
+    },
+}
+
+MAPPING_META_TAG_VALUES_MIXED_STRINGS_INTS = {
+    "c": {
+        "10": "tag-1",
+        "20": "tag-2",
+        "22": "value-2",
+        "30": "tag-3",
+    },
+    "d": {"33": "value-3"},
+}
+
 SET_MESSAGE_SHARED = {
     "use_case_id": "release-health",
     "org_id": 1,
@@ -54,6 +72,34 @@ SET_MESSAGE_SHARED = {
     # test enforce retention days of 30
     "retention_days": 22,
     "mapping_meta": MAPPING_META_COMMON,
+}
+
+SET_MESSAGE_TAG_VALUES_STRINGS = {
+    "use_case_id": "release-health",
+    "org_id": 1,
+    "project_id": 2,
+    "metric_id": 1232341,
+    "type": "s",
+    "timestamp": timestamp,
+    "tags": {"10": "value-1", "20": "value-2", "30": "value-3"},
+    "value": [324234, 345345, 456456, 567567],
+    # test enforce retention days of 30
+    "retention_days": 22,
+    "mapping_meta": MAPPING_META_TAG_VALUES_STRINGS,
+}
+
+SET_MESSAGE_TAG_VALUES_MIXED_STRINGS_INTS = {
+    "use_case_id": "release-health",
+    "org_id": 1,
+    "project_id": 2,
+    "metric_id": 1232341,
+    "type": "s",
+    "timestamp": timestamp,
+    "tags": {"10": "value-1", "20": 22, "30": 33},
+    "value": [324234, 345345, 456456, 567567],
+    # test enforce retention days of 30
+    "retention_days": 22,
+    "mapping_meta": MAPPING_META_TAG_VALUES_MIXED_STRINGS_INTS,
 }
 
 COUNTER_MESSAGE_SHARED = {
@@ -491,7 +537,52 @@ TEST_CASES_GENERIC = [
                 "granularities": [1, 2, 3],
             }
         ],
-    )
+        id="all tag values ints",
+    ),
+    pytest.param(
+        SET_MESSAGE_TAG_VALUES_STRINGS,
+        [
+            {
+                "use_case_id": "release-health",
+                "org_id": 1,
+                "project_id": 2,
+                "metric_id": 1232341,
+                "timestamp": expected_timestamp,
+                "tags.key": [10, 20, 30],
+                "tags.indexed_value": [0, 0, 0],
+                "tags.raw_value": ["value-1", "value-2", "value-3"],
+                "metric_type": "set",
+                "set_values": [324234, 345345, 456456, 567567],
+                "materialization_version": 1,
+                "timeseries_id": ANY,
+                "retention_days": 30,
+                "granularities": [1, 2, 3],
+            }
+        ],
+        id="all tag values strings",
+    ),
+    pytest.param(
+        SET_MESSAGE_TAG_VALUES_MIXED_STRINGS_INTS,
+        [
+            {
+                "use_case_id": "release-health",
+                "org_id": 1,
+                "project_id": 2,
+                "metric_id": 1232341,
+                "timestamp": expected_timestamp,
+                "tags.key": [10, 20, 30],
+                "tags.indexed_value": [0, 22, 33],
+                "tags.raw_value": ["value-1", "value-2", "value-3"],
+                "metric_type": "set",
+                "set_values": [324234, 345345, 456456, 567567],
+                "materialization_version": 1,
+                "timeseries_id": ANY,
+                "retention_days": 30,
+                "granularities": [1, 2, 3],
+            }
+        ],
+        id="mixed tag values",
+    ),
 ]
 
 


### PR DESCRIPTION
When the metrics indexer starts writing tag values as strings, the payload of the message would change. We need to start accepting strings for tag values during migration to the new system. Once we migrate, we can change the protocol to only accept strings.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
