### PR TITLE
feat(slicing): StorageSetKey override config for slicing

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -404,7 +404,7 @@ class UndefinedClickhouseCluster(SerializableException):
 
 
 def get_cluster(
-    storage_set_key: StorageSetKey, slice_id: Optional[int]
+    storage_set_key: StorageSetKey, slice_id: Optional[int] = None
 ) -> ClickhouseCluster:
     """Return a clickhouse cluster for a storage set key.
 

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -421,7 +421,8 @@ def get_cluster(
         ]
         storage_set_key = StorageSetKey(sliced_key_name)
 
-    # we assume that below map will be updated accordingly with the new clusters
+    # we assume that below map will be updated accordingly with
+    # the new clusters and sliced StorageSetKeys
     res = _get_storage_set_cluster_map().get(storage_set_key, None)
     if res is None:
         raise UndefinedClickhouseCluster(

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -403,7 +403,9 @@ class UndefinedClickhouseCluster(SerializableException):
     pass
 
 
-def get_cluster(storage_set_key: StorageSetKey) -> ClickhouseCluster:
+def get_cluster(
+    storage_set_key: StorageSetKey, slice_id: Optional[int]
+) -> ClickhouseCluster:
     """Return a clickhouse cluster for a storage set key.
 
     If the storage set key is not defined
@@ -412,6 +414,14 @@ def get_cluster(storage_set_key: StorageSetKey) -> ClickhouseCluster:
     assert (
         storage_set_key not in DEV_STORAGE_SETS or settings.ENABLE_DEV_FEATURES
     ), f"Storage set {storage_set_key} is disabled"
+
+    if slice_id:
+        sliced_key_name = settings.OVERRIDE_STORAGE_SET_KEYS[storage_set_key.value][
+            slice_id
+        ]
+        storage_set_key = StorageSetKey(sliced_key_name)
+
+    # we assume that below map will be updated accordingly with the new clusters
     res = _get_storage_set_cluster_map().get(storage_set_key, None)
     if res is None:
         raise UndefinedClickhouseCluster(

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, FrozenSet, Iterator, Optional
+from typing import Any, FrozenSet, Iterator
 
 _HARDCODED_STORAGE_SET_KEYS = {
     "CDC": "cdc",
@@ -62,7 +62,7 @@ class StorageSetKey(metaclass=_StorageSetKey):
     Storage sets are assigned to clusters via configuration.
     """
 
-    def __init__(self, value: str, slice_id: Optional[int] = None):
+    def __init__(self, value: str):
         self.value = value
 
     def __hash__(self) -> int:
@@ -72,10 +72,7 @@ class StorageSetKey(metaclass=_StorageSetKey):
         return isinstance(other, StorageSetKey) and other.value == self.value
 
     def __repr__(self) -> str:
-        return f"slice(StorageSetKey.{self.value.upper()}, {self.slice_id})"
-
-    def for_slice(self, slice_id: Optional[int]) -> None:
-        self.slice_id = slice_id
+        return f"StorageSetKey.{self.value.upper()}"
 
 
 def register_storage_set_key(key: str) -> StorageSetKey:

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, FrozenSet, Iterator
+from typing import Any, FrozenSet, Iterator, Optional
 
 _HARDCODED_STORAGE_SET_KEYS = {
     "CDC": "cdc",
@@ -62,7 +62,7 @@ class StorageSetKey(metaclass=_StorageSetKey):
     Storage sets are assigned to clusters via configuration.
     """
 
-    def __init__(self, value: str):
+    def __init__(self, value: str, slice_id: Optional[int] = None):
         self.value = value
 
     def __hash__(self) -> int:
@@ -72,7 +72,10 @@ class StorageSetKey(metaclass=_StorageSetKey):
         return isinstance(other, StorageSetKey) and other.value == self.value
 
     def __repr__(self) -> str:
-        return f"StorageSetKey.{self.value.upper()}"
+        return f"slice(StorageSetKey.{self.value.upper()}, {self.slice_id})"
+
+    def for_slice(self, slice_id: Optional[int]) -> None:
+        self.slice_id = slice_id
 
 
 def register_storage_set_key(key: str) -> StorageSetKey:

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -39,7 +39,8 @@ class Storage(ABC):
     def get_storage_set_key(self) -> StorageSetKey:
         return self.__storage_set_key
 
-    def get_cluster(self) -> ClickhouseCluster:
+    def get_cluster(self, slice_id: Optional[int]) -> ClickhouseCluster:
+        self.__storage_set_key.for_slice(slice_id)
         return get_cluster(self.__storage_set_key)
 
     def get_schema(self) -> Schema:

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -39,7 +39,7 @@ class Storage(ABC):
     def get_storage_set_key(self) -> StorageSetKey:
         return self.__storage_set_key
 
-    def get_cluster(self, slice_id: Optional[int]) -> ClickhouseCluster:
+    def get_cluster(self, slice_id: Optional[int] = None) -> ClickhouseCluster:
         return get_cluster(self.__storage_set_key, slice_id)
 
     def get_schema(self) -> Schema:

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -40,8 +40,7 @@ class Storage(ABC):
         return self.__storage_set_key
 
     def get_cluster(self, slice_id: Optional[int]) -> ClickhouseCluster:
-        self.__storage_set_key.for_slice(slice_id)
-        return get_cluster(self.__storage_set_key)
+        return get_cluster(self.__storage_set_key, slice_id)
 
     def get_schema(self) -> Schema:
         return self.__schema

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -29,6 +29,7 @@ DISABLED_DATASETS: Set[str] = set()
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
+# Mapping of StorageSetKeys to a Mapping of slice id to sliced StorageSetKeys
 OVERRIDE_STORAGE_SET_KEYS: Mapping[str, Mapping[int, str]] = {}
 
 # Mapping of logical (key) to physical (value) partitions for storages

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -29,9 +29,8 @@ DISABLED_DATASETS: Set[str] = set()
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
-# The number of physical partitions that we will need to map resources to
-# for storage partitioning
-LOCAL_PHYSICAL_PARTITIONS = 1
+OVERRIDE_STORAGE_SET_KEYS: Mapping[str, Mapping[int, str]] = {}
+
 # Mapping of logical (key) to physical (value) partitions for storages
 # that are partitioned in Snuba resources
 LOGICAL_PARTITION_MAPPING: Mapping[str, int] = {

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -88,10 +88,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
 
     for logical_part in range(0, SENTRY_LOGICAL_PARTITIONS):
         physical_part = locals["LOGICAL_PARTITION_MAPPING"].get(str(logical_part))
-        partition_count = locals["LOCAL_PHYSICAL_PARTITIONS"]
+
         assert (
             physical_part is not None
         ), f"missing physical partition for logical partition {logical_part}"
-        assert (
-            physical_part < locals["LOCAL_PHYSICAL_PARTITIONS"]
-        ), f"physical partition for logical partition {logical_part} is {physical_part}, but only {partition_count} physical partitions exist"

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -53,17 +53,6 @@ def test_topics_sync_in_settings_validator() -> None:
         all_settings["KAFKA_TOPIC_MAP"] = default_map
 
 
-def test_validation_catches_bad_partition_mapping() -> None:
-    all_settings = build_settings_dict()
-
-    part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
-    part_mapping["2"] = 1  # only slice 0 is valid if LOCAL_PHYSICAL_PARTITIONS is = 1
-
-    with pytest.raises(AssertionError):
-        validate_settings(all_settings)
-    part_mapping["2"] = 0
-
-
 def test_validation_catches_unmapped_logical_parts() -> None:
     all_settings = build_settings_dict()
 

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -56,7 +56,6 @@ def test_topics_sync_in_settings_validator() -> None:
 def test_validation_catches_bad_partition_mapping() -> None:
     all_settings = build_settings_dict()
 
-    assert all_settings["LOCAL_PHYSICAL_PARTITIONS"] == 1
     part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
     part_mapping["2"] = 1  # only slice 0 is valid if LOCAL_PHYSICAL_PARTITIONS is = 1
 


### PR DESCRIPTION
- removes `LOCAL_PHYSICAL_PARTITIONS` which assumes a constant number of slices across storages, and an associated test
- adds config for storage set key overrides based on slice ID

- addresses SNS-1688, SNS-1707, and partially addresses SNS-1708
(https://getsentry.atlassian.net/browse/SNS-1688, https://getsentry.atlassian.net/browse/SNS-1708 and https://getsentry.atlassian.net/browse/SNS-1707)