### PR TITLE
Fix unit test: Initialize entity factory to register config entity keys

### DIFF
--- a/tests/datasets/test_entity_factory.py
+++ b/tests/datasets/test_entity_factory.py
@@ -4,9 +4,12 @@ from snuba.datasets.entities.factory import (
     get_all_entity_names,
     get_entity,
     get_entity_name,
+    initialize_entity_factory,
     reset_entity_factory,
 )
 from snuba.datasets.entity import Entity
+
+initialize_entity_factory()
 
 ENTITY_KEYS = [
     EntityKey.DISCOVER,


### PR DESCRIPTION
The addition of the EntityKey class was breaking `tests/datasets/test_entity_factory.py` when individually executed. This is because config entity keys  (currently `GENERIC_METRICS_SETS` and `GENERIC_METRICS_DISTRIBUTIONS`) are registered when the `PluggableEntity` is created. As a result, this isolated test threw an AttributeError when trying to access config entity keys before the factory was created.