### PR TITLE
fix migrations for clickhouse 21.9+, 0014_backfill_errors, error: snu…

### DIFF
--- a/snuba/snuba_migrations/events/0014_backfill_errors.py
+++ b/snuba/snuba_migrations/events/0014_backfill_errors.py
@@ -61,7 +61,7 @@ COLUMNS = [
     ("timestamp", "timestamp"),
     (
         "event_id",
-        "toUUID(UUIDNumToString(toFixedString(unhex(toString(event_id)), 16)))",
+        "toUUID(UUIDNumToString(toFixedString(unhex(toString(assumeNotNull(event_id))), 16)))",
     ),
     ("platform", "ifNull(`platform`, '')"),
     ("environment", "environment"),


### PR DESCRIPTION
fix migrations for clickhouse 21.9+, `0014_backfill_errors`, error: snuba.clickhouse.errors.ClickhouseError: DB::Exception: Illegal column Nullable(FixedString(32)) of first argument of function toString, 
look https://github.com/ClickHouse/ClickHouse/issues/41490 for details

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
