### PR TITLE
feat(optimize): track merge state

### DIFF
--- a/snuba/cleanup.py
+++ b/snuba/cleanup.py
@@ -31,7 +31,7 @@ def get_active_partitions(
 
     response = clickhouse.execute(
         """
-        SELECT DISTINCT partition
+        SELECT DISTINCT partition, partition_id
         FROM system.parts
         WHERE database = %(database)s
         AND table = %(table)s

--- a/snuba/cleanup.py
+++ b/snuba/cleanup.py
@@ -31,7 +31,7 @@ def get_active_partitions(
 
     response = clickhouse.execute(
         """
-        SELECT DISTINCT partition, partition_id
+        SELECT DISTINCT partition
         FROM system.parts
         WHERE database = %(database)s
         AND table = %(table)s

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -204,7 +204,7 @@ def get_current_merging_partitions_info(
     table: str,
 ) -> Sequence[util.MergeInfo]:
     """
-    Returns a dictionary of partitions that are currently part of large merged. Merges
+    Returns a dictionary of partitions that are currently part of large merge. Merges
     are considered large if they are longer than OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME
     or if they are larger than OPTIMIZE_MERGE_MIN_PARTS_CUTTOFF_TIME.
     """

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -174,9 +174,9 @@ def get_partitions_to_optimize(
         WHERE active
         AND database = %(database)s
         AND table = %(table)s
-        GROUP BY partition, partition_id
+        GROUP BY partition
         HAVING c > 1
-        ORDER BY c DESC, partition, partition_id
+        ORDER BY c DESC, partition
         """,
         {"database": database, "table": table},
     )

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -41,8 +41,6 @@ def run_optimize(
     assert isinstance(schema, TableSchema)
     table = schema.get_local_table_name()
     database = storage.get_cluster().get_database()
-    part_format = schema.get_part_format()
-    assert part_format is not None
 
     partitions = get_partitions_to_optimize(
         clickhouse, storage, database, table, before
@@ -87,8 +85,6 @@ def run_optimize_cron_job(
     assert isinstance(schema, TableSchema)
     table = schema.get_local_table_name()
     database = storage.get_cluster().get_database()
-    part_format = schema.get_part_format()
-    assert part_format
     optimize_scheduler = OptimizeScheduler(parallel=parallel)
 
     try:

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -213,7 +213,7 @@ def get_current_merging_partitions_info(
         SELECT
             result_part_name,
             elapsed,
-            progress,      -- get the slowest merge combination possible
+            progress,
             total_size_bytes_compressed
         FROM system.merges
         WHERE database = %(database)s

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -375,7 +375,7 @@ def is_busy_merging(
     """
     Returns true and the estimated sleep time if clickhouse is busy with merges in progress
     for the table. Clickhouse is considered busy if
-        1. there are more than OPTIMIZE_MERGE_MAX_CONCURRENT_JOBS merges in progress
+        1. there are more than OPTIMIZE_MERGE_MAX_CONCURRENT_JOBS merges in progress with an elapsed time greater than OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME
         2. or there is a merge of size greater than OPTIMIZE_MERGE_SIZE_CUTOFF
     """
     merge_info = get_current_merging_partitions_info(clickhouse, database, table)

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -169,7 +169,6 @@ def get_partitions_to_optimize(
         """
         SELECT
             partition,
-            partition_id,
             count() AS c
         FROM system.parts
         WHERE active

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -385,7 +385,7 @@ def is_busy_merging(
             merge_info, key=lambda x: x.estimated_time
         ).estimated_time
         logger.info(
-            f"too many concurrent merges {len(merge_info)}, sleeping for {estimated_sleep_time}s"
+            f"too many concurrent long merges {len(merge_info)}, sleeping for {estimated_sleep_time}s"
         )
         return True, estimated_sleep_time
 

--- a/snuba/optimize_tracker.py
+++ b/snuba/optimize_tracker.py
@@ -108,7 +108,7 @@ class OptimizedPartitionTracker:
 
         """
         all_partitions = self.get_all_partitions()
-        completed_partitions = self.get_scheduled_partitions()
+        scheduled_partitions = self.get_scheduled_partitions()
 
         if not all_partitions:
             raise NoOptimizedStateException

--- a/snuba/optimize_tracker.py
+++ b/snuba/optimize_tracker.py
@@ -41,7 +41,7 @@ class OptimizedPartitionTracker:
             f"{self.__table}:{today}"
         )
         self.__all_bucket = f"{common_prefix}:all"
-        self.__completed_bucket = f"{common_prefix}:completed"
+        self.__scheduled_bucket = f"{common_prefix}:scheduled"
         self.__key_expire_time = expire_time
 
     def __get_partitions(self, bucket: str) -> Set[str]:
@@ -63,11 +63,11 @@ class OptimizedPartitionTracker:
         """
         return self.__get_partitions(self.__all_bucket)
 
-    def get_completed_partitions(self) -> Set[str]:
+    def get_scheduled_partitions(self) -> Set[str]:
         """
-        Get a set of partitions that have completed optimization.
+        Get a set of partitions that have been scheduled for optimization.
         """
-        return self.__get_partitions(self.__completed_bucket)
+        return self.__get_partitions(self.__scheduled_bucket)
 
     def __update_partitions(
         self, bucket: str, encoded_part_names: Sequence[bytes]
@@ -90,11 +90,11 @@ class OptimizedPartitionTracker:
         encoded_part_names = [part.encode("utf-8") for part in part_names]
         self.__update_partitions(self.__all_bucket, encoded_part_names)
 
-    def update_completed_partitions(self, part_name: str) -> None:
+    def update_scheduled_partitions(self, part_name: str) -> None:
         """
-        Add partitions that have completed optimization.
+        Add partitions that have scheduled for optimization.
         """
-        self.__update_partitions(self.__completed_bucket, [part_name.encode("utf-8")])
+        self.__update_partitions(self.__scheduled_bucket, [part_name.encode("utf-8")])
 
     def get_partitions_to_optimize(self) -> Set[str]:
         """
@@ -108,7 +108,7 @@ class OptimizedPartitionTracker:
 
         """
         all_partitions = self.get_all_partitions()
-        completed_partitions = self.get_completed_partitions()
+        completed_partitions = self.get_scheduled_partitions()
 
         if not all_partitions:
             raise NoOptimizedStateException
@@ -125,5 +125,5 @@ class OptimizedPartitionTracker:
         """
         pipe = self.__redis_client.pipeline()
         pipe.delete(self.__all_bucket)
-        pipe.delete(self.__completed_bucket)
+        pipe.delete(self.__scheduled_bucket)
         pipe.execute()

--- a/snuba/optimize_tracker.py
+++ b/snuba/optimize_tracker.py
@@ -113,10 +113,10 @@ class OptimizedPartitionTracker:
         if not all_partitions:
             raise NoOptimizedStateException
 
-        if not completed_partitions:
+        if not scheduled_partitions:
             return all_partitions
         else:
-            return all_partitions - completed_partitions
+            return all_partitions - scheduled_partitions
 
     def delete_all_states(self) -> None:
         """

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -288,10 +288,11 @@ OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 OPTIMIZE_BASE_SLEEP_TIME = 300  # 5 mins
 # merges longer than this will be considered long running
 OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10  # 10 mins
-# merges larger than this will be considered long running and will be waited on
+# merges larger than this will be considered large and will be waited on
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
-# max number of running merges to wait on
-OPTIMIZE_MERGE_MAX_CONCURRENT_JOBS = 3
+# max number of long running merges to wait on. long running are merges
+# running longer thatn the min elapsed time cutoff
+OPTIMIZE_MERGE_MAX_LONG_CONCURRENT_JOBS = 3
 
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -286,6 +286,12 @@ OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
 OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 # sleep time to wait for a merge to complete
 OPTIMIZE_BASE_SLEEP_TIME = 300  # 5 mins
+# merges longer than this will be considered long running
+OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10  # 10 mins
+# merges larger than this will be considered long running and will be waited on
+OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
+# max number of running merges to wait on
+OPTIMIZE_MERGE_MAX_CONCURRENT_JOBS = 3
 
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -285,7 +285,7 @@ PARALLEL_OPTIMIZE_JOB_END_TIME = timedelta(hours=9)
 OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
 OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 # sleep time to wait for a merge to complete
-OPTIMIZE_BASE_SLEEP_TIME = 3000
+OPTIMIZE_BASE_SLEEP_TIME = 300  # 5 mins
 
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -291,7 +291,7 @@ OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10  # 10 mins
 # merges larger than this will be considered large and will be waited on
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
 # max number of long running merges to wait on. long running are merges
-# running longer thatn the min elapsed time cutoff
+# running longer than the min elapsed time cutoff
 OPTIMIZE_MERGE_MAX_LONG_CONCURRENT_JOBS = 3
 
 # Maximum jitter to add to the scheduling of threads of an optimize job

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -284,6 +284,8 @@ PARALLEL_OPTIMIZE_JOB_END_TIME = timedelta(hours=9)
 # avoid spilling over to the next day.
 OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
 OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
+# sleep time to wait for a merge to complete
+OPTIMIZE_BASE_SLEEP_TIME = 3000
 
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 import numbers
 import re
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from enum import Enum
 from functools import partial, wraps
@@ -279,3 +280,16 @@ def with_span(op: str = "function") -> Callable[[F], F]:
         return cast(F, wrapper)
 
     return decorator
+
+
+@dataclass
+class MergeInfo:
+    partition_id: str
+    result_part_name: str
+    elapsed: float
+    progress: float
+    size: int
+
+    @property
+    def estimated_time(self) -> float:
+        return self.elapsed / (self.progress + 0.0001)

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -160,6 +160,7 @@ class Part(NamedTuple):
     name: str
     date: datetime
     retention_days: int
+    partition_id: str
 
 
 class PartSegment(Enum):
@@ -200,7 +201,10 @@ def decode_part_str(part_str: str, partition_format: Sequence[PartSegment]) -> P
 
     if date_str and retention_days:
         return Part(
-            part_str, datetime.strptime(date_str, "%Y-%m-%d"), int(retention_days)
+            part_str,
+            datetime.strptime(date_str, "%Y-%m-%d"),
+            int(retention_days),
+            partition_id,
         )
 
     else:

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -280,12 +280,12 @@ def with_span(op: str = "function") -> Callable[[F], F]:
 
 @dataclass
 class MergeInfo:
-    partition_id: str
     result_part_name: str
     elapsed: float
     progress: float
     size: int
 
     @property
+    # estimated time remaining in seconds
     def estimated_time(self) -> float:
         return self.elapsed / (self.progress + 0.0001)

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -161,7 +161,6 @@ class Part(NamedTuple):
     name: str
     date: datetime
     retention_days: int
-    partition_id: str
 
 
 class PartSegment(Enum):
@@ -202,10 +201,7 @@ def decode_part_str(part_str: str, partition_format: Sequence[PartSegment]) -> P
 
     if date_str and retention_days:
         return Part(
-            part_str,
-            datetime.strptime(date_str, "%Y-%m-%d"),
-            int(retention_days),
-            partition_id,
+            part_str, datetime.strptime(date_str, "%Y-%m-%d"), int(retention_days)
         )
 
     else:

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -5,7 +5,7 @@ from typing import Callable, Mapping
 import pytest
 from freezegun import freeze_time
 
-from snuba import optimize, settings, util
+from snuba import optimize, settings
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -188,17 +188,12 @@ class TestOptimize:
 
         tracker.update_all_partitions([part.name for part in partitions])
 
-        merging_partitions_info = optimize.get_current_merging_partitions_info(
-            clickhouse, database, table, partitions
-        )
-
         with freeze_time(current_time):
             optimize.optimize_partition_runner(
                 clickhouse=clickhouse,
                 database=database,
                 table=table,
                 partitions=[part.name for part in partitions],
-                current_merge_info=merging_partitions_info,
                 scheduler=scheduler,
                 tracker=tracker,
                 clickhouse_host="some-hostname.domain.com",
@@ -257,13 +252,6 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     dummy_partition = "(90,'2022-03-28')"
     tracker.update_all_partitions([dummy_partition])
 
-    merging_partitions_info = optimize.get_current_merging_partitions_info(
-        clickhouse_pool,
-        database,
-        table,
-        [util.Part(dummy_partition, datetime(2022, 3, 28), 90, "90-20220328")],
-    )
-
     with freeze_time(
         last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(minutes=15)
     ):
@@ -274,7 +262,6 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
                 database=database,
                 table=table,
                 partitions=[dummy_partition],
-                current_merge_info=merging_partitions_info,
                 scheduler=scheduler,
                 tracker=tracker,
                 clickhouse_host="some-hostname.domain.com",

--- a/tests/test_optimize_tracker.py
+++ b/tests/test_optimize_tracker.py
@@ -1,9 +1,12 @@
+import asyncio
 import uuid
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 
-from snuba import optimize, settings
+from snuba import optimize, settings, util
+from snuba.clickhouse.native import ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.factory import get_writable_storage
@@ -35,17 +38,17 @@ redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
 )
 def test_optimized_partition_tracker(tracker: OptimizedPartitionTracker) -> None:
     assert len(tracker.get_all_partitions()) == 0
-    assert len(tracker.get_completed_partitions()) == 0
+    assert len(tracker.get_scheduled_partitions()) == 0
     with pytest.raises(NoOptimizedStateException):
         tracker.get_partitions_to_optimize()
 
     tracker.update_all_partitions(["Partition 1", "Partition 2"])
-    tracker.update_completed_partitions("Partition 1")
-    assert tracker.get_completed_partitions() == {"Partition 1"}
+    tracker.update_scheduled_partitions("Partition 1")
+    assert tracker.get_scheduled_partitions() == {"Partition 1"}
     assert tracker.get_partitions_to_optimize() == {"Partition 2"}
 
-    tracker.update_completed_partitions("Partition 2")
-    assert tracker.get_completed_partitions() == {"Partition 1", "Partition 2"}
+    tracker.update_scheduled_partitions("Partition 2")
+    assert tracker.get_scheduled_partitions() == {"Partition 1", "Partition 2"}
     partitions_to_optimize = tracker.get_partitions_to_optimize()
     # Check that we don't return None but a set whose length is 0 indicating
     # that all optimizations have been run.
@@ -54,7 +57,7 @@ def test_optimized_partition_tracker(tracker: OptimizedPartitionTracker) -> None
 
     tracker.delete_all_states()
     assert len(tracker.get_all_partitions()) == 0
-    assert len(tracker.get_completed_partitions()) == 0
+    assert len(tracker.get_scheduled_partitions()) == 0
 
 
 def test_run_optimize_with_partition_tracker() -> None:
@@ -109,15 +112,15 @@ def test_run_optimize_with_partition_tracker() -> None:
     original_num_partitions = len(partitions)
     assert original_num_partitions > 0
     assert len(tracker.get_all_partitions()) == 0
-    assert len(tracker.get_completed_partitions()) == 0
+    assert len(tracker.get_scheduled_partitions()) == 0
 
     # Mark the partitions as optimized in partition tracker to test behavior.
     tracker.update_all_partitions([partition.name for partition in partitions])
     for partition in partitions:
         tracker.update_all_partitions([partition.name])
-        tracker.update_completed_partitions(partition.name)
+        tracker.update_scheduled_partitions(partition.name)
 
-    tracker_completed_partitions = tracker.get_completed_partitions()
+    tracker_completed_partitions = tracker.get_scheduled_partitions()
     assert tracker_completed_partitions is not None
     assert len(tracker_completed_partitions) == original_num_partitions
 
@@ -143,3 +146,129 @@ def test_run_optimize_with_partition_tracker() -> None:
         tracker=tracker,
     )
     assert num_optimized == original_num_partitions
+
+
+def test_run_optimize_with_ongoing_merges() -> None:
+    def write_error_message(writable_storage: WritableTableStorage, time: int) -> None:
+        write_processed_messages(
+            writable_storage,
+            [
+                InsertBatch(
+                    [
+                        {
+                            "event_id": str(uuid.uuid4()),
+                            "project_id": 1,
+                            "deleted": 0,
+                            "timestamp": time,
+                            "retention_days": settings.DEFAULT_RETENTION_DAYS,
+                        }
+                    ],
+                    None,
+                ),
+            ],
+        )
+
+    storage = get_writable_storage(StorageKey.ERRORS)
+    cluster = storage.get_cluster()
+    clickhouse_pool = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
+    table = storage.get_table_writer().get_schema().get_local_table_name()
+    database = cluster.get_database()
+    tracker = OptimizedPartitionTracker(
+        redis_client=redis_client,
+        host=cluster.get_host(),
+        port=cluster.get_port(),
+        database=database,
+        table=table,
+        expire_time=(datetime.now() + timedelta(minutes=3)),
+    )
+    tracker.delete_all_states()
+
+    # Write some messages to the database
+    for week in range(0, 4):
+        write_error_message(
+            writable_storage=storage,
+            time=int((datetime.now() - timedelta(weeks=week)).timestamp()),
+        )
+        write_error_message(
+            writable_storage=storage,
+            time=int((datetime.now() - timedelta(weeks=week)).timestamp()),
+        )
+
+    partitions = optimize.get_partitions_to_optimize(
+        clickhouse_pool, storage, database, table
+    )
+
+    original_num_partitions = len(partitions)
+    assert original_num_partitions > 0
+    assert len(tracker.get_all_partitions()) == 0
+    assert len(tracker.get_scheduled_partitions()) == 0
+
+    with patch("snuba.optimize.get_current_merging_partitions_info") as mock_merge_ids:
+
+        # mock ongoing merges on half the partitions
+        num_merging_parititons = len(partitions) // 2
+        mock_merge_ids.return_value = {
+            partition.name: {
+                "partition_id": partition.partition_id,
+                "elapsed": 123,
+                "progress": 0.5,
+                "estimated_time": 10,  # sleep for 10 seconds on each partition
+            }
+            for partition in partitions[:num_merging_parititons]
+        }
+
+        with patch.object(asyncio, "sleep") as sleep_mock:
+            num_optimized = run_optimize_cron_job(
+                clickhouse=clickhouse_pool,
+                storage=storage,
+                database=database,
+                parallel=1,
+                clickhouse_host="localhost",
+                tracker=tracker,
+            )
+            assert num_optimized == original_num_partitions
+            assert mock_merge_ids.call_count == 1
+
+            sleep_mock.assert_called_with(10)
+            sleep_mock.call_count = (
+                num_merging_parititons  # only sleep on merging partitions
+            )
+
+
+def test_build_merge_info() -> None:
+    storage = get_writable_storage(StorageKey.ERRORS)
+    part_format = storage.get_table_writer().get_schema().get_part_format()
+    assert part_format is not None
+
+    partitions = [
+        util.decode_part_str(part, part_format, partition_id)
+        for part, partition_id in [
+            ("(90,'2022-06-13')", "90-20220613"),
+            ("(90,'2022-09-12')", "90-20220912"),
+        ]
+    ]
+
+    merge_query_result = ClickhouseResult(
+        results=[
+            ["90-20220613_0_1216096_1417", 8020.61436897, 0.9895385071013121, 1],
+            ["90-20220912_133168_133172_1", 0.181636831, 1.0, 1],
+        ]
+    )
+
+    merge_info = optimize.__build_merging_partitions_info(
+        merge_query_result, partitions
+    )
+    assert merge_info == {
+        "(90,'2022-06-13')": {
+            "partition_id": "90-20220613",
+            "elapsed": 8020.61436897,
+            "progress": 0.9895385071013121,
+            "estimated_time": 8020.61436897 / (0.9895385071013121 + 0.0001),
+        },
+        "(90,'2022-09-12')": {
+            "partition_id": "90-20220912",
+            "elapsed": 0.181636831,
+            "progress": 1.0,
+            "estimated_time": 0.181636831 / (1.0 + 0.0001),
+        },
+    }

--- a/tests/test_optimize_tracker.py
+++ b/tests/test_optimize_tracker.py
@@ -11,7 +11,7 @@ from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.optimize import BASE_SLEEP_TIME, run_optimize_cron_job
+from snuba.optimize import run_optimize_cron_job
 from snuba.optimize_tracker import NoOptimizedStateException, OptimizedPartitionTracker
 from snuba.processor import InsertBatch
 from snuba.redis import RedisClientKey, get_redis_client
@@ -229,7 +229,7 @@ def test_run_optimize_with_ongoing_merges() -> None:
             assert num_optimized == original_num_partitions
             assert mock_merge_ids.call_count == 1
 
-            sleep_mock.assert_called_with(BASE_SLEEP_TIME + 10)
+            sleep_mock.assert_called_with(settings.OPTIMIZE_BASE_SLEEP_TIME + 10)
             sleep_mock.call_count = (
                 num_merging_parititons  # only sleep on merging partitions
             )

--- a/tests/test_optimize_tracker.py
+++ b/tests/test_optimize_tracker.py
@@ -210,7 +210,6 @@ def test_run_optimize_with_ongoing_merges() -> None:
         # mock ongoing merges on half the partitions
         current_merges = [
             util.MergeInfo(
-                "90-20220613",
                 "90-20220613_0_1216096_1417",
                 10,
                 0.5,
@@ -260,7 +259,7 @@ def test_merge_info() -> None:
 
     with patch.object(ClickhousePool, "execute") as mock_clickhouse_execute:
         mock_clickhouse_execute.return_value = merge_query_result
-        merge_info = optimize.get_current_merging_partitions_info(
+        merge_info = optimize.get_current_large_merges(
             clickhouse=ClickhousePool(
                 "localhost", 9000, "user", "password", "database"
             ),
@@ -269,14 +268,12 @@ def test_merge_info() -> None:
         )
         assert merge_info == [
             util.MergeInfo(
-                "90-20220613",
                 "90-20220613_0_1216096_1417",
                 8020.61436897,
                 0.9895385071013121,
                 40_000_000_000,
             ),
             util.MergeInfo(
-                "90-20220912",
                 "90-20220912_133168_133172_1",
                 0.181636831,
                 1.0,

--- a/tests/test_optimize_tracker.py
+++ b/tests/test_optimize_tracker.py
@@ -246,10 +246,6 @@ def test_run_optimize_with_ongoing_merges() -> None:
 
 
 def test_merge_info() -> None:
-    storage = get_writable_storage(StorageKey.ERRORS)
-    part_format = storage.get_table_writer().get_schema().get_part_format()
-    assert part_format is not None
-
     merge_query_result = ClickhouseResult(
         results=[
             [

--- a/tests/test_optimize_tracker.py
+++ b/tests/test_optimize_tracker.py
@@ -203,9 +203,7 @@ def test_run_optimize_with_ongoing_merges() -> None:
     assert len(tracker.get_all_partitions()) == 0
     assert len(tracker.get_scheduled_partitions()) == 0
 
-    with patch.object(
-        optimize, "get_current_merging_partitions_info"
-    ) as mock_merge_ids:
+    with patch.object(optimize, "get_current_large_merges") as mock_merge_ids:
 
         # mock ongoing merges on half the partitions
         current_merges = [

--- a/tests/test_optimize_tracker.py
+++ b/tests/test_optimize_tracker.py
@@ -1,4 +1,4 @@
-import asyncio
+import time
 import uuid
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -11,7 +11,7 @@ from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.optimize import run_optimize_cron_job
+from snuba.optimize import BASE_SLEEP_TIME, run_optimize_cron_job
 from snuba.optimize_tracker import NoOptimizedStateException, OptimizedPartitionTracker
 from snuba.processor import InsertBatch
 from snuba.redis import RedisClientKey, get_redis_client
@@ -217,7 +217,7 @@ def test_run_optimize_with_ongoing_merges() -> None:
             for partition in partitions[:num_merging_parititons]
         }
 
-        with patch.object(asyncio, "sleep") as sleep_mock:
+        with patch.object(time, "sleep") as sleep_mock:
             num_optimized = run_optimize_cron_job(
                 clickhouse=clickhouse_pool,
                 storage=storage,
@@ -229,7 +229,7 @@ def test_run_optimize_with_ongoing_merges() -> None:
             assert num_optimized == original_num_partitions
             assert mock_merge_ids.call_count == 1
 
-            sleep_mock.assert_called_with(10)
+            sleep_mock.assert_called_with(BASE_SLEEP_TIME + 10)
             sleep_mock.call_count = (
                 num_merging_parititons  # only sleep on merging partitions
             )


### PR DESCRIPTION
Addresses [SNS-1483](https://getsentry.atlassian.net/browse/SNS-1483). 

Adds functionality to query `system.merges` at the start of an optimization and delay running `OPTIMIZE` on a partition if there are already ongoing merges on that partition.

It works by calling `optimize.is_busy_merging()` to check if it should execute a merge or sleep then retry later. 

`is_busy_merging` queries `system.merges` table for merges executing and returns true and the estimated sleep time if clickhouse is busy with merges in progress for the table. Clickhouse is considered busy if:
1. there are more than `settings.OPTIMIZE_MERGE_MAX_CONCURRENT_JOBS` merges in progress with an elapsed time > `settings.OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME`. These are merges that we consider long running and should probably wait on before attempting again.
2. or there is a merge where `total_size_bytes_compressed` is greater than `settings.OPTIMIZE_MERGE_SIZE_CUTOFF`. These are merges on large parts and we should wait for them.

In both cases, the sleep time is `setting.OPTIMIZE_BASE_SLEEP_TIME + estimated_sleep_time` where `estimated_sleep_time` is the max of `elapsed/progress` of the ongoing merges found in the query.