### PR TITLE
build(dependabot): Ignore parsimonious

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 50
+    ignore:
+      - dependency-name: "parsimonious"


### PR DESCRIPTION
Unfortunately bumping this package caused major performance issues in the past. Ignore upgrades so we don't get bugged about this every week.