### PR TITLE
Revert "fix migrations for clickhouse 21.9+, 0014_backfill_errors, er…

### DIFF
--- a/snuba/snuba_migrations/events/0014_backfill_errors.py
+++ b/snuba/snuba_migrations/events/0014_backfill_errors.py
@@ -61,7 +61,7 @@ COLUMNS = [
     ("timestamp", "timestamp"),
     (
         "event_id",
-        "toUUID(UUIDNumToString(toFixedString(unhex(toString(assumeNotNull(event_id))), 16)))",
+        "toUUID(UUIDNumToString(toFixedString(unhex(toString(event_id)), 16)))",
     ),
     ("platform", "ifNull(`platform`, '')"),
     ("environment", "environment"),


### PR DESCRIPTION
This reverts commit 34741411c8ecd27c1a932dc5378a079336cfd0ad.

This is causing distributed tests in CI (which run on ClickHouse 20.3) to fail.
