### PR TITLE
Revert "build(deps): bump urllib3 from 1.26.11 to 1.26.12 (#3084)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ sentry-arroyo==1.0.4
 sentry-relay==0.8.13
 sentry-sdk==1.9.4
 simplejson==3.17.6
-urllib3==1.26.12
+urllib3==1.26.11
 pyuwsgi==2.0.20
 Werkzeug==2.2.2
 PyYAML==6.0


### PR DESCRIPTION
This reverts commit d744178f89ee4a45c1ab4f9fdaa4902dbf706362.

Snuba admin pod is in a crashloop for some reason after this change. More investigation is needed, let's revert first though.
