### PR TITLE
(fix): Use venv created by pre-commit for validate config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,8 @@ repos:
     hooks:
       - id: validate-configs-syntax
         name: validate-configs-syntax
-        entry: python3 ./snuba/validate_configs.py
-        language: system
-        pass_filenames: false
+        entry: python3 -m snuba.validate_configs
+        language: python
+        additional_dependencies: [ 'jsonschema', 'pyyaml' ]
 default_language_version:
   python: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
         entry: python3 -m snuba.validate_configs
         language: python
         additional_dependencies: [ 'jsonschema', 'pyyaml' ]
-        files: 'snuba/datasets/configuration/*'
+        pass_filenames: false
+        files: 'snuba/datasets/configuration/.*'
 default_language_version:
   python: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,5 +44,6 @@ repos:
         entry: python3 -m snuba.validate_configs
         language: python
         additional_dependencies: [ 'jsonschema', 'pyyaml' ]
+        files: 'snuba/datasets/configuration/*'
 default_language_version:
   python: python3.8


### PR DESCRIPTION
The `validate-configs-syntax` pre-commit hook should be using the venv created by pre-commit by default when specifying `language: python`. Calling `python3 ./snuba/validate_configs.py` does not import the current directory by default. This can be achieved by running the library module as a script. Thanks @asottile-sentry for the reference. 