### PR TITLE
feat: Run ClickHouse 21.8 in CI

### DIFF
--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -51,7 +51,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
       KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
   clickhouse:
-    image: 'yandex/clickhouse-server:20.3.9.70'
+    image: 'yandex/clickhouse-server:21.8.8.29'
     volumes:
       - ./config/clickhouse/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml


### PR DESCRIPTION
This aligns to the ClickHouse version we are using for the majority of tables in production.

It is needed for features like https://github.com/getsentry/snuba/pull/2633.
