### PR TITLE
ref(clickhouse-clusters): Add cluster_nodes to ClickhouseCluster

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -208,6 +208,9 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         distributed_cluster_name: Optional[str] = None,
         cache_partition_id: Optional[str] = None,
         query_settings_prefix: Optional[str] = None,
+        cluster_nodes: Optional[
+            Mapping[str, Sequence[Tuple[str, int, Optional[int], Optional[int]]]]
+        ] = None,
     ):
         super().__init__(storage_sets)
         self.__host = host
@@ -224,6 +227,7 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         self.__connection_cache = connection_cache
         self.__cache_partition_id = cache_partition_id
         self.__query_settings_prefix = query_settings_prefix
+        self.__cluster_nodes = cluster_nodes
 
     def __str__(self) -> str:
         return str(self.__query_node)
@@ -334,6 +338,11 @@ class ClickhouseCluster(Cluster[ClickhouseWriterOptions]):
         )
 
     def __get_cluster_nodes(self, cluster_name: str) -> Sequence[ClickhouseNode]:
+        if self.__cluster_nodes and self.__cluster_nodes.get(cluster_name):
+            return [
+                ClickhouseNode(*node) for node in self.__cluster_nodes[cluster_name]
+            ]
+
         return [
             ClickhouseNode(*host)
             for host in self.get_query_connection(ClickhouseClientSettings.QUERY)
@@ -366,6 +375,7 @@ CLUSTERS = [
         else None,
         cache_partition_id=cluster.get("cache_partition_id"),
         query_settings_prefix=cluster.get("query_settings_prefix"),
+        cluster_nodes=cluster.get("cluster_nodes"),
     )
     for cluster in settings.CLUSTERS
 ]

--- a/snuba/settings/settings_distributed_migrations.py
+++ b/snuba/settings/settings_distributed_migrations.py
@@ -1,0 +1,77 @@
+import os
+
+# Three cluster set up, one for storage nodes, one for dedicated query node,
+# and one for the single node migrations cluster.
+CLUSTERS = [
+    {
+        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PORT", 9005)),
+        "user": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
+        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8225)),
+        "storage_sets": {},
+        "single_node": False,
+        "cluster_name": "cluster_example_one_query",
+        "distributed_cluster_name": "cluster_example_one_query",
+        "cluster_nodes": {
+            "cluster_example_one_query": [
+                (
+                    "localhost",
+                    9005,
+                )
+            ]
+        },
+    },
+    {
+        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PORT", 9005)),
+        "user": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
+        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8225)),
+        "storage_sets": {
+            "cdc",
+            "discover",
+            "events",
+            "events_ro",
+            "metrics",
+            # migrations,
+            "outcomes",
+            "querylog",
+            "sessions",
+            "transactions",
+            "transactions_ro",
+            "transactions_v2",
+            "errors_v2",
+            "errors_v2_ro",
+            "profiles",
+            "functions",
+            "replays",
+            "generic_metrics_sets",
+            "generic_metrics_distributions",
+        },
+        "single_node": False,
+        "cluster_name": "cluster_example_one",
+        "distributed_cluster_name": "cluster_example_one_query",
+        "cluster_nodes": {
+            "cluster_example_one_query": [("localhost", 9005)],
+            "cluster_example_one": [
+                ("localhost", 9051, 1, 1),
+                ("localhost", 9052, 1, 2),
+                ("localhost", 9053, 2, 1),
+                # ("localhost", 9055, 2, 2),
+            ],
+        },
+    },
+    {
+        "host": os.environ.get("CLICKHOUSE_HOST", "localhost"),
+        "port": int(os.environ.get("CLICKHOUSE_PORT", 9054)),
+        "user": os.environ.get("CLICKHOUSE_USER", "default"),
+        "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
+        "database": os.environ.get("CLICKHOUSE_DATABASE", "default"),
+        "http_port": int(os.environ.get("CLICKHOUSE_HTTP_PORT", 8254)),
+        "storage_sets": {"migrations"},
+        "single_node": True,
+    },
+]


### PR DESCRIPTION
I've been playing around with using the `clickhouse-setup` repo, (specifically this setup https://github.com/getsentry/clickhouse-setup/pull/4) to test out the migrations tool. This works well except for the fact that because the clickhouse nodes are running in containers, the migrations tool doesn't have access to the internal ports. And those are needed to in order to run the migrations on the nodes. 

When you connect to a clickhouse node through `docker exec -it` we can see that the `system.clusters` table doesn't give us those internal ports:

```sql
clickhouse-01 :) select * from system.clusters

SELECT *
FROM system.clusters

┌─cluster─────────────────────┬─shard_num─┬─shard_weight─┬─replica_num─┬─host_name────────────────┬─host_address─┬─port─┬─is_local─┬─user────┬─default_database─┬─errors_count─┬─estimated_recovery_time─┐
│ cluster_example_one         │         1 │            1 │           1 │ clickhouse-01            │ 172.18.0.5   │ 9000 │        1 │ default │                  │            0 │                       0 │
│ cluster_example_one         │         1 │            1 │           2 │ clickhouse-01-replica    │ 172.18.0.6   │ 9000 │        0 │ default │                  │            0 │                       0 │
│ cluster_example_one         │         2 │            1 │           1 │ clickhouse-02            │ 172.18.0.7   │ 9000 │        0 │ default │                  │            0 │                       0 │
│ cluster_migrations          │         1 │            1 │           1 │ clickhouse-migrations-01 │ 172.18.0.3   │ 9000 │        0 │ default │                  │            0 │                       0 │
│ test_shard_localhost        │         1 │            1 │           1 │ localhost                │ 127.0.0.1    │ 9000 │        1 │ default │                  │            0 │                       0 │
│ test_shard_localhost_secure │         1 │            1 │           1 │ localhost                │ 127.0.0.1    │ 9440 │        0 │ default │                  │            0 │                       0 │
└─────────────────────────────┴───────────┴──────────────┴─────────────┴──────────────────────────┴──────────────┴──────┴──────────┴─────────┴──────────────────┴──────────────┴─────────────────────────┘

6 rows in set. Elapsed: 0.005 sec.
```

This is why I've added an option `cluster_nodes` param to be able to specify what those ports are so that instead of querying the system tables, the nodes are predefined. This is not something that should be used in production, but would make it easier to test out with the `clickhouse-setup` repostitory. I've added a [not so finished `README.md`](https://github.com/getsentry/clickhouse-setup/blob/0779b1e17ef72d1312d5d4a624a48af5285244d2/examples/new_replica/README.md) to show how this flow would work.