### PR TITLE
feat(profiling): Handle sample format

### DIFF
--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -34,8 +34,8 @@ class ProfilesMessageProcessor(MessageProcessor):
                     additional_fields[field] = message["os"][field]
             else:
                 additional_fields = {
-                    key: message.get(f"device_{key}", "")
-                    for key in ["locale", "classification", "manufacturer", "model"]
+                    f"device_{field}": message.get(f"device_{field}", "")
+                    for field in ["locale", "classification", "manufacturer", "model"]
                 }
                 additional_fields["architecture"] = message.get(
                     "architecture", "unknown"

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -30,8 +30,22 @@ class ProfilesMessageProcessor(MessageProcessor):
                 )
                 additional_fields["version_name"] = message["release"]
 
-                for field in ["name", "version"]:
-                    additional_fields[field] = message["os"][field]
+                for field in ["name", "version", "build_number"]:
+                    additional_fields[f"device_os_{field}"] = message["os"].get(field)
+
+                transaction = message["transactions"][0]
+                additional_fields.update(
+                    {
+                        "transaction_id": transaction["id"],
+                        "transaction_name": transaction["name"],
+                        "trace_id": transaction["trace_id"],
+                        "duration_ns": int(
+                            transaction["relative_end_ns"]
+                            - transaction["relative_start_ns"]
+                        ),
+                        "profile_id": str(UUID(message["event_id"])),
+                    }
+                )
             else:
                 additional_fields = {
                     f"device_{field}": message.get(f"device_{field}", "")
@@ -43,27 +57,32 @@ class ProfilesMessageProcessor(MessageProcessor):
                 additional_fields["version_name"] = message["version_name"]
                 additional_fields["device_os_name"] = message["device_os_name"]
                 additional_fields["device_os_version"] = message["device_os_version"]
+                additional_fields["duration_ns"] = message["duration_ns"]
+                additional_fields["transaction_name"] = message["transaction_name"]
+                additional_fields["transaction_id"] = str(
+                    UUID(message["transaction_id"])
+                )
+                additional_fields["trace_id"] = str(UUID(message["trace_id"]))
+                additional_fields["profile_id"] = str(UUID(message["profile_id"]))
 
             processed = {
                 "android_api_level": message.get("android_api_level"),
                 "device_os_build_number": message.get("device_os_build_number"),
-                "duration_ns": message["duration_ns"],
                 "environment": message.get("environment"),
                 "offset": metadata.offset,
                 "organization_id": message["organization_id"],
                 "partition": metadata.partition,
                 "platform": message["platform"],
                 "profile": "",  # deprecated
-                "profile_id": str(UUID(message["profile_id"])),
                 "project_id": message["project_id"],
                 "received": datetime.utcfromtimestamp(message["received"]),
                 "retention_days": message["retention_days"],
-                "trace_id": str(UUID(message["trace_id"])),
-                "transaction_id": str(UUID(message["transaction_id"])),
-                "transaction_name": message["transaction_name"],
                 "version_code": message.get("version_code", ""),
             }
             processed.update(additional_fields)
+        except IndexError:
+            metrics.increment("invalid_transaction")
+            return None
         except ValueError:
             metrics.increment("invalid_uuid")
             return None

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -17,15 +17,17 @@ class ProfilesMessageProcessor(MessageProcessor):
         try:
             if "version" in message:
                 additional_fields = {
-                    key: message["device"].get(key, "")
-                    for key in [
+                    f"device_{field}": message["device"].get(field, "")
+                    for field in [
                         "locale",
                         "classification",
                         "manufacturer",
                         "model",
-                        "architecture",
                     ]
                 }
+                additional_fields["architecture"] = message["device"].get(
+                    "architecture", "unknown"
+                )
                 additional_fields["version_name"] = message["release"]
 
                 for field in ["name", "version"]:

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.datasets.event_format import EventTooOld, enforce_retention
+from snuba.datasets.events_format import EventTooOld, enforce_retention
 from snuba.processor import InsertBatch, MessageProcessor, ProcessedMessage
 from snuba.utils.metrics.wrapper import MetricsWrapper
 

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -9,44 +9,59 @@ from snuba.utils.metrics.wrapper import MetricsWrapper
 
 metrics = MetricsWrapper(environment.metrics, "profiles.processor")
 
-RETENTION_DAYS_ALLOWED = frozenset([30, 90])
-
 
 class ProfilesMessageProcessor(MessageProcessor):
     def process_message(
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
     ) -> Optional[ProcessedMessage]:
         try:
-            retention_days = message["retention_days"]
-            if retention_days not in RETENTION_DAYS_ALLOWED:
-                retention_days = 30
+            if "version" in message:
+                additional_fields = {
+                    key: message["device"].get(key, "")
+                    for key in [
+                        "locale",
+                        "classification",
+                        "manufacturer",
+                        "model",
+                        "architecture",
+                    ]
+                }
+                additional_fields["version_name"] = message["release"]
+
+                for field in ["name", "version"]:
+                    additional_fields[field] = message["os"][field]
+            else:
+                additional_fields = {
+                    key: message.get(f"device_{key}", "")
+                    for key in ["locale", "classification", "manufacturer", "model"]
+                }
+                additional_fields["architecture"] = message.get(
+                    "architecture", "unknown"
+                )
+                additional_fields["version_name"] = message["version_name"]
+                additional_fields["device_os_name"] = message["device_os_name"]
+                additional_fields["device_os_version"] = message["device_os_version"]
+
             processed = {
-                "organization_id": message["organization_id"],
-                "project_id": message["project_id"],
-                "transaction_id": str(UUID(message["transaction_id"])),
-                "profile_id": str(UUID(message["profile_id"])),
-                "received": datetime.utcfromtimestamp(message["received"]),
-                "profile": message["profile"],
                 "android_api_level": message.get("android_api_level"),
-                "device_classification": message["device_classification"],
-                "device_locale": message["device_locale"],
-                "device_manufacturer": message["device_manufacturer"],
-                "device_model": message["device_model"],
                 "device_os_build_number": message.get("device_os_build_number"),
-                "device_os_name": message["device_os_name"],
-                "device_os_version": message["device_os_version"],
-                "architecture": message.get("architecture", "unknown"),
                 "duration_ns": message["duration_ns"],
                 "environment": message.get("environment"),
-                "platform": message["platform"],
-                "trace_id": str(UUID(message["trace_id"])),
-                "transaction_name": message["transaction_name"],
-                "version_name": message["version_name"],
-                "version_code": message["version_code"],
-                "retention_days": retention_days,
                 "offset": metadata.offset,
+                "organization_id": message["organization_id"],
                 "partition": metadata.partition,
+                "platform": message["platform"],
+                "profile": "",  # deprecated
+                "profile_id": str(UUID(message["profile_id"])),
+                "project_id": message["project_id"],
+                "received": datetime.utcfromtimestamp(message["received"]),
+                "retention_days": message["retention_days"],
+                "trace_id": str(UUID(message["trace_id"])),
+                "transaction_id": str(UUID(message["transaction_id"])),
+                "transaction_name": message["transaction_name"],
+                "version_code": message.get("version_code", ""),
             }
+            processed.update(additional_fields)
         except ValueError:
             metrics.increment("invalid_uuid")
             return None

--- a/snuba/datasets/profiles_processor.py
+++ b/snuba/datasets/profiles_processor.py
@@ -16,10 +16,8 @@ class ProfilesMessageProcessor(MessageProcessor):
         self, message: Mapping[str, Any], metadata: KafkaMessageMetadata
     ) -> Optional[ProcessedMessage]:
         try:
-            received = datetime.fromutctimestamp(message["received"])
-            retention_days = enforce_retention(
-                message["project_id"], message["retention_days"], received
-            )
+            received = datetime.utcfromtimestamp(message["received"])
+            retention_days = enforce_retention(message["retention_days"], received)
 
             if "version" in message:
                 processed = _normalize_sample_format(

--- a/tests/datasets/test_profiles_processor.py
+++ b/tests/datasets/test_profiles_processor.py
@@ -9,12 +9,63 @@ from snuba.processor import InsertBatch
 
 
 @dataclass
+class SampleProfileEvent:
+    device: dict
+    environment: Optional[str]
+    offset: int
+    organization_id: int
+    os: dict
+    partition: int
+    platform: str
+    event_id: str
+    project_id: int
+    received: int
+    release: str
+    retention_days: int
+    timestamp: str
+    transactions: list
+    version: str
+
+    def serialize(self) -> Mapping[str, Any]:
+        return asdict(self)
+
+    def build_result(self, meta: KafkaMessageMetadata) -> Mapping[str, Any]:
+        transaction = self.transactions[0]
+        return {
+            "android_api_level": None,
+            "offset": meta.offset,
+            "partition": meta.partition,
+            "received": datetime.utcfromtimestamp(self.received),
+            "architecture": "arm64e",
+            "device_classification": "high",
+            "device_locale": "fr_FR",
+            "device_manufacturer": "Pierre",
+            "device_model": "ThePierrePhone",
+            "device_os_build_number": "13",
+            "device_os_name": "PierreOS",
+            "device_os_version": "47",
+            "duration_ns": 1234567890,
+            "environment": "production",
+            "organization_id": 123456789,
+            "platform": "cocoa",
+            "profile": "",
+            "profile_id": self.event_id,
+            "project_id": 987654321,
+            "retention_days": 30,
+            "trace_id": transaction["trace_id"],
+            "transaction_id": transaction["id"],
+            "transaction_name": transaction["name"],
+            "version_code": "",
+            "version_name": "v42.0.0 (999)",
+        }
+
+
+@dataclass
 class ProfileEvent:
     organization_id: int
     project_id: int
     transaction_id: str
     received: int
-    profile: str
     profile_id: str
     android_api_level: Optional[int]
     device_classification: str
@@ -41,6 +92,7 @@ class ProfileEvent:
 
     def build_result(self, meta: KafkaMessageMetadata) -> Mapping[str, Any]:
         result = asdict(self)
+        result["profile"] = ""
         result["received"] = datetime.utcfromtimestamp(self.received)
         result["offset"] = meta.offset
         result["partition"] = meta.partition
@@ -48,6 +100,49 @@ class ProfileEvent:
 
 
 class TestProfilesProcessor:
+    def test_sample_profile_message(self) -> None:
+        meta = KafkaMessageMetadata(
+            offset=0, partition=0, timestamp=datetime(1970, 1, 1)
+        )
+        message = SampleProfileEvent(
+            organization_id=123456789,
+            project_id=987654321,
+            transactions=[
+                {
+                    "id": str(uuid.uuid4()),
+                    "name": "lets-get-ready-to-party",
+                    "trace_id": str(uuid.uuid4()),
+                    "relative_start_ns": 0,
+                    "relative_end_ns": 1234567890,
+                }
+            ],
+            device={
+                "classification": "high",
+                "locale": "fr_FR",
+                "manufacturer": "Pierre",
+                "model": "ThePierrePhone",
+                "architecture": "arm64e",
+            },
+            os={
+                "build_number": "13",
+                "name": "PierreOS",
+                "version": "47",
+            },
+            timestamp=datetime.utcnow().isoformat(),
+            received=datetime.utcnow().timestamp(),
+            event_id=str(uuid.uuid4()),
+            environment="production",
+            platform="cocoa",
+            release="v42.0.0 (999)",
+            version="1",
+            retention_days=30,
+            partition=meta.partition,
+            offset=meta.offset,
+        )
+        assert ProfilesMessageProcessor().process_message(
+            message.serialize(), meta
+        ) == InsertBatch([message.build_result(meta)], None)
+
     def test_missing_symbols(self) -> None:
         meta = KafkaMessageMetadata(
             offset=1, partition=0, timestamp=datetime(1970, 1, 1)
@@ -57,7 +152,6 @@ class TestProfilesProcessor:
             project_id=987654321,
             transaction_id=str(uuid.uuid4()),
             received=datetime.utcnow().timestamp(),
-            profile="someprofile",
             profile_id=str(uuid.uuid4()),
             android_api_level=None,
             device_classification="high",
@@ -93,7 +187,6 @@ class TestProfilesProcessor:
             project_id=987654321,
             transaction_id=str(uuid.uuid4()),
             received=datetime.utcnow().timestamp(),
-            profile="someprofile",
             profile_id=str(uuid.uuid4()),
             android_api_level=None,
             device_classification="high",


### PR DESCRIPTION
We have a new format for profiles and we need to map fields slightly differently than the usual format we handle. We detect this new format by looking if a field called `version` is set in the message.