### PR TITLE
ref(migrations): Add copy_tables command

### DIFF
--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -436,7 +436,7 @@ class Runner:
                     python_op.execute_new_node(storage_sets)
 
     @classmethod
-    def create_tables(
+    def copy_tables(
         self,
         node_type: ClickhouseNodeType,
         host_name: str,


### PR DESCRIPTION
**context:**
We have some ClickHouse [migrations tooling](https://github.com/getsentry/snuba/blob/master/MIGRATIONS.md#running-migrations) that currently used to `run` and `reverse` migrations in addition to `list`-ing the current status of migrations. This is great for existing datasets where we already have the clusters set up how we want. However, if we want to add a replica or a shard to an existing cluster we cannot easy do so.

**`add_node` today:**
There is some prior art which is the current [add_node](https://github.com/getsentry/snuba/blob/master/MIGRATIONS.md#adding-a-new-node) command. This basically runs all the migrations in order for a specific storage set on a new node. The end result is hopefully that the node is now in the same state as all the other nodes in the clusters. This works only in the case where the initial `CREATE TABLE` statement doesn't differ from what the current schema is. 

**why it doesn't quite work:**
ClickHouse requires the table schema to be same in order to replicate any data. If we have a table that has gone through many schema iterations, the moment we try to run the `0001_add_table...` migration, the table on the new node is in a different state than the other nodes in the cluster. When we try to grab parts from ZooKeeper to replicate data we will get some sort of error. 

For example, in the case below, the first migration for the `generic_metrics` actually has multiple SQL operations, first `CREATE TABLE`, then `ADD COLUMN` (and then some other add columns/add indexes). But right after we run the first `CREATE TABLE`, we get an error about the `_indexed_tags_hash` missing, which makes sense because it hasn't been added yet (that was the next SQL statement). 
```bash
15:41 $ snuba migrations add-node --type=local --storage-set=generic_metrics_sets --port=9051
migration <snuba.snuba_migrations.generic_metrics.0001_sets_aggregate_table.Migration object at 0x10f8d8790>
Traceback (most recent call last):
  File "/Users/meredith/snuba/snuba/clickhouse/native.py", line 192, in execute
    result_data = query_execute()
  File "/Users/meredith/snuba/.venv/lib/python3.8/site-packages/clickhouse_driver/client.py", line 304, in execute
    rv = self.process_ordinary_query(
  File "/Users/meredith/snuba/.venv/lib/python3.8/site-packages/clickhouse_driver/client.py", line 491, in process_ordinary_query
    return self.receive_result(with_column_types=with_column_types,
  File "/Users/meredith/snuba/.venv/lib/python3.8/site-packages/clickhouse_driver/client.py", line 151, in receive_result
    return result.get_result()
  File "/Users/meredith/snuba/.venv/lib/python3.8/site-packages/clickhouse_driver/result.py", line 50, in get_result
    for packet in self.packet_generator:
  File "/Users/meredith/snuba/.venv/lib/python3.8/site-packages/clickhouse_driver/client.py", line 167, in packet_generator
    packet = self.receive_packet()
  File "/Users/meredith/snuba/.venv/lib/python3.8/site-packages/clickhouse_driver/client.py", line 184, in receive_packet
    raise packet.exception
clickhouse_driver.errors.ServerException: Code: 47.
DB::Exception: Missing columns: '_indexed_tags_hash' while processing query: '_indexed_tags_hash', required columns: '_indexed_tags_hash', source columns: 'value' 'tags.raw_value' 'use_case_id' 'tags.key' 'tags.indexed_value' 'org_id' 'project_id' 'timestamp' 'retention_days' 'granularity' 'metric_id'. Stack trace:
```

**solution**
We don't really care about running the migrations in order, since as far as the cluster in concerned, the migrations are up to date (its just the new node that's not). Instead we can copy the current table statement, using `SHOW CREATE TABLE`, and the use that to create the tables on the new node. This way the schema should be identical to all the other nodes in the cluster, preventing any errors of missing columns, missing indexes etc. 

In order to do this we need:
* access a current node in the cluster to run the `SHOW CREATE TABLE` command
* the table names that we actually want to copy over 
* access to the new node to run the collected table statements.

In this PR I've added the option to either pass in the list of table names, or for the command to do that automatically by running the `SHOW TABLE` command on the node we are copying the table statements from. 