### PR TITLE
fix: undo accidental metric renaming

### DIFF
--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -19,7 +19,7 @@ from snuba.state import get_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger(__name__)
-metrics = MetricsWrapper(environment.metrics, "processors.physical.replaced_groups")
+metrics = MetricsWrapper(environment.metrics, "processors.replaced_groups")
 FINAL_METRIC = "final"
 CONSISTENCY_DENYLIST_METRIC = "post_replacement_consistency_projects_denied"
 


### PR DESCRIPTION
This was changed accidentally in #3098 because the string mirrored the import path. I've double checked the PR that no other metric was renamed in this way. Changing it back so we don't have to update all the dashboards