### PR TITLE
ref(migrations): Allow running migrations per group

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -49,19 +49,25 @@ def list() -> None:
 
 @migrations.command()
 @click.option("--force", is_flag=True)
+@click.option("--group", help="Migration group")
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
-def migrate(force: bool, log_level: Optional[str] = None) -> None:
+def migrate(
+    force: bool, group: Optional[str] = None, log_level: Optional[str] = None
+) -> None:
     """
-    Runs all migrations. Blocking migrations will not be run unless --force is passed.
+    If group is specified, runs all the migrations for a group (including any pending
+    system migrations), otherwise runs all migrations for all groups.
+
+    Blocking migrations will not be run unless --force is passed.
     """
     setup_logging(log_level)
     check_clickhouse_connections()
     runner = Runner()
 
     try:
-        runner.run_all(force=force)
+        runner.run_all(force=force, group=group)
     except MigrationError as e:
         raise click.ClickException(str(e))
 


### PR DESCRIPTION
**context:**
Right now if you run ClickHouse migrations from scratch it is going to run all the migrations for all the groups (that are active). This can make sense for local development on snuba datasets, but for some of the development on the migrations tooling, often it's enough to test with just one group.

Additionally, long term goals for migrations are for folks to own their datasets, and if you were to bring up a new cluster, you are not going to need all the groups, just the groups for that cluster. You could _technically_ get away with that by running each migration individually for each group using `snuba migrations run --migration-id=<migration_id>` but that isn't super user friendly.

This PR adds the ability to run migrations per group at a time. It also makes sure to run the `system` migrations (if they haven't been run yet) to make sure we have the `migrations_local` table created before we try to add data to it. 

**_future work_**
There are some groups that may need to be run together but in order e.g. `discover` migration group relies on other group migrations being run. We can add some sort of `depends_on` for migration groups in the future so that a user can't mistaken run group migrations out of order, but this is not covered in this PR specifically
