### PR TITLE
feat(MDC): Auto import logical processors

### DIFF
--- a/snuba/datasets/common/condition_checker.py
+++ b/snuba/datasets/common/condition_checker.py
@@ -1,0 +1,25 @@
+from abc import ABC, abstractmethod
+
+from snuba.query.expressions import Expression
+
+
+class ConditionChecker(ABC):
+    """
+    Checks if an expression matches a specific shape and content.
+
+    These are declared by storages as mandatory conditions that are
+    supposed to be in the query before it is executed for the query
+    to be acceptable.
+
+    This system is meant to be a failsafe mechanism to prevent
+    bugs in any step of query processing to generate queries that are
+    missing project_id and org_id conditions from the query.
+    """
+
+    @abstractmethod
+    def get_id(self) -> str:
+        raise NotImplementedError
+
+    @abstractmethod
+    def check(self, expression: Expression) -> bool:
+        raise NotImplementedError

--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -78,7 +78,7 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limit
+    processor: referrer_rate_limiter
   -
     processor: org_rate_limiter
     args:

--- a/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
@@ -48,7 +48,7 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limit
+    processor: referrer_rate_limiter
   -
     processor: org_rate_limiter
     args:

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -8,12 +8,12 @@ from snuba.clusters.cluster import (
     get_cluster,
 )
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.common.condition_checker import ConditionChecker
 from snuba.datasets.plans.split_strategy import QuerySplitStrategy
 from snuba.datasets.schemas import Schema
 from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.datasets.table_storage import KafkaStreamLoader, TableWriter
-from snuba.query.expressions import Expression
 from snuba.query.logical import Query
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
@@ -44,28 +44,6 @@ class Storage(ABC):
 
     def get_schema(self) -> Schema:
         return self.__schema
-
-
-class ConditionChecker(ABC):
-    """
-    Checks if an expression matches a specific shape and content.
-
-    These are declared by storages as mandatory conditions that are
-    supposed to be in the query before it is executed for the query
-    to be acceptable.
-
-    This system is meant to be a failsafe mechanism to prevent
-    bugs in any step of query processing to generate queries that are
-    missing project_id and org_id conditions from the query.
-    """
-
-    @abstractmethod
-    def get_id(self) -> str:
-        raise NotImplementedError
-
-    @abstractmethod
-    def check(self, expression: Expression) -> bool:
-        raise NotImplementedError
 
 
 class ReadableStorage(Storage):

--- a/snuba/query/processors/logical/__init__.py
+++ b/snuba/query/processors/logical/__init__.py
@@ -1,9 +1,14 @@
 import os
 from abc import ABC, abstractmethod
+from typing import cast
 
 from snuba.query.logical import Query
 from snuba.query.query_settings import QuerySettings
 from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
+
+
+class ProcessorUnsupportedFromConfig(Exception):
+    pass
 
 
 class LogicalQueryProcessor(ABC, metaclass=RegisteredClass):
@@ -22,9 +27,16 @@ class LogicalQueryProcessor(ABC, metaclass=RegisteredClass):
     instance may be reused.
     """
 
+    def __init__(self) -> None:
+        pass
+
     @classmethod
-    def config_key(cls) -> str:
-        return cls.__name__
+    def get_from_name(cls, name: str) -> "LogicalQueryProcessor":
+        return cast("LogicalQueryProcessor", cls.class_from_name(name))
+
+    @classmethod
+    def from_kwargs(cls, **kwargs: str) -> "LogicalQueryProcessor":
+        return cls(**kwargs)
 
     @abstractmethod
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:

--- a/snuba/query/processors/logical/__init__.py
+++ b/snuba/query/processors/logical/__init__.py
@@ -1,10 +1,12 @@
+import os
 from abc import ABC, abstractmethod
 
 from snuba.query.logical import Query
 from snuba.query.query_settings import QuerySettings
+from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
 
 
-class LogicalQueryProcessor(ABC):
+class LogicalQueryProcessor(ABC, metaclass=RegisteredClass):
     """
     A transformation applied to a Query. This depends on the query structure and
     on the request.query_settings. No additional context is provided.
@@ -20,6 +22,10 @@ class LogicalQueryProcessor(ABC):
     instance may be reused.
     """
 
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
+
     @abstractmethod
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         # TODO: Now the query is moved around through the Request object, which
@@ -29,3 +35,8 @@ class LogicalQueryProcessor(ABC):
         # existing one in place. We can move towards an immutable structure
         # after changing Request.
         raise NotImplementedError
+
+
+import_submodules_in_directory(
+    os.path.dirname(os.path.realpath(__file__)), "snuba.query.processors.logical"
+)

--- a/snuba/query/processors/logical/basic_functions.py
+++ b/snuba/query/processors/logical/basic_functions.py
@@ -18,6 +18,10 @@ class BasicFunctionsProcessor(LogicalQueryProcessor):
     This exists only to preserve the current Snuba syntax and only works on the new AST.
     """
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "basic_functions"
+
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_functions(exp: Expression) -> Expression:
             if isinstance(exp, FunctionCall):

--- a/snuba/query/processors/logical/custom_function.py
+++ b/snuba/query/processors/logical/custom_function.py
@@ -5,7 +5,10 @@ from snuba.query.exceptions import InvalidExpressionException
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query
 from snuba.query.parser.expressions import parse_clickhouse_function
-from snuba.query.processors.logical import LogicalQueryProcessor
+from snuba.query.processors.logical import (
+    LogicalQueryProcessor,
+    ProcessorUnsupportedFromConfig,
+)
 from snuba.query.query_settings import QuerySettings
 from snuba.query.validation import InvalidFunctionCall
 from snuba.query.validation.signature import ParamType, SignatureValidator
@@ -39,6 +42,13 @@ def partial_function(body: str, constants: Sequence[Tuple[str, Any]]) -> Express
 
 class CustomFunction(LogicalQueryProcessor):
     """
+    WARNING
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        This query processor is not referencable from config
+
+        TODO: either make it work or remove it
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
     Defines a custom snuba function.
     The custom function has a name, a signature in the form of a list of
     parameter names and types, an expanded expression which is the body
@@ -80,6 +90,16 @@ class CustomFunction(LogicalQueryProcessor):
             self.__param_names, param_types = zip(*signature)
         self.__body = body
         self.__validator = SignatureValidator(param_types)
+
+    @classmethod
+    def config_key(cls) -> str:
+        return "__unsupported__:custom_function"
+
+    @classmethod
+    def from_kwargs(cls, **kwargs: str) -> LogicalQueryProcessor:
+        raise ProcessorUnsupportedFromConfig(
+            f"{cls.__name__} is cannot be referenced from configuration because it has a constructor with a python object parameter, either change the constructor to take a basic type (e.g. str, int) or reconsider using this processor"
+        )
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def apply_function(expression: Expression) -> Expression:

--- a/snuba/query/processors/logical/granularity_processor.py
+++ b/snuba/query/processors/logical/granularity_processor.py
@@ -15,6 +15,10 @@ DEFAULT_GRANULARITY_RAW = 60
 class GranularityProcessor(LogicalQueryProcessor):
     """Use the granularity set on the query to filter on the granularity column"""
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "granularity"
+
     @staticmethod
     def __get_granularity(query: Query) -> int:
         """Find the best fitting granularity for this query"""
@@ -89,6 +93,10 @@ class MappedGranularityProcessor(LogicalQueryProcessor):
             mapping.raw for mapping in self._accepted_granularities
         ]
         self._default_granularity_enum = default_granularity
+
+    @classmethod
+    def config_key(cls) -> str:
+        return "handle_mapped_granularities"
 
     def __get_granularity(self, query: Query) -> int:
         """Find the best fitting granularity for this query"""

--- a/snuba/query/processors/logical/handled_functions.py
+++ b/snuba/query/processors/logical/handled_functions.py
@@ -42,6 +42,10 @@ class HandledFunctionsProcessor(LogicalQueryProcessor):
     def __init__(self, column: str):
         self.__column = column
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "handled_functions"
+
     def validate_parameters(self, exp: FunctionCall, entity: QueryEntity) -> None:
         validator = SignatureValidator([])
         try:

--- a/snuba/query/processors/logical/object_id_rate_limiter.py
+++ b/snuba/query/processors/logical/object_id_rate_limiter.py
@@ -45,6 +45,10 @@ class ObjectIDRateLimiterProcessor(LogicalQueryProcessor):
                 return True
         return False
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "object_id_rate_limiter"
+
     def get_object_id(
         self, query: Query, query_settings: QuerySettings
     ) -> Optional[str]:
@@ -135,6 +139,10 @@ class OnlyIfConfiguredRateLimitProcessor(ObjectIDRateLimiterProcessor):
 
         query_settings.add_rate_limit(rate_limit)
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "only_if_configured_rate_limiter"
+
 
 class OrganizationRateLimiterProcessor(ObjectIDRateLimiterProcessor):
     """
@@ -150,6 +158,10 @@ class OrganizationRateLimiterProcessor(ObjectIDRateLimiterProcessor):
             "org_per_second_limit",
             "org_concurrent_limit",
         )
+
+    @classmethod
+    def config_key(cls) -> str:
+        return "org_rate_limiter"
 
 
 class ProjectReferrerRateLimiter(OnlyIfConfiguredRateLimitProcessor):
@@ -179,6 +191,10 @@ class ProjectReferrerRateLimiter(OnlyIfConfiguredRateLimitProcessor):
         obj_id = str(obj_ids.pop())
         return str(obj_id)
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "project_referrer_rate_limiter"
+
 
 class ReferrerRateLimiterProcessor(OnlyIfConfiguredRateLimitProcessor):
     """This is more of a load shedder than a rate limiter. we limit a specific
@@ -192,6 +208,10 @@ class ReferrerRateLimiterProcessor(OnlyIfConfiguredRateLimitProcessor):
             "referrer_concurrent_limit",
             query_settings_field="referrer",
         )
+
+    @classmethod
+    def config_key(cls) -> str:
+        return "referrer_rate_limiter"
 
     def get_object_id(self, query: Query, query_settings: QuerySettings) -> str:
         return query_settings.referrer
@@ -211,3 +231,7 @@ class ProjectRateLimiterProcessor(ObjectIDRateLimiterProcessor):
             "project_per_second_limit",
             "project_concurrent_limit",
         )
+
+    @classmethod
+    def config_key(cls) -> str:
+        return "project_rate_limiter"

--- a/snuba/query/processors/logical/quota_processor.py
+++ b/snuba/query/processors/logical/quota_processor.py
@@ -17,6 +17,10 @@ class ResourceQuotaProcessor(LogicalQueryProcessor):
     def __init__(self, project_field: str):
         self.__project_field = project_field
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "resource_quota_limiter"
+
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         enabled = get_config(ENABLED_CONFIG, 1)
         if not enabled:

--- a/snuba/query/processors/logical/tags_expander.py
+++ b/snuba/query/processors/logical/tags_expander.py
@@ -14,6 +14,10 @@ class TagsExpanderProcessor(LogicalQueryProcessor):
     valid column name.
     """
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "tags_expander"
+
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_expression(exp: Expression) -> Expression:
             # This is intentionally not configurable in order to discourage creating

--- a/snuba/query/processors/logical/tags_type_transformer.py
+++ b/snuba/query/processors/logical/tags_type_transformer.py
@@ -11,6 +11,10 @@ class TagsTypeTransformer(LogicalQueryProcessor):
     used by the metrics and generic_metrics entities
     """
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "transform_tag_types"
+
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_expression(exp: Expression) -> Expression:
             if not isinstance(exp, SubscriptableReference):

--- a/snuba/query/processors/logical/timeseries_processor.py
+++ b/snuba/query/processors/logical/timeseries_processor.py
@@ -92,6 +92,10 @@ class TimeSeriesProcessor(LogicalQueryProcessor):
             ),
         )
 
+    @classmethod
+    def config_key(cls) -> str:
+        return "translate_time_series"
+
     def __group_time_column(
         self, exp: Expression, granularity: Optional[int]
     ) -> Expression:

--- a/snuba/query/processors/physical/__init__.py
+++ b/snuba/query/processors/physical/__init__.py
@@ -1,12 +1,14 @@
+import os
 from abc import ABC, abstractmethod
 
 from snuba.clickhouse.query import Query
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
 from snuba.query.query_settings import QuerySettings
+from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
 
 
-class ClickhouseQueryProcessor(ABC):
+class ClickhouseQueryProcessor(ABC, metaclass=RegisteredClass):
     """
     A transformation applied to a Clickhouse Query. This transformation mutates the
     Query object in place.
@@ -20,6 +22,10 @@ class ClickhouseQueryProcessor(ABC):
     Processors are designed to be stateless. There is no guarantee whether the same
     instance will be reused.
     """
+
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
 
     @abstractmethod
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
@@ -43,3 +49,8 @@ class CompositeQueryProcessor(ABC):
         self, query: CompositeQuery[Table], query_settings: QuerySettings
     ) -> None:
         raise NotImplementedError
+
+
+import_submodules_in_directory(
+    os.path.dirname(os.path.realpath(__file__)), "snuba.query.processors.physical"
+)

--- a/snuba/query/processors/physical/__init__.py
+++ b/snuba/query/processors/physical/__init__.py
@@ -1,14 +1,12 @@
-import os
 from abc import ABC, abstractmethod
 
 from snuba.clickhouse.query import Query
 from snuba.query.composite import CompositeQuery
 from snuba.query.data_source.simple import Table
 from snuba.query.query_settings import QuerySettings
-from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
 
 
-class ClickhouseQueryProcessor(ABC, metaclass=RegisteredClass):
+class ClickhouseQueryProcessor(ABC):
     """
     A transformation applied to a Clickhouse Query. This transformation mutates the
     Query object in place.
@@ -22,10 +20,6 @@ class ClickhouseQueryProcessor(ABC, metaclass=RegisteredClass):
     Processors are designed to be stateless. There is no guarantee whether the same
     instance will be reused.
     """
-
-    @classmethod
-    def config_key(cls) -> str:
-        return cls.__name__
 
     @abstractmethod
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
@@ -49,8 +43,3 @@ class CompositeQueryProcessor(ABC):
         self, query: CompositeQuery[Table], query_settings: QuerySettings
     ) -> None:
         raise NotImplementedError
-
-
-import_submodules_in_directory(
-    os.path.dirname(os.path.realpath(__file__)), "snuba.query.processors.physical"
-)

--- a/snuba/query/processors/physical/conditions_enforcer.py
+++ b/snuba/query/processors/physical/conditions_enforcer.py
@@ -2,7 +2,7 @@ import logging
 from typing import Sequence
 
 from snuba.clickhouse.query import Expression, Query
-from snuba.datasets.storage import ConditionChecker
+from snuba.datasets.common.condition_checker import ConditionChecker
 from snuba.query.conditions import (
     ConditionFunctions,
     condition_pattern,

--- a/snuba/query/processors/physical/null_column_caster.py
+++ b/snuba/query/processors/physical/null_column_caster.py
@@ -1,4 +1,4 @@
-from typing import Dict, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, Sequence
 
 from snuba.clickhouse.columns import FlattenedColumn, SchemaModifiers
 from snuba.clickhouse.query import Query

--- a/snuba/query/processors/physical/null_column_caster.py
+++ b/snuba/query/processors/physical/null_column_caster.py
@@ -1,12 +1,14 @@
-from typing import Dict, Sequence
+from typing import Dict, Sequence, TYPE_CHECKING
 
 from snuba.clickhouse.columns import FlattenedColumn, SchemaModifiers
 from snuba.clickhouse.query import Query
-from snuba.datasets.storage import ReadableTableStorage
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.functions import AGGREGATION_FUNCTIONS
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
+
+if TYPE_CHECKING:
+    from snuba.datasets.storage import ReadableTableStorage
 
 
 def _col_is_nullable(col: FlattenedColumn) -> bool:
@@ -69,7 +71,7 @@ class NullColumnCaster(ClickhouseQueryProcessor):
 
         return mismatched_col_name_to_col
 
-    def __init__(self, merge_table_sources: Sequence[ReadableTableStorage]):
+    def __init__(self, merge_table_sources: Sequence["ReadableTableStorage"]):
         """
         Args:
             merge_table_sources: sequence of the storages which make up the merge table,

--- a/snuba/utils/registered_class.py
+++ b/snuba/utils/registered_class.py
@@ -54,10 +54,21 @@ class RegisteredClass(ABCMeta):
                 return "sub_class"
 
 
-        assert SomeGenericClass.from_name("sub_class") is Subclass
+        assert SomeGenericClass.class_from_name("sub_class") is Subclass
 
     Notes:
-        The base class cannot be looked up by name, only subclasses
+        -   The base class cannot be looked up by name, only subclasses
+        -   The `class_from_name` function cannot be typed due to the constraints of python metaclases.
+            In order to  get around this limitation, the following workaround is used
+
+            class SomeGenericClass(metaclass=RegisteredClass):
+
+                # the `get_from_name` naming is used as convention
+                @classmethod
+                def get_from_name(cls, name: str) -> "SomeGenericClass":
+                    return typing.cast("SomeGenericClass", cls.class_from_name(name))
+
+
     """
 
     def config_key(cls) -> str:

--- a/snuba/utils/registered_class.py
+++ b/snuba/utils/registered_class.py
@@ -144,7 +144,7 @@ def import_submodules_in_directory(
         # to not infinite loop on re-importing __init__.py but we can just avoid
         # that check. Whether this is called in an __init__.py or not, if we're executing
         # this code, we've already imported the __init__.py
-        if fname == "__init__.py":
+        if fname == "__init__.py" or not fname.endswith(".py"):
             continue
         # ------------------------------------------------------------------------
         module_name = fname.replace(".py", "")

--- a/tests/datasets/configuration/broken_entity_bad_query_processor.yaml
+++ b/tests/datasets/configuration/broken_entity_bad_query_processor.yaml
@@ -51,7 +51,7 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limit
+    processor: referrer_rate_limiter
   -
     processor: org_rate_limiter
     args:

--- a/tests/datasets/configuration/broken_entity_positional_validator_args.yaml
+++ b/tests/datasets/configuration/broken_entity_positional_validator_args.yaml
@@ -50,7 +50,7 @@ query_processors:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limit
+    processor: referrer_rate_limiter
   -
     processor: org_rate_limiter
     args:


### PR DESCRIPTION
Currently query processors work in the entity builder because of a hack that manually imports them and adds them to a dictionary. This PR makes the LogicalQueryProcessor a registered class and auto imports the files. In order to make this work, the `config_key` property had to be defined on all the processors which is most of the lines in this PR.

There shouldn't be much to review here