### PR TITLE
fix(errors): Allow input format mismatch

### DIFF
--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -55,4 +55,7 @@ storage = WritableTableStorage(
         promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},
         state_name=ReplacerState.ERRORS,
     ),
+    writer_options={
+        "input_format_skip_unknown_fields": 1,
+    },
 )


### PR DESCRIPTION
If there is a mismatch between the input format and clickhouse format, by default clickhouse throws an error. That will lead to ingestion backlogs in case of format mismatches. Allow the error storage to skip unknown fields during insertion to make it more robust. This is already happening when writing to transactions storage https://github.com/getsentry/snuba/blob/master/snuba/datasets/storages/transactions.py#L43-L46
