### PR TITLE
fix(typing): Annoying untyped variables

### DIFF
--- a/snuba/attribution/log.py
+++ b/snuba/attribution/log.py
@@ -19,7 +19,7 @@ from snuba.utils.streams.topics import Topic
 
 from .appid import AppID
 
-kfk = None
+kfk: Producer | None = None
 
 
 @dataclass(frozen=True)

--- a/snuba/datasets/entity_subscriptions/factory.py
+++ b/snuba/datasets/entity_subscriptions/factory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Generator, Mapping, MutableMapping, Sequence, Type
 
 from snuba import settings
@@ -91,7 +93,7 @@ class InvalidEntitySubscriptionError(SerializableException):
     """Exception raised on invalid entity access."""
 
 
-_ENT_SUB_FACTORY = None
+_ENT_SUB_FACTORY: _EntitySubscriptionFactory | None = None
 
 
 def _ent_sub_factory() -> _EntitySubscriptionFactory:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -89,8 +91,8 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
 PARTITIONED_CLUSTERS: Sequence[Mapping[str, Any]] = []
 
 # Dogstatsd Options
-DOGSTATSD_HOST = None
-DOGSTATSD_PORT = None
+DOGSTATSD_HOST: str | None = None
+DOGSTATSD_PORT: int | None = None
 DOGSTATSD_SAMPLING_RATES = {
     "subscriptions.receive_latency": 0.1,
     "subscriptions.process_message": 0.1,
@@ -108,7 +110,7 @@ CLICKHOUSE_TRACE_PASSWORD = os.environ.get("CLICKHOUSE_TRACE_PASS", "")
 # Redis Options
 USE_REDIS_CLUSTER = os.environ.get("USE_REDIS_CLUSTER", "0") != "0"
 
-REDIS_CLUSTER_STARTUP_NODES = None
+REDIS_CLUSTER_STARTUP_NODES: list[dict[str, Any]] | None = None
 REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
 REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
 REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
@@ -125,7 +127,7 @@ RECORD_QUERIES = False
 CONFIG_MEMOIZE_TIMEOUT = 10
 
 # Sentry Options
-SENTRY_DSN = None
+SENTRY_DSN: str | None = None
 SENTRY_TRACE_SAMPLE_RATE = 0
 
 # Snuba Admin Options

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 import logging
 import time
@@ -30,7 +30,7 @@ from snuba.utils.streams.topics import Topic
 metrics = MetricsWrapper(environment.metrics, "snuba.state")
 logger = logging.getLogger("snuba.state")
 
-kfk = None
+kfk: Producer | None = None
 rds = redis_client
 
 ratelimit_prefix = "snuba-ratelimit:"

--- a/snuba/utils/serializable_exception.py
+++ b/snuba/utils/serializable_exception.py
@@ -41,6 +41,7 @@ Usage:
 >>> recvd_exception_dict = rapidjson.loads(recv())
 >>> raise SerializableException.from_dict(recvd_exception_dict) # this will be an instance of MyException
 """
+from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Type, TypedDict, Union, cast
 
@@ -75,7 +76,7 @@ class _ExceptionRegistry:
         return self.__mapping.get(cls_name)
 
 
-_REGISTRY = None
+_REGISTRY: _ExceptionRegistry | None = None
 
 
 def _get_registry() -> _ExceptionRegistry:
@@ -98,7 +99,7 @@ class SerializableException(Exception):
         self,
         message: Optional[str] = None,
         should_report: bool = True,
-        **extra_data: JsonSerializable
+        **extra_data: JsonSerializable,
     ) -> None:
         self.message = message or ""
         self.extra_data = extra_data or {}
@@ -124,7 +125,7 @@ class SerializableException(Exception):
             return defined_exception(
                 message=edict.get("__message__", ""),
                 should_report=edict.get("__should_report__", True),
-                **edict.get("__extra_data__", {})
+                **edict.get("__extra_data__", {}),
             )
         # if an exception is created from a dictionary which is not in the registry,
         # create a new Exception type with that name and message dynamically.
@@ -135,7 +136,7 @@ class SerializableException(Exception):
             type(edict["__name__"], (cls,), {})(
                 message=edict.get("__message__", ""),
                 should_report=edict.get("__should_report__", True),
-                **edict.get("__extra_data__", {})
+                **edict.get("__extra_data__", {}),
             ),
         )
 


### PR DESCRIPTION
- There are a few random variables/constants around the codebase in the form `X = None` without any typing info
- Technically our mypy settings are soft enough so it doesn't complain but the mypy extension on vscode still complains about it