### PR TITLE
Add logging for committing offsets for subscriptions executor, scheduler

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -441,6 +441,7 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             or force is True
         ):
             if self.__commit_data:
+                logger.info("Committing offsets: %r", self.__commit_data)
                 self.__commit(self.__commit_data)
                 self.__last_committed = now
                 self.__commit_data = {}
@@ -492,6 +493,7 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
 
             future.result(remaining)
 
-            self.__commit(
-                {message.partition: Position(message.offset, message.timestamp)}
-            )
+            offset = {message.partition: Position(message.offset, message.timestamp)}
+
+            logger.info("Committing remaining offset: %r", offset)
+            self.__commit(offset)

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -495,5 +495,5 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
 
             offset = {message.partition: Position(message.offset, message.timestamp)}
 
-            logger.info("Committing remaining offset: %r", offset)
+            logger.info("Committing offset: %r", offset)
             self.__commit(offset)

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -515,5 +515,5 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
                         tick_subscription.tick_message.timestamp,
                     )
                 }
-                logger.info("Committing remaining offset: %r", offset)
+                logger.info("Committing offset: %r", offset)
                 self.__commit(offset)

--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -426,14 +426,14 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
             self.__queue.popleft()
 
             if tick_subscription.offset_to_commit:
-                self.__commit(
-                    {
-                        tick_subscription.tick_message.partition: Position(
-                            tick_subscription.offset_to_commit,
-                            tick_subscription.tick_message.timestamp,
-                        )
-                    }
-                )
+                offset = {
+                    tick_subscription.tick_message.partition: Position(
+                        tick_subscription.offset_to_commit,
+                        tick_subscription.tick_message.timestamp,
+                    )
+                }
+                logger.info("Committing offset: %r", offset)
+                self.__commit(offset)
 
     def submit(self, message: Message[CommittableTick]) -> None:
         assert not self.__closed
@@ -462,13 +462,13 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
         # If there are no subscriptions for a tick, immediately commit if an offset
         # to commit is provided.
         if len(encoded_tasks) == 0 and message.payload.offset_to_commit is not None:
-            self.__commit(
-                {
-                    message.partition: Position(
-                        message.payload.offset_to_commit, message.timestamp
-                    )
-                }
-            )
+            offset = {
+                message.partition: Position(
+                    message.payload.offset_to_commit, message.timestamp
+                )
+            }
+            logger.info("Committing offset: %r", offset)
+            self.__commit(offset)
             return
 
         # Record the amount of time between the message timestamp and when scheduling
@@ -509,11 +509,11 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
             tick_subscription.subscription_future.result(remaining)
 
             if tick_subscription.offset_to_commit is not None:
-                self.__commit(
-                    {
-                        tick_subscription.tick_message.partition: Position(
-                            tick_subscription.offset_to_commit,
-                            tick_subscription.tick_message.timestamp,
-                        )
-                    }
-                )
+                offset = {
+                    tick_subscription.tick_message.partition: Position(
+                        tick_subscription.offset_to_commit,
+                        tick_subscription.tick_message.timestamp,
+                    )
+                }
+                logger.info("Committing remaining offset: %r", offset)
+                self.__commit(offset)


### PR DESCRIPTION
In an effort to have a bit more visibility into both the subscriptions executor and subscriptions scheduler, I'm logging the offsets when we commit them. 

For the scheduler, I believe that we only commit once all the partitions have caught up to the same tick in (`GLOBAL` mode), and for the executor, I believe that we only commit once per second max (using the `COMMIT_FREQUENCY_SEC`).