### PR TITLE
ref(tests): Move scheduler inside freezetime

### DIFF
--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -229,6 +229,7 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     """
     Tests that a JobTimeoutException is raised when a cutoff time is reached.
     """
+    settings.OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
     storage = get_writable_storage(StorageKey.ERRORS)
     cluster = storage.get_cluster()
     clickhouse_pool = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -229,6 +229,7 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     """
     Tests that a JobTimeoutException is raised when a cutoff time is reached.
     """
+    prev_job_cutoff_time = settings.OPTIMIZE_JOB_CUTOFF_TIME
     settings.OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
     storage = get_writable_storage(StorageKey.ERRORS)
     cluster = storage.get_cluster()
@@ -264,3 +265,4 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
             )
 
     tracker.delete_all_states()
+    settings.OPTIMIZE_JOB_CUTOFF_TIME = prev_job_cutoff_time

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -229,8 +229,6 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     """
     Tests that a JobTimeoutException is raised when a cutoff time is reached.
     """
-    prev_job_cutoff_time = settings.OPTIMIZE_JOB_CUTOFF_TIME
-    settings.OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
     storage = get_writable_storage(StorageKey.ERRORS)
     cluster = storage.get_cluster()
     clickhouse_pool = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
@@ -248,11 +246,11 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
 
     dummy_partition = "(90,'2022-03-28')"
     tracker.update_all_partitions([dummy_partition])
-    scheduler = OptimizeScheduler(2)
 
     with freeze_time(
         last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(minutes=15)
     ):
+        scheduler = OptimizeScheduler(2)
         with pytest.raises(OptimizedSchedulerTimeout):
             optimize_partition_runner(
                 clickhouse=clickhouse_pool,
@@ -265,4 +263,3 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
             )
 
     tracker.delete_all_states()
-    settings.OPTIMIZE_JOB_CUTOFF_TIME = prev_job_cutoff_time

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -229,6 +229,8 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     """
     Tests that a JobTimeoutException is raised when a cutoff time is reached.
     """
+    prev_job_cutoff_time = settings.OPTIMIZE_JOB_CUTOFF_TIME
+    settings.OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
     storage = get_writable_storage(StorageKey.ERRORS)
     cluster = storage.get_cluster()
     clickhouse_pool = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)
@@ -263,3 +265,4 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
             )
 
     tracker.delete_all_states()
+    settings.OPTIMIZE_JOB_CUTOFF_TIME = prev_job_cutoff_time


### PR DESCRIPTION
Since it is the optimize scheduler's cutoff time which determines whether to raise an exception or not, move the creation of the scheduler inside frozen time to have a consistent behavior during tests.

The setting `settings.OPTIMIZE_JOB_CUTOFF_TIME` also defaults to 1 day by default to avoid tests running into timeout exception. For this test, we should change it to 23 hours.
