### PR TITLE
fix(logging): remove auth for health check

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -50,9 +50,10 @@ def handle_invalid_json(exception: UnauthorizedException) -> Response:
 @application.before_request
 def authorize() -> None:
     logger.debug("authorize.entered")
-    user = authorize_request()
-    logger.info("authorize.finished", user=user)
-    g.user = user
+    if request.endpoint != "health":
+        user = authorize_request()
+        logger.info("authorize.finished", user=user)
+        g.user = user
 
 
 @application.route("/")

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Sequence, Tuple, cast
 import simplejson as json
 import structlog
 from flask import Flask, Response, g, jsonify, make_response, request
+from structlog.contextvars import bind_contextvars, clear_contextvars
 
 from snuba import state
 from snuba.admin.auth import UnauthorizedException, authorize_request
@@ -45,6 +46,12 @@ def handle_invalid_json(exception: UnauthorizedException) -> Response:
         401,
         {"Content-Type": "application/json"},
     )
+
+
+@application.before_request
+def set_logging_context() -> None:
+    clear_contextvars()
+    bind_contextvars(endpoint=request.endpoint, user_ip=request.remote_addr)
 
 
 @application.before_request


### PR DESCRIPTION
Now that we log the result of all auth calls (currently a no-op) we're getting spammed about once/second with what I assume must be health check calls (given the low traffic to snuba admin).

Verified locally that this bypasses the method for `/health` but keeps it intact for others.

Additionally, add some logging context to benefit us in the future