### PR TITLE
Remove duplicate warning logs from threaded_function_delagator

### DIFF
--- a/snuba/utils/threaded_function_delegator.py
+++ b/snuba/utils/threaded_function_delegator.py
@@ -86,9 +86,7 @@ class ThreadedFunctionDelegator(Generic[TInput, TResult]):
                     if self.__callback_func is not None:
                         self.__callback_func(primary_result, other_results)
                 except Exception as error:
-                    if self.__ignore_secondary_exceptions:
-                        logger.warning(error, exc_info=True)
-                    else:
+                    if not self.__ignore_secondary_exceptions:
                         logger.exception(error)
 
             executor.submit(execute_callback)


### PR DESCRIPTION
Warning logs emitted by `logger:snuba.utils.threaded_function_delegator` are already being captured by `logger:snuba.query` and `logger:snuba.api`. These extra logs are causing duplicate sentry issues (specifically errors from readthrough cache and rate limiting).

Examples:
* This RuntimeError logged by [snuba.utils.threaded_function_delegator](https://sentry.io/organizations/sentry/issues/3198654668/?project=300688&query=is%3Aunresolved&statsPeriod=14d) is already captured by [snuba.query](https://sentry.io/organizations/sentry/issues/3198654751/?project=300688&query=is%3Aunresolved&statsPeriod=14d)
* This TimeoutError logged by [snuba.utils.threaded_function_delegator](https://sentry.io/organizations/sentry/issues/3545430296/?project=300688&query=is%3Aunresolved) is already captured by [snuba.query](https://sentry.io/organizations/sentry/issues/1861122395/?project=300688&query=is%3Aunresolved)
* This RateLimitExceeded warning logged by [snuba.utils.threaded_function_delegator](https://sentry.io/organizations/sentry/issues/3542573771/?project=300688&query=is%3Aunresolved+project+concurrent+of&statsPeriod=90d) is already captured by [snuba.api](https://sentry.io/organizations/sentry/issues/3542232742/?project=300688&query=is%3Aunresolved+project+concurrent+of&statsPeriod=90d)