### PR TITLE
feat(dependabot): upgrade urrllib3 again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ sentry-sdk==1.9.8
 simplejson==3.17.6
 structlog==22.1.0
 structlog-sentry==2.0.0
-urllib3==1.26.11
+urllib3==1.26.12
 pyuwsgi==2.0.20
 Werkzeug==2.2.2
 PyYAML==6.0


### PR DESCRIPTION
When we upgraded this last, we thought it caused admin to die. Since then we have new information as to why admin was dying and we have fixed it. We should upgrade it now