### PR TITLE
fix(slices): Rename physical partition to slice

### DIFF
--- a/docs/source/architecture/partitioning.rst
+++ b/docs/source/architecture/partitioning.rst
@@ -9,34 +9,34 @@ datasets and storages that span multiple physical resources
 (Kafka clusters, Redis instances, Postgres databases, ClickHouse clusters,
 etc.) with the same schema. Across Sentry, data records will
 have a logical partition assignment based on the data's organization_id. In Snuba,
-we maintain a mapping of logical to physical partitions in
+we maintain a mapping of logical partitions to physical slices in
 ``settings.LOGICAL_PARTITION_MAPPING``.
 
 In a future revision, this ``settings.LOGICAL_PARTITION_MAPPING`` will be
-used along with ``settings.PARTITIONED_STORAGES`` to map queries and incoming
+used along with ``settings.SLICED_STORAGES`` to map queries and incoming
 data from consumers to different ClickHouse clusters by overriding the
 StorageSet key that exists in configuration.
 
 ===========================
-Adding a physical partition
+Adding a slice
 ===========================
 
 Add the logical:physical mapping
 --------------------------------
 To add a physical partition to the logical:physical mapping, or repartition, increment the
-value of ``settings.LOCAL_PHYSICAL_PARTITIONS`` and change
+value of ``settings.LOCAL_SLICES`` and change
 the mapping of relevant partitions in ``settings.LOGICAL_PARTITION_MAPPING``.
-Every logical partition **must** be assigned to a physical partition and the
-valid values of physical partitions are in the range
-of ``[0,settings.LOCAL_PHYSICAL_PARTITIONS)``.
+Every logical partition **must** be assigned to a slice and the
+valid values of slices are in the range
+of ``[0,settings.LOCAL_SLICES)``.
 
-Defining partitioned clusters
+Defining sliced clusters
 --------------------------------
-To add a cluster with an associated (storage set key, partition) pair, add cluster definitions
-to ``settings.PARTITIONED_CLUSTERS`` in the desired environment's settings. Follow the same structure as
-regular cluster definitions in ``settings.CLUSTERS``. In the ``storage_set_partitions`` field, partitioned storage
-sets should be added in the form of ``(StorageSetKey, partition_id)`` where partition_id is in
-the range ``[0,settings.LOCAL_PHYSICAL_PARTITIONS)``.
+To add a cluster with an associated (storage set key, slice) pair, add cluster definitions
+to ``settings.SLICED_CLUSTERS`` in the desired environment's settings. Follow the same structure as
+regular cluster definitions in ``settings.CLUSTERS``. In the ``storage_set_slices`` field, sliced storage
+sets should be added in the form of ``(StorageSetKey, slice_id)`` where slice_id is in
+the range ``[0,settings.LOCAL_SLICES)``.
 
 
 TODO: adding storages, migrating subscriptions, etc.

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -33,14 +33,14 @@ CLICKHOUSE_MAX_POOL_SIZE = 25
 
 # The number of physical partitions that we will need to map resources to
 # for storage partitioning
-LOCAL_PHYSICAL_PARTITIONS = 1
+LOCAL_SLICES = 1
 # Mapping of logical (key) to physical (value) partitions for storages
 # that are partitioned in Snuba resources
 LOGICAL_PARTITION_MAPPING: Mapping[str, int] = {
     str(x): 0 for x in range(0, SENTRY_LOGICAL_PARTITIONS)
 }
 # Storage names to apply dataset partitioning to
-PARTITIONED_STORAGES: Set[str] = set()
+SLICED_STORAGES: Set[str] = set()
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {
@@ -76,19 +76,19 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
 ]
 
 # Storage set keys should be defined either in CLUSTERS
-# or PARTITIONED_CLUSTERS. CLUSTERS will define clusters
-# which are not partitioned, i.e. are associated with
-# only the default partition_id (0). CLUSTERS is defined in
-# the default way, without adding partition id in
+# or SLICED_CLUSTERS. CLUSTERS will define clusters
+# which are not sliced, i.e. are associated with
+# only the default slice_id (0). CLUSTERS is defined in
+# the default way, without adding slice id in
 # the storage_sets field.
 
-# We define partitioned clusters, i.e. clusters that reside
-# on multiple physical partitions (partition ids), in
-# PARTITIONED_CLUSTERS. We define all associated
-# (storage set, partition id) pairs in PARTITIONED_CLUSTERS
+# We define sliced clusters, i.e. clusters that reside
+# on multiple physical partitions (slice ids), in
+# SLICED_CLUSTERS. We define all associated
+# (storage set, slice id) pairs in SLICED_CLUSTERS
 # in the storage_sets field. Other fields are defined
 # in the same way as they are in CLUSTERS.
-PARTITIONED_CLUSTERS: Sequence[Mapping[str, Any]] = []
+SLICED_CLUSTERS: Sequence[Mapping[str, Any]] = []
 
 # Dogstatsd Options
 DOGSTATSD_HOST: str | None = None

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -88,10 +88,10 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
 
     for logical_part in range(0, SENTRY_LOGICAL_PARTITIONS):
         physical_part = locals["LOGICAL_PARTITION_MAPPING"].get(str(logical_part))
-        partition_count = locals["LOCAL_PHYSICAL_PARTITIONS"]
+        partition_count = locals["LOCAL_SLICES"]
         assert (
             physical_part is not None
-        ), f"missing physical partition for logical partition {logical_part}"
+        ), f"missing physical slice for logical partition {logical_part}"
         assert (
-            physical_part < locals["LOCAL_PHYSICAL_PARTITIONS"]
-        ), f"physical partition for logical partition {logical_part} is {physical_part}, but only {partition_count} physical partitions exist"
+            physical_part < locals["LOCAL_SLICES"]
+        ), f"physical slice for logical partition {logical_part} is {physical_part}, but only {partition_count} physical slices exist"

--- a/tests/clusters/test_cluster.py
+++ b/tests/clusters/test_cluster.py
@@ -79,7 +79,7 @@ FULL_CONFIG = [
     },
 ]
 
-PARTITIONED_CLUSTERS_CONFIG = [
+SLICED_CLUSTERS_CONFIG = [
     {
         "host": "host_slice",
         "port": 9000,
@@ -87,7 +87,7 @@ PARTITIONED_CLUSTERS_CONFIG = [
         "password": "",
         "database": "default",
         "http_port": 8123,
-        "storage_set_partitions": {("generic_metrics_distributions", 0)},
+        "storage_set_slices": {("generic_metrics_distributions", 0)},
         "single_node": True,
     },
     {
@@ -97,7 +97,7 @@ PARTITIONED_CLUSTERS_CONFIG = [
         "password": "",
         "database": "slice_1_default",
         "http_port": 8124,
-        "storage_set_partitions": {("generic_metrics_distributions", 1)},
+        "storage_set_slices": {("generic_metrics_distributions", 1)},
         "single_node": True,
     },
 ]
@@ -221,8 +221,8 @@ def test_cache_connections() -> None:
     ) != cluster_3.get_query_connection(cluster.ClickhouseClientSettings.QUERY)
 
 
-@patch("snuba.settings.PARTITIONED_CLUSTERS", PARTITIONED_CLUSTERS_CONFIG)
-def test_partitioned_cluster() -> None:
+@patch("snuba.settings.SLICED_CLUSTERS", SLICED_CLUSTERS_CONFIG)
+def test_sliced_cluster() -> None:
     importlib.reload(cluster)
 
     res_cluster = cluster.get_cluster(StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS, 1)

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -56,7 +56,7 @@ def test_topics_sync_in_settings_validator() -> None:
 def test_validation_catches_bad_partition_mapping() -> None:
     all_settings = build_settings_dict()
 
-    assert all_settings["LOCAL_PHYSICAL_PARTITIONS"] == 1
+    assert all_settings["LOCAL_SLICES"] == 1
     part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
     part_mapping["2"] = 1  # only slice 0 is valid if LOCAL_PHYSICAL_PARTITIONS is = 1
 


### PR DESCRIPTION
After discussion, we reached a consensus to change naming from `physical partition` to `slice` where applicable. This PR has those changes.