### PR TITLE
fix(MDC) Allow init arguments for storage pre-filters 

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -47,7 +47,9 @@ stream_loader:
   default_topic: snuba-generic-metrics
   pre_filter:
     type: kafka_header_select_filter
-    args: [metric_type, d]
+    args:
+      header_key: metric_type
+      header_value: d
   commit_log_topic: snuba-generic-metrics-distributions-commit-log
   subscription_scheduler_mode: global
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-distributions

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -47,7 +47,9 @@ stream_loader:
   default_topic: snuba-generic-metrics
   pre_filter:
     type: kafka_header_select_filter
-    args: [metric_type, s]
+    args:
+      header_key: metric_type
+      header_value: s
   commit_log_topic: snuba-generic-metrics-sets-commit-log
   subscription_scheduler_mode: global
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-sets

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -58,8 +58,7 @@ STREAM_LOADER_SCHEMA = {
                     "description": "Name of StreamMessageFilter class key",
                 },
                 "args": {
-                    "type": "array",
-                    "items": {"type": "string"},
+                    "type": "object",
                     "description": "Key/value mappings required to instantiate StreamMessageFilter class.",
                 },
             },

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -78,11 +78,10 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
 def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
     processor = CONF_TO_PROCESSOR[loader_config["processor"]]()
     default_topic = Topic(loader_config["default_topic"])
-
     # optionals
     pre_filter = (
         CONF_TO_PREFILTER[loader_config[PRE_FILTER]["type"]](
-            *loader_config[PRE_FILTER]["args"]
+            **loader_config[PRE_FILTER]["args"]
         )
         if PRE_FILTER in loader_config and loader_config[PRE_FILTER] is not None
         else None

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -43,7 +43,7 @@ def test_build_stream_loader() -> None:
             "default_topic": "snuba-generic-metrics",
             "pre_filter": {
                 "type": "kafka_header_select_filter",
-                "args": ["metric_type", "s"],
+                "args": {"header_key": "metric_type", "header_value": "s"},
             },
             "commit_log_topic": "snuba-generic-metrics-sets-commit-log",
             "subscription_scheduler_mode": "global",


### PR DESCRIPTION
This PR is a prerequisite for auto-importing pre-filters in storage config. The pre-filter jsonschema should follow the same convention as query_processors, mappers, validators, and etc. This change involves making the pre-filter arguments an object as opposed to list for instantiating the python filter classes.