### PR TITLE
fix(sessions): Limit data retention on sessions table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -226,7 +226,12 @@ class SessionsLoader(DirectoryLoader):
         super().__init__("snuba.snuba_migrations.sessions")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_sessions", "0002_sessions_aggregates", "0003_sessions_matview"]
+        return [
+            "0001_sessions",
+            "0002_sessions_aggregates",
+            "0003_sessions_matview",
+            "0004_sessions_ttl",
+        ]
 
 
 class QuerylogLoader(DirectoryLoader):

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Sequence, Tuple
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple
 
 from snuba.clickhouse.columns import Column
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
@@ -10,8 +10,11 @@ from snuba.migrations.table_engines import TableEngine
 
 
 class SqlOperation(ABC):
-    def __init__(self, storage_set: StorageSetKey):
+    def __init__(
+        self, storage_set: StorageSetKey, settings: Optional[Mapping[str, Any]] = None
+    ):
         self._storage_set = storage_set
+        self._settings = settings
 
     @property
     def storage_set(self) -> StorageSetKey:
@@ -26,7 +29,7 @@ class SqlOperation(ABC):
             connection = cluster.get_node_connection(
                 ClickhouseClientSettings.MIGRATE, node
             )
-            connection.execute(self.format_sql())
+            connection.execute(self.format_sql(), settings=self._settings)
 
     @abstractmethod
     def format_sql(self) -> str:
@@ -135,8 +138,12 @@ class ModifyTableTTL(SqlOperation):
         table_name: str,
         reference_column: str,
         ttl_days: int,
+        materialize_ttl_on_modify: bool = False,
     ):
-        super().__init__(storage_set)
+        self.__materialize_ttl_on_modify = 1 if materialize_ttl_on_modify else 0
+        super().__init__(
+            storage_set, {"materialize_ttl_on_modify": self.__materialize_ttl_on_modify}
+        )
         self.__table_name = table_name
         self.__reference_column = reference_column
         self.__ttl_days = ttl_days
@@ -152,6 +159,8 @@ class ModifyTableTTL(SqlOperation):
 class RemoveTableTTL(SqlOperation):
     """
     Remove TTL from a table.
+    NOTE: This cannot be used right now since Clickhouse version 20.3 does not
+    support REMOVE TTL command
     """
 
     def __init__(self, storage_set: StorageSetKey, table_name: str):

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -124,6 +124,44 @@ class TruncateTable(SqlOperation):
         return f"TRUNCATE TABLE IF EXISTS {self.__table_name};"
 
 
+class ModifyTableTTL(SqlOperation):
+    """
+    Modify TTL of a table
+    """
+
+    def __init__(
+        self,
+        storage_set: StorageSetKey,
+        table_name: str,
+        reference_column: str,
+        ttl_days: int,
+    ):
+        super().__init__(storage_set)
+        self.__table_name = table_name
+        self.__reference_column = reference_column
+        self.__ttl_days = ttl_days
+
+    def format_sql(self) -> str:
+        return (
+            f"ALTER TABLE {self.__table_name} MODIFY TTL "
+            f"{self.__reference_column} + "
+            f"toIntervalDay({self.__ttl_days});"
+        )
+
+
+class RemoveTableTTL(SqlOperation):
+    """
+    Remove TTL from a table.
+    """
+
+    def __init__(self, storage_set: StorageSetKey, table_name: str):
+        super().__init__(storage_set)
+        self.__table_name = table_name
+
+    def format_sql(self) -> str:
+        return f"ALTER TABLE {self.__table_name} REMOVE TTL;"
+
+
 class AddColumn(SqlOperation):
     """
     Adds a column to a table.

--- a/snuba/snuba_migrations/sessions/0004_sessions_ttl.py
+++ b/snuba/snuba_migrations/sessions/0004_sessions_ttl.py
@@ -1,0 +1,30 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyTableTTL(
+                StorageSetKey.SESSIONS, "sessions_raw_local", "started", 30
+            ),
+            operations.ModifyTableTTL(
+                StorageSetKey.SESSIONS, "sessions_hourly_local", "started", 90
+            ),
+        ]
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.RemoveTableTTL(StorageSetKey.SESSIONS, "sessions_raw_local"),
+            operations.RemoveTableTTL(StorageSetKey.SESSIONS, "sessions_hourly_local"),
+        ]
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/snuba_migrations/sessions/0004_sessions_ttl.py
+++ b/snuba/snuba_migrations/sessions/0004_sessions_ttl.py
@@ -18,10 +18,11 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
-        return [
-            operations.RemoveTableTTL(StorageSetKey.SESSIONS, "sessions_raw_local"),
-            operations.RemoveTableTTL(StorageSetKey.SESSIONS, "sessions_hourly_local"),
-        ]
+        """
+        Removing a TTL is not supported by Clickhouse version 20.3. So there is
+        no backwards migration.
+        """
+        return []
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
         return []


### PR DESCRIPTION
The sessions tables does not have any retention configured. That means the table data would keep on growing forever. That is unnecessary since the product does not allow querying data older than 90 days. With this fix, data in the raw table is retained for 30 days and data in the rollup table is retained for 90 days. This should fix https://github.com/getsentry/snuba/issues/3191

Verified locally that both tables had the TTL configured after applying the migration
`
create table if not exists sessions_raw_local
(
    session_id     UUID,
    distinct_id    UUID,
    quantity       UInt32 default 1,
    seq            UInt64,
    org_id         UInt64,
    project_id     UInt64,
    retention_days UInt16,
    duration       UInt32,
    status         UInt8,
    errors         UInt16,
    received       DateTime,
    started        DateTime,
    release LowCardinality(String),
    environment LowCardinality(String),
    user_agent LowCardinality(String),
    os LowCardinality(String)
)
    engine = MergeTree() PARTITION BY toMonday(started) ORDER BY (org_id, project_id, release, environment, started) TTL started + toIntervalDay(30) SETTINGS index_granularity = 16384;
`

`
create table if not exists sessions_hourly_local
(
    org_id     UInt64,
    project_id UInt64,
    started    DateTime,
    release LowCardinality(String),
    environment LowCardinality(String),
    user_agent LowCardinality(String),
    os LowCardinality(String),
    duration_quantiles AggregateFunction(quantilesIf(0.5, 0.9), UInt32, UInt8),
    duration_avg AggregateFunction(avgIf, UInt32, UInt8),
    sessions AggregateFunction(countIf, UUID, UInt8),
    sessions_preaggr AggregateFunction(sumIf, UInt32, UInt8),
    users AggregateFunction(uniqIf, UUID, UInt8),
    sessions_crashed AggregateFunction(countIf, UUID, UInt8),
    sessions_crashed_preaggr AggregateFunction(sumIf, UInt32, UInt8),
    sessions_abnormal AggregateFunction(countIf, UUID, UInt8),
    sessions_abnormal_preaggr AggregateFunction(sumIf, UInt32, UInt8),
    sessions_errored AggregateFunction(uniqIf, UUID, UInt8),
    sessions_errored_preaggr AggregateFunction(sumIf, UInt32, UInt8),
    users_crashed AggregateFunction(uniqIf, UUID, UInt8),
    users_abnormal AggregateFunction(uniqIf, UUID, UInt8),
    users_errored AggregateFunction(uniqIf, UUID, UInt8)
)
    engine = AggregatingMergeTree() PARTITION BY toMonday(started) ORDER BY (org_id, project_id, release, environment, started) TTL started + toIntervalDay(90) SETTINGS index_granularity = 256;
`
