### PR TITLE
feat(slices): Make slice count vary by storage

### DIFF
--- a/docs/source/architecture/partitioning.rst
+++ b/docs/source/architecture/partitioning.rst
@@ -23,12 +23,12 @@ Adding a slice
 
 Add the logical:physical mapping
 --------------------------------
-To add a physical partition to the logical:physical mapping, or repartition, increment the
-value of ``settings.LOCAL_SLICES`` and change
-the mapping of relevant partitions in ``settings.LOGICAL_PARTITION_MAPPING``.
+To add a physical partition to a storage set's logical:physical mapping, or repartition,
+increment the slice count in ``settings.SLICED_STORAGE_SETS`` for the relevant
+storage set. Change the mapping of the relevant storage set's
+logical partitions in ``settings.LOGICAL_PARTITION_MAPPING``.
 Every logical partition **must** be assigned to a slice and the
-valid values of slices are in the range
-of ``[0,settings.LOCAL_SLICES)``.
+valid values of slices are in the range of ``[0,settings.SLICED_STORAGE_SETS[storage_set])``.
 
 Defining sliced clusters
 --------------------------------
@@ -36,7 +36,7 @@ To add a cluster with an associated (storage set key, slice) pair, add cluster d
 to ``settings.SLICED_CLUSTERS`` in the desired environment's settings. Follow the same structure as
 regular cluster definitions in ``settings.CLUSTERS``. In the ``storage_set_slices`` field, sliced storage
 sets should be added in the form of ``(StorageSetKey, slice_id)`` where slice_id is in
-the range ``[0,settings.LOCAL_SLICES)``.
+the range ``[0,settings.settings.SLICED_STORAGE_SETS[storage_set])``.
 
 
 TODO: adding storages, migrating subscriptions, etc.

--- a/docs/source/architecture/partitioning.rst
+++ b/docs/source/architecture/partitioning.rst
@@ -23,12 +23,12 @@ Adding a slice
 
 Add the logical:physical mapping
 --------------------------------
-To add a physical partition to a storage set's logical:physical mapping, or repartition,
-increment the slice count in ``settings.SLICED_STORAGE_SETS`` for the relevant
-storage set. Change the mapping of the relevant storage set's
+To add a physical partition to a storage's logical:physical mapping, or repartition,
+increment the slice count in ``settings.SLICED_STORAGES`` for the relevant
+storage. Change the mapping of the relevant storage's
 logical partitions in ``settings.LOGICAL_PARTITION_MAPPING``.
 Every logical partition **must** be assigned to a slice and the
-valid values of slices are in the range of ``[0,settings.SLICED_STORAGE_SETS[storage_set])``.
+valid values of slices are in the range of ``[0,settings.SLICED_STORAGES[storage])``.
 
 Defining sliced clusters
 --------------------------------
@@ -36,7 +36,7 @@ To add a cluster with an associated (storage set key, slice) pair, add cluster d
 to ``settings.SLICED_CLUSTERS`` in the desired environment's settings. Follow the same structure as
 regular cluster definitions in ``settings.CLUSTERS``. In the ``storage_set_slices`` field, sliced storage
 sets should be added in the form of ``(StorageSetKey, slice_id)`` where slice_id is in
-the range ``[0,settings.settings.SLICED_STORAGE_SETS[storage_set])``.
+the range ``[0,settings.SLICED_STORAGES[storage])`` for relevant storages.
 
 
 TODO: adding storages, migrating subscriptions, etc.

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -31,16 +31,37 @@ DISABLED_DATASETS: Set[str] = set()
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
-# The number of physical partitions that we will need to map resources to
-# for storage partitioning
-LOCAL_SLICES = 1
-# Mapping of logical (key) to physical (value) partitions for storages
-# that are partitioned in Snuba resources
-LOGICAL_PARTITION_MAPPING: Mapping[str, int] = {
-    str(x): 0 for x in range(0, SENTRY_LOGICAL_PARTITIONS)
+# Mapping storage set key to a mapping of logical partition
+# to slice id
+LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {
+    storage_set: {x: 0 for x in range(0, SENTRY_LOGICAL_PARTITIONS)}
+    for storage_set in {
+        "cdc",
+        "discover",
+        "events",
+        "events_ro",
+        "metrics",
+        "migrations",
+        "outcomes",
+        "querylog",
+        "sessions",
+        "transactions",
+        "transactions_ro",
+        "transactions_v2",
+        "errors_v2",
+        "errors_v2_ro",
+        "profiles",
+        "functions",
+        "replays",
+        "generic_metrics_sets",
+        "generic_metrics_distributions",
+    }
 }
-# Storage names to apply dataset partitioning to
-SLICED_STORAGES: Set[str] = set()
+
+# Mapping of storage set key to slice count
+# Only includes storage sets that are
+# assocated with multiple slices
+SLICED_STORAGE_SETS: Mapping[str, int] = {}
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Mapping, MutableMapping, Sequence, Set
 
-from snuba.datasets.partitioning import SENTRY_LOGICAL_PARTITIONS
 from snuba.settings.validation import validate_settings
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
@@ -31,37 +30,14 @@ DISABLED_DATASETS: Set[str] = set()
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
 
-# Mapping storage set key to a mapping of logical partition
+# Mapping storage key to a mapping of logical partition
 # to slice id
-LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {
-    storage_set: {x: 0 for x in range(0, SENTRY_LOGICAL_PARTITIONS)}
-    for storage_set in {
-        "cdc",
-        "discover",
-        "events",
-        "events_ro",
-        "metrics",
-        "migrations",
-        "outcomes",
-        "querylog",
-        "sessions",
-        "transactions",
-        "transactions_ro",
-        "transactions_v2",
-        "errors_v2",
-        "errors_v2_ro",
-        "profiles",
-        "functions",
-        "replays",
-        "generic_metrics_sets",
-        "generic_metrics_distributions",
-    }
-}
+LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {}
 
-# Mapping of storage set key to slice count
-# Only includes storage sets that are
+# Mapping of storage key to slice count
+# Only includes storages that are
 # assocated with multiple slices
-SLICED_STORAGE_SETS: Mapping[str, int] = {}
+SLICED_STORAGES: Mapping[str, int] = {}
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -90,14 +90,13 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
                 # that are not defined in StorageSetKey.
                 pass
 
-    for storage in locals["LOGICAL_PARTITION_MAPPING"]:
-        storage_mapping = locals["LOGICAL_PARTITION_MAPPING"][storage]
+    for storage in locals["SLICED_STORAGES"]:
+        assert (
+            storage in locals["LOGICAL_PARTITION_MAPPING"]
+        ), "sliced mapping must be defined for sliced storage {storage}"
 
-        # check if this is a sliced storage
-        if storage in locals["SLICED_STORAGES"]:
-            defined_slice_count = locals["SLICED_STORAGES"][storage]
-        else:
-            defined_slice_count = 1
+        storage_mapping = locals["LOGICAL_PARTITION_MAPPING"][storage]
+        defined_slice_count = locals["SLICED_STORAGES"][storage]
 
         for logical_part in range(0, SENTRY_LOGICAL_PARTITIONS):
             slice_id = storage_mapping.get(logical_part)

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -105,6 +105,8 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
                 slice_id is not None
             ), f"missing physical slice for storage {storage}'s logical partition {logical_part}"
 
-            assert slice_id < defined_slice_count, slice_count_validation_msg.format(
+            assert (
+                slice_id >= 0 and slice_id < defined_slice_count
+            ), slice_count_validation_msg.format(
                 storage, logical_part, slice_id, defined_slice_count
             )

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -65,7 +65,7 @@ def test_validation_catches_bad_partition_mapping() -> None:
     part_mapping["events"] = {0: 0, 1: 0}
     part_mapping["events"][0] = 1
     # only slice 0 is valid in this case
-    # since cdc is not a sliced storage
+    # since events is not a sliced storage
 
     with pytest.raises(AssertionError):
         validate_settings(all_settings)

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -56,21 +56,23 @@ def test_topics_sync_in_settings_validator() -> None:
 def test_validation_catches_bad_partition_mapping() -> None:
     all_settings = build_settings_dict()
 
-    assert all_settings["LOCAL_SLICES"] == 1
     part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
-    part_mapping["2"] = 1  # only slice 0 is valid if LOCAL_PHYSICAL_PARTITIONS is = 1
+    part_mapping["cdc"][2] = 1
+    # only slice 0 is valid in this case
+    # since cdc is not a sliced storage set
 
     with pytest.raises(AssertionError):
         validate_settings(all_settings)
-    part_mapping["2"] = 0
+    part_mapping["cdc"][2] = 0
 
 
 def test_validation_catches_unmapped_logical_parts() -> None:
     all_settings = build_settings_dict()
 
     part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
-    del part_mapping["2"]
+    del part_mapping["cdc"][2]
 
     with pytest.raises(AssertionError):
         validate_settings(all_settings)
-    part_mapping["2"] = 0
+
+    part_mapping["cdc"][2] = 0


### PR DESCRIPTION
This PR:

- Removes `LOCAL_SLICES` from settings
- Modifies the definitions of `LOGICAL_PARTITION_MAPPING` and `SLICED_STORAGE_SETS` accordingly
- Updates validation and tests
- Renames `SLICED_STORAGES` --> `SLICED_STORAGE_SETS` (point to potentially discuss)
- Updates docs 