### PR TITLE
ref(admin): add migration_groups API

### DIFF
--- a/snuba/admin/clickhouse/migration_groups.py
+++ b/snuba/admin/clickhouse/migration_groups.py
@@ -1,8 +1,0 @@
-from typing import Sequence, TypedDict
-
-from snuba.migrations.groups import MigrationGroup
-
-
-class MigrationGroupData(TypedDict):
-    group: MigrationGroup
-    migration_ids: Sequence[str]

--- a/snuba/admin/clickhouse/migration_groups.py
+++ b/snuba/admin/clickhouse/migration_groups.py
@@ -1,0 +1,8 @@
+from typing import Sequence, TypedDict
+
+from snuba.migrations.groups import MigrationGroup
+
+
+class MigrationGroupData(TypedDict):
+    group: MigrationGroup
+    migration_ids: Sequence[str]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -23,6 +23,16 @@ ADMIN_URL = os.environ.get("ADMIN_URL", "http://localhost:1219")
 
 ADMIN_AUTH_PROVIDER = "NOOP"
 
+# Migrations Groups that are allowed to be managed
+# in the snuba admin tool.
+ADMIN_ALLOWED_MIGRATION_GROUPS = {
+    "system",
+    "generic_metrics",
+    "profiles",
+    "functions",
+    "replays",
+}
+
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 
 DEFAULT_DATASET_NAME = "events"

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import simplejson as json
+from flask.testing import FlaskClient
+
+from snuba.migrations.groups import get_group_loader
+
+
+@pytest.fixture
+def admin_api() -> FlaskClient:
+    from snuba.admin.views import application
+
+    return application.test_client()
+
+
+def test_migration_groups(admin_api: FlaskClient) -> None:
+    with patch("snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS", {}):
+        response = admin_api.get("/migrations/groups")
+
+    assert response.status_code == 200
+    assert json.loads(response.data) == []
+
+    with patch(
+        "snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS", {"system", "generic_metrics"}
+    ):
+        response = admin_api.get("/migrations/groups")
+
+    assert response.status_code == 200
+    assert json.loads(response.data) == [
+        {
+            "group": "system",
+            "migration_ids": get_group_loader("system").get_migrations(),
+        },
+        {
+            "group": "generic_metrics",
+            "migration_ids": get_group_loader("generic_metrics").get_migrations(),
+        },
+    ]


### PR DESCRIPTION
**context:**
A bit of context is in https://github.com/getsentry/snuba/pull/3221, but basically we want to add migrations tooling to the snuba admin tool. As seen in the previously mentioned PR, in order to know which migrations to run, a user must first pick a group. This endpoint is to populate that first dropdown of all the possible groups that one could run (or reverse) a migration for. 

**example payload:**

```json
{
    "group": "generic_metrics",
    "migration_ids": [
        "0001_sets_aggregate_table",
        "0002_sets_raw_table",
        "0003_sets_mv",
        "0004_sets_raw_add_granularities",
        "0005_sets_replace_mv",
        "0006_sets_raw_add_granularities_dist_table",
        "0007_distributions_aggregate_table",
        "0008_distributions_raw_table",
        "0009_distributions_mv"
     ]
}
```

Users can pick any migration to run (or reverse) since they could technically run each migration one by one if setting up a new cluster. The logic of whether a migration is appropriate to run will be handled when some tries to do a dry run or actually run the migration itself, and that endpoint and error handling will be done in a future PR. 

**ADMIN_ALLOWED_MIGRATION_GROUPS**:
There are certain groups that may not be safe to manage through the snuba admin tool (or at least not yet without some more fine grain permissions). So for now I've added a hardcoded list of migration groups that are allowed, and we can add to this once we audit the other groups. 

I'm also filtering by `active` groups, which is still TBD on if there is a case of for allowing folks to be able to run migrations on their own datasets that have infrastructure set up, but just aren't live for customers in any way.

This PR does not address filtering `migration_ids` by those that are considered dangerous, that will be addressed later once we've implemented a mechanism for determining said "dangerous" status.