### PR TITLE
fix(MDC): Use class names for translators, mappers, and validators config_key

### DIFF
--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -67,7 +67,7 @@ class FunctionCallMapper(
 
     @classmethod
     def config_key(cls) -> str:
-        return "function_call_mapper_base"
+        return cls.__name__
 
     @classmethod
     def get_from_name(cls, name: str) -> Type["FunctionCallMapper"]:
@@ -82,7 +82,7 @@ class CurriedFunctionCallMapper(
 ):
     @classmethod
     def config_key(cls) -> str:
-        return "curried_function_call_mapper_base"
+        return cls.__name__
 
     @classmethod
     def get_from_name(cls, name: str) -> Type["CurriedFunctionCallMapper"]:
@@ -107,7 +107,7 @@ class SubscriptableReferenceMapper(
 
     @classmethod
     def config_key(cls) -> str:
-        return "subref_mapper_base"
+        return cls.__name__
 
     @classmethod
     def get_from_name(cls, name: str) -> Type["SubscriptableReferenceMapper"]:

--- a/snuba/clickhouse/translators/snuba/defaults.py
+++ b/snuba/clickhouse/translators/snuba/defaults.py
@@ -58,10 +58,6 @@ class DefaultSubscriptableMapper(SubscriptableReferenceMapper):
 
 
 class DefaultFunctionMapper(FunctionCallMapper):
-    @classmethod
-    def config_key(cls) -> str:
-        return "default_function"
-
     def attempt_map(
         self,
         expression: FunctionCall,

--- a/snuba/clickhouse/translators/snuba/function_call_mappers.py
+++ b/snuba/clickhouse/translators/snuba/function_call_mappers.py
@@ -48,10 +48,6 @@ class AggregateFunctionMapper(FunctionCallMapper):
     to_name: str
     aggr_col_name: str
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "aggregate_function"
-
     def attempt_map(
         self,
         expression: FunctionCall,
@@ -80,10 +76,6 @@ class AggregateCurriedFunctionMapper(CurriedFunctionCallMapper):
     from_name: str
     to_name: str
     aggr_col_name: str
-
-    @classmethod
-    def config_key(_cls) -> str:
-        return "aggregate_curried_function"
 
     def attempt_map(
         self,

--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -138,10 +138,6 @@ class SubscriptableMapper(SubscriptableReferenceMapper):
     value_subcolumn_name: str = "value"
     nullable: bool = False
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "subscriptable"
-
     def attempt_map(
         self,
         expression: SubscriptableReference,
@@ -279,10 +275,6 @@ class FunctionNameMapper(FunctionCallMapper):
 
     from_name: str
     to_name: str
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "simple_func"
 
     def attempt_map(
         self,

--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -62,9 +62,9 @@ readable_storage: generic_metrics_distributions
 writable_storage: generic_metrics_distributions_raw
 query_processors:
   -
-    processor: transform_tag_types
+    processor: TagsTypeTransformer
   -
-    processor: handle_mapped_granularities
+    processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
@@ -72,96 +72,96 @@ query_processors:
         86400: 3
       default_granularity: 1
   -
-    processor: translate_time_series
+    processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limiter
+    processor: ReferrerRateLimiterProcessor
   -
-    processor: org_rate_limiter
+    processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
   -
-    processor: project_referrer_rate_limiter
+    processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
   -
-    processor: project_rate_limiter
+    processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
   -
-    processor: resource_quota_limiter
+    processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: min
         to_name: minMerge
         aggr_col_name: min
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: minIf
         to_name: minMergeIf
         aggr_col_name: minIf
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: max
         to_name: maxMerge
         aggr_col_name: max
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: maxIf
         to_name: maxMergeIf
         aggr_col_name: max
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: avg
         to_name: avgMerge
         aggr_col_name: avg
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: avgIf
         to_name: avgMergeIf
         aggr_col_name: avg
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: sum
         to_name: sumMerge
         aggr_col_name: sum
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: sumIf
         to_name: sumMergeIf
         aggr_col_name: sum
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: count
         to_name: countMerge
         aggr_col_name: count
     -
-      mapper: aggregate_function
+      mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: countIf
@@ -169,28 +169,28 @@ translation_mappers:
         aggr_col_name: count
   curried_functions:
     -
-      mapper: aggregate_curried_function
+      mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: quantiles
         to_name: quantilesMerge
         aggr_col_name: percentiles
     -
-      mapper: aggregate_curried_function
+      mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: quantilesIf
         to_name: quantilesMergeIf
         aggr_col_name: percentiles
     -
-      mapper: aggregate_curried_function
+      mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: histogram
         to_name: histogramMerge
         aggr_col_name: histogram_buckets
     -
-      mapper: aggregate_curried_function
+      mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: histogramIf
@@ -198,7 +198,7 @@ translation_mappers:
         aggr_col_name: histogram_buckets
   subscriptables:
     -
-      mapper: subscriptable
+      mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags_raw
@@ -206,7 +206,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
     -
-      mapper: subscriptable
+      mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags
@@ -215,7 +215,7 @@ translation_mappers:
         value_subcolumn_name: indexed_value
 validators:
   -
-    validator: entity_required
+    validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
 required_time_column: timestamp

--- a/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
@@ -32,9 +32,9 @@ readable_storage: generic_metrics_sets
 writable_storage: generic_metrics_sets_raw
 query_processors:
   -
-    processor: transform_tag_types
+    processor: TagsTypeTransformer
   -
-    processor: handle_mapped_granularities
+    processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
@@ -42,44 +42,44 @@ query_processors:
         86400: 3
       default_granularity: 1
   -
-    processor: translate_time_series
+    processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limiter
+    processor: ReferrerRateLimiterProcessor
   -
-    processor: org_rate_limiter
+    processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
   -
-    processor: project_referrer_rate_limiter
+    processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
   -
-    processor: project_rate_limiter
+    processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
   -
-    processor: resource_quota_limiter
+    processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
     -
-      mapper: simple_func
+      mapper: FunctionNameMapper
       args:
         from_name: uniq
         to_name: uniqCombined64Merge
     -
-      mapper: simple_func
+      mapper: FunctionNameMapper
       args:
         from_name: uniqIf
         to_name: uniqCombined64MergeIf
   subscriptables:
     -
-      mapper: subscriptable
+      mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags_raw
@@ -87,7 +87,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
     -
-      mapper: subscriptable
+      mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags
@@ -96,7 +96,7 @@ translation_mappers:
         value_subcolumn_name: indexed_value
 validators:
   -
-    validator: entity_required
+    validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
 required_time_column: timestamp

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -14,7 +14,10 @@ TYPE_NULLABLE_STRING = {"type": ["string", "null"]}
 FUNCTION_CALL_SCHEMA = {
     "type": "object",
     "properties": {
-        "type": {"type": "string", "description": "FunctionCall class name"},
+        "type": {
+            "type": "string",
+            "description": "Name of FunctionCall class config key",
+        },
         "args": {"type": "array", "items": {"type": "string"}, "description": ""},
     },
     "additionalProperties": False,
@@ -25,7 +28,7 @@ STREAM_LOADER_SCHEMA = {
     "properties": {
         "processor": {
             "type": "string",
-            "description": "Processor class name. Responsible for converting an incoming message body from the event stream into a row or statement to be inserted or executed against clickhouse",
+            "description": "Name of Processor class config key. Responsible for converting an incoming message body from the event stream into a row or statement to be inserted or executed against clickhouse",
         },
         "default_topic": {
             "type": "string",
@@ -37,7 +40,7 @@ STREAM_LOADER_SCHEMA = {
         },
         "subscription_scheduled_topic": {
             "type": ["string", "null"],
-            "description": "Name of the subscroption scheduled Kafka topic",
+            "description": "Name of the subscription scheduled Kafka topic",
         },
         "subscription_scheduler_mode": {
             "type": ["string", "null"],
@@ -56,7 +59,7 @@ STREAM_LOADER_SCHEMA = {
             "properties": {
                 "type": {
                     "type": "string",
-                    "description": "StreamMessageFilter class name",
+                    "description": "Name of StreamMessageFilter class config key",
                 },
                 "args": {
                     "type": "object",
@@ -226,7 +229,7 @@ STORAGE_QUERY_PROCESSOR = {
     "properties": {
         "processor": {
             "type": "string",
-            "description": "Name of ClickhouseQueryProcessor class responsible for the transformation applied to a query.",
+            "description": "Name of ClickhouseQueryProcessor class config key. Responsible for the transformation applied to a query.",
         },
         "args": {
             "type": "object",
@@ -246,7 +249,7 @@ ENTITY_QUERY_PROCESSOR = {
     "properties": {
         "processor": {
             "type": "string",
-            "description": "Name of LogicalQueryProcessor class responsible for the transformation applied to a query.",
+            "description": "Name of LogicalQueryProcessor class config key. Responsible for the transformation applied to a query.",
         },
         "args": {
             "type": "object",

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -71,10 +71,6 @@ class DefaultNoneColumnMapper(ColumnMapper):
 
     columns: ColumnSet
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "default_none_column"
-
     def attempt_map(
         self,
         expression: Column,
@@ -100,10 +96,6 @@ class DefaultNoneFunctionMapper(FunctionCallMapper):
 
     function_names: Set[str]
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "default_none_function"
-
     def __post_init__(self) -> None:
         self.function_match = FunctionCallMatch(
             Or([StringMatch(func) for func in self.function_names])
@@ -126,10 +118,6 @@ class DefaultIfNullFunctionMapper(FunctionCallMapper):
     If a function is being called on a column that doesn't exist, or is being
     called on NULL, change the entire function to be NULL.
     """
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "default_if_null"
 
     function_match = FunctionCallMatch(
         StringMatch("identity"), (LiteralMatch(value=Any(type(None))),)
@@ -168,10 +156,6 @@ class DefaultIfNullCurriedFunctionMapper(CurriedFunctionCallMapper):
 
     function_match = FunctionCallMatch(StringMatch("identity"), (LiteralMatch(),))
 
-    @classmethod
-    def config_key(_cls) -> str:
-        return "default_if_null_curried_function"
-
     def attempt_map(
         self,
         expression: CurriedFunctionCall,
@@ -201,10 +185,6 @@ class DefaultNoneSubscriptMapper(SubscriptableReferenceMapper):
     """
 
     subscript_names: Set[str]
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "default_none_subscript"
 
     def attempt_map(
         self,

--- a/snuba/query/processors/logical/__init__.py
+++ b/snuba/query/processors/logical/__init__.py
@@ -31,6 +31,10 @@ class LogicalQueryProcessor(ABC, metaclass=RegisteredClass):
         pass
 
     @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
+
+    @classmethod
     def get_from_name(cls, name: str) -> "LogicalQueryProcessor":
         return cast("LogicalQueryProcessor", cls.class_from_name(name))
 

--- a/snuba/query/processors/logical/basic_functions.py
+++ b/snuba/query/processors/logical/basic_functions.py
@@ -18,10 +18,6 @@ class BasicFunctionsProcessor(LogicalQueryProcessor):
     This exists only to preserve the current Snuba syntax and only works on the new AST.
     """
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "basic_functions"
-
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def process_functions(exp: Expression) -> Expression:
             if isinstance(exp, FunctionCall):

--- a/snuba/query/processors/logical/custom_function.py
+++ b/snuba/query/processors/logical/custom_function.py
@@ -93,7 +93,7 @@ class CustomFunction(LogicalQueryProcessor):
 
     @classmethod
     def config_key(cls) -> str:
-        return "__unsupported__:custom_function"
+        return "__unsupported__:CustomFunction"
 
     @classmethod
     def from_kwargs(cls, **kwargs: str) -> LogicalQueryProcessor:

--- a/snuba/query/processors/logical/granularity_processor.py
+++ b/snuba/query/processors/logical/granularity_processor.py
@@ -15,10 +15,6 @@ DEFAULT_GRANULARITY_RAW = 60
 class GranularityProcessor(LogicalQueryProcessor):
     """Use the granularity set on the query to filter on the granularity column"""
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "granularity"
-
     @staticmethod
     def __get_granularity(query: Query) -> int:
         """Find the best fitting granularity for this query"""
@@ -93,10 +89,6 @@ class MappedGranularityProcessor(LogicalQueryProcessor):
             mapping.raw for mapping in self._accepted_granularities
         ]
         self._default_granularity_enum = default_granularity
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "handle_mapped_granularities"
 
     def __get_granularity(self, query: Query) -> int:
         """Find the best fitting granularity for this query"""

--- a/snuba/query/processors/logical/handled_functions.py
+++ b/snuba/query/processors/logical/handled_functions.py
@@ -42,10 +42,6 @@ class HandledFunctionsProcessor(LogicalQueryProcessor):
     def __init__(self, column: str):
         self.__column = column
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "handled_functions"
-
     def validate_parameters(self, exp: FunctionCall, entity: QueryEntity) -> None:
         validator = SignatureValidator([])
         try:

--- a/snuba/query/processors/logical/object_id_rate_limiter.py
+++ b/snuba/query/processors/logical/object_id_rate_limiter.py
@@ -45,10 +45,6 @@ class ObjectIDRateLimiterProcessor(LogicalQueryProcessor):
                 return True
         return False
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "object_id_rate_limiter"
-
     def get_object_id(
         self, query: Query, query_settings: QuerySettings
     ) -> Optional[str]:
@@ -139,10 +135,6 @@ class OnlyIfConfiguredRateLimitProcessor(ObjectIDRateLimiterProcessor):
 
         query_settings.add_rate_limit(rate_limit)
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "only_if_configured_rate_limiter"
-
 
 class OrganizationRateLimiterProcessor(ObjectIDRateLimiterProcessor):
     """
@@ -158,10 +150,6 @@ class OrganizationRateLimiterProcessor(ObjectIDRateLimiterProcessor):
             "org_per_second_limit",
             "org_concurrent_limit",
         )
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "org_rate_limiter"
 
 
 class ProjectReferrerRateLimiter(OnlyIfConfiguredRateLimitProcessor):
@@ -191,10 +179,6 @@ class ProjectReferrerRateLimiter(OnlyIfConfiguredRateLimitProcessor):
         obj_id = str(obj_ids.pop())
         return str(obj_id)
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "project_referrer_rate_limiter"
-
 
 class ReferrerRateLimiterProcessor(OnlyIfConfiguredRateLimitProcessor):
     """This is more of a load shedder than a rate limiter. we limit a specific
@@ -208,10 +192,6 @@ class ReferrerRateLimiterProcessor(OnlyIfConfiguredRateLimitProcessor):
             "referrer_concurrent_limit",
             query_settings_field="referrer",
         )
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "referrer_rate_limiter"
 
     def get_object_id(self, query: Query, query_settings: QuerySettings) -> str:
         return query_settings.referrer
@@ -231,7 +211,3 @@ class ProjectRateLimiterProcessor(ObjectIDRateLimiterProcessor):
             "project_per_second_limit",
             "project_concurrent_limit",
         )
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "project_rate_limiter"

--- a/snuba/query/processors/logical/quota_processor.py
+++ b/snuba/query/processors/logical/quota_processor.py
@@ -17,10 +17,6 @@ class ResourceQuotaProcessor(LogicalQueryProcessor):
     def __init__(self, project_field: str):
         self.__project_field = project_field
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "resource_quota_limiter"
-
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         enabled = get_config(ENABLED_CONFIG, 1)
         if not enabled:

--- a/snuba/query/processors/logical/tags_expander.py
+++ b/snuba/query/processors/logical/tags_expander.py
@@ -14,10 +14,6 @@ class TagsExpanderProcessor(LogicalQueryProcessor):
     valid column name.
     """
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "tags_expander"
-
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_expression(exp: Expression) -> Expression:
             # This is intentionally not configurable in order to discourage creating

--- a/snuba/query/processors/logical/tags_type_transformer.py
+++ b/snuba/query/processors/logical/tags_type_transformer.py
@@ -11,10 +11,6 @@ class TagsTypeTransformer(LogicalQueryProcessor):
     used by the metrics and generic_metrics entities
     """
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "transform_tag_types"
-
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         def transform_expression(exp: Expression) -> Expression:
             if not isinstance(exp, SubscriptableReference):

--- a/snuba/query/processors/logical/timeseries_processor.py
+++ b/snuba/query/processors/logical/timeseries_processor.py
@@ -92,10 +92,6 @@ class TimeSeriesProcessor(LogicalQueryProcessor):
             ),
         )
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "translate_time_series"
-
     def __group_time_column(
         self, exp: Expression, granularity: Optional[int]
     ) -> Expression:

--- a/snuba/query/validation/validators.py
+++ b/snuba/query/validation/validators.py
@@ -39,7 +39,7 @@ class QueryValidator(ABC, metaclass=RegisteredClass):
 
     @classmethod
     def config_key(cls) -> str:
-        return "query_validator_base"
+        return cls.__name__
 
     @classmethod
     def get_from_name(cls, name: str) -> Type["QueryValidator"]:
@@ -71,10 +71,6 @@ class EntityRequiredColumnValidator(QueryValidator):
     This validator checks if the Query contains filters by all of the required columns.
     """
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "entity_required"
-
     def __init__(self, required_filter_columns: Set[str]) -> None:
         self.required_columns = required_filter_columns
 
@@ -102,10 +98,6 @@ class EntityContainsColumnsValidator(QueryValidator):
     """
     Ensures that all columns in the query actually exist in the entity.
     """
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "entity_contains_columns"
 
     def __init__(
         self, entity_data_model: EntityColumnSet, validation_mode: ColumnValidationMode
@@ -143,10 +135,6 @@ class NoTimeBasedConditionValidator(QueryValidator):
     column and ensure there are no conditions.
     """
 
-    @classmethod
-    def config_key(cls) -> str:
-        return "no_time_based_condition"
-
     def __init__(self, required_time_column: str) -> None:
         self.required_time_column = required_time_column
         self.match = build_match(
@@ -178,10 +166,6 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
     Subscriptions expect a very specific query structure. This will ensure that only the allowed
     clauses are being used in the query, and that those clauses are in the correct structure.
     """
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "subscription_allowed_clauses"
 
     def __init__(
         self, max_allowed_aggregations: int, disallowed_aggregations: Sequence[str]
@@ -257,10 +241,6 @@ class SubscriptionAllowedClausesValidator(QueryValidator):
 
 class GranularityValidator(QueryValidator):
     """Verify that the given granularity is a multiple of the configured value"""
-
-    @classmethod
-    def config_key(cls) -> str:
-        return "granularity"
 
     def __init__(self, minimum: int, required: bool = False):
         self.minimum = minimum

--- a/snuba/utils/registered_class.py
+++ b/snuba/utils/registered_class.py
@@ -47,14 +47,15 @@ class RegisteredClass(ABCMeta):
     """Metaclass for making classes that can be looked up by name
     Usage:
         class SomeGenericClass(metaclass=RegisteredClass):
-            pass
+            @classmethod
+            def config_key(cls) -> str:
+                return cls.__name__
 
         class Subclass(SomeGenericClass):
-            def config_key(self) -> str:
-                return "sub_class"
+            pass
 
 
-        assert SomeGenericClass.class_from_name("sub_class") is Subclass
+        assert SomeGenericClass.class_from_name("Subclass") is Subclass
 
     Notes:
         -   The base class cannot be looked up by name, only subclasses

--- a/tests/clickhouse/translators/test_auto_import.py
+++ b/tests/clickhouse/translators/test_auto_import.py
@@ -3,4 +3,4 @@ def test_auto_import():
         FunctionCallMapper,
     )
 
-    assert FunctionCallMapper.get_from_name("aggregate_function") is not None
+    assert FunctionCallMapper.get_from_name("AggregateFunctionMapper") is not None

--- a/tests/datasets/configuration/broken_entity_bad_query_processor.yaml
+++ b/tests/datasets/configuration/broken_entity_bad_query_processor.yaml
@@ -35,9 +35,9 @@ writable_storage: generic_metrics_sets_raw
 query_processors:
   -
     # this object is invalid without a processor: attribute
-    # processor: transform_tag_types
+    # processor: TagsTypeTransformer
   -
-    processor: handle_mapped_granularities
+    processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
@@ -45,38 +45,38 @@ query_processors:
         86400: 3
       default_granularity: 1
   -
-    processor: translate_time_series
+    processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limiter
+    processor: ReferrerRateLimiterProcessor
   -
-    processor: org_rate_limiter
+    processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
   -
-    processor: project_referrer_rate_limiter
+    processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
   -
-    processor: project_rate_limiter
+    processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
   -
-    processor: resource_quota_limiter
+    processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
     -
-      mapper: simple_func
+      mapper: FunctionNameMapper
       args:
         from_name: uniq
         to_name: uniqCombined64Merge
     -
-      mapper: simple_func
+      mapper: FunctionNameMapper
       args:
         from_name: uniqIf
         to_name: uniqCombined64MergeIf
@@ -99,7 +99,7 @@ translation_mappers:
         value_subcolumn_name: indexed_value
 validators:
   -
-    validator: entity_required
+    validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
 required_time_column: timestamp

--- a/tests/datasets/configuration/broken_entity_positional_validator_args.yaml
+++ b/tests/datasets/configuration/broken_entity_positional_validator_args.yaml
@@ -34,9 +34,9 @@ readable_storage: generic_metrics_sets
 writable_storage: generic_metrics_sets_raw
 query_processors:
   -
-    processor: transform_tag_types
+    processor: TagsTypeTransformer
   -
-    processor: handle_mapped_granularities
+    processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
@@ -44,44 +44,44 @@ query_processors:
         86400: 3
       default_granularity: 1
   -
-    processor: translate_time_series
+    processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
   -
-    processor: referrer_rate_limiter
+    processor: ReferrerRateLimiterProcessor
   -
-    processor: org_rate_limiter
+    processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
   -
-    processor: project_referrer_rate_limiter
+    processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
   -
-    processor: project_rate_limiter
+    processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
   -
-    processor: resource_quota_limiter
+    processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
     -
-      mapper: simple_func
+      mapper: FunctionNameMapper
       args:
         from_name: uniq
         to_name: uniqCombined64Merge
     -
-      mapper: simple_func
+      mapper: FunctionNameMapper
       args:
         from_name: uniqIf
         to_name: uniqCombined64MergeIf
   subscriptables:
     -
-      mapper: subscriptable
+      mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags_raw
@@ -89,7 +89,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
     -
-      mapper: subscriptable
+      mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags
@@ -98,7 +98,7 @@ translation_mappers:
         value_subcolumn_name: indexed_value
 validators:
   -
-    validator: entity_required
+    validator: EntityRequiredColumnValidator
     args:
       # correct: required_filter_columns: ["org_id", "project_id"]
       - org_id


### PR DESCRIPTION
This PR is responsible for adding a `config_key()` classmethod to all base classes for translators, mappers, and validators. 

Changes are the following:
* Modified configs to use class names instead of snake-case names
* Added `config_key` methods to all base class which inherit from `RegisteredClass`