### PR TITLE
 ref(admin): add migration groups list endpoint

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -28,7 +28,7 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.migrations.groups import MigrationGroup, get_group_loader
-from snuba.migrations.runner import get_active_migration_groups
+from snuba.migrations.runner import Runner, get_active_migration_groups
 from snuba.query.exceptions import InvalidQueryException
 from snuba.utils.metrics.timer import Timer
 from snuba.web.views import dataset_query
@@ -84,6 +84,27 @@ def migrations_groups() -> Response:
             group_migrations = get_group_loader(migration_group).get_migrations()
             res.append({"group": migration_group, "migration_ids": group_migrations})
     return make_response(jsonify(res), 200)
+
+
+@application.route("/migrations/<group>/list")
+def migrations_groups_list(group: str) -> Response:
+    runner = Runner()
+    for runner_group, runner_group_migrations in runner.show_all():
+        if runner_group == MigrationGroup(group):
+            return make_response(
+                jsonify(
+                    [
+                        {
+                            "migration_id": migration_id,
+                            "status": status.value,
+                            "blocking": blocking,
+                        }
+                        for migration_id, status, blocking in runner_group_migrations
+                    ]
+                ),
+                200,
+            )
+    return make_response(jsonify({"error": "Invalid group"}), 400)
 
 
 @application.route("/clickhouse_queries")

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -88,6 +88,10 @@ def migrations_groups() -> Response:
 
 @application.route("/migrations/<group>/list")
 def migrations_groups_list(group: str) -> Response:
+
+    if group not in settings.ADMIN_ALLOWED_MIGRATION_GROUPS:
+        return make_response(jsonify({"error": "Group not allowed"}), 400)
+
     runner = Runner()
     for runner_group, runner_group_migrations in runner.show_all():
         if runner_group == MigrationGroup(group):

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -39,3 +40,54 @@ def test_migration_groups(admin_api: FlaskClient) -> None:
             "migration_ids": get_group_loader("generic_metrics").get_migrations(),
         },
     ]
+
+
+def test_list_migration_status(admin_api: FlaskClient) -> None:
+    with patch(
+        "snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS", {"system", "generic_metrics"}
+    ):
+        response = admin_api.get("/migrations/system/list")
+        assert response.status_code == 200
+        expected_json = [
+            {
+                "blocking": False,
+                "migration_id": "0001_migrations",
+                "status": "completed",
+            }
+        ]
+        assert json.loads(response.data) == expected_json
+
+        # invalid migration group
+        response = admin_api.get("/migrations/sessions/list")
+        assert response.status_code == 400
+        assert json.loads(response.data)["error"] == "Group not allowed"
+
+        response = admin_api.get("/migrations/bad_group/list")
+        assert response.status_code == 400
+
+    with patch(
+        "snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS", {"sessions", "generic_metrics"}
+    ):
+        response = admin_api.get("/migrations/sessions/list")
+    assert response.status_code == 200
+    expected_json = [
+        {"blocking": False, "migration_id": "0001_sessions", "status": "completed"},
+        {
+            "blocking": False,
+            "migration_id": "0002_sessions_aggregates",
+            "status": "completed",
+        },
+        {
+            "blocking": False,
+            "migration_id": "0003_sessions_matview",
+            "status": "completed",
+        },
+    ]
+
+    def sort_by_migration_id(migration: Any) -> Any:
+        return migration["migration_id"]
+
+    sorted_response = sorted(json.loads(response.data), key=sort_by_migration_id)
+    sorted_expected_json = sorted(expected_json, key=sort_by_migration_id)
+
+    assert sorted_response == sorted_expected_json


### PR DESCRIPTION
More context in #3227 

Add an endpoint `migrations/{group}/list` to show the migration for a group. Returns error 400 : invalid group  if the `group` is not found

e.g

```
curl http: //localhost:1219/migrations/replays/list 

[{
      "blocking": false,
      "migration_id": "0001_replays",
      "status": "completed"
}, .... {
      "blocking": false,
      "migration_id": "0006_add_is_archived_column",
      "status": "completed"
}]
```