### PR TITLE
ref: Use new commit policy from Arroyo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
-sentry-arroyo==1.0.5
+sentry-arroyo==1.0.6
 sentry-relay==0.8.13
 sentry-sdk==1.9.8
 simplejson==3.17.6

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -1,6 +1,6 @@
 from dataclasses import replace
 from datetime import timedelta
-from typing import Callable, Mapping, NamedTuple, Optional, Sequence, cast
+from typing import Mapping, NamedTuple, Optional, Sequence, cast
 
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Producer
@@ -8,7 +8,7 @@ from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
-from arroyo.types import Position
+from arroyo.types import Commit
 
 from snuba import settings
 from snuba.datasets.dataset import Dataset
@@ -212,7 +212,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
 
     def create_with_partitions(
         self,
-        commit: Callable[[Mapping[Partition, Position]], None],
+        commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[Tick]:
         execute_step = self.__executor_factory.create_with_partitions(

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -6,16 +6,17 @@ import time
 from collections import deque
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime
-from typing import Callable, Deque, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Deque, Mapping, Optional, Sequence, Tuple
 
 import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Producer
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import MessageRejected, ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory
-from arroyo.types import Position
+from arroyo.types import Commit, Position
 
 from snuba import state
 from snuba.consumers.utils import get_partition_count
@@ -43,8 +44,6 @@ from snuba.utils.streams.configuration_builder import build_kafka_consumer_confi
 from snuba.web.query import parse_and_run_query
 
 logger = logging.getLogger(__name__)
-
-COMMIT_FREQUENCY_SEC = 1
 
 
 def calculate_max_concurrent_queries(
@@ -168,6 +167,7 @@ def build_executor_consumer(
             stale_threshold_seconds,
             result_topic_spec.topic_name,
         ),
+        commit_policy=ONCE_PER_SECOND,
     )
 
 
@@ -194,7 +194,7 @@ class SubscriptionExecutorProcessingFactory(ProcessingStrategyFactory[KafkaPaylo
 
     def create_with_partitions(
         self,
-        commit: Callable[[Mapping[Partition, Position]], None],
+        commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
 
@@ -239,8 +239,6 @@ class ExecuteQuery(ProcessingStrategy[KafkaPayload]):
         self.__stale_threshold_seconds = stale_threshold_seconds
         self.__metrics = metrics
         self.__next_step = next_step
-
-        self.__last_committed: Optional[float] = None
 
         self.__encoder = SubscriptionScheduledTaskEncoder()
 
@@ -409,15 +407,11 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
         self,
         producer: Producer[KafkaPayload],
         result_topic: str,
-        commit: Callable[[Mapping[Partition, Position]], None],
+        commit: Commit,
     ):
         self.__producer = producer
         self.__result_topic = Topic(result_topic)
         self.__commit = commit
-        self.__commit_data: MutableMapping[Partition, Position] = {}
-
-        # Time we last called commit
-        self.__last_committed: Optional[float] = None
 
         self.__encoder = SubscriptionTaskResultEncoder()
 
@@ -428,24 +422,6 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
         self.__max_buffer_size = 10000
         self.__closed = False
 
-    def __throttled_commit(self, force: bool = False) -> None:
-        # Commits all offsets and resets self.__commit_data at most
-        # every COMMIT_FREQUENCY_SEC. If force=True is passed, the
-        # commit frequency is ignored and we immediately commit.
-
-        now = time.time()
-
-        if (
-            self.__last_committed is None
-            or now - self.__last_committed >= COMMIT_FREQUENCY_SEC
-            or force is True
-        ):
-            if self.__commit_data:
-                logger.info("Committing offsets: %r", self.__commit_data)
-                self.__commit(self.__commit_data)
-                self.__last_committed = now
-                self.__commit_data = {}
-
     def poll(self) -> None:
         while self.__queue:
             message, future = self.__queue[0]
@@ -455,10 +431,9 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
 
             self.__queue.popleft()
 
-            self.__commit_data[message.partition] = Position(
-                message.next_offset, message.timestamp
+            self.__commit(
+                {message.partition: Position(message.next_offset, message.timestamp)}
             )
-        self.__throttled_commit()
 
     def submit(self, message: Message[SubscriptionTaskResult]) -> None:
         assert not self.__closed
@@ -481,7 +456,7 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
         start = time.time()
 
         # Commit all pending offsets
-        self.__throttled_commit(force=True)
+        self.__commit({}, force=True)
 
         while self.__queue:
             remaining = timeout - (time.time() - start) if timeout is not None else None
@@ -496,4 +471,4 @@ class ProduceResult(ProcessingStrategy[SubscriptionTaskResult]):
             offset = {message.partition: Position(message.offset, message.timestamp)}
 
             logger.info("Committing offset: %r", offset)
-            self.__commit(offset)
+            self.__commit(offset, force=True)

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -6,7 +6,7 @@ import rapidjson
 from arroyo import Message, Partition, Topic
 from arroyo.backends.abstract import Consumer, Producer
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
-from arroyo.commit import CommitCodec
+from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.abstract import ProcessingStrategyFactory

--- a/snuba/utils/streams/kafka_consumer_with_commit_log.py
+++ b/snuba/utils/streams/kafka_consumer_with_commit_log.py
@@ -2,7 +2,8 @@ from typing import Any, Mapping, Optional
 
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
-from arroyo.commit import Commit, CommitCodec
+from arroyo.backends.kafka.commit import CommitCodec
+from arroyo.commit import Commit
 from arroyo.types import Position
 from arroyo.utils.retries import RetryPolicy
 from confluent_kafka import KafkaError

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -354,14 +354,13 @@ def test_produce_result() -> None:
     strategy.poll()
     assert commit.call_count == 1
 
-    # Commit is throttled so if we immediately submit another message, the commit count will not change
     strategy.submit(message)
     strategy.poll()
-    assert commit.call_count == 1
+    assert commit.call_count == 2
 
     # Commit count immediately increases once we call join()
     strategy.join()
-    assert commit.call_count == 2
+    assert commit.call_count == 3
 
 
 def test_execute_and_produce_result() -> None:

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -9,10 +9,11 @@ from unittest import mock
 import pytest
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload, KafkaProducer
+from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.backends.local.backend import LocalBroker as Broker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
+from arroyo.commit import Commit
 from arroyo.errors import ConsumerError
-from arroyo.synchronized import Commit, commit_codec
 from arroyo.utils.clock import TestingClock
 from confluent_kafka.admin import AdminClient
 
@@ -31,6 +32,8 @@ from snuba.utils.streams.topics import Topic as SnubaTopic
 from snuba.utils.types import Interval
 from tests.assertions import assert_changes
 from tests.backends.metrics import TestingMetricsBackend
+
+commit_codec = CommitCodec()
 
 
 def test_scheduler_consumer() -> None:

--- a/tests/utils/streams/test_kafka_consumer_with_commit_log.py
+++ b/tests/utils/streams/test_kafka_consumer_with_commit_log.py
@@ -5,7 +5,8 @@ from typing import Iterator
 
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
-from arroyo.synchronized import Commit, commit_codec
+from arroyo.backends.kafka.commit import CommitCodec
+from arroyo.commit import Commit
 from arroyo.types import Position
 
 from snuba.utils.streams.configuration_builder import get_default_kafka_configuration
@@ -67,7 +68,7 @@ def test_commit_log_consumer() -> None:
         commit_message = commit_log_producer.messages[0]
         assert commit_message.topic() == "commit-log"
 
-        assert commit_codec.decode(
+        assert CommitCodec().decode(
             KafkaPayload(
                 commit_message.key(),
                 commit_message.value(),


### PR DESCRIPTION
Arroyo now supports commit policies. We no longer need to implement commit throttling by ourselves.
