### PR TITLE
ref(MDC): Topics Enum to Class

### DIFF
--- a/snuba/attribution/log.py
+++ b/snuba/attribution/log.py
@@ -106,7 +106,7 @@ def record_attribution(attr_data: AttributionData) -> None:
         producer.poll(0)  # trigger queued delivery callbacks
         producer.produce(
             settings.KAFKA_TOPIC_MAP.get(
-                Topic.ATTRIBUTION.value, Topic.ATTRIBUTION.value
+                Topic.SNUBA_ATTRIBUTION.value, Topic.SNUBA_ATTRIBUTION.value
             ),
             data_str.encode("utf-8"),
             on_delivery=_record_attribution_delivery_callback,

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -26,7 +26,7 @@ from snuba.datasets.table_storage import (
     build_kafka_stream_loader_from_settings,
 )
 from snuba.subscriptions.utils import SchedulingWatermarkMode
-from snuba.utils.streams.topics import Topic
+from snuba.utils.streams.topics import Topic, register_topic
 
 KIND = "kind"
 WRITABLE_STORAGE = "writable_storage"
@@ -91,7 +91,7 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
     processor = DatasetMessageProcessor.get_from_name(
         loader_config["processor"]
     ).from_kwargs()
-    default_topic = Topic(loader_config["default_topic"])
+    default_topic = register_topic(loader_config["default_topic"])
     # optionals
     pre_filter = None
     if PRE_FILTER in loader_config and loader_config[PRE_FILTER] is not None:
@@ -131,7 +131,7 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
 
 def __get_topic(stream_loader_config: dict[str, Any], name: str | None) -> Topic | None:
     return (
-        Topic(stream_loader_config[name])
+        register_topic(stream_loader_config[name])
         if name in stream_loader_config and stream_loader_config[name] is not None
         else None
     )

--- a/snuba/datasets/configuration/validation/post_loader.py
+++ b/snuba/datasets/configuration/validation/post_loader.py
@@ -14,7 +14,7 @@ def validate_storages() -> None:
 
 def validate_topics_with_settings() -> None:
     """
-    This functoion validates topics specified in settings are valid
+    This function validates topics specified in settings are valid
     topics that have been loaded into the Topics registry (via storage builder).
     """
     topic_names: Set[str] = set([t.value for t in Topic])

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -39,10 +39,10 @@ storage = WritableTableStorage(
         processor=ErrorsProcessor(promoted_tag_columns),
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
-        commit_log_topic=Topic.COMMIT_LOG,
+        commit_log_topic=Topic.SNUBA_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_EVENTS,
+        subscription_result_topic=Topic.EVENTS_SUBSCRIPTION_RESULTS,
     ),
     # This is the default, just showing where it goes for the PR
     write_format=WriteFormat.JSON,

--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -112,10 +112,10 @@ storage = WritableTableStorage(
         processor=ErrorsProcessor(promoted_tag_columns),
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
-        commit_log_topic=Topic.COMMIT_LOG,
+        commit_log_topic=Topic.SNUBA_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.PARTITION,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_EVENTS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_EVENTS,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_EVENTS,
+        subscription_result_topic=Topic.EVENTS_SUBSCRIPTION_RESULTS,
     ),
     replacer_processor=ErrorsReplacer(
         schema=schema,

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -7,9 +7,9 @@ from typing import Generator
 from snuba import settings
 from snuba.datasets.cdc import CdcStorage
 from snuba.datasets.configuration.storage_builder import build_storage
+from snuba.datasets.configuration.validation.post_loader import validate_storages
 from snuba.datasets.storage import ReadableTableStorage, Storage, WritableTableStorage
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.datasets.storages.validation import validate_storages
 from snuba.state import get_config
 from snuba.utils.config_component_factory import ConfigComponentFactory
 

--- a/snuba/datasets/storages/factory.py
+++ b/snuba/datasets/storages/factory.py
@@ -9,6 +9,7 @@ from snuba.datasets.cdc import CdcStorage
 from snuba.datasets.configuration.storage_builder import build_storage
 from snuba.datasets.storage import ReadableTableStorage, Storage, WritableTableStorage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.datasets.storages.validation import validate_storages
 from snuba.state import get_config
 from snuba.utils.config_component_factory import ConfigComponentFactory
 
@@ -28,6 +29,7 @@ class _StorageFactory(ConfigComponentFactory[Storage, StorageKey]):
         self._dev_non_writable_storages: dict[StorageKey, Storage] = {}
         self._all_storages: dict[StorageKey, Storage] = {}
         self.__initialize()
+        validate_storages()
 
     def __initialize(self) -> None:
 

--- a/snuba/datasets/storages/functions.py
+++ b/snuba/datasets/storages/functions.py
@@ -59,7 +59,7 @@ raw_storage = WritableTableStorage(
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=FunctionsMessageProcessor(),
-        default_topic=Topic.PROFILES_FUNCTIONS,
+        default_topic=Topic.PROFILES_CALL_TREE,
     ),
 )
 

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -48,9 +48,11 @@ def produce_policy_creator() -> DeadLetterQueuePolicy:
     """
     return ProduceInvalidMessagePolicy(
         KafkaProducer(
-            build_kafka_producer_configuration(Topic.DEAD_LETTER_GENERIC_METRICS)
+            build_kafka_producer_configuration(
+                Topic.DEAD_LETTER_GSNUBA_DEAD_LETTER_GENERIC_METRICSENERIC_METRICS
+            )
         ),
-        KafkaTopic(Topic.DEAD_LETTER_GENERIC_METRICS.value),
+        KafkaTopic(Topic.SNUBA_DEAD_LETTER_GENERIC_METRICS.value),
     )
 
 
@@ -137,12 +139,12 @@ sets_bucket_storage = WritableTableStorage(
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=GenericSetsMetricsProcessor(),
-        default_topic=Topic.GENERIC_METRICS,
+        default_topic=Topic.SNUBA_GENERIC_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
-        commit_log_topic=Topic.GENERIC_METRICS_SETS_COMMIT_LOG,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_SETS,
+        commit_log_topic=Topic.SNUBA_GENERIC_METRICS_SETS_COMMIT_LOG,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_GENERIC_METRICS_SETS,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_GENERIC_METRICS_SETS,
+        subscription_result_topic=Topic.GENERIC_METRICS_SETS_SUBSCRIPTION_RESULTS,
         pre_filter=KafkaHeaderSelectFilter("metric_type", InputType.SET.value),
     ),
 )
@@ -177,12 +179,12 @@ distributions_bucket_storage = WritableTableStorage(
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=GenericDistributionsMetricsProcessor(),
-        default_topic=Topic.GENERIC_METRICS,
+        default_topic=Topic.SNUBA_GENERIC_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
-        commit_log_topic=Topic.GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_DISTRIBUTIONS,
+        commit_log_topic=Topic.SNUBA_GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_GENERIC_METRICS_DISTRIBUTIONS,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_GENERIC_METRICS_DISTRIBUTIONS,
+        subscription_result_topic=Topic.GENERIC_METRICS_DISTRIBUTIONS_SUBSCRIPTION_RESULTS,
         pre_filter=KafkaHeaderSelectFilter("metric_type", InputType.DISTRIBUTION.value),
     ),
 )

--- a/snuba/datasets/storages/metrics.py
+++ b/snuba/datasets/storages/metrics.py
@@ -64,8 +64,10 @@ def produce_policy_creator() -> DeadLetterQueuePolicy:
     Produce all bad messages to dead-letter topic.
     """
     return ProduceInvalidMessagePolicy(
-        KafkaProducer(build_kafka_producer_configuration(Topic.DEAD_LETTER_METRICS)),
-        KafkaTopic(Topic.DEAD_LETTER_METRICS.value),
+        KafkaProducer(
+            build_kafka_producer_configuration(Topic.SNUBA_DEAD_LETTER_METRICS)
+        ),
+        KafkaTopic(Topic.SNUBA_DEAD_LETTER_METRICS.value),
     )
 
 
@@ -90,11 +92,11 @@ polymorphic_bucket = WritableTableStorage(
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=PolymorphicMetricsProcessor(),
-        default_topic=Topic.METRICS,
-        commit_log_topic=Topic.METRICS_COMMIT_LOG,
+        default_topic=Topic.SNUBA_METRICS,
+        commit_log_topic=Topic.SNUBA_METRICS_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_METRICS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_METRICS,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_METRICS,
+        subscription_result_topic=Topic.METRICS_SUBSCRIPTION_RESULTS,
         dead_letter_queue_policy_creator=produce_policy_creator,
     ),
 )
@@ -128,7 +130,7 @@ sets_storage = WritableTableStorage(
     query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
     stream_loader=build_kafka_stream_loader_from_settings(
         SetsAggregateProcessor(),
-        default_topic=Topic.METRICS,
+        default_topic=Topic.SNUBA_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
     ),
     write_format=WriteFormat.VALUES,
@@ -151,7 +153,7 @@ counters_storage = WritableTableStorage(
     query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
     stream_loader=build_kafka_stream_loader_from_settings(
         CounterAggregateProcessor(),
-        default_topic=Topic.METRICS,
+        default_topic=Topic.SNUBA_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
     ),
     write_format=WriteFormat.VALUES,
@@ -205,7 +207,7 @@ distributions_storage = WritableTableStorage(
     query_processors=[ArrayJoinKeyValueOptimizer("tags"), TableRateLimit()],
     stream_loader=build_kafka_stream_loader_from_settings(
         DistributionsAggregateProcessor(),
-        default_topic=Topic.METRICS,
+        default_topic=Topic.SNUBA_METRICS,
         dead_letter_queue_policy_creator=produce_policy_creator,
     ),
     write_format=WriteFormat.VALUES,

--- a/snuba/datasets/storages/profiles.py
+++ b/snuba/datasets/storages/profiles.py
@@ -28,7 +28,7 @@ processors = [
 
 loader = build_kafka_stream_loader_from_settings(
     processor=ProfilesMessageProcessor(),
-    default_topic=Topic.PROFILES,
+    default_topic=Topic.PROCESSED_PROFILES,
 )
 
 readable_columns = ColumnSet(

--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -71,6 +71,6 @@ storage = WritableTableStorage(
     query_processors=[],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=QuerylogProcessor(),
-        default_topic=Topic.QUERYLOG,
+        default_topic=Topic.SNUBA_QUERIES,
     ),
 )

--- a/snuba/datasets/storages/replays.py
+++ b/snuba/datasets/storages/replays.py
@@ -89,8 +89,10 @@ schema = WritableTableSchema(
 def produce_policy_creator() -> DeadLetterQueuePolicy:
     """Produce all bad messages to dead-letter topic."""
     return ProduceInvalidMessagePolicy(
-        KafkaProducer(build_kafka_producer_configuration(Topic.DEAD_LETTER_REPLAYS)),
-        KafkaTopic(Topic.DEAD_LETTER_REPLAYS.value),
+        KafkaProducer(
+            build_kafka_producer_configuration(Topic.SNUBA_DEAD_LETTER_REPLAYS)
+        ),
+        KafkaTopic(Topic.SNUBA_DEAD_LETTER_REPLAYS.value),
     )
 
 
@@ -102,7 +104,7 @@ storage = WritableTableStorage(
     mandatory_condition_checkers=[ProjectIdEnforcer()],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=ReplaysProcessor(),
-        default_topic=Topic.REPLAYEVENTS,
+        default_topic=Topic.INGEST_REPLAY_EVENTS,
         dead_letter_queue_policy_creator=produce_policy_creator,
     ),
 )

--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -117,7 +117,7 @@ class MinuteResolutionProcessor(ClickhouseQueryProcessor):
 
 
 kafka_stream_loader = build_kafka_stream_loader_from_settings(
-    processor=SessionsProcessor(), default_topic=Topic.SESSIONS
+    processor=SessionsProcessor(), default_topic=Topic.INGEST_SESSIONS
 )
 
 raw_storage = WritableTableStorage(

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -33,10 +33,10 @@ storage = WritableTableStorage(
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),
         default_topic=Topic.TRANSACTIONS,
-        commit_log_topic=Topic.TRANSACTIONS_COMMIT_LOG,
+        commit_log_topic=Topic.SNUBA_TRANSACTIONS_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_TRANSACTIONS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_TRANSACTIONS,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_TRANSACTIONS,
+        subscription_result_topic=Topic.TRANSACTIONS_SUBSCRIPTION_RESULTS,
     ),
     query_splitters=query_splitters,
     mandatory_condition_checkers=mandatory_condition_checkers,

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -33,10 +33,10 @@ storage = WritableTableStorage(
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),
         default_topic=Topic.TRANSACTIONS,
-        commit_log_topic=Topic.TRANSACTIONS_COMMIT_LOG,
+        commit_log_topic=Topic.SNUBA_TRANSACTIONS_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,
-        subscription_scheduled_topic=Topic.SUBSCRIPTION_SCHEDULED_TRANSACTIONS,
-        subscription_result_topic=Topic.SUBSCRIPTION_RESULTS_TRANSACTIONS,
+        subscription_scheduled_topic=Topic.SCHEDULED_SUBSCRIPTIONS_TRANSACTIONS,
+        subscription_result_topic=Topic.TRANSACTIONS_SUBSCRIPTION_RESULTS,
     ),
     query_splitters=query_splitters,
     mandatory_condition_checkers=mandatory_condition_checkers,

--- a/snuba/datasets/storages/validation.py
+++ b/snuba/datasets/storages/validation.py
@@ -1,0 +1,28 @@
+from typing import Set
+
+from snuba import settings
+from snuba.utils.streams.topics import Topic
+
+
+class InvalidTopicError(ValueError):
+    pass
+
+
+def validate_storages() -> None:
+    validate_topics_with_settings()
+
+
+def validate_topics_with_settings() -> None:
+    """
+    This functoion validates topics specified in settings are valid
+    topics that have been loaded into the Topics registry (via storage builder).
+    """
+    topic_names: Set[str] = set([t.value for t in Topic])
+
+    for key in settings.KAFKA_TOPIC_MAP.keys():
+        if key not in topic_names:
+            raise InvalidTopicError(f"Invalid topic value: {key}")
+
+    for key in settings.KAFKA_BROKER_CONFIG.keys():
+        if key not in topic_names:
+            raise ValueError(f"Invalid topic value {key}")

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -82,6 +82,46 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
     },
 ]
 
+ALLOWED_TOPICS: Set[str] = {
+    "events",
+    "event-replacements",
+    "transactions",
+    "snuba-commit-log",
+    "snuba-transactions-commit-log",
+    "snuba-sessions-commit-log",
+    "snuba-metrics-commit-log",
+    "cdc",
+    "snuba-metrics",
+    "outcomes",
+    "ingest-sessions",
+    "snuba-queries",
+    "scheduled-subscriptions-events",
+    "scheduled-subscriptions-transactions",
+    "scheduled-subscriptions-sessions",
+    "scheduled-subscriptions-metrics",
+    "scheduled-subscriptions-generic-metrics-sets",
+    "scheduled-subscriptions-generic-metrics-distributions",
+    "events-subscription-results",
+    "transactions-subscription-results",
+    "sessions-subscription-results",
+    "metrics-subscription-results",
+    "generic-metrics-sets-subscription-results",
+    "generic-metrics-distributions-subscription-results",
+    "snuba-dead-letter-inserts",
+    "processed-profiles",
+    "snuba-attribution",
+    "profiles-call-tree",
+    "ingest-replay-events",
+    "snuba-replay-events",
+    "snuba-dead-letter-replays",
+    "snuba-generic-metrics",
+    "snuba-generic-metrics-sets-commit-log",
+    "snuba-generic-metrics-distributions-commit-log",
+    "snuba-dead-letter-generic-metrics",
+    "snuba-dead-letter-sessions",
+    "snuba-dead-letter-metrics",
+}
+
 # Dogstatsd Options
 DOGSTATSD_HOST: str | None = None
 DOGSTATSD_PORT: int | None = None

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -82,46 +82,6 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
     },
 ]
 
-ALLOWED_TOPICS: Set[str] = {
-    "events",
-    "event-replacements",
-    "transactions",
-    "snuba-commit-log",
-    "snuba-transactions-commit-log",
-    "snuba-sessions-commit-log",
-    "snuba-metrics-commit-log",
-    "cdc",
-    "snuba-metrics",
-    "outcomes",
-    "ingest-sessions",
-    "snuba-queries",
-    "scheduled-subscriptions-events",
-    "scheduled-subscriptions-transactions",
-    "scheduled-subscriptions-sessions",
-    "scheduled-subscriptions-metrics",
-    "scheduled-subscriptions-generic-metrics-sets",
-    "scheduled-subscriptions-generic-metrics-distributions",
-    "events-subscription-results",
-    "transactions-subscription-results",
-    "sessions-subscription-results",
-    "metrics-subscription-results",
-    "generic-metrics-sets-subscription-results",
-    "generic-metrics-distributions-subscription-results",
-    "snuba-dead-letter-inserts",
-    "processed-profiles",
-    "snuba-attribution",
-    "profiles-call-tree",
-    "ingest-replay-events",
-    "snuba-replay-events",
-    "snuba-dead-letter-replays",
-    "snuba-generic-metrics",
-    "snuba-generic-metrics-sets-commit-log",
-    "snuba-generic-metrics-distributions-commit-log",
-    "snuba-dead-letter-generic-metrics",
-    "snuba-dead-letter-sessions",
-    "snuba-dead-letter-metrics",
-}
-
 # Dogstatsd Options
 DOGSTATSD_HOST: str | None = None
 DOGSTATSD_PORT: int | None = None

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, MutableMapping, Optional, Set
+from typing import Any, Mapping, MutableMapping
 
 from snuba.datasets.partitioning import SENTRY_LOGICAL_PARTITIONS
 
@@ -27,18 +27,6 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         raise ValueError(
             "DEFAULT_STORAGE_BROKERS is deprecated. Use KAFKA_BROKER_CONFIG instead."
         )
-
-    topic_names: Optional[Set[str]] = locals.get("ALLOWED_TOPICS")
-    if not topic_names:
-        topic_names = set()
-
-    for key in locals["KAFKA_TOPIC_MAP"].keys():
-        if key not in topic_names:
-            raise InvalidTopicError(f"Invalid topic value: {key}")
-
-    for key in locals["KAFKA_BROKER_CONFIG"].keys():
-        if key not in topic_names:
-            raise ValueError(f"Invalid topic value {key}")
 
     # Validate cluster configuration
     from snuba.clusters.storage_sets import StorageSetKey

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, MutableMapping
+from typing import Any, Mapping, MutableMapping, Optional, Set
 
 from snuba.datasets.partitioning import SENTRY_LOGICAL_PARTITIONS
 
@@ -28,45 +28,9 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
             "DEFAULT_STORAGE_BROKERS is deprecated. Use KAFKA_BROKER_CONFIG instead."
         )
 
-    topic_names = {
-        "events",
-        "event-replacements",
-        "transactions",
-        "snuba-commit-log",
-        "snuba-transactions-commit-log",
-        "snuba-sessions-commit-log",
-        "snuba-metrics-commit-log",
-        "cdc",
-        "snuba-metrics",
-        "outcomes",
-        "ingest-sessions",
-        "snuba-queries",
-        "scheduled-subscriptions-events",
-        "scheduled-subscriptions-transactions",
-        "scheduled-subscriptions-sessions",
-        "scheduled-subscriptions-metrics",
-        "scheduled-subscriptions-generic-metrics-sets",
-        "scheduled-subscriptions-generic-metrics-distributions",
-        "events-subscription-results",
-        "transactions-subscription-results",
-        "sessions-subscription-results",
-        "metrics-subscription-results",
-        "generic-metrics-sets-subscription-results",
-        "generic-metrics-distributions-subscription-results",
-        "snuba-dead-letter-inserts",
-        "processed-profiles",
-        "snuba-attribution",
-        "profiles-call-tree",
-        "ingest-replay-events",
-        "snuba-replay-events",
-        "snuba-dead-letter-replays",
-        "snuba-generic-metrics",
-        "snuba-generic-metrics-sets-commit-log",
-        "snuba-generic-metrics-distributions-commit-log",
-        "snuba-dead-letter-generic-metrics",
-        "snuba-dead-letter-sessions",
-        "snuba-dead-letter-metrics",
-    }
+    topic_names: Optional[Set[str]] = locals.get("ALLOWED_TOPICS")
+    if not topic_names:
+        topic_names = set()
 
     for key in locals["KAFKA_TOPIC_MAP"].keys():
         if key not in topic_names:

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -339,7 +339,9 @@ def record_query(query_metadata: Mapping[str, Any]) -> None:
         ).execute()
         producer.poll(0)  # trigger queued delivery callbacks
         producer.produce(
-            settings.KAFKA_TOPIC_MAP.get(Topic.QUERYLOG.value, Topic.QUERYLOG.value),
+            settings.KAFKA_TOPIC_MAP.get(
+                Topic.SNUBA_QUERIES.value, Topic.SNUBA_QUERIES.value
+            ),
             data.encode("utf-8"),
             on_delivery=_record_query_delivery_callback,
         )

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -1,53 +1,77 @@
-from enum import Enum
-from typing import Mapping
+from __future__ import annotations
 
+from typing import Any, Iterator, Mapping
 
 # These are the default topic names, they can be changed via settings
-class Topic(Enum):
-    EVENTS = "events"
-    EVENT_REPLACEMENTS = "event-replacements"
-    COMMIT_LOG = "snuba-commit-log"
-    CDC = "cdc"
-    TRANSACTIONS = "transactions"
-    TRANSACTIONS_COMMIT_LOG = "snuba-transactions-commit-log"
-    METRICS = "snuba-metrics"
-    OUTCOMES = "outcomes"
-    SESSIONS = "ingest-sessions"
-    METRICS_COMMIT_LOG = "snuba-metrics-commit-log"
-    SUBSCRIPTION_SCHEDULED_EVENTS = "scheduled-subscriptions-events"
-    SUBSCRIPTION_SCHEDULED_TRANSACTIONS = "scheduled-subscriptions-transactions"
-    SUBSCRIPTION_SCHEDULED_METRICS = "scheduled-subscriptions-metrics"
-    SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_SETS = (
-        "scheduled-subscriptions-generic-metrics-sets"
-    )
-    SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_DISTRIBUTIONS = (
-        "scheduled-subscriptions-generic-metrics-distributions"
-    )
-    SUBSCRIPTION_RESULTS_EVENTS = "events-subscription-results"
-    SUBSCRIPTION_RESULTS_TRANSACTIONS = "transactions-subscription-results"
-    SUBSCRIPTION_RESULTS_METRICS = "metrics-subscription-results"
-    SUBSCRIPTION_RESULTS_GENERIC_METRICS_SETS = (
-        "generic-metrics-sets-subscription-results"
-    )
-    SUBSCRIPTION_RESULTS_GENERIC_METRICS_DISTRIBUTIONS = (
-        "generic-metrics-distributions-subscription-results"
-    )
-    QUERYLOG = "snuba-queries"
-    PROFILES = "processed-profiles"
-    PROFILES_FUNCTIONS = "profiles-call-tree"
-    REPLAYEVENTS = "ingest-replay-events"
-    GENERIC_METRICS = "snuba-generic-metrics"
-    GENERIC_METRICS_SETS_COMMIT_LOG = "snuba-generic-metrics-sets-commit-log"
-    GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG = (
-        "snuba-generic-metrics-distributions-commit-log"
-    )
+_HARDCODED_TOPICS = {
+    "EVENTS": "events",
+    "EVENT_REPLACEMENTS": "event-replacements",
+    "COMMIT_LOG": "snuba-commit-log",
+    "CDC": "cdc",
+    "TRANSACTIONS": "transactions",
+    "TRANSACTIONS_COMMIT_LOG": "snuba-transactions-commit-log",
+    "METRICS": "snuba-metrics",
+    "OUTCOMES": "outcomes",
+    "SESSIONS": "ingest-sessions",
+    "METRICS_COMMIT_LOG": "snuba-metrics-commit-log",
+    "SUBSCRIPTION_SCHEDULED_EVENTS": "scheduled-subscriptions-events",
+    "SUBSCRIPTION_SCHEDULED_TRANSACTIONS": "scheduled-subscriptions-transactions",
+    "SUBSCRIPTION_SCHEDULED_METRICS": "scheduled-subscriptions-metrics",
+    "SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_SETS": "scheduled-subscriptions-generic-metrics-sets",
+    "SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_DISTRIBUTIONS": "scheduled-subscriptions-generic-metrics-distributions",
+    "SUBSCRIPTION_RESULTS_EVENTS": "events-subscription-results",
+    "SUBSCRIPTION_RESULTS_TRANSACTIONS": "transactions-subscription-results",
+    "SUBSCRIPTION_RESULTS_METRICS": "metrics-subscription-results",
+    "SUBSCRIPTION_RESULTS_GENERIC_METRICS_SETS": "generic-metrics-sets-subscription-results",
+    "SUBSCRIPTION_RESULTS_GENERIC_METRICS_DISTRIBUTIONS": "generic-metrics-distributions-subscription-results",
+    "QUERYLOG": "snuba-queries",
+    "PROFILES": "processed-profiles",
+    "PROFILES_FUNCTIONS": "profiles-call-tree",
+    "REPLAYEVENTS": "ingest-replay-events",
+    "GENERIC_METRICS": "snuba-generic-metrics",
+    "GENERIC_METRICS_SETS_COMMIT_LOG": "snuba-generic-metrics-sets-commit-log",
+    "GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG": "snuba-generic-metrics-distributions-commit-log",
+    "DEAD_LETTER_QUEUE_INSERTS": "snuba-dead-letter-inserts",
+    "ATTRIBUTION": "snuba-attribution",
+    "DEAD_LETTER_METRICS": "snuba-dead-letter-metrics",
+    "DEAD_LETTER_SESSIONS": "snuba-dead-letter-sessions",
+    "DEAD_LETTER_GENERIC_METRICS": "snuba-dead-letter-generic-metrics",
+    "DEAD_LETTER_REPLAYS": "snuba-dead-letter-replays",
+}
 
-    DEAD_LETTER_QUEUE_INSERTS = "snuba-dead-letter-inserts"
-    ATTRIBUTION = "snuba-attribution"
-    DEAD_LETTER_METRICS = "snuba-dead-letter-metrics"
-    DEAD_LETTER_SESSIONS = "snuba-dead-letter-sessions"
-    DEAD_LETTER_GENERIC_METRICS = "snuba-dead-letter-generic-metrics"
-    DEAD_LETTER_REPLAYS = "snuba-dead-letter-replays"
+_REGISTERED_TOPICS: dict[str, str] = {}
+
+
+class _Topic(type):
+    def __getattr__(self, attr: str) -> "Topic":
+        if attr not in _HARDCODED_TOPICS and attr not in _REGISTERED_TOPICS:
+            raise AttributeError(attr)
+        return Topic(attr.lower())
+
+    def __iter__(self) -> Iterator[Topic]:
+        return iter(
+            Topic(value)
+            for value in {**_HARDCODED_TOPICS, **_REGISTERED_TOPICS}.values()
+        )
+
+
+class Topic(metaclass=_Topic):
+    def __init__(self, value: str):
+        self.value = value
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, Topic) and other.value == self.value
+
+    def __repr__(self) -> str:
+        return f"Topic.{self.value.upper()}"
+
+
+def register_topic(key: str) -> Topic:
+    _REGISTERED_TOPICS[key.upper()] = key.lower()
+    return Topic(key)
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -6,37 +6,37 @@ from typing import Any, Iterator, Mapping
 _HARDCODED_TOPICS = {
     "EVENTS": "events",
     "EVENT_REPLACEMENTS": "event-replacements",
-    "COMMIT_LOG": "snuba-commit-log",
+    "SNUBA_COMMIT_LOG": "snuba-commit-log",
     "CDC": "cdc",
     "TRANSACTIONS": "transactions",
-    "TRANSACTIONS_COMMIT_LOG": "snuba-transactions-commit-log",
-    "METRICS": "snuba-metrics",
+    "SNUBA_TRANSACTIONS_COMMIT_LOG": "snuba-transactions-commit-log",
+    "SNUBA_METRICS": "snuba-metrics",
     "OUTCOMES": "outcomes",
-    "SESSIONS": "ingest-sessions",
-    "METRICS_COMMIT_LOG": "snuba-metrics-commit-log",
-    "SUBSCRIPTION_SCHEDULED_EVENTS": "scheduled-subscriptions-events",
-    "SUBSCRIPTION_SCHEDULED_TRANSACTIONS": "scheduled-subscriptions-transactions",
-    "SUBSCRIPTION_SCHEDULED_METRICS": "scheduled-subscriptions-metrics",
-    "SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_SETS": "scheduled-subscriptions-generic-metrics-sets",
-    "SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_DISTRIBUTIONS": "scheduled-subscriptions-generic-metrics-distributions",
-    "SUBSCRIPTION_RESULTS_EVENTS": "events-subscription-results",
-    "SUBSCRIPTION_RESULTS_TRANSACTIONS": "transactions-subscription-results",
-    "SUBSCRIPTION_RESULTS_METRICS": "metrics-subscription-results",
-    "SUBSCRIPTION_RESULTS_GENERIC_METRICS_SETS": "generic-metrics-sets-subscription-results",
-    "SUBSCRIPTION_RESULTS_GENERIC_METRICS_DISTRIBUTIONS": "generic-metrics-distributions-subscription-results",
-    "QUERYLOG": "snuba-queries",
-    "PROFILES": "processed-profiles",
-    "PROFILES_FUNCTIONS": "profiles-call-tree",
-    "REPLAYEVENTS": "ingest-replay-events",
-    "GENERIC_METRICS": "snuba-generic-metrics",
-    "GENERIC_METRICS_SETS_COMMIT_LOG": "snuba-generic-metrics-sets-commit-log",
-    "GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG": "snuba-generic-metrics-distributions-commit-log",
-    "DEAD_LETTER_QUEUE_INSERTS": "snuba-dead-letter-inserts",
-    "ATTRIBUTION": "snuba-attribution",
-    "DEAD_LETTER_METRICS": "snuba-dead-letter-metrics",
-    "DEAD_LETTER_SESSIONS": "snuba-dead-letter-sessions",
-    "DEAD_LETTER_GENERIC_METRICS": "snuba-dead-letter-generic-metrics",
-    "DEAD_LETTER_REPLAYS": "snuba-dead-letter-replays",
+    "INGEST_SESSIONS": "ingest-sessions",
+    "SNUBA_METRICS_COMMIT_LOG": "snuba-metrics-commit-log",
+    "SCHEDULED_SUBSCRIPTIONS_EVENTS": "scheduled-subscriptions-events",
+    "SCHEDULED_SUBSCRIPTIONS_TRANSACTIONS": "scheduled-subscriptions-transactions",
+    "SCHEDULED_SUBSCRIPTIONS_METRICS": "scheduled-subscriptions-metrics",
+    "SCHEDULED_SUBSCRIPTIONS_GENERIC_METRICS_SETS": "scheduled-subscriptions-generic-metrics-sets",
+    "SCHEDULED_SUBSCRIPTIONS_GENERIC_METRICS_DISTRIBUTIONS": "scheduled-subscriptions-generic-metrics-distributions",
+    "EVENTS_SUBSCRIPTION_RESULTS": "events-subscription-results",
+    "TRANSACTIONS_SUBSCRIPTION_RESULTS": "transactions-subscription-results",
+    "METRICS_SUBSCRIPTION_RESULTS": "metrics-subscription-results",
+    "GENERIC_METRICS_SETS_SUBSCRIPTION_RESULTS": "generic-metrics-sets-subscription-results",
+    "GENERIC_METRICS_DISTRIBUTIONS_SUBSCRIPTION_RESULTS": "generic-metrics-distributions-subscription-results",
+    "SNUBA_QUERIES": "snuba-queries",
+    "PROCESSED_PROFILES": "processed-profiles",
+    "PROFILES_CALL_TREE": "profiles-call-tree",
+    "INGEST_REPLAY_EVENTS": "ingest-replay-events",
+    "SNUBA_GENERIC_METRICS": "snuba-generic-metrics",
+    "SNUBA_GENERIC_METRICS_SETS_COMMIT_LOG": "snuba-generic-metrics-sets-commit-log",
+    "SNUBA_GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG": "snuba-generic-metrics-distributions-commit-log",
+    "SNUBA_DEAD_LETTER_INSERTS": "snuba-dead-letter-inserts",
+    "SNUBA_ATTRIBUTION": "snuba-attribution",
+    "SNUBA_DEAD_LETTER_METRICS": "snuba-dead-letter-metrics",
+    "SNUBA_DEAD_LETTER_SESSIONS": "snuba-dead-letter-sessions",
+    "SNUBA_DEAD_LETTER_GENERIC_METRICS": "snuba-dead-letter-generic-metrics",
+    "SNUBA_DEAD_LETTER_REPLAYS": "snuba-dead-letter-replays",
 }
 
 _REGISTERED_TOPICS: dict[str, str] = {}
@@ -46,7 +46,7 @@ class _Topic(type):
     def __getattr__(self, attr: str) -> "Topic":
         if attr not in _HARDCODED_TOPICS and attr not in _REGISTERED_TOPICS:
             raise AttributeError(attr)
-        return Topic(attr.lower())
+        return Topic(attr.lower().replace("_", "-"))
 
     def __iter__(self) -> Iterator[Topic]:
         return iter(
@@ -70,7 +70,7 @@ class Topic(metaclass=_Topic):
 
 
 def register_topic(key: str) -> Topic:
-    _REGISTERED_TOPICS[key.upper()] = key.lower()
+    _REGISTERED_TOPICS[key.upper().replace("-", "_")] = key.lower()
     return Topic(key)
 
 
@@ -78,9 +78,9 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
     config = {
         Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"},
         Topic.TRANSACTIONS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.METRICS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.PROFILES: {"message.timestamp.type": "LogAppendTime"},
-        Topic.REPLAYEVENTS: {"message.timestamp.type": "LogAppendTime"},
-        Topic.GENERIC_METRICS: {"message.timestamp.type": "LogAppendTime"},
+        Topic.SNUBA_METRICS: {"message.timestamp.type": "LogAppendTime"},
+        Topic.PROCESSED_PROFILES: {"message.timestamp.type": "LogAppendTime"},
+        Topic.INGEST_REPLAY_EVENTS: {"message.timestamp.type": "LogAppendTime"},
+        Topic.SNUBA_GENERIC_METRICS: {"message.timestamp.type": "LogAppendTime"},
     }
     return config.get(topic, {})

--- a/tests/consumers/test_utils.py
+++ b/tests/consumers/test_utils.py
@@ -15,7 +15,7 @@ from snuba.utils.streams.topics import Topic
 
 def test_get_partition_count() -> None:
     admin_client = AdminClient(get_default_kafka_configuration())
-    create_topics(admin_client, [Topic.SUBSCRIPTION_SCHEDULED_TRANSACTIONS])
+    create_topics(admin_client, [Topic.SCHEDULED_SUBSCRIPTIONS_TRANSACTIONS])
 
     entity = get_entity(EntityKey("transactions"))
     storage = entity.get_writable_storage()

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -33,7 +33,7 @@ def assert_valid_policy_creator(
 def test_generate_policy_creator() -> None:
     assert_valid_policy_creator(
         generate_policy_creator(
-            {"type": "produce", "args": [Topic.DEAD_LETTER_GENERIC_METRICS.value]}
+            {"type": "produce", "args": [Topic.SNUBA_DEAD_LETTER_GENERIC_METRICS.value]}
         )
     )
 
@@ -58,24 +58,24 @@ def test_build_stream_loader() -> None:
         }
     )
     assert isinstance(loader.get_processor(), GenericSetsMetricsProcessor)
-    assert loader.get_default_topic_spec().topic == Topic.GENERIC_METRICS
+    assert loader.get_default_topic_spec().topic == Topic.SNUBA_GENERIC_METRICS
     assert isinstance(loader.get_pre_filter(), KafkaHeaderSelectFilter)
     commit_log_topic_spec = loader.get_commit_log_topic_spec()
     assert (
         commit_log_topic_spec is not None
-        and commit_log_topic_spec.topic == Topic.GENERIC_METRICS_SETS_COMMIT_LOG
+        and commit_log_topic_spec.topic == Topic.SNUBA_GENERIC_METRICS_SETS_COMMIT_LOG
     )
     assert loader.get_subscription_scheduler_mode() == SchedulingWatermarkMode.GLOBAL
     scheduled_topic_spec = loader.get_subscription_scheduled_topic_spec()
     assert (
         scheduled_topic_spec is not None
         and scheduled_topic_spec.topic
-        == Topic.SUBSCRIPTION_SCHEDULED_GENERIC_METRICS_SETS
+        == Topic.SCHEDULED_SUBSCRIPTIONS_GENERIC_METRICS_SETS
     )
     result_topic_spec = loader.get_subscription_result_topic_spec()
     assert (
         result_topic_spec is not None
-        and result_topic_spec.topic == Topic.SUBSCRIPTION_RESULTS_GENERIC_METRICS_SETS
+        and result_topic_spec.topic == Topic.GENERIC_METRICS_SETS_SUBSCRIPTION_RESULTS
     )
     assert_valid_policy_creator(loader.get_dead_letter_queue_policy_creator())
 

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,18 +1,18 @@
 import importlib
-from copy import deepcopy
 from typing import Any, Dict
 from unittest.mock import patch
 
 import pytest
 
 from snuba import settings
+from snuba.datasets.storages.factory import _storage_factory
+from snuba.datasets.storages.validation import validate_topics_with_settings
 from snuba.settings import validation
 from snuba.settings.validation import (
     InvalidTopicError,
     validate_settings,
     validate_slicing_settings,
 )
-from snuba.utils.streams.topics import Topic
 
 
 def build_settings_dict() -> Dict[str, Any]:
@@ -39,25 +39,12 @@ def test_invalid_storage() -> None:
         cluster[0]["storage_sets"].remove("non_existing_storage")
 
 
-def test_topics_sync_in_settings_validator() -> None:
-    all_settings = build_settings_dict()
-    # Make a copy of the default Kafka topic map from settings
-    default_map = deepcopy(all_settings["KAFKA_TOPIC_MAP"])
-    # Overwrite topic map temporarily to include all defined topic names
-    all_settings["KAFKA_TOPIC_MAP"] = {t.value: {} for t in Topic}
-
-    # Validate settings with the new topic map to check
-    # whether all defined topic names correspond to the
-    # topic names in the settings validator
+def test_topics_sync_with_settings() -> None:
     try:
-        validate_settings(all_settings)
+        _storage_factory()
+        validate_topics_with_settings()
     except InvalidTopicError:
-        pytest.fail(
-            "Defined Kafka Topics are not in sync with topic names in validator"
-        )
-    # Restore the default settings Kafka topic map
-    finally:
-        all_settings["KAFKA_TOPIC_MAP"] = default_map
+        pytest.fail("Defined Kafka Topics are not in sync with topic names in settings")
 
 
 @patch("snuba.datasets.partitioning.SENTRY_LOGICAL_PARTITIONS", 2)

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 import pytest
 
 from snuba import settings
+from snuba.datasets.configuration.validation.post_loader import (
+    validate_topics_with_settings,
+)
 from snuba.datasets.storages.factory import _storage_factory
-from snuba.datasets.storages.validation import validate_topics_with_settings
 from snuba.settings import validation
 from snuba.settings.validation import (
     InvalidTopicError,

--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -49,7 +49,7 @@ def test_combined_scheduler_and_executor() -> None:
     commit = mock.Mock()
 
     producer = KafkaProducer(
-        build_kafka_producer_configuration(SnubaTopic.SUBSCRIPTION_RESULTS_EVENTS)
+        build_kafka_producer_configuration(SnubaTopic.EVENTS_SUBSCRIPTION_RESULTS)
     )
 
     with closing(producer):

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -54,8 +54,8 @@ def test_executor_consumer() -> None:
     End to end integration test
     """
     admin_client = AdminClient(get_default_kafka_configuration())
-    create_topics(admin_client, [SnubaTopic.SUBSCRIPTION_SCHEDULED_EVENTS])
-    create_topics(admin_client, [SnubaTopic.SUBSCRIPTION_RESULTS_EVENTS])
+    create_topics(admin_client, [SnubaTopic.SCHEDULED_SUBSCRIPTIONS_EVENTS])
+    create_topics(admin_client, [SnubaTopic.EVENTS_SUBSCRIPTION_RESULTS])
 
     dataset_name = "events"
     entity_name = "events"

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -41,7 +41,7 @@ def test_scheduler_consumer() -> None:
     importlib.reload(scheduler_consumer)
 
     admin_client = AdminClient(get_default_kafka_configuration())
-    create_topics(admin_client, [SnubaTopic.COMMIT_LOG])
+    create_topics(admin_client, [SnubaTopic.SNUBA_COMMIT_LOG])
 
     metrics_backend = TestingMetricsBackend()
     entity_name = "events"

--- a/tests/subscriptions/test_scheduler_processing_strategy.py
+++ b/tests/subscriptions/test_scheduler_processing_strategy.py
@@ -586,7 +586,7 @@ def test_produce_scheduled_subscription_message() -> None:
     strategy = ProduceScheduledSubscriptionMessage(
         schedulers,
         producer,
-        KafkaTopicSpec(SnubaTopic.SUBSCRIPTION_SCHEDULED_EVENTS),
+        KafkaTopicSpec(SnubaTopic.SCHEDULED_SUBSCRIPTIONS_EVENTS),
         commit,
         None,
         metrics_backend,
@@ -687,7 +687,7 @@ def test_produce_stale_message() -> None:
     strategy = ProduceScheduledSubscriptionMessage(
         schedulers,
         producer,
-        KafkaTopicSpec(SnubaTopic.SUBSCRIPTION_SCHEDULED_EVENTS),
+        KafkaTopicSpec(SnubaTopic.SCHEDULED_SUBSCRIPTIONS_EVENTS),
         commit,
         stale_threshold_seconds,
         metrics_backend,


### PR DESCRIPTION
Similar to what we've done with `StorageKey` and `EntityKey`, we also want to use to metaclass design pattern to remove the Topic enum. However, the only difference between `Topic` and `StorageKey` and `EntityKey` is that the `Topic` key/value pairs are not uppercased/lowercased mirrors of each other. For example: `"QUERYLOG": "snuba-queries"`. As a result, when topics are registered through definition in config, they are assigned a different key name than the existing ones in code. Since topic keys are **only** used to reference topics in code and do not reflect real infrastructure (done with value pair), this was fixed by refactoring topic keys to mirror their respective value pairs.

This PR is responsible for the following:
* Deleted Topic enum and added Topic class and metaclass
* Refactored the topic keys to uppercased and underscored strings of value pair
* Updated all old references of topic keys

Note: In a subsequent PR, the generic metric topics can be removed from `_HARDCODED_TOPICS`

Edit:
* Move topics in `validation.py` to settings `ALLOWED_TOPICS`