### PR TITLE
fix(TDC) Make QuerySplitStrategy a RegisteredClass

### DIFF
--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -12,6 +12,7 @@ from snuba.datasets.configuration.loader import load_configuration_data
 from snuba.datasets.configuration.utils import (
     generate_policy_creator,
     get_query_processors,
+    get_query_splitters,
     parse_columns,
 )
 from snuba.datasets.message_filters import StreamMessageFilter
@@ -35,6 +36,7 @@ SCHEMA = "schema"
 STREAM_LOADER = "stream_loader"
 PRE_FILTER = "pre_filter"
 QUERY_PROCESSORS = "query_processors"
+QUERY_SPLITTERS = "query_splitters"
 SUBCRIPTION_SCHEDULER_MODE = "subscription_scheduler_mode"
 DLQ_POLICY = "dlq_policy"
 
@@ -70,6 +72,9 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
         ),
         QUERY_PROCESSORS: get_query_processors(
             config[QUERY_PROCESSORS] if QUERY_PROCESSORS in config else []
+        ),
+        QUERY_SPLITTERS: get_query_splitters(
+            config[QUERY_SPLITTERS] if QUERY_SPLITTERS in config else []
         ),
         # TODO: Rest of readable storage optional args
     }

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -19,6 +19,7 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
+from snuba.datasets.plans.splitters import QuerySplitStrategy
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.utils.schemas import UUID, AggregateFunction
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
@@ -27,6 +28,11 @@ from snuba.utils.streams.topics import Topic
 
 class QueryProcessorDefinition(TypedDict):
     processor: str
+    args: dict[str, Any]
+
+
+class QuerySplitterDefinition(TypedDict):
+    splitter: str
     args: dict[str, Any]
 
 
@@ -58,6 +64,17 @@ def get_query_processors(
             **qp.get("args", {})
         )
         for qp in query_processor_objects
+    ]
+
+
+def get_query_splitters(
+    query_splitter_objects: list[QuerySplitterDefinition],
+) -> list[QuerySplitStrategy]:
+    return [
+        QuerySplitStrategy.get_from_name(qs["splitter"]).from_kwargs(
+            **qs.get("args", {})
+        )
+        for qs in query_splitter_objects
     ]
 
 

--- a/snuba/datasets/plans/single_storage.py
+++ b/snuba/datasets/plans/single_storage.py
@@ -12,7 +12,7 @@ from snuba.datasets.plans.query_plan import (
     QueryPlanExecutionStrategy,
     QueryRunner,
 )
-from snuba.datasets.plans.split_strategy import QuerySplitStrategy
+from snuba.datasets.plans.splitters import QuerySplitStrategy
 from snuba.datasets.plans.translator.query import QueryTranslator
 from snuba.datasets.schemas import RelationalSource
 from snuba.datasets.schemas.tables import TableSource

--- a/snuba/datasets/plans/splitters/strategies.py
+++ b/snuba/datasets/plans/splitters/strategies.py
@@ -8,7 +8,7 @@ from typing import Optional
 from snuba import environment, settings, state, util
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_dsl.accessors import get_time_range
-from snuba.datasets.plans.split_strategy import QuerySplitStrategy, SplitQueryRunner
+from snuba.datasets.plans.splitters import QuerySplitStrategy, SplitQueryRunner
 from snuba.query import OrderByDirection, SelectedExpression
 from snuba.query.conditions import (
     OPERATOR_TO_FUNCTION,

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -9,7 +9,7 @@ from snuba.clusters.cluster import (
 )
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.common.condition_checker import ConditionChecker
-from snuba.datasets.plans.split_strategy import QuerySplitStrategy
+from snuba.datasets.plans.splitters import QuerySplitStrategy
 from snuba.datasets.schemas import Schema
 from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storages.storage_key import StorageKey

--- a/snuba/datasets/storages/discover.py
+++ b/snuba/datasets/storages/discover.py
@@ -10,6 +10,10 @@ from snuba.clickhouse.columns import (
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.plans.splitters.strategies import (
+    ColumnSplitQueryStrategy,
+    TimeSplitQueryStrategy,
+)
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import ReadableTableStorage
 from snuba.datasets.storages.errors import storage as error_storage
@@ -36,7 +40,6 @@ from snuba.query.processors.physical.type_converters.hexint_column_processor imp
 from snuba.query.processors.physical.type_converters.uuid_column_processor import (
     UUIDColumnProcessor,
 )
-from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 columns = ColumnSet(
     [

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -9,6 +9,10 @@ from snuba.clickhouse.columns import (
 )
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
+from snuba.datasets.plans.splitters.strategies import (
+    ColumnSplitQueryStrategy,
+    TimeSplitQueryStrategy,
+)
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.expressions import Column, Literal
 from snuba.query.processors.physical.arrayjoin_keyvalue_optimizer import (
@@ -46,7 +50,6 @@ from snuba.query.processors.physical.uniq_in_select_and_having import (
 )
 from snuba.query.processors.physical.user_column_processor import UserColumnProcessor
 from snuba.replacers.replacer_processor import ReplacerState
-from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 required_columns = [
     "event_id",

--- a/snuba/datasets/storages/transactions_common.py
+++ b/snuba/datasets/storages/transactions_common.py
@@ -10,6 +10,7 @@ from snuba.clickhouse.columns import (
 )
 from snuba.clickhouse.columns import SchemaModifiers as Modifiers
 from snuba.clickhouse.columns import String, UInt
+from snuba.datasets.plans.splitters.strategies import TimeSplitQueryStrategy
 from snuba.query.processors.physical.array_has_optimizer import ArrayHasOptimizer
 from snuba.query.processors.physical.arrayjoin_keyvalue_optimizer import (
     ArrayJoinKeyValueOptimizer,
@@ -38,7 +39,6 @@ from snuba.query.processors.physical.type_converters.uuid_column_processor impor
 from snuba.query.processors.physical.uniq_in_select_and_having import (
     UniqInSelectAndHavingProcessor,
 )
-from snuba.web.split import TimeSplitQueryStrategy
 
 columns = ColumnSet(
     [

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -13,6 +13,10 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.plans.single_storage import SimpleQueryPlanExecutionStrategy
+from snuba.datasets.plans.splitters.strategies import (
+    ColumnSplitQueryStrategy,
+    TimeSplitQueryStrategy,
+)
 from snuba.datasets.plans.translator.query import identity_translate
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Table
@@ -21,7 +25,6 @@ from snuba.query.query_settings import HTTPQuerySettings, QuerySettings
 from snuba.query.snql.parser import parse_snql_query
 from snuba.reader import Reader
 from snuba.web import QueryResult
-from snuba.web.split import ColumnSplitQueryStrategy, TimeSplitQueryStrategy
 
 
 def setup_function(function) -> None:


### PR DESCRIPTION
The transactions storage uses query splitters, so those need to be imported
automatically in the same way as other RegisteredClasses so they can be used
in configuration.