### PR TITLE
fix: Remove filtering on offset for transactions subscriptions

### DIFF
--- a/snuba/datasets/configuration/entity_subscription_builder.py
+++ b/snuba/datasets/configuration/entity_subscription_builder.py
@@ -4,7 +4,6 @@ from typing import Mapping, Type
 from snuba.datasets.configuration.json_schema import V1_ENTITY_SUBSCIPTION_SCHEMA
 from snuba.datasets.configuration.loader import load_configuration_data
 from snuba.datasets.entity_subscriptions.entity_subscription import (
-    BaseEventsSubscription,
     EntitySubscription,
     SessionsSubscription,
 )
@@ -16,7 +15,6 @@ logger = logging.getLogger("snuba.entity_subscriptions_builder")
 
 
 _PARENT_SUBSCRIPTION_CLASS_MAPPING: Mapping[str, Type[EntitySubscription]] = {
-    "base_events_subscription": BaseEventsSubscription,
     "sessions_subscription": SessionsSubscription,
 }
 

--- a/snuba/datasets/entity_subscriptions/entity_subscription.py
+++ b/snuba/datasets/entity_subscriptions/entity_subscription.py
@@ -89,7 +89,7 @@ class SessionsSubscription(EntitySubscriptionValidation, EntitySubscription):
         return {"organization": self.organization}
 
 
-class BaseEventsSubscription(EntitySubscriptionValidation, EntitySubscription, ABC):
+class EventsSubscription(EntitySubscriptionValidation, EntitySubscription):
     def get_entity_subscription_conditions_for_snql(
         self, offset: Optional[int] = None
     ) -> Sequence[Expression]:
@@ -112,11 +112,7 @@ class BaseEventsSubscription(EntitySubscriptionValidation, EntitySubscription, A
         return {}
 
 
-class EventsSubscription(BaseEventsSubscription):
-    ...
-
-
-class TransactionsSubscription(BaseEventsSubscription):
+class TransactionsSubscription(EntitySubscription):
     ...
 
 

--- a/snuba/datasets/entity_subscriptions/entity_subscription.py
+++ b/snuba/datasets/entity_subscriptions/entity_subscription.py
@@ -113,7 +113,13 @@ class EventsSubscription(EntitySubscriptionValidation, EntitySubscription):
 
 
 class TransactionsSubscription(EntitySubscriptionValidation, EntitySubscription):
-    ...
+    def get_entity_subscription_conditions_for_snql(
+        self, offset: Optional[int] = None
+    ) -> Sequence[Expression]:
+        return []
+
+    def to_dict(self) -> Mapping[str, Any]:
+        return {}
 
 
 class MetricsCountersSubscription(SessionsSubscription):

--- a/snuba/datasets/entity_subscriptions/entity_subscription.py
+++ b/snuba/datasets/entity_subscriptions/entity_subscription.py
@@ -112,7 +112,7 @@ class EventsSubscription(EntitySubscriptionValidation, EntitySubscription):
         return {}
 
 
-class TransactionsSubscription(EntitySubscription):
+class TransactionsSubscription(EntitySubscriptionValidation, EntitySubscription):
     ...
 
 

--- a/tests/subscriptions/entity_subscriptions/test_entity_subscriptions.py
+++ b/tests/subscriptions/entity_subscriptions/test_entity_subscriptions.py
@@ -90,17 +90,7 @@ TESTS_CONDITIONS_SNQL_METHOD = [
     ),
     pytest.param(
         TransactionsSubscription(data_dict={}),
-        [
-            binary_condition(
-                ConditionFunctions.LTE,
-                FunctionCall(
-                    None,
-                    "ifNull",
-                    (Column(None, None, "offset"), Literal(None, 0)),
-                ),
-                Literal(None, 5),
-            )
-        ],
+        [],
         True,
         id="Transactions subscription with offset of type SNQL",
     ),


### PR DESCRIPTION
Transactions will be randomly partitioned, this clause does not make sense unless all events are in the same partition.
