### PR TITLE
ref(migrations): add copy-tables script

### DIFF
--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -1,5 +1,7 @@
 import argparse
 import re
+from collections import OrderedDict
+from typing import Optional, Sequence
 
 from clickhouse_driver import Client
 
@@ -11,7 +13,9 @@ SETTINGS = {
 }
 
 
-def _get_client(host, port, user, password, database) -> Client:
+def _get_client(
+    host: str, port: int, user: str, password: str, database: str
+) -> Client:
     return Client(
         host=host,
         port=port,
@@ -22,73 +26,141 @@ def _get_client(host, port, user, password, database) -> Client:
     )
 
 
-def verify_zk_replica_path(client, database, tables) -> None:
+def verify_zk_replica_path(
+    source_client: Client, curr_create_table_statement: str, table: str
+) -> None:
     """
     Before we copy over table statements from other nodes, we need to make sure
     that the current zookeeper paths use the macros defined and align with the path
     that is generated in the create table statement.
 
     """
-    print("Looking up macros...")
-    ((_, replica), (_, shard)) = client.execute(
+    print("...looking up macros")
+    ((_, replica), (_, shard)) = source_client.execute(
         "SELECT macro, substitution FROM system.macros"
     )
-    print(f"Found replica: {replica} for shard: {shard}")
+    print(f"...found replica: {replica} for shard: {shard}")
 
-    for table in tables:
-        print(f"Verifying zk replica path for table: {table}...")
-        ((replica_path,),) = client.execute(
-            f"SELECT replica_path FROM system.replicas where table = '{table}'"
-        )
+    print(f"...verifying zk replica path for table: {table}...")
+    ((replica_path,),) = source_client.execute(
+        f"SELECT replica_path FROM system.replicas where table = '{table}'"
+    )
 
-        ((curr_create_table_statement,),) = source_client.execute(
-            f"SHOW CREATE TABLE {database}.{table}"
-        )
-        match = re.search("\/clickhouse(.*,)", curr_create_table_statement)
-        create_table_path = match.group(0)[:-2].replace("{shard}", shard)
+    match = re.search("\/clickhouse(.*,)", curr_create_table_statement)
+    create_table_path = match.group(0)[:-2].replace("{shard}", shard)
 
-        built_replica_path = f"{create_table_path}/replicas/{replica}"
+    built_replica_path = f"{create_table_path}/replicas/{replica}"
 
-        assert (
-            built_replica_path == replica_path
-        ), f"{built_replica_path} should match zk path: {replica_path}"
-        print(f"Zookeeper replica paths verified for table: {table} ! :)")
+    assert (
+        built_replica_path == replica_path
+    ), f"{built_replica_path} should match zk path: {replica_path}"
+    print(f"...zookeeper replica paths verified for table: {table} ! :)")
 
 
-def copy_tables(source_client, new_client, tables, database, dry_run) -> None:
+def verify_local_tables_exist_from_mv(
+    target_client: Client, curr_create_table_statement: str, table: str
+) -> None:
+    """
+    Verifies that the materialized views we want to create
+    are being created after the local tables that the view reference.
 
-    verify_zk_replica_path(source_client, args.database, tables)
+    The create view statement will look something like:
+
+    CREATE MATERIALIZED VIEW
+        default.generic_metric_sets_aggregation_mv
+    TO default.generic_metric_sets_local
+    ...
+    FROM default.generic_metric_sets_raw_local
+
+    """
+    print(f"...checking table statement: {table}")
+    to_search = re.search("TO(.[.\w]*)", curr_create_table_statement)
+    from_search = re.search("FROM(.[.\w]*)", curr_create_table_statement)
+
+    # make sure we ditch the "default." before checking against SHOW TABLES
+    _, to_local_table = to_search.group(1).strip().split(".")
+    _, from_local_table = from_search.group(1).strip().split(".")
+
+    print(f"...looking for local tables: {to_local_table}, {from_local_table} ")
+
+    all_tables = [result[0] for result in target_client.execute("SHOW TABLES")]
+
+    assert (
+        to_local_table in all_tables
+    ), f"{to_local_table} needs to be created before {table}"
+    assert (
+        from_local_table in all_tables
+    ), f"{from_local_table} needs to be created before {table}"
+    print("...local tables found, mv check complete !\n")
+
+
+def copy_tables(
+    source_client: Client,
+    target_client: Client,
+    database: str,
+    execute: bool,
+    tables: Optional[Sequence[str]],
+) -> None:
 
     if not tables:
-        tables = [result[0] for result in source_client.execute("SHOW TABLES").results]
+        tables = [result[0] for result in source_client.execute("SHOW TABLES")]
 
-    show_table_statments = {}
+    show_table_statments = OrderedDict()
 
     for name in tables:
+        ((engine,),) = source_client.execute(
+            f"SELECT engine FROM system.tables WHERE name = '{name}'"
+        )
+
         ((curr_create_table_statement,),) = source_client.execute(
             f"SHOW CREATE TABLE {database}.{name}"
         )
+
+        if engine == "MaterializedView":
+            print("\nMaterialized View Check:")
+            verify_local_tables_exist_from_mv(
+                target_client, curr_create_table_statement, name
+            )
+
+        if engine.startswith("Replicated"):
+            print("\nReplicated Table Check:")
+            verify_zk_replica_path(source_client, curr_create_table_statement, name)
+
         show_table_statments[name] = curr_create_table_statement
 
     for table_name, statement in show_table_statments.items():
         print(f"creating {table_name}...")
-        if dry_run:
-            print(f"create table statement: \n {statement}")
+        if execute:
+            target_client.execute(statement)
+            print(f"created {table_name} !")
             return
-        new_client.execute(statement)
+        print(f"\ncreate table statement: \n {statement}\n")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Copy ClickHouse Tables")
-    parser.add_argument("--source-host", default="localhost", help="clickhouse host")
-    parser.add_argument("--source-port", help="source port")
-    parser.add_argument("--new-host", default="localhost")
-    parser.add_argument("--new-port", help="new port")
+    parser.add_argument(
+        "--source-host",
+        help="IP/name for node that tables should be copied from.",
+    )
+    parser.add_argument(
+        "--source-port",
+        help="Port for node that tables should be copied from.",
+        default=9000,
+    )
+    parser.add_argument(
+        "--target-host", help="IP/name for node that needs tables created."
+    )
+    parser.add_argument(
+        "--target-port", help="Port for node that needs tables created.", default=9000
+    )
     parser.add_argument("--user", default="default")
     parser.add_argument("--password", default="")
     parser.add_argument("--database", default="default")
-    parser.add_argument("--tables")
-    parser.add_argument("--dry-run", type=bool, default=False)
+    parser.add_argument("--tables", help="One or more tables separated by ','.")
+    parser.add_argument(
+        "--execute", action="store_true", help="Executes the create table statements."
+    )
 
     args = parser.parse_args()
 
@@ -100,14 +172,14 @@ if __name__ == "__main__":
         database=args.database,
     )
 
-    new_client = _get_client(
-        host=args.new_host,
-        port=args.new_port,
+    target_client = _get_client(
+        host=args.target_host,
+        port=args.target_port,
         user=args.user,
         password=args.password,
         database=args.database,
     )
 
-    tables = args.tables.split(",")
+    tables = args.tables and args.tables.split(",")
 
-    copy_tables(source_client, new_client, tables, args.database, args.dry_run)
+    copy_tables(source_client, target_client, args.database, args.execute, tables)

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+#
 import argparse
 import re
 from collections import OrderedDict

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Copy ClickHouse Tables")
     parser.add_argument(
         "--source-host",
+        required=True,
         help="IP/name for node that tables should be copied from.",
     )
     parser.add_argument(
@@ -149,7 +150,9 @@ if __name__ == "__main__":
         default=9000,
     )
     parser.add_argument(
-        "--target-host", help="IP/name for node that needs tables created."
+        "--target-host",
+        required=True,
+        help="IP/name for node that needs tables created.",
     )
     parser.add_argument(
         "--target-port", help="Port for node that needs tables created.", default=9000

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -154,9 +154,8 @@ def copy_tables(
         if execute:
             target_client.execute(statement)
             print(f"created {table_name} !")
-            return
-        print(f"\ncreate table statement: \n {statement}\n")
-
+        else:
+            print(f"\ncreate table statement: \n {statement}\n")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Copy ClickHouse Tables")

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -1,0 +1,113 @@
+import argparse
+import re
+
+from clickhouse_driver import Client
+
+SETTINGS = {
+    "load_balancing": "in_order",
+    "replication_alter_partitions_sync": 2,
+    "mutations_sync": 2,
+    "database_atomic_wait_for_drop_and_detach_synchronously": 1,
+}
+
+
+def _get_client(host, port, user, password, database):
+    return Client(
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=database,
+        settings=SETTINGS,
+    )
+
+
+def verify_zk_replica_path(client, database, tables):
+    """
+    Before we copy over table statements from other nodes, we need to make sure
+    that the current zookeeper paths use the macros defined and align with the path
+    that is generated in the create table statement.
+
+    """
+    print("Looking up macros...")
+    ((_, replica), (_, shard)) = client.execute(
+        "SELECT macro, substitution FROM system.macros"
+    )
+    print(f"Found replica: {replica} for shard: {shard}")
+
+    for table in tables:
+        print(f"Verifying zk replica path for table: {table}...")
+        ((replica_path,),) = client.execute(
+            f"SELECT replica_path FROM system.replicas where table = '{table}'"
+        )
+
+        ((curr_create_table_statement,),) = source_client.execute(
+            f"SHOW CREATE TABLE {database}.{table}"
+        )
+        match = re.search("\/clickhouse(.*,)", curr_create_table_statement)
+        create_table_path = match.group(0)[:-2].replace("{shard}", shard)
+
+        built_replica_path = f"{create_table_path}/replicas/{replica}"
+
+        assert (
+            built_replica_path == replica_path
+        ), f"{built_replica_path} should match zk path: {replica_path}"
+        print(f"Zookeeper replica paths verified for table: {table} ! :)")
+
+
+def copy_tables(source_client, new_client, tables, database, dry_run):
+
+    verify_zk_replica_path(source_client, args.database, tables)
+
+    if not tables:
+        tables = [result[0] for result in source_client.execute("SHOW TABLES").results]
+
+    show_table_statments = {}
+
+    for name in tables:
+        ((curr_create_table_statement,),) = source_client.execute(
+            f"SHOW CREATE TABLE {database}.{name}"
+        )
+        show_table_statments[name] = curr_create_table_statement
+
+    for table_name, statement in show_table_statments.items():
+        print(f"creating {table_name}...")
+        if dry_run:
+            print(f"create table statement: \n {statement}")
+            return
+        new_client.execute(statement)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Copy ClickHouse Tables")
+    parser.add_argument("--source-host", default="localhost", help="clickhouse host")
+    parser.add_argument("--source-port", help="source port")
+    parser.add_argument("--new-host", default="localhost")
+    parser.add_argument("--new-port", help="new port")
+    parser.add_argument("--user", default="default")
+    parser.add_argument("--password", default="")
+    parser.add_argument("--database", default="default")
+    parser.add_argument("--tables")
+    parser.add_argument("--dry-run", type=bool, default=False)
+
+    args = parser.parse_args()
+
+    source_client = _get_client(
+        host=args.source_host,
+        port=args.source_port,
+        user=args.user,
+        password=args.password,
+        database=args.database,
+    )
+
+    new_client = _get_client(
+        host=args.source_host,
+        port=args.source_port,
+        user=args.user,
+        password=args.password,
+        database=args.database,
+    )
+
+    tables = args.tables.split(",")
+
+    copy_tables(source_client, new_client, tables, args.database, args.dry_run)

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -2,7 +2,6 @@
 
 import argparse
 import re
-import sys
 from collections import OrderedDict
 from typing import Optional, Sequence
 

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -11,7 +11,7 @@ SETTINGS = {
 }
 
 
-def _get_client(host, port, user, password, database):
+def _get_client(host, port, user, password, database) -> Client:
     return Client(
         host=host,
         port=port,
@@ -22,7 +22,7 @@ def _get_client(host, port, user, password, database):
     )
 
 
-def verify_zk_replica_path(client, database, tables):
+def verify_zk_replica_path(client, database, tables) -> None:
     """
     Before we copy over table statements from other nodes, we need to make sure
     that the current zookeeper paths use the macros defined and align with the path
@@ -55,7 +55,7 @@ def verify_zk_replica_path(client, database, tables):
         print(f"Zookeeper replica paths verified for table: {table} ! :)")
 
 
-def copy_tables(source_client, new_client, tables, database, dry_run):
+def copy_tables(source_client, new_client, tables, database, dry_run) -> None:
 
     verify_zk_replica_path(source_client, args.database, tables)
 
@@ -101,8 +101,8 @@ if __name__ == "__main__":
     )
 
     new_client = _get_client(
-        host=args.source_host,
-        port=args.source_port,
+        host=args.new_host,
+        port=args.new_port,
         user=args.user,
         password=args.password,
         database=args.database,

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -2,6 +2,7 @@
 
 import argparse
 import re
+import sys
 from collections import OrderedDict
 from typing import Optional, Sequence
 
@@ -94,7 +95,8 @@ def verify_local_tables_exist_from_mv(
 def copy_tables(
     source_client: Client,
     target_client: Client,
-    database: str,
+    source_database: str,
+    target_database: str,
     execute: bool,
     tables: Optional[Sequence[str]],
 ) -> None:
@@ -121,7 +123,7 @@ def copy_tables(
     if not tables:
         tables = [result[0] for result in source_client.execute("SHOW TABLES")]
 
-    show_table_statments = OrderedDict()
+    show_table_statements = OrderedDict()
 
     for name in tables:
         ((engine,),) = source_client.execute(
@@ -129,7 +131,7 @@ def copy_tables(
         )
 
         ((curr_create_table_statement,),) = source_client.execute(
-            f"SHOW CREATE TABLE {database}.{name}"
+            f"SHOW CREATE TABLE {source_database}.{name}"
         )
 
         if engine == "MaterializedView":
@@ -142,20 +144,29 @@ def copy_tables(
             print("\nReplicated Table Check:")
             verify_zk_replica_path(source_client, curr_create_table_statement, name)
 
-        show_table_statments[name] = curr_create_table_statement
+        show_table_statements[name] = curr_create_table_statement
 
     ((_, target_replica), (_, target_shard)) = target_client.execute(
         "SELECT macro, substitution FROM system.macros"
     )
-    for table_name, statement in show_table_statments.items():
+    for table_name, statement in show_table_statements.items():
+        if source_database != target_database:
+            print(
+                f"Mismatched databases.. Replacing: {source_database}.{table_name} with {target_database}.{table_name}"
+            )
+            statement = statement.replace(
+                f"CREATE TABLE {source_database}.{table_name}",
+                f"CREATE TABLE {target_database}.{table_name}",
+            )
         print(
-            f"creating {table_name}... on replica: {target_replica}, shard: {target_shard}"
+            f"creating {table_name}... on replica: {target_replica}, shard: {target_shard}, database: {target_database}"
         )
         if execute:
             target_client.execute(statement)
             print(f"created {table_name} !")
         else:
             print(f"\ncreate table statement: \n {statement}\n")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Copy ClickHouse Tables")
@@ -179,7 +190,8 @@ if __name__ == "__main__":
     )
     parser.add_argument("--user", default="default")
     parser.add_argument("--password", default="")
-    parser.add_argument("--database", default="default")
+    parser.add_argument("--source-database", default="default")
+    parser.add_argument("--target-database", default="default")
     parser.add_argument("--tables", help="One or more tables separated by ','.")
     parser.add_argument(
         "--execute", action="store_true", help="Executes the create table statements."
@@ -192,7 +204,7 @@ if __name__ == "__main__":
         port=args.source_port,
         user=args.user,
         password=args.password,
-        database=args.database,
+        database=args.source_database,
     )
 
     target_client = _get_client(
@@ -200,9 +212,16 @@ if __name__ == "__main__":
         port=args.target_port,
         user=args.user,
         password=args.password,
-        database=args.database,
+        database=args.target_database,
     )
 
     tables = args.tables and args.tables.split(",")
 
-    copy_tables(source_client, target_client, args.database, args.execute, tables)
+    copy_tables(
+        source_client,
+        target_client,
+        args.source_database,
+        args.target_database,
+        args.execute,
+        tables,
+    )

--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#
+
 import argparse
 import re
 from collections import OrderedDict


### PR DESCRIPTION
**context:**
Similar to https://github.com/getsentry/snuba/pull/3174 except that this script is independent of Snuba dependencies. The reason for adding this would be so that this script could be used by ops easily without having to run the snuba cli commands.


```shell
(.venv) ✔ ~/snuba [meredith/SNS-1753|⚑ 121]
17:20 $ python scripts/copy-tables.py --table=generic_metric_sets_aggregation_mv,generic_metric_distributions_aggregation_mv --source-host=localhost --target-host=localhost

Materialized View Check:
...checking table statement: generic_metric_sets_aggregation_mv
...looking for local tables: generic_metric_sets_local, generic_metric_sets_raw_local
...local tables found, mv check complete !


Materialized View Check:
...checking table statement: generic_metric_distributions_aggregation_mv
...looking for local tables: generic_metric_distributions_aggregated_local, generic_metric_distributions_raw_local
...local tables found, mv check complete !

creating generic_metric_sets_aggregation_mv...

create table statement:
 CREATE MATERIALIZED VIEW default.generic_metric_sets_aggregation_mv TO default.generic_metric_sets_local (`org_id` UInt64, `project_id` UInt64, `metric_id` UInt64, `granularity` UInt8, `timestamp` DateTime CODEC(DoubleDelta), `retention_days` UInt16, `tags.key` Array(UInt64), `tags.indexed_value` Array(UInt64), `tags.raw_value` Array(String), `value` AggregateFunction(uniqCombined64, UInt64), `use_case_id` LowCardinality(String)) AS SELECT use_case_id, org_id, project_id, metric_id, arrayJoin(granularities) AS granularity, tags.key, tags.indexed_value, tags.raw_value, toDateTime(multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1) * intDiv(toUnixTimestamp(timestamp), multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1))) AS timestamp, retention_days, uniqCombined64State(arrayJoin(set_values)) AS value FROM default.generic_metric_sets_raw_local WHERE (materialization_version = 1) AND (metric_type = 'set') GROUP BY use_case_id, org_id, project_id, metric_id, tags.key, tags.indexed_value, tags.raw_value, timestamp, granularity, retention_days

creating generic_metric_distributions_aggregation_mv...

create table statement:
 CREATE MATERIALIZED VIEW default.generic_metric_distributions_aggregation_mv TO default.generic_metric_distributions_aggregated_local (`org_id` UInt64, `project_id` UInt64, `metric_id` UInt64, `granularity` UInt8, `timestamp` DateTime CODEC(DoubleDelta), `retention_days` UInt16, `tags.key` Array(UInt64), `tags.indexed_value` Array(UInt64), `tags.raw_value` Array(String), `value` AggregateFunction(uniqCombined64, UInt64), `use_case_id` LowCardinality(String)) AS SELECT use_case_id, org_id, project_id, metric_id, arrayJoin(granularities) AS granularity, tags.key, tags.indexed_value, tags.raw_value, toDateTime(multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1) * intDiv(toUnixTimestamp(timestamp), multiIf(granularity = 0, 10, granularity = 1, 60, granularity = 2, 3600, granularity = 3, 86400, -1))) AS timestamp, retention_days, quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)(arrayJoin(distribution_values) AS values_rows) AS percentiles, minState(values_rows) AS min, maxState(values_rows) AS max, avgState(values_rows) AS avg, sumState(values_rows) AS sum, countState(values_rows) AS count, histogramState(250)(values_rows) AS histogram_buckets FROM default.generic_metric_distributions_raw_local WHERE (materialization_version = 1) AND (metric_type = 'distribution') GROUP BY use_case_id, org_id, project_id, metric_id, tags.key, tags.indexed_value, tags.raw_value, timestamp, granularity, retention_days
```