### PR TITLE
build: Increase timeout minutes in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
   snuba-image:
     name: Build snuba CI image
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
     steps:
@@ -226,7 +226,8 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        snuba_settings: ["test", "test_distributed", "test_distributed_migrations"]
+        snuba_settings:
+          ["test", "test_distributed", "test_distributed_migrations"]
     steps:
       - uses: actions/checkout@v2
         name: Checkout code


### PR DESCRIPTION
The distributed tests often take around 20 minutes and sometimes over, bump timeout to 25