### PR TITLE
fix(MDC): Incorrect column name in Gen Metrics

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -110,7 +110,7 @@ translation_mappers:
         column_to_map: value
         from_name: minIf
         to_name: minMergeIf
-        aggr_col_name: minIf
+        aggr_col_name: min
     -
       mapper: AggregateFunctionMapper
       args:


### PR DESCRIPTION
An incorrectly named column in Generic Metrics config is causing some queries to fail.

This PR fixes the issue ([SNS-1760](https://getsentry.atlassian.net/browse/SNS-1760))