### PR TITLE
feat(admin): run and reverse migrations

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -6,6 +6,7 @@ import simplejson as json
 import structlog
 from flask import Flask, Response, g, jsonify, make_response, request
 from structlog.contextvars import bind_contextvars, clear_contextvars
+from werkzeug.routing import BaseConverter
 
 from snuba import settings, state
 from snuba.admin.auth import UnauthorizedException, authorize_request
@@ -28,12 +29,10 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.migrations.groups import MigrationGroup, get_group_loader
-from snuba.migrations.runner import Runner, MigrationKey, get_active_migration_groups
+from snuba.migrations.runner import MigrationKey, Runner, get_active_migration_groups
 from snuba.query.exceptions import InvalidQueryException
 from snuba.utils.metrics.timer import Timer
 from snuba.web.views import dataset_query
-from werkzeug.routing import BaseConverter
-
 
 logger = structlog.get_logger().bind(module=__name__)
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -136,14 +136,17 @@ def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Resp
 
     force = request.args.get("force", False, type=str_to_bool)
     fake = request.args.get("fake", False, type=str_to_bool)
+    dry_run = request.args.get("dry_run", False, type=str_to_bool)
 
     try:
         if action == "run":
-            runner.run_migration(migration_key, force=force, fake=fake)
+            runner.run_migration(migration_key, force=force, fake=fake, dry_run=dry_run)
         else:
-            runner.reverse_migration(migration_key, force=force, fake=fake)
-    except Exception as e:
-        return make_response(jsonify({"error": repr(e)}), 500)
+            runner.reverse_migration(
+                migration_key, force=force, fake=fake, dry_run=dry_run
+            )
+    except KeyError:
+        return make_response(jsonify({"error": "Group not found"}), 400)
 
     return Response("OK", 200)
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -150,14 +150,11 @@ def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Resp
             )
 
     try:
-        if dry_run:
-            # temporarily redirect stdout to a buffer so we can return it
-            with io.StringIO() as output:
-                with redirect_stdout(output):
-                    do_action()
-                return make_response(jsonify({"stdout": output.getvalue()}), 200)
-        else:
-            do_action()
+        # temporarily redirect stdout to a buffer so we can return it
+        with io.StringIO() as output:
+            with redirect_stdout(output):
+                do_action()
+            return make_response(jsonify({"stdout": output.getvalue()}), 200)
 
     except KeyError as err:
         logger.error(err, exc_info=True)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -28,10 +28,12 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.migrations.groups import MigrationGroup, get_group_loader
-from snuba.migrations.runner import Runner, get_active_migration_groups
+from snuba.migrations.runner import Runner, MigrationKey, get_active_migration_groups
 from snuba.query.exceptions import InvalidQueryException
 from snuba.utils.metrics.timer import Timer
 from snuba.web.views import dataset_query
+from werkzeug.routing import BaseConverter
+
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -109,6 +111,42 @@ def migrations_groups_list(group: str) -> Response:
                 200,
             )
     return make_response(jsonify({"error": "Invalid group"}), 400)
+
+
+class MigrationActionConverter(BaseConverter):
+    regex = r"(?:run|reverse)"
+
+
+application.url_map.converters["migration_action"] = MigrationActionConverter
+
+
+@application.route(
+    "/migrations/<group>/<migration_action:action>/<migration_id>",
+    methods=["POST"],
+)
+def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Response:
+    if group not in settings.ADMIN_ALLOWED_MIGRATION_GROUPS:
+        return make_response(jsonify({"error": "Group not allowed"}), 400)
+
+    runner = Runner()
+    migration_group = MigrationGroup(group)
+    migration_key = MigrationKey(migration_group, migration_id)
+
+    def str_to_bool(s: str) -> bool:
+        return s.strip().lower() in ("yes", "true", "t", "1")
+
+    force = request.args.get("force", False, type=str_to_bool)
+    fake = request.args.get("fake", False, type=str_to_bool)
+
+    try:
+        if action == "run":
+            runner.run_migration(migration_key, force=force, fake=fake)
+        else:
+            runner.reverse_migration(migration_key, force=force, fake=fake)
+    except Exception as e:
+        return make_response(jsonify({"error": repr(e)}), 500)
+
+    return Response("OK", 200)
 
 
 @application.route("/clickhouse_queries")

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -114,7 +114,6 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
         with patch.object(Runner, method) as mock_run_migration:
             response = admin_api.post(f"/migrations/system/{action}/0001_migrations")
             assert response.status_code == 200
-            assert response.data == b"OK"
             migration_key = MigrationKey(group="system", migration_id="0001_migrations")
             mock_run_migration.assert_called_once_with(
                 migration_key, force=False, fake=False, dry_run=False
@@ -153,10 +152,10 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
             mock_run_migration.side_effect = print_something
             response = admin_api.post(
-                f"/migrations/system/{action}/0001_migrations?fake=1&force=true&dry_run=yes"
+                f"/migrations/system/{action}/0001_migrations?fake=0&force=false&dry_run=yes"
             )
             assert response.status_code == 200
             assert json.loads(response.data) == {"stdout": "a dry run\n"}
             mock_run_migration.assert_called_once_with(
-                migration_key, force=True, fake=True, dry_run=True
+                migration_key, force=False, fake=False, dry_run=True
             )

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -139,9 +139,9 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
         with patch.object(Runner, method) as mock_run_migration:
             # fake migration
             response = admin_api.post(
-                f"/migrations/system/{action}/0001_migrations?fake=1&force=true"
+                f"/migrations/system/{action}/0001_migrations?fake=1&force=true&dry_run=yes"
             )
             assert response.status_code == 200
             mock_run_migration.assert_called_once_with(
-                migration_key, force=True, fake=True, dry_run=False
+                migration_key, force=True, fake=True, dry_run=True
             )

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -8,6 +8,7 @@ import simplejson as json
 from flask.testing import FlaskClient
 
 from snuba.migrations.groups import get_group_loader
+from snuba.migrations.runner import MigrationKey, Runner
 
 
 @pytest.fixture
@@ -91,3 +92,56 @@ def test_list_migration_status(admin_api: FlaskClient) -> None:
     sorted_expected_json = sorted(expected_json, key=sort_by_migration_id)
 
     assert sorted_response == sorted_expected_json
+
+
+@pytest.mark.parametrize("action", ["run", "reverse"])
+def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
+
+    method = "run_migration" if action == "run" else "reverse_migration"
+
+    with patch(
+        "snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS", {"system", "invalid_group"}
+    ):
+        # invalid action
+        response = admin_api.post("/migrations/system/invalid_action/0001_migrations/")
+        assert response.status_code == 404
+
+        # invalid migration group
+        response = admin_api.post(f"/migrations/invalid_group/{action}/0001_migrations")
+        assert response.status_code == 500
+        assert json.loads(response.data) == {"error": "KeyError('invalid_group')"}
+
+        with patch.object(Runner, method) as mock_run_migration:
+            response = admin_api.post(f"/migrations/system/{action}/0001_migrations")
+            assert response.status_code == 200
+            assert response.data == b"OK"
+            migration_key = MigrationKey(group="system", migration_id="0001_migrations")
+            mock_run_migration.assert_called_once_with(
+                migration_key, force=False, fake=False
+            )
+
+        with patch.object(Runner, method) as mock_run_migration:
+            # not allowed migration group
+            response = admin_api.post(f"/migrations/sessions/{action}/0001_sessions")
+            assert response.status_code == 400
+            assert json.loads(response.data) == {"error": "Group not allowed"}
+            assert mock_run_migration.call_count == 0
+
+            # forced migration
+            response = admin_api.post(
+                f"/migrations/system/{action}/0001_migrations?force=1"
+            )
+            assert response.status_code == 200
+            mock_run_migration.assert_called_once_with(
+                migration_key, force=True, fake=False
+            )
+
+        with patch.object(Runner, method) as mock_run_migration:
+            # fake migration
+            response = admin_api.post(
+                f"/migrations/system/{action}/0001_migrations?fake=1&force=true"
+            )
+            assert response.status_code == 200
+            mock_run_migration.assert_called_once_with(
+                migration_key, force=True, fake=True
+            )

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -108,8 +108,8 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
         # invalid migration group
         response = admin_api.post(f"/migrations/invalid_group/{action}/0001_migrations")
-        assert response.status_code == 500
-        assert json.loads(response.data) == {"error": "KeyError('invalid_group')"}
+        assert response.status_code == 400
+        assert json.loads(response.data) == {"error": "Group not found"}
 
         with patch.object(Runner, method) as mock_run_migration:
             response = admin_api.post(f"/migrations/system/{action}/0001_migrations")
@@ -117,7 +117,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
             assert response.data == b"OK"
             migration_key = MigrationKey(group="system", migration_id="0001_migrations")
             mock_run_migration.assert_called_once_with(
-                migration_key, force=False, fake=False
+                migration_key, force=False, fake=False, dry_run=False
             )
 
         with patch.object(Runner, method) as mock_run_migration:
@@ -133,7 +133,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
             )
             assert response.status_code == 200
             mock_run_migration.assert_called_once_with(
-                migration_key, force=True, fake=False
+                migration_key, force=True, fake=False, dry_run=False
             )
 
         with patch.object(Runner, method) as mock_run_migration:
@@ -143,5 +143,5 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
             )
             assert response.status_code == 200
             mock_run_migration.assert_called_once_with(
-                migration_key, force=True, fake=True
+                migration_key, force=True, fake=True, dry_run=False
             )


### PR DESCRIPTION

Adds endpoints to run and reverse migration via snuba admin. 

endpoints:
`/migrations/<group>/<run,reverse>/<migration_id>`

Clients can pass in the force, and fake params via the query url e.g `/migrations/system/run/0001_migrations?force=true`

If a migration is not in `settings.ADMIN_ALLOWED_MIGRATION_GROUPS` returns error 400, otherwise runs and returns `"OK", 200` if successful.