### PR TITLE
ref: Remove filtering of error and transaction messages

### DIFF
--- a/snuba/datasets/message_filters.py
+++ b/snuba/datasets/message_filters.py
@@ -45,33 +45,11 @@ class PassthroughKafkaFilter(StreamMessageFilter[KafkaPayload]):
 
 
 @dataclass
-class KafkaHeaderFilter(StreamMessageFilter[KafkaPayload]):
-    """
-    A filter over messages coming from a stream which matches whether the given message
-    has the provided header key and if it matches the provided header value. If there is
-    a match, the message gets dropped.
-    """
-
-    header_key: str
-    header_value: str
-
-    def should_drop(self, message: Message[KafkaPayload]) -> bool:
-        for key, value in message.payload.headers:
-            if key != self.header_key:
-                continue
-
-            str_value = value.decode("utf-8")
-            return True if str_value == self.header_value else False
-
-        return False
-
-
-@dataclass
 class KafkaHeaderSelectFilter(StreamMessageFilter[KafkaPayload]):
     """
     A filter over messages coming from a stream which matches whether the given message
     has the provided header key and if it matches the provided header value. If there is
-    a match, the message gets processed. (This is the inverse of KafkaHeaderFilter)
+    a match, the message gets processed.
     """
 
     header_key: str
@@ -86,38 +64,6 @@ class KafkaHeaderSelectFilter(StreamMessageFilter[KafkaPayload]):
             return str_value != self.header_value
 
         return True
-
-
-@dataclass
-class KafkaHeaderWithBypassFilter(KafkaHeaderFilter):
-    """
-    A special case filter which is similar to KafkaHeaderFilter but allows a message to
-    which would have been dropped to pass through after reaching a consecutive limit.
-    The reason to use this has to do with the way Kafka works. Kafka works with offsets
-    of messages which need to be committed to the broker to acknowledge them.
-    In cases where there is a shared topic, and only one type of messages on the topic,
-    if we drop all messages then that consumer would never commit offsets to the broker
-    which would result in increase in consumer group lag of the consumer group.
-    This leads to false positives regrading consumer group having some issues.
-
-    This implementation gives us the benefit of reducing CPU cycles by filtering messages
-    and avoiding unnecessary increase in consumer group lag in edge cases.
-    """
-
-    consecutive_drop_limit: int
-    consecutive_drop_count: int = 0
-
-    def should_drop(self, message: Message[KafkaPayload]) -> bool:
-        if not super().should_drop(message):
-            self.consecutive_drop_count = 0
-            return False
-
-        self.consecutive_drop_count += 1
-        if self.consecutive_drop_count < self.consecutive_drop_limit:
-            return True
-        else:
-            self.consecutive_drop_count = 0
-            return False
 
 
 class CdcTableNameMessageFilter(StreamMessageFilter[KafkaPayload]):

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -1,7 +1,6 @@
 from snuba import util
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.errors_replacer import ErrorsReplacer
-from snuba.datasets.message_filters import KafkaHeaderWithBypassFilter
 from snuba.datasets.processors.errors_processor import ErrorsProcessor
 from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storage import WritableTableStorage
@@ -38,7 +37,6 @@ storage = WritableTableStorage(
     mandatory_condition_checkers=[ProjectIdEnforcer()],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=ErrorsProcessor(promoted_tag_columns),
-        pre_filter=KafkaHeaderWithBypassFilter("transaction_forwarder", "1", 100),
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,

--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -1,7 +1,6 @@
 from snuba import util
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.errors_replacer import ErrorsReplacer
-from snuba.datasets.message_filters import KafkaHeaderFilter
 from snuba.datasets.processors.errors_processor import ErrorsProcessor
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storage import WritableTableStorage
@@ -111,7 +110,6 @@ storage = WritableTableStorage(
     mandatory_condition_checkers=[ProjectIdEnforcer()],
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=ErrorsProcessor(promoted_tag_columns),
-        pre_filter=KafkaHeaderFilter("transaction_forwarder", "1"),
         default_topic=Topic.EVENTS,
         replacement_topic=Topic.EVENT_REPLACEMENTS,
         commit_log_topic=Topic.COMMIT_LOG,

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -1,6 +1,5 @@
 from snuba import util
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.message_filters import KafkaHeaderWithBypassFilter
 from snuba.datasets.processors.transactions_processor import (
     TransactionsMessageProcessor,
 )
@@ -33,7 +32,6 @@ storage = WritableTableStorage(
     query_processors=query_processors,
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),
-        pre_filter=KafkaHeaderWithBypassFilter("transaction_forwarder", "0", 100),
         default_topic=Topic.TRANSACTIONS,
         commit_log_topic=Topic.TRANSACTIONS_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -1,6 +1,5 @@
 from snuba import util
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.message_filters import KafkaHeaderFilter
 from snuba.datasets.processors.transactions_processor import (
     TransactionsMessageProcessor,
 )
@@ -33,7 +32,6 @@ storage = WritableTableStorage(
     query_processors=query_processors,
     stream_loader=build_kafka_stream_loader_from_settings(
         processor=TransactionsMessageProcessor(),
-        pre_filter=KafkaHeaderFilter("transaction_forwarder", "0"),
         default_topic=Topic.TRANSACTIONS,
         commit_log_topic=Topic.TRANSACTIONS_COMMIT_LOG,
         subscription_scheduler_mode=SchedulingWatermarkMode.GLOBAL,

--- a/tests/datasets/test_message_filters.py
+++ b/tests/datasets/test_message_filters.py
@@ -4,15 +4,10 @@ import pytest
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
 
-from snuba.datasets.message_filters import (
-    KafkaHeaderFilter,
-    KafkaHeaderSelectFilter,
-    KafkaHeaderWithBypassFilter,
-)
+from snuba.datasets.message_filters import KafkaHeaderSelectFilter
 
 test_data = [
     pytest.param(
-        KafkaHeaderFilter("should_drop", "1"),
         KafkaHeaderSelectFilter("should_drop", "1"),
         Message(
             Partition(Topic("random"), 1),
@@ -24,7 +19,6 @@ test_data = [
         id="matching-headers",
     ),
     pytest.param(
-        KafkaHeaderFilter("should_drop", "0"),
         KafkaHeaderSelectFilter("should_drop", "0"),
         Message(
             Partition(Topic("random"), 1),
@@ -36,7 +30,6 @@ test_data = [
         id="mismatched-headers",
     ),
     pytest.param(
-        KafkaHeaderFilter("should_drop", "1"),
         KafkaHeaderSelectFilter("should_drop", "1"),
         Message(
             Partition(Topic("random"), 1),
@@ -50,31 +43,10 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize(
-    "header_filter, select_filter, message, expected_drop_result", test_data
-)
+@pytest.mark.parametrize("select_filter, message, expected_drop_result", test_data)
 def test_kafka_filter_header_should_drop(
-    header_filter: KafkaHeaderFilter,
     select_filter: KafkaHeaderSelectFilter,
     message: Message[KafkaPayload],
     expected_drop_result: bool,
 ) -> None:
-    assert header_filter.should_drop(message) == expected_drop_result
     assert select_filter.should_drop(message) == (not expected_drop_result)
-
-
-def test_kafka_filter_header_with_bypass() -> None:
-    header_filter = KafkaHeaderWithBypassFilter("should_drop", "1", 5)
-    message = Message(
-        Partition(Topic("random"), 1),
-        1,
-        KafkaPayload(b"key", b"value", [("should_drop", b"1")]),
-        datetime.now(),
-    )
-
-    for _ in range(3):
-        assert header_filter.should_drop(message) is True
-        assert header_filter.should_drop(message) is True
-        assert header_filter.should_drop(message) is True
-        assert header_filter.should_drop(message) is True
-        assert header_filter.should_drop(message) is False


### PR DESCRIPTION
Errors and transactions have fully separated pipelines now. We don't need to filter based on `transaction_forwarder` anymore. This header will no longer be sent.