### PR TITLE
feat: Remove default mapping of "transaction" topic to "events"

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -185,11 +185,7 @@ BROKER_CONFIG: Mapping[str, Any] = {
 }
 
 # Mapping of default Kafka topic name to custom names
-KAFKA_TOPIC_MAP: Mapping[str, str] = {
-    # TODO: Remove once we are done splitting transactions from the shared events topic
-    "transactions": "events",
-    "snuba-transactions-commit-log": "snuba-commit-log",
-}
+KAFKA_TOPIC_MAP: Mapping[str, str] = {}
 
 # Mapping of default Kafka topic name to broker config
 KAFKA_BROKER_CONFIG: Mapping[str, Mapping[str, Any]] = {}


### PR DESCRIPTION
Should be (roughly) synchronized with https://github.com/getsentry/sentry/pull/39988 which will send events to the new topic.

This would only affect self hosted and dev users who are using the Kafka backend. All Sentry prod environments have already been migrated via other methods to ensure zero downtime during the transition.