### PR TITLE
fix(JWT): stop trying to get JWT audience dynamically, hard-code in config

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -30,6 +30,7 @@ ADMIN_PORT = int(os.environ.get("ADMIN_PORT", 1219))
 ADMIN_URL = os.environ.get("ADMIN_URL", "http://localhost:1219")
 
 ADMIN_AUTH_PROVIDER = "NOOP"
+ADMIN_AUTH_JWT_AUDIENCE = ""
 
 # Migrations Groups that are allowed to be managed
 # in the snuba admin tool.


### PR DESCRIPTION
Based on this Sentry issue: https://sentry.io/organizations/sentry/issues/3669148611/?project=300688&query=is%3Aunresolved we were blocked from enforcing JWT auth in snuba admin

We don't have a way to dynamically retrieve the JWT audience that we know of that matches the format `/projects/{x}/global/backendServices/{y}` (we have x but don't know how to retrieve y). Since this won't change very much, we will just hardcode the expected audience in settings.