### PR TITLE
ref(migrations): Add MigrationPolicy

### DIFF
--- a/snuba/migrations/policies.py
+++ b/snuba/migrations/policies.py
@@ -1,0 +1,63 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+
+from snuba.migrations.migration import Migration
+from snuba.migrations.status import Status
+
+
+class MigrationAction(Enum):
+    FORWARDS = "forwards"
+    BACKWARDS = "backwards"
+
+
+class MigrationPolicy(ABC):
+    """
+    A MigrationPolicy implements an `is_allowed` method
+    that determines whether or not a migration can be applied
+    from snuba admin.
+
+    A policy can be used by a migration group to determine the
+    level of access a group has to run migrations.
+    """
+
+    @abstractmethod
+    def allows(migration: Migration, action: MigrationAction) -> bool:
+        raise NotImplementedError
+
+
+class ReadOnlyPolicy(MigrationPolicy):
+    """
+    No migration is allowed to be run or reversed.
+    """
+
+    def allows(migration: Migration, action: MigrationAction) -> bool:
+        return False
+
+
+class WriteSafeAndPendingPolicy(MigrationPolicy):
+    """
+    Safe migrations can be run in addition to dangerous migrations that
+    are in a pending state. All backwards migrations are considered
+    dangerous in this policy.
+
+    This policy defers to the `blocking` attribute for a migration to
+    determine if the migration is safe or not.
+    """
+
+    def allows(migration: Migration, action: MigrationAction) -> bool:
+        if action == MigrationAction.BACKWARDS:
+            # todo: actually handle getting the status
+            if migration.status == Status.IN_PROGRESS:
+                return True
+            return False
+        return False if migration.blocking else True
+
+
+class WriteAllPolicy(MigrationPolicy):
+    """
+    All migrations are allowed - both CodeMigrations and
+    ClickhouseNodeMigration (SQL) migrations
+    """
+
+    def allows(migration: Migration, action: MigrationAction) -> bool:
+        return True

--- a/tests/migrations/test_policies.py
+++ b/tests/migrations/test_policies.py
@@ -1,9 +1,11 @@
-from unittest.mock import patch
+from typing import Mapping
+from unittest.mock import Mock, patch
 
 import pytest
 
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.policies import (
+    MigrationPolicy,
     ReadOnlyPolicy,
     WriteAllPolicy,
     WriteSafeAndPendingPolicy,
@@ -11,21 +13,21 @@ from snuba.migrations.policies import (
 from snuba.migrations.runner import MigrationKey
 from snuba.migrations.status import Status
 
-POLICIES = {
+POLICIES: Mapping[str, MigrationPolicy] = {
     "read_only": ReadOnlyPolicy(),
     "write_pending": WriteSafeAndPendingPolicy(),
     "write_all": WriteAllPolicy(),
 }
 
 
-def code_migration_key() -> None:
+def code_migration_key() -> MigrationKey:
     """
     Code Migration with blocking == True
     """
     return MigrationKey(MigrationGroup("events"), "0014_backfill_errors")
 
 
-def sql_migration_key() -> None:
+def sql_migration_key() -> MigrationKey:
     """
     SQL Migration with blocking == False
     """
@@ -34,7 +36,7 @@ def sql_migration_key() -> None:
 
 class TestMigrationPolicies:
     @pytest.mark.parametrize(
-        "migration_key, action, policy, expected",
+        "migration_key, action, policy_str, expected",
         [
             pytest.param(
                 code_migration_key(),
@@ -80,17 +82,19 @@ class TestMigrationPolicies:
             ),
         ],
     )
-    def test_policies(self, migration_key, action, policy, expected) -> None:
+    def test_policies(
+        self, migration_key: MigrationKey, action: str, policy_str: str, expected: bool
+    ) -> None:
         if action == "run":
-            assert POLICIES[policy].can_run(migration_key) == expected
+            assert POLICIES[policy_str].can_run(migration_key) == expected
         else:
-            assert POLICIES[policy].can_reverse(migration_key) == expected
+            assert POLICIES[policy_str].can_reverse(migration_key) == expected
 
     @patch(
         "snuba.migrations.runner.Runner.get_status",
         return_value=(Status.IN_PROGRESS, None),
     )
-    def test_pending_migration_reverse(self, mock_get_status):
+    def test_pending_migration_reverse(self, mock_get_status: Mock) -> None:
         migration_key = MigrationKey(
             MigrationGroup("events"), "0016_drop_legacy_events"
         )

--- a/tests/migrations/test_policies.py
+++ b/tests/migrations/test_policies.py
@@ -1,0 +1,88 @@
+import pytest
+
+from snuba.migrations.groups import MigrationGroup, get_group_loader
+from snuba.migrations.policies import (
+    MigrationAction,
+    ReadOnlyPolicy,
+    WriteAllPolicy,
+    WriteSafeAndPendingPolicy,
+)
+from snuba.migrations.status import Status
+
+
+def code_migration() -> None:
+    """
+    Code Migration with blocking == True
+    """
+    events_loader = get_group_loader(MigrationGroup("events"))
+    return events_loader.load_migration("0014_backfill_errors")
+
+
+def sql_migration() -> None:
+    """
+    SQL Migration with blocking == False
+    """
+    events_loader = get_group_loader(MigrationGroup("events"))
+    return events_loader.load_migration("0015_truncate_events")
+
+
+def pending_migration() -> None:
+    """
+    SQL Migration with blocking == False, and with a status set
+    """
+    events_loader = get_group_loader(MigrationGroup("events"))
+    m = events_loader.load_migration("0016_drop_legacy_events")
+    m.status = Status.IN_PROGRESS
+    return m
+
+
+class TestMigrationPolicies:
+    @pytest.mark.parametrize(
+        "migration, action, policy, expected",
+        [
+            pytest.param(
+                code_migration(),
+                MigrationAction.FORWARDS,
+                ReadOnlyPolicy,
+                False,
+                id="ReadOnly Code Migration",
+            ),
+            pytest.param(
+                sql_migration(),
+                MigrationAction.FORWARDS,
+                ReadOnlyPolicy,
+                False,
+                id="ReadOnly SQL Migration",
+            ),
+            pytest.param(
+                code_migration(),
+                MigrationAction.FORWARDS,
+                WriteSafeAndPendingPolicy,
+                False,
+                id="WriteSafeAndPending Code Migration",
+            ),
+            pytest.param(
+                pending_migration(),
+                MigrationAction.BACKWARDS,
+                WriteSafeAndPendingPolicy,
+                True,
+                id="WriteSafeAndPending Pending Migration",
+            ),
+            pytest.param(
+                code_migration(),
+                MigrationAction.FORWARDS,
+                WriteAllPolicy,
+                True,
+                id="WriteAll Code Migration",
+            ),
+            pytest.param(
+                sql_migration(),
+                MigrationAction.BACKWARDS,
+                WriteAllPolicy,
+                True,
+                id="WriteAll SQL Migration",
+            ),
+        ],
+    )
+    def test_policies(self, migration, action, policy, expected) -> None:
+        assert policy.allows(migration, action) == expected


### PR DESCRIPTION
**context**
As we build out snuba admin tooling for clickhouse migrations, we want to make sure we have some way of deciding which migrations are actually "safe" to run in the admin tool, which may be different for various folks and migration groups. 

**MigrationPolicy**
To start out, each migration group can have a policy. The default policy (if we want a default can be the `NoMigrationsPolicy`.

```python
# these are just examples, not necessarily the
# levels we would give these groups
{
    "generic_metrics": NonBlockingMigrationsPolicy,
    "replays": AllMigrationsPolicy,
}
```
so that when we look up a migration group we know what policy to apply. Down the road we could expand this to have different access groups (google groups for example) which would have their own definitions for the groups

```python
# these are just examples, not necessarily the
# levels we would give these groups
{
    "generic_metrics": {
         "default": NoMigrationsPolicy,
         "team-sns": NonBlockingMigrationsPolicy,
    }
}
```