### PR TITLE
fix(gen-metrics): distributed table name wrong in config

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -40,7 +40,7 @@ schema:
       { name: timeseries_id, type: UInt, args: { size: 32 } },
     ]
   local_table_name: generic_metric_distributions_raw_local
-  dist_table_name: generic_metric_distributions_raw_local
+  dist_table_name: generic_metric_distributions_raw_dist
 
 stream_loader:
   processor: GenericDistributionsMetricsProcessor

--- a/snuba/datasets/storages/generic_metrics.py
+++ b/snuba/datasets/storages/generic_metrics.py
@@ -171,7 +171,7 @@ distributions_bucket_storage = WritableTableStorage(
     schema=WritableTableSchema(
         columns=ColumnSet([*common_columns, *bucket_columns]),
         local_table_name="generic_metric_distributions_raw_local",
-        dist_table_name="generic_metric_distributions_raw_local",
+        dist_table_name="generic_metric_distributions_raw_dist",
         storage_set_key=StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS,
     ),
     query_processors=[],


### PR DESCRIPTION
Stuff broke when we tried switching to the [distributed] query node which correctly does not have local tables

https://sentry.io/organizations/sentry/issues/3671781868/?project=300688&query=is%3Aunresolved
https://sentry.io/organizations/sentry/issues/3671799059/?project=300688&query=is%3Aunresolved

🤦 