### PR TITLE
feat: Drop filtering by offset on errors dataset

### DIFF
--- a/snuba/datasets/entity_subscriptions/entity_subscription.py
+++ b/snuba/datasets/entity_subscriptions/entity_subscription.py
@@ -6,7 +6,7 @@ from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.data_source.simple import Entity
 from snuba.query.exceptions import InvalidQueryException
-from snuba.query.expressions import Column, Expression, FunctionCall, Literal
+from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.logical import Query
 from snuba.query.validation.validators import (
     NoTimeBasedConditionValidator,
@@ -93,20 +93,7 @@ class EventsSubscription(EntitySubscriptionValidation, EntitySubscription):
     def get_entity_subscription_conditions_for_snql(
         self, offset: Optional[int] = None
     ) -> Sequence[Expression]:
-        if offset is None:
-            return []
-
-        return [
-            binary_condition(
-                ConditionFunctions.LTE,
-                FunctionCall(
-                    None,
-                    "ifNull",
-                    (Column(None, None, "offset"), Literal(None, 0)),
-                ),
-                Literal(None, offset),
-            )
-        ]
+        return []
 
     def to_dict(self) -> Mapping[str, Any]:
         return {}

--- a/tests/subscriptions/entity_subscriptions/test_entity_subscriptions.py
+++ b/tests/subscriptions/entity_subscriptions/test_entity_subscriptions.py
@@ -12,7 +12,7 @@ from snuba.datasets.entity_subscriptions.entity_subscription import (
 )
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.exceptions import InvalidQueryException
-from snuba.query.expressions import Column, FunctionCall, Literal
+from snuba.query.expressions import Column, Literal
 
 TESTS = [
     pytest.param(
@@ -68,17 +68,7 @@ TESTS = [
 TESTS_CONDITIONS_SNQL_METHOD = [
     pytest.param(
         EventsSubscription(data_dict={}),
-        [
-            binary_condition(
-                ConditionFunctions.LTE,
-                FunctionCall(
-                    None,
-                    "ifNull",
-                    (Column(None, None, "offset"), Literal(None, 0)),
-                ),
-                Literal(None, 5),
-            )
-        ],
+        [],
         True,
         id="Events subscription with offset of type SNQL",
     ),


### PR DESCRIPTION
None of the other datasets apply this condition (they cannot since they are non semantically partitioned).

We sometimes flip large projects into to random partitioning mode to avoid backlogs and incidents. Doing so causes the alert to be completely wrong unless we remove this condition as the offset across different partitions can no longer be compared.