### PR TITLE
build: Actually increase the right CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
   snuba-image:
     name: Build snuba CI image
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     outputs:
       branch: ${{ steps.branch.outputs.branch }}
     steps:
@@ -223,7 +223,7 @@ jobs:
     needs: [linting, snuba-image]
     name: Tests and code coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       matrix:
         snuba_settings:


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/3242 was supposed to increase the timeout for the distributed tests not building the snuba image. This actually does that.