### PR TITLE
test(migrations): Add example migrations for testing

### DIFF
--- a/tests/migrations/examples/0001_sql_migration.py
+++ b/tests/migrations/examples/0001_sql_migration.py
@@ -1,0 +1,19 @@
+from typing import Sequence
+
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/tests/migrations/examples/0001_sql_migration.py
+++ b/tests/migrations/examples/0001_sql_migration.py
@@ -1,19 +1,61 @@
 from typing import Sequence
 
-from snuba.migrations import migration, operations
+from snuba.clickhouse.columns import UUID, Array, Column, DateTime, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+columns: Sequence[Column[Modifiers]] = [
+    Column("request_id", UUID()),
+    Column("projects", Array(UInt(64))),
+    Column("organization", UInt(64, Modifiers(nullable=True))),
+    Column("timestamp", DateTime()),
+]
 
 
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="dummy_querylog_local",
+                columns=columns,
+                engine=table_engines.MergeTree(
+                    storage_set=StorageSetKey.QUERYLOG,
+                    order_by="(toStartOfDay(timestamp), request_id)",
+                    partition_by="(toMonday(timestamp))",
+                    sample_by="request_id",
+                ),
+            )
+        ]
 
     def backwards_local(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="dummy_querylog_local",
+            )
+        ]
 
     def forwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="dummy_querylog_dist",
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="dummy_querylog_local",
+                    sharding_key=None,
+                ),
+            )
+        ]
 
     def backwards_dist(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="dummy_querylog_dist",
+            )
+        ]

--- a/tests/migrations/examples/0002_code_migration.py
+++ b/tests/migrations/examples/0002_code_migration.py
@@ -1,0 +1,19 @@
+from typing import Sequence
+
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.CodeMigration):
+    blocking = False
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/tests/migrations/sample_migrations.py
+++ b/tests/migrations/sample_migrations.py
@@ -1,0 +1,22 @@
+from typing import List, Sequence, Tuple
+
+from snuba.migrations.groups import DirectoryLoader, GroupLoader, MigrationGroup
+
+
+class ExampleLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("tests.migrations.examples")
+
+    def get_migrations(self) -> Sequence[str]:
+        return ["0001_sql_migration", "0002_code_migration"]
+
+
+REGISTERED_GROUPS_EX: List[Tuple[str, GroupLoader]] = [
+    ("examples", ExampleLoader()),
+]
+
+REGISTERED_GROUPS_LOOKUP_EX = {k: v for (k, v) in REGISTERED_GROUPS_EX}
+
+
+def get_group_loader_example(group: MigrationGroup) -> GroupLoader:
+    return REGISTERED_GROUPS_LOOKUP_EX[group]

--- a/tests/migrations/test_groups.py
+++ b/tests/migrations/test_groups.py
@@ -6,3 +6,13 @@ def test_load_all_migrations() -> None:
         group_loader = get_group_loader(group)
         for migration in group_loader.get_migrations():
             group_loader.load_migration(migration)
+
+
+def test_example_migrations() -> None:
+    from tests.migrations.sample_migrations import get_group_loader_example
+
+    group_loader = get_group_loader_example("examples")
+    assert group_loader.get_migrations() == [
+        "0001_sql_migration",
+        "0002_code_migration",
+    ]


### PR DESCRIPTION
An attempt to create some dummy migrations that could be used by https://github.com/getsentry/snuba/pull/3258/ to test out the migration policies. 

My thought was to create a group loader that could override the `get_group_loader` in tests for the migration policies that need to load the migration. 