### PR TITLE
fix(jwt): extract correct user ID field from JWT

### DIFF
--- a/snuba/admin/jwt.py
+++ b/snuba/admin/jwt.py
@@ -40,4 +40,4 @@ def validate_assertion(assertion: str) -> AdminUser:
     from jose import jwt
 
     info = jwt.decode(assertion, _certs(), algorithms=["ES256"], audience=_audience())
-    return AdminUser(email=info["email"], id=info["id"])
+    return AdminUser(email=info["email"], id=info["sub"])


### PR DESCRIPTION
We wanted `sub`, or subject, not `id` which is a non-populated property: https://sentry.io/organizations/sentry/issues/3677952001/?project=300688&query=is%3Aunresolved

https://cloud.google.com/endpoints/docs/openapi/migrate-to-esp-v2#handle-jwt