### PR TITLE
fix(TDC): Add ColumnToUserNullIf for transaction translation mapper migration

### DIFF
--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -135,6 +135,25 @@ class ColumnToIPAddress(ColumnToFunction):
 
 
 @dataclass(frozen=True)
+class ColumnToUserNullIf(ColumnToFunction):
+    """
+    Custom column mapper for mapping user columns to null.
+    TODO: Can remove when we support dynamic expression parsing in config
+    """
+
+    def __init__(
+        self, from_table_name: str, from_col_name: str, to_function_name: str
+    ) -> None:
+        to_function_params: Tuple[ColumnExpr, LiteralExpr] = (
+            ColumnExpr(None, None, "user"),
+            LiteralExpr(None, ""),
+        )
+        super().__init__(
+            from_table_name, from_col_name, to_function_name, to_function_params
+        )
+
+
+@dataclass(frozen=True)
 class ColumnToCurriedFunction(ColumnToExpression):
     """
     Maps a column into a curried function expression that preserves the alias.

--- a/tests/datasets/configuration/entity_with_ip_column_mappers.yaml
+++ b/tests/datasets/configuration/entity_with_ip_column_mappers.yaml
@@ -27,6 +27,12 @@ translation_mappers:
         from_col_name: ip_address
         to_function_name: coalesce
     -
+      mapper: ColumnToUserNullIf
+      args:
+        from_table_name:
+        from_col_name: user
+        to_function_name: nullIf
+    -
       mapper: ColumnToMapping
       args:
         from_table_name:

--- a/tests/datasets/configuration/test_entity_loader.py
+++ b/tests/datasets/configuration/test_entity_loader.py
@@ -6,13 +6,15 @@ from jsonschema.exceptions import ValidationError
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToColumn,
     ColumnToFunction,
+    ColumnToIPAddress,
     ColumnToMapping,
+    ColumnToUserNullIf,
 )
 from snuba.datasets.configuration.entity_builder import build_entity_from_config
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.pluggable_entity import PluggableEntity
-from snuba.query.expressions import Column, FunctionCall
+from snuba.query.expressions import Column, FunctionCall, Literal
 
 
 def test_build_entity_from_config_matches_python_definition() -> None:
@@ -77,16 +79,18 @@ def test_entity_loader_for_enitity_with_column_mappers() -> None:
     )
     column_mappers = pluggable_entity.translation_mappers.columns
 
-    # Check that ColumnToFunction mapper was successfully loaded from config
-    column_to_function = get_object_in_list_by_class(column_mappers, ColumnToFunction)
-    assert isinstance(column_to_function, ColumnToFunction)
+    # Check that ColumnToIpAdress mapper was successfully loaded from config
+    column_to_ip_address = get_object_in_list_by_class(
+        column_mappers, ColumnToIPAddress
+    )
+    assert isinstance(column_to_ip_address, ColumnToFunction)
 
-    # Check that nested expressions were loaded correctly in ColumnToFunction
-    assert len(column_to_function.to_function_params) == 2
+    # Check that nested expressions were loaded correctly in ColumnToIPAddress
+    assert len(column_to_ip_address.to_function_params) == 2
     function_call = next(
         (
             fc
-            for fc in column_to_function.to_function_params
+            for fc in column_to_ip_address.to_function_params
             if isinstance(fc, FunctionCall) and fc.function_name == "IPv4NumToString"
         ),
         None,
@@ -94,6 +98,22 @@ def test_entity_loader_for_enitity_with_column_mappers() -> None:
     assert function_call is not None
     assert len(function_call.parameters) == 1
     assert any(isinstance(param, Column) for param in function_call.parameters)
+
+    # Check that ColumnToIpAdress mapper was successfully loaded from config
+    column_to_user_null_if = get_object_in_list_by_class(
+        column_mappers, ColumnToUserNullIf
+    )
+    assert isinstance(column_to_user_null_if, ColumnToFunction)
+
+    # Check that nested expressions were loaded correctly in ColumnToUserNullIf
+    assert len(column_to_user_null_if.to_function_params) == 2
+    assert any(
+        isinstance(param, Column) for param in column_to_user_null_if.to_function_params
+    )
+    assert any(
+        isinstance(param, Literal)
+        for param in column_to_user_null_if.to_function_params
+    )
 
     # Check that other column mappers (which do not contain expressions) were loaded correctly
     column_to_mapping = get_object_in_list_by_class(column_mappers, ColumnToMapping)


### PR DESCRIPTION
The Transactions Entity has an additional column mapper which was missed in https://github.com/getsentry/snuba/pull/3261.
This PR adds that column mapper (namely: `ColumnToUserNullIf`). See linked PR for more details.

