### PR TITLE
feat(observability): Add measurements to readthrough cache

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -233,7 +233,7 @@ class RedisCache(Cache[TValue]):
                 effective_timeout,
             )
             queue_len = self.__client.llen(build_notify_queue_key(task_ident))
-            metrics.gauge("notify_queye_len", queue_len, tags=metric_tags)
+            metrics.gauge("notify_queue_len", queue_len, tags=metric_tags)
             notification_received = (
                 self.__client.blpop(
                     build_notify_queue_key(task_ident), effective_timeout

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -147,7 +147,6 @@ class RedisCache(Cache[TValue]):
         if result[0] == RESULT_VALUE:
             # If we got a cache hit, this is easy -- we just return it.
             logger.debug("Immediately returning result from cache hit.")
-            metrics.increment("cache_hit", tags=metric_tags)
             return self.__codec.decode(result[1])
         elif result[0] == RESULT_EXECUTE:
 
@@ -232,8 +231,6 @@ class RedisCache(Cache[TValue]):
                 task_ident,
                 effective_timeout,
             )
-            queue_len = self.__client.llen(build_notify_queue_key(task_ident))
-            metrics.gauge("notify_queue_len", queue_len, tags=metric_tags)
             notification_received = (
                 self.__client.blpop(
                     build_notify_queue_key(task_ident), effective_timeout

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -73,7 +73,7 @@ class Timer:
         return self.__data
 
     @property
-    def tags(self):
+    def tags(self) -> Optional[Mapping[str, str]]:
         return self.__tags
 
     def for_json(self) -> TimerData:

--- a/snuba/utils/metrics/timer.py
+++ b/snuba/utils/metrics/timer.py
@@ -72,6 +72,10 @@ class Timer:
 
         return self.__data
 
+    @property
+    def tags(self):
+        return self.__tags
+
     def for_json(self) -> TimerData:
         return self.finish()
 


### PR DESCRIPTION
We are having issues with occasionally spiking query times in snuba. We have evidence to believe that this is because of the readthrough cache but we don't know why exactly because its inner workings are not visible at runtime. This PR introduces metrics about the cache's operation such that they can be observed when another spike happens