### PR TITLE
fix(metrics): Remove broken statsd metric for rate limiter

### DIFF
--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -136,10 +136,7 @@ def rate_limit(
 
     pipe = rds.pipeline(transaction=False)
     # cleanup old query timestamps past our retention window
-    stale_queries = pipe.zremrangebyscore(
-        bucket, "-inf", "({:f}".format(now - rate_history_s)
-    )
-    metrics.increment("rate_limit.stale", stale_queries, tags={"bucket": bucket})
+    pipe.zremrangebyscore(bucket, "-inf", "({:f}".format(now - rate_history_s))
 
     # Now for the tricky bit:
     # ======================


### PR DESCRIPTION
`stale_queries` is not a number, because the pipeline didn't execute
yet. In datadog the metric does not exist. It would be easy to fix this
metric but I doubt its usefulness. We already have alerts on growing
redis memory usage that tell us when the rate limiter is misbehaving.
