### PR TITLE
Add migration policy middleware SNS-1776

### DIFF
--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Dict
+
+from flask import Response, jsonify, make_response
+from werkzeug.routing import BaseConverter
+
+from snuba import settings
+from snuba.migrations.policies import (
+    AllMigrationsPolicy,
+    MigrationPolicy,
+    NoMigrationsPolicy,
+    NonBlockingMigrationsPolicy,
+)
+from snuba.migrations.runner import MigrationKey
+
+policy_map = {
+    "AllMigrationsPolicy": AllMigrationsPolicy(),
+    "NoMigrationsPolicy": NoMigrationsPolicy(),
+    "NonBlockingMigrationsPolicy": NonBlockingMigrationsPolicy(),
+}
+
+
+class MigrationActionConverter(BaseConverter):
+    regex = r"(?:run|reverse)"
+
+
+def check_migration_perms(f: Callable[..., Response]) -> Callable[..., Response]:
+    @wraps(f)
+    def check_group_perms(*args: Any, **kwargs: Any) -> Response:
+        ADMIN_ALLOWED_MIGRATION_GROUPS: Dict[str, MigrationPolicy] = {
+            k: policy_map[v] for k, v in settings.ADMIN_ALLOWED_MIGRATION_GROUPS.items()
+        }
+        group = kwargs["group"]
+        if group not in ADMIN_ALLOWED_MIGRATION_GROUPS:
+
+            return make_response(jsonify({"error": "Group not allowed"}), 400)
+
+        if "action" in kwargs:
+            action = kwargs["action"]
+            migration_id = kwargs["migration_id"]
+            migration_key = MigrationKey(group, migration_id)
+            policy = ADMIN_ALLOWED_MIGRATION_GROUPS[group]
+            if action == "run":
+                if not policy.can_run(migration_key):
+                    return make_response(
+                        jsonify({"error": "Group not allowed run policy"}), 400
+                    )
+            elif action == "reverse":
+                if not policy.can_reverse(migration_key):
+                    return make_response(
+                        jsonify({"error": "Group not allowed reverse policy"}), 400
+                    )
+        return f(*args, **kwargs)
+
+    return check_group_perms

--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from functools import wraps
 from typing import Any, Callable, Dict
 
-from flask import Response, jsonify, make_response
+from flask import Response, jsonify, make_response, request
 from werkzeug.routing import BaseConverter
 
 from snuba import settings
@@ -15,43 +15,54 @@ from snuba.migrations.policies import (
 )
 from snuba.migrations.runner import MigrationKey
 
-policy_map = {
-    "AllMigrationsPolicy": AllMigrationsPolicy(),
-    "NoMigrationsPolicy": NoMigrationsPolicy(),
-    "NonBlockingMigrationsPolicy": NonBlockingMigrationsPolicy(),
-}
-
 
 class MigrationActionConverter(BaseConverter):
     regex = r"(?:run|reverse)"
 
 
 def check_migration_perms(f: Callable[..., Response]) -> Callable[..., Response]:
+    """
+    A wrapper decorator applied to endpoints handling migrations. It checks that
+    the migration group is in the ADMIN_ALLOWED_MIGRATION_GROUPS setting and checks
+    that the migration has the appropriate run/reverse policy
+    """
+
     @wraps(f)
     def check_group_perms(*args: Any, **kwargs: Any) -> Response:
+        policy_map = {
+            "AllMigrationsPolicy": AllMigrationsPolicy(),
+            "NoMigrationsPolicy": NoMigrationsPolicy(),
+            "NonBlockingMigrationsPolicy": NonBlockingMigrationsPolicy(),
+        }
         ADMIN_ALLOWED_MIGRATION_GROUPS: Dict[str, MigrationPolicy] = {
             k: policy_map[v] for k, v in settings.ADMIN_ALLOWED_MIGRATION_GROUPS.items()
         }
         group = kwargs["group"]
         if group not in ADMIN_ALLOWED_MIGRATION_GROUPS:
-
-            return make_response(jsonify({"error": "Group not allowed"}), 400)
+            return make_response(jsonify({"error": "Group not allowed"}), 403)
 
         if "action" in kwargs:
             action = kwargs["action"]
             migration_id = kwargs["migration_id"]
             migration_key = MigrationKey(group, migration_id)
             policy = ADMIN_ALLOWED_MIGRATION_GROUPS[group]
-            if action == "run":
-                if not policy.can_run(migration_key):
-                    return make_response(
-                        jsonify({"error": "Group not allowed run policy"}), 400
-                    )
-            elif action == "reverse":
-                if not policy.can_reverse(migration_key):
-                    return make_response(
-                        jsonify({"error": "Group not allowed reverse policy"}), 400
-                    )
+
+            def str_to_bool(s: str) -> bool:
+                return s.strip().lower() in ("yes", "true", "t", "1")
+
+            dry_run = request.args.get("dry_run", False, type=str_to_bool)
+
+            if not dry_run:
+                if action == "run":
+                    if not policy.can_run(migration_key):
+                        return make_response(
+                            jsonify({"error": "Group not allowed run policy"}), 403
+                        )
+                elif action == "reverse":
+                    if not policy.can_reverse(migration_key):
+                        return make_response(
+                            jsonify({"error": "Group not allowed reverse policy"}), 403
+                        )
         return f(*args, **kwargs)
 
     return check_group_perms

--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -4,15 +4,10 @@ from functools import wraps
 from typing import Any, Callable, Dict
 
 from flask import Response, jsonify, make_response, request
-from werkzeug.routing import BaseConverter
 
 from snuba import settings
 from snuba.migrations.policies import MigrationPolicy
 from snuba.migrations.runner import MigrationKey
-
-
-class MigrationActionConverter(BaseConverter):
-    regex = r"(?:run|reverse)"
 
 
 def check_migration_perms(f: Callable[..., Response]) -> Callable[..., Response]:

--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict
 from flask import Response, jsonify, make_response, request
 
 from snuba import settings
+from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.policies import MigrationPolicy
 from snuba.migrations.runner import MigrationKey
 
@@ -30,7 +31,7 @@ def check_migration_perms(f: Callable[..., Response]) -> Callable[..., Response]
         if "action" in kwargs:
             action = kwargs["action"]
             migration_id = kwargs["migration_id"]
-            migration_key = MigrationKey(group, migration_id)
+            migration_key = MigrationKey(MigrationGroup(group), migration_id)
             policy = ADMIN_ALLOWED_MIGRATION_GROUPS[group]
 
             def str_to_bool(s: str) -> bool:

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import io
 from contextlib import redirect_stdout
-from functools import wraps
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, cast
+from typing import Any, List, Mapping, Optional, Sequence, Tuple, cast
 
 import simplejson as json
 import structlog
 from flask import Flask, Response, g, jsonify, make_response, request
 from structlog.contextvars import bind_contextvars, clear_contextvars
-from werkzeug.routing import BaseConverter
 
 from snuba import settings, state
 from snuba.admin.auth import USER_HEADER_KEY, UnauthorizedException, authorize_request
@@ -20,6 +18,10 @@ from snuba.admin.clickhouse.querylog import describe_querylog_schema, run_queryl
 from snuba.admin.clickhouse.system_queries import run_system_query_on_host_with_sql
 from snuba.admin.clickhouse.tracing import run_query_and_get_trace
 from snuba.admin.kafka.topics import get_broker_data
+from snuba.admin.migrations_policies import (
+    MigrationActionConverter,
+    check_migration_perms,
+)
 from snuba.admin.notifications.base import RuntimeConfigAction, RuntimeConfigAutoClient
 from snuba.admin.runtime_config import (
     ConfigChange,
@@ -34,12 +36,6 @@ from snuba.datasets.factory import (
 )
 from snuba.migrations.errors import MigrationError
 from snuba.migrations.groups import MigrationGroup, get_group_loader
-from snuba.migrations.policies import (
-    AllMigrationsPolicy,
-    MigrationPolicy,
-    NoMigrationsPolicy,
-    NonBlockingMigrationsPolicy,
-)
 from snuba.migrations.runner import MigrationKey, Runner, get_active_migration_groups
 from snuba.query.exceptions import InvalidQueryException
 from snuba.utils.metrics.timer import Timer
@@ -86,32 +82,6 @@ def health() -> Response:
     return Response("OK", 200)
 
 
-def check_migration_perms(f: Callable[..., Response]) -> Callable[..., Response]:
-    @wraps(f)
-    def check_group_perms(*args: Any, **kwargs: Any) -> Response:
-        group = kwargs["group"]
-        if group not in settings.ADMIN_ALLOWED_MIGRATION_GROUPS:
-            return make_response(jsonify({"error": "Group not allowed"}), 400)
-
-        if "action" in kwargs:
-            action = kwargs["action"]
-            migration_id = kwargs["migration_id"]
-            migration_key = MigrationKey(group, migration_id)
-            if action == "run":
-                if not POLICIES[action].can_run(migration_key):
-                    return make_response(
-                        jsonify({"error": "Group not allowed run policy"}), 400
-                    )
-            elif action == "reverse":
-                if not POLICIES[action].can_reverse(migration_key):
-                    return make_response(
-                        jsonify({"error": "Group not allowed reverse policy"}), 400
-                    )
-        return f(*args, **kwargs)
-
-    return check_group_perms
-
-
 @application.route("/migrations/groups")
 def migrations_groups() -> Response:
     res: List[Mapping[str, MigrationGroup | Sequence[str]]] = []
@@ -144,10 +114,6 @@ def migrations_groups_list(group: str) -> Response:
                 200,
             )
     return make_response(jsonify({"error": "Invalid group"}), 400)
-
-
-class MigrationActionConverter(BaseConverter):
-    regex = r"(?:run|reverse)"
 
 
 application.url_map.converters["migration_action"] = MigrationActionConverter

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -168,8 +168,6 @@ def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Resp
             jsonify({"error": "clickhouse error: " + err.message}), 400
         )
 
-    return Response("OK", 200)
-
 
 @application.route("/clickhouse_queries")
 def clickhouse_queries() -> Response:

--- a/snuba/migrations/policies.py
+++ b/snuba/migrations/policies.py
@@ -3,9 +3,10 @@ from abc import ABC, abstractmethod
 from snuba.migrations.groups import get_group_loader
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
+from snuba.utils.registered_class import RegisteredClass
 
 
-class MigrationPolicy(ABC):
+class MigrationPolicy(ABC, metaclass=RegisteredClass):
     """
     A MigrationPolicy implements `can_run` and
     `can_reverse` methods that determines whether or not
@@ -18,6 +19,10 @@ class MigrationPolicy(ABC):
     the policy. A policy doesn't verify access to a group, it
     verifies group access to running/reversing migrations.
     """
+
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
 
     @abstractmethod
     def can_run(self, migration_key: MigrationKey) -> bool:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -35,11 +35,11 @@ ADMIN_AUTH_JWT_AUDIENCE = ""
 # Migrations Groups that are allowed to be managed
 # in the snuba admin tool.
 ADMIN_ALLOWED_MIGRATION_GROUPS = {
-    "system",
-    "generic_metrics",
-    "profiles",
-    "functions",
-    "replays",
+    "system": "NonBlockingMigrationsPolicy",
+    "generic_metrics": "NonBlockingMigrationsPolicy",
+    "profiles": "NonBlockingMigrationsPolicy",
+    "functions": "NonBlockingMigrationsPolicy",
+    "replays": "NonBlockingMigrationsPolicy",
 }
 
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -161,7 +161,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
             # forced migration
             response = admin_api.post(
-                f"/migrations/system/{action}/0001_migrations?force=1"
+                f"/migrations/system/{action}/0001_migrations?force=true"
             )
             assert response.status_code == 200
             mock_run_migration.assert_called_once_with(
@@ -243,7 +243,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
             mock_run_migration.side_effect = print_something
             response = admin_api.post(
-                f"/migrations/events/{action}/0014_backfill_errors?dry_run=yes"
+                f"/migrations/events/{action}/0014_backfill_errors?dry_run=true"
             )
             assert response.status_code == 200
             assert json.loads(response.data) == {"stdout": "a dry run\n"}

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -129,8 +129,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
         response = admin_api.post(
             f"/migrations/invalid_but_allowed_group/{action}/0001_migrations"
         )
-        assert response.status_code == 400
-        assert json.loads(response.data) == {"error": "Group not found"}
+        assert response.status_code == 500
 
         with patch.object(Runner, method) as mock_run_migration:
             response = admin_api.post(f"/migrations/system/{action}/0001_migrations")
@@ -211,7 +210,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
                 )
                 assert response.status_code == 200
                 migration_key = MigrationKey(
-                    group="events", migration_id="0015_truncate_events"
+                    group=MigrationGroup.EVENTS, migration_id="0015_truncate_events"
                 )
                 mock_run_migration.assert_called_once_with(
                     migration_key, force=False, fake=False, dry_run=False
@@ -225,7 +224,8 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
                         return_value=(Status.IN_PROGRESS, None),
                     ):
                         migration_key = MigrationKey(
-                            group="events", migration_id="0016_drop_legacy_events"
+                            group=MigrationGroup.EVENTS,
+                            migration_id="0016_drop_legacy_events",
                         )
                         response = admin_api.post(
                             f"/migrations/events/{action}/0016_drop_legacy_events"


### PR DESCRIPTION
Makes the migration policy checking middleware in snuba admin. The middleware gets the migration group policy from the settings map then runs `can_run` / `can_reverese` to if the migration key is allowed to run.
