### PR TITLE
feat(TDC): Add support for transactions entity subscription to config

### DIFF
--- a/snuba/datasets/configuration/entity_subscription_builder.py
+++ b/snuba/datasets/configuration/entity_subscription_builder.py
@@ -1,12 +1,13 @@
 import logging
-from typing import Type
+from typing import Type, Union
 
 import sentry_sdk
 
 from snuba.datasets.configuration.json_schema import V1_ENTITY_SUBSCIPTION_SCHEMA
 from snuba.datasets.configuration.loader import load_configuration_data
 from snuba.datasets.entity_subscriptions.pluggable_entity_subscription import (
-    PluggableEntitySubscription,
+    PluggableEntitySubscriptionComplex,
+    PluggableEntitySubscriptionSimple,
 )
 
 logger = logging.getLogger("snuba.entity_subscriptions_builder")
@@ -14,18 +15,29 @@ logger = logging.getLogger("snuba.entity_subscriptions_builder")
 
 def build_entity_subscription_from_config(
     file_path: str,
-) -> Type[PluggableEntitySubscription]:
+) -> Type[Union[PluggableEntitySubscriptionComplex, PluggableEntitySubscriptionSimple]]:
     config = load_configuration_data(
         file_path, {"entity_subscription": V1_ENTITY_SUBSCIPTION_SCHEMA}
     )
+
     with sentry_sdk.start_span(
         op="build", description=f"Entity Subscription: {config['name']}"
     ):
+        # Default to simple entity subscription
+        PluggableEntitySubscription: Type[
+            Union[PluggableEntitySubscriptionComplex, PluggableEntitySubscriptionSimple]
+        ] = PluggableEntitySubscriptionSimple
+
+        if "type" in config and config["type"] == "complex":
+            PluggableEntitySubscription = PluggableEntitySubscriptionComplex
+
         PluggableEntitySubscription.name = config["name"]
-        PluggableEntitySubscription.MAX_ALLOWED_AGGREGATIONS = config[
-            "max_allowed_aggregations"
-        ]
-        PluggableEntitySubscription.disallowed_aggregations = config[
-            "disallowed_aggregations"
-        ]
-        return PluggableEntitySubscription
+        if "max_allowed_aggregations" in config:
+            PluggableEntitySubscription.MAX_ALLOWED_AGGREGATIONS = config[
+                "max_allowed_aggregations"
+            ]
+        if "disallowed_aggregations" in config:
+            PluggableEntitySubscription.disallowed_aggregations = config[
+                "disallowed_aggregations"
+            ]
+    return PluggableEntitySubscription

--- a/snuba/datasets/configuration/generic_metrics/entity_subscriptions/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entity_subscriptions/distributions.yaml
@@ -1,6 +1,7 @@
 version: v1
 kind: entity_subscription
 name: generic_metrics_distributions_subscription
+type: complex
 
 max_allowed_aggregations: 3
 disallowed_aggregations: ["having", "orderby"]

--- a/snuba/datasets/configuration/generic_metrics/entity_subscriptions/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entity_subscriptions/sets.yaml
@@ -1,6 +1,7 @@
 version: v1
 kind: entity_subscription
 name: generic_metrics_sets_subscription
+type: complex
 
 max_allowed_aggregations: 3
 disallowed_aggregations: ["having", "orderby"]

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -446,7 +446,14 @@ V1_ENTITY_SUBSCIPTION_SCHEMA = {
     "type": "object",
     "properties": {
         "version": {"const": "v1", "description": "Version of schema"},
-        "kind": {"const": "entity_subscription", "description": "Component kind"},
+        "kind": {
+            "const": "entity_subscription",
+            "description": "Component kind",
+        },
+        "type": {
+            "type": ["string", "null"],
+            "description": "Type of entity subscription [simple | complex]",
+        },
         "name": {"type": "string", "description": "Name of the entity subscription"},
         "max_allowed_aggregations": {
             "type": ["integer", "null"],

--- a/snuba/datasets/configuration/transactions/entity_subscriptions/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entity_subscriptions/transactions.yaml
@@ -1,0 +1,7 @@
+version: v1
+kind: entity_subscription
+name: transactions_subscription
+type: simple
+
+max_allowed_aggregations: 1
+disallowed_aggregations: ["groupby", "having", "orderby"]

--- a/snuba/datasets/entity_subscriptions/entity_subscription.py
+++ b/snuba/datasets/entity_subscriptions/entity_subscription.py
@@ -62,9 +62,17 @@ class EntitySubscriptionValidation:
             NoTimeBasedConditionValidator(entity.required_time_column).validate(query)
 
 
-class SessionsSubscription(EntitySubscriptionValidation, EntitySubscription):
-    MAX_ALLOWED_AGGREGATIONS: int = 2
+class SimpleEntitySubscription(EntitySubscriptionValidation, EntitySubscription):
+    def get_entity_subscription_conditions_for_snql(
+        self, offset: Optional[int] = None
+    ) -> Sequence[Expression]:
+        return []
 
+    def to_dict(self) -> Mapping[str, Any]:
+        return {}
+
+
+class ComplexEntitySubscription(EntitySubscriptionValidation, EntitySubscription):
     def __init__(self, data_dict: Mapping[str, Any]) -> None:
         super().__init__(data_dict)
         try:
@@ -89,41 +97,33 @@ class SessionsSubscription(EntitySubscriptionValidation, EntitySubscription):
         return {"organization": self.organization}
 
 
-class EventsSubscription(EntitySubscriptionValidation, EntitySubscription):
-    def get_entity_subscription_conditions_for_snql(
-        self, offset: Optional[int] = None
-    ) -> Sequence[Expression]:
-        return []
-
-    def to_dict(self) -> Mapping[str, Any]:
-        return {}
+class EventsSubscription(SimpleEntitySubscription):
+    pass
 
 
-class TransactionsSubscription(EntitySubscriptionValidation, EntitySubscription):
-    def get_entity_subscription_conditions_for_snql(
-        self, offset: Optional[int] = None
-    ) -> Sequence[Expression]:
-        return []
-
-    def to_dict(self) -> Mapping[str, Any]:
-        return {}
+class TransactionsSubscription(SimpleEntitySubscription):
+    pass
 
 
-class MetricsCountersSubscription(SessionsSubscription):
+class SessionsSubscription(ComplexEntitySubscription):
+    MAX_ALLOWED_AGGREGATIONS: int = 2
+
+
+class MetricsCountersSubscription(ComplexEntitySubscription):
     MAX_ALLOWED_AGGREGATIONS: int = 3
     disallowed_aggregations = ["having", "orderby"]
 
 
-class MetricsSetsSubscription(SessionsSubscription):
+class MetricsSetsSubscription(ComplexEntitySubscription):
     MAX_ALLOWED_AGGREGATIONS: int = 3
     disallowed_aggregations = ["having", "orderby"]
 
 
-class GenericMetricsSetsSubscription(SessionsSubscription):
+class GenericMetricsSetsSubscription(ComplexEntitySubscription):
     MAX_ALLOWED_AGGREGATIONS: int = 3
     disallowed_aggregations = ["having", "orderby"]
 
 
-class GenericMetricsDistributionsSubscription(SessionsSubscription):
+class GenericMetricsDistributionsSubscription(ComplexEntitySubscription):
     MAX_ALLOWED_AGGREGATIONS: int = 3
     disallowed_aggregations = ["having", "orderby"]

--- a/snuba/datasets/entity_subscriptions/pluggable_entity_subscription.py
+++ b/snuba/datasets/entity_subscriptions/pluggable_entity_subscription.py
@@ -1,15 +1,30 @@
 from typing import Sequence
 
-from snuba.datasets.entity_subscriptions.entity_subscription import SessionsSubscription
+from snuba.datasets.entity_subscriptions.entity_subscription import (
+    ComplexEntitySubscription,
+    SimpleEntitySubscription,
+)
 
 
-class PluggableEntitySubscription(SessionsSubscription):
+class PluggableEntitySubscriptionComplex(ComplexEntitySubscription):
     """
-    PluggableEntitySubscription is a version of EntitySubscription that is design to be populated by
+    PluggableEntitySubscriptionComplex is a version of EntitySubscription that is design to be populated by
     static YAML-based configuration files.
 
-    TODO: This always extends SessionsSubscription for now.
-    We will need to add functionality to extend other base classes in the future
+    TODO: This temporary and always extends ComplexEntitySubscription for now.
+    """
+
+    name: str
+    MAX_ALLOWED_AGGREGATIONS: int
+    disallowed_aggregations: Sequence[str]
+
+
+class PluggableEntitySubscriptionSimple(SimpleEntitySubscription):
+    """
+    PluggableEntitySubscriptionSimple is a version of EntitySubscription that is design to be populated by
+    static YAML-based configuration files.
+
+    TODO: This temporary and always extends ComplexEntitySubscription for now.
     """
 
     name: str

--- a/tests/subscriptions/entity_subscriptions/configuration/broken_entity_subscription_bad_attribute.yaml
+++ b/tests/subscriptions/entity_subscriptions/configuration/broken_entity_subscription_bad_attribute.yaml
@@ -1,6 +1,7 @@
 version: v1
 kind: entity_subscription
 name: generic_metrics_sets_subscription
+type: complex
 
 max_allowed_aggregations: "5"
 disallowed_aggregations: ["having", "orderby"]

--- a/tests/subscriptions/entity_subscriptions/configuration/test_entity_subscription_loader.py
+++ b/tests/subscriptions/entity_subscriptions/configuration/test_entity_subscription_loader.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Union
 
 import pytest
 from jsonschema.exceptions import ValidationError
@@ -7,28 +7,56 @@ from snuba.datasets.configuration.entity_subscription_builder import (
     build_entity_subscription_from_config,
 )
 from snuba.datasets.entity_subscriptions.entity_subscription import (
+    ComplexEntitySubscription,
     GenericMetricsSetsSubscription,
+    SimpleEntitySubscription,
+    TransactionsSubscription,
 )
 from snuba.datasets.entity_subscriptions.pluggable_entity_subscription import (
-    PluggableEntitySubscription,
+    PluggableEntitySubscriptionComplex,
+    PluggableEntitySubscriptionSimple,
 )
 
 data = {"organization": 1}
 
 
-def test_build_entity_subscription_from_config() -> None:
+def test_build_complex_entity_subscription_from_config() -> None:
     config_sets_entity_subscription: Type[
-        PluggableEntitySubscription
+        Union[PluggableEntitySubscriptionComplex, PluggableEntitySubscriptionSimple]
     ] = build_entity_subscription_from_config(
         "snuba/datasets/configuration/generic_metrics/entity_subscriptions/sets.yaml"
     )
     py_sets_entity_subscription = GenericMetricsSetsSubscription
+    assert issubclass(config_sets_entity_subscription, ComplexEntitySubscription)
     assert config_sets_entity_subscription.name == "generic_metrics_sets_subscription"
 
     config_sets = config_sets_entity_subscription(data_dict=data)
     py_sets = py_sets_entity_subscription(data_dict=data)
 
     assert config_sets.name == "generic_metrics_sets_subscription"
+
+    assert config_sets.MAX_ALLOWED_AGGREGATIONS == py_sets.MAX_ALLOWED_AGGREGATIONS
+    assert config_sets.disallowed_aggregations == py_sets.disallowed_aggregations
+    assert (
+        config_sets.get_entity_subscription_conditions_for_snql()
+        == py_sets.get_entity_subscription_conditions_for_snql()
+    )
+
+
+def test_build_simple_entity_subscription_from_config() -> None:
+    config_sets_entity_subscription: Type[
+        Union[PluggableEntitySubscriptionComplex, PluggableEntitySubscriptionSimple]
+    ] = build_entity_subscription_from_config(
+        "snuba/datasets/configuration/transactions/entity_subscriptions/transactions.yaml"
+    )
+    py_transactions_entity_subscription = TransactionsSubscription
+    assert issubclass(config_sets_entity_subscription, SimpleEntitySubscription)
+    assert config_sets_entity_subscription.name == "transactions_subscription"
+
+    config_sets = config_sets_entity_subscription(data_dict=data)
+    py_sets = py_transactions_entity_subscription(data_dict=data)
+
+    assert config_sets.name == "transactions_subscription"
 
     assert config_sets.MAX_ALLOWED_AGGREGATIONS == py_sets.MAX_ALLOWED_AGGREGATIONS
     assert config_sets.disallowed_aggregations == py_sets.disallowed_aggregations

--- a/tests/subscriptions/entity_subscriptions/test_pluggable_entity_subscription.py
+++ b/tests/subscriptions/entity_subscriptions/test_pluggable_entity_subscription.py
@@ -10,7 +10,7 @@ from snuba.datasets.entity_subscriptions.entity_subscription import (
     GenericMetricsSetsSubscription,
 )
 from snuba.datasets.entity_subscriptions.pluggable_entity_subscription import (
-    PluggableEntitySubscription,
+    PluggableEntitySubscriptionComplex,
 )
 from snuba.datasets.factory import get_dataset
 from snuba.redis import RedisClientKey, get_redis_client
@@ -47,15 +47,15 @@ def subscription_data_builder(
 
 @pytest.fixture
 def pluggable_sets_entity_subscription() -> EntitySubscription:
-    PluggableEntitySubscription.name = "generic_metrics_sets_subscription"
-    PluggableEntitySubscription.MAX_ALLOWED_AGGREGATIONS = 3
-    PluggableEntitySubscription.disallowed_aggregations = ["having", "orderby"]
-    assert issubclass(PluggableEntitySubscription, EntitySubscription)
-    return PluggableEntitySubscription(data_dict=data)
+    PluggableEntitySubscriptionComplex.name = "generic_metrics_sets_subscription"
+    PluggableEntitySubscriptionComplex.MAX_ALLOWED_AGGREGATIONS = 3
+    PluggableEntitySubscriptionComplex.disallowed_aggregations = ["having", "orderby"]
+    assert issubclass(PluggableEntitySubscriptionComplex, EntitySubscription)
+    return PluggableEntitySubscriptionComplex(data_dict=data)
 
 
 def test_entity_subscription_generic_metrics_sets_regular_vs_pluggable(
-    pluggable_sets_entity_subscription: PluggableEntitySubscription,
+    pluggable_sets_entity_subscription: PluggableEntitySubscriptionComplex,
 ) -> None:
     sets_entity_subscription = GenericMetricsSetsSubscription(data_dict=data)
 


### PR DESCRIPTION
This PR is responsible for adding support for the `TransactionsSubscription` to move into config. For some context, the original `PluggableEntitySubscription` only inherited from `SessionsSubscription`. This is because we did not want config to support inheritance. However, this becomes an issue we begin to migrate the Transactions entity subscription. Since the TransactionsSubscription inherits from something different we need to add support for this. There were a few options that were considered:

* Create a separate pluggable entity which supports a different base class
* Dynamic inheritance with using `type()` in `__new__()` of `PluggableEntitySubscription`
* Encode subscription into the Entity itself.

For the purpose of this task, creating a separate pluggable entity subscription class seemed like a quick/easiest approach (future work would be to eliminate entity subscriptions altogether and embed into entity?).

As a result, this PR contains the following changes:
* Added additional pluggable entity subscription class which inherits the necessary classes that `TransactionsSubscription` requires.
* Added field in config file called `type: [simple | complex]` which allows user to configure which base class to use.
* Created two new top level classes: `SimpleEntitySubscription` and `ComplexEntitySubscription`
* Refactored all entity subscriptions to inherit from these two classes (previously a bunch of them were inheriting from the SessionsSubscription).