### PR TITLE
fix(logs): Snuba init transaction was not sampled

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -33,7 +33,9 @@ def main() -> None:
     `OoO'  o   O `OoO'o `OoO' `OoO'o"""
 
 
-with sentry_sdk.start_transaction(op="snuba_init", name="Snuba CLI Initialization"):
+with sentry_sdk.start_transaction(
+    op="snuba_init", name="Snuba CLI Initialization", sampled=True
+):
     for loader, module_name, is_pkg in walk_packages(__path__, __name__ + "."):
         logger.info(f"Loading module {module_name}")
         with sentry_sdk.start_span(op="import", description=module_name):

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import, annotations
+from __future__ import absolute_import
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Optional
 
 import sentry_sdk
 import structlog
@@ -70,12 +70,6 @@ def setup_logging(level: Optional[str] = None) -> None:
     )
 
 
-def _traces_sampler(sampling_context: dict[str, Any]) -> int:
-    if sampling_context["transaction_context"]["op"] == "snuba_init":
-        return 1
-    return settings.SENTRY_TRACE_SAMPLE_RATE
-
-
 def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
@@ -86,7 +80,7 @@ def setup_sentry() -> None:
             RedisIntegration(),
         ],
         release=os.getenv("SNUBA_RELEASE"),
-        traces_sampler=_traces_sampler,
+        traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
     )
 
 

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -1,8 +1,8 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 import sentry_sdk
 import structlog
@@ -70,6 +70,12 @@ def setup_logging(level: Optional[str] = None) -> None:
     )
 
 
+def _traces_sampler(sampling_context: dict[str, Any]) -> int:
+    if sampling_context["transaction_context"]["op"] == "snuba_init":
+        return 1
+    return settings.SENTRY_TRACE_SAMPLE_RATE
+
+
 def setup_sentry() -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
@@ -80,7 +86,7 @@ def setup_sentry() -> None:
             RedisIntegration(),
         ],
         release=os.getenv("SNUBA_RELEASE"),
-        traces_sample_rate=settings.SENTRY_TRACE_SAMPLE_RATE,
+        traces_sampler=_traces_sampler,
     )
 
 


### PR DESCRIPTION
### Overview
- Snuba's sampling rate is 0 and we don't ever start a transaction anywhere
- I introduced a transaction in #3200 which is populating the Datadog metric just fine but Snuba isn't sending the transaction so we basically still have no visibility
- This PR swaps out our hardcoded sampling rate with a function that sets sampling rate to 1 if the transaction op is `snuba_init` and the default 0 otherwise

### Questions
- This works fine locally - could this break anything in prod? (There are no instances where we start a fresh transaction anywhere in Snuba so this is the first time we're adding one)
- Is it possible that some global transaction (coming from wherever the current Snuba transactions are started) could have the op name "snuba_init" and hence be sampled 100%?
    - If so, would having the check be more thorough be sufficient?
    - Eg `if op == "snuba_init" and name == "Snuba CLI Initialization"` instead of just `if op == "snuba_init"`