### PR TITLE
feat(redis): Add second shard to rate limiter and cache

### DIFF
--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -121,7 +121,9 @@ def _initialize_specialized_redis_cluster(
 
 class RedisClientKey(Enum):
     CACHE = "cache"
+    CACHE_V2 = "cache_v2"
     RATE_LIMITER = "rate_limiter"
+    RATE_LIMITER_V2 = "rate_limiter_v2"
     SUBSCRIPTION_STORE = "subscription_store"
     REPLACEMENTS_STORE = "replacements_store"
     CONFIG = "config"
@@ -133,8 +135,14 @@ _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
     RedisClientKey.CACHE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["cache"]
     ),
+    RedisClientKey.CACHE_V2: _initialize_specialized_redis_cluster(
+        settings.REDIS_CLUSTERS["cache_v2"]
+    ),
     RedisClientKey.RATE_LIMITER: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["rate_limiter"]
+    ),
+    RedisClientKey.RATE_LIMITER_V2: _initialize_specialized_redis_cluster(
+        settings.REDIS_CLUSTERS["rate_limiter_v2"]
     ),
     RedisClientKey.SUBSCRIPTION_STORE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["subscription_store"]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -128,7 +128,9 @@ T = TypeVar("T")
 
 class RedisClusters(TypedDict):
     cache: RedisClusterConfig | None
+    cache_v2: RedisClusterConfig | None
     rate_limiter: RedisClusterConfig | None
+    rate_limiter_v2: RedisClusterConfig | None
     subscription_store: RedisClusterConfig | None
     replacements_store: RedisClusterConfig | None
     config: RedisClusterConfig | None
@@ -138,7 +140,9 @@ class RedisClusters(TypedDict):
 
 REDIS_CLUSTERS: RedisClusters = {
     "cache": None,
+    "cache_v2": None,
     "rate_limiter": None,
+    "rate_limiter_v2": None,
     "subscription_store": None,
     "replacements_store": None,
     "config": None,

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -45,7 +45,13 @@ REDIS_CLUSTERS = {
     }
     for i, key in [
         (2, "cache"),
+        # ensure that cache and cache_v2 are on different
+        # clusters, without running out of db values
+        (3, "cache_v2"),
         (3, "rate_limiter"),
+        # ensure that rate_limiter and rate_limiter_v2 are on different
+        # clusters, without running out of db values
+        (4, "rate_limiter_v2"),
         (4, "subscription_store"),
         (5, "replacements_store"),
         (6, "config"),

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -5,12 +5,14 @@ import uuid
 from collections import ChainMap, namedtuple
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from dataclasses import dataclass
+from hashlib import md5
 from types import TracebackType
 from typing import ChainMap as TypingChainMap
 from typing import Iterator, MutableMapping, Optional, Sequence, Type
 
 from snuba import environment, state
 from snuba.redis import RedisClientKey, get_redis_client
+from snuba.util import force_bytes
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.serializable_exception import SerializableException
 
@@ -24,7 +26,10 @@ TABLE_RATE_LIMIT_NAME = "table"
 
 metrics = MetricsWrapper(environment.metrics, "api")
 
-rds = get_redis_client(RedisClientKey.RATE_LIMITER)
+redis_clients = [
+    get_redis_client(RedisClientKey.RATE_LIMITER),
+    get_redis_client(RedisClientKey.RATE_LIMITER_V2),
+]
 
 
 @dataclass(frozen=True)
@@ -124,15 +129,26 @@ def rate_limit(
     query_id = str(uuid.uuid4())
 
     now = time.time()
-    bypass_rate_limit, rate_history_s = state.get_configs(
-        [("bypass_rate_limit", 0), ("rate_history_sec", 3600)]
-        #                               ^ number of seconds the timestamps are kept
+    bypass_rate_limit, rate_history_s, v2_cluster_rollout_rate = state.get_configs(
+        [
+            ("bypass_rate_limit", 0),
+            # number of seconds the timestamps are kept
+            ("rate_history_sec", 3600),
+            ("rate_limit_use_v2_cluster", 0.0),
+        ]
     )
     assert isinstance(rate_history_s, (int, float))
+    assert isinstance(v2_cluster_rollout_rate, float)
 
     if bypass_rate_limit == 1:
         yield None
         return
+
+    should_use_v2 = (
+        int(md5(force_bytes(bucket)).hexdigest(), 16) % 1000
+        < v2_cluster_rollout_rate * 1000
+    )
+    rds = redis_clients[int(should_use_v2)]
 
     pipe = rds.pipeline(transaction=False)
     # cleanup old query timestamps past our retention window

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,11 +124,14 @@ def _build_snql_post_methods(
     return simple_post
 
 
+SnubaSetConfig = Callable[[str, Any], None]
+
+
 @pytest.fixture
-def snuba_set_config(request) -> Callable[[str, Any], None]:
+def snuba_set_config(request: pytest.FixtureRequest) -> SnubaSetConfig:
     finalizers_registered = set()
 
-    def set_config(key: str, value: Any):
+    def set_config(key: str, value: Any) -> None:
         # should register finalizer only once because 1) we don't have to undo
         # every single value change step-by-step 2) teardown-order via pytest
         # finalizers is poorly understood
@@ -143,6 +146,6 @@ def snuba_set_config(request) -> Callable[[str, Any], None]:
 
 
 @pytest.fixture
-def disable_query_cache(snuba_set_config) -> None:
+def disable_query_cache(snuba_set_config: SnubaSetConfig) -> None:
     snuba_set_config("use_cache", False)
     snuba_set_config("use_readthrough_query_cache", 0)

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -11,7 +11,12 @@ from unittest import mock
 import pytest
 import rapidjson
 
-from snuba.redis import RedisClientKey, RedisClientType, get_redis_client
+from snuba.redis import (
+    RedisClientKey,
+    RedisClientType,
+    RetryingStrictRedisCluster,
+    get_redis_client,
+)
 from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import ExceptionAwareCodec
@@ -301,6 +306,10 @@ def test_notify_queue_ttl() -> None:
         redis_client.flushdb()
 
 
+@pytest.mark.skipif(
+    isinstance(redis_client, RetryingStrictRedisCluster),
+    reason="test requires support for db parameter, and redis cluster does not support DBs",
+)
 def test_multiple_redis_keys(request, snuba_set_config):
     backend = RedisCache(
         [redis_client, redis_client_v2],

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from snuba import state
-from snuba.redis import RedisClientKey, get_redis_client
+from snuba.redis import RedisClientKey, RetryingStrictRedisCluster, get_redis_client
 from snuba.state.rate_limit import (
     RateLimitAggregator,
     RateLimitExceeded,
@@ -14,6 +14,7 @@ from snuba.state.rate_limit import (
     RateLimitStats,
     RateLimitStatsContainer,
     rate_limit,
+    redis_clients,
 )
 
 
@@ -190,6 +191,10 @@ def test_rate_limit_failures(vals: Tuple[int, int, int]) -> None:
         assert count == 0
 
 
+@pytest.mark.skipif(
+    isinstance(redis_clients[0], RetryingStrictRedisCluster),
+    reason="test requires support for db parameter, and redis cluster does not support DBs",
+)
 def test_rate_limit_v2_cluster(snuba_set_config):
     params = RateLimitParameters("foo", "foo", None, 4)
 
@@ -217,6 +222,10 @@ def test_rate_limit_v2_cluster(snuba_set_config):
                 pass
 
 
+@pytest.mark.skipif(
+    isinstance(redis_clients[0], RetryingStrictRedisCluster),
+    reason="test requires support for db parameter, and redis cluster does not support DBs",
+)
 def test_rate_limit_v2_cluster_inconsistency(snuba_set_config):
     params = RateLimitParameters("foo", "foo", None, 4)
 


### PR DESCRIPTION
We want to split out those usecases to a new redis cluster, but instead
of doing a hard cutover to a new redis instance we want to do it slowly.

We don't care much about dataloss (particularly for those usecases), our
primary concern is whether the new Redis instance can take the load of
those usecases. We have little insight into what causes the most load on
the current redis cluster, and at the same time hope to get away with a
single memorystore instance per-usecase as memorystore does not support
sharding yet.

In order to facilitate a "slow" cutover we introduce two new rollout
rate settings. Increasing a rollout rate will make the corresponding
usecase gradually start a different redis cluster (represented as a new
"v2 usecase"), and once we hit 1.0 on both of them we can essentially
revert this PR and point the "v1" usecase directly to the new cluster
(in one deploy)

There is a chance this doesn't go well and a single memorystore instance
cannot take the load of either the rate limit or caching usecase, in
which case we have to consider building sharding into Snuba.

Longer-term I'd ideally want us to move to Envoy's Redis proxy or a
similar abstraction layer between the redis client and the actual
instances. That would give us dual-writes and key-based sharding OOTB
without having to build it into the app itself.

