### PR TITLE
fix(devserver): Fix snuba transaction consumer in dev

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -45,7 +45,6 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 "--log-level=debug",
                 "--storage=transactions",
                 "--consumer-group=transactions_group",
-                "--commit-log-topic=snuba-commit-log",
             ],
         ),
         (


### PR DESCRIPTION
Snuba transaction consumer was writing the wrong commit log topic in dev.
Subscriptions and post process would have been broken in dev.