### PR TITLE
fix: Rename part_storage to partition_storage

### DIFF
--- a/snuba/cleanup.py
+++ b/snuba/cleanup.py
@@ -42,9 +42,9 @@ def get_active_partitions(
 
     schema = storage.get_schema()
     assert isinstance(schema, TableSchema)
-    part_format = schema.get_part_format()
-    assert part_format is not None
-    return [util.decode_part_str(part, part_format) for part, in response.results]
+    partition_format = schema.get_partition_format()
+    assert partition_format is not None
+    return [util.decode_part_str(part, partition_format) for part, in response.results]
 
 
 def current_time() -> datetime:

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -85,7 +85,7 @@ def __build_storage_schema(config: dict[str, Any]) -> TableSchema:
         local_table_name=config[SCHEMA]["local_table_name"],
         dist_table_name=config[SCHEMA]["dist_table_name"],
         storage_set_key=StorageSetKey(config[STORAGE][SET_KEY]),
-        part_format=partition_formats,  # TODO: Rename `part_format` to `partition_format` in the class
+        partition_format=partition_formats,
     )
 
 

--- a/snuba/datasets/schemas/tables.py
+++ b/snuba/datasets/schemas/tables.py
@@ -52,14 +52,14 @@ class TableSchema(Schema):
         dist_table_name: str,
         storage_set_key: StorageSetKey,
         mandatory_conditions: Optional[Sequence[FunctionCall]] = None,
-        part_format: Optional[Sequence[util.PartSegment]] = None,
+        partition_format: Optional[Sequence[util.PartSegment]] = None,
     ):
         self.__local_table_name = local_table_name
         self.__dist_table_name = dist_table_name
         self.__storage_set_key = storage_set_key
         self.__columns = columns
         self.__mandatory_conditions = mandatory_conditions
-        self.__part_format = part_format
+        self.__partition_format = partition_format
 
     def get_data_source(self) -> TableSource:
         """
@@ -93,11 +93,11 @@ class TableSchema(Schema):
             else self.__dist_table_name
         )
 
-    def get_part_format(self) -> Optional[Sequence[util.PartSegment]]:
+    def get_partition_format(self) -> Optional[Sequence[util.PartSegment]]:
         """
         Partition format required for cleanup and optimize.
         """
-        return self.__part_format
+        return self.__partition_format
 
 
 class WritableTableSchema(TableSchema):

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -25,7 +25,7 @@ schema = WritableTableSchema(
     dist_table_name="errors_dist",
     storage_set_key=StorageSetKey.EVENTS,
     mandatory_conditions=mandatory_conditions,
-    part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
+    partition_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
 storage = WritableTableStorage(

--- a/snuba/datasets/storages/errors_v2.py
+++ b/snuba/datasets/storages/errors_v2.py
@@ -96,7 +96,7 @@ schema = WritableTableSchema(
     dist_table_name="errors_dist",
     storage_set_key=StorageSetKey.ERRORS_V2,
     mandatory_conditions=mandatory_conditions,
-    part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
+    partition_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
 storage = WritableTableStorage(

--- a/snuba/datasets/storages/transactions.py
+++ b/snuba/datasets/storages/transactions.py
@@ -22,7 +22,7 @@ schema = WritableTableSchema(
     dist_table_name="transactions_dist",
     storage_set_key=StorageSetKey.TRANSACTIONS,
     mandatory_conditions=[],
-    part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
+    partition_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
 storage = WritableTableStorage(

--- a/snuba/datasets/storages/transactions_v2.py
+++ b/snuba/datasets/storages/transactions_v2.py
@@ -22,7 +22,7 @@ schema = WritableTableSchema(
     dist_table_name="transactions_dist",
     storage_set_key=StorageSetKey.TRANSACTIONS_V2,
     mandatory_conditions=[],
-    part_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
+    partition_format=[util.PartSegment.RETENTION_DAYS, util.PartSegment.DATE],
 )
 
 storage = WritableTableStorage(

--- a/snuba/optimize.py
+++ b/snuba/optimize.py
@@ -174,11 +174,12 @@ def get_partitions_to_optimize(
     )
     schema = storage.get_schema()
     assert isinstance(schema, TableSchema)
-    part_format = schema.get_part_format()
-    assert part_format is not None
+    partition_format = schema.get_partition_format()
+    assert partition_format is not None
 
     parts = [
-        util.decode_part_str(part, part_format) for part, count in active_parts.results
+        util.decode_part_str(part, partition_format)
+        for part, count in active_parts.results
     ]
 
     if before:

--- a/snuba/util.py
+++ b/snuba/util.py
@@ -170,7 +170,7 @@ class PartSegment(Enum):
 re_cache: MutableMapping[str, Pattern[Any]] = {}
 
 
-def decode_part_str(part_str: str, part_format: Sequence[PartSegment]) -> Part:
+def decode_part_str(part_str: str, partition_format: Sequence[PartSegment]) -> Part:
     def get_re(format: Sequence[PartSegment]) -> Pattern[Any]:
         cache_key = ",".join([segment.value for segment in format])
 
@@ -185,12 +185,12 @@ def decode_part_str(part_str: str, part_format: Sequence[PartSegment]) -> Part:
             return re_cache[cache_key]
         except KeyError:
             re_cache[cache_key] = re.compile(
-                f"\({SEP.join([PARTSEGMENT_RE[s] for s in part_format])}\)"
+                f"\({SEP.join([PARTSEGMENT_RE[s] for s in partition_format])}\)"
             )
 
         return re_cache[cache_key]
 
-    match = get_re(part_format).match(part_str)
+    match = get_re(partition_format).match(part_str)
 
     if not match:
         raise ValueError("Unknown part name/format: " + str(part_str))


### PR DESCRIPTION
The variable name was always referencing the partition, but the short form was a
little confusing because Clickhouse also has parts. Rename to partition to avoid
this problem in the future.

This came out of a discussion on a different PR: https://github.com/getsentry/snuba/pull/3274#discussion_r1002125829