### PR TITLE
fix(tests): Fix migration tests api

### DIFF
--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -83,6 +83,7 @@ def test_list_migration_status(admin_api: FlaskClient) -> None:
             "migration_id": "0003_sessions_matview",
             "status": "completed",
         },
+        {"blocking": False, "migration_id": "0004_sessions_ttl", "status": "completed"},
     ]
 
     def sort_by_migration_id(migration: Any) -> Any:


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/3223 introduced a new migration to the sessions table. But it seems like the migration api tests depend on the migrations on the sessions table to verify their operations. So we need to fix the test.