### PR TITLE
feat(TDC): Migrate transactions migrate group to configuration

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -515,6 +515,10 @@ V1_MIGRATION_GROUP_SCHEMA = {
             "type": "boolean",
             "description": "Flag to determine if migration group is optional",
         },
+        "execute_before": {
+            "type": "string",
+            "description": "The migration group this should be run directly before.",
+        },
         "migrations": {
             "type": "array",
             "items": {"type": "string", "description": "Names of migrations"},

--- a/snuba/datasets/configuration/transactions/migrations/transactions_migration_group.yaml
+++ b/snuba/datasets/configuration/transactions/migrations/transactions_migration_group.yaml
@@ -1,0 +1,24 @@
+version: v1
+kind: migration_group
+name: transactions
+optional: false
+execute_before: discover
+
+migrations:
+  - 0001_transactions
+  - 0002_transactions_onpremise_fix_orderby_and_partitionby
+  - 0003_transactions_onpremise_fix_columns
+  - 0004_transactions_add_tags_hash_map
+  - 0005_transactions_add_measurements
+  - 0006_transactions_add_http_fields
+  - 0007_transactions_add_discover_cols
+  - 0008_transactions_add_timestamp_index
+  - 0009_transactions_fix_title_and_message
+  - 0010_transactions_nullable_trace_id
+  - 0011_transactions_add_span_op_breakdowns
+  - 0012_transactions_add_spans
+  - 0013_transactions_reduce_spans_exclusive_time
+  - 0014_transactions_remove_flattened_columns
+  - 0015_transactions_add_source_column
+  - 0016_transactions_add_group_ids_column
+  - 0017_transactions_add_app_start_type_column

--- a/tests/datasets/configuration/test_migration_groups.py
+++ b/tests/datasets/configuration/test_migration_groups.py
@@ -1,5 +1,6 @@
 from snuba.migrations.groups import (
     OPTIONAL_GROUPS,
+    REGISTERED_GROUPS,
     REGISTERED_GROUPS_LOOKUP,
     MigrationGroup,
     get_group_loader,
@@ -29,3 +30,14 @@ class TestMigrationGroupConfiguration(ConfigurationTest):
 
         m = generic_metrics_loader.load_migration("0005_sets_replace_mv")
         assert isinstance(m, Migration)
+
+    def test_transaction_group_order(self) -> None:
+        assert "transactions" in REGISTERED_GROUPS_LOOKUP
+
+        transactions_idx = REGISTERED_GROUPS.index(
+            ("transactions", get_group_loader(MigrationGroup("transactions")))
+        )
+        discover_idx = REGISTERED_GROUPS.index(
+            ("discover", get_group_loader(MigrationGroup("discover")))
+        )
+        assert transactions_idx == discover_idx - 1


### PR DESCRIPTION
Move the transaction migration group to configuration. Since the transactions
migrations need to be executed before the discover migrations, also add the
concept of an "execute_before" field, which can be used to organize the
migrations.