### PR TITLE
build: Bump relay to 0.8.15 [INGEST-1674]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo==1.0.7
-sentry-relay==0.8.13
+sentry-relay==0.8.14
 sentry-sdk==1.9.8
 simplejson==3.17.6
 structlog==22.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo==1.0.7
-sentry-relay==0.8.14
+sentry-relay==0.8.15
 sentry-sdk==1.9.8
 simplejson==3.17.6
 structlog==22.1.0

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -385,6 +385,14 @@ class TestOutcomesAPI(BaseApiTest):
             category=DataCategory.TRANSACTION,
         )
         self.generate_outcomes(
+            org_id=1,
+            project_id=project_id,
+            num_outcomes=3,
+            outcome=0,
+            time_since_base=timedelta(minutes=30),
+            category=DataCategory.TRANSACTION_INDEXED,
+        )
+        self.generate_outcomes(
             org_id=2,
             project_id=project_id,
             num_outcomes=10,


### PR DESCRIPTION
Update sentry-relay version to 0.8.15 to get the `TRANSACTION_INDEXED` data category.

Note: 0.8.14 had a bug so it had to be yanked.

Add a smoke test to see if the data category is now available.