### PR TITLE
feat(snuba-init): Faster cli initialization

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -5,6 +5,7 @@ import os
 import time
 
 import click
+import sentry_sdk
 import structlog
 
 from snuba.environment import metrics as environment_metrics
@@ -12,56 +13,53 @@ from snuba.environment import setup_logging, setup_sentry
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 setup_sentry()
-setup_logging("DEBUG")
-logger = logging.getLogger("snuba_init")
 
-start = time.perf_counter()
-logger.info("Initializing Snuba...")
-metrics = MetricsWrapper(environment_metrics, "cli")
+with sentry_sdk.start_transaction(
+    op="snuba_init", name="Snuba CLI Initialization", sampled=True
+):
 
-plugin_folder = os.path.dirname(__file__)
+    setup_logging("DEBUG")
+    logger = logging.getLogger("snuba_init")
 
+    start = time.perf_counter()
+    logger.info("Initializing Snuba...")
+    metrics = MetricsWrapper(environment_metrics, "cli")
 
-class SnubaCLI(click.MultiCommand):
-    def list_commands(self, ctx) -> list[str]:
-        rv = []
-        for filename in os.listdir(plugin_folder):
-            if filename.endswith(".py") and filename != "__init__.py":
-                rv.append(filename[:-3])
-        rv.sort()
-        return rv
+    plugin_folder = os.path.dirname(__file__)
 
-    def get_command(self, ctx, name):
-        ns = {}
-        fn = os.path.join(plugin_folder, name + ".py")
-        with open(fn) as f:
-            code = compile(f.read(), fn, "exec")
-            eval(code, ns, ns)
-        return ns[name]
+    class SnubaCLI(click.MultiCommand):
+        def list_commands(self, ctx) -> list[str]:
+            rv = []
+            for filename in os.listdir(plugin_folder):
+                if filename.endswith(".py") and filename != "__init__.py":
+                    rv.append(filename[:-3])
+            rv.sort()
+            return rv
 
+        def get_command(self, ctx, name):
+            logger.info(f"Loading command {name}")
+            with sentry_sdk.start_span(op="import", description=name):
+                ns = {}
+                fn = os.path.join(plugin_folder, name + ".py")
+                with open(fn) as f:
+                    code = compile(f.read(), fn, "exec")
+                    eval(code, ns, ns)
+                return ns[name]
 
-@click.command(cls=SnubaCLI)
-def main():
-    """snuba"""
+    @click.command(cls=SnubaCLI)
+    def main():
+        """\b
+                             o
+                            O
+                            O
+                            o
+        .oOo  'OoOo. O   o  OoOo. .oOoO'
+        `Ooo.  o   O o   O  O   o O   o
+            O  O   o O   o  o   O o   O
+        `OoO'  o   O `OoO'o `OoO' `OoO'o"""
 
+    init_time = time.perf_counter() - start
+    metrics.gauge("snuba_init", init_time)
+    logger.info(f"Snuba initialization took {init_time}s")
 
-# with sentry_sdk.start_transaction(
-#     op="snuba_init", name="Snuba CLI Initialization", sampled=True
-# ):
-# for loader, module_name, is_pkg in walk_packages(__path__, __name__ + "."):
-# 	  logger.info(f"Loading module {module_name}")
-# 	  with sentry_sdk.start_span(op="import", description=module_name):
-# 		  import pdb
-
-# 		  pdb.set_trace()
-
-# 		  module = __import__(module_name, globals(), locals(), ["__name__"])
-# 		  cmd = getattr(module, module_name.rsplit(".", 1)[-1])
-# 		  if isinstance(cmd, click.Command):
-# 			  main.add_command(cmd)
-
-init_time = time.perf_counter() - start
-metrics.gauge("snuba_init", init_time)
-logger.info(f"Snuba initialization took {init_time}s")
-
-structlog.reset_defaults()
+    structlog.reset_defaults()

--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import logging
+import os
 import time
-from pkgutil import walk_packages
 
 import click
-import sentry_sdk
 import structlog
 
 from snuba.environment import metrics as environment_metrics
@@ -18,31 +19,46 @@ start = time.perf_counter()
 logger.info("Initializing Snuba...")
 metrics = MetricsWrapper(environment_metrics, "cli")
 
-
-@click.group()
-@click.version_option()
-def main() -> None:
-    """\b
-                         o
-                        O
-                        O
-                        o
-    .oOo  'OoOo. O   o  OoOo. .oOoO'
-    `Ooo.  o   O o   O  O   o O   o
-        O  O   o O   o  o   O o   O
-    `OoO'  o   O `OoO'o `OoO' `OoO'o"""
+plugin_folder = os.path.dirname(__file__)
 
 
-with sentry_sdk.start_transaction(
-    op="snuba_init", name="Snuba CLI Initialization", sampled=True
-):
-    for loader, module_name, is_pkg in walk_packages(__path__, __name__ + "."):
-        logger.info(f"Loading module {module_name}")
-        with sentry_sdk.start_span(op="import", description=module_name):
-            module = __import__(module_name, globals(), locals(), ["__name__"])
-            cmd = getattr(module, module_name.rsplit(".", 1)[-1])
-            if isinstance(cmd, click.Command):
-                main.add_command(cmd)
+class SnubaCLI(click.MultiCommand):
+    def list_commands(self, ctx) -> list[str]:
+        rv = []
+        for filename in os.listdir(plugin_folder):
+            if filename.endswith(".py") and filename != "__init__.py":
+                rv.append(filename[:-3])
+        rv.sort()
+        return rv
+
+    def get_command(self, ctx, name):
+        ns = {}
+        fn = os.path.join(plugin_folder, name + ".py")
+        with open(fn) as f:
+            code = compile(f.read(), fn, "exec")
+            eval(code, ns, ns)
+        return ns[name]
+
+
+@click.command(cls=SnubaCLI)
+def main():
+    """snuba"""
+
+
+# with sentry_sdk.start_transaction(
+#     op="snuba_init", name="Snuba CLI Initialization", sampled=True
+# ):
+# for loader, module_name, is_pkg in walk_packages(__path__, __name__ + "."):
+# 	  logger.info(f"Loading module {module_name}")
+# 	  with sentry_sdk.start_span(op="import", description=module_name):
+# 		  import pdb
+
+# 		  pdb.set_trace()
+
+# 		  module = __import__(module_name, globals(), locals(), ["__name__"])
+# 		  cmd = getattr(module, module_name.rsplit(".", 1)[-1])
+# 		  if isinstance(cmd, click.Command):
+# 			  main.add_command(cmd)
 
 init_time = time.perf_counter() - start
 metrics.gauge("snuba_init", init_time)

--- a/snuba/cli/api.py
+++ b/snuba/cli/api.py
@@ -33,6 +33,7 @@ def api(
             raise click.ClickException("bind can only be in the format <host>:<port>")
     else:
         host, port = settings.HOST, settings.PORT
+
     if debug:
         if processes > 1 or threads > 1:
             raise click.ClickException("processes/threads can only be 1 in debug")

--- a/snuba/cli/api.py
+++ b/snuba/cli/api.py
@@ -33,7 +33,6 @@ def api(
             raise click.ClickException("bind can only be in the format <host>:<port>")
     else:
         host, port = settings.HOST, settings.PORT
-
     if debug:
         if processes > 1 or threads > 1:
             raise click.ClickException("processes/threads can only be 1 in debug")


### PR DESCRIPTION
## Blast Radius

This affects every snuba deployment as it fundamentally changes how the snuba cli commands are invoked.

## Before State
Every CLI command would be imported no matter what cli command was called. This would add about two seconds to startup time. 

## After State 
The CLI still discovers the files in this directory as before but does not actually run their code until they are invoked. Thus `snuba api` would only ever import the `snuba/cli/api.py` module

## Testing Notes
I ran the `snuba <cmd>` for every subcommand in the CLI directory and made sure it still works. Also made sure to test the startup speed:

master:
```
❯ time snuba api --help
2022-10-25 09:24:06,784 Initializing Snuba...
2022-10-25 09:24:06,786 Loading module snuba.cli.admin
2022-10-25 09:24:06,789 Loading module snuba.cli.api
2022-10-25 09:24:06,886 Loading module snuba.cli.bootstrap
2022-10-25 09:24:07,346 Loading module snuba.cli.bulk_load
2022-10-25 09:24:07,961 Loading module snuba.cli.cleanup
2022-10-25 09:24:07,962 Loading module snuba.cli.config
2022-10-25 09:24:07,964 Loading module snuba.cli.consumer
2022-10-25 09:24:07,980 Loading module snuba.cli.devserver
2022-10-25 09:24:07,981 Loading module snuba.cli.entities
2022-10-25 09:24:08,335 Loading module snuba.cli.migrations
2022-10-25 09:24:08,337 Loading module snuba.cli.multistorage_consumer
2022-10-25 09:24:08,339 Loading module snuba.cli.offline_replacer
2022-10-25 09:24:08,346 Loading module snuba.cli.optimize
2022-10-25 09:24:08,352 Loading module snuba.cli.replacer
2022-10-25 09:24:08,354 Loading module snuba.cli.subscriptions_executor
2022-10-25 09:24:09,569 Loading module snuba.cli.subscriptions_scheduler
2022-10-25 09:24:09,576 Loading module snuba.cli.subscriptions_scheduler_executor
2022-10-25 09:24:09,579 Loading module snuba.cli.test_consumer
2022-10-25 09:24:09,581 Snuba initialization took 2.796583355s
Usage: snuba api [OPTIONS]

Options:
  --bind TEXT          Address to listen on.
  --debug
  --log-level TEXT     Logging level to use.
  --processes INTEGER
  --threads INTEGER
  --help               Show this message and exit.
snuba api --help  2.60s user 0.42s system 85% cpu 3.560 total
```

current branch:
```
❯ time snuba api --help
2022-10-25 09:31:26,456 Initializing Snuba...
2022-10-25 09:31:26,456 Snuba initialization took 0.0006065120000000035s
2022-10-25 09:31:26,457 Loading command api
Usage: snuba api [OPTIONS]

Options:
  --bind TEXT          Address to listen on.
  --debug
  --log-level TEXT     Logging level to use.
  --processes INTEGER
  --threads INTEGER
  --help               Show this message and exit.
snuba api --help  0.35s user 0.12s system 73% cpu 0.639 total
```