### PR TITLE
ref: Allow init args in configuration of DatasetMessageProcessor

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -43,7 +43,8 @@ schema:
   dist_table_name: generic_metric_distributions_raw_dist
 
 stream_loader:
-  processor: GenericDistributionsMetricsProcessor
+  processor:
+    name: GenericDistributionsMetricsProcessor
   default_topic: snuba-generic-metrics
   pre_filter:
     type: KafkaHeaderSelectFilter

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -43,7 +43,8 @@ schema:
   dist_table_name: generic_metric_sets_raw_dist
 
 stream_loader:
-  processor: GenericSetsMetricsProcessor
+  processor:
+    name: GenericSetsMetricsProcessor
   default_topic: snuba-generic-metrics
   pre_filter:
     type: KafkaHeaderSelectFilter

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -27,8 +27,17 @@ STREAM_LOADER_SCHEMA = {
     "type": "object",
     "properties": {
         "processor": {
-            "type": "string",
-            "description": "Name of Processor class config key. Responsible for converting an incoming message body from the event stream into a row or statement to be inserted or executed against clickhouse",
+            "type": "object",
+            "description": "Name of Processor class config key and it's arguments. Responsible for converting an incoming message body from the event stream into a row or statement to be inserted or executed against clickhouse",
+            "properties": {
+                "name": TYPE_STRING,
+                "args": {
+                    "type": "object",
+                    "description": "Key/value mappings required to instantiate the processor class.",
+                },
+            },
+            "additionalProperties": False,
+            "required": ["name"],
         },
         "default_topic": {
             "type": "string",

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -110,9 +110,10 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
+    processor_config = loader_config["processor"]
     processor = DatasetMessageProcessor.get_from_name(
-        loader_config["processor"]
-    ).from_kwargs()
+        processor_config["name"]
+    ).from_kwargs(**processor_config.get("args", {}))
     default_topic = Topic(loader_config["default_topic"])
     # optionals
     pre_filter = None

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -191,7 +191,8 @@ writer_options:
   input_format_skip_unknown_fields: 1
 
 stream_loader:
-  processor: TransactionsMessageProcessor
+  processor:
+    name: TransactionsMessageProcessor
   default_topic: transactions
   commit_log_topic: snuba-transactions-commit-log
   subscription_scheduler_mode: global

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
 from arroyo.processing.strategies.dead_letter_queue import (
@@ -10,13 +10,16 @@ from arroyo.processing.strategies.dead_letter_queue import (
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
+from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.configuration.json_schema import V1_READABLE_STORAGE_SCHEMA
 from snuba.datasets.configuration.storage_builder import build_stream_loader
 from snuba.datasets.configuration.utils import generate_policy_creator
 from snuba.datasets.message_filters import KafkaHeaderSelectFilter
+from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.datasets.processors.generic_metrics_processor import (
     GenericSetsMetricsProcessor,
 )
+from snuba.processor import ProcessedMessage
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -41,7 +44,9 @@ def test_generate_policy_creator() -> None:
 def test_build_stream_loader() -> None:
     loader = build_stream_loader(
         {
-            "processor": "GenericSetsMetricsProcessor",
+            "processor": {
+                "name": "GenericSetsMetricsProcessor",
+            },
             "default_topic": "snuba-generic-metrics",
             "pre_filter": {
                 "type": "KafkaHeaderSelectFilter",
@@ -78,6 +83,42 @@ def test_build_stream_loader() -> None:
         and result_topic_spec.topic == Topic.SUBSCRIPTION_RESULTS_GENERIC_METRICS_SETS
     )
     assert_valid_policy_creator(loader.get_dead_letter_queue_policy_creator())
+
+
+def test_stream_loader_processor_init_arg() -> None:
+    class TestProcessor(DatasetMessageProcessor):
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+        def process_message(
+            self, message: Any, metadata: KafkaMessageMetadata
+        ) -> ProcessedMessage | None:
+            raise NotImplementedError
+
+    loader = build_stream_loader(
+        {
+            "processor": {
+                "name": "TestProcessor",
+                "args": {"value": 6},
+            },
+            "default_topic": "snuba-generic-metrics",
+            "pre_filter": {
+                "type": "KafkaHeaderSelectFilter",
+                "args": {"header_key": "metric_type", "header_value": "s"},
+            },
+            "commit_log_topic": "snuba-generic-metrics-sets-commit-log",
+            "subscription_scheduler_mode": "global",
+            "subscription_scheduled_topic": "scheduled-subscriptions-generic-metrics-sets",
+            "subscription_result_topic": "generic-metrics-sets-subscription-results",
+            "dlq_policy": {
+                "type": "produce",
+                "args": ["snuba-dead-letter-generic-metrics"],
+            },
+        }
+    )
+
+    assert isinstance(loader.get_processor(), TestProcessor)
+    assert getattr(loader.get_processor(), "value") == 6
 
 
 def test_invalid_storage() -> None:


### PR DESCRIPTION
Generic metrics and transactions don't have message processors that require any
init args in their classes, but there are other processors that do. This is
enabling that case for future datasets.