### PR TITLE
ref(consumer): Merge Snuba Consumer and Multistorage Consumer, step 1

### DIFF
--- a/snuba/cli/test_consumer.py
+++ b/snuba/cli/test_consumer.py
@@ -139,7 +139,7 @@ def test_consumer(
     configure_metrics(StreamMetricsAdapter(metrics))
 
     consumer_builder = ConsumerBuilder(
-        storage_key=storage_key,
+        storage_keys=[storage_key],
         kafka_params=KafkaParameters(
             raw_topic=None,
             replacements_topic=None,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -116,6 +116,10 @@ class ConsumerBuilder:
                 },
             )
 
+            # XXX: This can result in a producer being built in cases where it's
+            # not actually required.
+            self.producer = Producer(self.producer_broker_config)
+
         storage_keys = [*self.storages.keys()]
 
         self.raw_topic: ArroyoTopic
@@ -171,10 +175,6 @@ class ConsumerBuilder:
                 raise ValueError("only one commit log topic is supported")
 
         self.stats_callback = stats_callback
-
-        # XXX: This can result in a producer being built in cases where it's
-        # not actually required.
-        self.producer = Producer(self.producer_broker_config)
 
         self.metrics = metrics
         self.max_batch_size = max_batch_size


### PR DESCRIPTION
Currently, the (single-storage) Consumer and Multistorage Consumer live in separate files, but share a lot of common logic and there's duplication within/across these files. The goal of this PR is to start the process of merging the two into a single consumer CLI entrypoint (`snuba/cli/consumer.py`) and Consumer Builder (`snuba/consumers/consumer_builder.py`). More context on this change can be found here: https://getsentry.atlassian.net/browse/SNS-1810. 

This PR: 
- Serves as the first incremental step
- Allows the Snuba consumer CLI to accept multiple storages 
- Introduces some logic from `multistorage_consumer.py` in constructor of `ConsumerBuilder` by resolving multiple topics for multiple storages
- `__build_consumer` and `__build_streaming_strategy_factory` do not have any multistorage logic yet
- Note that the consumer is still meant only for single-storage use cases (we are incrementally adding/transferring functionality until it works for both single and multistorage)
