### PR TITLE
Update 0014_backfill_errors.py

### DIFF
--- a/snuba/snuba_migrations/events/0014_backfill_errors.py
+++ b/snuba/snuba_migrations/events/0014_backfill_errors.py
@@ -98,7 +98,7 @@ COLUMNS = [
     ("group_id", "group_id"),
     (
         "primary_hash",
-        "toUUID(UUIDNumToString(toFixedString(unhex(toString(primary_hash)), 16)))",
+        "toUUID(UUIDNumToString(toFixedString(unhex(toString(assumeNotNull(primary_hash))), 16)))",
     ),
     ("received", "ifNull(`received`, now())"),
     ("message", "ifNull(`message`, '')"),


### PR DESCRIPTION

the same as in PR
https://github.com/getsentry/snuba/pull/3155
second script require NotNull too
I've run this migration on clickhouse 22.6 and it works

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
