### PR TITLE
ref(migrations): use env varibles for CLICKHOUSE_MIGRATIONS_HOST

### DIFF
--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -5,7 +5,7 @@ from snuba.settings.settings_test import *  # noqa
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {
-        "host": "clickhouse-query",
+        "host": os.environ.get("CLICKHOUSE_HOST", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
@@ -17,7 +17,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "distributed_cluster_name": "query_cluster",
     },
     {
-        "host": "clickhouse-query",
+        "host": os.environ.get("CLICKHOUSE_MIGRATIONS_HOST", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
@@ -31,7 +31,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "distributed_cluster_name": "query_cluster",
     },
     {
-        "host": "clickhouse-query",
+        "host": os.environ.get("CLICKHOUSE_HOST", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -5,7 +5,7 @@ from snuba.settings.settings_test import *  # noqa
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {
-        "host": os.environ.get("CLICKHOUSE_HOST", "clickhouse-query"),
+        "host": os.environ.get("CLICKHOUSE_HOST_MIGRATIONS", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
@@ -17,7 +17,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "distributed_cluster_name": "query_cluster",
     },
     {
-        "host": os.environ.get("CLICKHOUSE_HOST", "clickhouse-query"),
+        "host": os.environ.get("CLICKHOUSE_HOST_MIGRATIONS", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
@@ -31,7 +31,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "distributed_cluster_name": "query_cluster",
     },
     {
-        "host": os.environ.get("CLICKHOUSE_HOST", "clickhouse-query"),
+        "host": os.environ.get("CLICKHOUSE_HOST_MIGRATIONS", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -17,7 +17,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "distributed_cluster_name": "query_cluster",
     },
     {
-        "host": os.environ.get("CLICKHOUSE_MIGRATIONS_HOST", "clickhouse-query"),
+        "host": os.environ.get("CLICKHOUSE_HOST", "clickhouse-query"),
         "port": int(os.environ.get("CLICKHOUSE_PORT", 9000)),
         "user": os.environ.get("CLICKHOUSE_USER", "default"),
         "password": os.environ.get("CLICKHOUSE_PASSWORD", ""),
@@ -26,7 +26,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "storage_sets": {
             "migrations",
         },
-        "single_node": True,
+        "single_node": False,
         "cluster_name": "migrations_cluster",
         "distributed_cluster_name": "query_cluster",
     },


### PR DESCRIPTION
**context:**
Adding in `CLICKHOUSE_MIGRATIONS_HOST` so that I can get this to work with https://github.com/getsentry/clickhouse-setup/pull/4. We set `CLICKHOUSE_HOST` here https://github.com/getsentry/snuba/blob/174398093727ebf337fc3a781aa727638eef8cde/docker-compose.gcb.yml#L27 so we can't use that if we want the host to be different, aka `clickhouse-query`.

Also, need the `single_node=False` change in order for the `migrations_local` table to be created on the right node. Having `single_node=True` means that the local tables get created on the query node (with this set up).

The `single_node` fix was done in https://github.com/getsentry/snuba/pull/3304 but got reverted so im just adding it back in here.

This should all one to test out changes to snuba by having the clickhouse-setup docker compose build the new snuba image with the changes.