### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,13 @@ setup-git:
 test:
 	SNUBA_SETTINGS=test pytest -vv tests -v -m "not ci_only"
 
+CLICKHOUSE_IMAGE?=yandex/clickhouse-server:20.3.9.70
+
 test-distributed-migrations:
 	docker build . -t snuba-test
-	SNUBA_IMAGE=snuba-test docker-compose --profile multi_node -f docker-compose.gcb.yml down
-	SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml up -d
-	SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
+	CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE} SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml down
+	CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE} SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml up -d
+	CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE} SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
 
 tests: test
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test
   clickhouse:
-    image: yandex/clickhouse-server:20.3.9.70
+    image: ${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}
     ports:
       - "9000:9000"
       - "9009:9009"

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -26,7 +26,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "storage_sets": {
             "migrations",
         },
-        "single_node": True,
+        "single_node": False,
         "cluster_name": "migrations_cluster",
         "distributed_cluster_name": "query_cluster",
     },


### PR DESCRIPTION
* Fix the make file to use the `CLICKHOUSE_IMAGE` variable if it exists, otherwise set it to `yandex/clickhouse-server:20.3.9.70`; making it compatible with the CI dockerfile change #3292
* Fix a bug where migrations cluster was mistakenly set to single node and writing to the query node instead of cluster