### PR TITLE
fix(consumer): Remove shared producers in consumer

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -188,3 +188,5 @@ def consumer(
     signal.signal(signal.SIGTERM, handler)
 
     consumer.run()
+    consumer_builder.commit_log_producer.close()
+    consumer_builder.replacements_producer.close()

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -188,5 +188,4 @@ def consumer(
     signal.signal(signal.SIGTERM, handler)
 
     consumer.run()
-    consumer_builder.commit_log_producer.close()
-    consumer_builder.replacements_producer.close()
+    consumer_builder.close_producers()

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -187,4 +187,5 @@ def consumer(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    consumer_builder.close(consumer)
+    consumer.run()
+    consumer_builder.flush()

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -187,5 +187,4 @@ def consumer(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    consumer.run()
-    consumer_builder.close_producers()
+    consumer_builder.close(consumer)

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -274,14 +274,18 @@ class ConsumerBuilder:
         return strategy_factory
 
     def close(self, consumer: StreamProcessor[KafkaPayload]) -> None:
-        if not self.commit_log_producer and not self.replacements_producer:
+        if self.commit_log_producer is None and self.replacements_producer is None:
             consumer.run()
 
-        elif self.commit_log_producer and not self.replacements_producer:
+        elif (
+            self.commit_log_producer is not None and self.replacements_producer is None
+        ):
             with closing(self.commit_log_producer):
                 consumer.run()
 
-        elif self.replacements_producer and not self.commit_log_producer:
+        elif (
+            self.replacements_producer is not None and self.commit_log_producer is None
+        ):
             with closing(self.replacements_producer):
                 consumer.run()
 

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -134,12 +134,7 @@ class ConsumerBuilder:
             if commit_log_topic_spec is not None:
                 self.commit_log_topic = Topic(commit_log_topic_spec.topic_name)
                 self.commit_log_producer = Producer(
-                    build_kafka_producer_configuration(commit_log_topic_spec.topic),
-                    bootstrap_servers=kafka_params.bootstrap_servers,
-                    override_params={
-                        "partitioner": "consistent",
-                        "message.max.bytes": 50000000,  # 50MB, default is 1MB)
-                    },
+                    build_kafka_producer_configuration(commit_log_topic_spec.topic)
                 )
             else:
                 self.commit_log_topic = None
@@ -279,4 +274,7 @@ class ConsumerBuilder:
         """
         Builds the consumer.
         """
-        return self.__build_consumer(self.__build_streaming_strategy_factory())
+        processor = self.__build_consumer(self.__build_streaming_strategy_factory())
+        self.commit_log_producer.close()
+        self.replacements_producer.close()
+        return processor

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -273,9 +273,6 @@ class ConsumerBuilder:
         return strategy_factory
 
     def flush(self) -> None:
-        if self.commit_log_producer:
-            self.commit_log_producer.flush()
-
         if self.replacements_producer:
             self.replacements_producer.flush()
 

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -114,7 +114,14 @@ class ConsumerBuilder:
             if replacement_topic_spec is not None:
                 self.replacements_topic = Topic(replacement_topic_spec.topic_name)
                 self.replacements_producer = Producer(
-                    build_kafka_producer_configuration(replacement_topic_spec.topic)
+                    build_kafka_producer_configuration(
+                        replacement_topic_spec.topic,
+                        bootstrap_servers=kafka_params.bootstrap_servers,
+                        override_params={
+                            "partitioner": "consistent",
+                            "message.max.bytes": 50000000,  # 50MB, default is 1MB)
+                        },
+                    )
                 )
             else:
                 self.replacements_topic = None
@@ -127,7 +134,12 @@ class ConsumerBuilder:
             if commit_log_topic_spec is not None:
                 self.commit_log_topic = Topic(commit_log_topic_spec.topic_name)
                 self.commit_log_producer = Producer(
-                    build_kafka_producer_configuration(commit_log_topic_spec.topic)
+                    build_kafka_producer_configuration(commit_log_topic_spec.topic),
+                    bootstrap_servers=kafka_params.bootstrap_servers,
+                    override_params={
+                        "partitioner": "consistent",
+                        "message.max.bytes": 50000000,  # 50MB, default is 1MB)
+                    },
                 )
             else:
                 self.commit_log_topic = None

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -134,7 +134,8 @@ class ConsumerBuilder:
             if commit_log_topic_spec is not None:
                 self.commit_log_topic = Topic(commit_log_topic_spec.topic_name)
                 self.commit_log_producer = Producer(
-                    build_kafka_producer_configuration(commit_log_topic_spec.topic)
+                    build_kafka_producer_configuration(commit_log_topic_spec.topic),
+                    bootstrap_servers=kafka_params.bootstrap_servers,
                 )
             else:
                 self.commit_log_topic = None
@@ -274,7 +275,4 @@ class ConsumerBuilder:
         """
         Builds the consumer.
         """
-        processor = self.__build_consumer(self.__build_streaming_strategy_factory())
-        self.commit_log_producer.close()
-        self.replacements_producer.close()
-        return processor
+        return self.__build_consumer(self.__build_streaming_strategy_factory())


### PR DESCRIPTION
This PR:

- Removes the shared default producer code in the consumer
- Instead, creates a replacements-specific producer and a commit log-specific producer in the respective locations 
- Having dedicated producers is also more similar to how the Multistorage Consumer creates producers (in `snuba/cli/multistorage_consumer.py`). 

This change is not associated with any particular JIRA ticket, but was something I noticed while working on https://github.com/getsentry/snuba/pull/3301. 