### PR TITLE
evanh/fix/revert ci changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,14 +226,8 @@ jobs:
     timeout-minutes: 25
     strategy:
       matrix:
-        snuba_settings: ["test"]
-        clickhouse_image: ['yandex/clickhouse-server:20.3.9.70',
-                           'altinity/clickhouse-server:21.8.13.1.altinitystable']
-        include:
-          - snuba_settings: "test_distributed"
-            clickhouse_image: 'yandex/clickhouse-server:20.3.9.70'
-          - snuba_settings: "test_distributed_migrations"
-            clickhouse_image: 'yandex/clickhouse-server:20.3.9.70'
+        snuba_settings:
+          ["test", "test_distributed", "test_distributed_migrations"]
     steps:
       - uses: actions/checkout@v2
         name: Checkout code
@@ -259,15 +253,13 @@ jobs:
 
       - name: Docker Snuba tests
         run: |
-          export CLICKHOUSE_IMAGE=${{ matrix.clickhouse_image }} &&
           SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker-compose -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings != 'test_distributed_migrations' }}
 
       - name: Docker Snuba Multi-Node Tests
         run: |
-          export CLICKHOUSE_IMAGE=${{ matrix.clickhouse_image }} &&
-          SNUBA_SETTINGS=${{ matrix.snuba_settings }} docker-compose --profile multi_node -f docker-compose.gcb.yml up -d
-          SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=${{ matrix.snuba_settings }} TEST_LOCATION=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
+          SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml up -d
+          SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
         if: ${{ matrix.snuba_settings == 'test_distributed_migrations' }}
 
       - name: Upload to codecov

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,11 @@ setup-git:
 test:
 	SNUBA_SETTINGS=test pytest -vv tests -v -m "not ci_only"
 
-CLICKHOUSE_IMAGE?=yandex/clickhouse-server:20.3.9.70
-
 test-distributed-migrations:
 	docker build . -t snuba-test
-	CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE} SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml down
-	CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE} SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml up -d
-	CLICKHOUSE_IMAGE=${CLICKHOUSE_IMAGE} SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
+	SNUBA_IMAGE=snuba-test docker-compose --profile multi_node -f docker-compose.gcb.yml down
+	SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml up -d
+	SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test_distributed_migrations TEST_LOCATION=test_distributed_migrations docker-compose --profile multi_node -f docker-compose.gcb.yml run --rm snuba-test
 
 tests: test
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,7 +26,6 @@ steps:
       - snuba-test
     env:
       - 'SNUBA_SETTINGS=test'
-      - 'CLICKHOUSE_IMAGE=yandex/clickhouse-server:20.3.9.70'
   # Clean up after tests
   - name: "gcr.io/$PROJECT_ID/docker-compose"
     id: unit-tests-cleanup
@@ -40,9 +39,6 @@ steps:
       - "local"
       - "-v"
       - "--remove-orphans"
-    env:
-      - 'SNUBA_SETTINGS=test'
-      - 'CLICKHOUSE_IMAGE=yandex/clickhouse-server:20.3.9.70'
   - name: "gcr.io/$PROJECT_ID/docker-compose"
     id: get-self-hosted-repo
     waitFor:

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -53,7 +53,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: 'WARN'
       KAFKA_TOOLS_LOG4J_LOGLEVEL: 'WARN'
   clickhouse:
-    image: '$CLICKHOUSE_IMAGE'
+    image: 'yandex/clickhouse-server:20.3.9.70'
     volumes:
       - ./config/clickhouse/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test
   clickhouse:
-    image: ${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}
+    image: yandex/clickhouse-server:20.3.9.70
     ports:
       - "9000:9000"
       - "9009:9009"

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -26,7 +26,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
         "storage_sets": {
             "migrations",
         },
-        "single_node": False,
+        "single_node": True,
         "cluster_name": "migrations_cluster",
         "distributed_cluster_name": "query_cluster",
     },

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -55,7 +55,6 @@ class TestCleanup:
         test_data,
     )
     @patch("snuba.cleanup.current_time")
-    @pytest.mark.skip(reason="This test does not work with clickhouse version 21.8")
     def test_main_cases(
         self,
         current_time: MagicMock,

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -191,8 +191,17 @@ class TestDiscoverApi(BaseApiTest):
             ),
             entity="discover_transactions",
         )
+        data = json.loads(response.data)
 
         assert response.status_code == 200
+        assert data["data"] == [
+            {
+                "type": "transaction",
+                "count": 0,
+                "uniq_group_id": 0,
+                "uniq_ex_stacks": None,
+            }
+        ]
 
         response = self.post(
             json.dumps(


### PR DESCRIPTION
One or both of these changes are blocking master from deploying. Revert both to
unblock deploys and then we can figure out what can be safely added back.

- Revert "use clickhouse image var in makefile and fix migration test cluster bug"
- Revert "ci(clickhouse): Enable running tests against clickhouse version 21.8 (#3292)"