### PR TITLE
ref(migrations): Show all for a specific groups

### DIFF
--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -73,10 +73,10 @@ def test_show_all() -> None:
     )
 
 
-def test_show_all_for_group() -> None:
+def test_show_all_for_groups() -> None:
     runner = Runner()
     migration_key = MigrationKey(MigrationGroup("system"), "0001_migrations")
-    results = runner.show_all("system")
+    results = runner.show_all(["system"])
 
     assert len(results) == 1
     group, migrations = results[0]
@@ -84,7 +84,7 @@ def test_show_all_for_group() -> None:
     assert all([migration.status == Status.NOT_STARTED for migration in migrations])
 
     runner.run_migration(migration_key)
-    results = runner.show_all("system")
+    results = runner.show_all(["system"])
 
     assert len(results) == 1
     group, migrations = results[0]

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -73,6 +73,25 @@ def test_show_all() -> None:
     )
 
 
+def test_show_all_for_group() -> None:
+    runner = Runner()
+    migration_key = MigrationKey(MigrationGroup("system"), "0001_migrations")
+    results = runner.show_all("system")
+
+    assert len(results) == 1
+    group, migrations = results[0]
+    assert group == MigrationGroup("system")
+    assert all([migration.status == Status.NOT_STARTED for migration in migrations])
+
+    runner.run_migration(migration_key)
+    results = runner.show_all("system")
+
+    assert len(results) == 1
+    group, migrations = results[0]
+    assert group == MigrationGroup("system")
+    assert all([migration.status == Status.COMPLETED for migration in migrations])
+
+
 def test_run_migration() -> None:
     runner = Runner()
     runner.run_migration(MigrationKey(MigrationGroup("system"), "0001_migrations"))


### PR DESCRIPTION
**context**
A while back I added an endpoint to get a list of groups and their migration ids https://github.com/getsentry/snuba/pull/3227. What we really want is the status along with the migration ids in addition to information on what migrations can actually be run/reversed.

Right now `show_all()` gets the status for all migration groups, but we want to isolate migration groups based on user permissions. The `migrations/groups/` endpoint should only show you groups you have access to, so I've added the option to get the status for a select amount of groups. 

This will allow us to add to the `migrations/groups` endpoint to do things like:
* check whether the migrations can be run or reversed (e.g. already run migrations can't be run again, migrations cant be reversed if there is a migration after it that is completed)
* check the policies (using whether the migration is blocking or not, and the status)
* return the status, and the results of the checks in the payload so the UI can display that information