### PR TITLE
RFC: InitRecorder

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -227,6 +227,9 @@ TURBO_SAMPLE_RATE = 0.1
 PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 PRETTY_FORMAT_EXPRESSIONS = True
 
+# has no use in any production environment, only useful for local scripts
+ENABLE_INIT_RECORDER = False
+
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
 
 COLUMN_SPLIT_MIN_COLS = 6

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -22,6 +22,11 @@ ENABLE_DEV_FEATURES = True
 # to explore the unrefined Expression structure
 PRETTY_FORMAT_EXPRESSIONS = True
 
+# For converting code storages/entities/datasets to yaml we need to record what
+# arguments certain classes were instantiated with. This has no purpose in a production
+# environment. Thus it is only enabled here
+ENABLE_INIT_RECORDER = True
+
 # override replacer threshold to write to redis every time a replacement message is consumed
 REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms
 

--- a/tests/datasets/storages/test_py_2_yaml.py
+++ b/tests/datasets/storages/test_py_2_yaml.py
@@ -1,0 +1,58 @@
+from abc import ABCMeta
+from copy import deepcopy
+from typing import Any, Dict, Tuple, Type
+
+from snuba import settings
+
+
+class InitRecorder(ABCMeta):
+    """Records the arguments passed to the __init__ function of classes
+    in an init_kwargs member. Only useful if said objects need to be converted
+    to declarative configuration
+
+    Handles positional arguments by inspecting the signature and turning them into kwargs
+    for ease of use
+    """
+
+    def __new__(cls, name: str, bases: Tuple[Type[Any]], dct: Dict[str, Any]) -> Any:
+        res = super().__new__(cls, name, bases, dct)
+        # this is not useful in production in any way, hence this is a noop unless explicitly enabled
+        if settings.ENABLE_INIT_RECORDER:
+            from inspect import signature
+
+            orig_init = getattr(res, "__init__")
+
+            def __init__(self, *args, **kwargs):
+                self.init_kwargs = deepcopy(kwargs)
+                if args:
+                    init_param_names = [p for p in signature(orig_init).parameters]
+                    i = 0
+                    while i < len(args):
+                        self.init_kwargs[init_param_names[i + 1]] = args[i]
+                        i += 1
+                return orig_init(self, *args, **kwargs)
+
+            setattr(res, "__init__", __init__)
+        return res
+
+
+def test_record_init_args():
+    class A(metaclass=InitRecorder):
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+
+    instance = A(a="a", b="b")
+    assert instance.init_kwargs == {"a": "a", "b": "b"}
+
+    instance2 = A("a", "b")
+    assert instance2.init_kwargs == {"a": "a", "b": "b"}
+
+    instance3 = A("a", b="b")
+    assert instance3.init_kwargs == {"a": "a", "b": "b"}
+
+    class NoInit(metaclass=InitRecorder):
+        pass
+
+    no_init_instance = NoInit()
+    assert no_init_instance.init_kwargs == {}


### PR DESCRIPTION
## Why
This is possibly a necessary step to converting the datasets which are in code to configuration automatically

## Blast Radius
This metaclass would be on every Column, QueryProcessor, QuerySplitter, etc. It would be a no-op in any actual production environment and will be removed after the python -> yaml conversion is complete. 

## The problem

Many classes that make up a storage or entity are instantiated with arguments which are then used to drive its behavior. Those arguments are not guaranteed to be accessible after instantiation ([example](https://github.com/getsentry/snuba/blob/master/snuba/query/processors/physical/array_has_optimizer.py#L29)). For these classes to be declared in configuration, we need to know what arguments they were declared with in such a way that we can reliably access them.

## The (proposed) solution

Introduce a temporary metaclass into the classes that are part of the data model declaration. which will allow the inspection of the arguments they were called with. 