### PR TITLE
ref (migrations): allow specifying order in migrations  SNS-1816

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -113,6 +113,9 @@ class ClickhouseNodeMigration(Migration, ABC):
     completely unrelated, they are probably better as separate migrations.
     """
 
+    forwards_local_first: bool = True
+    backwards_local_first: bool = True
+
     @abstractmethod
     def forwards_local(self) -> Sequence[SqlOperation]:
         raise NotImplementedError
@@ -141,10 +144,19 @@ class ClickhouseNodeMigration(Migration, ABC):
         # so do not update status yet
         if not self.is_first_migration():
             update_status(Status.IN_PROGRESS)
-        for op in self.forwards_local():
-            op.execute(local=True)
-        for op in self.forwards_dist():
-            op.execute(local=False)
+
+        local_ops = list(self.forwards_local())
+        dist_ops = list(self.forwards_dist())
+        ops = (
+            local_ops + dist_ops if self.forwards_local_first else dist_ops + local_ops
+        )
+
+        for op in ops:
+            if op in local_ops:
+                op.execute(local=True)
+            if op in dist_ops:
+                op.execute(local=False)
+
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)
 
@@ -156,10 +168,18 @@ class ClickhouseNodeMigration(Migration, ABC):
         migration_id, logger, update_status = context
         logger.info(f"Reversing migration: {migration_id}")
         update_status(Status.IN_PROGRESS)
-        for op in self.backwards_dist():
-            op.execute(local=False)
-        for op in self.backwards_local():
-            op.execute(local=True)
+
+        local_ops = list(self.backwards_local())
+        dist_ops = list(self.backwards_dist())
+        ops = (
+            local_ops + dist_ops if self.backwards_local_first else dist_ops + local_ops
+        )
+
+        for op in ops:
+            if op in local_ops:
+                op.execute(local=True)
+            if op in dist_ops:
+                op.execute(local=False)
         logger.info(f"Finished reversing: {migration_id}")
 
         # The migrations table will be destroyed if the first

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -114,7 +114,7 @@ class ClickhouseNodeMigration(Migration, ABC):
     """
 
     forwards_local_first: bool = True
-    backwards_local_first: bool = True
+    backwards_local_first: bool = False
 
     @abstractmethod
     def forwards_local(self) -> Sequence[SqlOperation]:

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -1,9 +1,13 @@
 import os
-from typing import Sequence
+from logging import Logger
+from typing import Callable, Sequence
+from unittest.mock import Mock
 
 from snuba.clickhouse.columns import Column, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration
 from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.context import Context
 from snuba.migrations.operations import (
     AddColumn,
     AddIndex,
@@ -17,6 +21,7 @@ from snuba.migrations.operations import (
     ModifyTableTTL,
     RemoveTableTTL,
     RenameTable,
+    SqlOperation,
     TruncateTable,
 )
 from snuba.migrations.table_engines import ReplacingMergeTree
@@ -182,3 +187,57 @@ def test_modify_ttl() -> None:
         ).format_sql()
         == "ALTER TABLE test_table REMOVE TTL;"
     )
+
+
+def test_specify_order() -> None:
+    """
+    Test that specifying the migration order works when changing forwards_local_first
+    """
+    create_local_op = Mock(CreateTable)
+    create_dist_op = Mock(CreateTable)
+    drop_local_op = Mock(DropTable)
+    drop_dist_op = Mock(DropTable)
+    logger = Logger("test")
+    context = Context("001", logger, lambda x: None)
+
+    class TestMigration(migration.ClickhouseNodeMigration):
+        blocking = False
+
+        def forwards_local(self) -> Sequence[SqlOperation]:
+            return [create_local_op]
+
+        def backwards_local(self) -> Sequence[SqlOperation]:
+            return [drop_local_op]
+
+        def forwards_dist(self) -> Sequence[SqlOperation]:
+            return [create_dist_op]
+
+        def backwards_dist(self) -> Sequence[SqlOperation]:
+            return [drop_dist_op]
+
+    ops = [create_local_op, create_dist_op, drop_local_op, drop_dist_op]
+    order = []
+    for op in ops:
+
+        def effect(op: Mock) -> Callable[[bool], None]:
+            def add_op(local: bool) -> None:
+                order.append(op)
+
+            return add_op
+
+        op.execute.side_effect = effect(op)
+
+    test_migration = TestMigration()
+    test_migration.forwards(context)
+    assert order == [create_local_op, create_dist_op]
+    order.clear()
+    test_migration.backwards(context, False)
+    assert order == [drop_dist_op, drop_local_op]
+    order.clear()
+    test_migration.forwards_local_first = False
+    test_migration.forwards(context)
+    assert order == [create_dist_op, create_local_op]
+    order.clear()
+    test_migration.backwards_local_first = True
+    test_migration.backwards(context, False)
+    assert order == [drop_local_op, drop_dist_op]


### PR DESCRIPTION
Allow migrations to specify if they want to execute the local ops before distributed ops for run and reverse. This is the first PR in a change in migrations to better handle the order of operations to avoid getting into an inconsistent state.

**Context**
There are certain SQL ops that must be applied to the distributed tables before local tables and vice versa. Right now, our migrations always run local first and this leads to errors.  By introducing the local_first flag, creaters of migrations can specify the correct order.  The follow up to this PR will include a best effort checker that will run test to check that the order specified is consistent with the SQL ops in the migration and will not cause errors.

**Blast Radius**
Migrations Base Class

**Before**
All migrations run local ops before distributed ops

**After** 
Run local ops first by default, but allow users to specify distributed ops first in their migrations.

