### PR TITLE
Fix ClickHouse version check

### DIFF
--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 
 from packaging import version
@@ -47,11 +48,10 @@ def check_clickhouse_connections() -> None:
 
 def check_clickhouse(clickhouse: ClickhousePool) -> None:
     ver = clickhouse.execute("SELECT version()").results[0][0]
-    # The newer versions of altinity on arm add this to the version
-    # and it breaks this check
-    ver = ver.replace(".testingarm", "")
-    ver = ver.replace(".altinitystable", "")
-    if version.parse(ver) < version.parse(CLICKHOUSE_SERVER_MIN_VERSION):
+    ver = re.search("(\d+.\d+.\d+.\d+)", ver)
+    if ver is None or version.parse(ver.group()) < version.parse(
+        CLICKHOUSE_SERVER_MIN_VERSION
+    ):
         raise InvalidClickhouseVersion(
-            f"Snuba requires Clickhouse version {CLICKHOUSE_SERVER_MIN_VERSION} ({clickhouse.host}:{clickhouse.port} - {ver})"
+            f"Snuba requires minimum Clickhouse version {CLICKHOUSE_SERVER_MIN_VERSION} ({clickhouse.host}:{clickhouse.port} - {ver})"
         )


### PR DESCRIPTION
We run custom built ClickHouse and snuba migration command fails with error:

```
  File "/usr/src/snuba/snuba/cli/migrations.py", line 66, in migrate
    check_clickhouse_connections()
  File "/usr/src/snuba/snuba/migrations/connect.py", line 30, in check_clickhouse_connections
    check_clickhouse(clickhouse)
  File "/usr/src/snuba/snuba/migrations/connect.py", line 55, in check_clickhouse
    raise InvalidClickhouseVersion(
snuba.migrations.errors.InvalidClickhouseVersion: Snuba requires Clickhouse version 20.3.9.70 (<REDACTED> - 21.8.10.19-lts-a382a48cdc5)
```

```
>>> version.parse("21.8.10.19-lts-a382a48cdc5") < version.parse("20.3.9.70")
True
>>> version.parse("21.8.10.19") < version.parse("20.3.9.70")
False
```
Current ClickHouse version check replaces the custom version strings.
This commit makes use of regex to extract the ClickHouse version. This would help all users running custom built ClickHouse.

cc: @lynnagara 