### PR TITLE
feat(api): Snuba healthcheck observability

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -468,7 +468,11 @@ def get_cluster(
         res = part_storage_set_cluster_map.get((storage_set_key, slice_id), None)
         if res is None:
             raise UndefinedClickhouseCluster(
-                f"{(storage_set_key, slice_id)} is not defined in the SLICED_CLUSTERS setting for this environment"
+                f"{(storage_set_key, slice_id)} is not defined in the SLICED_CLUSTERS setting for this environment",
+                extra_data={
+                    "storage_set_key_not_defined": storage_set_key,
+                    "slice_id": slice_id,
+                },
             )
 
     else:
@@ -476,6 +480,7 @@ def get_cluster(
         res = storage_set_cluster_map.get(storage_set_key, None)
         if res is None:
             raise UndefinedClickhouseCluster(
-                f"{storage_set_key} is not defined in the CLUSTERS setting for this environment"
+                f"{storage_set_key} is not defined in the CLUSTERS setting for this environment",
+                extra_data={"storage_set_key_not_defined": storage_set_key},
             )
     return res

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -381,6 +381,16 @@ def health() -> Response:
             body["clickhouse_ok"] = clickhouse_health
         status = 502
 
+    if status != 200:
+        metrics.increment(
+            "healthcheck_failed",
+            tags={
+                "down_file_exists": str(down_file_exists),
+                "clickhouse_ok": str(clickhouse_health),
+                "thorough": str(thorough),
+            },
+        )
+
     return Response(json.dumps(body), status, {"Content-Type": "application/json"})
 
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import itertools
 import logging
@@ -37,7 +39,11 @@ from werkzeug.exceptions import InternalServerError
 from snuba import environment, settings, state, util
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.http import JSONRowEncoder
-from snuba.clusters.cluster import ClickhouseClientSettings, ConnectionId
+from snuba.clusters.cluster import (
+    ClickhouseClientSettings,
+    ConnectionId,
+    UndefinedClickhouseCluster,
+)
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.factory import get_entity_name
@@ -111,7 +117,9 @@ else:
             return False
 
 
-def check_clickhouse(ignore_experimental: bool = True) -> bool:
+def check_clickhouse(
+    ignore_experimental: bool = True, metric_tags: dict[str, Any] | None = None
+) -> bool:
     """
     Checks if all the tables in all the enabled datasets exist in ClickHouse
     """
@@ -155,9 +163,24 @@ def check_clickhouse(ignore_experimental: bool = True) -> bool:
             for table in known_table_names:
                 if (table,) not in clickhouse_tables:
                     logger.error(f"{table} not present in cluster {cluster}")
+                    if metric_tags is not None:
+                        metric_tags["table_not_present"] = table
+                        metric_tags["cluster"] = str(cluster)
                     return False
 
         return True
+
+    except UndefinedClickhouseCluster as err:
+        if metric_tags is not None and isinstance(err.extra_data, dict):
+            metric_tags.update(err.extra_data)
+        logger.error(err)
+        return False
+
+    except ClickhouseError as err:
+        if metric_tags and err.__cause__:
+            metric_tags["exception"] = type(err.__cause__).__name__
+        logger.error(err)
+        return False
 
     except Exception as err:
         logger.error(err)
@@ -365,9 +388,21 @@ def config_changes() -> RespTuple:
 
 @application.route("/health")
 def health() -> Response:
+
     down_file_exists = check_down_file_exists()
     thorough = http_request.args.get("thorough", False)
-    clickhouse_health = check_clickhouse(ignore_experimental=True) if thorough else True
+
+    metric_tags = {
+        "down_file_exists": str(down_file_exists),
+        "thorough": str(thorough),
+    }
+
+    clickhouse_health = (
+        check_clickhouse(ignore_experimental=True, metric_tags=metric_tags)
+        if thorough
+        else True
+    )
+    metric_tags["clickhouse_ok"] = str(clickhouse_health)
 
     body: Mapping[str, Union[str, bool]]
     if not down_file_exists and clickhouse_health:
@@ -382,14 +417,9 @@ def health() -> Response:
         status = 502
 
     if status != 200:
-        metrics.increment(
-            "healthcheck_failed",
-            tags={
-                "down_file_exists": str(down_file_exists),
-                "clickhouse_ok": str(clickhouse_health),
-                "thorough": str(thorough),
-            },
-        )
+        metrics.increment("healthcheck_failed", tags=metric_tags)
+
+    print(metric_tags)
 
     return Response(json.dumps(body), status, {"Content-Type": "application/json"})
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -419,8 +419,6 @@ def health() -> Response:
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
 
-    print(metric_tags)
-
     return Response(json.dumps(body), status, {"Content-Type": "application/json"})
 
 


### PR DESCRIPTION
### Overview
- Closes [SNS-1740](https://getsentry.atlassian.net/browse/SNS-1740)
- This PR introduces a new `healthcheck_failed` metric for non 200 responses in the Snuba API `/health` route
    - The metric also records a couple relevant booleans as tags

As far as Clickhouse goes, I believe we are already logging the errors on health check:

https://github.com/getsentry/snuba/blob/ed5cbef9086204cbd5dc105a4a69091f96080ba6/snuba/web/views.py#L155-L164

We can check Sentry/GCP logs for when we see a failed health check where `clickhouse_ok` is `False`