### PR TITLE
feat: Pass the slice_id to storage.get_cluster()

### DIFF
--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -39,8 +39,8 @@ class Storage(ABC):
     def get_storage_set_key(self) -> StorageSetKey:
         return self.__storage_set_key
 
-    def get_cluster(self) -> ClickhouseCluster:
-        return get_cluster(self.__storage_set_key)
+    def get_cluster(self, slice_id: Optional[int] = None) -> ClickhouseCluster:
+        return get_cluster(self.__storage_set_key, slice_id)
 
     def get_schema(self) -> Schema:
         return self.__schema


### PR DESCRIPTION
For a sliced storage, this function would return the wrong cluster unless we pass the slice_id along. Defaults to None for backward compatibility - not everything is slice aware yet.