### PR TITLE
feat: Make multistorage consumer dlq respect the policy defined

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -34,9 +34,6 @@ from arroyo.processing.strategies.dead_letter_queue import (
     InvalidKafkaMessage,
     InvalidMessages,
 )
-from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
-    DeadLetterQueue,
-)
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
@@ -785,6 +782,7 @@ class MultistorageConsumerProcessingStrategyFactory(
             output_block_size=output_block_size,
             initialize_parallel_transform=initialize_parallel_transform,
             parallel_collect=parallel_collect,
+            dead_letter_queue_policy_creator=self.__dead_letter_policy_creator,
         )
 
     def create_with_partitions(
@@ -792,16 +790,10 @@ class MultistorageConsumerProcessingStrategyFactory(
         commit: Callable[[Mapping[Partition, Position]], None],
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
-        strategy: ProcessingStrategy[KafkaPayload]
-        strategy = TransformStep(
+        return TransformStep(
             partial(find_destination_storages, self.__storages),
             FilterStep(
                 has_destination_storages,
                 self.__inner_factory.create_with_partitions(commit, partitions),
             ),
         )
-
-        if self.__dead_letter_policy_creator:
-            strategy = DeadLetterQueue(strategy, self.__dead_letter_policy_creator())
-
-        return strategy

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -762,8 +762,6 @@ class MultistorageConsumerProcessingStrategyFactory(
         self.__storages = storages
         self.__metrics = metrics
         self.__dead_letter_policy_creator = dead_letter_policy_creator
-        # self.__producer = producer
-        # self.__topic = topic
 
         self.__process_message_fn = process_message_multistorage
         if any(

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -1,15 +1,13 @@
 import itertools
 import logging
 import time
-from collections import defaultdict, deque
-from concurrent.futures import Future
+from collections import defaultdict
 from datetime import datetime
 from functools import partial
 from pickle import PickleBuffer
 from typing import (
     Any,
     Callable,
-    Deque,
     Dict,
     List,
     Mapping,
@@ -27,7 +25,6 @@ from typing import (
 
 import rapidjson
 from arroyo import Message, Partition, Topic
-from arroyo.backends.abstract import Producer as AbstractProducer
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.processing.strategies import FilterStep
 from arroyo.processing.strategies import ProcessingStrategy
@@ -36,6 +33,12 @@ from arroyo.processing.strategies import ProcessingStrategyFactory, TransformSte
 from arroyo.processing.strategies.dead_letter_queue import (
     InvalidKafkaMessage,
     InvalidMessages,
+)
+from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
+    DeadLetterQueue,
+)
+from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
+    DeadLetterQueuePolicy,
 )
 from arroyo.processing.strategies.factory import (
     ConsumerStrategyFactory,
@@ -391,98 +394,6 @@ def build_mock_batch_writer(
     return build_writer
 
 
-class DeadLetterStep(
-    ProcessingStep[Tuple[StorageKey, Union[None, BytesInsertBatch, ReplacementBatch]]]
-):
-    """
-    If a batch failed to be inserted to ClickHouse for some reason, we put those messages
-    into a dead letter topic so that they can be consumed later and tried again.
-
-    This is only possible for the MultiStorageConsumerFactory right now, and it is an
-    optional step for the MultistorageCollector. Additionally, this is only enabled if
-    the storages have `ignore_errors` set to True.
-
-    """
-
-    def __init__(
-        self,
-        producer: AbstractProducer[KafkaPayload],
-        topic: Topic,
-        metrics: MetricsBackend,
-    ):
-        self.__producer = producer
-        self.__topic = topic
-        self.__metrics = metrics
-        self.__futures: Deque[Future[Message[KafkaPayload]]] = deque()
-        self.__closed = False
-
-    def __format_payload(
-        self,
-        message: Message[
-            Tuple[StorageKey, Union[None, BytesInsertBatch, ReplacementBatch]]
-        ],
-    ) -> List[KafkaPayload]:
-        kafka_payloads: List[KafkaPayload] = []
-        storage_key, payload = message.payload
-        if isinstance(payload, BytesInsertBatch):
-            for row in payload.rows:
-                kafka_payloads.append(
-                    KafkaPayload(storage_key.value.encode("utf-8"), row, [])
-                )
-        return kafka_payloads
-
-    def poll(self) -> None:
-        pass
-
-    def submit(
-        self,
-        message: Message[
-            Tuple[StorageKey, Union[None, BytesInsertBatch, ReplacementBatch]]
-        ],
-    ) -> None:
-        submit_start = time.time()
-        payloads = self.__format_payload(message)
-
-        produce_start = time.time()
-        for payload in payloads:
-            self.__futures.append(self.__producer.produce(self.__topic, payload))
-        submit_end = time.time()
-
-        submit_duration_ms = (submit_end - submit_start) * 1000.0
-        produce_duration_ms = (submit_end - produce_start) * 1000.0
-        self.__metrics.timing("dead_letter_step.submit_duration_ms", submit_duration_ms)
-        self.__metrics.timing(
-            "dead_letter_step.produce_duration_ms", produce_duration_ms
-        )
-
-    def close(self) -> None:
-        self.__closed = True
-
-    def terminate(self) -> None:
-        self.__closed = True
-
-    def join(self, timeout: Optional[float] = None) -> None:
-        start = time.time()
-
-        while self.__futures:
-            if not timeout or timeout < time.time() - start:
-                self.__metrics.increment(
-                    "dead_letter_step.join_error", tags={"reason": "timeout"}
-                )
-                break
-            if self.__futures[0].done():
-                future = self.__futures.popleft()
-                try:
-                    future.result()
-                except Exception:
-                    self.__metrics.increment(
-                        "dead_letter_step.join_error", tags={"reason": "exception"}
-                    )
-                    logger.warning(
-                        "Failed dead letter queue future result", exc_info=True
-                    )
-
-
 class MultistorageCollector(
     ProcessingStep[
         Sequence[Tuple[StorageKey, Union[None, BytesInsertBatch, ReplacementBatch]]]
@@ -494,17 +405,11 @@ class MultistorageCollector(
             StorageKey,
             ProcessingStep[Union[None, BytesInsertBatch, ReplacementBatch]],
         ],
-        dead_letter_step: Optional[
-            ProcessingStep[
-                Tuple[StorageKey, Union[None, BytesInsertBatch, ReplacementBatch]]
-            ]
-        ],
         ignore_errors: Optional[Set[StorageKey]] = None,
     ):
         self.__steps = steps
         self.__closed = False
         self.__ignore_errors = ignore_errors
-        self.__dead_letter_step = dead_letter_step
         self.__messages: MutableMapping[
             StorageKey,
             List[
@@ -552,29 +457,13 @@ class MultistorageCollector(
         self.__closed = True
 
         for storage_key, step in self.__steps.items():
-            if self.__ignore_errors and storage_key in self.__ignore_errors:
-                try:
-                    step.close()
-                except Exception as e:
-                    messages = self.__messages[storage_key]
-                    if self.__dead_letter_step and messages:
-                        logger.info(
-                            f"Submitting {len(messages)} {storage_key.value} messages to dead letter step..."
-                        )
-                        for message in self.__messages[storage_key]:
-                            self.__dead_letter_step.submit(message)
-                    logger.warning("Error while writing data to clickhouse", exc_info=e)
-            else:
-                step.close()
+            step.close()
 
     def terminate(self) -> None:
         self.__closed = True
 
         for step in self.__steps.values():
             step.terminate()
-
-        if self.__dead_letter_step:
-            self.__dead_letter_step.terminate()
 
     def join(self, timeout: Optional[float] = None) -> None:
         start = time.time()
@@ -590,9 +479,6 @@ class MultistorageCollector(
             step.join(timeout_remaining)
 
         self.__messages = {}
-        if self.__dead_letter_step:
-            # timeout of 5.0 was set arbitrarily, can be changed
-            self.__dead_letter_step.join(5.0)
 
 
 class MultistorageKafkaPayload(NamedTuple):
@@ -827,16 +713,7 @@ def build_multistorage_batch_writer(
 def build_collector(
     metrics: MetricsBackend,
     storages: Sequence[WritableTableStorage],
-    topic: Optional[Topic],
-    producer: Optional[ConfluentKafkaProducer] = None,
 ) -> ProcessingStep[MultistorageProcessedMessage]:
-    dead_letter_step: Optional[DeadLetterStep] = None
-    if producer and topic:
-        dead_letter_step = DeadLetterStep(
-            producer=producer,
-            topic=topic,
-            metrics=metrics,
-        )
     return MultistorageCollector(
         {
             storage.get_storage_key(): build_multistorage_batch_writer(metrics, storage)
@@ -847,7 +724,6 @@ def build_collector(
             for storage in storages
             if storage.get_is_write_error_ignorable() is True
         },
-        dead_letter_step=dead_letter_step,
     )
 
 
@@ -869,10 +745,9 @@ class MultistorageConsumerProcessingStrategyFactory(
         input_block_size: Optional[int],
         output_block_size: Optional[int],
         metrics: MetricsBackend,
-        producer: Optional[AbstractProducer[KafkaPayload]],
-        topic: Optional[Topic],
+        dead_letter_policy_creator: Optional[Callable[[], DeadLetterQueuePolicy]],
         initialize_parallel_transform: Optional[Callable[[], None]] = None,
-    ):
+    ) -> None:
         if processes is not None:
             assert input_block_size is not None, "input block size required"
             assert output_block_size is not None, "output block size required"
@@ -886,8 +761,9 @@ class MultistorageConsumerProcessingStrategyFactory(
 
         self.__storages = storages
         self.__metrics = metrics
-        self.__producer = producer
-        self.__topic = topic
+        self.__dead_letter_policy_creator = dead_letter_policy_creator
+        # self.__producer = producer
+        # self.__topic = topic
 
         self.__process_message_fn = process_message_multistorage
         if any(
@@ -903,8 +779,6 @@ class MultistorageConsumerProcessingStrategyFactory(
                 build_collector,
                 self.__metrics,
                 self.__storages,
-                self.__topic,
-                self.__producer,
             ),
             max_batch_size=max_batch_size,
             max_batch_time=max_batch_time,
@@ -920,10 +794,16 @@ class MultistorageConsumerProcessingStrategyFactory(
         commit: Callable[[Mapping[Partition, Position]], None],
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
-        return TransformStep(
+        strategy: ProcessingStrategy[KafkaPayload]
+        strategy = TransformStep(
             partial(find_destination_storages, self.__storages),
             FilterStep(
                 has_destination_storages,
                 self.__inner_factory.create_with_partitions(commit, partitions),
             ),
         )
+
+        if self.__dead_letter_policy_creator:
+            strategy = DeadLetterQueue(strategy, self.__dead_letter_policy_creator())
+
+        return strategy

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -10,16 +10,12 @@ from unittest.mock import Mock, call
 import pytest
 from arroyo import Message, Partition, Topic
 from arroyo.backends.kafka import KafkaPayload
-from arroyo.backends.local.backend import LocalBroker as Broker
-from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.processing.strategies.factory import KafkaConsumerStrategyFactory
 from arroyo.types import Position
-from arroyo.utils.clock import TestingClock
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.consumer import (
     BytesInsertBatch,
-    DeadLetterStep,
     InsertBatchWriter,
     MultistorageConsumerProcessingStrategyFactory,
     ProcessedMessageBatchWriter,
@@ -210,54 +206,6 @@ def test_multistorage_strategy(
         ):
             strategy.close()
             strategy.join()
-
-
-def test_dead_letter_step() -> None:
-    from snuba.datasets.storages.storage_key import StorageKey
-
-    clock = TestingClock()
-    broker: Broker[KafkaPayload] = Broker(MemoryMessageStorage(), clock)
-
-    topic = Topic("test-dlq")
-
-    broker.create_topic(topic, partitions=1)
-
-    producer = broker.get_producer()
-
-    dead_letter_step = DeadLetterStep(
-        producer=producer, topic=topic, metrics=TestingMetricsBackend()
-    )
-    storage_key = StorageKey.ERRORS
-
-    # We only produce to dead letter topic if the payload is an insert
-    # so payload of `None` shouldn't produce any futures
-    none_message = Message(
-        Partition(Topic("topic"), 0),
-        0,
-        (storage_key, None),
-        datetime.now(),
-    )
-    dead_letter_step.submit(none_message)
-    assert not dead_letter_step._DeadLetterStep__futures
-
-    # We only produce to dead letter topic if the payload is an insert
-    # so we should see futures with BytesInsertBatch payloads
-    insert_payload = BytesInsertBatch(rows=[b""], origin_timestamp=None)
-    insert_message = Message(
-        Partition(Topic("topic"), 0),
-        1,
-        (storage_key, insert_payload),
-        datetime.now(),
-    )
-    dead_letter_step.submit(insert_message)
-    assert len(dead_letter_step._DeadLetterStep__futures) == 1
-
-    # dead letter join must be called with a timeout because the close()
-    # step of the previous strategy is what calls the submit() of the
-    # dead letter step.
-    dead_letter_step.close()
-    dead_letter_step.join(5.0)
-    assert not dead_letter_step._DeadLetterStep__futures
 
 
 def test_metrics_writing_e2e() -> None:


### PR DESCRIPTION
Currently the multistorage consumer completely ignores the policy defined on the storage itself and just applies it's own policy which produces the message to a topic. This is wrong and also different to how the main consumer works where the policy defined on the storage is the one that is used. It was also applied on a different part of the pipeline (only wraps the collector step). This also means the collector implementation was inconsistent in the two consumer variants.

When this hack was first introduced, it's likely there were practical reasons we needed this at Sentry, but since this particular code path (multistorage consumer with dlq) is never used today, those obviously don't exist anymore.

This is a step on the path to folding the multistorage consumer into the main consumer and making them behave in the same way.
