### PR TITLE
fix: Skip negative project IDs in querylog processor

### DIFF
--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -257,3 +257,80 @@ def test_missing_fields() -> None:
             ],
             None,
         )
+
+
+def test_negative_project_id_fields() -> None:
+    request_body = {
+        "selected_columns": ["event_id"],
+        "orderby": "event_id",
+        "sample": 0.1,
+        "limit": 100,
+        "offset": 50,
+        "project": -11,
+    }
+
+    query = Query(
+        Entity(EntityKey.EVENTS, get_entity(EntityKey.EVENTS).get_data_model())
+    )
+
+    request = Request(
+        id=uuid.UUID("a" * 32).hex,
+        original_body=request_body,
+        query=query,
+        snql_anonymized="",
+        query_settings=HTTPQuerySettings(referrer="search"),
+        attribution_info=AttributionInfo(
+            get_app_id("default"), "search", None, None, None
+        ),
+    )
+
+    time = TestingClock()
+
+    timer = Timer("test", clock=time)
+    time.sleep(0.01)
+
+    message = SnubaQueryMetadata(
+        request=request,
+        start_timestamp=None,
+        end_timestamp=None,
+        dataset="events",
+        timer=timer,
+        query_list=[
+            ClickhouseQueryMetadata(
+                sql="select event_id from sentry_dist sample 0.1 prewhere project_id in (-11) limit 50, 100",
+                sql_anonymized="select event_id from sentry_dist sample 0.1 prewhere project_id in ($I) limit 50, 100",
+                start_timestamp=None,
+                end_timestamp=None,
+                stats={"sample": 10},
+                status=QueryStatus.SUCCESS,
+                profile=ClickhouseQueryProfile(
+                    time_range=10,
+                    table="events",
+                    all_columns={"timestamp", "tags"},
+                    multi_level_condition=False,
+                    where_profile=FilterProfile(
+                        columns={"timestamp"},
+                        mapping_cols={"tags"},
+                    ),
+                    groupby_cols=set(),
+                    array_join_cols=set(),
+                ),
+                trace_id="b" * 32,
+            )
+        ],
+        projects={-2},
+        snql_anonymized=request.snql_anonymized,
+        entity=EntityKey.EVENTS.value,
+    ).to_dict()
+
+    processor = (
+        get_writable_storage(StorageKey.QUERYLOG)
+        .get_table_writer()
+        .get_stream_loader()
+        .get_processor()
+    )
+
+    assert (
+        processor.process_message(message, KafkaMessageMetadata(0, 0, datetime.now()))
+        is None
+    )


### PR DESCRIPTION
A negative project ID got into the querylog processor which was causing
Clickhouse writer failures downstream. Skip and log messages with negative
project IDs for now.

References INC-251