### PR TITLE
feat(replays): Add additional parsing safety to integer and datetime column types

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -86,7 +86,7 @@ class ReplaysProcessor(DatasetMessageProcessor):
     ) -> None:
         processed["replay_id"] = str(uuid.UUID(replay_event["replay_id"]))
         processed["segment_id"] = maybe(
-            coerce_segment_id, replay_event.get("segment_id")
+            _coerce_segment_id, replay_event.get("segment_id")
         )
         processed["trace_ids"] = self.__process_trace_ids(replay_event.get("trace_ids"))
 
@@ -251,11 +251,6 @@ def maybe(into: Callable[[T], U], value: T | None) -> U | None:
     return None if value is None else into(value)
 
 
-def coerce_segment_id(value: Any) -> int:
-    """Return a 16-bit integer or err."""
-    return _collapse_or_err(_collapse_uint16, _intify(value))
-
-
 def stringify(value: Any) -> str:
     """Return a string or err.
 
@@ -309,6 +304,11 @@ def _collapse_or_err(callable: Callable[[int], int | None], value: int) -> int:
 def _timestamp_to_datetime(timestamp: int) -> datetime:
     """Convert an integer timestamp to a timezone-aware utc datetime instance."""
     return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+def _coerce_segment_id(value: Any) -> int:
+    """Return a 16-bit integer or err."""
+    return _collapse_or_err(_collapse_uint16, _intify(value))
 
 
 def utcnow() -> datetime:

--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -276,19 +276,7 @@ def datetimeify(value: Any) -> datetime:
 
     Datetimes for the replays schema standardize on 32 bit dates.
     """
-    return _timestamp_to_datetime(_collapse_or_err(_collapse_uint32, _intify(value)))
-
-
-def _intify(value: Any) -> int:
-    """Return an integer or err."""
-    if isinstance(value, int):
-        return value
-    elif isinstance(value, (str, float)):
-        return int(value)
-    else:
-        raise TypeError(
-            f'Expected value of type "int"; received "{type(value)}" with a value of "{value}".'
-        )
+    return _timestamp_to_datetime(_collapse_or_err(_collapse_uint32, int(value)))
 
 
 def _collapse_or_err(callable: Callable[[int], int | None], value: int) -> int:
@@ -308,7 +296,7 @@ def _timestamp_to_datetime(timestamp: int) -> datetime:
 
 def _coerce_segment_id(value: Any) -> int:
     """Return a 16-bit integer or err."""
-    return _collapse_or_err(_collapse_uint16, _intify(value))
+    return _collapse_or_err(_collapse_uint16, int(value))
 
 
 def utcnow() -> datetime:

--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -96,7 +96,7 @@ class ReplaysProcessor(DatasetMessageProcessor):
         processed["trace_ids"] = self.__process_trace_ids(replay_event.get("trace_ids"))
 
         processed["timestamp"] = default(
-            maybe(datetimeify, replay_event.get("timestamp")), utcnow()
+            utcnow, maybe(datetimeify, replay_event.get("timestamp"))
         )
         processed["replay_start_timestamp"] = maybe(
             datetimeify, replay_event.get("replay_start_timestamp")
@@ -244,12 +244,12 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
-def default(value: Any, default: Any) -> Any:
+def default(default: Callable[[], T], value: T | None) -> T:
     """Return a default value only if the given value was null.
 
     Falsey types such as 0, "", False, [], {} are returned.
     """
-    return default if value is None else value
+    return default() if value is None else value
 
 
 def maybe(into: Callable[[T], U], value: T | None) -> U | None:

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -12,8 +12,8 @@ import pytest
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.processors.replays_processor import (
     ReplaysProcessor,
+    _coerce_segment_id,
     _timestamp_to_datetime,
-    coerce_segment_id,
     datetimeify,
     maybe,
     normalize_tags,
@@ -411,18 +411,18 @@ class TestReplaysProcessor:
         ReplaysProcessor().process_message(message.serialize(), meta)
 
     def test_coerce_segment_id(self) -> None:
-        """Test "coerce_segment_id" function."""
-        assert coerce_segment_id(0) == 0
-        assert coerce_segment_id(65535) == 65535
-        assert coerce_segment_id(1.25) == 1
-        assert coerce_segment_id("1") == 1
+        """Test "_coerce_segment_id" function."""
+        assert _coerce_segment_id(0) == 0
+        assert _coerce_segment_id(65535) == 65535
+        assert _coerce_segment_id(1.25) == 1
+        assert _coerce_segment_id("1") == 1
 
         with pytest.raises(ValueError):
-            coerce_segment_id(65536)
+            _coerce_segment_id(65536)
         with pytest.raises(ValueError):
-            coerce_segment_id(-1)
+            _coerce_segment_id(-1)
         with pytest.raises(TypeError):
-            coerce_segment_id([1])
+            _coerce_segment_id([1])
 
     def test_datetimeify(self) -> None:
         """Test "datetimeify" function."""


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/193

- Strictly collapses integers or errs.
- Generates timezone aware datetimes from integer timestamps.
- Defaults to timezone aware utc now.
- Adds missing key safety for default-able fields.