### PR TITLE
feat(migrations): add migration order validator SNS-1831

### DIFF
--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -62,12 +62,12 @@ class CreateTable(SqlOperation):
         super().__init__(storage_set)
         self.table_name = table_name
         self.__columns = columns
-        self.__engine = engine
+        self.engine = engine
 
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
         cluster = get_cluster(self._storage_set)
-        engine = self.__engine.get_sql(cluster, self.table_name)
+        engine = self.engine.get_sql(cluster, self.table_name)
 
         return (
             f"CREATE TABLE IF NOT EXISTS {self.table_name} ({columns}) ENGINE {engine};"

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -60,16 +60,18 @@ class CreateTable(SqlOperation):
         engine: TableEngine,
     ):
         super().__init__(storage_set)
-        self.__table_name = table_name
+        self.table_name = table_name
         self.__columns = columns
         self.__engine = engine
 
     def format_sql(self) -> str:
         columns = ", ".join([col.for_schema() for col in self.__columns])
         cluster = get_cluster(self._storage_set)
-        engine = self.__engine.get_sql(cluster, self.__table_name)
+        engine = self.__engine.get_sql(cluster, self.table_name)
 
-        return f"CREATE TABLE IF NOT EXISTS {self.__table_name} ({columns}) ENGINE {engine};"
+        return (
+            f"CREATE TABLE IF NOT EXISTS {self.table_name} ({columns}) ENGINE {engine};"
+        )
 
 
 class CreateMaterializedView(SqlOperation):
@@ -188,14 +190,14 @@ class AddColumn(SqlOperation):
         after: Optional[str] = None,
     ):
         super().__init__(storage_set)
-        self.__table_name = table_name
-        self.__column = column
+        self.table_name = table_name
+        self.column = column
         self.__after = after
 
     def format_sql(self) -> str:
-        column = self.__column.for_schema()
+        column = self.column.for_schema()
         optional_after_clause = f" AFTER {self.__after}" if self.__after else ""
-        return f"ALTER TABLE {self.__table_name} ADD COLUMN IF NOT EXISTS {column}{optional_after_clause};"
+        return f"ALTER TABLE {self.table_name} ADD COLUMN IF NOT EXISTS {column}{optional_after_clause};"
 
 
 class DropColumn(SqlOperation):
@@ -211,11 +213,13 @@ class DropColumn(SqlOperation):
 
     def __init__(self, storage_set: StorageSetKey, table_name: str, column_name: str):
         super().__init__(storage_set)
-        self.__table_name = table_name
-        self.__column_name = column_name
+        self.table_name = table_name
+        self.column_name = column_name
 
     def format_sql(self) -> str:
-        return f"ALTER TABLE {self.__table_name} DROP COLUMN IF EXISTS {self.__column_name};"
+        return (
+            f"ALTER TABLE {self.table_name} DROP COLUMN IF EXISTS {self.column_name};"
+        )
 
 
 class ModifyColumn(SqlOperation):

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -1,0 +1,159 @@
+import re
+from typing import Union
+
+from snuba.clickhouse.native import ClickhousePool
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.operations import AddColumn, CreateTable, DropColumn, SqlOperation
+
+ENGINE_REGEX = r"^Distributed(\(.+\))$"
+
+
+class InvalidMigrationOrderError(Exception):
+    """
+    Raised when a migration ops are not in the correct order.
+    """
+
+    pass
+
+
+class NoDistClusterNodes(Exception):
+    """
+    The migration has no distributed cluster nodes, so we can't validate the order.
+    """
+
+    pass
+
+
+def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
+    """
+    Validates that the migration order is correct. Chesk that the order of
+    AddColumn, CreateTable and DropColumn operations are correct with reagards to being
+    applied on local and distributed tables.
+    """
+    local_ops = migration.forwards_local()
+    dist_ops = migration.forwards_dist()
+
+    if migration.forwards_local_first:
+        for dist_op in dist_ops:
+            if isinstance(dist_op, DropColumn):
+                if any(
+                    conflicts_drop_column_op(local_op, dist_op)
+                    for local_op in local_ops
+                    if isinstance(local_op, DropColumn)
+                ):
+                    raise InvalidMigrationOrderError(
+                        f"DropColumn {dist_op.table_name}.{dist_op.column_name} operation must applied on dist table before local"
+                    )
+
+    else:
+        for local_op in local_ops:
+            if isinstance(local_op, AddColumn):
+                if any(
+                    conflicts_add_column_op(local_op, dist_op)
+                    for dist_op in dist_ops
+                    if isinstance(dist_op, AddColumn)
+                ):
+                    raise InvalidMigrationOrderError(
+                        f"AddColumn {local_op.table_name}.{local_op.column.name} operation must applied on local table before dist"
+                    )
+
+            if isinstance(local_op, CreateTable):
+                if any(
+                    conflicts_create_table_op(local_op, dist_op)
+                    for dist_op in dist_ops
+                    if isinstance(dist_op, CreateTable)
+                ):
+                    raise InvalidMigrationOrderError(
+                        f"CreateTable {local_op.table_name} operation must applied on local table before dist"
+                    )
+
+
+def conflicts_create_table_op(
+    local_create: CreateTable, dist_create: CreateTable
+) -> bool:
+    """
+    Returns True if create table operation and local create table operation
+    target same underlying local table.
+    """
+    if local_create._storage_set != dist_create._storage_set:
+        return False
+    try:
+        if local_create.table_name == _get_local_table_name(dist_create):
+            return True
+    except NoDistClusterNodes:
+        # If there are no distributed nodes, we can't validate the order.
+        pass
+
+    return False
+
+
+def conflicts_add_column_op(local_add: AddColumn, dist_add: AddColumn) -> bool:
+    """
+    Returns True if distributed add column operation and local add column operation
+    target the same column and same underlying local table.
+    """
+    if (
+        local_add.column != dist_add.column
+        or local_add._storage_set != dist_add._storage_set
+    ):
+        return False
+    try:
+        if local_add.table_name == _get_local_table_name(dist_add):
+            return True
+    except NoDistClusterNodes:
+        # If there are no distributed nodes, we can't validate the order.
+        pass
+
+    return False
+
+
+def conflicts_drop_column_op(local_drop: DropColumn, dist_drop: DropColumn) -> bool:
+    """
+    Returns True if distributed drop column operation and local drop column operation
+    target the same column and same underlying local table.
+    """
+
+    if (
+        local_drop.column_name != dist_drop.column_name
+        or local_drop._storage_set != dist_drop._storage_set
+    ):
+        return False
+    try:
+        if local_drop.table_name == _get_local_table_name(dist_drop):
+            return True
+    except NoDistClusterNodes:
+        # If there are no distributed nodes, we can't validate the order.
+        pass
+
+    return False
+
+
+def _get_dist_connection(dist_op: SqlOperation) -> ClickhousePool:
+    cluster = get_cluster(dist_op._storage_set)
+    nodes = cluster.get_distributed_nodes()
+    if not nodes:
+        raise NoDistClusterNodes(f"No distributed nodes for {dist_op._storage_set}")
+    node = nodes[0]
+    connection = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, node)
+    return connection
+
+
+def _get_local_table_name(dist_op: Union[CreateTable, AddColumn, DropColumn]) -> str:
+    """
+    Returns the local table name for a distributed table.
+    """
+    clickhouse = _get_dist_connection(dist_op)
+    dist_table_name = dist_op.table_name
+    engine: str = clickhouse.execute(
+        f"SELECT engine_full FROM system.tables WHERE name = '{dist_table_name}' AND database = '{clickhouse.database}'"
+    ).results[0][0]
+
+    params = re.match(ENGINE_REGEX, engine)
+    assert (
+        params
+    ), f"Cannot match engine {engine} for distributed table {dist_table_name}"
+
+    dist_engine_args = params.group(1)[1:-1].split(",")
+    local_table_name = dist_engine_args[2].strip()
+    return local_table_name.strip("'")

--- a/snuba/snuba_migrations/events/0016_drop_legacy_events.py
+++ b/snuba/snuba_migrations/events/0016_drop_legacy_events.py
@@ -123,6 +123,8 @@ class Migration(migration.ClickhouseNodeMigration):
     """
 
     blocking = False
+    forwards_local_first: bool = False
+    backwards_local_first: bool = True
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [

--- a/snuba/snuba_migrations/profiles/0004_drop_profile_column.py
+++ b/snuba/snuba_migrations/profiles/0004_drop_profile_column.py
@@ -8,6 +8,8 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
+    forwards_local_first: bool = False
+    backwards_local_first: bool = True
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [

--- a/snuba/snuba_migrations/transactions/0014_transactions_remove_flattened_columns.py
+++ b/snuba/snuba_migrations/transactions/0014_transactions_remove_flattened_columns.py
@@ -8,6 +8,8 @@ from snuba.migrations import migration, operations
 class Migration(migration.ClickhouseNodeMigration):
 
     blocking = False
+    forwards_local_first: bool = False
+    backwards_local_first: bool = True
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3,14 +3,11 @@ from logging import Logger
 from typing import Callable, Sequence
 from unittest.mock import Mock
 
-import pytest
-
 from snuba.clickhouse.columns import Column, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.context import Context
-from snuba.migrations.groups import MigrationGroup, get_group_loader
 from snuba.migrations.operations import (
     AddColumn,
     AddIndex,
@@ -28,7 +25,6 @@ from snuba.migrations.operations import (
     TruncateTable,
 )
 from snuba.migrations.table_engines import ReplacingMergeTree
-from snuba.migrations.validator import validate_migration_order
 from snuba.utils.schemas import DateTime
 
 
@@ -245,14 +241,3 @@ def test_specify_order() -> None:
     test_migration.backwards_local_first = True
     test_migration.backwards(context, False)
     assert order == [drop_local_op, drop_dist_op]
-
-
-@pytest.mark.ci_only
-def test_validate_migrations() -> None:
-    for group in MigrationGroup:
-        group_loader = get_group_loader(group)
-
-        for migration_id in group_loader.get_migrations():
-            snuba_migration = group_loader.load_migration(migration_id)
-            if isinstance(snuba_migration, migration.ClickhouseNodeMigration):
-                validate_migration_order(snuba_migration)

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -3,11 +3,14 @@ from logging import Logger
 from typing import Callable, Sequence
 from unittest.mock import Mock
 
+import pytest
+
 from snuba.clickhouse.columns import Column, String, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.context import Context
+from snuba.migrations.groups import MigrationGroup, get_group_loader
 from snuba.migrations.operations import (
     AddColumn,
     AddIndex,
@@ -25,6 +28,7 @@ from snuba.migrations.operations import (
     TruncateTable,
 )
 from snuba.migrations.table_engines import ReplacingMergeTree
+from snuba.migrations.validator import validate_migration_order
 from snuba.utils.schemas import DateTime
 
 
@@ -241,3 +245,14 @@ def test_specify_order() -> None:
     test_migration.backwards_local_first = True
     test_migration.backwards(context, False)
     assert order == [drop_local_op, drop_dist_op]
+
+
+@pytest.mark.ci_only
+def test_validate_migrations() -> None:
+    for group in MigrationGroup:
+        group_loader = get_group_loader(group)
+
+        for migration_id in group_loader.get_migrations():
+            snuba_migration = group_loader.load_migration(migration_id)
+            if isinstance(snuba_migration, migration.ClickhouseNodeMigration):
+                validate_migration_order(snuba_migration)

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -23,6 +23,9 @@ from snuba.migrations.validator import (
 
 
 def test_validate_all_migrations() -> None:
+    """
+    Runs the migration validator on all existing migrations.
+    """
     for group in MigrationGroup:
         group_loader = get_group_loader(group)
 
@@ -213,8 +216,6 @@ def test_conflicts(mock_get_local_table_name: Mock) -> None:
     """
     Test that the conlicts functions detect conflicting SQL operations that target the same table.
     """
-    # database = os.environ.get("CLICKHOUSE_DATABASE", "default")
-    # dist_to_local: Dict[SqlOperation, str] = {}
     storage = StorageSetKey.EVENTS
 
     def _dist_to_local(op: Union[CreateTable, AddColumn, DropColumn]) -> str:

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -200,7 +200,7 @@ def test_parse_engine(mock_get_dist_connection: Mock) -> None:
     # test parsing the local table name from engine
     mock_dist_op.table_name = "test_dist_table"
     assert _get_local_table_name(mock_dist_op) == "test_local_table"
-    mock_dist_op = "test_sharded_dist_table"
+    mock_dist_op.table_name = "test_sharded_dist_table"
     assert _get_local_table_name(mock_dist_op) == "test_local_table"
 
     # cleanup

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -1,0 +1,209 @@
+from typing import Sequence, Union
+from unittest.mock import Mock, patch
+
+from snuba.clickhouse.columns import Column, String, UInt
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, validator
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.groups import MigrationGroup, get_group_loader
+from snuba.migrations.operations import AddColumn, CreateTable, DropColumn, SqlOperation
+from snuba.migrations.table_engines import Distributed, ReplacingMergeTree
+from snuba.migrations.validator import (
+    _get_local_table_name,
+    conflicts_add_column_op,
+    conflicts_create_table_op,
+    conflicts_drop_column_op,
+    validate_migration_order,
+)
+
+
+def test_validate_all_migrations() -> None:
+    for group in MigrationGroup:
+        group_loader = get_group_loader(group)
+
+        for migration_id in group_loader.get_migrations():
+            snuba_migration = group_loader.load_migration(migration_id)
+            if isinstance(snuba_migration, migration.ClickhouseNodeMigration):
+                validate_migration_order(snuba_migration)
+
+
+@patch.object(validator, "_get_local_table_name")
+def test_out_of_order_create(mock_get_local_table_name: Mock) -> None:
+    def _dist_to_local(op: Union[CreateTable, AddColumn, DropColumn]) -> str:
+        if op.table_name == "test_dist_table":
+            return "test_local_table"
+        if op.table_name == "test_dist_table2":
+            return "test_local_table2"
+        return op.table_name
+
+    mock_get_local_table_name.side_effect = _dist_to_local
+    columns: Sequence[Column[Modifiers]] = [
+        Column("col1", String()),
+    ]
+    storage = StorageSetKey.EVENTS
+    # create_local_op = Mock(CreateTable)
+    create_local_op = CreateTable(
+        storage,
+        "test_local_table",
+        columns,
+        ReplacingMergeTree(
+            storage_set=storage,
+            order_by="version",
+        ),
+    )
+    create_dist_op = CreateTable(
+        storage,
+        "test_dist_table",
+        columns,
+        Distributed("test_local_table", None),
+    )
+    # create_dist_op = Mock(CreateTable)
+    # drop_local_op = Mock(DropTable)??
+    # drop_dist_op = Mock(DropTable)??
+    # logger = Logger("test")
+    # context = Context("001", logger, lambda x: None)
+
+    class TestMigration(migration.ClickhouseNodeMigration):
+        blocking = False
+
+        def forwards_local(self) -> Sequence[SqlOperation]:
+            return [create_local_op]
+
+        def backwards_local(self) -> Sequence[SqlOperation]:
+            return []
+
+        def forwards_dist(self) -> Sequence[SqlOperation]:
+            return [create_dist_op]
+
+        def backwards_dist(self) -> Sequence[SqlOperation]:
+            return []
+
+    validate_migration_order(TestMigration())
+
+
+@patch.object(validator, "_get_local_table_name")
+def test_conflicts(mock_get_local_table_name: Mock) -> None:
+    """
+    Test that the conlicts functions detect conflicting SQL operations that target the same table.
+    """
+    # database = os.environ.get("CLICKHOUSE_DATABASE", "default")
+    # dist_to_local: Dict[SqlOperation, str] = {}
+    storage = StorageSetKey.EVENTS
+
+    def _dist_to_local(op: Union[CreateTable, AddColumn, DropColumn]) -> str:
+        if op.table_name == "test_dist_table":
+            return "test_local_table"
+        if op.table_name == "test_dist_table2":
+            return "test_local_table2"
+        return op.table_name
+
+    mock_get_local_table_name.side_effect = _dist_to_local
+
+    columns: Sequence[Column[Modifiers]] = [
+        Column("id", String()),
+        Column("name", String(Modifiers(nullable=True))),
+        Column("version", UInt(64)),
+    ]
+
+    create_local_op = CreateTable(
+        storage,
+        "test_local_table",
+        columns,
+        ReplacingMergeTree(
+            storage_set=storage,
+            order_by="version",
+        ),
+    )
+
+    create_local_op_table2 = CreateTable(
+        storage,
+        "test_local_table2",
+        columns,
+        ReplacingMergeTree(
+            storage_set=storage,
+            order_by="version",
+        ),
+    )
+
+    create_dist_op = CreateTable(
+        storage,
+        "test_dist_table",
+        columns,
+        Distributed("test_local_table", None),
+    )
+
+    assert conflicts_create_table_op(create_local_op, create_dist_op)
+    assert not conflicts_create_table_op(create_local_op_table2, create_dist_op)
+
+    add_col1: Column[Modifiers] = Column("col1", String())
+    add_col2: Column[Modifiers] = Column("col2", String())
+    add_col_local_op = AddColumn(storage, "test_local_table", add_col1, None)
+    add_col_dist_op = AddColumn(storage, "test_dist_table", add_col1, None)
+    add_col_dist_op_col_2 = AddColumn(storage, "test_dist_table", add_col2, None)
+    add_col_local_op_col_2 = AddColumn(storage, "test_local_table", add_col2, None)
+    add_col_dist_op_table_2 = AddColumn(storage, "test_dist_table2", add_col1, None)
+    add_col_local_op_table_2 = AddColumn(storage, "test_local_table2", add_col1, None)
+
+    assert conflicts_add_column_op(add_col_local_op, add_col_dist_op)
+    assert conflicts_add_column_op(add_col_local_op_table_2, add_col_dist_op_table_2)
+    assert not conflicts_add_column_op(add_col_local_op_col_2, add_col_dist_op)
+    assert not conflicts_add_column_op(add_col_local_op, add_col_dist_op_col_2)
+    assert not conflicts_add_column_op(add_col_local_op, add_col_dist_op_table_2)
+    assert not conflicts_add_column_op(add_col_local_op_table_2, add_col_dist_op)
+    assert not conflicts_add_column_op(add_col_local_op, add_col_dist_op_col_2)
+
+    drop_col1, drop_col2 = "col1", "col2"
+    drop_col_local_op = DropColumn(storage, "test_local_table", drop_col1)
+    drop_col_dist_op = DropColumn(storage, "test_dist_table", drop_col1)
+    drop_col_dist_op_col_2 = DropColumn(storage, "test_dist_table", drop_col2)
+    drop_col_local_op_col_2 = DropColumn(storage, "test_local_table", drop_col2)
+    drop_col_dist_op_table_2 = DropColumn(storage, "test_dist_table2", drop_col1)
+    drop_col_local_op_table_2 = DropColumn(storage, "test_local_table2", drop_col1)
+
+    assert conflicts_drop_column_op(drop_col_local_op, drop_col_dist_op)
+    assert conflicts_drop_column_op(drop_col_local_op_table_2, drop_col_dist_op_table_2)
+    assert not conflicts_drop_column_op(drop_col_local_op_col_2, drop_col_dist_op)
+    assert not conflicts_drop_column_op(drop_col_local_op, drop_col_dist_op_col_2)
+    assert not conflicts_drop_column_op(drop_col_local_op, drop_col_dist_op_table_2)
+    assert not conflicts_drop_column_op(drop_col_local_op_table_2, drop_col_dist_op)
+    assert not conflicts_drop_column_op(drop_col_local_op, drop_col_dist_op_col_2)
+
+
+@patch.object(validator, "_get_dist_connection")
+def test_parse_engine(mock_get_dist_connection: Mock) -> None:
+    cluster = get_cluster(StorageSetKey.MIGRATIONS)
+    connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+    database = connection.database
+    mock_get_dist_connection.return_value = connection
+
+    # setup
+    connection.execute(f"DROP TABLE IF EXISTS {database}.test_local_table")
+    connection.execute(f"DROP TABLE IF EXISTS {database}.test_dist_table")
+    connection.execute(f"DROP TABLE IF EXISTS {database}.test_sharded_dist_table")
+
+    connection.execute(
+        f"CREATE TABLE {database}.test_local_table (id String) ENGINE = Merge('{database}','test_local_table')"
+    )
+    connection.execute(
+        f"CREATE TABLE {database}.test_dist_table (id String)"
+        f"ENGINE = Distributed(test_shard_localhost, {database}, test_local_table)"
+    )
+    mock_sql_op = Mock(spec=SqlOperation)
+    mock_dist_op = mock_sql_op()
+
+    connection.execute(
+        f"CREATE TABLE {database}.test_sharded_dist_table (id String)"
+        f"ENGINE = Distributed(test_shard_localhost, {database}, test_local_table, rand())"
+    )
+
+    # test parsing the local table name from engine
+    mock_dist_op.table_name = "test_dist_table"
+    assert _get_local_table_name(mock_dist_op) == "test_local_table"
+    mock_dist_op = "test_sharded_dist_table"
+    assert _get_local_table_name(mock_dist_op) == "test_local_table"
+
+    # cleanup
+    connection.execute(f"DROP TABLE {database}.test_local_table")
+    connection.execute(f"DROP TABLE {database}.test_dist_table")
+    connection.execute(f"DROP TABLE {database}.test_sharded_dist_table")


### PR DESCRIPTION
Adds a script to validate the order of migration and introduce a test in CI that checks existing migrations

## Context
#3324 added the option to set flags to specify order, this PR introduces a checker to validate the specified order does not introduce errors. The checker uses the following spec:

1. For two `AddColumn` OPs with the same target table and target column, the local OP must be applied first
2. For two `CreateTable` OPs with the same target table name, the local OP must be applied first
3. For two `DropColumn` OPs with the same target table and target column, the dist OP must be applied first

The target table for distributed ops is then extracted either by looking at the engine attribute in the case of `CreateTable`, or by parsing the the local table name from the table engine in Clickhouse via querying `SELECT engine_full FROM system.tables WHERE name = table_name` for `AddColumn`,`DropColumn` ops. For distributed tables, the target is the third argument in the `Distributed()` engine_full value.

## Before
We wouldn't be able to detect if the wrong order was specified in migrations

## After
A checker script is run that can catch some errors when the wrong migration operation order is specified

##  Blast Radius
The validator is an independent script in the migrations package. It doesn't affect the migrations themselves, but this PR add a test to check the existing migrations. 

To make it easier to implement, we make public some attributes of `SqlOperations` such as the table name and column.

For migrations `0004_drop_profile_column.py`,  `0016_drop_legacy_events` and `0014_transactions_remove_flattened_columns.py` we corrected the order flags as the checker detected errors.

## Testing
Unit tests check the utility methods for detecting conflicting ops that target the same underlying table and column 

A parameterized test creates a series of Migrations with create, add column and drop column ops and checks that if the order is violated the validator throws the correct exception and message

A unit test creates empty tables in Clickhouse and checks that the local table name can be parsed properly from the engine name 