### PR TITLE
feat(replays): Add additional safety to tags processor

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -300,8 +300,7 @@ def process_tags_object(value: Any) -> Tag:
     transaction = None
 
     for key, value in tags:
-        # Keys and values are stored as strings regardless of their input type.  In the schema,
-        # both are technically optional in the schema only the value part logically allows null.
+        # Keys and values are stored as optional strings regardless of their input type.
         parsed_key, parsed_value = stringify(key), maybe(stringify, value)
 
         if key == "transaction":

--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import uuid
 from datetime import datetime
@@ -10,17 +11,11 @@ import rapidjson
 
 from snuba import environment
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.datasets.events_format import (
-    EventTooOld,
-    enforce_retention,
-    extract_extra_tags,
-    extract_user,
-)
+from snuba.datasets.events_format import EventTooOld, enforce_retention, extract_user
 from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.processor import (
     InsertBatch,
     ProcessedMessage,
-    _as_dict_safe,
     _ensure_valid_date,
     _ensure_valid_ip,
 )
@@ -128,11 +123,10 @@ class ReplaysProcessor(DatasetMessageProcessor):
     def _process_tags(
         self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict
     ) -> None:
-        tags: MutableMapping[str, Any] = _as_dict_safe(replay_event.get("tags", None))
-        if "transaction" in tags:
-            processed["title"] = tags["transaction"]
-        tags.pop("transaction", None)
-        processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
+        tags = process_tags_object(replay_event.get("tags"))
+        processed["title"] = tags.transaction
+        processed["tags.key"] = tags.keys
+        processed["tags.value"] = tags.values
 
     def _add_user_column(
         self,
@@ -268,8 +262,80 @@ def stringify(value: Any) -> str:
     """
     if isinstance(value, (bool, dict, list)):
         result: str = rapidjson.dumps(value)
-        return result
+        return _encode_utf8(result)
     elif value is None:
         return ""
     else:
-        return str(value).encode("utf8", errors="backslashreplace").decode("utf8")
+        return _encode_utf8(str(value))
+
+
+def _encode_utf8(value: str) -> str:
+    """Return a utf-8 encoded string."""
+    return value.encode("utf8", errors="backslashreplace").decode("utf8")
+
+
+# Tags processor.
+
+
+@dataclasses.dataclass
+class Tag:
+    keys: list[str]
+    values: list[str | None]
+    transaction: str | None
+
+    @classmethod
+    def empty_set(cls) -> Tag:
+        return cls([], [], None)
+
+
+def process_tags_object(value: Any) -> Tag:
+    if value is None:
+        return Tag.empty_set()
+
+    # Excess tags are trimmed.
+    tags = capped_list(normalize_tags(value))
+
+    keys = []
+    values = []
+    transaction = None
+
+    for key, value in tags:
+        # Keys and values are stored as strings regardless of their input type.
+        parsed_key, parsed_value = stringify(key), maybe(stringify, value)
+
+        if key == "transaction":
+            transaction = parsed_value
+        else:
+            keys.append(parsed_key)
+            values.append(parsed_value)
+
+    return Tag(keys=keys, values=values, transaction=transaction)
+
+
+def normalize_tags(value: Any) -> list[tuple[str, str]]:
+    """Normalize tags payload to a single format."""
+    if isinstance(value, dict):
+        return _coerce_tags_dictionary(value)
+    elif isinstance(value, list):
+        return _coerce_tags_tuple_list(value)
+    else:
+        raise TypeError(f'Invalid tags type specified: "{type(value)}"')
+
+
+def _coerce_tags_dictionary(tags: dict[str, Any]) -> list[tuple[str, str]]:
+    """Return a list of tag tuples from an unspecified dictionary."""
+    return [(key, value) for key, value in tags.items() if isinstance(key, str)]
+
+
+def _coerce_tags_tuple_list(tags_list: list[Any]) -> list[tuple[str, str]]:
+    """Return a list of tag tuples from an unspecified list of values."""
+    return [
+        (item[0], item[1])
+        for item in tags_list
+        if (isinstance(item, (list, tuple)) and len(item) == 2)
+    ]
+
+
+def capped_list(value: list[Any]) -> list[Any]:
+    """Return a list with a maximum configured length."""
+    return value[:LIST_ELEMENT_LIMIT]

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -7,10 +7,13 @@ from datetime import datetime, timezone
 from hashlib import md5
 from typing import Any, Mapping
 
+import pytest
+
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.processors.replays_processor import (
     ReplaysProcessor,
     maybe,
+    normalize_tags,
     stringify,
 )
 from snuba.processor import InsertBatch
@@ -345,3 +348,18 @@ class TestReplaysProcessor:
         assert stringify([0, 1]) == "[0,1]"
         assert stringify("hello") == "hello"
         assert stringify({"hello": "world"}) == '{"hello":"world"}'
+
+    def test_normalize_tags(self) -> None:
+        """Test "normalize_tags" function."""
+        assert normalize_tags([("hello", "world")]) == [("hello", "world")]
+        assert normalize_tags({"hello": "world"}) == [("hello", "world")]
+        assert normalize_tags([("hello", "world", "!")]) == []
+
+        with pytest.raises(TypeError):
+            normalize_tags(1)
+
+        with pytest.raises(TypeError):
+            normalize_tags(None)
+
+        with pytest.raises(TypeError):
+            normalize_tags("a")


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/194

- Add upper limit to the number of tags accepted per request.
- Enforces non-null string keys.
- Enforces nullable string values.
- Preserves duplicate tag keys (supported by the replays product).
- Skips (instead of erring on) malformed tag tuples.