### PR TITLE
fix(querylog): filter out negative project ids instead of rejecting the whole query

### DIFF
--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -318,7 +318,7 @@ def test_negative_project_id_fields() -> None:
                 trace_id="b" * 32,
             )
         ],
-        projects={-2},
+        projects={-2, 0, 420},
         snql_anonymized=request.snql_anonymized,
         entity=EntityKey.EVENTS.value,
     ).to_dict()
@@ -329,8 +329,8 @@ def test_negative_project_id_fields() -> None:
         .get_stream_loader()
         .get_processor()
     )
-
-    assert (
-        processor.process_message(message, KafkaMessageMetadata(0, 0, datetime.now()))
-        is None
+    res_batch = processor.process_message(
+        message, KafkaMessageMetadata(0, 0, datetime.now())
     )
+    # We keep only valid project ids (>= 0)
+    assert res_batch.rows[0]["projects"] == [420]


### PR DESCRIPTION
In order to mitigate an incident with a negative project id in a query, we simply would discard that query from the querylog. 

This PR just takes those negative ids out of the field to be inserted but keeps the rest of the query intact