### PR TITLE
MIGRATION: add bytes_scanned to querylog

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -241,7 +241,12 @@ class QuerylogLoader(DirectoryLoader):
         super().__init__("snuba.snuba_migrations.querylog")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_querylog", "0002_status_type_change", "0003_add_profile_fields"]
+        return [
+            "0001_querylog",
+            "0002_status_type_change",
+            "0003_add_profile_fields",
+            "0004_add_bytes_scanned",
+        ]
 
 
 class ProfilesLoader(DirectoryLoader):

--- a/snuba/snuba_migrations/querylog/0004_add_bytes_scanned.py
+++ b/snuba/snuba_migrations/querylog/0004_add_bytes_scanned.py
@@ -1,0 +1,55 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Array, Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds fields for query profile.
+    """
+
+    blocking = True
+
+    def __forward_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name=table_name,
+                column=Column(
+                    "clickhouse_queries.bytes_scanned",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            default="arrayResize([0], length(clickhouse_queries.sql))"
+                        ),
+                    ),
+                ),
+                after="clickhouse_queries.array_join_columns",
+            ),
+        ]
+
+    def __backwards_migrations(
+        self, table_name: str
+    ) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.QUERYLOG, table_name, "clickhouse_queries.bytes_scanned"
+            ),
+        ]
+
+    def forwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("querylog_local")
+
+    def backwards_local(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("querylog_local")
+
+    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__forward_migrations("querylog_dist")
+
+    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+        return self.__backwards_migrations("querylog_dist")

--- a/snuba/snuba_migrations/querylog/0004_add_bytes_scanned.py
+++ b/snuba/snuba_migrations/querylog/0004_add_bytes_scanned.py
@@ -3,7 +3,6 @@ from typing import Sequence
 from snuba.clickhouse.columns import Array, Column, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
-from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
 class Migration(migration.ClickhouseNodeMigration):
@@ -24,9 +23,6 @@ class Migration(migration.ClickhouseNodeMigration):
                     "clickhouse_queries.bytes_scanned",
                     Array(
                         UInt(64),
-                        Modifiers(
-                            default="arrayResize([0], length(clickhouse_queries.sql))"
-                        ),
                     ),
                 ),
                 after="clickhouse_queries.array_join_columns",


### PR DESCRIPTION
The attribution log contains attribution for internal customers but not for sentry customers (no project_id in attribution log). We want to be able to analyze bytes scanned by sentry customers as well. Hence we need to add this column