### PR TITLE
fix(rate_limit): Set explicit TTL for set of open requests [SNS-1864]

### DIFF
--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -230,6 +230,11 @@ def rate_limit(
     #              | current time
     pipe.zadd(query_bucket, {query_id: now + state.max_query_duration_s})
 
+    # bump the expiration date of the entire set so that it roughly aligns with
+    # the expiration date of the latest item. round up and cast to int since
+    # `expire` doesn't take floats
+    pipe.expire(query_bucket, int(state.max_query_duration_s + 1))
+
     if rate_limit_params.per_second_limit is not None:
         # count queries that have finished for the per-second rate
         for shard_i in range(rate_limit_shard_factor):

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -178,7 +178,7 @@ class TestRateLimit:
             pass
 
         ttl = get_redis_client(RedisClientKey.RATE_LIMITER).ttl(bucket)
-        assert 0 < ttl <= time.time() + state.max_query_duration_s
+        assert 0 < ttl <= 3600 + 60 + 1
 
 
 tests = [

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -170,6 +170,16 @@ class TestRateLimit:
 
         assert count() == 2
 
+    def test_rate_limit_ttl(self) -> None:
+        params = RateLimitParameters("foo", "bar", None, 5)
+        bucket = "{}{}".format(state.ratelimit_prefix, params.bucket)
+
+        with rate_limit(params):
+            pass
+
+        ttl = get_redis_client(RedisClientKey.RATE_LIMITER).ttl(bucket)
+        assert 0 < ttl <= time.time() + state.max_query_duration_s
+
 
 tests = [
     pytest.param((0, 5, 5)),


### PR DESCRIPTION
step to repro leak:

1) add set items, but do not explicitly remove them. possible by killing
   processes while a query is running
2) stop processing requests for a particular bucket. possible by
   deleting a project that receives queries. we maintain sets of open
   requests per-project, using https://github.com/getsentry/snuba/blob/a9ef6c56594246d0182a2b07728d1446a10e881b/snuba/query/processors/logical/object_id_rate_limiter.py#L19

without 1), we would be deleting set items explicitly on context manager
exit. Empty sets are equivalent to deleted keys in Redis.

without 2), we would have an extremely limited number of possible values
for `bucket`, so the issue is practically nonexistent. but since we
maintain sets per "object id" it's possible for a user to produce new
redis keys without ttl by creating/deleting projects

without an explicit TTL, we will be leaking tiny sets over time.

