### PR TITLE
fix(admin): Allow ARRAY JOIN with clickhouse_queries in admin

### DIFF
--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -23,7 +23,9 @@ def run_querylog_query(query: str, user: str) -> ClickhouseResult:
     """
     schema = get_storage(StorageKey.QUERYLOG).get_schema()
     assert isinstance(schema, TableSchema)
-    validate_ro_query(sql_query=query, allowed_tables={schema.get_table_name(), "clickhouse_queries"})
+    validate_ro_query(
+        sql_query=query, allowed_tables={schema.get_table_name(), "clickhouse_queries"}
+    )
     if get_config(ENABLE_QUERYLOG_API_CONFIG, 0):
         return __run_querylog_query(query)
     raise InvalidCustomQuery("Production ClickHouse querylog access is not yet ready.")

--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -23,7 +23,7 @@ def run_querylog_query(query: str, user: str) -> ClickhouseResult:
     """
     schema = get_storage(StorageKey.QUERYLOG).get_schema()
     assert isinstance(schema, TableSchema)
-    validate_ro_query(sql_query=query, allowed_tables={schema.get_table_name()})
+    validate_ro_query(sql_query=query, allowed_tables={schema.get_table_name(), "clickhouse_queries"})
     if get_config(ENABLE_QUERYLOG_API_CONFIG, 0):
         return __run_querylog_query(query)
     raise InvalidCustomQuery("Production ClickHouse querylog access is not yet ready.")


### PR DESCRIPTION
Currently we cannot do a query like this in the admin tool because `clikhouse_queries` is not an allowed table to query

```sql
SELECT
	toStartOfTenMinutes(timestamp) AS time,
	COUNT(clickhouse_queries.is_duplicate) as dup_count,
	SUM(duration_ms) as duration_sum
FROM
	querylog_local
ARRAY JOIN
	clickhouse_queries <--- rejected by tool
WHERE
  (timestamp > (now() - (3600 * 5))) AND
	status = 'error' AND
	clickhouse_queries.is_duplicate = 1
GROUP BY
	time
ORDER BY 
    time ASC
LIMIT 1 BY time
```