### PR TITLE
feat(DC): More inner types for Array

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -34,8 +34,8 @@ schema:
         type: Array,
         args:
           {
-            inner_type:
-              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+            inner_type: { type: UInt, args: { size: 64 } },
+            schema_modifiers: [readonly],
           },
       },
       {
@@ -43,8 +43,8 @@ schema:
         type: Array,
         args:
           {
-            inner_type:
-              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+            inner_type: { type: UInt, args: { size: 64 } },
+            schema_modifiers: [readonly],
           },
       },
       { name: granularity, type: UInt, args: { size: 8 } },

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -32,12 +32,20 @@ schema:
       {
         name: _raw_tags_hash,
         type: Array,
-        args: { type: UInt, arg: 64, schema_modifiers: [readonly] },
+        args:
+          {
+            inner_type:
+              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+          },
       },
       {
         name: _indexed_tags_hash,
         type: Array,
-        args: { type: UInt, arg: 64, schema_modifiers: [readonly] },
+        args:
+          {
+            inner_type:
+              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+          },
       },
       { name: granularity, type: UInt, args: { size: 8 } },
 

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -29,13 +29,21 @@ schema:
           },
       },
 
-      { name: granularities, type: Array, args: { type: UInt, arg: 8 } },
+      {
+        name: granularities,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
       { name: count_value, type: Float, args: { size: 64 } },
-      { name: set_values, type: Array, args: { type: UInt, arg: 64 } },
+      {
+        name: set_values,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 64 } } },
+      },
       {
         name: distribution_values,
         type: Array,
-        args: { type: Float, arg: 64 },
+        args: { inner_type: { type: Float, args: { size: 64 } } },
       },
       { name: timeseries_id, type: UInt, args: { size: 32 } },
     ]

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -34,8 +34,8 @@ schema:
         type: Array,
         args:
           {
-            inner_type:
-              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+            inner_type: { type: UInt, args: { size: 64 } },
+            schema_modifiers: [readonly],
           },
       },
       {
@@ -43,8 +43,8 @@ schema:
         type: Array,
         args:
           {
-            inner_type:
-              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+            inner_type: { type: UInt, args: { size: 64 } },
+            schema_modifiers: [readonly],
           },
       },
       { name: granularity, type: UInt, args: { size: 8 } },

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -32,12 +32,20 @@ schema:
       {
         name: _raw_tags_hash,
         type: Array,
-        args: { type: UInt, arg: 64, schema_modifiers: [readonly] },
+        args:
+          {
+            inner_type:
+              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+          },
       },
       {
         name: _indexed_tags_hash,
         type: Array,
-        args: { type: UInt, arg: 64, schema_modifiers: [readonly] },
+        args:
+          {
+            inner_type:
+              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+          },
       },
       { name: granularity, type: UInt, args: { size: 8 } },
 

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -29,13 +29,21 @@ schema:
           },
       },
 
-      { name: granularities, type: Array, args: { type: UInt, arg: 8 } },
+      {
+        name: granularities,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
       { name: count_value, type: Float, args: { size: 64 } },
-      { name: set_values, type: Array, args: { type: UInt, arg: 64 } },
+      {
+        name: set_values,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 64 } } },
+      },
       {
         name: distribution_values,
         type: Array,
-        args: { type: Float, arg: 64 },
+        args: { inner_type: { type: Float, args: { size: 64 } } },
       },
       { name: timeseries_id, type: UInt, args: { size: 32 } },
     ]

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -188,20 +188,7 @@ SIMPLE_ARRAY_SUBCOLUMN_TYPES = [
 ]
 
 
-ARRAY_SCHEMA = make_column_schema(
-    column_type={"const": "Array"},
-    args={
-        "type": "object",
-        "properties": {
-            "type": TYPE_STRING,
-            "arg": {"type": "number"},
-        },
-        "additionalProperties": False,
-    },
-)
-
-
-SUB_ARRAY_SCHEMA = make_column_schema(
+_SUB_ARRAY_SCHEMA = make_column_schema(
     column_type={"const": "Array"},
     args={
         "type": "object",
@@ -211,16 +198,16 @@ SUB_ARRAY_SCHEMA = make_column_schema(
 )
 
 # Up to one subarray is supported. Eg Array(Array(String())).
-# ARRAY_SCHEMA = make_column_schema(
-#     column_type={"const": "Array"},
-#     args={
-#         "type": "object",
-#         "properties": {
-#             "inner_type": {"anyOf": [*SIMPLE_ARRAY_SUBCOLUMN_TYPES, SUB_ARRAY_SCHEMA]}
-#         },
-#         "additionalProperties": False,
-#     },
-# )
+ARRAY_SCHEMA = make_column_schema(
+    column_type={"const": "Array"},
+    args={
+        "type": "object",
+        "properties": {
+            "inner_type": {"anyOf": [*SIMPLE_ARRAY_SUBCOLUMN_TYPES, _SUB_ARRAY_SCHEMA]}
+        },
+        "additionalProperties": False,
+    },
+)
 
 COLUMN_TYPES = [
     *SIMPLE_COLUMN_TYPES,
@@ -242,80 +229,6 @@ NESTED_SCHEMA = make_column_schema(
         "additionalProperties": False,
     },
 )
-
-# {
-#     "definitions": {
-#         "MenuItem": {
-#             "title": "MenuItem",
-#             "properties": {
-#                 "display_name": {
-#                     "type": "string",
-#                     "title": "Link display name",
-#                     "minLength": 2,
-#                 },
-#                 "url": {"type": "string", "title": "URL address", "minLength": 2},
-#                 "children": {
-#                     "type": "array",
-#                     "title": "Children",
-#                     "items": {"$ref": "#/definitions/MenuItem"},
-#                 },
-#             },
-#         }
-#     },
-#     "title": "MenuItems",
-#     "type": "array",
-#     "items": {"$ref": "#/definitions/MenuItem"},
-# }
-
-# {
-#     "type": "object",
-#     # "items": {"$ref": "#/definitions/MenuItem"},
-#     "properties": {},
-#     "definitions": {
-#         "ArraySchema": {
-#             "type": "object",
-#             "properties": {
-#                 "name": TYPE_STRING,
-#                 "type": {"const": "Array"},
-#                 "args": {
-#                     "type": "object",
-#                     "properties": {
-#                         "schema_modifiers": TYPE_STRING_ARRAY,
-#                         "inner_type": {
-#                             "anyOf": COLUMN_TYPES
-#                             + [{"$ref": "#/definitions/ArraySchema"}]
-#                         },
-#                     },
-#                     "additionalProperties": False,
-#                 },
-#             },
-#             "additionalProperties": False,
-#         }
-#     },
-#     "additionalProperties": False,
-# }
-
-
-# ARRAY_SCHEMA2 = {
-#     "type": "object",
-#     "properties": {
-#         "name": TYPE_STRING,
-#         "type": {"const": "Array"},
-#         "args": {
-#             "type": "object",
-#             "properties": {
-#                 "schema_modifiers": TYPE_STRING_ARRAY,
-#                 "inner_type": {
-#                     "anyOf": COLUMN_TYPES + [{"$ref": "#/definitions/ArraySchema"}],
-#                     "definitions": {},
-#                 },
-#             },
-#             "additionalProperties": False,
-#         },
-#     },
-#     "additionalProperties": False,
-# }
-
 
 SCHEMA_COLUMNS = {
     "type": "array",

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -220,10 +220,7 @@ NESTED_SCHEMA = make_column_schema(
     args={
         "type": "object",
         "properties": {
-            "subcolumns": {
-                "type": "array",
-                "items": {"anyOf": COLUMN_TYPES},
-            }
+            "subcolumns": {"type": "array", "items": {"anyOf": COLUMN_TYPES}}
         },
         "additionalProperties": False,
     },

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -183,27 +183,27 @@ SIMPLE_COLUMN_TYPES = [
     AGGREGATE_FUNCTION_SCHEMA,
 ]
 
-SIMPLE_ARRAY_SUBCOLUMN_TYPES = [
+# Array inner types are the same as normal column types except they don't have a name
+_SIMPLE_ARRAY_INNER_TYPES = [
     del_name_field(col_type) for col_type in SIMPLE_COLUMN_TYPES
 ]
 
-
+# Up to one subarray is supported. Eg Array(Array(String())).
 _SUB_ARRAY_SCHEMA = make_column_schema(
     column_type={"const": "Array"},
     args={
         "type": "object",
-        "properties": {"inner_type": {"anyOf": SIMPLE_ARRAY_SUBCOLUMN_TYPES}},
+        "properties": {"inner_type": {"anyOf": _SIMPLE_ARRAY_INNER_TYPES}},
         "additionalProperties": False,
     },
 )
 
-# Up to one subarray is supported. Eg Array(Array(String())).
 ARRAY_SCHEMA = make_column_schema(
     column_type={"const": "Array"},
     args={
         "type": "object",
         "properties": {
-            "inner_type": {"anyOf": [*SIMPLE_ARRAY_SUBCOLUMN_TYPES, _SUB_ARRAY_SCHEMA]}
+            "inner_type": {"anyOf": [*_SIMPLE_ARRAY_INNER_TYPES, _SUB_ARRAY_SCHEMA]}
         },
         "additionalProperties": False,
     },
@@ -214,7 +214,6 @@ COLUMN_TYPES = [
     ARRAY_SCHEMA,
 ]
 
-ARRAY_SUBCOLUMN_TYPES = [*SIMPLE_ARRAY_SUBCOLUMN_TYPES, del_name_field(ARRAY_SCHEMA)]
 
 NESTED_SCHEMA = make_column_schema(
     column_type={"const": "Nested"},

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -56,7 +56,11 @@ schema:
     {
       name: _tags_hash_map,
       type: Array,
-      args: { type: UInt, arg: 64, schema_modifiers: [readonly] },
+      args:
+        {
+          inner_type:
+            { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+        },
     },
     {
       name: contexts,
@@ -115,7 +119,11 @@ schema:
     { name: title, type: String, args: { schema_modifiers: [readonly] } },
     { name: transaction_source, type: String },
     { name: timestamp, type: DateTime, args: { schema_modifiers: [readonly] } },
-    { name: group_ids, type: Array, args: { type: UInt, arg: 64 } },
+    {
+      name: group_ids,
+      type: Array,
+      args: { inner_type: { type: UInt, args: { size: 64 } } },
+    },
     { name: app_start_type, type: String },
   ]
 

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -58,8 +58,8 @@ schema:
       type: Array,
       args:
         {
-          inner_type:
-            { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+          inner_type: { type: UInt, args: { size: 64 } },
+          schema_modifiers: [readonly],
         },
     },
     {

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -83,8 +83,8 @@ schema:
         type: Array,
         args:
           {
-            inner_type:
-              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+            inner_type: { type: UInt, args: { size: 64 } },
+            schema_modifiers: [readonly],
           },
       },
       {

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -14,7 +14,11 @@ schema:
       { name: trace_id, type: UUID, args: { schema_modifiers: [nullable] } },
       { name: span_id, type: UInt, args: { size: 64 } },
       { name: transaction_name, type: String },
-      { name: transaction_hash, type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+      {
+        name: transaction_hash,
+        type: UInt,
+        args: { size: 64, schema_modifiers: [readonly] },
+      },
       { name: transaction_op, type: String },
       { name: transaction_status, type: UInt, args: { size: 8 } },
       { name: start_ts, type: DateTime },
@@ -23,43 +27,73 @@ schema:
       { name: finish_ms, type: UInt, args: { size: 16 } },
       { name: duration, type: UInt, args: { size: 32 } },
       { name: platform, type: String },
-      { name: environment, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: environment,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
       { name: release, type: String, args: { schema_modifiers: [nullable] } },
       { name: dist, type: String, args: { schema_modifiers: [nullable] } },
-      { name: ip_address_v4, type: IPv4, args: { schema_modifiers: [nullable] } },
-      { name: ip_address_v6, type: IPv6, args: { schema_modifiers: [nullable] } },
+      {
+        name: ip_address_v4,
+        type: IPv4,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: ip_address_v6,
+        type: IPv6,
+        args: { schema_modifiers: [nullable] },
+      },
       { name: user, type: String },
-      { name: user_hash, type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+      {
+        name: user_hash,
+        type: UInt,
+        args: { size: 64, schema_modifiers: [readonly] },
+      },
       { name: user_id, type: String, args: { schema_modifiers: [nullable] } },
       { name: user_name, type: String, args: { schema_modifiers: [nullable] } },
-      { name: user_email, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: user_email,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
       { name: sdk_name, type: String },
       { name: sdk_version, type: String },
-      { name: http_method, type: String, args: { schema_modifiers: [nullable] } },
-      { name: http_referer, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: http_method,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: http_referer,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
       {
         name: tags,
         type: Nested,
         args:
           {
             subcolumns:
-              [
-                { name: key, type: String },
-                { name: value, type: String },
-              ],
+              [{ name: key, type: String }, { name: value, type: String }],
           },
       },
-      { name: _tags_hash_map, type: Array, args: { type: UInt, arg: 64, schema_modifiers: [readonly] } },
+      {
+        name: _tags_hash_map,
+        type: Array,
+        args:
+          {
+            inner_type:
+              { type: UInt, args: { size: 64, schema_modifiers: [readonly] } },
+          },
+      },
       {
         name: contexts,
         type: Nested,
         args:
           {
             subcolumns:
-              [
-                { name: key, type: String },
-                { name: value, type: String },
-              ],
+              [{ name: key, type: String }, { name: value, type: String }],
           },
       },
       {
@@ -109,8 +143,16 @@ schema:
       { name: message, type: String, args: { schema_modifiers: [readonly] } },
       { name: title, type: String, args: { schema_modifiers: [readonly] } },
       { name: transaction_source, type: String },
-      { name: timestamp, type: DateTime, args: { schema_modifiers: [readonly] } },
-      { name: group_ids, type: Array, args: { type: UInt, arg: 64 } },
+      {
+        name: timestamp,
+        type: DateTime,
+        args: { schema_modifiers: [readonly] },
+      },
+      {
+        name: group_ids,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 64 } } },
+      },
       { name: app_start_type, type: String },
     ]
   local_table_name: transactions_local
@@ -173,13 +215,13 @@ query_processors:
       columns: [spans.group]
   - processor: PrewhereProcessor
     args:
-      prewhere_candidates: [event_id, trace_id, span_id, transaction_name, transaction, title]
+      prewhere_candidates:
+        [event_id, trace_id, span_id, transaction_name, transaction, title]
   - processor: TableRateLimit
   - processor: TupleUnaliaser
 
 query_splitters:
-  -
-    splitter: TimeSplitQueryStrategy
+  - splitter: TimeSplitQueryStrategy
     args:
       timestamp_col: finish_ts
 

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -95,7 +95,7 @@ def get_mandatory_condition_checkers(
     ]
 
 
-NUMBER_COLUMN_TYPES: dict[str, Type[ColumnType[SchemaModifiers]]] = {
+NUMBER_COLUMN_TYPES: dict[str, Any] = {
     "UInt": UInt,
     "Float": Float,
 }
@@ -119,9 +119,9 @@ def __parse_simple(
 def __parse_number(
     col: dict[str, Any], modifiers: SchemaModifiers | None
 ) -> ColumnType[SchemaModifiers]:
-    col_type = NUMBER_COLUMN_TYPES[col["type"]]
+    col_type = NUMBER_COLUMN_TYPES[col["type"]](col["args"]["size"], modifiers)
     assert isinstance(col_type, UInt) or isinstance(col_type, Float)
-    return col_type(col["args"]["size"], modifiers)
+    return col_type
 
 
 def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -120,8 +120,8 @@ def __parse_number(
     col: dict[str, Any], modifiers: SchemaModifiers | None
 ) -> ColumnType[SchemaModifiers]:
     col_type = NUMBER_COLUMN_TYPES[col["type"]]
-    # UInt and Float ColumnType accepts a size parameter
-    return col_type(col["args"]["size"], modifiers)  # type: ignore
+    assert isinstance(col_type, UInt) or isinstance(col_type, Float)
+    return col_type(col["args"]["size"], modifiers)
 
 
 def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -22,7 +22,7 @@ from snuba.clickhouse.columns import (
 from snuba.datasets.plans.splitters import QuerySplitStrategy
 from snuba.query.processors.condition_checkers import ConditionChecker
 from snuba.query.processors.physical import ClickhouseQueryProcessor
-from snuba.utils.schemas import UUID, AggregateFunction, ColumnType, IPv4, IPv6, _Number
+from snuba.utils.schemas import UUID, AggregateFunction, ColumnType, IPv4, IPv6
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.topics import Topic
 
@@ -95,7 +95,7 @@ def get_mandatory_condition_checkers(
     ]
 
 
-NUMBER_COLUMN_TYPES: dict[str, Type[_Number[SchemaModifiers]]] = {
+NUMBER_COLUMN_TYPES: dict[str, Type[ColumnType[SchemaModifiers]]] = {
     "UInt": UInt,
     "Float": Float,
 }
@@ -119,7 +119,9 @@ def __parse_simple(
 def __parse_number(
     col: dict[str, Any], modifiers: SchemaModifiers | None
 ) -> ColumnType[SchemaModifiers]:
-    return NUMBER_COLUMN_TYPES[col["type"]](col["args"]["size"], modifiers)
+    col_type = NUMBER_COLUMN_TYPES[col["type"]]
+    # UInt and Float ColumnType accepts a size parameter
+    return col_type(col["args"]["size"], modifiers)  # type: ignore
 
 
 def __parse_column_type(

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -124,9 +124,7 @@ def __parse_number(
     return col_type(col["args"]["size"], modifiers)  # type: ignore
 
 
-def __parse_column_type(
-    col: dict[str, Any], no_name: bool = False
-) -> ColumnType[SchemaModifiers]:
+def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:
     # TODO: Add more of Column/Value types as needed
 
     column_type: ColumnType[SchemaModifiers] | None = None
@@ -144,11 +142,7 @@ def __parse_column_type(
     elif col["type"] == "Nested":
         column_type = Nested(parse_columns(col["args"]["subcolumns"]), modifiers)
     elif col["type"] == "Array":
-        column_type = Array(
-            SIMPLE_COLUMN_TYPES[col["args"]["type"]](col["args"]["arg"]),
-            modifiers,
-        )
-
+        column_type = Array(__parse_column_type(col["args"]["inner_type"]), modifiers)
     elif col["type"] == "AggregateFunction":
         column_type = AggregateFunction(
             col["args"]["func"],

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -497,7 +497,11 @@ class UInt(ColumnType[TModifiers]):
 
 
 class Float(ColumnType[TModifiers]):
-    def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
+    def __init__(
+        self,
+        size: int,
+        modifiers: Optional[TModifiers] = None,
+    ) -> None:
         super().__init__(modifiers)
         assert size in (32, 64)
         self.size = size

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -470,10 +470,9 @@ class FixedString(ColumnType[TModifiers]):
         return FixedString(self.length)
 
 
-class UInt(ColumnType[TModifiers]):
+class _Number(ColumnType[TModifiers]):
     def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
         super().__init__(modifiers)
-        assert size in (8, 16, 32, 64)
         self.size = size
 
     def _repr_content(self) -> str:
@@ -482,9 +481,15 @@ class UInt(ColumnType[TModifiers]):
     def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.get_modifiers() == cast(UInt[TModifiers], other).get_modifiers()
-            and self.size == cast(UInt[TModifiers], other).size
+            and self.get_modifiers() == cast(_Number[TModifiers], other).get_modifiers()
+            and self.size == cast(_Number[TModifiers], other).size
         )
+
+
+class UInt(_Number[TModifiers]):
+    def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
+        super().__init__(size, modifiers)
+        assert size in (8, 16, 32, 64)
 
     def _for_schema_impl(self) -> str:
         return "UInt{}".format(self.size)
@@ -496,25 +501,10 @@ class UInt(ColumnType[TModifiers]):
         return UInt(self.size)
 
 
-class Float(ColumnType[TModifiers]):
-    def __init__(
-        self,
-        size: int,
-        modifiers: Optional[TModifiers] = None,
-    ) -> None:
-        super().__init__(modifiers)
+class Float(_Number[TModifiers]):
+    def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
+        super().__init__(size, modifiers)
         assert size in (32, 64)
-        self.size = size
-
-    def _repr_content(self) -> str:
-        return str(self.size)
-
-    def __eq__(self, other: object) -> bool:
-        return (
-            self.__class__ == other.__class__
-            and self.get_modifiers() == cast(Float[TModifiers], other).get_modifiers()
-            and self.size == cast(Float[TModifiers], other).size
-        )
 
     def _for_schema_impl(self) -> str:
         return "Float{}".format(self.size)

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -470,9 +470,10 @@ class FixedString(ColumnType[TModifiers]):
         return FixedString(self.length)
 
 
-class _Number(ColumnType[TModifiers]):
+class UInt(ColumnType[TModifiers]):
     def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
         super().__init__(modifiers)
+        assert size in (8, 16, 32, 64)
         self.size = size
 
     def _repr_content(self) -> str:
@@ -481,15 +482,9 @@ class _Number(ColumnType[TModifiers]):
     def __eq__(self, other: object) -> bool:
         return (
             self.__class__ == other.__class__
-            and self.get_modifiers() == cast(_Number[TModifiers], other).get_modifiers()
-            and self.size == cast(_Number[TModifiers], other).size
+            and self.get_modifiers() == cast(UInt[TModifiers], other).get_modifiers()
+            and self.size == cast(UInt[TModifiers], other).size
         )
-
-
-class UInt(_Number[TModifiers]):
-    def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
-        super().__init__(size, modifiers)
-        assert size in (8, 16, 32, 64)
 
     def _for_schema_impl(self) -> str:
         return "UInt{}".format(self.size)
@@ -501,10 +496,21 @@ class UInt(_Number[TModifiers]):
         return UInt(self.size)
 
 
-class Float(_Number[TModifiers]):
+class Float(ColumnType[TModifiers]):
     def __init__(self, size: int, modifiers: Optional[TModifiers] = None) -> None:
-        super().__init__(size, modifiers)
+        super().__init__(modifiers)
         assert size in (32, 64)
+        self.size = size
+
+    def _repr_content(self) -> str:
+        return str(self.size)
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            self.__class__ == other.__class__
+            and self.get_modifiers() == cast(Float[TModifiers], other).get_modifiers()
+            and self.size == cast(Float[TModifiers], other).size
+        )
 
     def _for_schema_impl(self) -> str:
         return "Float{}".format(self.size)

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -2,11 +2,24 @@ from __future__ import annotations
 
 import os
 import tempfile
+from typing import Any
 
+from snuba.clickhouse.columns import (
+    Array,
+    Column,
+    DateTime,
+    Float,
+    Nested,
+    SchemaModifiers,
+    String,
+    UInt,
+)
 from snuba.datasets.configuration.storage_builder import build_storage_from_config
+from snuba.datasets.configuration.utils import parse_columns
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import ReadableTableStorage, Storage, WritableTableStorage
 from snuba.datasets.storages.factory import get_config_built_storages
+from snuba.utils.schemas import AggregateFunction
 
 # this has to be done before the storage import because there's a cyclical dependency error
 CONFIG_BUILT_STORAGES = get_config_built_storages()
@@ -148,3 +161,66 @@ query_processors:
             assert getattr(qp, "_MappingOptimizer__column_name") == "a"
             assert getattr(qp, "_MappingOptimizer__hash_map_name") == "hashmap"
             assert getattr(qp, "_MappingOptimizer__killswitch") == "kill"
+
+    def test_column_parser(self) -> None:
+        serialized_columns: list[dict[str, Any]] = [
+            {"name": "int_col", "type": "UInt", "args": {"size": 64}},
+            {"name": "float_col", "type": "Float", "args": {"size": 32}},
+            {"name": "string_col", "type": "String"},
+            {"name": "time_col", "type": "DateTime"},
+            {
+                "name": "nested_col",
+                "type": "Nested",
+                "args": {
+                    "subcolumns": [
+                        {"name": "sub_col", "type": "UInt", "args": {"size": 64}},
+                    ],
+                },
+            },
+            {
+                "name": "func_col",
+                "type": "AggregateFunction",
+                "args": {
+                    "func": "uniqCombined64",
+                    "arg_types": [{"type": "UInt", "arg": 64}],
+                },
+            },
+            {
+                "name": "array_col",
+                "type": "Array",
+                "args": {
+                    "inner_type": {"type": "UInt", "args": {"size": 64}},
+                    "schema_modifiers": ["readonly"],
+                },
+            },
+            {
+                "name": "double_array_col",
+                "type": "Array",
+                "args": {
+                    "inner_type": {
+                        "type": "Array",
+                        "args": {"inner_type": {"type": "UInt", "args": {"size": 64}}},
+                    },
+                    "schema_modifiers": ["readonly"],
+                },
+            },
+        ]
+
+        expected_python_columns = [
+            Column("int_col", UInt(64)),
+            Column("float_col", Float(32)),
+            Column("string_col", String()),
+            Column("time_col", DateTime()),
+            Column("nested_col", Nested([Column("sub_col", UInt(64))])),
+            Column("func_col", AggregateFunction("uniqCombined64", [UInt(64)])),
+            Column(
+                "array_col",
+                Array(UInt(64), SchemaModifiers(nullable=False, readonly=True)),
+            ),
+            Column(
+                "double_array_col",
+                Array(Array(UInt(64)), SchemaModifiers(nullable=False, readonly=True)),
+            ),
+        ]
+
+        assert parse_columns(serialized_columns) == expected_python_columns


### PR DESCRIPTION
### Overview
- Currently, the JSON Schema and Parser assume `Array` Column types will only have a `Float` or `UInt` inner type
- This was sufficient for many datasets but as we work on more configs, we need to add support for all types of Arrays
- This PR modifies the Array schema to now accept recursive inner types
    - The validation limits this to up to 1 layer of recursion, eg `Array(Array(String()))`
    - This is good enough as I haven't seen any instances of `Array(Array(Array(...)))`
    - The parser technically has no limit, it supports as much recursion as needed but the validation will block this

### Code level changes
- Updated JSON Schema
- Updated parser to support additional recursive inner types for Array
- Updated all existing configs with Array's to use the new format
- Modified `parse_columns()` function to split out responsibility into sub functions which deal solely with `ColumnType` while the main function takes care of building the `Column` object itself

### Blast radius
- Dataset Configs

### Notes
- As far as I know, the documentation surrounding JSON Schema _should_ auto update but I will do it manually if I'm wrong