### PR TITLE
fix(init): uWSGI Snuba API processes not initializing Snuba

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -56,7 +56,7 @@ class SnubaCLI(click.MultiCommand):
             # That way if any command code references any snuba construct that needs
             # to be initialized (e.g. a factory) at import time, it is already initialized
             # into the runtime
-            initialize.initialize()
+            initialize.initialize_snuba()
             fn = os.path.join(plugin_folder, actual_command_name + ".py")
             with open(fn) as f:
                 code = compile(f.read(), fn, "exec")

--- a/snuba/core/initialize.py
+++ b/snuba/core/initialize.py
@@ -29,8 +29,8 @@ def _load_entities() -> None:
     initialize_entity_factory()
 
 
-def initialize() -> None:
-    logger.info("Initializing snuba")
+def initialize_snuba() -> None:
+    logger.info("Initializing Snuba")
 
     # The order of the functions matters The reference direction is
     #

--- a/snuba/web/wsgi.py
+++ b/snuba/web/wsgi.py
@@ -1,6 +1,8 @@
+from snuba.core.initialize import initialize_snuba
 from snuba.environment import setup_logging, setup_sentry
 
 setup_logging()
 setup_sentry()
+initialize_snuba()
 
 from snuba.web.views import application  # noqa

--- a/test_initialization/test_initialize.py
+++ b/test_initialization/test_initialize.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from snuba.core.initialize import initialize
+from snuba.core.initialize import initialize_snuba
 
 
 class TestInitialization:
@@ -17,7 +17,7 @@ class TestInitialization:
         for factory in (_DS_FACTORY, _ENT_FACTORY, _STORAGE_FACTORY):
             assert factory is None
 
-        initialize()
+        initialize_snuba()
         from snuba.datasets.entities.factory import get_all_entity_names
         from snuba.datasets.factory import get_enabled_dataset_names
         from snuba.datasets.storages.factory import get_all_storage_keys


### PR DESCRIPTION
### Overview
- When uWSGI starts a new Snuba API process, it simply starts the Flask app
- This is a problem as the first query which hits this new process will force Snuba to load all datasets/entities/storages from config before the query can be executed
- This is causing timeouts as queries which normally take <1s will randomly take >5s to execute

### Before State
- First query to any Snuba API process loads all datasets

### After State
- Datasets are loaded before the Snuba API is declared "ready" by uWSGI

### Blast Radius
- Snuba API
- Initialization is more explicit once again

### Testing Notes
- Tested locally to verify the old version forces datasets to load on first query and now it does not 👨‍🔬 