### PR TITLE
config(slicing) - add slice ID to emitted metrics tags

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -148,11 +148,15 @@ def consumer(
     logger.info("Consumer Starting")
     storage_key = StorageKey(storage_name)
 
-    metrics = MetricsWrapper(
-        environment.metrics,
-        "consumer",
-        tags={"group": consumer_group, "storage": storage_key.value},
-    )
+    metrics_tags = {
+        "group": consumer_group,
+        "storage": storage_key.value,
+    }
+
+    if slice_id:
+        metrics_tags["slice_id"] = str(slice_id)
+
+    metrics = MetricsWrapper(environment.metrics, "consumer", tags=metrics_tags)
     configure_metrics(StreamMetricsAdapter(metrics))
 
     def stats_callback(stats_json: str) -> None:


### PR DESCRIPTION
Adds a slice_id tag to all metrics for a consumer if slice_id is present in the CLI flags. This doesn't change run-time behavior.

## Before State
There is no way to distinguish metrics across slices without using host info

## After State 
Consumers passed slice_id will report that as a tag to metrics, to allow for filtering