### PR TITLE
feat(abi-abuse): add bytes scanned to the querylog consumer

### DIFF
--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -53,6 +53,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
         where_mapping_columns = []
         groupby_columns = []
         array_join_columns = []
+        bytes_scanned_columns = []
 
         for query in query_list:
             sql.append(query["sql"])
@@ -78,7 +79,9 @@ class QuerylogProcessor(DatasetMessageProcessor):
                 "where_profile": {"columns": [], "mapping_cols": []},
                 "groupby_cols": [],
                 "array_join_cols": [],
+                "bytes_scanned": 0,
             }
+            result_profile = query.get("result_profile") or {"bytes": 0}
             time_range = profile["time_range"]
             num_days.append(
                 time_range if time_range is not None and time_range >= 0 else 0
@@ -89,6 +92,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
             where_mapping_columns.append(profile["where_profile"]["mapping_cols"])
             groupby_columns.append(profile["groupby_cols"])
             array_join_columns.append(profile["array_join_cols"])
+            bytes_scanned_columns.append(result_profile.get("bytes", 0))
 
         return {
             "clickhouse_queries.sql": sql,
@@ -111,6 +115,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
             "clickhouse_queries.where_mapping_columns": where_mapping_columns,
             "clickhouse_queries.groupby_columns": groupby_columns,
             "clickhouse_queries.array_join_columns": array_join_columns,
+            "clickhouse_queries.bytes_scanned": bytes_scanned_columns,
         }
 
     def _remove_invalid_data(self, processed: dict[str, Any]) -> None:

--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -73,4 +73,5 @@ storage = WritableTableStorage(
         processor=QuerylogProcessor(),
         default_topic=Topic.QUERYLOG,
     ),
+    writer_options={"input_format_skip_unknown_fields": 1},
 )

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -81,6 +81,7 @@ def test_simple() -> None:
                     groupby_cols=set(),
                     array_join_cols=set(),
                 ),
+                result_profile={"bytes": 1337},
                 trace_id="b" * 32,
             )
         ],
@@ -132,6 +133,7 @@ def test_simple() -> None:
                 "clickhouse_queries.where_mapping_columns": [["tags"]],
                 "clickhouse_queries.groupby_columns": [[]],
                 "clickhouse_queries.array_join_columns": [[]],
+                "clickhouse_queries.bytes_scanned": [1337],
             }
         ],
         None,
@@ -253,6 +255,7 @@ def test_missing_fields() -> None:
                     "clickhouse_queries.where_mapping_columns": [["tags"]],
                     "clickhouse_queries.groupby_columns": [[]],
                     "clickhouse_queries.array_join_columns": [[]],
+                    "clickhouse_queries.bytes_scanned": [0],
                 }
             ],
             None,


### PR DESCRIPTION
## Context

We need to have bytes_scanned in the querylog consumer to better pinpoint api abuse. This is a prereq to #3360. 

## Notes

The only other place this data is accessed is in the [attribution recording](https://github.com/getsentry/snuba/blob/master/snuba/querylog/__init__.py#L61). It may be useful to put it in a more visible place. I'm open to doing that but didn't want that to stop the PR