### PR TITLE
feat(querylog): add bytes_scanned column to querylog storage

### DIFF
--- a/snuba/datasets/storages/querylog.py
+++ b/snuba/datasets/storages/querylog.py
@@ -51,6 +51,7 @@ columns = ColumnSet(
         ("clickhouse_queries.where_mapping_columns", Array(Array(String()))),
         ("clickhouse_queries.groupby_columns", Array(Array(String()))),
         ("clickhouse_queries.array_join_columns", Array(Array(String()))),
+        ("clickhouse_queries.bytes_scanned", Array(UInt(64))),
     ]
 )
 


### PR DESCRIPTION
#3360 and #3375 have already been merged and the migration has been applied

Now all we need is the storage to reflect the table.