### PR TITLE
feat(DC): Querylog Storage as a Config

### DIFF
--- a/snuba/datasets/configuration/querylog/storages/querylog.yaml
+++ b/snuba/datasets/configuration/querylog/storages/querylog.yaml
@@ -1,0 +1,158 @@
+version: v1
+kind: writable_storage
+name: querylog
+storage:
+  key: querylog
+  set_key: querylog
+schema:
+  columns:
+    [
+      { name: request_id, type: UUID },
+      { name: request_body, type: String },
+      { name: referrer, type: String },
+      { name: dataset, type: String },
+      {
+        name: projects,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 64 } } },
+      },
+      {
+        name: organization,
+        type: UInt,
+        args: { schema_modifiers: [nullable], size: 64 },
+      },
+      { name: timestamp, type: DateTime },
+      { name: duration_ms, type: UInt, args: { size: 32 } },
+      { name: status, type: String },
+      {
+        name: clickhouse_queries.sql,
+        type: Array,
+        args: { inner_type: { type: String } },
+      },
+      {
+        name: clickhouse_queries.status,
+        type: Array,
+        args: { inner_type: { type: String } },
+      },
+      {
+        name: clickhouse_queries.trace_id,
+        type: Array,
+        args:
+          {
+            inner_type: { type: UUID, args: { schema_modifiers: [nullable] } },
+          },
+      },
+      {
+        name: clickhouse_queries.duration_ms,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 32 } } },
+      },
+      {
+        name: clickhouse_queries.stats,
+        type: Array,
+        args: { inner_type: { type: String } },
+      },
+      {
+        name: clickhouse_queries.final,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
+      {
+        name: clickhouse_queries.cache_hit,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
+      {
+        name: clickhouse_queries.sample,
+        type: Array,
+        args: { inner_type: { type: Float, args: { size: 32 } } },
+      },
+      {
+        name: clickhouse_queries.max_threads,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
+      {
+        name: clickhouse_queries.num_days,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 32 } } },
+      },
+      {
+        name: clickhouse_queries.clickhouse_table,
+        type: Array,
+        args: { inner_type: { type: String } },
+      },
+      {
+        name: clickhouse_queries.query_id,
+        type: Array,
+        args: { inner_type: { type: String } },
+      },
+      {
+        name: clickhouse_queries.is_duplicate,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
+      {
+        name: clickhouse_queries.consistent,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
+      {
+        name: clickhouse_queries.all_columns,
+        type: Array,
+        args:
+          {
+            inner_type: { type: Array, args: { inner_type: { type: String } } },
+          },
+      },
+      {
+        name: clickhouse_queries.or_conditions,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 8 } } },
+      },
+      {
+        name: clickhouse_queries.where_columns,
+        type: Array,
+        args:
+          {
+            inner_type: { type: Array, args: { inner_type: { type: String } } },
+          },
+      },
+      {
+        name: clickhouse_queries.where_mapping_columns,
+        type: Array,
+        args:
+          {
+            inner_type: { type: Array, args: { inner_type: { type: String } } },
+          },
+      },
+      {
+        name: clickhouse_queries.groupby_columns,
+        type: Array,
+        args:
+          {
+            inner_type: { type: Array, args: { inner_type: { type: String } } },
+          },
+      },
+      {
+        name: clickhouse_queries.array_join_columns,
+        type: Array,
+        args:
+          {
+            inner_type: { type: Array, args: { inner_type: { type: String } } },
+          },
+      },
+      {
+        name: clickhouse_queries.bytes_scanned,
+        type: Array,
+        args: { inner_type: { type: UInt, args: { size: 64 } } },
+      },
+    ]
+  local_table_name: querylog_local
+  dist_table_name: querylog_dist
+writer_options:
+  input_format_skip_unknown_fields: 1
+stream_loader:
+  processor:
+    name: QuerylogProcessor
+  default_topic: snuba-queries

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -32,6 +32,7 @@ from snuba.datasets.storages.generic_metrics import (
     sets_storage,
 )
 from snuba.datasets.storages.profiles import writable_storage as profiles
+from snuba.datasets.storages.querylog import storage as querylog
 from snuba.datasets.storages.transactions import storage as transactions
 from snuba.datasets.table_storage import KafkaStreamLoader
 from tests.datasets.configuration.utils import ConfigurationTest
@@ -109,6 +110,7 @@ class TestStorageConfiguration(ConfigurationTest):
         sets_storage,
         transactions,
         profiles,
+        querylog,
     ]
 
     def test_config_file_discovery(self) -> None:


### PR DESCRIPTION
### Overview
- Adding Querylog storage as a config
- Storage config was generated and tested using scripts from #3336 

### Changes
- Any call to `get_storage(StorageKey.QUERYLOG)` will return the querylog storage built from config instead of the hardcoded version


### Testing Notes
- How config was generated:
    - `python3 scripts/pystorage_2_yaml.py querylog querylog.yaml`
    - Removed quotes around `columns` in schema, format yaml file with Prettier
- How config was tested:
    - `python3 scripts/check_yaml_against_code.py querylog querylog.yaml`
    - Updated `tests/datasets/configuration/test_storage_loader.py`
