### PR TITLE
feat(DC): Replays Storage as Config

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -1,0 +1,120 @@
+version: v1
+kind: writable_storage
+name: replays
+storage:
+  key: replays
+  set_key: replays
+schema:
+  columns:
+    [
+      { name: replay_id, type: UUID },
+      { name: event_hash, type: UUID },
+      {
+        name: segment_id,
+        type: UInt,
+        args: { schema_modifiers: [nullable], size: 16 },
+      },
+      { name: timestamp, type: DateTime },
+      {
+        name: replay_start_timestamp,
+        type: DateTime,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: trace_ids, type: Array, args: { inner_type: { type: UUID } } },
+      { name: error_ids, type: Array, args: { inner_type: { type: UUID } } },
+      { name: title, type: String, args: { schema_modifiers: [readonly] } },
+      { name: url, type: String, args: { schema_modifiers: [nullable] } },
+      { name: urls, type: Array, args: { inner_type: { type: String } } },
+      {
+        name: is_archived,
+        type: UInt,
+        args: { schema_modifiers: [nullable], size: 8 },
+      },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: platform, type: String },
+      {
+        name: environment,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: release, type: String, args: { schema_modifiers: [nullable] } },
+      { name: dist, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: ip_address_v4,
+        type: IPv4,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: ip_address_v6,
+        type: IPv6,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: user, type: String },
+      { name: user_id, type: String, args: { schema_modifiers: [nullable] } },
+      { name: user_name, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: user_email,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: os_name, type: String, args: { schema_modifiers: [nullable] } },
+      {
+        name: os_version,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: browser_name,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: browser_version,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: device_name,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: device_brand,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: device_family,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      {
+        name: device_model,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: sdk_name, type: String },
+      { name: sdk_version, type: String },
+      {
+        name: tags,
+        type: Nested,
+        args:
+          {
+            subcolumns:
+              [{ name: key, type: String }, { name: value, type: String }],
+          },
+      },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+      { name: partition, type: UInt, args: { size: 16 } },
+      { name: offset, type: UInt, args: { size: 64 } },
+    ]
+  local_table_name: replays_local
+  dist_table_name: replays_dist
+query_processors:
+  - processor: TableRateLimit
+mandatory_condition_checkers:
+  - condition: ProjectIdEnforcer
+stream_loader:
+  processor:
+    name: ReplaysProcessor
+  default_topic: ingest-replay-events

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -32,6 +32,7 @@ from snuba.datasets.storages.generic_metrics import (
     sets_storage,
 )
 from snuba.datasets.storages.profiles import writable_storage as profiles
+from snuba.datasets.storages.replays import storage as replays
 from snuba.datasets.storages.transactions import storage as transactions
 from snuba.datasets.table_storage import KafkaStreamLoader
 from tests.datasets.configuration.utils import ConfigurationTest
@@ -109,6 +110,7 @@ class TestStorageConfiguration(ConfigurationTest):
         sets_storage,
         transactions,
         profiles,
+        replays,
     ]
 
     def test_config_file_discovery(self) -> None:


### PR DESCRIPTION
### Overview
- Adding Replays storage as a config
- Storage config was generated and tested using scripts from #3336 

### Changes
- Any call to `get_storage(StorageKey.REPLAYS)` will return the replays storage built from config instead of the hardcoded version


### Testing Notes
- How config was generated:
    - `python3 scripts/pystorage_2_yaml.py replays replays.yaml`
    - Removed quotes around `columns` in schema, format yaml file with Prettier
- How config was tested:
    - `python3 scripts/check_yaml_against_code.py replays replays.yaml`
    - Updated `tests/datasets/configuration/test_storage_loader.py`
