### PR TITLE
feat(DC): Better AggregateFunction arg types

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -24,189 +24,173 @@ schema:
     {
       name: percentiles,
       type: AggregateFunction,
-      args: { func: "quantiles(0.5, 0.75, 0.9, 0.95, 0.99)", arg_types: [{ type: Float, arg: 64 }] },
+      args:
+        {
+          func: "quantiles(0.5, 0.75, 0.9, 0.95, 0.99)",
+          arg_types: [{ type: Float, args: { size: 64 } }],
+        },
     },
     {
       name: min,
       type: AggregateFunction,
-      args: { func: min, arg_types: [{ type: Float, arg: 64 }] }
+      args: { func: min, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
     {
       name: max,
       type: AggregateFunction,
-      args: { func: max, arg_types: [{ type: Float, arg: 64 }] }
+      args: { func: max, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
     {
       name: avg,
       type: AggregateFunction,
-      args: { func: avg, arg_types: [{ type: Float, arg: 64 }] }
+      args: { func: avg, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
     {
       name: sum,
       type: AggregateFunction,
-      args: { func: sum, arg_types: [{ type: Float, arg: 64 }] }
+      args: { func: sum, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
     {
       name: count,
       type: AggregateFunction,
-      args: { func: count, arg_types: [{ type: Float, arg: 64 }] }
+      args: { func: count, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
     {
       name: histogram_buckets,
       type: AggregateFunction,
-      args: { func: histogram(250), arg_types: [{ type: Float, arg: 64 }] }
-    }
+      args:
+        {
+          func: histogram(250),
+          arg_types: [{ type: Float, args: { size: 64 } }],
+        },
+    },
   ]
 
 readable_storage: generic_metrics_distributions
 writable_storage: generic_metrics_distributions_raw
 query_processors:
-  -
-    processor: TagsTypeTransformer
-  -
-    processor: MappedGranularityProcessor
+  - processor: TagsTypeTransformer
+  - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
         3600: 2
         86400: 3
       default_granularity: 1
-  -
-    processor: TimeSeriesProcessor
+  - processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  -
-    processor: ReferrerRateLimiterProcessor
-  -
-    processor: OrganizationRateLimiterProcessor
+  - processor: ReferrerRateLimiterProcessor
+  - processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
-  -
-    processor: ProjectReferrerRateLimiter
+  - processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
-  -
-    processor: ProjectRateLimiterProcessor
+  - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
-  -
-    processor: ResourceQuotaProcessor
+  - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: min
         to_name: minMerge
         aggr_col_name: min
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: minIf
         to_name: minMergeIf
         aggr_col_name: min
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: max
         to_name: maxMerge
         aggr_col_name: max
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: maxIf
         to_name: maxMergeIf
         aggr_col_name: max
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: avg
         to_name: avgMerge
         aggr_col_name: avg
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: avgIf
         to_name: avgMergeIf
         aggr_col_name: avg
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: sum
         to_name: sumMerge
         aggr_col_name: sum
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: sumIf
         to_name: sumMergeIf
         aggr_col_name: sum
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: count
         to_name: countMerge
         aggr_col_name: count
-    -
-      mapper: AggregateFunctionMapper
+    - mapper: AggregateFunctionMapper
       args:
         column_to_map: value
         from_name: countIf
         to_name: countMergeIf
         aggr_col_name: count
   curried_functions:
-    -
-      mapper: AggregateCurriedFunctionMapper
+    - mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: quantiles
         to_name: quantilesMerge
         aggr_col_name: percentiles
-    -
-      mapper: AggregateCurriedFunctionMapper
+    - mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: quantilesIf
         to_name: quantilesMergeIf
         aggr_col_name: percentiles
-    -
-      mapper: AggregateCurriedFunctionMapper
+    - mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: histogram
         to_name: histogramMerge
         aggr_col_name: histogram_buckets
-    -
-      mapper: AggregateCurriedFunctionMapper
+    - mapper: AggregateCurriedFunctionMapper
       args:
         column_to_map: value
         from_name: histogramIf
         to_name: histogramMergeIf
         aggr_col_name: histogram_buckets
   subscriptables:
-    -
-      mapper: SubscriptableMapper
+    - mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags_raw
         to_nested_col_table:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
-    -
-      mapper: SubscriptableMapper
+    - mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags
@@ -214,8 +198,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: indexed_value
 validators:
-  -
-    validator: EntityRequiredColumnValidator
+  - validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
 required_time_column: timestamp

--- a/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
@@ -24,70 +24,62 @@ schema:
     {
       name: value,
       type: AggregateFunction,
-      args: { func: "uniqCombined64", arg_types: [{ type: UInt, arg: 64 }] },
+      args:
+        {
+          func: "uniqCombined64",
+          arg_types: [{ type: UInt, args: { size: 64 } }],
+        },
     },
   ]
 
 readable_storage: generic_metrics_sets
 writable_storage: generic_metrics_sets_raw
 query_processors:
-  -
-    processor: TagsTypeTransformer
-  -
-    processor: MappedGranularityProcessor
+  - processor: TagsTypeTransformer
+  - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
         3600: 2
         86400: 3
       default_granularity: 1
-  -
-    processor: TimeSeriesProcessor
+  - processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  -
-    processor: ReferrerRateLimiterProcessor
-  -
-    processor: OrganizationRateLimiterProcessor
+  - processor: ReferrerRateLimiterProcessor
+  - processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
-  -
-    processor: ProjectReferrerRateLimiter
+  - processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
-  -
-    processor: ProjectRateLimiterProcessor
+  - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
-  -
-    processor: ResourceQuotaProcessor
+  - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
-    -
-      mapper: FunctionNameMapper
+    - mapper: FunctionNameMapper
       args:
         from_name: uniq
         to_name: uniqCombined64Merge
-    -
-      mapper: FunctionNameMapper
+    - mapper: FunctionNameMapper
       args:
         from_name: uniqIf
         to_name: uniqCombined64MergeIf
   subscriptables:
-    -
-      mapper: SubscriptableMapper
+    - mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags_raw
         to_nested_col_table:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
-    -
-      mapper: SubscriptableMapper
+    - mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags
@@ -95,8 +87,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: indexed_value
 validators:
-  -
-    validator: EntityRequiredColumnValidator
+  - validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
 required_time_column: timestamp

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -55,38 +55,43 @@ schema:
         args:
           {
             func: "quantiles(0.5, 0.75, 0.9, 0.95, 0.99)",
-            arg_types: [{ type: Float, arg: 64 }],
+            arg_types: [{ type: Float, args: { size: 64 } }],
           },
       },
       {
         name: min,
         type: AggregateFunction,
-        args: { func: "min", arg_types: [{ type: Float, arg: 64 }] },
+        args: { func: "min", arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: max,
         type: AggregateFunction,
-        args: { func: "max", arg_types: [{ type: Float, arg: 64 }] },
+        args: { func: "max", arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: avg,
         type: AggregateFunction,
-        args: { func: "avg", arg_types: [{ type: Float, arg: 64 }] },
+        args: { func: "avg", arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: sum,
         type: AggregateFunction,
-        args: { func: "sum", arg_types: [{ type: Float, arg: 64 }] },
+        args: { func: "sum", arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: count,
         type: AggregateFunction,
-        args: { func: "count", arg_types: [{ type: Float, arg: 64 }] },
+        args:
+          { func: "count", arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: histogram_buckets,
         type: AggregateFunction,
-        args: { func: "histogram(250)", arg_types: [{ type: Float, arg: 64 }] },
+        args:
+          {
+            func: "histogram(250)",
+            arg_types: [{ type: Float, args: { size: 64 } }],
+          },
       },
     ]
   local_table_name: generic_metric_distributions_aggregated_local

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -52,7 +52,11 @@ schema:
       {
         name: value,
         type: AggregateFunction,
-        args: { func: "uniqCombined64", arg_types: [{ type: UInt, arg: 64 }] },
+        args:
+          {
+            func: "uniqCombined64",
+            arg_types: [{ type: UInt, args: { size: 64 } }],
+          },
       },
     ]
   local_table_name: generic_metric_sets_local

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -155,6 +155,11 @@ NO_ARG_SCHEMA = make_column_schema(
     },
 )
 
+# Get just the type
+_SIMPLE_COLUMN_TYPES = [
+    del_name_field(col_type) for col_type in [NUMBER_SCHEMA, NO_ARG_SCHEMA]
+]
+
 AGGREGATE_FUNCTION_SCHEMA = make_column_schema(
     column_type={"const": "AggregateFunction"},
     args={
@@ -163,21 +168,14 @@ AGGREGATE_FUNCTION_SCHEMA = make_column_schema(
             "func": TYPE_STRING,
             "arg_types": {
                 "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "type": {"enum": ["Float", "UUID", "UInt"]},
-                        "arg": {"type": ["number", "null"]},
-                    },
-                    "additionalProperties": False,
-                },
+                "items": {"anyOf": _SIMPLE_COLUMN_TYPES},
             },
         },
         "additionalProperties": False,
     },
 )
 
-SIMPLE_COLUMN_TYPES = [
+SIMPLE_COLUMN_SCHEMAS = [
     NUMBER_SCHEMA,
     NO_ARG_SCHEMA,
     AGGREGATE_FUNCTION_SCHEMA,
@@ -185,7 +183,7 @@ SIMPLE_COLUMN_TYPES = [
 
 # Array inner types are the same as normal column types except they don't have a name
 _SIMPLE_ARRAY_INNER_TYPES = [
-    del_name_field(col_type) for col_type in SIMPLE_COLUMN_TYPES
+    del_name_field(col_type) for col_type in SIMPLE_COLUMN_SCHEMAS
 ]
 
 # Up to one subarray is supported. Eg Array(Array(String())).
@@ -209,8 +207,8 @@ ARRAY_SCHEMA = make_column_schema(
     },
 )
 
-COLUMN_TYPES = [
-    *SIMPLE_COLUMN_TYPES,
+COLUMN_SCHEMAS = [
+    *SIMPLE_COLUMN_SCHEMAS,
     ARRAY_SCHEMA,
 ]
 
@@ -220,7 +218,7 @@ NESTED_SCHEMA = make_column_schema(
     args={
         "type": "object",
         "properties": {
-            "subcolumns": {"type": "array", "items": {"anyOf": COLUMN_TYPES}}
+            "subcolumns": {"type": "array", "items": {"anyOf": COLUMN_SCHEMAS}}
         },
         "additionalProperties": False,
     },
@@ -228,7 +226,7 @@ NESTED_SCHEMA = make_column_schema(
 
 SCHEMA_COLUMNS = {
     "type": "array",
-    "items": {"anyOf": [*COLUMN_TYPES, NESTED_SCHEMA]},
+    "items": {"anyOf": [*COLUMN_SCHEMAS, NESTED_SCHEMA]},
     "description": "Objects (or nested objects) representing columns containg a name, type and args",
 }
 

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -146,12 +146,8 @@ def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:
     elif col["type"] == "AggregateFunction":
         column_type = AggregateFunction(
             col["args"]["func"],
-            [
-                SIMPLE_COLUMN_TYPES[c["type"]](c["arg"])
-                if "arg" in c
-                else SIMPLE_COLUMN_TYPES[c["type"]]()
-                for c in col["args"]["arg_types"]
-            ],
+            [__parse_column_type(c) for c in col["args"]["arg_types"]],
+            modifiers,
         )
     assert column_type is not None
     return column_type

--- a/tests/datasets/configuration/broken_entity_bad_query_processor.yaml
+++ b/tests/datasets/configuration/broken_entity_bad_query_processor.yaml
@@ -26,7 +26,11 @@ schema:
     {
       name: value,
       type: AggregateFunction,
-      args: { func: "uniqCombined64", arg_types: [{ type: UInt, arg: 64 }] },
+      args:
+        {
+          func: "uniqCombined64",
+          arg_types: [{ type: UInt, args: { size: 64 } }],
+        },
     },
   ]
 
@@ -36,61 +40,50 @@ query_processors:
   -
     # this object is invalid without a processor: attribute
     # processor: TagsTypeTransformer
-  -
-    processor: MappedGranularityProcessor
+  - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
         3600: 2
         86400: 3
       default_granularity: 1
-  -
-    processor: TimeSeriesProcessor
+  - processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  -
-    processor: ReferrerRateLimiterProcessor
-  -
-    processor: OrganizationRateLimiterProcessor
+  - processor: ReferrerRateLimiterProcessor
+  - processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
-  -
-    processor: ProjectReferrerRateLimiter
+  - processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
-  -
-    processor: ProjectRateLimiterProcessor
+  - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
-  -
-    processor: ResourceQuotaProcessor
+  - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
-    -
-      mapper: FunctionNameMapper
+    - mapper: FunctionNameMapper
       args:
         from_name: uniq
         to_name: uniqCombined64Merge
-    -
-      mapper: FunctionNameMapper
+    - mapper: FunctionNameMapper
       args:
         from_name: uniqIf
         to_name: uniqCombined64MergeIf
   subscriptables:
-    -
-      mapper: subscriptable
+    - mapper: subscriptable
       args:
         from_column_table:
         from_column_name: tags_raw
         to_nested_col_table:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
-    -
-      mapper: subscriptable
+    - mapper: subscriptable
       args:
         from_column_table:
         from_column_name: tags
@@ -98,8 +91,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: indexed_value
 validators:
-  -
-    validator: EntityRequiredColumnValidator
+  - validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
 required_time_column: timestamp

--- a/tests/datasets/configuration/broken_entity_positional_validator_args.yaml
+++ b/tests/datasets/configuration/broken_entity_positional_validator_args.yaml
@@ -26,70 +26,62 @@ schema:
     {
       name: value,
       type: AggregateFunction,
-      args: { func: "uniqCombined64", arg_types: [{ type: UInt, arg: 64 }] },
+      args:
+        {
+          func: "uniqCombined64",
+          arg_types: [{ type: UInt, args: { size: 64 } }],
+        },
     },
   ]
 
 readable_storage: generic_metrics_sets
 writable_storage: generic_metrics_sets_raw
 query_processors:
-  -
-    processor: TagsTypeTransformer
-  -
-    processor: MappedGranularityProcessor
+  - processor: TagsTypeTransformer
+  - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
         60: 1
         3600: 2
         86400: 3
       default_granularity: 1
-  -
-    processor: TimeSeriesProcessor
+  - processor: TimeSeriesProcessor
     args:
       time_group_columns:
         bucketed_time: timestamp
       time_parse_columns: [timestamp]
-  -
-    processor: ReferrerRateLimiterProcessor
-  -
-    processor: OrganizationRateLimiterProcessor
+  - processor: ReferrerRateLimiterProcessor
+  - processor: OrganizationRateLimiterProcessor
     args:
       org_column: org_id
-  -
-    processor: ProjectReferrerRateLimiter
+  - processor: ProjectReferrerRateLimiter
     args:
       project_column: project_id
-  -
-    processor: ProjectRateLimiterProcessor
+  - processor: ProjectRateLimiterProcessor
     args:
       project_column: project_id
-  -
-    processor: ResourceQuotaProcessor
+  - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
 translation_mappers:
   functions:
-    -
-      mapper: FunctionNameMapper
+    - mapper: FunctionNameMapper
       args:
         from_name: uniq
         to_name: uniqCombined64Merge
-    -
-      mapper: FunctionNameMapper
+    - mapper: FunctionNameMapper
       args:
         from_name: uniqIf
         to_name: uniqCombined64MergeIf
   subscriptables:
-    -
-      mapper: SubscriptableMapper
+    - mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags_raw
         to_nested_col_table:
         to_nested_col_name: tags
         value_subcolumn_name: raw_value
-    -
-      mapper: SubscriptableMapper
+    - mapper: SubscriptableMapper
       args:
         from_column_table:
         from_column_name: tags
@@ -97,8 +89,7 @@ translation_mappers:
         to_nested_col_name: tags
         value_subcolumn_name: indexed_value
 validators:
-  -
-    validator: EntityRequiredColumnValidator
+  - validator: EntityRequiredColumnValidator
     args:
       # correct: required_filter_columns: ["org_id", "project_id"]
       - org_id

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -184,7 +184,7 @@ query_processors:
                 "type": "AggregateFunction",
                 "args": {
                     "func": "uniqCombined64",
-                    "arg_types": [{"type": "UInt", "arg": 64}],
+                    "arg_types": [{"type": "UInt", "args": {"size": 64}}],
                 },
             },
             {


### PR DESCRIPTION
### Overview
- Currently, the JSON Schema and Parser treat the `AggregateFunction` column type's inner/arg types differently but they are themselves just `ColumnType`'s as well
- Updated the schema and parser to recursively parse arg types as ColumnType's

### Code level changes
- Updated JSON Schema
- Updated parser to support additional arg types for AggregateFunction
- Updated all existing configs with AggFuncs to use the new format

### Blast radius
- Dataset Configs

### Notes
- As far as I know, the documentation surrounding JSON Schema _should_ auto update but I will do it manually if I'm wrong
- A lot of this PR is just my auto formatter 😅 