### PR TITLE
fix(api-abuse): Querylog receiving bad clickhouse_query_settings 

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -322,9 +322,7 @@ def _apply_thread_quota_to_clickhouse_query_settings(
     query_settings: QuerySettings,
     clickhouse_query_settings: MutableMapping[str, Any],
     project_rate_limit_stats: Optional[RateLimitStats],
-) -> MutableMapping[str, Any]:
-    res: MutableMapping[str, Any] = {}
-    res.update(clickhouse_query_settings)
+) -> None:
     thread_quota = query_settings.get_resource_quota()
     if (
         "max_threads" in clickhouse_query_settings or thread_quota is not None
@@ -334,8 +332,9 @@ def _apply_thread_quota_to_clickhouse_query_settings(
             if thread_quota is None
             else thread_quota.max_threads
         )
-        res["max_threads"] = max(1, maxt - project_rate_limit_stats.concurrent + 1)
-    return res
+        clickhouse_query_settings["max_threads"] = max(
+            1, maxt - project_rate_limit_stats.concurrent + 1
+        )
 
 
 @with_span(op="db")
@@ -360,7 +359,7 @@ def execute_query_with_rate_limits(
         project_rate_limit_stats = rate_limit_stats_container.get_stats(
             PROJECT_RATE_LIMIT_NAME
         )
-        clickhouse_query_settings = _apply_thread_quota_to_clickhouse_query_settings(
+        _apply_thread_quota_to_clickhouse_query_settings(
             query_settings, clickhouse_query_settings, project_rate_limit_stats
         )
 

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -93,7 +93,8 @@ def test_apply_thread_quota(
     for rlimit in rate_limit_params:
         settings.add_rate_limit(rlimit)
     settings.set_resource_quota(resource_quota)
-    clickhouse_query_settings = _apply_thread_quota_to_clickhouse_query_settings(
-        settings, {}, rate_limit_stats
+    clickhouse_query_settings: MutableMapping[str, Any] = {}
+    _apply_thread_quota_to_clickhouse_query_settings(
+        settings, clickhouse_query_settings, rate_limit_stats
     )
     assert clickhouse_query_settings == expected_query_settings


### PR DESCRIPTION
### Overview
The querylog is not writing `max_thread` to `stats`. When the query metadata message gets produced to querylog topic, it is missing `max_threads` key in its payload. This is caused by the introduction of applying thread quota to `clickhouse_query_settings`. 

### Before State:
* In `raw_query()` we pass `clickhouse_query_settings` and mutate its contents by reference. However, `_apply_thread_quota_to_clickhouse_query_settings` creates a new dictionary (with new memory address) and writes max_threads. As a result, the original  dictionary in the top level function does not contain `max_threads` key.

### After State:
* Mutate the original dictionary

### Blast Radius:
* The payload of Querylog messages

### Testing Done:
* Validated that `max_threads` is correctly passed through pipeline.
* Validate `max_threads` now exists in querylog Kafka message.