### PR TITLE
ref(admin): Refactor Runtime notification client

### DIFF
--- a/snuba/admin/notifications/base.py
+++ b/snuba/admin/notifications/base.py
@@ -5,9 +5,9 @@ from typing import Any, Mapping, Optional
 
 
 class NotificationAction(Enum):
-    ADDED = "added"
-    REMOVED = "removed"
-    UPDATED = "updated"
+    CONFIG_OPTION_ADDED = "option.added"
+    CONFIG_OPTION_REMOVED = "option.removed"
+    CONFIG_OPTION_UPDATED = "option.updated"
 
 
 class NotificationBase(ABC):

--- a/snuba/admin/notifications/base.py
+++ b/snuba/admin/notifications/base.py
@@ -1,27 +1,13 @@
 from abc import ABC
 from datetime import datetime
 from enum import Enum
-from typing import Any, MutableMapping, Optional, TypedDict, Union
-
-import structlog
-
-from snuba import settings
-from snuba.admin.notifications.slack.client import SlackClient
-from snuba.admin.notifications.slack.utils import build_blocks
+from typing import Any, Mapping, Optional
 
 
-class RuntimeConfigAction(Enum):
+class NotificationAction(Enum):
     ADDED = "added"
     REMOVED = "removed"
     UPDATED = "updated"
-
-
-ConfigType = Union[str, int, float]
-
-NotificationData = TypedDict(
-    "NotificationData",
-    {"option": str, "old": Optional[ConfigType], "new": Optional[ConfigType]},
-)
 
 
 class NotificationBase(ABC):
@@ -32,8 +18,8 @@ class NotificationBase(ABC):
 
     def notify(
         self,
-        action: RuntimeConfigAction,
-        data: NotificationData,
+        action: NotificationAction,
+        data: Mapping[str, Any],
         user: Optional[str],
         timestamp: Optional[str] = None,
     ) -> None:
@@ -45,115 +31,3 @@ class NotificationBase(ABC):
         timestamp: time the action occurred (or can be generated when notify is called)
         """
         raise NotImplementedError()
-
-
-class RuntimeConfigLogClient(NotificationBase):
-    def __init__(self) -> None:
-        self.logger = structlog.get_logger().bind(module=__name__)
-
-    def _get_value_text(
-        self,
-        action: RuntimeConfigAction,
-        old: Optional[ConfigType],
-        new: Optional[ConfigType],
-    ) -> str:
-        if action == RuntimeConfigAction.REMOVED:
-            return f"(value:{old})"
-        elif action == RuntimeConfigAction.ADDED:
-            return f"(value:{new})"
-        elif action == RuntimeConfigAction.UPDATED:
-            return f"(from value:{old} to value:{new})"
-        else:
-            return ""
-
-    def notify(
-        self,
-        action: RuntimeConfigAction,
-        data: NotificationData,
-        user: Optional[str],
-        timestamp: Optional[str] = None,
-    ) -> None:
-        """
-        Data has the runtime option, its old value, and new value.
-        If it's being removed, the new value will be `None`. Likewise
-        if it's being added, the old value will be `None`.
-
-        example:
-            {
-                "option": "enable_events_read_only_table",
-                "old": 0, // or None if added
-                "new": 1, // or None if removed
-            }
-
-        """
-
-        self.logger.info(
-            event="value_updated",
-            user=user,
-            action=action.value,
-            option=data["option"],
-            old=data["old"],
-            new=data["new"],
-            timestamp=timestamp,
-        )
-
-
-class RuntimeConfigSlackClient(NotificationBase):
-    def __init__(self) -> None:
-        self.client = SlackClient()
-        # feed-sns-admin channel
-        self.channel_id = settings.SNUBA_SLACK_CHANNEL_ID
-
-    def notify(
-        self,
-        action: RuntimeConfigAction,
-        data: NotificationData,
-        user: Optional[str],
-        timestamp: Optional[str] = None,
-    ) -> None:
-        """
-        Data has the runtime option, its old value, and new value.
-        If it's being removed, the new value will be `None`. Likewise
-        if it's being added, the old value will be `None`.
-
-        example:
-            {
-                "option": "enable_events_read_only_table",
-                "old": 0, // or None if added
-                "new": 1, // or None if removed
-            }
-
-        """
-        if not timestamp:
-            timestamp = self.timestamp
-
-        blocks = build_blocks(data, action.value, timestamp, user or "")
-        payload: MutableMapping[str, Any] = {"blocks": blocks}
-
-        self.client.post_message(message=payload, channel=self.channel_id)
-
-
-class RuntimeConfigAutoClient(NotificationBase):
-    """
-    Uses the Slack client if is is configured, otherwise falls back to the log client
-    """
-
-    def __init__(self) -> None:
-        is_slack_configured = (
-            settings.SNUBA_SLACK_CHANNEL_ID is not None
-            and settings.SLACK_API_TOKEN is not None
-        )
-        self.__notification_client = (
-            RuntimeConfigSlackClient()
-            if is_slack_configured
-            else RuntimeConfigLogClient()
-        )
-
-    def notify(
-        self,
-        action: RuntimeConfigAction,
-        data: NotificationData,
-        user: Optional[str],
-        timestamp: Optional[str] = None,
-    ) -> None:
-        return self.__notification_client.notify(action, data, user, timestamp)

--- a/snuba/admin/notifications/runtime_config/client.py
+++ b/snuba/admin/notifications/runtime_config/client.py
@@ -20,11 +20,11 @@ class RuntimeConfigLogClient(NotificationBase):
         old: Optional[ConfigType],
         new: Optional[ConfigType],
     ) -> str:
-        if action == NotificationAction.REMOVED:
+        if action == NotificationAction.CONFIG_OPTION_REMOVED:
             return f"(value:{old})"
-        elif action == NotificationAction.ADDED:
+        elif action == NotificationAction.CONFIG_OPTION_ADDED:
             return f"(value:{new})"
-        elif action == NotificationAction.UPDATED:
+        elif action == NotificationAction.CONFIG_OPTION_UPDATED:
             return f"(from value:{old} to value:{new})"
         else:
             return ""
@@ -90,7 +90,7 @@ class RuntimeConfigSlackClient(NotificationBase):
         if not timestamp:
             timestamp = self.timestamp
 
-        blocks = build_blocks(data, action.value, timestamp, user or "")
+        blocks = build_blocks(data, action, timestamp, user or "")
         payload: MutableMapping[str, Any] = {"blocks": blocks}
 
         self.client.post_message(message=payload, channel=self.channel_id)

--- a/snuba/admin/notifications/runtime_config/client.py
+++ b/snuba/admin/notifications/runtime_config/client.py
@@ -1,0 +1,122 @@
+from typing import Any, Mapping, MutableMapping, Optional, Union
+
+import structlog
+
+from snuba import settings
+from snuba.admin.notifications.base import NotificationAction, NotificationBase
+from snuba.admin.notifications.slack.client import slack_client
+from snuba.admin.notifications.slack.utils import build_blocks
+
+ConfigType = Union[str, int, float]
+
+
+class RuntimeConfigLogClient(NotificationBase):
+    def __init__(self) -> None:
+        self.logger = structlog.get_logger().bind(module=__name__)
+
+    def _get_value_text(
+        self,
+        action: NotificationAction,
+        old: Optional[ConfigType],
+        new: Optional[ConfigType],
+    ) -> str:
+        if action == NotificationAction.REMOVED:
+            return f"(value:{old})"
+        elif action == NotificationAction.ADDED:
+            return f"(value:{new})"
+        elif action == NotificationAction.UPDATED:
+            return f"(from value:{old} to value:{new})"
+        else:
+            return ""
+
+    def notify(
+        self,
+        action: NotificationAction,
+        data: Mapping[str, Any],
+        user: Optional[str],
+        timestamp: Optional[str] = None,
+    ) -> None:
+        """
+        Data has the runtime option, its old value, and new value.
+        If it's being removed, the new value will be `None`. Likewise
+        if it's being added, the old value will be `None`.
+
+        example:
+            {
+                "option": "enable_events_read_only_table",
+                "old": 0, // or None if added
+                "new": 1, // or None if removed
+            }
+
+        """
+
+        self.logger.info(
+            event="value_updated",
+            user=user,
+            action=action.value,
+            option=data["option"],
+            old=data["old"],
+            new=data["new"],
+            timestamp=timestamp,
+        )
+
+
+class RuntimeConfigSlackClient(NotificationBase):
+    def __init__(self) -> None:
+        self.client = slack_client
+        # feed-sns-admin channel
+        self.channel_id = settings.SNUBA_SLACK_CHANNEL_ID
+
+    def notify(
+        self,
+        action: NotificationAction,
+        data: Mapping[str, Any],
+        user: Optional[str],
+        timestamp: Optional[str] = None,
+    ) -> None:
+        """
+        Data has the runtime option, its old value, and new value.
+        If it's being removed, the new value will be `None`. Likewise
+        if it's being added, the old value will be `None`.
+
+        example:
+            {
+                "option": "enable_events_read_only_table",
+                "old": 0, // or None if added
+                "new": 1, // or None if removed
+            }
+
+        """
+        if not timestamp:
+            timestamp = self.timestamp
+
+        blocks = build_blocks(data, action.value, timestamp, user or "")
+        payload: MutableMapping[str, Any] = {"blocks": blocks}
+
+        self.client.post_message(message=payload, channel=self.channel_id)
+
+
+class RuntimeConfigAutoClient(NotificationBase):
+    """
+    Uses the Slack client if is is configured, otherwise falls back to the log client
+    """
+
+    def __init__(self) -> None:
+        is_slack_configured = (
+            settings.SNUBA_SLACK_CHANNEL_ID is not None
+            and settings.SLACK_API_TOKEN is not None
+        )
+        self.__notification_client = (
+            RuntimeConfigSlackClient()
+            if is_slack_configured
+            else RuntimeConfigLogClient()
+        )
+
+    def notify(
+        self,
+        action: NotificationAction,
+        data: Mapping[str, Any],
+        user: Optional[str],
+        timestamp: Optional[str] = None,
+    ) -> None:
+        return self.__notification_client.notify(action, data, user, timestamp)

--- a/snuba/admin/notifications/slack/client.py
+++ b/snuba/admin/notifications/slack/client.py
@@ -49,3 +49,6 @@ class SlackClient(object):
 
         if not is_ok:
             logger.error(f"Slack error: {str(error_option)}")
+
+
+slack_client = SlackClient()

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List, Optional, Union
 
 from snuba import settings
+from snuba.admin.notifications.base import NotificationAction
 
 
 def build_blocks(data: Any, action: str, timestamp: str, user: str) -> List[Any]:
@@ -13,11 +14,11 @@ def build_text(data: Any, action: str) -> Optional[str]:
     added = f"```{{'{data['option']}': {data['new']}}}```"
     updated = f"{removed} {added}"
 
-    if action == "removed":
+    if action == NotificationAction.CONFIG_OPTION_REMOVED:
         return f"{base} :put_litter_in_its_place:\n\n {removed}"
-    elif action == "added":
+    elif action == NotificationAction.CONFIG_OPTION_ADDED:
         return f"{base} :new:\n\n {added}"
-    elif action == "updated":
+    elif action == NotificationAction.CONFIG_OPTION_UPDATED:
         return f"{base} :up: :date:\n\n {updated}"
     else:
         # todo: raise error, cause slack won't accept this

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -417,7 +417,7 @@ def configs() -> Response:
         }
 
         runtime_notification_client.notify(
-            NotificationAction.ADDED,
+            NotificationAction.CONFIG_OPTION_ADDED,
             {"option": key, "old": None, "new": evaluated_value},
             user,
         )
@@ -471,7 +471,7 @@ def config(config_key: str) -> Response:
             state.delete_config_description(config_key, user=user)
 
         runtime_notification_client.notify(
-            NotificationAction.REMOVED,
+            NotificationAction.CONFIG_OPTION_REMOVED,
             {"option": config_key, "old": old, "new": None},
             user,
         )
@@ -524,7 +524,7 @@ def config(config_key: str) -> Response:
 
         # Send notification
         runtime_notification_client.notify(
-            NotificationAction.UPDATED,
+            NotificationAction.CONFIG_OPTION_UPDATED,
             {"option": config_key, "old": old, "new": evaluated_value},
             user=user,
         )


### PR DESCRIPTION
The `NotificationBase` class was never meant to be hyper specific to the runtime config, I think the types worked for the runtime config, but I think the notification data should be more generic. 