### PR TITLE
fix(DC): Move missed ClickhouseQueryProcessor

### DIFF
--- a/snuba/datasets/storages/sessions.py
+++ b/snuba/datasets/storages/sessions.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from snuba.clickhouse.columns import (
     UUID,
     AggregateFunction,
@@ -8,23 +6,21 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
-from snuba.clickhouse.query import Query
-from snuba.clickhouse.query_dsl.accessors import get_time_range
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.processors.sessions_processor import SessionsProcessor
 from snuba.datasets.schemas.tables import TableSchema, WritableTableSchema
 from snuba.datasets.storage import ReadableTableStorage, WritableTableStorage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
-from snuba.query.exceptions import ValidationException
 from snuba.query.processors.condition_checkers.checkers import (
     OrgIdEnforcer,
     ProjectIdEnforcer,
 )
-from snuba.query.processors.physical import ClickhouseQueryProcessor
+from snuba.query.processors.physical.minute_resolution_processor import (
+    MinuteResolutionProcessor,
+)
 from snuba.query.processors.physical.prewhere import PrewhereProcessor
 from snuba.query.processors.physical.table_rate_limit import TableRateLimit
-from snuba.query.query_settings import QuerySettings
 from snuba.utils.streams.topics import Topic
 
 WRITE_LOCAL_TABLE_NAME = "sessions_raw_local"
@@ -103,17 +99,6 @@ materialized_view_schema = TableSchema(
     storage_set_key=StorageSetKey.SESSIONS,
     columns=read_columns,
 )
-
-
-class MinuteResolutionProcessor(ClickhouseQueryProcessor):
-    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
-        # NOTE: the product side is restricted to a 6h window, however it rounds
-        # outwards, which extends the window to 7h.
-        from_date, to_date = get_time_range(query, "started")
-        if not from_date or not to_date or (to_date - from_date) > timedelta(hours=7):
-            raise ValidationException(
-                "Minute-resolution queries are restricted to a 7-hour time window."
-            )
 
 
 kafka_stream_loader = build_kafka_stream_loader_from_settings(

--- a/snuba/query/processors/physical/minute_resolution_processor.py
+++ b/snuba/query/processors/physical/minute_resolution_processor.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+
+from snuba.clickhouse.query import Query
+from snuba.clickhouse.query_dsl.accessors import get_time_range
+from snuba.query.exceptions import ValidationException
+from snuba.query.processors.physical import ClickhouseQueryProcessor
+from snuba.query.query_settings import QuerySettings
+
+
+class MinuteResolutionProcessor(ClickhouseQueryProcessor):
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        # NOTE: the product side is restricted to a 6h window, however it rounds
+        # outwards, which extends the window to 7h.
+        from_date, to_date = get_time_range(query, "started")
+        if not from_date or not to_date or (to_date - from_date) > timedelta(hours=7):
+            raise ValidationException(
+                "Minute-resolution queries are restricted to a 7-hour time window."
+            )


### PR DESCRIPTION
### Overview
- `MinuteResolutionProcessor` seems to have been missed in #3160 
- Moved it to appropriate folder so it can be picked up by the registered class