### PR TITLE
fix(DC): Fix ReadableStorage Schema

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -421,8 +421,8 @@ V1_READABLE_STORAGE_SCHEMA = {
         "storage": STORAGE_SCHEMA,
         "schema": SCHEMA_SCHEMA,
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
-        "query_splitters": STORAGE_QUERY_PROCESSORS_SCHEMA,
-        "mandatory_condition_checkers": STORAGE_QUERY_PROCESSORS_SCHEMA,
+        "query_splitters": STORAGE_QUERY_SPLITTERS_SCHEMA,
+        "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
     },
     "required": [
         "version",


### PR DESCRIPTION
ReadableStorage JSON schema has a bug. Currently, the `STORAGE_QUERY_PROCESSORS_SCHEMA` is used for query_processors, query_splitters, and mandatory_condition_checkers. This PR fixes and updates those fields to use their correct schemas. 