### PR TITLE
ref(migrations): make migration use single ordered sequence SNS-1830

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -182,6 +182,9 @@ class ClickhouseNodeMigration(Migration, ABC):
 
 
 class ClickhouseNodeMigrationLegacy(ClickhouseNodeMigration, ABC):
+    """
+    This is now deprecated. Use ClickhouseNodeMigration instead.
+    """
 
     forwards_local_first: bool = True
     backwards_local_first: bool = False

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -166,19 +166,19 @@ class ClickhouseNodeMigration(Migration, ABC):
         self,
         ops: Sequence[SqlOperation],
     ) -> None:
-        def print_dist_op(op: SqlOperation, is_single_node: bool) -> None:
+        def print_dist_op(op: SqlOperation) -> None:
+            cluster = get_cluster(op._storage_set)
+            is_single_node = cluster.is_single_node()
             if not is_single_node:
                 print(f"Distributed op: {op.format_sql()}")
             else:
                 print("Skipped dist operation - single node cluster")
 
         for op in ops:
-            cluster = get_cluster(op._storage_set)
-            is_single_node = cluster.is_single_node()
             if op.target == OperationTarget.LOCAL:
                 print(f"Local op: {op.format_sql()}")
             elif op.target == OperationTarget.DISTRIBUTED:
-                print_dist_op(op, is_single_node)
+                print_dist_op(op)
 
 
 class ClickhouseNodeMigrationLegacy(ClickhouseNodeMigration, ABC):

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -94,7 +94,7 @@ class CodeMigration(Migration, ABC):
         update_status(Status.NOT_STARTED)
 
 
-class ClickhouseNodeMigrationLegacy(Migration, ABC):
+class ClickhouseNodeMigration(Migration, ABC):
     """
     A ClickhouseNodeMigration consists of one or more forward operations which will be executed
     on all of the local and distributed nodes of the cluster. Upon error, the backwards

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -25,8 +25,8 @@ class SqlOperation(ABC):
     def __init__(
         self,
         storage_set: StorageSetKey,
-        target: OperationTarget,
         settings: Optional[Mapping[str, Any]] = None,
+        target: OperationTarget = OperationTarget.UNSET,
     ):
         self._storage_set = storage_set
         self._settings = settings
@@ -189,8 +189,8 @@ class ModifyTableTTL(SqlOperation):
         self.__materialize_ttl_on_modify = 1 if materialize_ttl_on_modify else 0
         super().__init__(
             storage_set,
-            target,
             {"materialize_ttl_on_modify": self.__materialize_ttl_on_modify},
+            target=target,
         )
         self.__table_name = table_name
         self.__reference_column = reference_column

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -25,8 +25,8 @@ class SqlOperation(ABC):
     def __init__(
         self,
         storage_set: StorageSetKey,
+        target: OperationTarget,
         settings: Optional[Mapping[str, Any]] = None,
-        target: OperationTarget = OperationTarget.UNSET,
     ):
         self._storage_set = storage_set
         self._settings = settings
@@ -189,8 +189,8 @@ class ModifyTableTTL(SqlOperation):
         self.__materialize_ttl_on_modify = 1 if materialize_ttl_on_modify else 0
         super().__init__(
             storage_set,
+            target,
             {"materialize_ttl_on_modify": self.__materialize_ttl_on_modify},
-            target=target,
         )
         self.__table_name = table_name
         self.__reference_column = reference_column

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -3,8 +3,14 @@ from typing import Sequence, Union
 
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
-from snuba.migrations.migration import ClickhouseNodeMigrationLegacy
-from snuba.migrations.operations import AddColumn, CreateTable, DropColumn, SqlOperation
+from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.operations import (
+    AddColumn,
+    CreateTable,
+    DropColumn,
+    OperationTarget,
+    SqlOperation,
+)
 
 ENGINE_REGEX = r"^Distributed(\(.+\))$"
 
@@ -27,73 +33,102 @@ class NoDistClusterNodes(Exception):
 
 class DistributedEngineParseError(Exception):
     """
-    Cant parser the distributed engine string value
+    Cant parse the distributed engine string value
     """
 
     pass
 
 
-def validate_migration_order(migration: ClickhouseNodeMigrationLegacy) -> None:
+def _conflicts_ops(local_op: SqlOperation, dist_op: SqlOperation) -> bool:
+    if isinstance(local_op, CreateTable) and isinstance(dist_op, CreateTable):
+        return conflicts_create_table_op(local_op, dist_op)
+    elif isinstance(local_op, AddColumn) and isinstance(dist_op, AddColumn):
+        return conflicts_add_column_op(local_op, dist_op)
+    elif isinstance(local_op, DropColumn) and isinstance(dist_op, DropColumn):
+        return conflicts_drop_column_op(local_op, dist_op)
+    return False
+
+
+def _validate_add_col_or_create_table(
+    local_op: SqlOperation, dist_ops: Sequence[SqlOperation]
+) -> None:
+    if isinstance(local_op, (CreateTable, AddColumn)):
+        if any(_conflicts_ops(local_op, dist_op) for dist_op in dist_ops):
+            op_name = (
+                f"{local_op.table_name}.{local_op.column.name}"
+                if isinstance(local_op, AddColumn)
+                else local_op.table_name
+            )
+            raise InvalidMigrationOrderError(
+                f"{type(local_op).__name__} {op_name} operation "
+                "must be applied on local table before dist"
+            )
+
+
+def _validate_drop(dist_op: SqlOperation, local_ops: Sequence[SqlOperation]) -> None:
+    if isinstance(dist_op, (DropColumn)):
+        if any(_conflicts_ops(local_op, dist_op) for local_op in local_ops):
+            raise InvalidMigrationOrderError(
+                f"{type(dist_op).__name__} {dist_op.table_name}.{dist_op.column_name} "
+                "operation must be applied on dist table before local"
+            )
+
+
+def validate_order_old(
+    local_ops: Sequence[SqlOperation],
+    dist_ops: Sequence[SqlOperation],
+    local_first: bool,
+) -> None:
+    if local_first:
+        for dist_op in dist_ops:
+            _validate_drop(dist_op, local_ops)
+    else:
+        for local_op in local_ops:
+            _validate_add_col_or_create_table(local_op, dist_ops)
+
+
+def validate_order_new(
+    forward_ops: Sequence[SqlOperation], backwards_ops: Sequence[SqlOperation]
+) -> None:
+    for ops in [forward_ops, backwards_ops]:
+        for i, op in enumerate(ops):
+            local_ops_before = [
+                op for op in ops[:i] if op.target != OperationTarget.DISTRIBUTED
+            ]
+            dist_ops_before = [
+                op for op in ops[:i] if op.target != OperationTarget.LOCAL
+            ]
+            if isinstance(op, (CreateTable, AddColumn)):
+                if op.target == OperationTarget.LOCAL:
+                    _validate_add_col_or_create_table(op, dist_ops_before)
+            elif isinstance(op, DropColumn):
+                _validate_drop(op, local_ops_before)
+
+
+def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
     """
     Validates that the migration order is correct. Checks that the order of
     AddColumn, CreateTable and DropColumn operations are correct with regards to being
     applied on local and distributed tables.
     """
 
-    def conflicts_ops(local_op: SqlOperation, dist_op: SqlOperation) -> bool:
-        if isinstance(local_op, CreateTable) and isinstance(dist_op, CreateTable):
-            return conflicts_create_table_op(local_op, dist_op)
-        elif isinstance(local_op, AddColumn) and isinstance(dist_op, AddColumn):
-            return conflicts_add_column_op(local_op, dist_op)
-        elif isinstance(local_op, DropColumn) and isinstance(dist_op, DropColumn):
-            return conflicts_drop_column_op(local_op, dist_op)
-        return False
-
-    def validate_add_col_or_create_table(
-        local_op: SqlOperation, dist_ops: Sequence[SqlOperation]
-    ) -> None:
-        if isinstance(local_op, (CreateTable, AddColumn)):
-            if any(conflicts_ops(local_op, dist_op) for dist_op in dist_ops):
-                op_name = (
-                    f"{local_op.table_name}.{local_op.column.name}"
-                    if isinstance(local_op, AddColumn)
-                    else local_op.table_name
-                )
-                raise InvalidMigrationOrderError(
-                    f"{type(local_op).__name__} {op_name} operation "
-                    "must be applied on local table before dist"
-                )
-
-    def validate_drop(dist_op: SqlOperation, local_ops: Sequence[SqlOperation]) -> None:
-        if isinstance(dist_op, (DropColumn)):
-            if any(conflicts_ops(local_op, dist_op) for local_op in local_ops):
-                raise InvalidMigrationOrderError(
-                    f"{type(dist_op).__name__} {dist_op.table_name}.{dist_op.column_name} "
-                    "operation must be applied on dist table before local"
-                )
-
-    def validate_order(
-        local_ops: Sequence[SqlOperation],
-        dist_ops: Sequence[SqlOperation],
-        local_first: bool,
-    ) -> None:
-        if local_first:
-            for dist_op in dist_ops:
-                validate_drop(dist_op, local_ops)
-        else:
-            for local_op in local_ops:
-                validate_add_col_or_create_table(local_op, dist_ops)
-
-    validate_order(
-        migration.forwards_local(),
-        migration.forwards_dist(),
-        migration.forwards_local_first,
-    )
-    validate_order(
-        migration.backwards_local(),
-        migration.backwards_dist(),
-        migration.backwards_local_first,
-    )
+    try:
+        # old way of doing migrations
+        validate_order_old(
+            migration.forwards_local(),
+            migration.forwards_dist(),
+            migration.forwards_local_first,
+        )
+        validate_order_old(
+            migration.backwards_local(),
+            migration.backwards_dist(),
+            migration.backwards_local_first,
+        )
+    except NotImplementedError:
+        # try new way of doing migrations
+        forward_ops = migration.forwards_ops()
+        backward_ops = migration.backwards_ops()
+        validate_order_new(forward_ops, backward_ops)
 
 
 def conflicts_create_table_op(

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -3,7 +3,10 @@ from typing import Sequence, Union
 
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
-from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.migration import (
+    ClickhouseNodeMigration,
+    ClickhouseNodeMigrationLegacy,
+)
 from snuba.migrations.operations import (
     AddColumn,
     CreateTable,
@@ -112,7 +115,7 @@ def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
     applied on local and distributed tables.
     """
 
-    try:
+    if isinstance(migration, ClickhouseNodeMigrationLegacy):
         # old way of doing migrations
         validate_order_old(
             migration.forwards_local(),
@@ -124,7 +127,7 @@ def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
             migration.backwards_dist(),
             migration.backwards_local_first,
         )
-    except NotImplementedError:
+    else:
         # try new way of doing migrations
         forward_ops = migration.forwards_ops()
         backward_ops = migration.backwards_ops()

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -36,7 +36,7 @@ class NoDistClusterNodes(Exception):
 
 class DistributedEngineParseError(Exception):
     """
-    Cant parse the distributed engine string value
+    Can't parse the distributed engine string value
     """
 
     pass
@@ -77,11 +77,14 @@ def _validate_drop(dist_op: SqlOperation, local_ops: Sequence[SqlOperation]) -> 
             )
 
 
-def validate_order_old(
+def _validate_order_old(
     local_ops: Sequence[SqlOperation],
     dist_ops: Sequence[SqlOperation],
     local_first: bool,
 ) -> None:
+    """
+    Validates migration order for old style migrations ClickhouseNodeMigrationLegacy class.
+    """
     if local_first:
         for dist_op in dist_ops:
             _validate_drop(dist_op, local_ops)
@@ -90,9 +93,12 @@ def validate_order_old(
             _validate_add_col_or_create_table(local_op, dist_ops)
 
 
-def validate_order_new(
+def _validate_order_new(
     forward_ops: Sequence[SqlOperation], backwards_ops: Sequence[SqlOperation]
 ) -> None:
+    """
+    Validates migration order for new style migrations ClickhouseNodeMigration class.
+    """
     for ops in [forward_ops, backwards_ops]:
         for i, op in enumerate(ops):
             local_ops_before = [
@@ -117,12 +123,12 @@ def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
 
     if isinstance(migration, ClickhouseNodeMigrationLegacy):
         # old way of doing migrations
-        validate_order_old(
+        _validate_order_old(
             migration.forwards_local(),
             migration.forwards_dist(),
             migration.forwards_local_first,
         )
-        validate_order_old(
+        _validate_order_old(
             migration.backwards_local(),
             migration.backwards_dist(),
             migration.backwards_local_first,
@@ -131,7 +137,7 @@ def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
         # try new way of doing migrations
         forward_ops = migration.forwards_ops()
         backward_ops = migration.backwards_ops()
-        validate_order_new(forward_ops, backward_ops)
+        _validate_order_new(forward_ops, backward_ops)
 
 
 def conflicts_create_table_op(

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -19,12 +19,13 @@ from snuba.migrations.operations import (
     InsertIntoSelect,
     ModifyColumn,
     ModifyTableTTL,
+    OperationTarget,
     RemoveTableTTL,
     RenameTable,
     SqlOperation,
     TruncateTable,
 )
-from snuba.migrations.table_engines import ReplacingMergeTree
+from snuba.migrations.table_engines import Merge, ReplacingMergeTree
 from snuba.utils.schemas import DateTime
 
 
@@ -271,3 +272,145 @@ def test_specify_order() -> None:
     test_migration.backwards_local_first = True
     test_migration.backwards(context, False)
     assert order == [drop_local_op, drop_dist_op]
+
+
+def test_create_dist_table() -> None:
+    database = os.environ.get("CLICKHOUSE_DATABASE", "default")
+    columns: Sequence[Column[Modifiers]] = [
+        Column("id", String()),
+        Column("name", String(Modifiers(nullable=True))),
+        Column("version", UInt(64)),
+    ]
+
+    op = CreateTable(
+        StorageSetKey.EVENTS,
+        "test_table",
+        columns,
+        ReplacingMergeTree(
+            storage_set=StorageSetKey.EVENTS,
+            version_column="version",
+            order_by="version",
+            settings={"index_granularity": "256"},
+        ),
+        dist_table_name="test_dist_table",
+        target=OperationTarget.BOTH,
+        dist_engine=Merge("test_table"),
+    )
+
+    assert op.format_sql() in [
+        "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64) ENGINE ReplacingMergeTree(version) ORDER BY version SETTINGS index_granularity=256;",
+        "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64) ENGINE ReplicatedReplacingMergeTree('/clickhouse/tables/events/{shard}/"
+        + f"{database}/test_table'"
+        + ", '{replica}', version) ORDER BY version SETTINGS index_granularity=256;",
+    ]
+
+    assert (
+        op.format_sql(False)
+        == "CREATE TABLE IF NOT EXISTS test_dist_table (id String, name Nullable(String), version UInt64) ENGINE Merge(currentDatabase(), 'test_table');"
+    )
+
+
+def test_add_dist_column() -> None:
+    op = AddColumn(
+        StorageSetKey.EVENTS,
+        "test_table",
+        Column("new_column", String()),
+        after="id",
+        target=OperationTarget.BOTH,
+        dist_table_name="test_dist_table",
+    )
+
+    assert (
+        op.format_sql()
+        == "ALTER TABLE test_table ADD COLUMN IF NOT EXISTS new_column String AFTER id;"
+    )
+    assert (
+        op.format_sql(False)
+        == "ALTER TABLE test_dist_table ADD COLUMN IF NOT EXISTS new_column String AFTER id;"
+    )
+
+    local_op = AddColumn(
+        StorageSetKey.EVENTS,
+        "test_table",
+        Column("new_column", String()),
+        after="id",
+        target=OperationTarget.LOCAL,
+    )
+
+    assert (
+        local_op.format_sql()
+        == "ALTER TABLE test_table ADD COLUMN IF NOT EXISTS new_column String AFTER id;"
+    )
+
+    assert local_op.format_sql() == local_op.format_sql(False)
+
+
+def test_drop_dist_column() -> None:
+    op = DropColumn(
+        StorageSetKey.EVENTS,
+        "test_table",
+        "test_column",
+        target=OperationTarget.BOTH,
+        dist_table_name="test_dist_table",
+    )
+
+    assert (
+        op.format_sql() == "ALTER TABLE test_table DROP COLUMN IF EXISTS test_column;"
+    )
+    assert (
+        op.format_sql(False)
+        == "ALTER TABLE test_dist_table DROP COLUMN IF EXISTS test_column;"
+    )
+
+    dist_op = DropColumn(
+        StorageSetKey.EVENTS,
+        "test_dist_table",
+        "test_column",
+        target=OperationTarget.DISTRIBUTED,
+    )
+    assert (
+        dist_op.format_sql()
+        == "ALTER TABLE test_dist_table DROP COLUMN IF EXISTS test_column;"
+    )
+
+    assert dist_op.format_sql() == dist_op.format_sql(False)
+
+
+def test_refactored_migration() -> None:
+    """
+    Test that specifying the migration order works when changing
+    """
+    create_local_op = Mock(CreateTable)
+    create_dist_op = Mock(CreateTable)
+    drop_local_op = Mock(DropTable)
+    drop_dist_op = Mock(DropTable)
+    logger = Logger("test")
+    context = Context("001", logger, lambda x: None)
+
+    class TestMigration(migration.ClickhouseNodeMigration):
+        blocking = False
+
+        def forwards_ops(self) -> Sequence[SqlOperation]:
+            return [create_local_op, create_dist_op]
+
+        def backwards_ops(self) -> Sequence[SqlOperation]:
+            return [drop_dist_op, drop_local_op]
+
+    ops = [create_local_op, create_dist_op, drop_local_op, drop_dist_op]
+    order = []
+    for op in ops:
+
+        def effect(op: Mock) -> Callable[[], None]:
+            def add_op() -> None:
+                order.append(op)
+
+            return add_op
+
+        op.execute.side_effect = effect(op)
+
+    test_migration = TestMigration()
+    test_migration.forwards(context)
+    assert order == [create_local_op, create_dist_op]
+    order.clear()
+    test_migration.backwards(context, False)
+    assert order == [drop_dist_op, drop_local_op]


### PR DESCRIPTION
Refactors migrations to use a singe sequence of operations, rather having the user specify operations in `_dist()` and `_local()`.

## Context
To avoid ordering errors in migrations we refactor them to be a single sequence. The user no longer has to specify the order flags for the whole migration. Instead, each SQL operation takes a target flag specifying if it should run on local or dist. To make a node migration, the user has to only implement `forwards_ops()` and `backwards_ops()`. This removes the limitation of having the user dump all their ops in either `_dist()` or `_local()` methods and executing one before the other. Now the user has complete control of when their operations can execute.

To avoid errors introduced by giving the user more power, we use a validator that runs unit tests against migrations to ensure that there are no ops that will cause local/dist ordering issues.

This refactoring maintains backwards compatibility with migrations that use the old classes, avoiding a hard fork of the repo. Old migrations using the legacy classes are wrapped with their own `backwards_ops` and `forwards_ops` methods which are executed by the runner.

## Before
Users would have to implement the `_dist()` and `_local()` methods each for each backwards and forwards, and specify which one is executed first.

## After
Users would only need to implement `forwards_ops` and `backwards_ops`, specifying for each op if it should run local or dist.

## Blast radius
Refactors the node migration class in `migration.py`. The old class is renamed to `Legacy` (this rename affects all existing migrations). Both the old and new form of the class are compatible with the runner. The runner is simplified to iterate through a single sequence of ops for backwards/forwards. SQL operations in `operation.py` are refactor to take in a target enum flag specifying if they are to run local or dist. 

## Testing
Since the new and old classes are functionally compatible, we repurpose a lot of the tests targeting the old classes to run on the new classes.
