### PR TITLE
Add self-hosted Sentry end-to-end tests to CI using new Github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,8 +359,9 @@ jobs:
   self-hosted-end-to-end:
     needs: [snuba-image]
     runs-on: ubuntu-latest
+    # temporary, remove once we are confident the action is working
     continue-on-error: true
-    
+
     steps:
       - name: Checkout snuba
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,3 +356,21 @@ jobs:
         working-directory: sentry
         run: |
           make test-snuba
+  self-hosted-end-to-end:
+    needs: [snuba-image]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    
+    steps:
+      - name: Checkout snuba
+        uses: actions/checkout@v2
+
+      - name: Pull snuba CI images
+        run: |
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || docker pull ghcr.io/getsentry/snuba-ci:latest
+      - name: Run Sentry self-hosted e2e CI
+        uses: getsentry/action-self-hosted-e2e-tests@8385f9814d222326393f8f847864b830c6cd5b5e
+        with:
+          project_name: snuba
+          local_image: ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+          container_repo: ghcr.io/getsentry/snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,3 +375,4 @@ jobs:
           project_name: snuba
           local_image: ghcr.io/getsentry/snuba-ci:${{ github.sha }}
           container_repo: ghcr.io/getsentry/snuba
+          # TODO: add docker tag to build for


### PR DESCRIPTION
This is work as part of https://github.com/getsentry/self-hosted/issues/1756

Essentially, we want to move from Google Cloudbuild to a centralized Github Action that can be used across Sentry/Snuba/Relay/self-hosted. This adds a job which should use that action.