### PR TITLE
feat(DC): Functions Storages as Config

### DIFF
--- a/snuba/datasets/configuration/functions/storages/functions.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions.yaml
@@ -1,0 +1,82 @@
+version: v1
+kind: readable_storage
+name: functions
+storage:
+  key: functions
+  set_key: functions
+schema:
+  columns:
+    [
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: transaction_name, type: String },
+      { name: timestamp, type: DateTime },
+      { name: depth, type: UInt, args: { size: 32 } },
+      { name: parent_fingerprint, type: UInt, args: { size: 64 } },
+      { name: fingerprint, type: UInt, args: { size: 64 } },
+      { name: name, type: String },
+      { name: package, type: String },
+      { name: path, type: String },
+      { name: is_application, type: UInt, args: { size: 8 } },
+      { name: platform, type: String },
+      {
+        name: environment,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: release, type: String, args: { schema_modifiers: [nullable] } },
+      { name: os_name, type: String },
+      { name: os_version, type: String },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+      {
+        name: count,
+        type: AggregateFunction,
+        args: { func: count, arg_types: [{ type: Float, args: { size: 64 } }] },
+      },
+      {
+        name: percentiles,
+        type: AggregateFunction,
+        args:
+          {
+            func: "quantiles(0.5, 0.75, 0.9, 0.95, 0.99)",
+            arg_types: [{ type: Float, args: { size: 64 } }],
+          },
+      },
+      {
+        name: min,
+        type: AggregateFunction,
+        args: { func: min, arg_types: [{ type: Float, args: { size: 64 } }] },
+      },
+      {
+        name: max,
+        type: AggregateFunction,
+        args: { func: max, arg_types: [{ type: Float, args: { size: 64 } }] },
+      },
+      {
+        name: avg,
+        type: AggregateFunction,
+        args: { func: avg, arg_types: [{ type: Float, args: { size: 64 } }] },
+      },
+      {
+        name: sum,
+        type: AggregateFunction,
+        args: { func: sum, arg_types: [{ type: Float, args: { size: 64 } }] },
+      },
+      {
+        name: worst,
+        type: AggregateFunction,
+        args:
+          {
+            func: argMax,
+            arg_types: [{ type: UUID }, { type: Float, args: { size: 64 } }],
+          },
+      },
+      {
+        name: examples,
+        type: AggregateFunction,
+        args: { func: groupUniqArray(5), arg_types: [{ type: UUID }] },
+      },
+    ]
+  local_table_name: functions_mv_local
+  dist_table_name: functions_mv_dist
+query_processors:
+  - processor: TableRateLimit

--- a/snuba/datasets/configuration/functions/storages/functions_raw.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions_raw.yaml
@@ -1,0 +1,43 @@
+version: v1
+kind: writable_storage
+name: functions_raw
+storage:
+  key: functions_raw
+  set_key: functions
+schema:
+  columns:
+    [
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: transaction_name, type: String },
+      { name: timestamp, type: DateTime },
+      { name: depth, type: UInt, args: { size: 32 } },
+      { name: parent_fingerprint, type: UInt, args: { size: 64 } },
+      { name: fingerprint, type: UInt, args: { size: 64 } },
+      { name: name, type: String },
+      { name: package, type: String },
+      { name: path, type: String },
+      { name: is_application, type: UInt, args: { size: 8 } },
+      { name: platform, type: String },
+      {
+        name: environment,
+        type: String,
+        args: { schema_modifiers: [nullable] },
+      },
+      { name: release, type: String, args: { schema_modifiers: [nullable] } },
+      { name: os_name, type: String },
+      { name: os_version, type: String },
+      { name: retention_days, type: UInt, args: { size: 16 } },
+      {
+        name: durations,
+        type: Array,
+        args: { inner_type: { type: Float, args: { size: 64 } } },
+      },
+      { name: profile_id, type: UUID },
+      { name: materialization_version, type: UInt, args: { size: 8 } },
+    ]
+  local_table_name: functions_raw_local
+  dist_table_name: functions_raw_dist
+stream_loader:
+  processor:
+    name: FunctionsMessageProcessor
+  default_topic: profiles-call-tree

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -24,7 +24,8 @@ from snuba.utils.schemas import AggregateFunction
 # this has to be done before the storage import because there's a cyclical dependency error
 CONFIG_BUILT_STORAGES = get_config_built_storages()
 
-
+from snuba.datasets.storages.functions import agg_storage as functions
+from snuba.datasets.storages.functions import raw_storage as functions_raw
 from snuba.datasets.storages.generic_metrics import (
     distributions_bucket_storage,
     distributions_storage,
@@ -107,6 +108,8 @@ class TestStorageConfiguration(ConfigurationTest):
     python_storages: list[ReadableTableStorage] = [
         distributions_bucket_storage,
         distributions_storage,
+        functions,
+        functions_raw,
         sets_bucket_storage,
         sets_storage,
         transactions,


### PR DESCRIPTION
### Overview
- Adding all Functions storages as a config
- Storage configs were generated and tested using scripts from #3336 

### Changes
- Any call to `get_storage()` with a functions storage key will return the storage built from config instead of the hardcoded version


### Testing Notes
- How config was generated (eg functions_raw):
    - `python3 scripts/pystorage_2_yaml.py functions_raw functions_raw.yaml`
    - Removed quotes around `columns` in schema, format yaml file with Prettier
- How config was tested:
    - `python3 scripts/check_yaml_against_code.py functions_raw functions_raw.yaml`
    - Updated `tests/datasets/configuration/test_storage_loader.py`
