### PR TITLE
feat(slicing): Mega cluster using runtime overrides

### DIFF
--- a/snuba/datasets/plans/sliced_storage.py
+++ b/snuba/datasets/plans/sliced_storage.py
@@ -3,6 +3,7 @@ from typing import Optional, Sequence
 
 import sentry_sdk
 
+from snuba import state
 from snuba.clickhouse.query_dsl.accessors import get_object_ids_in_query_ast
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.clusters.cluster import ClickhouseCluster, get_cluster
@@ -34,6 +35,8 @@ from snuba.query.processors.physical.mandatory_condition_applier import (
 from snuba.query.query_settings import QuerySettings
 from snuba.util import with_span
 
+MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX = "slicing_mega_cluster_partitions"
+
 
 class StorageClusterSelector(ABC):
     """
@@ -49,11 +52,47 @@ class StorageClusterSelector(ABC):
         raise NotImplementedError
 
 
+def _should_use_mega_cluster(
+    storage_set: StorageSetKey, logical_partition: int
+) -> bool:
+    """
+    Helper method to find out whether a logical partition of a sliced storage
+    set needs to send queries to the mega cluster.
+
+    Mega cluster needs to be used when a logical partition's data might be
+    across multiple slices. This happens when a logical partition is mapped
+    to a new slice. In such cases, the old data resides in some different
+    slice than what the new mapping says.
+    """
+    key = f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_{storage_set.value}"
+    state.get_config(key, None)
+    slicing_read_override_config = state.get_config(key, None)
+
+    if slicing_read_override_config is None:
+        return False
+
+    slicing_read_override_config = slicing_read_override_config[1:-1]
+    if slicing_read_override_config:
+        logical_partition_overrides = [
+            int(p.strip()) for p in slicing_read_override_config.split(",")
+        ]
+        if logical_partition in logical_partition_overrides:
+            return True
+
+    return False
+
+
 class ColumnBasedStorageSliceSelector(StorageClusterSelector):
     """
-    Storage slice selector for the generic metrics storage. This is needed
-    because the generic metrics storage can be sliced and we would need to
-    know which slice to use for a specific query.
+    Storage slice selector based on a specific column of the query. This is
+    needed in order to select the cluster to use for a query. The cluster
+    selection depends on the value of the partition_key_column_name.
+
+    In most cases, the partition_key_column_name would get mapped to a logical
+    partition and then to a slice. But when a logical partition is being
+    transitioned to another slice, the old data resides in a different slice. In
+    those cases, we need to use the mega cluster to query both the old data and
+    the new data.
     """
 
     def __init__(
@@ -81,12 +120,13 @@ class ColumnBasedStorageSliceSelector(StorageClusterSelector):
         assert len(org_ids) == 1
         org_id = org_ids.pop()
 
-        slice_id = map_logical_partition_to_slice(
-            self.storage, map_org_id_to_logical_partition(org_id)
-        )
-        cluster = get_cluster(self.storage_set, slice_id)
-
-        return cluster
+        logical_partition = map_org_id_to_logical_partition(org_id)
+        if _should_use_mega_cluster(self.storage_set, logical_partition):
+            return get_cluster(self.storage_set)
+        else:
+            slice_id = map_logical_partition_to_slice(self.storage, logical_partition)
+            cluster = get_cluster(self.storage_set, slice_id)
+            return cluster
 
 
 class SlicedStorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -319,24 +319,27 @@ SLICED_STORAGES: Mapping[str, int] = {}
 # to slice id
 LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {}
 
-# The slice configs below are the "SLICED" versions to
-# the equivalent default settings above. For example,
-# "SLICED_KAFKA_TOPIC_MAP" is the "SLICED" version of
-# "KAFKA_TOPIC_MAP". These should be filled out
-# for any corresponding sliced storages defined above,
-# with the applicable number of slices in mind.
+# The slice configs below are the "SLICED" versions to the equivalent default
+# settings above. For example, "SLICED_KAFKA_TOPIC_MAP" is the "SLICED"
+# version of "KAFKA_TOPIC_MAP". These should be filled out for any
+# corresponding sliced storages defined above, with the applicable number of
+# slices in mind.
 
-# Storage set keys should be defined either in CLUSTERS
-# or SLICED_CLUSTERS. CLUSTERS will define clusters
-# which are not sliced, i.e. are associated with
-# only the default slice_id (0). CLUSTERS is defined in
-# the default way, without adding slice id in
-# the storage_sets field. We define sliced clusters,
-# i.e. clusters that reside on multiple slices
-# in SLICED_CLUSTERS. We define all associated
-# (storage set, slice id) pairs in SLICED_CLUSTERS
-# in the storage_sets field. Other fields are defined
-# in the same way as they are in CLUSTERS.
+# Cluster access can happen in one of the following ways:
+# 1. The storage set is not sliced. In this case, the storage set key should
+#    be defined in CLUSTERS only.
+# 2. The storage set is sliced and there is no mega-cluster needed. In this
+#    case, the storage set key should be defined in SLICED_CLUSTERS only.
+# 3. The storage set is sliced and there is a mega-cluster needed. In this
+#    case, the storage set key should be defined in both CLUSTERS and
+#    SLICED_CLUSTERS. SLICED_CLUSTERS would contain the cluster information
+#    of the sliced cluster. CLUSTERS would contain the cluster information of
+#    the mega-cluster.
+#
+# We define sliced clusters, i.e. clusters that reside on multiple slices
+# in SLICED_CLUSTERS. We define all associated(storage set, slice id) pairs in
+# SLICED_CLUSTERS in the storage_sets field. Other fields are defined in the
+# same way as they are in CLUSTERS.
 SLICED_CLUSTERS: Sequence[Mapping[str, Any]] = []
 
 # Mapping of (logical topic names, slice id) pairs to custom physical topic names

--- a/tests/datasets/plans/test_sliced_storage.py
+++ b/tests/datasets/plans/test_sliced_storage.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest.mock import patch
 
 import pytest
@@ -5,13 +6,19 @@ import pytest
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
-from snuba.datasets.plans.sliced_storage import ColumnBasedStorageSliceSelector
+from snuba.datasets.plans.sliced_storage import (
+    MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX,
+    ColumnBasedStorageSliceSelector,
+    _should_use_mega_cluster,
+)
+from snuba.datasets.slicing import map_org_id_to_logical_partition
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.conditions import binary_condition
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.expressions import Column, Literal
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.query_settings import HTTPQuerySettings
+from snuba.state import delete_config, set_config
 
 DISTS_ENTITY_KEY = EntityKey("generic_metrics_distributions")
 DISTS_STORAGE_KEY = StorageKey("generic_metrics_distributions")
@@ -58,22 +65,33 @@ SLICED_CLUSTERS_CONFIG = [
 test_data = [
     # org_id 1 should be assigned to slice 1 because (1 % 256 == logical partition 1) and
     # all odd logical partitions are assigned to slice 1
-    pytest.param(1, SLICE_1_DATABASE_VALUE, id="odd org ID slice"),
+    pytest.param(1, SLICE_1_DATABASE_VALUE, False, id="odd org ID slice"),
     # org_id 500 should be assigned to slice 0 because (500 % 256 == logical partition 244) and
     # all even logical partitions are assigned to slice 0
-    pytest.param(500, SLICE_0_DATABASE_VALUE, id="even org iD slice"),
+    pytest.param(500, SLICE_0_DATABASE_VALUE, False, id="even org iD slice"),
+    # org_id 1 should use mega cluster since the override to use the mega
+    # clusters is set to True
+    pytest.param(1, "snuba_test", True, id="slice use mega cluster"),
 ]
 
 
 @patch("snuba.settings.SLICED_STORAGES", {"generic_metrics_distributions": 2})
 @patch("snuba.settings.LOGICAL_PARTITION_MAPPING", MOCK_LOGICAL_PART_MAPPING)
 @patch("snuba.settings.SLICED_CLUSTERS", SLICED_CLUSTERS_CONFIG)
-@pytest.mark.parametrize("org_id, expected_slice_db", test_data)
-def test_column_based_partition_selector(org_id: int, expected_slice_db: str) -> None:
+@pytest.mark.parametrize("org_id, expected_slice_db, set_override", test_data)
+def test_column_based_partition_selector(
+    org_id: int, expected_slice_db: str, set_override: bool
+) -> None:
     """
     Tests that the column based partition selector selects the right cluster
     for a query.
     """
+    if set_override:
+        logical_partition = map_org_id_to_logical_partition(org_id)
+        set_config(
+            f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_generic_metrics_distributions",
+            f"[{logical_partition}]",
+        )
     query = LogicalQuery(
         QueryEntity(
             DISTS_ENTITY_KEY,
@@ -96,3 +114,58 @@ def test_column_based_partition_selector(org_id: int, expected_slice_db: str) ->
     cluster = selector.select_cluster(query, settings)
 
     assert cluster.get_database() == expected_slice_db
+    if set_override:
+        delete_config(
+            f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_generic_metrics_distributions"
+        )
+
+
+mega_cluster_test_data = [
+    pytest.param(
+        StorageSetKey("generic_metrics_distributions"),
+        1,
+        None,
+        False,
+        id="no " "override configured",
+    ),
+    pytest.param(
+        StorageSetKey("generic_metrics_distributions"),
+        1,
+        "[1]",
+        True,
+        id="" "override configured",
+    ),
+    pytest.param(
+        StorageSetKey("generic_metrics_distributions"),
+        1,
+        "[100]",
+        False,
+        id="" "override configured for different partition",
+    ),
+    pytest.param(
+        StorageSetKey("generic_metrics_distributions"),
+        1,
+        "[100, 40, 25, 1]",
+        True,
+        id="override configured using array",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "storage_set, logical_partition, override_config, " "expected",
+    mega_cluster_test_data,
+)
+def test_should_use_mega_cluster(
+    storage_set: StorageSetKey,
+    logical_partition: int,
+    override_config: Optional[str],
+    expected: bool,
+) -> None:
+    if override_config:
+        set_config(
+            f"{MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX}_{storage_set.value}", override_config
+        )
+    assert _should_use_mega_cluster(storage_set, logical_partition) == expected
+    if override_config:
+        delete_config(f"MEGA_CLUSTER_RUNTIME_CONFIG_PREFIX_{storage_set}")

--- a/tests/datasets/plans/test_sliced_storage.py
+++ b/tests/datasets/plans/test_sliced_storage.py
@@ -74,7 +74,7 @@ test_data = [
     # clusters is set to True
     pytest.param(
         1,
-        os.environ.get("CLICKHOUSE_DATABASE", "snuba_test"),
+        os.environ.get("CLICKHOUSE_DATABASE", "default"),
         True,
         id="slice use mega cluster",
     ),

--- a/tests/datasets/plans/test_sliced_storage.py
+++ b/tests/datasets/plans/test_sliced_storage.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 from unittest.mock import patch
 
@@ -71,7 +72,12 @@ test_data = [
     pytest.param(500, SLICE_0_DATABASE_VALUE, False, id="even org iD slice"),
     # org_id 1 should use mega cluster since the override to use the mega
     # clusters is set to True
-    pytest.param(1, "snuba_test", True, id="slice use mega cluster"),
+    pytest.param(
+        1,
+        os.environ.get("CLICKHOUSE_DATABASE", "snuba_test"),
+        True,
+        id="slice use mega cluster",
+    ),
 ]
 
 


### PR DESCRIPTION
### Context
With slicing, logical partitions could be one of 2 states
1. All data resides on a single sliced clickhouse cluster.
2. Partial data resides in some other sliced clickhouse cluster. This would happen when the mapping of a logical partition to a slice is modified. When the mapping is changed, **writes** of new data will happen on the new slice on which the logical partition is mapped. But we do not perform data migration of the logical partition from older slice to newer slice. So **reads** need to query across both the old slice and the new slice.

The overall system would look something like this
<img width="783" alt="Screen Shot 2022-11-17 at 9 45 33 AM" src="https://user-images.githubusercontent.com/84807402/202519912-22e0cf8d-879c-4009-bd62-b87f693f755a.png">

### Implementation
A new runtime config is introduced to identify which logical partitions of a storage_set have should use the mega cluster. If a  query belongs to a logical partition which is set in the runtime config, it uses cluster information from settings.CLUSTER.

### Tests
1. Added a test to validate that when runtime override is set, the database selected is from settings.CLUSTER even when slicing is enabled.
2. Added tests to check behavior of different values of the runtime config.