### PR TITLE
Add datadog events

### DIFF
--- a/snuba/utils/metrics/backends/abstract.py
+++ b/snuba/utils/metrics/backends/abstract.py
@@ -50,3 +50,14 @@ class MetricsBackend(ABC):
         metrics.timing("request.latency", request_latency_in_ms)
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        raise NotImplementedError

--- a/snuba/utils/metrics/backends/datadog.py
+++ b/snuba/utils/metrics/backends/datadog.py
@@ -75,3 +75,19 @@ class DatadogMetricsBackend(MetricsBackend):
             tags=self.__normalize_tags(tags),
             sample_rate=self.__sample_rates.get(name, 1.0),
         )
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        self.__client.event(
+            title=title,
+            text=text,
+            alert_type=alert_type,
+            tags=self.__normalize_tags(tags),
+            priority=priority,
+        )

--- a/snuba/utils/metrics/backends/dummy.py
+++ b/snuba/utils/metrics/backends/dummy.py
@@ -51,3 +51,19 @@ class DummyMetricsBackend(MetricsBackend):
             assert isinstance(value, (int, float))
             if tags is not None:
                 self.__validate_tags(tags)
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        if self.__strict:
+            assert isinstance(title, str)
+            assert isinstance(text, str)
+            assert isinstance(alert_type, str)
+            assert isinstance(priority, str)
+            if tags is not None:
+                self.__validate_tags(tags)

--- a/snuba/utils/metrics/backends/testing.py
+++ b/snuba/utils/metrics/backends/testing.py
@@ -93,3 +93,20 @@ class TestingMetricsBackend(MetricsBackend):
             assert isinstance(value, (int, float))
             if tags is not None:
                 self.__validate_tags(tags)
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        record_metric_call("events", title, 1, tags)
+        if self.__strict:
+            assert isinstance(title, str)
+            assert isinstance(text, str)
+            assert isinstance(alert_type, str)
+            assert isinstance(priority, str)
+            if tags is not None:
+                self.__validate_tags(tags)

--- a/snuba/utils/metrics/wrapper.py
+++ b/snuba/utils/metrics/wrapper.py
@@ -45,3 +45,15 @@ class MetricsWrapper(MetricsBackend):
         self, name: str, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         self.__backend.timing(self.__merge_name(name), value, self.__merge_tags(tags))
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        self.__backend.events(
+            title, text, alert_type, priority, self.__merge_tags(tags)
+        )

--- a/tests/backends/metrics.py
+++ b/tests/backends/metrics.py
@@ -22,6 +22,14 @@ class Timing(NamedTuple):
     tags: Optional[Tags]
 
 
+class Events(NamedTuple):
+    title: str
+    text: str
+    alert_type: str
+    priority: str
+    tags: Optional[Tags]
+
+
 class TestingMetricsBackend(MetricsBackend):
     """
     A metrics backend that logs all metrics recorded. Intended for testing
@@ -32,7 +40,7 @@ class TestingMetricsBackend(MetricsBackend):
     # TODO: This might make sense to extend the dummy metrics backend.
 
     def __init__(self) -> None:
-        self.calls: MutableSequence[Union[Increment, Gauge, Timing]] = []
+        self.calls: MutableSequence[Union[Increment, Gauge, Timing, Events]] = []
 
     def increment(
         self, name: str, value: Union[int, float] = 1, tags: Optional[Tags] = None
@@ -48,3 +56,13 @@ class TestingMetricsBackend(MetricsBackend):
         self, name: str, value: Union[int, float], tags: Optional[Tags] = None
     ) -> None:
         self.calls.append(Timing(name, value, tags))
+
+    def events(
+        self,
+        title: str,
+        text: str,
+        alert_type: str,
+        priority: str,
+        tags: Optional[Tags] = None,
+    ) -> None:
+        self.calls.append(Events(title, text, alert_type, priority, tags))


### PR DESCRIPTION
Allows the datadog backend to send events. This is useful for setups where we may want to trigger alerts in datadog based on events.