### PR TITLE
feat: Arroyo 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
-sentry-arroyo==1.1.0
+sentry-arroyo==1.2.0
 sentry-relay==0.8.15
 sentry-sdk==1.10.1
 simplejson==3.17.6


### PR DESCRIPTION
Updating arroyo. This should be a no-op for Snuba as we are not using any of the strategies that changed in this release.

