### PR TITLE
feat(slicing): Introduce slicing into Subscriptions Executor

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -52,7 +52,7 @@ from snuba.utils.streams.topics import Topic
 )
 @click.option(
     "--slice-id",
-    help="The slice to write on/read data from",
+    help="The slice to load scheduled queries from",
 )
 @click.option(
     "--total-concurrent-queries",

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -17,7 +17,6 @@ from snuba.subscriptions.executor_consumer import build_executor_consumer
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
-from snuba.utils.streams.topics import Topic
 
 
 @click.command()
@@ -122,11 +121,10 @@ def subscriptions_executor(
     stream_loader = storage.get_table_writer().get_stream_loader()
     result_topic_spec = stream_loader.get_subscription_result_topic_spec()
     assert result_topic_spec is not None
-    physical_topic_name = result_topic_spec.get_physical_topic_name(slice_id)
 
     producer = KafkaProducer(
         build_kafka_producer_configuration(
-            Topic(physical_topic_name),
+            result_topic_spec.topic,
             override_params={"partitioner": "consistent"},
         )
     )

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -104,10 +104,15 @@ def subscriptions_executor(
     setup_logging(log_level)
     setup_sentry()
 
+    metrics_tags = {
+        "dataset": dataset_name,
+    }
+
+    if slice_id:
+        metrics_tags["slice_id"] = str(slice_id)
+
     metrics = MetricsWrapper(
-        environment.metrics,
-        "subscriptions.executor",
-        tags={"dataset": dataset_name},
+        environment.metrics, "subscriptions.executor", tags=metrics_tags
     )
 
     configure_metrics(StreamMetricsAdapter(metrics))

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -125,7 +125,6 @@ def build_executor_consumer(
         ), "All entities must have same scheduled and result topics"
 
     physical_scheduled_topic = scheduled_topic_spec.get_physical_topic_name(slice_id)
-    physical_result_topic = result_topic_spec.get_physical_topic_name(slice_id)
 
     consumer_configuration = build_kafka_consumer_configuration(
         SnubaTopic(physical_scheduled_topic),
@@ -170,7 +169,7 @@ def build_executor_consumer(
             producer,
             metrics,
             stale_threshold_seconds,
-            physical_result_topic,
+            result_topic_spec.topic_name,
         ),
         commit_policy=ONCE_PER_SECOND,
     )

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -41,6 +41,7 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.gauge import Gauge, ThreadSafeGauge
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.streams.configuration_builder import build_kafka_consumer_configuration
+from snuba.utils.streams.topics import Topic as SnubaTopic
 from snuba.web.query import parse_and_run_query
 
 logger = logging.getLogger(__name__)
@@ -73,6 +74,7 @@ def build_executor_consumer(
     dataset_name: str,
     entity_names: Sequence[str],
     consumer_group: str,
+    slice_id: Optional[int],
     producer: Producer[KafkaPayload],
     total_concurrent_queries: int,
     auto_offset_reset: str,
@@ -122,14 +124,17 @@ def build_executor_consumer(
             result_topic_spec,
         ), "All entities must have same scheduled and result topics"
 
+    physical_scheduled_topic = scheduled_topic_spec.get_physical_topic_name(slice_id)
+    physical_result_topic = result_topic_spec.get_physical_topic_name(slice_id)
+
     consumer_configuration = build_kafka_consumer_configuration(
-        scheduled_topic_spec.topic,
+        SnubaTopic(physical_scheduled_topic),
         consumer_group,
         auto_offset_reset=auto_offset_reset,
         strict_offset_reset=strict_offset_reset,
     )
 
-    total_partition_count = get_partition_count(scheduled_topic_spec.topic)
+    total_partition_count = get_partition_count(SnubaTopic(physical_scheduled_topic))
 
     # Collect metrics from librdkafka if we have stats_collection_freq_ms set
     # for the consumer group, or use the default.
@@ -156,7 +161,7 @@ def build_executor_consumer(
 
     return StreamProcessor(
         KafkaConsumer(consumer_configuration),
-        Topic(scheduled_topic_spec.topic_name),
+        Topic(physical_scheduled_topic),
         SubscriptionExecutorProcessingFactory(
             total_concurrent_queries,
             total_partition_count,
@@ -165,7 +170,7 @@ def build_executor_consumer(
             producer,
             metrics,
             stale_threshold_seconds,
-            result_topic_spec.topic_name,
+            physical_result_topic,
         ),
         commit_policy=ONCE_PER_SECOND,
     )

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -107,6 +107,7 @@ def test_executor_consumer() -> None:
         dataset_name,
         [entity_name],
         consumer_group,
+        None,
         result_producer,
         2,
         auto_offset_reset,


### PR DESCRIPTION
This PR contains the changes necessary for slicing, at the level of subscription executors. Namely, we want to:

- Pass in `slice_id` optionally to the executor CLI
- Ensure that, when a `slice_id` is passed, the executor consumes from the "sliced" (physical) scheduled topic. These topics should be defined in slicing settings (`settings.SLICED_KAFKA_TOPIC_MAP`). Note that the result topic is not sliced, i.e. we use the common default across slices. 
- If no `slice_id` is passed, we should observe default behavior and the default scheduled and result topics should be used.

This work will synchronize with the slicing changes added to the subscriptions scheduler, once those are ready