### PR TITLE
ref(SLO) Track timeouts with a different status from errors

### DIFF
--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -12,6 +12,7 @@ class QueryStatus(Enum):
     ERROR = "error"  # A system error
     RATE_LIMITED = "rate-limited"
     INVALID_REQUEST = "invalid-request"
+    TIMEOUT = "timeout"
 
 
 Columnset = Set[str]


### PR DESCRIPTION
Add a new query status for timeouts so we can track them separately in DD. This
will require changing existing graphs in DD to handle the new status type.

Nothing will change in the graphs themselves, so the SLO remains the same. Now
the failed queries will be defined as error + timeout.

I looked into the possibility of creating a new metric with the new status and
keeping the old metric with the old status codes. That would have required
having two Timer objects and doing some Python trickery to overwrite the Timer
name. It seemed easier to update the graphs in DD.