### PR TITLE
Update end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || docker pull ghcr.io/getsentry/snuba-ci:latest
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@8385f9814d222326393f8f847864b830c6cd5b5e
+        uses: getsentry/action-self-hosted-e2e-tests@5bbd3d6725bbe4bf5cc12f8a3291ce87df6a891f
         with:
           project_name: snuba
           local_image: ghcr.io/getsentry/snuba-ci:${{ github.sha }}


### PR DESCRIPTION
The newer version does not push docker images for now so that won't fail.