### PR TITLE
feat(optimize): Add datadog alert event on optimize SNS-1841

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -65,6 +65,11 @@ def set_logging_context() -> None:
     bind_contextvars(endpoint=request.endpoint, user_ip=request.remote_addr)
 
 
+@application.teardown_request
+def clear_logging_context(exception: Optional[BaseException]) -> None:
+    clear_contextvars()
+
+
 @application.before_request
 def authorize() -> None:
     logger.debug("authorize.entered")

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -291,6 +291,8 @@ OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10 * 60  # 10 mins
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30
+# how long to wait for an optimize thread to complete before sending an alert
+OPTIMIZE_ALERT_THRESHOLD = 14 * 60 * 60  # 14 hours
 
 # Configuration directory settings
 CONFIG_FILES_PATH = f"{Path(__file__).parent.parent.as_posix()}/datasets/configuration"

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -291,7 +291,7 @@ OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10 * 60  # 10 mins
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30
-# how long to wait for an optimize thread to complete before sending an alert
+# how long to wait for an optimize runner to complete before sending an alert
 OPTIMIZE_ALERT_THRESHOLD = 14 * 60 * 60  # 14 hours
 
 # Configuration directory settings

--- a/tests/clickhouse/optimize/test_optimize_tracker.py
+++ b/tests/clickhouse/optimize/test_optimize_tracker.py
@@ -1,3 +1,5 @@
+import logging
+import os
 import time
 import uuid
 from datetime import datetime, timedelta
@@ -153,7 +155,7 @@ def test_run_optimize_with_partition_tracker() -> None:
     assert num_optimized == original_num_partitions
 
 
-def test_run_optimize_with_ongoing_merges() -> None:
+def test_run_optimize_with_ongoing_merges(caplog) -> None:
     def write_error_message(writable_storage: WritableTableStorage, time: int) -> None:
         write_processed_messages(
             writable_storage,
@@ -234,6 +236,7 @@ def test_run_optimize_with_ongoing_merges() -> None:
         ]  # first & second call returns large ongoing merges, third call returns small ongoing merges
 
         with patch.object(time, "sleep") as sleep_mock:
+            caplog.set_level(logging.INFO)
             num_optimized = run_optimize_cron_job(
                 clickhouse=clickhouse_pool,
                 storage=storage,
@@ -251,6 +254,17 @@ def test_run_optimize_with_ongoing_merges() -> None:
                 call(settings.OPTIMIZE_BASE_SLEEP_TIME),
                 call(settings.OPTIMIZE_BASE_SLEEP_TIME),
             ]
+
+            # check logs
+            assert " large ongoing merge detected" in caplog.text
+            assert (
+                f"busy merging, sleeping for 300s process_id={os.getpid()}"
+                in caplog.text
+            )
+            assert (
+                f" Optimizing partition: (90,'2022-12-05') process_id={os.getpid()}"
+                in caplog.text
+            )
 
 
 def test_merge_info() -> None:


### PR DESCRIPTION
Adds a monitor thread that sends an alert to datadog if the optimize cron job runner is taking longer than `OPTIMIZE_ALERT_THRESHOLD`. 

Additionally, switches logging to structlog so that log severity is recognized by GCP.