### PR TITLE
fix(logging): Log level was always DEBUG

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -21,7 +21,6 @@ setup_logging("DEBUG")
 logger = logging.getLogger("snuba_init")
 
 start = time.perf_counter()
-logger.info("Initializing Snuba CLI...")
 metrics = MetricsWrapper(environment_metrics, "cli")
 
 plugin_folder = os.path.dirname(__file__)
@@ -82,3 +81,4 @@ def main() -> None:
 
 
 structlog.reset_defaults()
+setup_logging()

--- a/snuba/core/initialize.py
+++ b/snuba/core/initialize.py
@@ -30,7 +30,7 @@ def _load_entities() -> None:
 
 
 def initialize_snuba() -> None:
-    logger.info("Initializing Snuba")
+    logger.info("Initializing Snuba...")
 
     # The order of the functions matters The reference direction is
     #


### PR DESCRIPTION
- Added a call to `setup_logging()` at the end of Snuba CLI init to reset log level back to `settings.LOG_LEVEL` ie INFO
- Removed extra snuba init log