### PR TITLE
optimize: add thread and process info to logs

### DIFF
--- a/snuba/clickhouse/optimize/optimize.py
+++ b/snuba/clickhouse/optimize/optimize.py
@@ -23,6 +23,17 @@ from snuba.settings import (
 from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger("snuba.optimize")
+
+# include thread and process info in log messages
+log_handler = logging.StreamHandler()
+log_handler.setFormatter(
+    logging.Formatter(
+        "%(levelname)s %(asctime)s %(name)s %(process)d-%(threadName)s %(message)s"
+    )
+)
+logger.addHandler(log_handler)
+logger.propagate = False
+
 metrics = MetricsWrapper(environment.metrics, "optimize")
 
 


### PR DESCRIPTION

It became confusing tracking down what logs belong to which threads inside the optimize jobs. This adds the process id and thread id to the logs. Threads belonging to the same cron job will log with the same process id.