### PR TITLE
ref(redis): Clean up code after cluster migration [sns-1899]

### DIFF
--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -121,9 +121,7 @@ def _initialize_specialized_redis_cluster(
 
 class RedisClientKey(Enum):
     CACHE = "cache"
-    CACHE_V2 = "cache_v2"
     RATE_LIMITER = "rate_limiter"
-    RATE_LIMITER_V2 = "rate_limiter_v2"
     SUBSCRIPTION_STORE = "subscription_store"
     REPLACEMENTS_STORE = "replacements_store"
     CONFIG = "config"
@@ -135,14 +133,8 @@ _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
     RedisClientKey.CACHE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["cache"]
     ),
-    RedisClientKey.CACHE_V2: _initialize_specialized_redis_cluster(
-        settings.REDIS_CLUSTERS["cache_v2"]
-    ),
     RedisClientKey.RATE_LIMITER: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["rate_limiter"]
-    ),
-    RedisClientKey.RATE_LIMITER_V2: _initialize_specialized_redis_cluster(
-        settings.REDIS_CLUSTERS["rate_limiter_v2"]
     ),
     RedisClientKey.SUBSCRIPTION_STORE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["subscription_store"]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -125,9 +125,7 @@ T = TypeVar("T")
 
 class RedisClusters(TypedDict):
     cache: RedisClusterConfig | None
-    cache_v2: RedisClusterConfig | None
     rate_limiter: RedisClusterConfig | None
-    rate_limiter_v2: RedisClusterConfig | None
     subscription_store: RedisClusterConfig | None
     replacements_store: RedisClusterConfig | None
     config: RedisClusterConfig | None
@@ -137,9 +135,7 @@ class RedisClusters(TypedDict):
 
 REDIS_CLUSTERS: RedisClusters = {
     "cache": None,
-    "cache_v2": None,
     "rate_limiter": None,
-    "rate_limiter_v2": None,
     "subscription_store": None,
     "replacements_store": None,
     "config": None,

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -45,13 +45,7 @@ REDIS_CLUSTERS = {
     }
     for i, key in [
         (2, "cache"),
-        # ensure that cache and cache_v2 are on different
-        # clusters, without running out of db values
-        (3, "cache_v2"),
         (3, "rate_limiter"),
-        # ensure that rate_limiter and rate_limiter_v2 are on different
-        # clusters, without running out of db values
-        (4, "rate_limiter_v2"),
         (4, "subscription_store"),
         (5, "replacements_store"),
         (6, "config"),

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -2,8 +2,7 @@ import concurrent.futures
 import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from hashlib import md5
-from typing import Callable, List, Optional, Union
+from typing import Callable, Optional
 
 from pkg_resources import resource_string
 
@@ -17,7 +16,6 @@ from snuba.state.cache.abstract import (
     ExecutionTimeoutError,
     TValue,
 )
-from snuba.util import force_bytes
 from snuba.utils.codecs import ExceptionAwareCodec
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
@@ -35,31 +33,24 @@ RESULT_WAIT = 2
 class RedisCache(Cache[TValue]):
     def __init__(
         self,
-        client: Union[RedisClientType, List[RedisClientType]],
+        client: RedisClientType,
         prefix: str,
         codec: ExceptionAwareCodec[bytes, TValue],
         executor: ThreadPoolExecutor,
     ) -> None:
-        self.__clients = [client] if not isinstance(client, list) else client
-        assert len(self.__clients) in (1, 2)
+        self.__client = client
         self.__prefix = prefix
         self.__codec = codec
         self.__executor = executor
 
         # TODO: This should probably be lazily instantiated, rather than
         # automatically happening at startup.
-        self.__scripts_get = [
-            client.register_script(
-                resource_string("snuba", "state/cache/redis/scripts/get.lua")
-            )
-            for client in self.__clients
-        ]
-        self.__scripts_set = [
-            client.register_script(
-                resource_string("snuba", "state/cache/redis/scripts/set.lua")
-            )
-            for client in self.__clients
-        ]
+        self.__script_get = client.register_script(
+            resource_string("snuba", "state/cache/redis/scripts/get.lua")
+        )
+        self.__script_set = client.register_script(
+            resource_string("snuba", "state/cache/redis/scripts/set.lua")
+        )
 
     def __build_key(
         self, key: str, prefix: Optional[str] = None, suffix: Optional[str] = None
@@ -68,27 +59,15 @@ class RedisCache(Cache[TValue]):
             [bit for bit in [prefix, f"{{{key}}}", suffix] if bit is not None]
         )
 
-    def __get_shard(self, key: str) -> int:
-        if len(self.__clients) != 2:
-            return 0
-        rollout_rate = get_config("cache_use_v2_cluster", 0.0)
-        assert isinstance(rollout_rate, float)
-        should_use_v2 = (
-            int(md5(force_bytes(key)).hexdigest(), 16) % 1000 < rollout_rate * 1000
-        )
-        return int(should_use_v2)
-
     def get(self, key: str) -> Optional[TValue]:
-        shard = self.__get_shard(key)
-        value = self.__clients[shard].get(self.__build_key(key))
+        value = self.__client.get(self.__build_key(key))
         if value is None:
             return None
 
         return self.__codec.decode(value)
 
     def set(self, key: str, value: TValue) -> None:
-        shard = self.__get_shard(key)
-        self.__clients[shard].set(
+        self.__client.set(
             self.__build_key(key),
             self.__codec.encode(value),
             ex=get_config("cache_expiry_sec", 1),
@@ -102,8 +81,6 @@ class RedisCache(Cache[TValue]):
         timeout: int,
         timer: Optional[Timer] = None,
     ) -> TValue:
-        shard = self.__get_shard(key)
-
         # This method is designed with the following goals in mind:
         # 1. The value generation function is only executed when no value
         # already exists for the key.
@@ -156,7 +133,7 @@ class RedisCache(Cache[TValue]):
         # wait for a different client to finish the work. We have to pass the
         # task creation parameters -- the timeout (execution deadline) and a
         # new task identity just in case we are the first in line.
-        result = self.__scripts_get[shard](
+        result = self.__script_get(
             [result_key, wait_queue_key, task_ident_key], [timeout, uuid.uuid1().hex]
         )
 
@@ -220,7 +197,7 @@ class RedisCache(Cache[TValue]):
                 # value, other clients will know that we raised an exception.
                 logger.debug("Setting result and waking blocked clients...")
                 try:
-                    self.__scripts_set[shard](
+                    self.__script_set(
                         [
                             redis_key_to_write_to,
                             wait_queue_key,
@@ -255,7 +232,7 @@ class RedisCache(Cache[TValue]):
                 effective_timeout,
             )
             notification_received = (
-                self.__clients[shard].blpop(
+                self.__client.blpop(
                     build_notify_queue_key(task_ident), effective_timeout
                 )
                 is not None
@@ -266,7 +243,7 @@ class RedisCache(Cache[TValue]):
 
             if notification_received:
                 # There should be a value waiting for us at the result key.
-                raw_value, upsteam_error_payload = self.__clients[shard].mget(
+                raw_value, upsteam_error_payload = self.__client.mget(
                     [result_key, error_key]
                 )
                 # If there is no value, that means that the client responsible

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -58,10 +58,7 @@ from snuba.web import QueryException, QueryResult, constants
 MAX_HASH_PLUS_ONE = 16**32  # Max value of md5 hash
 metrics = MetricsWrapper(environment.metrics, "db_query")
 
-redis_cache_clients = [
-    get_redis_client(RedisClientKey.CACHE),
-    get_redis_client(RedisClientKey.CACHE_V2),
-]
+redis_cache_client = get_redis_client(RedisClientKey.CACHE)
 
 
 class ResultCacheCodec(ExceptionAwareCodec[bytes, Result]):
@@ -87,7 +84,7 @@ DEFAULT_CACHE_PARTITION_ID = "default"
 # reader when running a query.
 cache_partitions: MutableMapping[str, Cache[Result]] = {
     DEFAULT_CACHE_PARTITION_ID: RedisCache(
-        redis_cache_clients,
+        redis_cache_client,
         "snuba-query-cache:",
         ResultCacheCodec(),
         ThreadPoolExecutor(),
@@ -440,7 +437,7 @@ def _get_cache_partition(reader: Reader) -> Cache[Result]:
             # of acquiring the lock is not needed.
             if partition_id not in cache_partitions:
                 cache_partitions[partition_id] = RedisCache(
-                    redis_cache_clients,
+                    redis_cache_client,
                     f"snuba-query-cache:{partition_id}:",
                     ResultCacheCodec(),
                     ThreadPoolExecutor(),

--- a/tests/state/test_cache.py
+++ b/tests/state/test_cache.py
@@ -11,12 +11,7 @@ from unittest import mock
 import pytest
 import rapidjson
 
-from snuba.redis import (
-    RedisClientKey,
-    RedisClientType,
-    RetryingStrictRedisCluster,
-    get_redis_client,
-)
+from snuba.redis import RedisClientKey, RedisClientType, get_redis_client
 from snuba.state.cache.abstract import Cache, ExecutionError, ExecutionTimeoutError
 from snuba.state.cache.redis.backend import RedisCache
 from snuba.utils.codecs import ExceptionAwareCodec
@@ -24,7 +19,6 @@ from snuba.utils.serializable_exception import SerializableException
 from tests.assertions import assert_changes, assert_does_not_change
 
 redis_client = get_redis_client(RedisClientKey.CACHE)
-redis_client_v2 = get_redis_client(RedisClientKey.CACHE_V2)
 
 
 def execute(function: Callable[[], Any]) -> Future[Any]:
@@ -291,39 +285,3 @@ def test_notify_queue_ttl() -> None:
     # make sure that all the waiters actually did hit the notification queue
     # and didn't just get a direct cache hit
     assert pop_calls == num_waiters
-
-
-@pytest.mark.skipif(
-    isinstance(redis_client, RetryingStrictRedisCluster),
-    reason="test requires support for db parameter, and redis cluster does not support DBs",
-)
-def test_multiple_redis_keys(request, snuba_set_config):
-    backend = RedisCache(
-        [redis_client, redis_client_v2],
-        "test",
-        PassthroughCodec(),
-        ThreadPoolExecutor(),
-    )
-
-    # ensure that in slow test environments, the cache does not expire halfway
-    # through the test
-    snuba_set_config("cache_expiry_sec", 1000)
-
-    backend.set("foo-key", b"hello")
-
-    assert backend.get("foo-key") == b"hello"
-    assert redis_client.get("test{foo-key}") == b"hello"
-
-    snuba_set_config("cache_use_v2_cluster", 1.0)
-
-    assert backend.get("foo-key") is None
-    assert redis_client.get("test{foo-key}") == b"hello"
-
-    backend.set("foo-key", b"hello2")
-
-    assert backend.get("foo-key") == b"hello2"
-    assert redis_client_v2.get("test{foo-key}") == b"hello2"
-    assert redis_client.get("test{foo-key}") == b"hello"
-
-    snuba_set_config("cache_use_v2_cluster", 0.0)
-    assert backend.get("foo-key") == b"hello"

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from snuba import state
-from snuba.redis import RedisClientKey, RetryingStrictRedisCluster, get_redis_client
+from snuba.redis import RedisClientKey, get_redis_client
 from snuba.state.rate_limit import (
     RateLimitAggregator,
     RateLimitExceeded,
@@ -14,7 +14,6 @@ from snuba.state.rate_limit import (
     RateLimitStats,
     RateLimitStatsContainer,
     rate_limit,
-    redis_clients,
 )
 
 
@@ -208,64 +207,3 @@ def test_rate_limit_failures(vals: Tuple[int, int, int], rate_limit_shards) -> N
             bucket, now - state.rate_lookback_s, now + state.rate_lookback_s
         )
         assert count == 0
-
-
-@pytest.mark.skipif(
-    isinstance(redis_clients[0], RetryingStrictRedisCluster),
-    reason="test requires support for db parameter, and redis cluster does not support DBs",
-)
-def test_rate_limit_v2_cluster(snuba_set_config):
-    params = RateLimitParameters("foo", "foo", None, 4)
-
-    # Start 4 concurrent "queries"... concurrent limit maxed out
-    with RateLimitAggregator([params] * 4):
-        # Exceed concurrent rate limit
-        with pytest.raises(RateLimitExceeded):
-            with RateLimitAggregator([params] * 4):
-                pass
-
-        # switch over to new cluster
-        snuba_set_config("rate_limit_use_v2_cluster", 1.0)
-
-        # since we switched over to a new cluster, the limit is
-        # practically reset
-        with RateLimitAggregator([params] * 4):
-            pass
-
-        snuba_set_config("rate_limit_use_v2_cluster", 0.0)
-
-        # assert that rollback succeeds and we exceed the limit
-        # again (since we're talking to the old cluster again)
-        with pytest.raises(RateLimitExceeded):
-            with RateLimitAggregator([params] * 4):
-                pass
-
-
-@pytest.mark.skipif(
-    isinstance(redis_clients[0], RetryingStrictRedisCluster),
-    reason="test requires support for db parameter, and redis cluster does not support DBs",
-)
-def test_rate_limit_v2_cluster_inconsistency(snuba_set_config):
-    params = RateLimitParameters("foo", "foo", None, 4)
-
-    # max out rate limit
-    with RateLimitAggregator([params] * 4):
-        snuba_set_config("rate_limit_use_v2_cluster", 1.0)
-
-    # asserted that rate limiter does not crash if cluster is switched
-    # halfway through (since the routing decision is only made once)
-
-    # check that rollback does not crash either
-    with RateLimitAggregator([params] * 4):
-        snuba_set_config("rate_limit_use_v2_cluster", 0.0)
-
-    with pytest.raises(RateLimitExceeded):
-        with RateLimitAggregator([params] * 5):
-            snuba_set_config("rate_limit_use_v2_cluster", 1.0)
-
-    snuba_set_config("rate_limit_use_v2_cluster", 0.0)
-
-    # assert that rate limits don't get "stuck" when clusters are switched
-    # while a query is rejected, and we can still run queries after
-    with RateLimitAggregator([params] * 4):
-        pass


### PR DESCRIPTION
This requires https://github.com/getsentry/ops/pull/5682 to be deployed
first.

We have successfully moved all traffic to the new clusters, so we can:

1. point the old, now unused logical cluster to the same physical resource (ops PR)
2. change the code to start using the old logical (v1) cluster again and
   remove v2 (this PR)

