### PR TITLE
fix(api-abuse): Add duration_ms to individual queries in querylog

### DIFF
--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -59,8 +59,6 @@ class QuerylogProcessor(DatasetMessageProcessor):
             sql.append(query["sql"])
             status.append(query["status"])
             trace_id.append(str(uuid.UUID(query["trace_id"])))
-            # TODO: Calculate subquery duration, for now just insert 0s
-            duration_ms.append(0)
             stats.append(self.__to_json_string(query["stats"]))
             final.append(int(query["stats"].get("final") or 0))
             cache_hit.append(int(query["stats"].get("cache_hit") or 0))
@@ -93,6 +91,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
             groupby_columns.append(profile["groupby_cols"])
             array_join_columns.append(profile["array_join_cols"])
             bytes_scanned_columns.append(result_profile.get("bytes", 0))
+            duration_ms.append(result_profile.get("elapsed", 0))
 
         return {
             "clickhouse_queries.sql": sql,

--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -91,7 +91,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
             groupby_columns.append(profile["groupby_cols"])
             array_join_columns.append(profile["array_join_cols"])
             bytes_scanned_columns.append(result_profile.get("bytes", 0))
-            duration_ms.append(result_profile.get("elapsed", 0))
+            duration_ms.append(result_profile.get("elapsed", 0) * 1000)
 
         return {
             "clickhouse_queries.sql": sql,

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -81,7 +81,7 @@ def test_simple() -> None:
                     groupby_cols=set(),
                     array_join_cols=set(),
                 ),
-                result_profile={"bytes": 1337, "elapsed": 42},
+                result_profile={"bytes": 1337, "elapsed": 0.042},
                 trace_id="b" * 32,
             )
         ],

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -81,7 +81,7 @@ def test_simple() -> None:
                     groupby_cols=set(),
                     array_join_cols=set(),
                 ),
-                result_profile={"bytes": 1337},
+                result_profile={"bytes": 1337, "elapsed": 42},
                 trace_id="b" * 32,
             )
         ],
@@ -116,7 +116,7 @@ def test_simple() -> None:
                 ],
                 "clickhouse_queries.status": ["success"],
                 "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
-                "clickhouse_queries.duration_ms": [0],
+                "clickhouse_queries.duration_ms": [42],
                 "clickhouse_queries.stats": ['{"error_code": 386, "sample": 10}'],
                 "clickhouse_queries.final": [0],
                 "clickhouse_queries.cache_hit": [0],


### PR DESCRIPTION
## Overview
The snuba querylog has a `duration_ms` which is the runtime of the entire snuba query. However, the runtime of the individual clickhouse query itself (time elapsed for Clickhouse to run a query on server) is not captured by querylog. This PR is responsible for adding this data to querylog.

## Before State
Querylog always writes `0` in `clickhouse_queries.duration_ms`

## After State
Querylog writes the elapsed time to run the clickhouse query in `clickhouse_queries.duration_ms`

## Testing
Tested locally to ensure messages produced to querylog topics are correct and contain accurate fields.