### PR TITLE
fix(admin): actually use slack channel id...

### DIFF
--- a/snuba/admin/notifications/slack/client.py
+++ b/snuba/admin/notifications/slack/client.py
@@ -21,16 +21,13 @@ class SlackClient(object):
     def token(self) -> Optional[str]:
         return settings.SLACK_API_TOKEN
 
-    def post_message(
-        self, message: MutableMapping[str, Any], channel: Optional[str] = None
-    ) -> None:
+    def post_message(self, message: MutableMapping[str, Any]) -> None:
         headers = {
             "Content-Type": "application/json",
             "Authorization": f"Bearer {self.token}",
         }
 
-        if channel:
-            message["channel"] = channel
+        message["channel"] = self.channel_id
 
         try:
             resp = requests.post(


### PR DESCRIPTION
I removed the passing of the slack channel in https://github.com/getsentry/snuba/pull/3406 or at least I THOUGHT I did, I think this change got lost in one of my rebases... FIXES SNUBA-30C