### PR TITLE
SNS-1753: support different source/target databases

### DIFF
--- a/scripts/copy-tables.py
+++ b/scripts/copy-tables.py
@@ -151,8 +151,13 @@ def copy_tables(
     )
     for table_name, statement in show_table_statements.items():
         if source_database != target_database:
-            print(f"Mismatched databases.. Replacing: {source_database}.{table_name} with {target_database}.{table_name}")
-            statement = statement.replace(f"CREATE TABLE {source_database}.{table_name}", f"CREATE TABLE {target_database}.{table_name}")
+            print(
+                f"Mismatched databases.. Replacing: {source_database}.{table_name} with {target_database}.{table_name}"
+            )
+            statement = statement.replace(
+                f"CREATE TABLE {source_database}.{table_name}",
+                f"CREATE TABLE {target_database}.{table_name}",
+            )
         print(
             f"creating {table_name}... on replica: {target_replica}, shard: {target_shard}, database: {target_database}"
         )
@@ -161,6 +166,7 @@ def copy_tables(
             print(f"created {table_name} !")
         else:
             print(f"\ncreate table statement: \n {statement}\n")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Copy ClickHouse Tables")
@@ -211,4 +217,11 @@ if __name__ == "__main__":
 
     tables = args.tables and args.tables.split(",")
 
-    copy_tables(source_client, target_client, args.source_database, args.target_database, args.execute, tables)
+    copy_tables(
+        source_client,
+        target_client,
+        args.source_database,
+        args.target_database,
+        args.execute,
+        tables,
+    )


### PR DESCRIPTION
Example use case: replacing chalet with snuba-access-logs

Chalet had a special "clicktail" database, but snuba-access-logs could just use "default"

### Example

```
snuba/scripts on  SNS-1753-support-different-databases [?] via 🐍 v3.10.6 (.venv) on ☁️  michael@sentry.io(us-central1)
❯ ./copy-tables.py --source-host 192.168.208.151 --target-host 192.168.208.204 --source-database clicktail --target-database default

Replicated Table Check:
...looking up macros
...found replica: chalet for shard: 0
...verifying zk replica path for table: access_log...
...zookeeper replica paths verified for table: access_log ! :)
Mismatched databases.. Replacing: clicktail.access_log with default.access_log
creating access_log... on replica: snuba-access-logs-1-1, shard: 1, database: default

create table statement:
 CREATE TABLE default.access_log
(
    `_time` DateTime CODEC(DoubleDelta, LZ4),
    `_date` Date DEFAULT toDate(_time),
    `_ms` UInt32,
    `body_bytes_sent` UInt32 CODEC(ZSTD(1)),
    ...
    INDEX minmax_status status TYPE minmax GRANULARITY 4,
    INDEX minmax_project_id project_id TYPE minmax GRANULARITY 4
)
ENGINE = ReplicatedMergeTree('/clickhouse/tables/clicktail/access_log', 'chalet')
PARTITION BY _date
ORDER BY (statsd_path, request_uri_path, _date, _time)
TTL _date + toIntervalDay(400)
SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 1000000000
```