### PR TITLE
Revert "Revert "rename old migrations""

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -93,7 +93,7 @@ class CodeMigration(Migration, ABC):
         update_status(Status.NOT_STARTED)
 
 
-class ClickhouseNodeMigration(Migration, ABC):
+class ClickhouseNodeMigrationLegacy(Migration, ABC):
     """
     A ClickhouseNodeMigration consists of one or more forward operations which will be executed
     on all of the local and distributed nodes of the cluster. Upon error, the backwards

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -22,7 +22,11 @@ from snuba.migrations.errors import (
     MigrationInProgress,
 )
 from snuba.migrations.groups import OPTIONAL_GROUPS, MigrationGroup, get_group_loader
-from snuba.migrations.migration import ClickhouseNodeMigration, CodeMigration, Migration
+from snuba.migrations.migration import (
+    ClickhouseNodeMigrationLegacy,
+    CodeMigration,
+    Migration,
+)
 from snuba.migrations.operations import SqlOperation
 from snuba.migrations.status import Status
 
@@ -439,7 +443,7 @@ class Runner:
                 migrations.append(migration)
 
         for migration in migrations:
-            if isinstance(migration, ClickhouseNodeMigration):
+            if isinstance(migration, ClickhouseNodeMigrationLegacy):
                 operations = (
                     migration.forwards_local()
                     if node_type == ClickhouseNodeType.LOCAL

--- a/snuba/migrations/system_migrations/0001_migrations.py
+++ b/snuba/migrations/system_migrations/0001_migrations.py
@@ -18,7 +18,7 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     This migration is the only one that sets is_first_migration = True since it is
     responsible for bootstrapping the migration system itself. It skips setting

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -3,7 +3,7 @@ from typing import Sequence, Union
 
 from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
-from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.migration import ClickhouseNodeMigrationLegacy
 from snuba.migrations.operations import AddColumn, CreateTable, DropColumn, SqlOperation
 
 ENGINE_REGEX = r"^Distributed(\(.+\))$"
@@ -33,7 +33,7 @@ class DistributedEngineParseError(Exception):
     pass
 
 
-def validate_migration_order(migration: ClickhouseNodeMigration) -> None:
+def validate_migration_order(migration: ClickhouseNodeMigrationLegacy) -> None:
     """
     Validates that the migration order is correct. Checks that the order of
     AddColumn, CreateTable and DropColumn operations are correct with regards to being

--- a/snuba/snuba_migrations/discover/0001_discover_merge_table.py
+++ b/snuba/snuba_migrations/discover/0001_discover_merge_table.py
@@ -42,7 +42,7 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/discover/0002_discover_add_deleted_tags_hash_map.py
+++ b/snuba/snuba_migrations/discover/0002_discover_add_deleted_tags_hash_map.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the _tags_hash_map and deleted columns to the merge table so we can use
     the tags optimization, and ensure deleted rows are omitted from queries.

--- a/snuba/snuba_migrations/discover/0003_discover_fix_user_column.py
+++ b/snuba/snuba_migrations/discover/0003_discover_fix_user_column.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The user column should not be low cardinality - it's not in the underlying errors
     or transactions tables.

--- a/snuba/snuba_migrations/discover/0004_discover_fix_title_and_message.py
+++ b/snuba/snuba_migrations/discover/0004_discover_fix_title_and_message.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The title and message column should not be nullable, since they are not in errors
     or transactions.

--- a/snuba/snuba_migrations/discover/0005_discover_fix_transaction_name.py
+++ b/snuba/snuba_migrations/discover/0005_discover_fix_transaction_name.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The transaction_name column should not be nullable; it is not in either errors or transacions
     """

--- a/snuba/snuba_migrations/discover/0006_discover_add_trace_id.py
+++ b/snuba/snuba_migrations/discover/0006_discover_add_trace_id.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Add trace_id to merge table
     """

--- a/snuba/snuba_migrations/discover/0007_discover_add_span_id.py
+++ b/snuba/snuba_migrations/discover/0007_discover_add_span_id.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Add span_id to merge table
     """

--- a/snuba/snuba_migrations/events/0001_events_initial.py
+++ b/snuba/snuba_migrations/events/0001_events_initial.py
@@ -113,7 +113,7 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/events/0002_events_onpremise_compatibility.py
+++ b/snuba/snuba_migrations/events/0002_events_onpremise_compatibility.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     This is a one-off migration to support on premise users who are upgrading from
     any older version of Snuba that used the old migration system. Since their sentry_local

--- a/snuba/snuba_migrations/events/0003_errors.py
+++ b/snuba/snuba_migrations/events/0003_errors.py
@@ -101,7 +101,7 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/events/0004_errors_onpremise_compatibility.py
+++ b/snuba/snuba_migrations/events/0004_errors_onpremise_compatibility.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Syncs the errors_local table for onpremise users migration from Snuba versions
     prior to the new migration system being introduced.

--- a/snuba/snuba_migrations/events/0005_events_tags_hash_map.py
+++ b/snuba/snuba_migrations/events/0005_events_tags_hash_map.py
@@ -7,7 +7,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the tags hash map column defined as Array(Int64) Materialized with
     arrayMap((k, v) -> cityHash64(

--- a/snuba/snuba_migrations/events/0006_errors_tags_hash_map.py
+++ b/snuba/snuba_migrations/events/0006_errors_tags_hash_map.py
@@ -7,7 +7,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the tags hash map column defined as Array(Int64) Materialized with
     arrayMap((k, v) -> cityHash64(

--- a/snuba/snuba_migrations/events/0007_groupedmessages.py
+++ b/snuba/snuba_migrations/events/0007_groupedmessages.py
@@ -24,7 +24,7 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/events/0008_groupassignees.py
+++ b/snuba/snuba_migrations/events/0008_groupassignees.py
@@ -18,7 +18,7 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/events/0009_errors_add_http_fields.py
+++ b/snuba/snuba_migrations/events/0009_errors_add_http_fields.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the http columns defined, with the method and referer coming from the request interface
     and url materialized from the tags.

--- a/snuba/snuba_migrations/events/0011_rebuild_errors.py
+++ b/snuba/snuba_migrations/events/0011_rebuild_errors.py
@@ -93,7 +93,7 @@ columns: Sequence[Column[Modifiers]] = [
 sample_expr = "cityHash64(event_id)"
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     This migration rebuilds the errors table, with the following changes:
 

--- a/snuba/snuba_migrations/events/0012_errors_make_level_nullable.py
+++ b/snuba/snuba_migrations/events/0012_errors_make_level_nullable.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def __forward_migrations(

--- a/snuba/snuba_migrations/events/0013_errors_add_hierarchical_hashes.py
+++ b/snuba/snuba_migrations/events/0013_errors_add_hierarchical_hashes.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the http columns defined, with the method and referer coming from the request interface
     and url materialized from the tags.

--- a/snuba/snuba_migrations/events/0015_truncate_events.py
+++ b/snuba/snuba_migrations/events/0015_truncate_events.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Truncate the events table. Cannot be reversed.
     """

--- a/snuba/snuba_migrations/events/0016_drop_legacy_events.py
+++ b/snuba/snuba_migrations/events/0016_drop_legacy_events.py
@@ -116,7 +116,7 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     This is exactly the same as 0001_events_initial with the forwards and backwards
     methods flipped around since we are deleting the table now.

--- a/snuba/snuba_migrations/functions/0001_functions.py
+++ b/snuba/snuba_migrations/functions/0001_functions.py
@@ -54,7 +54,7 @@ agg_columns: List[Column[Modifiers]] = common_columns + [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     index_granularity = "2048"
     storage_set = StorageSetKey.FUNCTIONS

--- a/snuba/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
+++ b/snuba/snuba_migrations/generic_metrics/0001_sets_aggregate_table.py
@@ -18,7 +18,7 @@ from snuba.migrations import migration, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     granularity = "2048"
     local_table_name = "generic_metric_sets_local"

--- a/snuba/snuba_migrations/generic_metrics/0002_sets_raw_table.py
+++ b/snuba/snuba_migrations/generic_metrics/0002_sets_raw_table.py
@@ -14,7 +14,7 @@ from snuba.migrations import migration, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     local_table_name = "generic_metric_sets_raw_local"
     dist_table_name = "generic_metric_sets_raw_dist"

--- a/snuba/snuba_migrations/generic_metrics/0003_sets_mv.py
+++ b/snuba/snuba_migrations/generic_metrics/0003_sets_mv.py
@@ -13,7 +13,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     view_name = "generic_metric_sets_aggregation_mv"
     dest_table_columns: Sequence[Column[Modifiers]] = [

--- a/snuba/snuba_migrations/generic_metrics/0004_sets_raw_add_granularities.py
+++ b/snuba/snuba_migrations/generic_metrics/0004_sets_raw_add_granularities.py
@@ -6,7 +6,7 @@ from snuba.migrations.columns import MigrationModifiers
 from snuba.utils.schemas import Array, Column, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     table_name = "generic_metric_sets_raw_local"
     new_column: Column[MigrationModifiers] = Column("granularities", Array(UInt(8)))

--- a/snuba/snuba_migrations/generic_metrics/0005_sets_replace_mv.py
+++ b/snuba/snuba_migrations/generic_metrics/0005_sets_replace_mv.py
@@ -13,7 +13,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     view_name = "generic_metric_sets_aggregation_mv"
     dest_table_columns: Sequence[Column[Modifiers]] = [

--- a/snuba/snuba_migrations/generic_metrics/0006_sets_raw_add_granularities_dist_table.py
+++ b/snuba/snuba_migrations/generic_metrics/0006_sets_raw_add_granularities_dist_table.py
@@ -6,7 +6,7 @@ from snuba.migrations.columns import MigrationModifiers
 from snuba.utils.schemas import Array, Column, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     table_name = "generic_metric_sets_raw_dist"
     new_column: Column[MigrationModifiers] = Column("granularities", Array(UInt(8)))

--- a/snuba/snuba_migrations/generic_metrics/0007_distributions_aggregate_table.py
+++ b/snuba/snuba_migrations/generic_metrics/0007_distributions_aggregate_table.py
@@ -19,7 +19,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.utils.schemas import Float
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     granularity = "2048"
     local_table_name = "generic_metric_distributions_aggregated_local"

--- a/snuba/snuba_migrations/generic_metrics/0008_distributions_raw_table.py
+++ b/snuba/snuba_migrations/generic_metrics/0008_distributions_raw_table.py
@@ -14,7 +14,7 @@ from snuba.migrations import migration, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     local_table_name = "generic_metric_distributions_raw_local"
     dist_table_name = "generic_metric_distributions_raw_dist"

--- a/snuba/snuba_migrations/generic_metrics/0009_distributions_mv.py
+++ b/snuba/snuba_migrations/generic_metrics/0009_distributions_mv.py
@@ -13,7 +13,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     view_name = "generic_metric_distributions_aggregation_mv"
     dest_table_columns: Sequence[Column[Modifiers]] = [

--- a/snuba/snuba_migrations/metrics/0001_metrics_buckets.py
+++ b/snuba/snuba_migrations/metrics/0001_metrics_buckets.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/metrics/0002_metrics_sets.py
+++ b/snuba/snuba_migrations/metrics/0002_metrics_sets.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/metrics/0003_counters_to_buckets.py
+++ b/snuba/snuba_migrations/metrics/0003_counters_to_buckets.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/metrics/0004_metrics_counters.py
+++ b/snuba/snuba_migrations/metrics/0004_metrics_counters.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/metrics/0005_metrics_distributions_buckets.py
+++ b/snuba/snuba_migrations/metrics/0005_metrics_distributions_buckets.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/metrics/0006_metrics_distributions.py
+++ b/snuba/snuba_migrations/metrics/0006_metrics_distributions.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/metrics/0007_metrics_sets_granularity_10.py
+++ b/snuba/snuba_migrations/metrics/0007_metrics_sets_granularity_10.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics sets with a 10 second granularity
     in addition to the existing 60 seconds view.

--- a/snuba/snuba_migrations/metrics/0008_metrics_counters_granularity_10.py
+++ b/snuba/snuba_migrations/metrics/0008_metrics_counters_granularity_10.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics counters with a 10 second granularity
     in addition to the existing 60 seconds view.

--- a/snuba/snuba_migrations/metrics/0009_metrics_distributions_granularity_10.py
+++ b/snuba/snuba_migrations/metrics/0009_metrics_distributions_granularity_10.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics distributions with a 10 second granularity
     in addition to the existing 60 seconds view.

--- a/snuba/snuba_migrations/metrics/0010_metrics_sets_granularity_1h.py
+++ b/snuba/snuba_migrations/metrics/0010_metrics_sets_granularity_1h.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics sets with a one hour granularity.
 

--- a/snuba/snuba_migrations/metrics/0011_metrics_counters_granularity_1h.py
+++ b/snuba/snuba_migrations/metrics/0011_metrics_counters_granularity_1h.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics counters with a one hour granularity.
 

--- a/snuba/snuba_migrations/metrics/0012_metrics_distributions_granularity_1h.py
+++ b/snuba/snuba_migrations/metrics/0012_metrics_distributions_granularity_1h.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics distributions with a one hour granularity.
 

--- a/snuba/snuba_migrations/metrics/0013_metrics_sets_granularity_1d.py
+++ b/snuba/snuba_migrations/metrics/0013_metrics_sets_granularity_1d.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics sets with a 24h granularity.
 

--- a/snuba/snuba_migrations/metrics/0014_metrics_counters_granularity_1d.py
+++ b/snuba/snuba_migrations/metrics/0014_metrics_counters_granularity_1d.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics counters with a 24h granularity.
 

--- a/snuba/snuba_migrations/metrics/0015_metrics_distributions_granularity_1d.py
+++ b/snuba/snuba_migrations/metrics/0015_metrics_distributions_granularity_1d.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics distributions with a 24h granularity.
 

--- a/snuba/snuba_migrations/metrics/0016_metrics_sets_consolidated_granularity.py
+++ b/snuba/snuba_migrations/metrics/0016_metrics_sets_consolidated_granularity.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics sets which writes to 10s, 1m, 1h, 1d granularities
 

--- a/snuba/snuba_migrations/metrics/0017_metrics_counters_consolidated_granularity.py
+++ b/snuba/snuba_migrations/metrics/0017_metrics_counters_consolidated_granularity.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics counters which writes to 10s, 1m, 1h, 1d granularities
 

--- a/snuba/snuba_migrations/metrics/0018_metrics_distributions_consolidated_granularity.py
+++ b/snuba/snuba_migrations/metrics/0018_metrics_distributions_consolidated_granularity.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a materialized view for metrics distributions which writes to 10s, 1m, 1h, 1d granularities
 

--- a/snuba/snuba_migrations/metrics/0019_aggregate_tables_add_ttl.py
+++ b/snuba/snuba_migrations/metrics/0019_aggregate_tables_add_ttl.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds TTLs to all the aggergate tables based on retention_days columns
     """

--- a/snuba/snuba_migrations/metrics/0020_polymorphic_buckets_table.py
+++ b/snuba/snuba_migrations/metrics/0020_polymorphic_buckets_table.py
@@ -6,7 +6,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.utils.schemas import Array, Column, DateTime, Float, Nested, String, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a polymorphic bucket table for metrics_sets,
     metrics_distributions, and metrics_counters

--- a/snuba/snuba_migrations/metrics/0021_polymorphic_bucket_materialized_views.py
+++ b/snuba/snuba_migrations/metrics/0021_polymorphic_bucket_materialized_views.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 from snuba.utils.schemas import AggregateFunction, Column, Float, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Creates materialized view for all metrics types which writes to 10s, 1m, 1h, 1d granularities
 

--- a/snuba/snuba_migrations/metrics/0022_repartition_polymorphic_table.py
+++ b/snuba/snuba_migrations/metrics/0022_repartition_polymorphic_table.py
@@ -6,7 +6,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.utils.schemas import Array, Column, DateTime, Float, Nested, String, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Create a polymorphic bucket table for metrics_sets,
     metrics_distributions, and metrics_counters.

--- a/snuba/snuba_migrations/metrics/0023_polymorphic_repartitioned_bucket_matview.py
+++ b/snuba/snuba_migrations/metrics/0023_polymorphic_repartitioned_bucket_matview.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 from snuba.utils.schemas import AggregateFunction, Column, Float, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Creates materialized view for all metrics types which writes to 10s, 1m, 1h, 1d granularities
     The backward migration does *not* delete any data from the destination tables.

--- a/snuba/snuba_migrations/metrics/0024_metrics_distributions_add_histogram.py
+++ b/snuba/snuba_migrations/metrics/0024_metrics_distributions_add_histogram.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Add HdrHistogram to distribution metrics.
     """

--- a/snuba/snuba_migrations/metrics/0025_metrics_counters_aggregate_v2.py
+++ b/snuba/snuba_migrations/metrics/0025_metrics_counters_aggregate_v2.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import COMMON_AGGR_COLUMNS
 from snuba.utils.schemas import AggregateFunction, Float, String
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     table_name = "metrics_counters_v2_local"
     dist_table_name = "metrics_counters_v2_dist"

--- a/snuba/snuba_migrations/metrics/0026_metrics_counters_v2_writing_matview.py
+++ b/snuba/snuba_migrations/metrics/0026_metrics_counters_v2_writing_matview.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 from snuba.utils.schemas import AggregateFunction, Column, Float
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Creates materialized view for all metrics types which writes to 10s, 1m, 1h, 1d granularities
     The backward migration does *not* delete any data from the destination tables.

--- a/snuba/snuba_migrations/metrics/0027_fix_migration_0026.py
+++ b/snuba/snuba_migrations/metrics/0027_fix_migration_0026.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 from snuba.utils.schemas import AggregateFunction, Column, Float
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Migration 0026 reused a materialized view name and then failed silently because
     of a CREATE ... IF NOT EXISTS clause

--- a/snuba/snuba_migrations/metrics/0028_metrics_sets_aggregate_v2.py
+++ b/snuba/snuba_migrations/metrics/0028_metrics_sets_aggregate_v2.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import COMMON_AGGR_COLUMNS
 from snuba.utils.schemas import AggregateFunction, String
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     table_name = "metrics_sets_v2_local"
     dist_table_name = "metrics_sets_v2_dist"

--- a/snuba/snuba_migrations/metrics/0029_metrics_distributions_aggregate_v2.py
+++ b/snuba/snuba_migrations/metrics/0029_metrics_distributions_aggregate_v2.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import COMMON_AGGR_COLUMNS
 from snuba.utils.schemas import AggregateFunction, Float, String
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     table_name = "metrics_distributions_v2_local"
     dist_table_name = "metrics_distributions_v2_dist"

--- a/snuba/snuba_migrations/metrics/0030_metrics_distributions_v2_writing_mv.py
+++ b/snuba/snuba_migrations/metrics/0030_metrics_distributions_v2_writing_mv.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Add a materialized view for writing to the v2 version of the metrics_distributions aggregate table
     """

--- a/snuba/snuba_migrations/metrics/0031_metrics_sets_v2_writing_mv.py
+++ b/snuba/snuba_migrations/metrics/0031_metrics_sets_v2_writing_mv.py
@@ -9,7 +9,7 @@ from snuba.snuba_migrations.metrics.templates import (
 )
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Add a materialized view for writing to the v2 version of the metrics_sets aggregate table
     """

--- a/snuba/snuba_migrations/metrics/0032_redo_0030_and_0031_without_timestamps.py
+++ b/snuba/snuba_migrations/metrics/0032_redo_0030_and_0031_without_timestamps.py
@@ -10,7 +10,7 @@ from snuba.snuba_migrations.metrics.templates import (
 from snuba.utils.schemas import AggregateFunction, Column, UInt
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Re-creates materialized views of 0030 and 0031 without timestamps for easier operations
     """

--- a/snuba/snuba_migrations/metrics/0033_metrics_cleanup_old_views.py
+++ b/snuba/snuba_migrations/metrics/0033_metrics_cleanup_old_views.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Drop unused materialized views
     """

--- a/snuba/snuba_migrations/metrics/0034_metrics_cleanup_old_tables.py
+++ b/snuba/snuba_migrations/metrics/0034_metrics_cleanup_old_tables.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Drop unused tables
     """

--- a/snuba/snuba_migrations/outcomes/0001_outcomes.py
+++ b/snuba/snuba_migrations/outcomes/0001_outcomes.py
@@ -36,7 +36,7 @@ materialized_view_columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
+++ b/snuba/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     We added the size and bytes_received columns on 15 Dec 2019 and reverted the next
     day. This migration ensures the column is dropped for all users on the off chance

--- a/snuba/snuba_migrations/outcomes/0003_outcomes_add_category_and_quantity.py
+++ b/snuba/snuba_migrations/outcomes/0003_outcomes_add_category_and_quantity.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds quantity and category columns to outcomes. updates hourly table to support
     category as a new dimension and quantity as a new measure.

--- a/snuba/snuba_migrations/outcomes/0004_outcomes_matview_additions.py
+++ b/snuba/snuba_migrations/outcomes/0004_outcomes_matview_additions.py
@@ -28,7 +28,7 @@ new_materialized_view_columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Updates materialized view query to support category and quantity.
     Note that the consumer needs to be stopped for this migration.

--- a/snuba/snuba_migrations/profiles/0001_profiles.py
+++ b/snuba/snuba_migrations/profiles/0001_profiles.py
@@ -39,7 +39,7 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/profiles/0002_disable_vertical_merge_algorithm.py
+++ b/snuba/snuba_migrations/profiles/0002_disable_vertical_merge_algorithm.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Use the horizontal merge algorithm
     """

--- a/snuba/snuba_migrations/profiles/0003_add_device_architecture.py
+++ b/snuba/snuba_migrations/profiles/0003_add_device_architecture.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/profiles/0004_drop_profile_column.py
+++ b/snuba/snuba_migrations/profiles/0004_drop_profile_column.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
     forwards_local_first: bool = False
     backwards_local_first: bool = True

--- a/snuba/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/snuba_migrations/querylog/0001_querylog.py
@@ -51,7 +51,7 @@ columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/querylog/0002_status_type_change.py
+++ b/snuba/snuba_migrations/querylog/0002_status_type_change.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Drops the status enum and replaces it with a LowCardinality string
     now that the support for low cardinality strings is better.

--- a/snuba/snuba_migrations/querylog/0003_add_profile_fields.py
+++ b/snuba/snuba_migrations/querylog/0003_add_profile_fields.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds fields for query profile.
     """

--- a/snuba/snuba_migrations/querylog/0004_add_bytes_scanned.py
+++ b/snuba/snuba_migrations/querylog/0004_add_bytes_scanned.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds fields for query profile.
     """

--- a/snuba/snuba_migrations/replays/0001_replays.py
+++ b/snuba/snuba_migrations/replays/0001_replays.py
@@ -56,7 +56,7 @@ raw_columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/replays/0002_add_url.py
+++ b/snuba/snuba_migrations/replays/0002_add_url.py
@@ -10,7 +10,7 @@ new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/replays/0003_alter_url_allow_null.py
+++ b/snuba/snuba_migrations/replays/0003_alter_url_allow_null.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/replays/0004_add_error_ids_column.py
+++ b/snuba/snuba_migrations/replays/0004_add_error_ids_column.py
@@ -39,7 +39,7 @@ drop_indexes: List[operations.SqlOperation] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/replays/0005_add_urls_user_agent_replay_start_timestamp.py
+++ b/snuba/snuba_migrations/replays/0005_add_urls_user_agent_replay_start_timestamp.py
@@ -22,7 +22,7 @@ new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/replays/0006_add_is_archived_column.py
+++ b/snuba/snuba_migrations/replays/0006_add_is_archived_column.py
@@ -10,7 +10,7 @@ new_columns: Sequence[Tuple[Column[Modifiers], str]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/sessions/0001_sessions.py
+++ b/snuba/snuba_migrations/sessions/0001_sessions.py
@@ -24,7 +24,7 @@ raw_columns: Sequence[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/sessions/0002_sessions_aggregates.py
+++ b/snuba/snuba_migrations/sessions/0002_sessions_aggregates.py
@@ -51,7 +51,7 @@ new_dest_columns: Sequence[Tuple[Column[Modifiers], str]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     This migration adds new columns to both the raw and aggregated sessions.
     The new `X_preaggr` columns in the aggregated dataset will be used later on

--- a/snuba/snuba_migrations/sessions/0003_sessions_matview.py
+++ b/snuba/snuba_migrations/sessions/0003_sessions_matview.py
@@ -93,7 +93,7 @@ GROUP BY
 """
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     This migration re-creates the materialized view that aggregates sessions.
     It is now using the new `X_preaggr` columns based on the `quantity`.

--- a/snuba/snuba_migrations/sessions/0004_sessions_ttl.py
+++ b/snuba/snuba_migrations/sessions/0004_sessions_ttl.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/transactions/0001_transactions.py
+++ b/snuba/snuba_migrations/transactions/0001_transactions.py
@@ -58,7 +58,7 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/transactions/0003_transactions_onpremise_fix_columns.py
+++ b/snuba/snuba_migrations/transactions/0003_transactions_onpremise_fix_columns.py
@@ -8,7 +8,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 UNKNOWN_SPAN_STATUS = 2
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The second of two migrations that syncs the transactions_local table for onpremise
     users migrating from versions of Snuba prior to the migration system.

--- a/snuba/snuba_migrations/transactions/0004_transactions_add_tags_hash_map.py
+++ b/snuba/snuba_migrations/transactions/0004_transactions_add_tags_hash_map.py
@@ -7,7 +7,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the tags hash map column defined as Array(Int64) Materialized with
     arrayMap((k, v) -> cityHash64(

--- a/snuba/snuba_migrations/transactions/0005_transactions_add_measurements.py
+++ b/snuba/snuba_migrations/transactions/0005_transactions_add_measurements.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the measurements nested column
     """

--- a/snuba/snuba_migrations/transactions/0006_transactions_add_http_fields.py
+++ b/snuba/snuba_migrations/transactions/0006_transactions_add_http_fields.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the http columns populated from the Request interface that is missing from transactions.
     """

--- a/snuba/snuba_migrations/transactions/0007_transactions_add_discover_cols.py
+++ b/snuba/snuba_migrations/transactions/0007_transactions_add_discover_cols.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Add the materialized columns required for the Discover merge table.
     """

--- a/snuba/snuba_migrations/transactions/0008_transactions_add_timestamp_index.py
+++ b/snuba/snuba_migrations/transactions/0008_transactions_add_timestamp_index.py
@@ -4,7 +4,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     blocking = False
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:

--- a/snuba/snuba_migrations/transactions/0009_transactions_fix_title_and_message.py
+++ b/snuba/snuba_migrations/transactions/0009_transactions_fix_title_and_message.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Removes the low cardinality modifier on the title and message fields. These column
     types need to match the corresponding fields in the errors table for Discover.

--- a/snuba/snuba_migrations/transactions/0010_transactions_nullable_trace_id.py
+++ b/snuba/snuba_migrations/transactions/0010_transactions_nullable_trace_id.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Make trace_id nullable to match errors.
     """

--- a/snuba/snuba_migrations/transactions/0011_transactions_add_span_op_breakdowns.py
+++ b/snuba/snuba_migrations/transactions/0011_transactions_add_span_op_breakdowns.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     Adds the span_op_breakdowns nested column
     """

--- a/snuba/snuba_migrations/transactions/0012_transactions_add_spans.py
+++ b/snuba/snuba_migrations/transactions/0012_transactions_add_spans.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
 
     blocking = False
 

--- a/snuba/snuba_migrations/transactions/0013_transactions_reduce_spans_exclusive_time.py
+++ b/snuba/snuba_migrations/transactions/0013_transactions_reduce_spans_exclusive_time.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
 
     blocking = False
 

--- a/snuba/snuba_migrations/transactions/0014_transactions_remove_flattened_columns.py
+++ b/snuba/snuba_migrations/transactions/0014_transactions_remove_flattened_columns.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
 
     blocking = False
     forwards_local_first: bool = False

--- a/snuba/snuba_migrations/transactions/0015_transactions_add_source_column.py
+++ b/snuba/snuba_migrations/transactions/0015_transactions_add_source_column.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The source column is required to query for transaction events
     in the transaction summary when the transaction name has been

--- a/snuba/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
+++ b/snuba/snuba_migrations/transactions/0016_transactions_add_group_ids_column.py
@@ -5,7 +5,7 @@ from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The group ids column is required to query for transaction events
     with the same performance issue.

--- a/snuba/snuba_migrations/transactions/0017_transactions_add_app_start_type_column.py
+++ b/snuba/snuba_migrations/transactions/0017_transactions_add_app_start_type_column.py
@@ -6,7 +6,7 @@ from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 
-class Migration(migration.ClickhouseNodeMigration):
+class Migration(migration.ClickhouseNodeMigrationLegacy):
     """
     The app start type column is required to query for different
     app start types.

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -200,7 +200,7 @@ def test_specify_order() -> None:
     logger = Logger("test")
     context = Context("001", logger, lambda x: None)
 
-    class TestMigration(migration.ClickhouseNodeMigration):
+    class TestMigration(migration.ClickhouseNodeMigrationLegacy):
         blocking = False
 
         def forwards_local(self) -> Sequence[SqlOperation]:

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -27,7 +27,7 @@ for group in MigrationGroup:
     group_loader = get_group_loader(group)
     for migration_id in group_loader.get_migrations():
         snuba_migration = group_loader.load_migration(migration_id)
-        if isinstance(snuba_migration, migration.ClickhouseNodeMigration):
+        if isinstance(snuba_migration, migration.ClickhouseNodeMigrationLegacy):
             all_migrations.append((migration_id, snuba_migration))
 
 
@@ -39,7 +39,7 @@ for group in MigrationGroup:
     ],
 )
 def test_validate_all_migrations(
-    snuba_migration: migration.ClickhouseNodeMigration,
+    snuba_migration: migration.ClickhouseNodeMigrationLegacy,
 ) -> None:
     """
     Runs the migration validator on all existing migrations.
@@ -213,7 +213,7 @@ class TestValidateMigrations:
         )
         mock_get_cluster.return_value = mock_cluster
 
-        class TestMigration(migration.ClickhouseNodeMigration):
+        class TestMigration(migration.ClickhouseNodeMigrationLegacy):
             blocking = False
             backwards_local_first: bool = backwards_local_first_val
             forwards_local_first: bool = forwards_local_first_val


### PR DESCRIPTION
Reverts getsentry/snuba#3429

Undoing this revert because it wasn't the source of migrations errors in CI