### PR TITLE
ref(migrations): update outcomes blocking flags

### DIFF
--- a/snuba/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
+++ b/snuba/snuba_migrations/outcomes/0002_outcomes_remove_size_and_bytes.py
@@ -11,7 +11,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     they had upgraded or attempted to upgrade to a version released in that window.
     """
 
-    blocking = False
+    blocking = True
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [

--- a/snuba/snuba_migrations/outcomes/0003_outcomes_add_category_and_quantity.py
+++ b/snuba/snuba_migrations/outcomes/0003_outcomes_add_category_and_quantity.py
@@ -11,7 +11,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
     category as a new dimension and quantity as a new measure.
     """
 
-    blocking = False
+    blocking = True
 
     def forwards_local(self) -> Sequence[operations.SqlOperation]:
         return [


### PR DESCRIPTION
**context**
We are getting ready to enable running migrations through the snuba admin tooling. We rely on the `blocking` flag to be accurate so that the policies we have in place will make sure that no one runs a migration they shouldn't run through the tooling.

**what is non blocking?**
* adding columns
* adding tables
* ...