### PR TITLE
chore: ignore .vscode log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ snuba.egg-info/
 .DS_Store
 .idea/
 node_modules
+.vscode/*.log


### PR DESCRIPTION
vscode was creating log files like:

configurationCache.log
dryrun.log
targets.log