### PR TITLE
ref(migrations): add migration target enum

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -3,7 +3,7 @@ from typing import Sequence
 
 from snuba.clusters.cluster import get_cluster
 from snuba.migrations.context import Context
-from snuba.migrations.operations import RunPython, SqlOperation
+from snuba.migrations.operations import OperationTarget, RunPython, SqlOperation
 from snuba.migrations.status import Status
 
 
@@ -157,9 +157,11 @@ class ClickhouseNodeMigrationLegacy(Migration, ABC):
 
         for op in ops:
             if op in local_ops:
-                op.execute(local=True)
+                op.target = OperationTarget.LOCAL
+                op.execute()
             if op in dist_ops:
-                op.execute(local=False)
+                op.target = OperationTarget.DISTRIBUTED
+                op.execute()
 
         logger.info(f"Finished: {migration_id}")
         update_status(Status.COMPLETED)
@@ -185,9 +187,11 @@ class ClickhouseNodeMigrationLegacy(Migration, ABC):
 
         for op in ops:
             if op in local_ops:
-                op.execute(local=True)
+                op.target = OperationTarget.LOCAL
+                op.execute()
             if op in dist_ops:
-                op.execute(local=False)
+                op.target = OperationTarget.DISTRIBUTED
+                op.execute()
         logger.info(f"Finished reversing: {migration_id}")
 
         # The migrations table will be destroyed if the first

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -25,8 +25,8 @@ class SqlOperation(ABC):
     def __init__(
         self,
         storage_set: StorageSetKey,
+        target: OperationTarget,
         settings: Optional[Mapping[str, Any]] = None,
-        target: OperationTarget = OperationTarget.UNSET,
     ):
         self._storage_set = storage_set
         self._settings = settings
@@ -63,8 +63,13 @@ class SqlOperation(ABC):
 
 
 class RunSql(SqlOperation):
-    def __init__(self, storage_set: StorageSetKey, statement: str) -> None:
-        super().__init__(storage_set)
+    def __init__(
+        self,
+        storage_set: StorageSetKey,
+        statement: str,
+        target: OperationTarget = OperationTarget.UNSET,
+    ) -> None:
+        super().__init__(storage_set, target=target)
         self.__statement = statement
 
     def format_sql(self) -> str:
@@ -184,8 +189,8 @@ class ModifyTableTTL(SqlOperation):
         self.__materialize_ttl_on_modify = 1 if materialize_ttl_on_modify else 0
         super().__init__(
             storage_set,
+            target,
             {"materialize_ttl_on_modify": self.__materialize_ttl_on_modify},
-            target=target,
         )
         self.__table_name = table_name
         self.__reference_column = reference_column

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -219,8 +219,8 @@ def test_specify_order() -> None:
     order = []
     for op in ops:
 
-        def effect(op: Mock) -> Callable[[bool], None]:
-            def add_op(local: bool) -> None:
+        def effect(op: Mock) -> Callable[[], None]:
+            def add_op() -> None:
                 order.append(op)
 
             return add_op


### PR DESCRIPTION
A precursor to #3399 . This adds the target enum to specify which nodes to run an op on.

### Before:
The runner would pass in the local flag to let an op know which nodes to run on

### After:
Ops take in the target enum as a parameter. When executing ops already know what nodes to target. By default, the target enum is set to "unset" and will throw an error if the user does not explicitly set it.
