### PR TITLE
fix(DC): Replays Storage DLQ

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -118,3 +118,6 @@ stream_loader:
   processor:
     name: ReplaysProcessor
   default_topic: ingest-replay-events
+  dlq_policy:
+    type: produce
+    args: [snuba-dead-letter-replays]


### PR DESCRIPTION
### Overview
- Seems the python to yaml script missed DLQ params in the stream loader
- Only replays storage was affected and this PR will add it back in
- I've checked for other potential missed params and will update the script accordingly