### PR TITLE
ref(DC): Generic Metrics storages from Script

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -1,11 +1,9 @@
 version: v1
 kind: readable_storage
-name: generic-metrics-distributions
-
+name: generic_metrics_distributions
 storage:
   key: generic_metrics_distributions
   set_key: generic_metrics_distributions
-
 schema:
   columns:
     [
@@ -28,14 +26,13 @@ schema:
               ],
           },
       },
-
       {
         name: _raw_tags_hash,
         type: Array,
         args:
           {
-            inner_type: { type: UInt, args: { size: 64 } },
             schema_modifiers: [readonly],
+            inner_type: { type: UInt, args: { size: 64 } },
           },
       },
       {
@@ -43,12 +40,11 @@ schema:
         type: Array,
         args:
           {
-            inner_type: { type: UInt, args: { size: 64 } },
             schema_modifiers: [readonly],
+            inner_type: { type: UInt, args: { size: 64 } },
           },
       },
       { name: granularity, type: UInt, args: { size: 8 } },
-
       {
         name: percentiles,
         type: AggregateFunction,
@@ -61,42 +57,40 @@ schema:
       {
         name: min,
         type: AggregateFunction,
-        args: { func: "min", arg_types: [{ type: Float, args: { size: 64 } }] },
+        args: { func: min, arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: max,
         type: AggregateFunction,
-        args: { func: "max", arg_types: [{ type: Float, args: { size: 64 } }] },
+        args: { func: max, arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: avg,
         type: AggregateFunction,
-        args: { func: "avg", arg_types: [{ type: Float, args: { size: 64 } }] },
+        args: { func: avg, arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: sum,
         type: AggregateFunction,
-        args: { func: "sum", arg_types: [{ type: Float, args: { size: 64 } }] },
+        args: { func: sum, arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: count,
         type: AggregateFunction,
-        args:
-          { func: "count", arg_types: [{ type: Float, args: { size: 64 } }] },
+        args: { func: count, arg_types: [{ type: Float, args: { size: 64 } }] },
       },
       {
         name: histogram_buckets,
         type: AggregateFunction,
         args:
           {
-            func: "histogram(250)",
+            func: histogram(250),
             arg_types: [{ type: Float, args: { size: 64 } }],
           },
       },
     ]
   local_table_name: generic_metric_distributions_aggregated_local
   dist_table_name: generic_metric_distributions_aggregated_dist
-
 query_processors:
-  - processor: "TableRateLimit"
-  - processor: "TupleUnaliaser"
+  - processor: TableRateLimit
+  - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -1,11 +1,9 @@
 version: v1
 kind: writable_storage
-name: generic-metrics-distributions-bucket
-
+name: generic_metrics_distributions_raw
 storage:
   key: generic_metrics_distributions_raw
   set_key: generic_metrics_distributions
-
 schema:
   columns:
     [
@@ -28,7 +26,6 @@ schema:
               ],
           },
       },
-
       {
         name: granularities,
         type: Array,
@@ -49,7 +46,6 @@ schema:
     ]
   local_table_name: generic_metric_distributions_raw_local
   dist_table_name: generic_metric_distributions_raw_dist
-
 stream_loader:
   processor:
     name: GenericDistributionsMetricsProcessor

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -1,11 +1,9 @@
 version: v1
 kind: readable_storage
-name: generic-metrics-sets
-
+name: generic_metrics_sets
 storage:
   key: generic_metrics_sets
   set_key: generic_metrics_sets
-
 schema:
   columns:
     [
@@ -28,14 +26,13 @@ schema:
               ],
           },
       },
-
       {
         name: _raw_tags_hash,
         type: Array,
         args:
           {
-            inner_type: { type: UInt, args: { size: 64 } },
             schema_modifiers: [readonly],
+            inner_type: { type: UInt, args: { size: 64 } },
           },
       },
       {
@@ -43,25 +40,23 @@ schema:
         type: Array,
         args:
           {
-            inner_type: { type: UInt, args: { size: 64 } },
             schema_modifiers: [readonly],
+            inner_type: { type: UInt, args: { size: 64 } },
           },
       },
       { name: granularity, type: UInt, args: { size: 8 } },
-
       {
         name: value,
         type: AggregateFunction,
         args:
           {
-            func: "uniqCombined64",
+            func: uniqCombined64,
             arg_types: [{ type: UInt, args: { size: 64 } }],
           },
       },
     ]
   local_table_name: generic_metric_sets_local
   dist_table_name: generic_metric_sets_aggregated_dist
-
 query_processors:
-  - processor: "TableRateLimit"
-  - processor: "TupleUnaliaser"
+  - processor: TableRateLimit
+  - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -1,11 +1,9 @@
 version: v1
 kind: writable_storage
-name: generic-metrics-sets-bucket
-
+name: generic_metrics_sets_raw
 storage:
   key: generic_metrics_sets_raw
   set_key: generic_metrics_sets
-
 schema:
   columns:
     [
@@ -28,7 +26,6 @@ schema:
               ],
           },
       },
-
       {
         name: granularities,
         type: Array,
@@ -49,7 +46,6 @@ schema:
     ]
   local_table_name: generic_metric_sets_raw_local
   dist_table_name: generic_metric_sets_raw_dist
-
 stream_loader:
   processor:
     name: GenericSetsMetricsProcessor


### PR DESCRIPTION
### Overview
- Generic metrics configs were manually created
- Redid them using the script to make them consistent with other configs
- This changes the "name" field in the gen metrics