### PR TITLE
feat(migrations): Allow TTL clause on columns in migrations

### DIFF
--- a/snuba/migrations/columns.py
+++ b/snuba/migrations/columns.py
@@ -17,6 +17,7 @@ class MigrationModifiers(TypeModifiers):
     default: Optional[str] = None
     materialized: Optional[str] = None
     codecs: Optional[Sequence[str]] = None
+    ttl: Optional[str] = None
 
     def _get_modifiers(self) -> Sequence[TypeModifier]:
         ret: List[TypeModifier] = []
@@ -30,6 +31,8 @@ class MigrationModifiers(TypeModifiers):
             ret.append(Materialized(self.materialized))
         if self.codecs is not None:
             ret.append(WithCodecs(self.codecs))
+        if self.ttl is not None:
+            ret.append(WithTTL(self.ttl))
         return ret
 
     def merge(self, other: MigrationModifiers) -> MigrationModifiers:
@@ -41,6 +44,7 @@ class MigrationModifiers(TypeModifiers):
             if other.materialized is None
             else other.materialized,
             codecs=self.codecs if other.codecs is None else other.codecs,
+            ttl=self.ttl if other.ttl is None else other.ttl,
         )
 
 
@@ -72,3 +76,11 @@ class WithDefault(TypeModifier):
 class LowCardinality(TypeModifier):
     def for_schema(self, content: str) -> str:
         return "LowCardinality({})".format(content)
+
+
+@dataclass(frozen=True)
+class WithTTL(TypeModifier):
+    ttl_clause: str
+
+    def for_schema(self, content: str) -> str:
+        return f"{content} TTL {self.ttl_clause}"

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -54,6 +54,36 @@ def test_create_table() -> None:
     ]
 
 
+def test_create_table_with_column_ttl() -> None:
+    database = os.environ.get("CLICKHOUSE_DATABASE", "default")
+    columns: Sequence[Column[Modifiers]] = [
+        Column("id", String()),
+        Column("name", String(Modifiers(nullable=True))),
+        Column("version", UInt(64)),
+        Column(
+            "restricted",
+            String(Modifiers(low_cardinality=True, ttl="timestamp + toIntervalDay(1)")),
+        ),
+    ]
+
+    assert CreateTable(
+        StorageSetKey.EVENTS,
+        "test_table",
+        columns,
+        ReplacingMergeTree(
+            storage_set=StorageSetKey.EVENTS,
+            version_column="version",
+            order_by="version",
+            settings={"index_granularity": "256"},
+        ),
+    ).format_sql() in [
+        "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64, restricted LowCardinality(String) TTL timestamp + toIntervalDay(1)) ENGINE ReplacingMergeTree(version) ORDER BY version SETTINGS index_granularity=256;",
+        "CREATE TABLE IF NOT EXISTS test_table (id String, name Nullable(String), version UInt64, restricted LowCardinality(String) TTL timestamp + toIntervalDay(1)) ENGINE ReplicatedReplacingMergeTree('/clickhouse/tables/events/{shard}/"
+        + f"{database}/test_table'"
+        + ", '{replica}', version) ORDER BY version SETTINGS index_granularity=256;",
+    ]
+
+
 def test_create_materialized_view() -> None:
     assert (
         CreateMaterializedView(


### PR DESCRIPTION
Currently the only way to specify a TTL for a specific column in a table is to
have a ModifyColumn migration to add the TTL after the table is created. It
should also be possible to specify those TTLs in the create table however.

Before:

There was no TTL modifier for a Column, so a ModifyColumn migration had to run
in order to add a TTL to a specific column.

After:

There is now a TTL modifier that can specify a custom TTL expression on a column
