### PR TITLE
Add clarification about optional and skipped migration groups

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -22,7 +22,8 @@ class MigrationGroup(Enum):
     GENERIC_METRICS = "generic_metrics"
 
 
-# Migration groups are mandatory by default, unless they are on this list
+# Migration groups are mandatory by default. Specific groups can
+# only be skipped (SKIPPED_MIGRATION_GROUPS) if the exist in this list.
 OPTIONAL_GROUPS = {
     MigrationGroup.METRICS,
     MigrationGroup.SESSIONS,

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -231,7 +231,8 @@ COLUMN_SPLIT_MIN_COLS = 6
 COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 
-# Migrations in skipped groups will not be run
+# The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
+# Migrations for skipped groups will not be run.
 SKIPPED_MIGRATION_GROUPS: Set[str] = {"querylog", "profiles", "functions"}
 
 MAX_RESOLUTION_FOR_JITTER = 60


### PR DESCRIPTION
It was a bit confusing to me why we had both `OPTIONAL_GROUPS` and `SKIPPED_MIGRATION_GROUPS`. 

There is nothing stopping someone from adding groups to `SKIPPED_MIGRATION_GROUPS` that don't exist in `OPTIONAL_GROUPS`, it just means that it won't actually skip it. And there is no messaging that would let someone know it wasn't skipped (or why). 