### PR TITLE
fix(init): Snuba init timing metric

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -61,7 +61,7 @@ class SnubaCLI(click.MultiCommand):
                 code = compile(f.read(), fn, "exec")
                 eval(code, ns, ns)
             init_time = time.perf_counter() - start
-            metrics.gauge("snuba_init", init_time)
+            metrics.timing("snuba_init", init_time)
             logger.info(f"Snuba initialization took {init_time}s")
             return ns[actual_command_name]
 

--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -61,7 +61,7 @@ class SnubaCLI(click.MultiCommand):
                 code = compile(f.read(), fn, "exec")
                 eval(code, ns, ns)
             init_time = time.perf_counter() - start
-            metrics.timing("snuba_init", init_time)
+            metrics.timing("snuba_init_time", init_time)
             logger.info(f"Snuba initialization took {init_time}s")
             return ns[actual_command_name]
 


### PR DESCRIPTION
- Should use `timing` instead of `gauge` for a timing metric