### PR TITLE
feat(data delete): allow arbitrary data deletions [WIP]

### DIFF
--- a/snuba/cli/data_delete.py
+++ b/snuba/cli/data_delete.py
@@ -78,15 +78,12 @@ def data_delete(
     from snuba.data_delete import logger
 
     storage = get_writable_storage(StorageKey(storage_name))
-
     (
         clickhouse_user,
         clickhouse_password,
     ) = storage.get_cluster().get_credentials()
 
     cluster = storage.get_cluster()
-
-    print(QUERY_PARAMS)
 
     result = delete_real(
         cluster,

--- a/snuba/cli/data_delete.py
+++ b/snuba/cli/data_delete.py
@@ -1,0 +1,81 @@
+from typing import Optional
+
+import click
+
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.datasets.storages.factory import get_writable_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.environment import setup_logging, setup_sentry
+
+
+@click.command()
+@click.option(
+    "--clickhouse-host",
+    help="Clickhouse server to write to.",
+)
+@click.option(
+    "--clickhouse-port",
+    type=int,
+    help="Clickhouse native port to write to.",
+)
+@click.option(
+    "--dry-run",
+    type=bool,
+    default=True,
+    help="If true, only print which partitions would be dropped.",
+)
+@click.option(
+    "--storage",
+    "storage_name",
+    type=click.Choice(["errors", "transactions"]),
+    help="The storage to target",
+    required=True,
+)
+@click.option("--log-level", help="Logging level to use.")
+def cleanup(
+    *,
+    clickhouse_host: Optional[str],
+    clickhouse_port: Optional[int],
+    dry_run: bool,
+    storage_name: str,
+    log_level: Optional[str] = None,
+) -> None:
+    """
+    Script the removal of data from tables using a customer-input ALTER DELETE command,
+    supporting automatically connecting to one replica on each shard in a cluster.
+
+    Optionally, add a verify command to see that each partition has 0 rows remaining.
+    """
+
+    setup_logging(log_level)
+    setup_sentry()
+
+    from snuba.clickhouse.native import ClickhousePool
+    from snuba.data_delete import data_delete, logger
+
+    storage = get_writable_storage(StorageKey(storage_name))
+
+    (
+        clickhouse_user,
+        clickhouse_password,
+    ) = storage.get_cluster().get_credentials()
+
+    cluster = storage.get_cluster()
+    database = cluster.get_database()
+
+    if clickhouse_host and clickhouse_port:
+        connection = ClickhousePool(
+            clickhouse_host,
+            clickhouse_port,
+            clickhouse_user,
+            clickhouse_password,
+            database,
+        )
+    elif not cluster.is_single_node():
+        raise click.ClickException("Provide ClickHouse host and port for cleanup")
+    else:
+        connection = cluster.get_query_connection(ClickhouseClientSettings.DATA_DELETE)
+
+    result = data_delete(connection, "SELECT 1", dry_run=dry_run)
+
+    logger.info(operation="data_delete", result=result)

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -45,6 +45,7 @@ class ConnectionId(NamedTuple):
 
 class ClickhouseClientSettings(Enum):
     CLEANUP = ClickhouseClientSettingsType({}, None)
+    DATA_DELETE = ClickhouseClientSettingsType({"mutations_sync": 2}, 10000)
     INSERT = ClickhouseClientSettingsType({}, None)
     MIGRATE = ClickhouseClientSettingsType(
         {

--- a/snuba/data_delete.py
+++ b/snuba/data_delete.py
@@ -31,10 +31,10 @@ def order_cluster_nodes(
     """
     ordered_nodes: Mapping[int, List[ClickhouseNode]] = defaultdict(list)
     for node in nodes:
-        # assert (
-        #     node.shard is not None
-        # ), f"cannot proceed with automatic delete, node {node} has empty shard"
-        ordered_nodes[node.shard or -1].append(node)
+        assert (
+            node.shard is not None
+        ), f"cannot proceed with automatic delete, node {node} has empty shard"
+        ordered_nodes[node.shard].append(node)
     return ordered_nodes
 
 
@@ -103,4 +103,4 @@ def data_delete(
                 sleep(10)
             logger.info("data_delete.finished")
             clear_contextvars()
-    return DeleteResult.FAILED
+    return DeleteResult.SUCCEEDED

--- a/snuba/data_delete.py
+++ b/snuba/data_delete.py
@@ -1,8 +1,18 @@
+from collections import defaultdict
 from enum import Enum
+from time import sleep
+from typing import Any, List, Mapping, Sequence
 
 import structlog
+from structlog.contextvars import bind_contextvars, clear_contextvars
 
-from snuba.clickhouse.native import ClickhousePool
+from snuba.clickhouse.native import ClickhousePool, ClickhouseResult
+from snuba.clusters.cluster import (
+    ClickhouseClientSettings,
+    ClickhouseCluster,
+    ClickhouseNode,
+    connection_cache,
+)
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -13,9 +23,84 @@ class DeleteResult(Enum):
     SUCCEEDED = 2
 
 
-def data_delete(
+def order_cluster_nodes(
+    nodes: Sequence[ClickhouseNode],
+) -> Mapping[int, Sequence[ClickhouseNode]]:
+    """
+    Given a series of unordered ClickHouseNode[s], arrange them by shard
+    """
+    ordered_nodes: Mapping[int, List[ClickhouseNode]] = defaultdict(list)
+    for node in nodes:
+        # assert (
+        #     node.shard is not None
+        # ), f"cannot proceed with automatic delete, node {node} has empty shard"
+        ordered_nodes[node.shard or -1].append(node)
+    return ordered_nodes
+
+
+def get_working_replica_node(
+    nodes: Sequence[ClickhouseNode], user: str, password: str, database: str
+) -> ClickhousePool:
+    # TODO actually fail to getting another node if we can't load this connection
+    return connection_cache.get_node_connection(
+        ClickhouseClientSettings.DATA_DELETE, nodes[0], user, password, database
+    )
+
+
+def execute_delete_command_on_replica(
     connection: ClickhousePool,
-    delete_query_without_partition: str,
+    query: str,
+    params: Mapping[str, Any],
+    dry_run: bool = False,
+) -> ClickhouseResult:
+    logger.info("data_delete.pre_delete", interpolated_query={query % params})
+    if dry_run:
+        return ClickhouseResult()
+    else:
+        return connection.execute(query, params, retryable=False)
+
+
+def assert_no_mutations_on_replica(connection: ClickhousePool) -> None:
+    assert not is_mutation_running(connection)
+
+
+def is_mutation_running(connection: ClickhousePool) -> bool:
+    return (
+        len(
+            connection.execute(
+                "SELECT * FROM system.mutations WHERE is_done = 0"
+            ).results
+        )
+        != 0
+    )
+
+
+def data_delete(
+    cluster: ClickhouseCluster,
+    ch_user: str,
+    ch_pass: str,
+    query_template: str,
+    query_parameters: Sequence[Mapping[str, Any]],
     dry_run: bool = True,
 ) -> DeleteResult:
-    pass
+    clickhouse_db = cluster.get_database()
+    cluster_nodes = order_cluster_nodes(cluster.get_local_nodes())
+
+    for (shard, shard_replicas) in cluster_nodes.items():
+        logger.info("data_delete.init", shard_id=shard)
+        replica_node = get_working_replica_node(
+            shard_replicas, ch_user, ch_pass, clickhouse_db
+        )
+        for query_parameter_row in query_parameters:
+            bind_contextvars(query_parameters=query_parameter_row)
+            assert_no_mutations_on_replica(replica_node)
+            execute_delete_command_on_replica(
+                replica_node, query_template, query_parameter_row, dry_run
+            )
+            logger.info("data_delete.started")
+            while is_mutation_running(replica_node):
+                logger.debug("data_delete.sleep")
+                sleep(10)
+            logger.info("data_delete.finished")
+            clear_contextvars()
+    return DeleteResult.FAILED

--- a/snuba/data_delete.py
+++ b/snuba/data_delete.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+import structlog
+
+from snuba.clickhouse.native import ClickhousePool
+
+logger = structlog.get_logger().bind(module=__name__)
+
+
+class DeleteResult(Enum):
+    IN_PROGRESS = 0
+    FAILED = 1
+    SUCCEEDED = 2
+
+
+def data_delete(
+    connection: ClickhousePool,
+    delete_query_without_partition: str,
+    dry_run: bool = True,
+) -> DeleteResult:
+    pass

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -50,15 +50,17 @@ def setup_logging(level: Optional[str] = None) -> None:
     if level is None:
         level = settings.LOG_LEVEL
 
+    py_logging_level = getattr(logging, level.upper())
+
     logging.basicConfig(
-        level=getattr(logging, level.upper()),
+        level=py_logging_level,
         format=settings.LOG_FORMAT,
         force=True,
     )
 
     structlog.configure(
         cache_logger_on_first_use=True,
-        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        wrapper_class=structlog.make_filtering_bound_logger(py_logging_level),
         processors=[
             add_severity_attribute,
             structlog.contextvars.merge_contextvars,


### PR DESCRIPTION
This is a work-in-progress but I wanted to see what people think about the high-level algorithm in the `data_delete` method in `snuba/data_delete.py`. This current script will run a query against a set of parameters, waiting each time for the number of mutations in the system to be 0.

TODO:
- make the query template a parameter of the CLI
- make the input query parameters read from a file specified in the CLI
- time out with a failure if the number of mutations never reaches 0
- some kind of verification step with a second query template that makes sure the partitions are empty for all the input query parameters
- ???