### PR TITLE
ref(slicing): Make Storage Set the level of Slicing

### DIFF
--- a/docs/source/architecture/slicing.rst
+++ b/docs/source/architecture/slicing.rst
@@ -13,9 +13,9 @@ we maintain a mapping of logical partitions to physical slices in
 ``settings.LOGICAL_PARTITION_MAPPING``.
 
 In a future revision, this ``settings.LOGICAL_PARTITION_MAPPING`` will be
-used along with ``settings.SLICED_STORAGES`` to map queries and incoming
-data from consumers to different ClickHouse clusters by overriding the
-StorageSet key that exists in configuration.
+used along with ``settings.SLICED_STORAGE_SETS`` to map queries and incoming
+data from consumers to different ClickHouse clusters using a
+(StorageSetKey, slice_id) pairing that exists in configuration.
 
 ===========================
 Adding a slice
@@ -23,12 +23,12 @@ Adding a slice
 
 Add the logical:physical mapping
 --------------------------------
-To add a slice to a storage's logical:physical mapping, or repartition,
-increment the slice count in ``settings.SLICED_STORAGES`` for the relevant
-storage. Change the mapping of the relevant storage's
+To add a slice to a storage set's logical:physical mapping, or repartition,
+increment the slice count in ``settings.SLICED_STORAGE_SETS`` for the relevant
+storage set. Change the mapping of the relevant storage set's
 logical partitions in ``settings.LOGICAL_PARTITION_MAPPING``.
 Every logical partition **must** be assigned to a slice and the
-valid values of slices are in the range of ``[0,settings.SLICED_STORAGES[storage])``.
+valid values of slices are in the range of ``[0,settings.SLICED_STORAGE_SETS[storage_set])``.
 
 Defining sliced ClickHouse clusters
 -----------------------------------
@@ -36,7 +36,7 @@ To add a cluster with an associated (storage set key, slice) pair, add cluster d
 to ``settings.SLICED_CLUSTERS`` in the desired environment's settings. Follow the same structure as
 regular cluster definitions in ``settings.CLUSTERS``. In the ``storage_set_slices`` field, sliced storage
 sets should be added in the form of ``(StorageSetKey, slice_id)`` where slice_id is in
-the range ``[0,settings.SLICED_STORAGES[storage])`` for storages relevant to the ``StorageSetKey``.
+the range ``[0,settings.SLICED_STORAGE_SETS[storage_set])`` for the relevant storage set.
 
 
 Preparing the storage for sharding

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -95,7 +95,8 @@ class ConsumerBuilder:
             .topic
         )
 
-        validate_passed_slice(storage_key, slice_id)
+        # Ensure that the slice, storage set combination is valid
+        validate_passed_slice(self.storage.get_storage_set_key(), slice_id)
 
         self.broker_config = get_default_kafka_configuration(
             topic, slice_id, bootstrap_servers=kafka_params.bootstrap_servers

--- a/snuba/datasets/plans/sliced_storage.py
+++ b/snuba/datasets/plans/sliced_storage.py
@@ -18,7 +18,7 @@ from snuba.datasets.plans.single_storage import (
 )
 from snuba.datasets.plans.translator.query import QueryTranslator
 from snuba.datasets.slicing import (
-    is_storage_sliced,
+    is_storage_set_sliced,
     map_logical_partition_to_slice,
     map_org_id_to_logical_partition,
 )
@@ -112,7 +112,7 @@ class ColumnBasedStorageSliceSelector(StorageClusterSelector):
         Selects the cluster to use for a query if the storage set is sliced.
         If the storage set is not sliced, it returns the default cluster.
         """
-        if not is_storage_sliced(self.storage):
+        if not is_storage_set_sliced(self.storage_set):
             return get_cluster(self.storage_set)
 
         org_ids = get_object_ids_in_query_ast(query, self.partition_key_column_name)
@@ -124,7 +124,9 @@ class ColumnBasedStorageSliceSelector(StorageClusterSelector):
         if _should_use_mega_cluster(self.storage_set, logical_partition):
             return get_cluster(self.storage_set)
         else:
-            slice_id = map_logical_partition_to_slice(self.storage, logical_partition)
+            slice_id = map_logical_partition_to_slice(
+                self.storage_set, logical_partition
+            )
             cluster = get_cluster(self.storage_set, slice_id)
             return cluster
 

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -15,7 +15,7 @@ from snuba.datasets.plans.sliced_storage import (
     ColumnBasedStorageSliceSelector,
     SlicedStorageQueryPlanBuilder,
 )
-from snuba.datasets.slicing import is_storage_sliced
+from snuba.datasets.slicing import is_storage_set_sliced
 from snuba.datasets.storage import ReadableTableStorage, Storage, WritableTableStorage
 from snuba.pipeline.query_pipeline import QueryPipelineBuilder
 from snuba.query.data_source.join import JoinRelationship
@@ -69,7 +69,7 @@ class PluggableEntity(Entity):
     def get_query_pipeline_builder(self) -> QueryPipelineBuilder[ClickhouseQueryPlan]:
         from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 
-        if is_storage_sliced(self.readable_storage.get_storage_key()):
+        if is_storage_set_sliced(self.readable_storage.get_storage_set_key()):
             assert (
                 self.partition_key_column_name is not None
             ), "partition key column name must be defined for a sliced storage"

--- a/snuba/datasets/slicing.py
+++ b/snuba/datasets/slicing.py
@@ -5,7 +5,7 @@ for repartitioning with less code changes per physical change.
 """
 from typing import Optional
 
-from snuba.datasets.storages.storage_key import StorageKey
+from snuba.clusters.storage_sets import StorageSetKey
 
 SENTRY_LOGICAL_PARTITIONS = 256
 
@@ -18,39 +18,41 @@ def map_org_id_to_logical_partition(org_id: int) -> int:
     return org_id % SENTRY_LOGICAL_PARTITIONS
 
 
-def map_logical_partition_to_slice(storage: StorageKey, logical_partition: int) -> int:
+def map_logical_partition_to_slice(
+    storage_set: StorageSetKey, logical_partition: int
+) -> int:
     """
     Maps a logical partition to a slice.
     """
     from snuba.settings import LOGICAL_PARTITION_MAPPING
 
-    assert is_storage_sliced(
-        storage
-    ), f"cannot retrieve slice of non-sliced storage {storage}"
+    assert is_storage_set_sliced(
+        storage_set
+    ), f"cannot retrieve slice of non-sliced storage set {storage_set}"
     assert (
-        storage.value in LOGICAL_PARTITION_MAPPING
-    ), f"logical partition mapping missing for {storage}"
+        storage_set.value in LOGICAL_PARTITION_MAPPING
+    ), f"logical partition mapping missing for storage set {storage_set}"
 
-    return LOGICAL_PARTITION_MAPPING[storage.value][logical_partition]
+    return LOGICAL_PARTITION_MAPPING[storage_set.value][logical_partition]
 
 
-def is_storage_sliced(storage: StorageKey) -> bool:
+def is_storage_set_sliced(storage_set: StorageSetKey) -> bool:
     """
     Returns whether the storage set is sliced.
     """
-    from snuba.settings import SLICED_STORAGES
+    from snuba.settings import SLICED_STORAGE_SETS
 
-    return True if storage.value in SLICED_STORAGES.keys() else False
+    return True if storage_set.value in SLICED_STORAGE_SETS.keys() else False
 
 
-def validate_passed_slice(storage_key: StorageKey, slice_id: Optional[int]) -> None:
+def validate_passed_slice(storage_set: StorageSetKey, slice_id: Optional[int]) -> None:
     """
-    Verifies that the given storage can be sliced
+    Verifies that the given storage set can be sliced
     and that the slice_id passed in is within the range
-    of the total number of slices for the given storage
+    of the total number of slices for the given storage set
     """
-    from snuba.settings import SLICED_STORAGES
+    from snuba.settings import SLICED_STORAGE_SETS
 
     if slice_id is not None:
-        assert storage_key.value in SLICED_STORAGES
-        assert slice_id < SLICED_STORAGES[storage_key.value]
+        assert storage_set.value in SLICED_STORAGE_SETS
+        assert slice_id < SLICED_STORAGE_SETS[storage_set.value]

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -310,11 +310,11 @@ COUNTER_WINDOW_SIZE = timedelta(minutes=10)
 
 # Slicing Configuration
 
-# Mapping of storage key to slice count
-# This is only for sliced storages
-SLICED_STORAGES: Mapping[str, int] = {}
+# Mapping of storage set key to slice count
+# This is only for sliced storage sets
+SLICED_STORAGE_SETS: Mapping[str, int] = {}
 
-# Mapping storage key to a mapping of logical partition
+# Mapping storage set key to a mapping of logical partition
 # to slice id
 LOGICAL_PARTITION_MAPPING: Mapping[str, Mapping[int, int]] = {}
 

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -7,7 +7,7 @@ class InvalidTopicError(ValueError):
     pass
 
 
-slice_count_validation_msg = """physical slice for storage {0}'s logical partition {1} is {2},
+slice_count_validation_msg = """physical slice for storage set {0}'s logical partition {1} is {2},
             but only {3} physical slices are assigned to {0}"""
 
 
@@ -92,25 +92,25 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
 
 
 def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
-    for storage in locals["SLICED_STORAGES"]:
+    for storage_set in locals["SLICED_STORAGE_SETS"]:
         assert (
-            storage in locals["LOGICAL_PARTITION_MAPPING"]
-        ), "sliced mapping must be defined for sliced storage {storage}"
+            storage_set in locals["LOGICAL_PARTITION_MAPPING"]
+        ), "sliced mapping must be defined for sliced storage set {storage_set}"
 
-        storage_mapping = locals["LOGICAL_PARTITION_MAPPING"][storage]
-        defined_slice_count = locals["SLICED_STORAGES"][storage]
+        storage_set_mapping = locals["LOGICAL_PARTITION_MAPPING"][storage_set]
+        defined_slice_count = locals["SLICED_STORAGES"][storage_set]
 
         for logical_part in range(0, SENTRY_LOGICAL_PARTITIONS):
-            slice_id = storage_mapping.get(logical_part)
+            slice_id = storage_set_mapping.get(logical_part)
 
             assert (
                 slice_id is not None
-            ), f"missing physical slice for storage {storage}'s logical partition {logical_part}"
+            ), f"missing physical slice for storage set {storage_set}'s logical partition {logical_part}"
 
             assert (
                 slice_id >= 0 and slice_id < defined_slice_count
             ), slice_count_validation_msg.format(
-                storage, logical_part, slice_id, defined_slice_count
+                storage_set, logical_part, slice_id, defined_slice_count
             )
 
     for topic_tuple in locals["SLICED_KAFKA_TOPIC_MAP"]:

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -98,7 +98,7 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
         ), "sliced mapping must be defined for sliced storage set {storage_set}"
 
         storage_set_mapping = locals["LOGICAL_PARTITION_MAPPING"][storage_set]
-        defined_slice_count = locals["SLICED_STORAGES"][storage_set]
+        defined_slice_count = locals["SLICED_STORAGE_SETS"][storage_set]
 
         for logical_part in range(0, SENTRY_LOGICAL_PARTITIONS):
             slice_id = storage_set_mapping.get(logical_part)

--- a/tests/datasets/plans/test_sliced_storage.py
+++ b/tests/datasets/plans/test_sliced_storage.py
@@ -81,7 +81,7 @@ test_data = [
 ]
 
 
-@patch("snuba.settings.SLICED_STORAGES", {"generic_metrics_distributions": 2})
+@patch("snuba.settings.SLICED_STORAGE_SETS", {"generic_metrics_distributions": 2})
 @patch("snuba.settings.LOGICAL_PARTITION_MAPPING", MOCK_LOGICAL_PART_MAPPING)
 @patch("snuba.settings.SLICED_CLUSTERS", SLICED_CLUSTERS_CONFIG)
 @pytest.mark.parametrize("org_id, expected_slice_db, set_override", test_data)

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -65,8 +65,8 @@ def test_validation_catches_bad_partition_mapping() -> None:
     importlib.reload(validation)
     all_settings = build_settings_dict()
 
-    sliced_storages = all_settings["SLICED_STORAGES"]
-    sliced_storages["events"] = 2
+    sliced_storage_sets = all_settings["SLICED_STORAGE_SETS"]
+    sliced_storage_sets["events"] = 2
 
     part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
     part_mapping["events"] = {0: 2, 1: 0}
@@ -77,7 +77,7 @@ def test_validation_catches_bad_partition_mapping() -> None:
         validate_slicing_settings(all_settings)
 
     del part_mapping["events"]
-    del sliced_storages["events"]
+    del sliced_storage_sets["events"]
 
 
 @patch("snuba.datasets.slicing.SENTRY_LOGICAL_PARTITIONS", 2)
@@ -85,8 +85,8 @@ def test_validation_catches_unmapped_logical_parts() -> None:
     importlib.reload(validation)
     all_settings = build_settings_dict()
 
-    sliced_storages = all_settings["SLICED_STORAGES"]
-    sliced_storages["events"] = 2
+    sliced_storage_sets = all_settings["SLICED_STORAGE_SETS"]
+    sliced_storage_sets["events"] = 2
 
     part_mapping = all_settings["LOGICAL_PARTITION_MAPPING"]
     part_mapping["events"] = {0: 1, 1: 0}
@@ -96,7 +96,7 @@ def test_validation_catches_unmapped_logical_parts() -> None:
         validate_slicing_settings(all_settings)
 
     del part_mapping["events"]
-    del sliced_storages["events"]
+    del sliced_storage_sets["events"]
 
 
 @patch("snuba.datasets.slicing.SENTRY_LOGICAL_PARTITIONS", 2)
@@ -104,15 +104,15 @@ def test_validation_catches_empty_slice_mapping() -> None:
     importlib.reload(validation)
     all_settings = build_settings_dict()
 
-    sliced_storages = all_settings["SLICED_STORAGES"]
-    sliced_storages["events"] = 2
+    sliced_storage_sets = all_settings["SLICED_STORAGE_SETS"]
+    sliced_storage_sets["events"] = 2
 
     # We forgot to add logical:slice mapping for events
 
     with pytest.raises(AssertionError):
         validate_slicing_settings(all_settings)
 
-    del sliced_storages["events"]
+    del sliced_storage_sets["events"]
 
 
 def test_validation_catches_unmapped_topic_pair() -> None:


### PR DESCRIPTION
As per design, slicing occurs at the level of storage set. However, this wasn't reflected entirely in slicing-related code changes, in slicing config, and in further usages. This PR attempts to do small refactors and renamings to make it clear that slicing indeed occurs by storage sets, not storages. Docs are and will continue to update accordingly to reflect this.