### PR TITLE
feat(DAC): make replacer state a string in storage definition

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -497,7 +497,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
         required_columns: Sequence[str],
         tag_column_map: Mapping[str, Mapping[str, str]],
         promoted_tags: Mapping[str, Sequence[str]],
-        state_name: ReplacerState,
+        state_name: str,
     ) -> None:
         super().__init__(schema=schema)
         self.__required_columns = required_columns
@@ -507,7 +507,7 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
 
         self.__tag_column_map = tag_column_map
         self.__promoted_tags = promoted_tags
-        self.__state_name = state_name
+        self.__state_name = ReplacerState(state_name)
         self.__schema = schema
         self.__replacement_context = ReplacementContext(
             all_columns=self.__all_columns,

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -15,7 +15,6 @@ from snuba.datasets.storages.errors_common import (
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.datasets.table_storage import build_kafka_stream_loader_from_settings
 from snuba.query.processors.condition_checkers.checkers import ProjectIdEnforcer
-from snuba.replacers.replacer_processor import ReplacerState
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -51,6 +50,6 @@ storage = WritableTableStorage(
         required_columns=required_columns,
         tag_column_map={"tags": promoted_tag_columns, "contexts": {}},
         promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},
-        state_name=ReplacerState.ERRORS,
+        state_name="errors",
     ),
 )

--- a/snuba/datasets/storages/errors_common.py
+++ b/snuba/datasets/storages/errors_common.py
@@ -47,7 +47,6 @@ from snuba.query.processors.physical.uuid_array_column_processor import (
     UUIDArrayColumnProcessor,
 )
 from snuba.query.processors.physical.uuid_column_processor import UUIDColumnProcessor
-from snuba.replacers.replacer_processor import ReplacerState
 
 required_columns = [
     "event_id",
@@ -168,8 +167,7 @@ query_processors = [
     UniqInSelectAndHavingProcessor(),
     TupleUnaliaser(),
     PostReplacementConsistencyEnforcer(
-        project_column="project_id",
-        replacer_state_name=ReplacerState.ERRORS,
+        project_column="project_id", replacer_state_name="errors"
     ),
     MappingColumnPromoter(
         mapping_specs={

--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -34,14 +34,14 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
     have to remove those rows manually or to run the query in FINAL mode.
     """
 
-    def __init__(
-        self, project_column: str, replacer_state_name: Optional[ReplacerState]
-    ) -> None:
+    def __init__(self, project_column: str, replacer_state_name: Optional[str]) -> None:
         self.__project_column = project_column
         self.__groups_column = "group_id"
         # This is used to allow us to keep the replacement state in redis for multiple
         # replacers on multiple tables. replacer_state_name is part of the redis key.
-        self.__replacer_state_name = replacer_state_name
+        self.__replacer_state_name = (
+            ReplacerState(replacer_state_name) if replacer_state_name else None
+        )
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         if query_settings.get_turbo():


### PR DESCRIPTION
## Context

Replacer state is an argument in the errors configuration but we don't want it to be an enum since that's not configurable in yaml. Convert it to an enum inside the init function of the replacer and the PostReplacementConsistencyEnforcer

## Blast Radius

Only the errors dataset is affected, there are no other replacement states defined in the codebase. 