### PR TITLE
feat(DC): Outcomes Storages as a Config

### DIFF
--- a/snuba/datasets/configuration/outcomes/storages/hourly.yaml
+++ b/snuba/datasets/configuration/outcomes/storages/hourly.yaml
@@ -1,0 +1,30 @@
+version: v1
+kind: readable_storage
+name: outcomes_hourly
+storage:
+  key: outcomes_hourly
+  set_key: outcomes
+schema:
+  columns:
+    [
+      { name: org_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: key_id, type: UInt, args: { size: 64 } },
+      { name: timestamp, type: DateTime },
+      { name: outcome, type: UInt, args: { size: 8 } },
+      { name: reason, type: String },
+      { name: quantity, type: UInt, args: { size: 64 } },
+      { name: category, type: UInt, args: { size: 8 } },
+      { name: times_seen, type: UInt, args: { size: 64 } },
+    ]
+  local_table_name: outcomes_hourly_local
+  dist_table_name: outcomes_hourly_dist
+query_processors:
+  - processor: PrewhereProcessor
+    args:
+      prewhere_candidates:
+        - project_id
+        - org_id
+  - processor: TableRateLimit
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer

--- a/snuba/datasets/configuration/outcomes/storages/raw.yaml
+++ b/snuba/datasets/configuration/outcomes/storages/raw.yaml
@@ -1,0 +1,33 @@
+version: v1
+kind: writable_storage
+name: outcomes_raw
+storage:
+  key: outcomes_raw
+  set_key: outcomes
+schema:
+  columns:
+    [
+      { name: org_id, type: UInt, args: { size: 64 } },
+      { name: project_id, type: UInt, args: { size: 64 } },
+      {
+        name: key_id,
+        type: UInt,
+        args: { schema_modifiers: [nullable], size: 64 },
+      },
+      { name: timestamp, type: DateTime },
+      { name: outcome, type: UInt, args: { size: 8 } },
+      { name: reason, type: String, args: { schema_modifiers: [nullable] } },
+      { name: event_id, type: UUID, args: { schema_modifiers: [nullable] } },
+      { name: quantity, type: UInt, args: { size: 32 } },
+      { name: category, type: UInt, args: { size: 8 } },
+    ]
+  local_table_name: outcomes_raw_local
+  dist_table_name: outcomes_raw_dist
+query_processors:
+  - processor: TableRateLimit
+mandatory_condition_checkers:
+  - condition: OrgIdEnforcer
+stream_loader:
+  processor:
+    name: OutcomesProcessor
+  default_topic: outcomes

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -43,6 +43,8 @@ from snuba.datasets.storages.metrics import (
 from snuba.datasets.storages.metrics import org_counters_storage
 from snuba.datasets.storages.metrics import polymorphic_bucket as metrics_raw
 from snuba.datasets.storages.metrics import sets_storage as metrics_sets
+from snuba.datasets.storages.outcomes import materialized_storage as outcomes_hourly
+from snuba.datasets.storages.outcomes import raw_storage as outcomes_raw
 from snuba.datasets.storages.profiles import writable_storage as profiles
 from snuba.datasets.storages.querylog import storage as querylog
 from snuba.datasets.storages.replays import storage as replays
@@ -134,6 +136,8 @@ class TestStorageConfiguration(ConfigurationTest):
         metrics_distributions_storage,
         metrics_raw,
         org_counters_storage,
+        outcomes_hourly,
+        outcomes_raw,
         transactions,
         profiles,
         replays,

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -149,7 +149,6 @@ class TestStorageConfiguration(ConfigurationTest):
             storage.get_storage_key() in CONFIG_BUILT_STORAGES
             for storage in self.python_storages
         )
-        assert len(CONFIG_BUILT_STORAGES) == len(self.python_storages)
 
     def test_compare_storages(self) -> None:
         for storage in self.python_storages:


### PR DESCRIPTION
### Overview
- Adding Outcomes storages as a config
- Storage config were generated and tested using scripts from #3336 

### Changes
- Any call to `get_storage()` with an outcomes storage key will return the storage built from config instead of the hardcoded version


### Testing Notes
- How config was generated (eg outcomes_raw):
    - `python3 scripts/pystorage_2_yaml.py outcomes_raw raw.yaml`
    - Removed quotes around `columns` in schema, format yaml file with Prettier
- How config was tested:
    - `python3 scripts/check_yaml_against_code.py outcomes_raw raw.yaml`
    - Updated `tests/datasets/configuration/test_storage_loader.py`
