### PR TITLE
feat(DC): CDC Processors Registered

### DIFF
--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, List, Mapping, Optional, Sequence, Type
+from typing import Any, List, Mapping, Optional, Sequence, Type, cast
 
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.processor import InsertBatch, MessageProcessor, ProcessedMessage
+from snuba.utils.registered_class import RegisteredClass
 from snuba.writer import WriterTableRow
 
 POSTGRES_DATE_FORMAT_WITH_NS = "%Y-%m-%d %H:%M:%S.%f%z"
@@ -70,10 +71,22 @@ class CdcMessageRow(ABC):
         raise NotImplementedError
 
 
-class CdcProcessor(MessageProcessor):
+class CdcProcessor(MessageProcessor, metaclass=RegisteredClass):
     def __init__(self, pg_table: str, message_row_class: Type[CdcMessageRow]):
         self.pg_table = pg_table
         self._message_row_class = message_row_class
+
+    @classmethod
+    def get_from_name(cls, name: str) -> Type["CdcProcessor"]:
+        return cast(Type["CdcProcessor"], cls.class_from_name(name))
+
+    @classmethod
+    def from_kwargs(cls, **kwargs: str) -> CdcProcessor:
+        return cls(**kwargs)  # type: ignore
+
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
 
     def _process_begin(self, offset: int) -> Sequence[WriterTableRow]:
         return []


### PR DESCRIPTION
### Overview
- CDC Message Processors do not inherit `DatasetMessageProcessor`
- They do inherit from another type `CdcProcessor`
- This class needs to be registered in order for CDC configs to be parsed correctly and have the message processor picked up