### PR TITLE
Increase optimize redis TTL 

### DIFF
--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -100,8 +100,8 @@ def optimize(
     # add 1 hour to make the redis TTL past the optimize job cuttoff time
     cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
     redis_expire_time = cutoff_time + timedelta(hours=1)
-    logger.info("Cutoff time: %s" % str(cutoff_time))
-    logger.info("redis_expire_time time: %s" % str(redis_expire_time))
+    logger.info(f"Cutoff time: {str(cutoff_time)}")
+    logger.info(f"redis_expire_time time: {str(redis_expire_time)}")
 
     schema = storage.get_schema()
     assert isinstance(schema, TableSchema)

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -96,7 +96,9 @@ def optimize(
     last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
         hour=0, minute=0, second=0, microsecond=0
     )
-    cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
+
+    # add 1 hour to make the reddit TTL past the optimize job cuttoff time
+    cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(hours=1)
     logger.info("Cutoff time: %s", str(cutoff_time))
 
     schema = storage.get_schema()

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -98,8 +98,10 @@ def optimize(
     )
 
     # add 1 hour to make the redis TTL past the optimize job cuttoff time
-    cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(hours=1)
-    logger.info("Cutoff time: %s", str(cutoff_time))
+    cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
+    redis_expire_time = cutoff_time + timedelta(hours=1)
+    logger.info("Cutoff time: %s" % str(cutoff_time))
+    logger.info("redis_expire_time time: %s" % str(redis_expire_time))
 
     schema = storage.get_schema()
     assert isinstance(schema, TableSchema)
@@ -110,7 +112,7 @@ def optimize(
         port=clickhouse_port,
         database=database,
         table=table,
-        expire_time=cutoff_time,
+        expire_time=redis_expire_time,
     )
 
     num_dropped = run_optimize_cron_job(

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -97,7 +97,7 @@ def optimize(
         hour=0, minute=0, second=0, microsecond=0
     )
 
-    # add 1 hour to make the reddit TTL past the optimize job cuttoff time
+    # add 1 hour to make the redis TTL past the optimize job cuttoff time
     cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(hours=1)
     logger.info("Cutoff time: %s", str(cutoff_time))
 


### PR DESCRIPTION

Increase optimize reddis TTL  by 1 hr passed job cuttoff time to avoid keys expiring same time as cuttoff.