### PR TITLE
Publish Docker images on DockerHub via Github Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,4 +375,4 @@ jobs:
           project_name: snuba
           local_image: ghcr.io/getsentry/snuba-ci:${{ github.sha }}
           docker_repo: ghcr.io/getsentry/snuba
-          # TODO: add docker tag to build for
+          docker_password: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
This PR simply adds the docker login information (to be stored in a secret) so that the e2e test action can push to DockerHub. For now the action pushes to a different tag, as not to conflict with Google Cloud Build pushing to the same repo at the same time. This will be changed once we are confident this action is stable and we can remove Google Cloud Build outright.