### PR TITLE
Add test migration

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -20,6 +20,7 @@ class MigrationGroup(Enum):
     FUNCTIONS = "functions"
     REPLAYS = "replays"
     GENERIC_METRICS = "generic_metrics"
+    TEST_MIGRATION = "test_migration"
 
 
 # Migration groups are mandatory by default. Specific groups can
@@ -32,6 +33,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.FUNCTIONS,
     MigrationGroup.REPLAYS,
     MigrationGroup.GENERIC_METRICS,
+    MigrationGroup.TEST_MIGRATION,
 }
 
 
@@ -251,6 +253,14 @@ class QuerylogLoader(DirectoryLoader):
         ]
 
 
+class TestMigrationLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.snuba_migrations.test_migration")
+
+    def get_migrations(self) -> Sequence[str]:
+        return ["0001_create_test_table", "0002_add_test_col"]
+
+
 class ProfilesLoader(DirectoryLoader):
     def __init__(self) -> None:
         super().__init__("snuba.snuba_migrations.profiles")
@@ -303,6 +313,7 @@ _REGISTERED_GROUPS = {
     MigrationGroup.FUNCTIONS: FunctionsLoader(),
     MigrationGroup.REPLAYS: ReplaysLoader(),
     MigrationGroup.GENERIC_METRICS: GenericMetricsLoader(),
+    MigrationGroup.TEST_MIGRATION: TestMigrationLoader(),
 }
 
 

--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -179,6 +179,8 @@ class ClickhouseNodeMigration(Migration, ABC):
                 print(f"Local op: {op.format_sql()}")
             elif op.target == OperationTarget.DISTRIBUTED:
                 print_dist_op(op)
+            else:
+                print("Skipped operation - no target specified")
 
 
 class ClickhouseNodeMigrationLegacy(ClickhouseNodeMigration, ABC):

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -41,6 +41,7 @@ ADMIN_ALLOWED_MIGRATION_GROUPS = {
     "profiles": "NonBlockingMigrationsPolicy",
     "functions": "NonBlockingMigrationsPolicy",
     "replays": "NonBlockingMigrationsPolicy",
+    "test_migration": "AllMigrationsPolicy",
 }
 
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -232,7 +232,12 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 
 # The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
 # Migrations for skipped groups will not be run.
-SKIPPED_MIGRATION_GROUPS: Set[str] = {"querylog", "profiles", "functions"}
+SKIPPED_MIGRATION_GROUPS: Set[str] = {
+    "querylog",
+    "profiles",
+    "functions",
+    "test_migration",
+}
 
 MAX_RESOLUTION_FOR_JITTER = 60
 

--- a/snuba/snuba_migrations/test_migration/0001_create_test_table.py
+++ b/snuba/snuba_migrations/test_migration/0001_create_test_table.py
@@ -1,0 +1,57 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+columns: Sequence[Column[Modifiers]] = [Column("test_col", UInt(8))]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    This is a test migration. It creates a test tables.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_local",
+                target=operations.OperationTarget.LOCAL,
+                columns=columns,
+                engine=table_engines.MergeTree(
+                    storage_set=StorageSetKey.QUERYLOG,
+                    order_by="test_col",
+                    partition_by="test_col",
+                    sample_by="test_col",
+                ),
+            ),
+            operations.CreateTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="querylog_local",
+                    sharding_key=None,
+                ),
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_local",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]

--- a/snuba/snuba_migrations/test_migration/0001_create_test_table.py
+++ b/snuba/snuba_migrations/test_migration/0001_create_test_table.py
@@ -46,12 +46,12 @@ class Migration(migration.ClickhouseNodeMigration):
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.QUERYLOG,
-                table_name="test_migration_local",
-                target=operations.OperationTarget.LOCAL,
+                table_name="test_migration_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
             ),
             operations.DropTable(
                 storage_set=StorageSetKey.QUERYLOG,
-                table_name="test_migration_dist",
-                target=operations.OperationTarget.DISTRIBUTED,
+                table_name="test_migration_local",
+                target=operations.OperationTarget.LOCAL,
             ),
         ]

--- a/snuba/snuba_migrations/test_migration/0002_add_test_col.py
+++ b/snuba/snuba_migrations/test_migration/0002_add_test_col.py
@@ -36,14 +36,14 @@ class Migration(migration.ClickhouseNodeMigration):
         return [
             operations.DropColumn(
                 storage_set=StorageSetKey.QUERYLOG,
-                table_name="test_migration_local",
-                target=operations.OperationTarget.LOCAL,
+                table_name="test_migration_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
                 column_name="test_col_1",
             ),
             operations.DropColumn(
                 storage_set=StorageSetKey.QUERYLOG,
-                table_name="test_migration_dist",
-                target=operations.OperationTarget.DISTRIBUTED,
+                table_name="test_migration_local",
+                target=operations.OperationTarget.LOCAL,
                 column_name="test_col_1",
             ),
         ]

--- a/snuba/snuba_migrations/test_migration/0002_add_test_col.py
+++ b/snuba/snuba_migrations/test_migration/0002_add_test_col.py
@@ -1,0 +1,49 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+columns: Sequence[Column[Modifiers]] = [Column("test_col", UInt(8))]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    This is a test migration. It add a column to the test tables.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_local",
+                target=operations.OperationTarget.LOCAL,
+                column=Column("test_col_1", UInt(8)),
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+                column=Column("test_col_1", UInt(8)),
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_local",
+                target=operations.OperationTarget.LOCAL,
+                column_name="test_col_1",
+            ),
+            operations.DropColumn(
+                storage_set=StorageSetKey.QUERYLOG,
+                table_name="test_migration_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+                column_name="test_col_1",
+            ),
+        ]

--- a/tests/cli/optimize.py
+++ b/tests/cli/optimize.py
@@ -1,0 +1,8 @@
+from click.testing import CliRunner
+
+from snuba.cli.optimize import optimize
+
+
+def test_optimize_cli() -> None:
+    runner = CliRunner()
+    runner.invoke(optimize, ["--parallel", "2", "--storage", "errors"])

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -34,7 +34,7 @@ for group in MigrationGroup:
     group_loader = get_group_loader(group)
     for migration_id in group_loader.get_migrations():
         snuba_migration = group_loader.load_migration(migration_id)
-        if isinstance(snuba_migration, migration.ClickhouseNodeMigrationLegacy):
+        if isinstance(snuba_migration, migration.ClickhouseNodeMigration):
             all_migrations.append((migration_id, snuba_migration))
 
 
@@ -46,7 +46,7 @@ for group in MigrationGroup:
     ],
 )
 def test_validate_all_migrations(
-    snuba_migration: migration.ClickhouseNodeMigrationLegacy,
+    snuba_migration: migration.ClickhouseNodeMigration,
 ) -> None:
     """
     Runs the migration validator on all existing migrations.


### PR DESCRIPTION
Add a simple test migration. This migration creates an empty table in the querylog storage set and adds a column to it. We can use this to test migrations tool on a real cluster.