### PR TITLE
test(slicing): Add more validation for slicing

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -185,6 +185,8 @@ BROKER_CONFIG: Mapping[str, Any] = {
 KAFKA_TOPIC_MAP: Mapping[str, str] = {}
 
 # Mapping of default Kafka topic name to broker config
+# Sliced Kafka topics and their corresponding broker configs
+# should be configured in SLICED_KAFKA_BROKER_CONFIG instead
 KAFKA_BROKER_CONFIG: Mapping[str, Mapping[str, Any]] = {}
 
 DEFAULT_MAX_BATCH_SIZE = 50000

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -118,12 +118,13 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
             topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
         ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
 
-    _STORAGE_SET_CLUSTER_MAP: Dict[str, Mapping[str, Any]] = {}
+    _STORAGE_SET_CLUSTER_MAP = {
+        storage_set: cluster
+        for cluster in locals["CLUSTERS"]
+        for storage_set in cluster["storage_sets"]
+    }
 
     _SLICED_STORAGE_SET_CLUSTER_MAP: Dict[Tuple[str, int], Mapping[str, Any]] = {}
-    for cluster in locals["CLUSTERS"]:
-        for storage_set in cluster["storage_sets"]:
-            _STORAGE_SET_CLUSTER_MAP[storage_set] = cluster
 
     for sliced_cluster in locals["SLICED_CLUSTERS"]:
         for storage_set_tuple in sliced_cluster["storage_set_slices"]:

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -119,16 +119,16 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
             sliced_logical_topic not in locals["KAFKA_BROKER_CONFIG"]
         ), f"logical topic {sliced_logical_topic} is sliced. It is defined in SLICED_KAFKA_TOPIC_MAP and should only be in SLICED_KAFKA_BROKER_CONFIG, not KAFKA_BROKER_CONFIG"
 
+        assert (
+            topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
+        ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
+
     for topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]:
         logical_topic = topic_tuple[0]
 
         assert (
             logical_topic not in locals["KAFKA_TOPIC_MAP"]
         ), f"logical topic {logical_topic} is not sliced. It is defined in KAFKA_TOPIC_MAP and should only be in KAFKA_BROKER_CONFIG, not SLICED_KAFKA_BROKER_CONFIG"
-
-        assert (
-            topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
-        ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
 
     _STORAGE_SET_CLUSTER_MAP: Dict[str, Mapping[str, Any]] = {}
 

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -114,21 +114,9 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
             )
 
     for topic_tuple in locals["SLICED_KAFKA_TOPIC_MAP"]:
-        sliced_logical_topic = topic_tuple[0]
-        assert (
-            sliced_logical_topic not in locals["KAFKA_BROKER_CONFIG"]
-        ), f"logical topic {sliced_logical_topic} is sliced. It is defined in SLICED_KAFKA_TOPIC_MAP and should only be in SLICED_KAFKA_BROKER_CONFIG, not KAFKA_BROKER_CONFIG"
-
         assert (
             topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
         ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
-
-    for topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]:
-        logical_topic = topic_tuple[0]
-
-        assert (
-            logical_topic not in locals["KAFKA_TOPIC_MAP"]
-        ), f"logical topic {logical_topic} is not sliced. It is defined in KAFKA_TOPIC_MAP and should only be in KAFKA_BROKER_CONFIG, not SLICED_KAFKA_BROKER_CONFIG"
 
     _STORAGE_SET_CLUSTER_MAP: Dict[str, Mapping[str, Any]] = {}
 

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -159,7 +159,11 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
 
     for storage_set_key in all_storage_set_keys:
         single_node_vals: Set[bool] = set()
-        single_node_vals.add(_STORAGE_SET_CLUSTER_MAP[storage_set_key]["single_node"])
+
+        if storage_set_key in _STORAGE_SET_CLUSTER_MAP:
+            single_node_vals.add(
+                _STORAGE_SET_CLUSTER_MAP[storage_set_key]["single_node"]
+            )
 
         for storage_set_tuple in _SLICED_STORAGE_SET_CLUSTER_MAP.keys():
             if storage_set_key in storage_set_tuple:

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -114,10 +114,6 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
             )
 
     for topic_tuple in locals["SLICED_KAFKA_TOPIC_MAP"]:
-        assert (
-            topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
-        ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
-
         sliced_logical_topic = topic_tuple[0]
         assert (
             sliced_logical_topic not in locals["KAFKA_BROKER_CONFIG"]
@@ -129,6 +125,10 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
         assert (
             logical_topic not in locals["KAFKA_TOPIC_MAP"]
         ), f"logical topic {logical_topic} is not sliced. It is defined in KAFKA_TOPIC_MAP and should only be in KAFKA_BROKER_CONFIG, not SLICED_KAFKA_BROKER_CONFIG"
+
+        assert (
+            topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
+        ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
 
     _STORAGE_SET_CLUSTER_MAP: Dict[str, Mapping[str, Any]] = {}
 

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -117,3 +117,15 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
         assert (
             topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]
         ), f"missing broker config definition for sliced Kafka topic {topic_tuple[0]} on slice {topic_tuple[1]}"
+
+        sliced_logical_topic = topic_tuple[0]
+        assert (
+            sliced_logical_topic not in locals["KAFKA_BROKER_CONFIG"]
+        ), f"logical topic {sliced_logical_topic} is sliced. It is defined in SLICED_KAFKA_TOPIC_MAP and should only be in SLICED_KAFKA_BROKER_CONFIG, not KAFKA_BROKER_CONFIG"
+
+    for topic_tuple in locals["SLICED_KAFKA_BROKER_CONFIG"]:
+        logical_topic = topic_tuple[0]
+
+        assert (
+            logical_topic not in locals["KAFKA_TOPIC_MAP"]
+        ), f"logical topic {logical_topic} is not sliced. It is defined in KAFKA_TOPIC_MAP and should only be in KAFKA_BROKER_CONFIG, not SLICED_KAFKA_BROKER_CONFIG"

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -138,8 +138,8 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
     for storage_set in locals["SLICED_STORAGE_SETS"]:
         num_slices = locals["SLICED_STORAGE_SETS"][storage_set]
 
-        for i in range(num_slices):
+        for slice_id in range(num_slices):
             assert (
                 storage_set,
-                i,
-            ) in sliced_storage_sets, f"storage set, slice id pair ({storage_set}, {i}) is not assigned any cluster in SLICED_CLUSTERS in settings"
+                slice_id,
+            ) in sliced_storage_sets, f"storage set, slice id pair ({storage_set}, {slice_id}) is not assigned any cluster in SLICED_CLUSTERS in settings"

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Mapping, MutableMapping, Set, Tuple
+from typing import Any, Mapping, MutableMapping, Set, Tuple
 
 from snuba.datasets.slicing import SENTRY_LOGICAL_PARTITIONS
 
@@ -124,7 +124,12 @@ def validate_slicing_settings(locals: Mapping[str, Any]) -> None:
         for storage_set in cluster["storage_sets"]
     }
 
-    _SLICED_STORAGE_SET_CLUSTER_MAP: Dict[Tuple[str, int], Mapping[str, Any]] = {}
+    StorageSet_SliceID_Tuple = Tuple[str, int]
+    Cluster_Mapping = Mapping[str, Any]
+
+    _SLICED_STORAGE_SET_CLUSTER_MAP: MutableMapping[
+        StorageSet_SliceID_Tuple, Cluster_Mapping
+    ] = {}
 
     for sliced_cluster in locals["SLICED_CLUSTERS"]:
         for storage_set_tuple in sliced_cluster["storage_set_slices"]:

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -130,42 +130,6 @@ def test_validation_catches_unmapped_topic_pair() -> None:
     del sliced_topics[("events", 1)]
 
 
-def test_sliced_kafka_broker_config() -> None:
-    importlib.reload(validation)
-    all_settings = build_settings_dict()
-
-    sliced_topic_map = all_settings["SLICED_KAFKA_TOPIC_MAP"]
-    sliced_topic_map[("events", 0)] = "events-0"
-    sliced_topic_map[("events", 1)] = "events-1"
-
-    default_broker_config = all_settings["BROKER_CONFIG"]
-    kafka_broker_config = all_settings["KAFKA_BROKER_CONFIG"]
-
-    # Mistakenly add a sliced topic to regular Kafka broker config
-    kafka_broker_config["events"] = default_broker_config
-
-    with pytest.raises(AssertionError):
-        validate_slicing_settings(all_settings)
-
-    del sliced_topic_map[("events", 0)]
-    del sliced_topic_map[("events", 1)]
-    del kafka_broker_config["events"]
-
-    topic_map = all_settings["KAFKA_TOPIC_MAP"]
-    topic_map["events"] = "events-custom"
-
-    sliced_kafka_broker_config = all_settings["SLICED_KAFKA_BROKER_CONFIG"]
-
-    # Mistakenly add an unsliced topic to sliced Kafka broker config
-    sliced_kafka_broker_config[("events", 0)] = default_broker_config
-
-    with pytest.raises(AssertionError):
-        validate_slicing_settings(all_settings)
-
-    del topic_map[("events")]
-    del sliced_kafka_broker_config[("events", 0)]
-
-
 CLUSTERS_CONFIG = [
     {
         "host": "host",

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -233,6 +233,7 @@ def test_sliced_clusters() -> None:
         validate_slicing_settings(all_settings)
 
     del sliced_storage_sets["generic_metrics_distributions"]
+    del all_settings["LOGICAL_PARTITION_MAPPING"]["generic_metrics_distributions"]
 
 
 @patch("snuba.settings.SLICED_CLUSTERS", SLICED_CLUSTERS_CONFIG)
@@ -265,3 +266,4 @@ def test_single_node_vals() -> None:
         validate_slicing_settings(all_settings)
 
     del sliced_storage_sets["generic_metrics_distributions"]
+    del all_settings["LOGICAL_PARTITION_MAPPING"]["generic_metrics_distributions"]

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -127,3 +127,46 @@ def test_validation_catches_unmapped_topic_pair() -> None:
         validate_slicing_settings(all_settings)
 
     del sliced_topics[("events", 1)]
+
+
+def test_sliced_kafka_broker_config() -> None:
+    importlib.reload(validation)
+    all_settings = build_settings_dict()
+
+    sliced_topic_map = all_settings["SLICED_KAFKA_TOPIC_MAP"]
+    sliced_topic_map[("events", 0)] = "events-0"
+    sliced_topic_map[("events", 1)] = "events-1"
+
+    default_broker_config = all_settings["BROKER_CONFIG"]
+    kafka_broker_config = all_settings["KAFKA_BROKER_CONFIG"]
+
+    # Mistakenly add a sliced topic to regular Kafka broker config
+    kafka_broker_config["events"] = default_broker_config
+
+    with pytest.raises(AssertionError):
+        validate_slicing_settings(all_settings)
+
+    del sliced_topic_map[("events", 0)]
+    del sliced_topic_map[("events", 1)]
+    del kafka_broker_config["events"]
+
+    topic_map = all_settings["KAFKA_TOPIC_MAP"]
+    topic_map["events"] = "events-custom"
+
+    sliced_kafka_broker_config = all_settings["SLICED_KAFKA_BROKER_CONFIG"]
+
+    # Mistakenly add an unsliced topic to sliced Kafka broker config
+    sliced_kafka_broker_config[("events", 0)] = default_broker_config
+
+    with pytest.raises(AssertionError):
+        validate_slicing_settings(all_settings)
+
+    del topic_map[("events")]
+    del sliced_kafka_broker_config[("events", 0)]
+
+    print(all_settings["SLICED_KAFKA_TOPIC_MAP"])
+    print(all_settings["KAFKA_TOPIC_MAP"])
+
+    print(all_settings["BROKER_CONFIG"])
+    print(all_settings["KAFKA_BROKER_CONFIG"])
+    print(all_settings["SLICED_KAFKA_BROKER_CONFIG"])


### PR DESCRIPTION
This PR:

- Adds validation for a few other cases with sliced/regular Kafka broker configs and sliced Clusters settings
- Also adds the corresponding tests to catch any bad configuration in settings
