### PR TITLE
ref(DC): move discover mappers with all the other mappers

### DIFF
--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -1,7 +1,10 @@
-from typing import Type, TypeVar, Union, cast
+from dataclasses import dataclass
+from typing import Optional, Set, Type, TypeVar, Union, cast
 
+from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.translators.snuba import SnubaClickhouseStrictTranslator
 from snuba.datasets.plans.translator.mapper import ExpressionMapper
+from snuba.query.dsl import identity
 from snuba.query.expressions import (
     Argument,
     Column,
@@ -11,6 +14,12 @@ from snuba.query.expressions import (
     Literal,
     SubscriptableReference,
 )
+from snuba.query.matchers import Any
+from snuba.query.matchers import FunctionCall as FunctionCallMatch
+from snuba.query.matchers import Literal as LiteralMatch
+from snuba.query.matchers import Or
+from snuba.query.matchers import String as StringMatch
+from snuba.util import qualified_column
 from snuba.utils.registered_class import RegisteredClass
 
 TExpIn = TypeVar("TExpIn")
@@ -128,3 +137,140 @@ class LambdaMapper(SnubaClickhouseMapper[Lambda, Lambda]):
 
 class ArgumentMapper(SnubaClickhouseMapper[Argument, Argument]):
     pass
+
+
+@dataclass(frozen=True)
+class DefaultNoneColumnMapper(ColumnMapper):
+    """
+    This maps a list of column names to None (NULL in SQL) as it is done
+    in the discover column_expr method today. It should not be used for
+    any other reason or use case, thus it should not be moved out of
+    the discover dataset file.
+    """
+
+    columns: ColumnSet
+
+    def attempt_map(
+        self,
+        expression: Column,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Optional[FunctionCall]:
+        if expression.column_name in self.columns:
+            return identity(
+                Literal(None, None),
+                expression.alias
+                or qualified_column(
+                    expression.column_name, expression.table_name or ""
+                ),
+            )
+        else:
+            return None
+
+
+@dataclass
+class DefaultNoneFunctionMapper(FunctionCallMapper):
+    """
+    Maps the list of function names to NULL.
+    """
+
+    function_names: Set[str]
+
+    def __post_init__(self) -> None:
+        self.function_match = FunctionCallMatch(
+            Or([StringMatch(func) for func in self.function_names])
+        )
+
+    def attempt_map(
+        self,
+        expression: FunctionCall,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Optional[FunctionCall]:
+        if self.function_match.match(expression):
+            return identity(Literal(None, None), expression.alias)
+
+        return None
+
+
+@dataclass(frozen=True)
+class DefaultIfNullFunctionMapper(FunctionCallMapper):
+    """
+    If a function is being called on a column that doesn't exist, or is being
+    called on NULL, change the entire function to be NULL.
+    """
+
+    function_match = FunctionCallMatch(
+        StringMatch("identity"), (LiteralMatch(value=Any(type(None))),)
+    )
+
+    def attempt_map(
+        self,
+        expression: FunctionCall,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Optional[FunctionCall]:
+
+        # HACK: Quick fix to avoid this function dropping important conditions from the query
+        logical_functions = {"and", "or", "xor"}
+
+        if expression.function_name in logical_functions:
+            return None
+
+        parameters = tuple(p.accept(children_translator) for p in expression.parameters)
+        for param in parameters:
+            # All impossible columns will have been converted to the identity function.
+            # So we know that if a function has the identity function as a parameter, we can
+            # collapse the entire expression.
+            fmatch = self.function_match.match(param)
+            if fmatch is not None:
+                return identity(Literal(None, None), expression.alias)
+
+        return None
+
+
+@dataclass(frozen=True)
+class DefaultIfNullCurriedFunctionMapper(CurriedFunctionCallMapper):
+    """
+    If a curried function is being called on a column that doesn't exist, or is being
+    called on NULL, change the entire function to be NULL.
+    """
+
+    function_match = FunctionCallMatch(StringMatch("identity"), (LiteralMatch(),))
+
+    def attempt_map(
+        self,
+        expression: CurriedFunctionCall,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Optional[Union[CurriedFunctionCall, FunctionCall]]:
+        internal_function = expression.internal_function.accept(children_translator)
+        assert isinstance(internal_function, FunctionCall)  # mypy
+        parameters = tuple(p.accept(children_translator) for p in expression.parameters)
+        for param in parameters:
+            # All impossible columns that have been converted to NULL will be the identity function.
+            # So we know that if a function has the identity function as a parameter, we can
+            # collapse the entire expression.
+            fmatch = self.function_match.match(param)
+            if fmatch is not None:
+                return identity(Literal(None, None), expression.alias)
+
+        return None
+
+
+@dataclass(frozen=True)
+class DefaultNoneSubscriptMapper(SubscriptableReferenceMapper):
+    """
+    This maps a subscriptable reference to None (NULL in SQL) as it is done
+    in the discover column_expr method today. It should not be used for
+    any other reason or use case, thus it should not be moved out of
+    the discover dataset file.
+    """
+
+    subscript_names: Set[str]
+
+    def attempt_map(
+        self,
+        expression: SubscriptableReference,
+        children_translator: SnubaClickhouseStrictTranslator,
+    ) -> Optional[FunctionCall]:
+        if expression.column.column_name in self.subscript_names:
+            return identity(Literal(None, None), expression.alias)
+        else:
+            return None


### PR DESCRIPTION
Discover defines translation mappers in its entity file. this makes it impossible to convert it to config. The mappers have to be with all the other ones so they can be references in config

## Blast radius

The discover dataset model definition. No other entities use these classes