### PR TITLE
ref(admin): minor migrations audit log fixes

### DIFF
--- a/snuba/admin/notifications/slack/client.py
+++ b/snuba/admin/notifications/slack/client.py
@@ -37,6 +37,7 @@ class SlackClient(object):
             )
         except Exception as exc:
             logger.error(exc, exc_info=True)
+            return
 
             # Slack error handling
             # Copied from https://github.com/getsentry/sentry/blob/601f829c9246ae73c8169510140fd7f47fc6dfc3/src/sentry/integrations/slack/client.py#L36-L53

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -45,9 +45,9 @@ def build_runtime_config_text(data: Any, action: AuditLogAction) -> Optional[str
 
 
 def build_migration_run_text(data: Any, action: AuditLogAction) -> Optional[str]:
-    if action == AuditLogAction.RAN_MIGRATION:
+    if action == AuditLogAction.RAN_MIGRATION_COMPLETED:
         action_text = f":athletic_shoe: ran migration `{data['migration']}`"
-    elif action == AuditLogAction.REVERSED_MIGRATION:
+    elif action == AuditLogAction.REVERSED_MIGRATION_COMPLETED:
         action_text = f":back: reversed migration `{data['migration']}`"
     else:
         return None

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -45,10 +45,10 @@ def build_runtime_config_text(data: Any, action: AuditLogAction) -> Optional[str
 
 
 def build_migration_run_text(data: Any, action: AuditLogAction) -> Optional[str]:
-    if action == AuditLogAction.RAN_MIGRATION_STARTED:
-        action_text = f":runner: ran migration {data['migration']}"
-    elif action == AuditLogAction.REVERSED_MIGRATION_STARTED:
-        action_text = f":uno-reverse: reversed migration {data['migration']}"
+    if action == AuditLogAction.RAN_MIGRATION:
+        action_text = f":athletic_shoe: ran migration `{data['migration']}`"
+    elif action == AuditLogAction.REVERSED_MIGRATION:
+        action_text = f":back: reversed migration `{data['migration']}`"
     else:
         return None
     return f":warning: *Migration:* \n\n{action_text} (force={data['force']}, fake={data['fake']})"

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -65,6 +65,11 @@ def set_logging_context() -> None:
     bind_contextvars(endpoint=request.endpoint, user_ip=request.remote_addr)
 
 
+@application.teardown_request
+def clear_logging_context(exception: Optional[BaseException]) -> None:
+    clear_contextvars()
+
+
 @application.before_request
 def authorize() -> None:
     logger.debug("authorize.entered")

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -65,11 +65,6 @@ def set_logging_context() -> None:
     bind_contextvars(endpoint=request.endpoint, user_ip=request.remote_addr)
 
 
-@application.teardown_request
-def clear_logging_context(exception: Optional[BaseException]) -> None:
-    clear_contextvars()
-
-
 @application.before_request
 def authorize() -> None:
     logger.debug("authorize.entered")


### PR DESCRIPTION
Found some minor things while I was testing this out for a demo:

* we should be returning early if we get an exception from Slack, otherwise we hit a `KeyError`
* ~we should be run/reversing migrations before we do the audit log, because otherwise we will create an audit log record even if we failed (and the audit log doesn't show that something failed)~ addressing in https://github.com/getsentry/snuba/pull/3493
* personal preference but I just updated the emojis to be 👟 and 🔙 , the :uno-reverse: is a custom slack emoji so just wanted something more generic and I got annoyed that the running person 🏃 looked like they were running backwards and not forwards lol