### PR TITLE
ref(admin): split started/completed audit migrations

### DIFF
--- a/snuba/admin/audit_log/action.py
+++ b/snuba/admin/audit_log/action.py
@@ -7,8 +7,10 @@ class AuditLogAction(Enum):
     REMOVED_OPTION = "removed.option"
     UPDATED_OPTION = "updated.option"
     RAN_QUERY = "ran.query"
-    RAN_MIGRATION = "ran.migration"
-    REVERSED_MIGRATION = "reversed.migration"
+    RAN_MIGRATION_STARTED = "ran.migration.started"
+    REVERSED_MIGRATION_STARTED = "reversed.migration.started"
+    RAN_MIGRATION_COMPLETED = "ran.migration.completed"
+    REVERSED_MIGRATION_COMPLETED = "reversed.migration.completed"
 
 
 RUNTIME_CONFIG_ACTIONS = [
@@ -18,6 +20,8 @@ RUNTIME_CONFIG_ACTIONS = [
 ]
 
 MIGRATION_ACTIONS = [
-    AuditLogAction.RAN_MIGRATION,
-    AuditLogAction.REVERSED_MIGRATION,
+    AuditLogAction.RAN_MIGRATION_STARTED,
+    AuditLogAction.REVERSED_MIGRATION_STARTED,
+    AuditLogAction.RAN_MIGRATION_COMPLETED,
+    AuditLogAction.REVERSED_MIGRATION_COMPLETED,
 ]

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -45,9 +45,9 @@ def build_runtime_config_text(data: Any, action: AuditLogAction) -> Optional[str
 
 
 def build_migration_run_text(data: Any, action: AuditLogAction) -> Optional[str]:
-    if action == AuditLogAction.RAN_MIGRATION:
+    if action == AuditLogAction.RAN_MIGRATION_STARTED:
         action_text = f":runner: ran migration {data['migration']}"
-    elif action == AuditLogAction.REVERSED_MIGRATION:
+    elif action == AuditLogAction.REVERSED_MIGRATION_STARTED:
         action_text = f":uno-reverse: reversed migration {data['migration']}"
     else:
         return None

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -165,11 +165,10 @@ def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Resp
         if not dry_run:
             audit_log.record(
                 user or "",
-                AuditLogAction.RAN_MIGRATION
+                AuditLogAction.RAN_MIGRATION_STARTED
                 if action == "run"
-                else AuditLogAction.REVERSED_MIGRATION,
+                else AuditLogAction.REVERSED_MIGRATION_STARTED,
                 {"migration": str(migration_key), "force": force, "fake": fake},
-                notify=True,
             )
 
         if action == "run":
@@ -177,6 +176,16 @@ def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Resp
         else:
             runner.reverse_migration(
                 migration_key, force=force, fake=fake, dry_run=dry_run
+            )
+
+        if not dry_run:
+            audit_log.record(
+                user or "",
+                AuditLogAction.RAN_MIGRATION_COMPLETED
+                if action == "run"
+                else AuditLogAction.REVERSED_MIGRATION_COMPLETED,
+                {"migration": str(migration_key), "force": force, "fake": fake},
+                notify=True,
             )
 
     try:


### PR DESCRIPTION
Originally was going to just switch where we put the audit log statements (in https://github.com/getsentry/snuba/pull/3492) but instead decided to split out `started` and `completed`. 

This way we have an audit of who ran something, even if it failed, and we only need to get notifications when something was completed. In the future if we wanted to have notifications on failure we could easily update the code to do so.