### PR TITLE
ref(replacements): Refactor Schema out of ReplacerProcessor init

### DIFF
--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -508,6 +508,11 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
         self.__storage_key_str = storage_key_str
 
     def __initialize_schema(self) -> None:
+        # This has to be imported here since the storage factory will also initialize this processor
+        # and importing it at the top will create an import cycle
+
+        # This could be avoided by passing the schema in as an argument for this class but that
+        # would inflate the config representation of any storage using this replacer
         from snuba.datasets.storages.factory import get_storage
 
         storage = get_storage(StorageKey(self.__storage_key_str))

--- a/snuba/datasets/errors_replacer.py
+++ b/snuba/datasets/errors_replacer.py
@@ -33,7 +33,6 @@ from snuba.clickhouse import DATETIME_FORMAT
 from snuba.clickhouse.columns import FlattenedColumn, Nullable, ReadOnly
 from snuba.clickhouse.escaping import escape_identifier, escape_string
 from snuba.datasets.schemas.tables import WritableTableSchema
-from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.processor import (
     REPLACEMENT_EVENT_TYPES,
@@ -509,6 +508,8 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
         self.__storage_key_str = storage_key_str
 
     def __initialize_schema(self) -> None:
+        from snuba.datasets.storages.factory import get_storage
+
         storage = get_storage(StorageKey(self.__storage_key_str))
         assert isinstance(schema := storage.get_schema(), WritableTableSchema)
         self.__schema = schema

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -159,6 +159,8 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             mandatory_condition_checkers,
         )
         assert isinstance(schema, WritableTableSchema)
+        if replacer_processor:
+            replacer_processor.initialize_schema(schema)
         self.__table_writer = TableWriter(
             storage_set=storage_set_key,
             write_schema=schema,

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -159,8 +159,6 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             mandatory_condition_checkers,
         )
         assert isinstance(schema, WritableTableSchema)
-        if replacer_processor:
-            replacer_processor.initialize_schema(schema)
         self.__table_writer = TableWriter(
             storage_set=storage_set_key,
             write_schema=schema,

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -50,5 +50,6 @@ storage = WritableTableStorage(
         tag_column_map={"tags": promoted_tag_columns, "contexts": {}},
         promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},
         state_name="errors",
+        storage_key_str="errors",
     ),
 )

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -46,7 +46,6 @@ storage = WritableTableStorage(
     # This is the default, just showing where it goes for the PR
     write_format=WriteFormat.JSON,
     replacer_processor=ErrorsReplacer(
-        schema=schema,
         required_columns=required_columns,
         tag_column_map={"tags": promoted_tag_columns, "contexts": {}},
         promoted_tags={"tags": list(promoted_tag_columns.keys()), "contexts": []},

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -68,17 +68,9 @@ class ReplacerProcessor(ABC, Generic[R]):
         """
         raise NotImplementedError
 
-    def initialize_schema(self, schema: WritableTableSchema) -> None:
-        """
-        Schema is initialized by the parent storage after ReplacerProcessor is
-        instantiated.
-
-        This method should be called before any processing is done by the processor!
-        """
-        self.__schema = schema
-
+    @abstractmethod
     def get_schema(self) -> WritableTableSchema:
-        return self.__schema
+        raise NotImplementedError
 
     @abstractmethod
     def get_state(self) -> ReplacerState:

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -61,15 +61,21 @@ class ReplacerProcessor(ABC, Generic[R]):
     instance of this class that will be used by the ReplacementWorker.
     """
 
-    def __init__(self, schema: WritableTableSchema) -> None:
-        self.__schema = schema
-
     @abstractmethod
     def process_message(self, message: ReplacementMessage) -> Optional[R]:
         """
         Processes one message from the topic.
         """
         raise NotImplementedError
+
+    def initialize_schema(self, schema: WritableTableSchema) -> None:
+        """
+        Schema is initialized by the parent storage after ReplacerProcessor is
+        instantiated.
+
+        This method should be called before any processing is done by the processor!
+        """
+        self.__schema = schema
 
     def get_schema(self) -> WritableTableSchema:
         return self.__schema


### PR DESCRIPTION
### Overview
- ReplacerProcessor currently requires a schema as an init param
- This makes the config representation of the errors storage very messy since it will first define the schema as the storage param and then once again for the processor

### Refactor
- Moved schema initialization into a new method which basically does what was done on init before, but runs later (once all storages are built)
- The parent storage key is passed to the processor instead of the schema
- This method would be called on the first process_message() or get_schema() call of the processor to initialize the schema