### PR TITLE
ref(abuse) Add the parent_api back to the metrics

### DIFF
--- a/snuba/attribution/log.py
+++ b/snuba/attribution/log.py
@@ -33,6 +33,7 @@ class QueryAttributionData:
 class AttributionData:
     app_id: AppID
     referrer: str
+    parent_api: str
     request_id: str
     timestamp: int
     duration_ms: int
@@ -46,6 +47,7 @@ def log_attribution_to_metrics(attr_data: AttributionData) -> None:
         tags = {
             "app_id": attr_data.app_id.key,
             "referrer": attr_data.referrer,
+            "parent_api": attr_data.parent_api,
             "dataset": attr_data.dataset,
             "entity": attr_data.entity,
             "table": q.table,

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -29,6 +29,14 @@ class QuerySettings(ABC):
         pass
 
     @abstractmethod
+    def get_parent_api(self) -> str:
+        """
+        This is an identifier used to denote the higher level request. That could be an API endpoint,
+        a celery task or something else entirely.
+        """
+        pass
+
+    @abstractmethod
     def get_dry_run(self) -> bool:
         pass
 
@@ -71,6 +79,7 @@ class HTTPQuerySettings(QuerySettings):
         # TODO: is this flag still relevant?
         legacy: bool = False,
         referrer: str = "unknown",
+        parent_api: str = "<unknown>",
     ) -> None:
         super().__init__()
         self.__turbo = turbo
@@ -81,6 +90,7 @@ class HTTPQuerySettings(QuerySettings):
         self.__rate_limit_params: List[RateLimitParameters] = []
         self.__resource_quota: Optional[ResourceQuota] = None
         self.referrer = referrer
+        self.__parent_api = parent_api
 
     def get_turbo(self) -> bool:
         return self.__turbo
@@ -90,6 +100,9 @@ class HTTPQuerySettings(QuerySettings):
 
     def get_debug(self) -> bool:
         return self.__debug
+
+    def get_parent_api(self) -> str:
+        return self.__parent_api
 
     def get_dry_run(self) -> bool:
         return self.__dry_run
@@ -119,11 +132,11 @@ class SubscriptionQuerySettings(QuerySettings):
     def __init__(
         self,
         consistent: bool = True,
-        parent_api: str = "subscription",
         team: str = "workflow",
         feature: str = "subscription",
         app_id: str = "default",
         referrer: str = "subscription",
+        parent_api: str = "subscription",
     ) -> None:
         self.__consistent = consistent
         self.__parent_api = parent_api

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -29,14 +29,6 @@ class QuerySettings(ABC):
         pass
 
     @abstractmethod
-    def get_parent_api(self) -> str:
-        """
-        This is an identifier used to denote the higher level request. That could be an API endpoint,
-        a celery task or something else entirely.
-        """
-        pass
-
-    @abstractmethod
     def get_dry_run(self) -> bool:
         pass
 
@@ -79,7 +71,6 @@ class HTTPQuerySettings(QuerySettings):
         # TODO: is this flag still relevant?
         legacy: bool = False,
         referrer: str = "unknown",
-        parent_api: str = "<unknown>",
     ) -> None:
         super().__init__()
         self.__turbo = turbo
@@ -90,7 +81,6 @@ class HTTPQuerySettings(QuerySettings):
         self.__rate_limit_params: List[RateLimitParameters] = []
         self.__resource_quota: Optional[ResourceQuota] = None
         self.referrer = referrer
-        self.__parent_api = parent_api
 
     def get_turbo(self) -> bool:
         return self.__turbo
@@ -100,9 +90,6 @@ class HTTPQuerySettings(QuerySettings):
 
     def get_debug(self) -> bool:
         return self.__debug
-
-    def get_parent_api(self) -> str:
-        return self.__parent_api
 
     def get_dry_run(self) -> bool:
         return self.__dry_run
@@ -136,10 +123,8 @@ class SubscriptionQuerySettings(QuerySettings):
         feature: str = "subscription",
         app_id: str = "default",
         referrer: str = "subscription",
-        parent_api: str = "subscription",
     ) -> None:
         self.__consistent = consistent
-        self.__parent_api = parent_api
         self.__team = team
         self.__feature = feature
         self.__app_id = app_id
@@ -153,9 +138,6 @@ class SubscriptionQuerySettings(QuerySettings):
 
     def get_debug(self) -> bool:
         return False
-
-    def get_parent_api(self) -> str:
-        return self.__parent_api
 
     def get_dry_run(self) -> bool:
         return False

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -30,6 +30,7 @@ def _record_timer_metrics(
         tags={
             "status": query_metadata.status.value,
             "referrer": referrer,
+            "parent_api": request.query_settings.get_parent_api(),
             "final": final,
             "dataset": query_metadata.dataset,
             "app_id": app_id,
@@ -37,6 +38,7 @@ def _record_timer_metrics(
         mark_tags={
             "final": final,
             "referrer": referrer,
+            "parent_api": request.query_settings.get_parent_api(),
             "dataset": query_metadata.dataset,
         },
     )
@@ -49,6 +51,7 @@ def _record_attribution_metrics(
     attr_data = AttributionData(
         app_id=request.attribution_info.app_id,
         referrer=request.referrer,
+        parent_api=request.query_settings.get_parent_api(),
         request_id=request.id,
         dataset=query_metadata.dataset,
         entity=query_metadata.entity,

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -25,12 +25,13 @@ def _record_timer_metrics(
     final = str(request.query.get_final())
     referrer = request.referrer or "none"
     app_id = request.attribution_info.app_id.key or "none"
+    parent_api = request.attribution_info.parent_api or "none"
     timer.send_metrics_to(
         metrics,
         tags={
             "status": query_metadata.status.value,
             "referrer": referrer,
-            "parent_api": request.query_settings.get_parent_api(),
+            "parent_api": parent_api,
             "final": final,
             "dataset": query_metadata.dataset,
             "app_id": app_id,
@@ -38,7 +39,7 @@ def _record_timer_metrics(
         mark_tags={
             "final": final,
             "referrer": referrer,
-            "parent_api": request.query_settings.get_parent_api(),
+            "parent_api": parent_api,
             "dataset": query_metadata.dataset,
         },
     )
@@ -51,7 +52,7 @@ def _record_attribution_metrics(
     attr_data = AttributionData(
         app_id=request.attribution_info.app_id,
         referrer=request.referrer,
-        parent_api=request.query_settings.get_parent_api(),
+        parent_api=request.attribution_info.parent_api or "none",
         request_id=request.id,
         dataset=query_metadata.dataset,
         entity=query_metadata.entity,

--- a/snuba/request/schema.py
+++ b/snuba/request/schema.py
@@ -175,7 +175,7 @@ SETTINGS_SCHEMAS: Mapping[Type[QuerySettings], Schema] = {
             # TODO: move this to attribution
             "legacy": {"type": "boolean", "default": False},
             "referrer": {"type": "string", "default": "<unknown>"},
-            "parent_api": {"type": "string", "default": "<unknown>"},
+            # "parent_api": {"type": "string", "default": "<unknown>"},
         },
         "additionalProperties": False,
     },

--- a/snuba/request/schema.py
+++ b/snuba/request/schema.py
@@ -175,6 +175,7 @@ SETTINGS_SCHEMAS: Mapping[Type[QuerySettings], Schema] = {
             # TODO: move this to attribution
             "legacy": {"type": "boolean", "default": False},
             "referrer": {"type": "string", "default": "<unknown>"},
+            "parent_api": {"type": "string", "default": "<unknown>"},
         },
         "additionalProperties": False,
     },

--- a/snuba/request/schema.py
+++ b/snuba/request/schema.py
@@ -175,7 +175,6 @@ SETTINGS_SCHEMAS: Mapping[Type[QuerySettings], Schema] = {
             # TODO: move this to attribution
             "legacy": {"type": "boolean", "default": False},
             "referrer": {"type": "string", "default": "<unknown>"},
-            # "parent_api": {"type": "string", "default": "<unknown>"},
         },
         "additionalProperties": False,
     },

--- a/tests/subscriptions/entity_subscriptions/test_entity_subscriptions_data.py
+++ b/tests/subscriptions/entity_subscriptions/test_entity_subscriptions_data.py
@@ -52,7 +52,7 @@ def test_entity_subscriptions_data() -> None:
         RedisSubscriptionDataStore(redis_client, entity_key, PartitionId(i))
         for i in range(topic_spec.partitions_number)
     ]
-    print(stores[0].all())
+
     assert len(stores) == 1
     assert len([s for s in stores[0].all()]) == 1
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -678,6 +678,7 @@ class TestSnQLApi(BaseApiTest):
                     "team": "sns",
                     "feature": "test",
                     "app_id": "default",
+                    "parent_api": "some/endpoint",
                 }
             ),
         )
@@ -698,6 +699,7 @@ class TestSnQLApi(BaseApiTest):
                     AND project_id IN tuple({self.project_id})
                     """,
                     "app_id": "default",
+                    "parent_api": "some/endpoint",
                 }
             ),
         )
@@ -708,6 +710,7 @@ class TestSnQLApi(BaseApiTest):
         assert metric_calls[0].value > 0
         assert metric_calls[0].tags["app_id"] == "default"
         assert metric_calls[0].tags["referrer"] == "test"
+        assert metric_calls[0].tags["parent_api"] == "some/endpoint"
         assert metric_calls[0].tags["dataset"] == "events"
         assert metric_calls[0].tags["entity"] == "events"
         assert metric_calls[0].tags["table"].startswith("errors")
@@ -736,6 +739,7 @@ class TestSnQLApi(BaseApiTest):
                     AND project_id IN tuple({self.project_id})
                     """,
                     "app_id": "something-good",
+                    "parent_api": "some/endpoint",
                 }
             ),
         )
@@ -745,6 +749,7 @@ class TestSnQLApi(BaseApiTest):
         assert len(metric_calls) == 1
         assert metric_calls[0].tags["status"] == "success"
         assert metric_calls[0].tags["referrer"] == "test"
+        assert metric_calls[0].tags["parent_api"] == "some/endpoint"
         assert metric_calls[0].tags["final"] == "False"
         assert metric_calls[0].tags["dataset"] == "events"
         assert metric_calls[0].tags["app_id"] == "something-good"


### PR DESCRIPTION
The parent_api metric can be useful to see which feature has spiked in abuse,
since one feature can call many referrers and make it harder to see changes in
traffic usage.

This metric was removed in the past because we found cases of the endpoint not
being correct. Referrers were attached to endpoints that didn't actually call
the referrer. However the Sentry SDK has improved quite a bit since then and
even if the endpoint is not correct, it can still be useful signal of a problem.