### PR TITLE
fix coverage paths

### DIFF
--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -19,9 +19,9 @@ services:
       - '--cov'
       - '.'
       - '--cov-report'
-      - 'xml:/.artifacts/coverage.xml'
+      - 'xml:/.artifacts/${TEST_LOCATION:-tests}/${SNUBA_SETTINGS}/coverage.xml'
       - '--junit-xml'
-      - '/.artifacts/pytest.junit.xml'
+      - '/.artifacts/${TEST_LOCATION:-tests}/${SNUBA_SETTINGS}/pytest.junit.xml'
     environment:
       SNUBA_SETTINGS: '$SNUBA_SETTINGS'
       CLICKHOUSE_HOST: clickhouse


### PR DESCRIPTION
Some of the tests were overwriting each others coverage files. This fix renames the coverage paths to give each tests its own coverage file.