### PR TITLE
fix(admin): bind log to configure it before using

### DIFF
--- a/snuba/admin/audit_log/base.py
+++ b/snuba/admin/audit_log/base.py
@@ -10,6 +10,8 @@ from snuba.admin.notifications.slack.utils import build_blocks
 
 class AuditLog:
     def __init__(self) -> None:
+        # because we don't previously configure structlog, we need to bind the logger otherwise
+        # we will have a lazy bound logger without processors
         self.logger = structlog.get_logger().bind(
             module=self.__class__.__module__, context_class=self.__class__.__qualname__
         )

--- a/snuba/admin/audit_log/base.py
+++ b/snuba/admin/audit_log/base.py
@@ -10,7 +10,9 @@ from snuba.admin.notifications.slack.utils import build_blocks
 
 class AuditLog:
     def __init__(self) -> None:
-        self.logger = structlog.get_logger()
+        self.logger = structlog.get_logger().bind(
+            module=self.__class__.__module__, context_class=self.__class__.__qualname__
+        )
         self.client = SlackClient()
 
     def record(

--- a/tests/admin/test_querylog_audit_log.py
+++ b/tests/admin/test_querylog_audit_log.py
@@ -1,12 +1,16 @@
+import importlib
+
 import pytest
 from structlog.testing import capture_logs
 
+import snuba.admin.audit_log.querylog
 from snuba.admin.audit_log.querylog import QueryExecutionStatus, audit_log
 from snuba.clickhouse.native import ClickhouseResult
 
 
 def test_audit_log_success() -> None:
     with capture_logs() as cap_logs:
+        importlib.reload(snuba.admin.audit_log.querylog)
 
         @audit_log
         def successful_query(query: str, user: str) -> ClickhouseResult:


### PR DESCRIPTION
The logger in `AuditLog` wasn't configured properly and was lazy so it was ignored in k8s. Adding bind to force it to configure properly and add the processors.