### PR TITLE
ref(replacements): Move ProjectsQueryFlags out of errors_replacer

### DIFF
--- a/snuba/datasets/replacements/errors_replacer.py
+++ b/snuba/datasets/replacements/errors_replacer.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import json
 import logging
 import random
-import sys
-import time
 import uuid
 from abc import abstractmethod
 from collections import deque
@@ -19,19 +17,16 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
-    Set,
     Tuple,
     Union,
     cast,
 )
 
-import sentry_sdk
-
-from redis.cluster import ClusterPipeline as StrictClusterPipeline
 from snuba import environment, settings
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.clickhouse.columns import FlattenedColumn, Nullable, ReadOnly
 from snuba.clickhouse.escaping import escape_identifier, escape_string
+from snuba.datasets.replacements.projects_query_flags import ProjectsQueryFlags
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.processor import (
@@ -40,7 +35,6 @@ from snuba.processor import (
     ReplacementType,
     _hashify,
 )
-from snuba.redis import RedisClientKey, get_redis_client
 from snuba.replacers.replacer_processor import Replacement as ReplacementBase
 from snuba.replacers.replacer_processor import (
     ReplacementMessage,
@@ -59,7 +53,6 @@ In theory this will be needed only during the events to errors migration.
 
 logger = logging.getLogger(__name__)
 metrics = MetricsWrapper(environment.metrics, "errors.replacer")
-redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
 
 
 @dataclass(frozen=True)
@@ -170,325 +163,6 @@ class LegacyReplacement(Replacement):
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
-
-
-def set_project_exclude_groups(
-    project_id: int,
-    group_ids: Sequence[int],
-    state_name: Optional[ReplacerState],
-    #  replacement type is just for metrics, not necessary for functionality
-    replacement_type: ReplacementType,
-) -> None:
-    """
-    This method is called when a replacement comes in. For a specific project, record
-    the group ids which were deleted as a result of this replacement
-
-    Add {group_id: now, ...} to the ZSET for each `group_id` to exclude,
-    remove outdated entries based on `settings.REPLACER_KEY_TTL`, and expire
-    the entire ZSET incase it's rarely touched.
-
-    Add replacement type for this replacement.
-    """
-    now = time.time()
-    key, type_key = ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
-        project_id, state_name
-    )
-    p = redis_client.pipeline()
-
-    # the redis key size limit is defined as 2 times the clickhouse query size
-    # limit. there is an explicit check in the query processor for the same
-    # limit
-    max_group_ids_exclude = get_config(
-        "max_group_ids_exclude",
-        settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE,
-    )
-    assert isinstance(max_group_ids_exclude, int)
-
-    group_id_data: MutableMapping[str | bytes, bytes | float | int | str] = {}
-    for group_id in group_ids:
-        group_id_data[str(group_id)] = now
-        if len(group_id_data) > 2 * max_group_ids_exclude:
-            break
-
-    p.zadd(key, group_id_data)
-    truncate_group_id_replacement_set(p, key, now, max_group_ids_exclude)
-    p.expire(key, int(settings.REPLACER_KEY_TTL))
-
-    # store the replacement type data
-    replacement_type_data: Mapping[str | bytes, bytes | float | int | str] = {
-        replacement_type: now
-    }
-    p.zadd(type_key, replacement_type_data)
-    truncate_group_id_replacement_set(p, type_key, now, max_group_ids_exclude)
-    p.expire(type_key, int(settings.REPLACER_KEY_TTL))
-
-    p.execute()
-
-
-def truncate_group_id_replacement_set(
-    p: StrictClusterPipeline, key: str, now: float, max_group_ids_exclude: int
-) -> None:
-    # remove group id deletions that should have been merged by now
-    p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
-
-    # remove group id deletions that exceed the maximum number of deletions
-    # snuba's query processor will put in a query.
-    #
-    # Add +2 because:
-    #
-    # - ranges are exclusive in redis (apparently)
-    # - such that the query processor will recognize that we exceeded the limit
-    #   and fall back to FINAL (because the set doesn't contain all group ids to
-    #   exclude anymore)
-    p.zremrangebyrank(key, 0, -(2 * max_group_ids_exclude + 2))
-
-
-def set_project_needs_final(
-    project_id: int,
-    state_name: Optional[ReplacerState],
-    replacement_type: ReplacementType,
-) -> None:
-    key, type_key = ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
-        project_id, state_name
-    )
-    p = redis_client.pipeline()
-    p.set(key, time.time(), ex=settings.REPLACER_KEY_TTL)
-    p.set(type_key, replacement_type, ex=settings.REPLACER_KEY_TTL)
-    p.execute()
-
-
-@dataclass
-class ProjectsQueryFlags:
-    """
-    These flags are useful for ensuring a Query does not look at certain replaced
-    data. They are also useful for knowing whether or not to set the Query as
-    FINAL overall.
-
-    - needs_final: Whether or not any project was set as final.
-    - group_ids_to_exclude: A set of group id's that have been replaced, and
-    the replacement has not yet been merged in the database. These groups should be
-    excluded from the data a Query looks through.
-    - replacement_types: A set of all replacement types across replacements for the
-    set of project ids.
-    - latest_replacement_time: The latest timestamp any replacement occured.
-    """
-
-    needs_final: bool
-    group_ids_to_exclude: Set[int]
-    replacement_types: Set[str]
-    latest_replacement_time: Optional[datetime]
-
-    @classmethod
-    def load_from_redis(
-        cls, project_ids: Sequence[int], state_name: Optional[ReplacerState]
-    ) -> ProjectsQueryFlags:
-        """
-        Loads flags for given project ids.
-
-        - Searches through Redis for relevant replacements info
-        - Splits up results from pipeline into something that makes sense
-        """
-        s_project_ids = set(project_ids)
-
-        p = redis_client.pipeline()
-
-        with sentry_sdk.start_span(op="function", description="build_redis_pipeline"):
-            cls._query_redis(s_project_ids, state_name, p)
-
-        with sentry_sdk.start_span(
-            op="function", description="execute_redis_pipeline"
-        ) as span:
-            results = p.execute()
-            # getting size of str(results) since sys.getsizeof() doesn't count recursively
-            span.set_tag("results_size", sys.getsizeof(str(results)))
-
-        with sentry_sdk.start_span(
-            op="function", description="process_redis_results"
-        ) as span:
-            flags = cls._process_redis_results(results, len(s_project_ids))
-            span.set_tag("projects", s_project_ids)
-            span.set_tag("exclude_groups", flags.group_ids_to_exclude)
-            span.set_tag("len(exclude_groups)", len(flags.group_ids_to_exclude))
-            span.set_tag("latest_replacement_time", flags.latest_replacement_time)
-            span.set_tag("replacement_types", flags.replacement_types)
-
-        return flags
-
-    @classmethod
-    def _process_redis_results(
-        cls, results: List[Any], len_projects: int
-    ) -> ProjectsQueryFlags:
-        """
-        Produces readable data from flattened list of Redis pipeline results.
-
-        `results` is a flat list of all the redis call results of _query_redis
-        [
-            needs_final: Sequence[timestamp]...,
-            _: Sequence[num_removed_elements]...,
-            exclude_groups: Sequence[List[group_id]]...,
-            needs_final_replacement_types: Sequence[Optional[str]]...,
-            _: Sequence[num_removed_elements]...,
-            groups_replacement_types: Sequence[List[str]]...,
-            latest_exclude_groups_replacements: Sequence[Optional[Tuple[group_id, datetime]]]...
-        ]
-        - The _ slices are the results of `zremrangebyscore` calls, unecessary data
-        - Since the Redis commands are built to result in something per project per command,
-        the results can be split up with multiples of `len_projects` as indices
-        """
-        needs_final_result = results[:len_projects]
-        exclude_groups_results = results[len_projects * 2 : len_projects * 3]
-        projects_replacment_types_result = results[len_projects * 3 : len_projects * 4]
-        groups_replacement_types_results = results[len_projects * 5 : len_projects * 6]
-        latest_exclude_groups_result = results[len_projects * 6 : len_projects * 7]
-
-        needs_final = any(needs_final_result)
-
-        exclude_groups = {
-            int(group_id)
-            for exclude_groups_result in exclude_groups_results
-            for group_id in exclude_groups_result
-        }
-
-        needs_final_replacement_types = {
-            replacement_type.decode("utf-8")
-            for replacement_type in projects_replacment_types_result
-            if replacement_type
-        }
-
-        groups_replacement_types = {
-            replacement_type.decode("utf-8")
-            for groups_replacement_types_result in groups_replacement_types_results
-            for replacement_type in groups_replacement_types_result
-        }
-
-        replacement_types = groups_replacement_types.union(
-            needs_final_replacement_types
-        )
-
-        latest_replacement_time = cls._process_latest_replacement(
-            needs_final, needs_final_result, latest_exclude_groups_result
-        )
-
-        flags = cls(
-            needs_final, exclude_groups, replacement_types, latest_replacement_time
-        )
-        return flags
-
-    @staticmethod
-    def _query_redis(
-        project_ids: Set[int],
-        state_name: Optional[ReplacerState],
-        p: StrictClusterPipeline,
-    ) -> None:
-        """
-        Builds Redis calls in the pipeline p to get all necessary replacements
-        data for the given set of project ids.
-
-        All queried data has been previously set in setter functions
-        above this class.
-        """
-        needs_final_keys_and_type_keys = [
-            ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
-                project_id, state_name
-            )
-            for project_id in project_ids
-        ]
-
-        for needs_final_key, _ in needs_final_keys_and_type_keys:
-            p.get(needs_final_key)
-
-        exclude_groups_keys_and_types = [
-            ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
-                project_id, state_name
-            )
-            for project_id in project_ids
-        ]
-
-        ProjectsQueryFlags._remove_stale_and_load_new_sorted_set_data(
-            p,
-            [groups_key for groups_key, _ in exclude_groups_keys_and_types],
-        )
-
-        for _, needs_final_type_key in needs_final_keys_and_type_keys:
-            p.get(needs_final_type_key)
-
-        ProjectsQueryFlags._remove_stale_and_load_new_sorted_set_data(
-            p, [type_key for _, type_key in exclude_groups_keys_and_types]
-        )
-
-        # retrieve the latest timestamp for any exclude groups replacement
-        for exclude_groups_key, _ in exclude_groups_keys_and_types:
-            p.zrevrange(
-                exclude_groups_key,
-                0,
-                0,
-                withscores=True,
-            )
-
-    @staticmethod
-    def _remove_stale_and_load_new_sorted_set_data(
-        p: StrictClusterPipeline, keys: List[str]
-    ) -> None:
-        """
-        Remove stale data per key according to TTL.
-        Get latest data per key.
-
-        Split across two loops to avoid intertwining Redis calls and
-        consequentially, their results.
-        """
-        now = time.time()
-
-        for key in keys:
-            p.zremrangebyscore(key, float("-inf"), now - settings.REPLACER_KEY_TTL)
-        for key in keys:
-            p.zrevrangebyscore(key, float("inf"), now - settings.REPLACER_KEY_TTL)
-
-    @staticmethod
-    def _process_latest_replacement(
-        needs_final: bool,
-        needs_final_result: List[Any],
-        latest_exclude_groups_result: List[Any],
-    ) -> Optional[datetime]:
-        """
-        Process the relevant replacements data to look for the latest timestamp
-        any replacement occured.
-        """
-        latest_replacements = set()
-        if needs_final:
-            latest_need_final_replacement_times = [
-                # Backwards compatibility: Before it was simply "True" at each key,
-                # now it's the timestamp at which the key was added.
-                float(timestamp)
-                for timestamp in needs_final_result
-                if timestamp and timestamp != b"True"
-            ]
-            if latest_need_final_replacement_times:
-                latest_replacements.add(max(latest_need_final_replacement_times))
-
-        for latest_exclude_groups in latest_exclude_groups_result:
-            if latest_exclude_groups:
-                [(_, timestamp)] = latest_exclude_groups
-                latest_replacements.add(timestamp)
-
-        return (
-            datetime.fromtimestamp(max(latest_replacements))
-            if latest_replacements
-            else None
-        )
-
-    @staticmethod
-    def _build_project_needs_final_key_and_type_key(
-        project_id: int, state_name: Optional[ReplacerState]
-    ) -> Tuple[str, str]:
-        key = f"project_needs_final:{f'{state_name.value}:' if state_name else ''}{project_id}"
-        return key, f"{key}-type"
-
-    @staticmethod
-    def _build_project_exclude_groups_key_and_type_key(
-        project_id: int, state_name: Optional[ReplacerState]
-    ) -> Tuple[str, str]:
-        key = f"project_exclude_groups:{f'{state_name.value}:' if state_name else ''}{project_id}"
-        return key, f"{key}-type"
 
 
 class ErrorsReplacer(ReplacerProcessor[Replacement]):
@@ -622,12 +296,12 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
 
         if not settings.REPLACER_IMMEDIATE_OPTIMIZE:
             if isinstance(query_time_flags, NeedsFinal):
-                set_project_needs_final(
+                ProjectsQueryFlags.set_project_needs_final(
                     project_id, self.__state_name, replacement.get_replacement_type()
                 )
 
             elif isinstance(query_time_flags, ExcludeGroups):
-                set_project_exclude_groups(
+                ProjectsQueryFlags.set_project_exclude_groups(
                     project_id,
                     query_time_flags.group_ids,
                     self.__state_name,

--- a/snuba/datasets/replacements/projects_query_flags.py
+++ b/snuba/datasets/replacements/projects_query_flags.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, List, Mapping, MutableMapping, Optional, Sequence, Set, Tuple
+
+import sentry_sdk
+
+from redis.cluster import ClusterPipeline as StrictClusterPipeline
+from snuba import settings
+from snuba.processor import ReplacementType
+from snuba.redis import RedisClientKey, get_redis_client
+from snuba.replacers.replacer_processor import ReplacerState
+from snuba.state import get_config
+
+redis_client = get_redis_client(RedisClientKey.REPLACEMENTS_STORE)
+
+
+@dataclass
+class ProjectsQueryFlags:
+    """
+    These flags are useful for ensuring a Query does not look at certain replaced
+    data. They are also useful for knowing whether or not to set the Query as
+    FINAL overall.
+
+    - needs_final: Whether or not any project was set as final.
+    - group_ids_to_exclude: A set of group id's that have been replaced, and
+    the replacement has not yet been merged in the database. These groups should be
+    excluded from the data a Query looks through.
+    - replacement_types: A set of all replacement types across replacements for the
+    set of project ids.
+    - latest_replacement_time: The latest timestamp any replacement occured.
+    """
+
+    needs_final: bool
+    group_ids_to_exclude: Set[int]
+    replacement_types: Set[str]
+    latest_replacement_time: Optional[datetime]
+
+    @staticmethod
+    def set_project_needs_final(
+        project_id: int,
+        state_name: Optional[ReplacerState],
+        replacement_type: ReplacementType,
+    ) -> None:
+        key, type_key = ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
+            project_id, state_name
+        )
+        p = redis_client.pipeline()
+        p.set(key, time.time(), ex=settings.REPLACER_KEY_TTL)
+        p.set(type_key, replacement_type, ex=settings.REPLACER_KEY_TTL)
+        p.execute()
+
+    @staticmethod
+    def set_project_exclude_groups(
+        project_id: int,
+        group_ids: Sequence[int],
+        state_name: Optional[ReplacerState],
+        #  replacement type is just for metrics, not necessary for functionality
+        replacement_type: ReplacementType,
+    ) -> None:
+        """
+        This method is called when a replacement comes in. For a specific project, record
+        the group ids which were deleted as a result of this replacement
+
+        Add {group_id: now, ...} to the ZSET for each `group_id` to exclude,
+        remove outdated entries based on `settings.REPLACER_KEY_TTL`, and expire
+        the entire ZSET incase it's rarely touched.
+
+        Add replacement type for this replacement.
+        """
+        now = time.time()
+        (
+            key,
+            type_key,
+        ) = ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
+            project_id, state_name
+        )
+        p = redis_client.pipeline()
+
+        # the redis key size limit is defined as 2 times the clickhouse query size
+        # limit. there is an explicit check in the query processor for the same
+        # limit
+        max_group_ids_exclude = get_config(
+            "max_group_ids_exclude",
+            settings.REPLACER_MAX_GROUP_IDS_TO_EXCLUDE,
+        )
+        assert isinstance(max_group_ids_exclude, int)
+
+        group_id_data: MutableMapping[str | bytes, bytes | float | int | str] = {}
+        for group_id in group_ids:
+            group_id_data[str(group_id)] = now
+            if len(group_id_data) > 2 * max_group_ids_exclude:
+                break
+
+        p.zadd(key, group_id_data)
+        ProjectsQueryFlags._truncate_group_id_replacement_set(
+            p, key, now, max_group_ids_exclude
+        )
+        p.expire(key, int(settings.REPLACER_KEY_TTL))
+
+        # store the replacement type data
+        replacement_type_data: Mapping[str | bytes, bytes | float | int | str] = {
+            replacement_type: now
+        }
+        p.zadd(type_key, replacement_type_data)
+        ProjectsQueryFlags._truncate_group_id_replacement_set(
+            p, type_key, now, max_group_ids_exclude
+        )
+        p.expire(type_key, int(settings.REPLACER_KEY_TTL))
+
+        p.execute()
+
+    @classmethod
+    def load_from_redis(
+        cls, project_ids: Sequence[int], state_name: Optional[ReplacerState]
+    ) -> ProjectsQueryFlags:
+        """
+        Loads flags for given project ids.
+
+        - Searches through Redis for relevant replacements info
+        - Splits up results from pipeline into something that makes sense
+        """
+        s_project_ids = set(project_ids)
+
+        p = redis_client.pipeline()
+
+        with sentry_sdk.start_span(op="function", description="build_redis_pipeline"):
+            cls._query_redis(s_project_ids, state_name, p)
+
+        with sentry_sdk.start_span(
+            op="function", description="execute_redis_pipeline"
+        ) as span:
+            results = p.execute()
+            # getting size of str(results) since sys.getsizeof() doesn't count recursively
+            span.set_tag("results_size", sys.getsizeof(str(results)))
+
+        with sentry_sdk.start_span(
+            op="function", description="process_redis_results"
+        ) as span:
+            flags = cls._process_redis_results(results, len(s_project_ids))
+            span.set_tag("projects", s_project_ids)
+            span.set_tag("exclude_groups", flags.group_ids_to_exclude)
+            span.set_tag("len(exclude_groups)", len(flags.group_ids_to_exclude))
+            span.set_tag("latest_replacement_time", flags.latest_replacement_time)
+            span.set_tag("replacement_types", flags.replacement_types)
+
+        return flags
+
+    @classmethod
+    def _process_redis_results(
+        cls, results: List[Any], len_projects: int
+    ) -> ProjectsQueryFlags:
+        """
+        Produces readable data from flattened list of Redis pipeline results.
+
+        `results` is a flat list of all the redis call results of _query_redis
+        [
+            needs_final: Sequence[timestamp]...,
+            _: Sequence[num_removed_elements]...,
+            exclude_groups: Sequence[List[group_id]]...,
+            needs_final_replacement_types: Sequence[Optional[str]]...,
+            _: Sequence[num_removed_elements]...,
+            groups_replacement_types: Sequence[List[str]]...,
+            latest_exclude_groups_replacements: Sequence[Optional[Tuple[group_id, datetime]]]...
+        ]
+        - The _ slices are the results of `zremrangebyscore` calls, unecessary data
+        - Since the Redis commands are built to result in something per project per command,
+        the results can be split up with multiples of `len_projects` as indices
+        """
+        needs_final_result = results[:len_projects]
+        exclude_groups_results = results[len_projects * 2 : len_projects * 3]
+        projects_replacment_types_result = results[len_projects * 3 : len_projects * 4]
+        groups_replacement_types_results = results[len_projects * 5 : len_projects * 6]
+        latest_exclude_groups_result = results[len_projects * 6 : len_projects * 7]
+
+        needs_final = any(needs_final_result)
+
+        exclude_groups = {
+            int(group_id)
+            for exclude_groups_result in exclude_groups_results
+            for group_id in exclude_groups_result
+        }
+
+        needs_final_replacement_types = {
+            replacement_type.decode("utf-8")
+            for replacement_type in projects_replacment_types_result
+            if replacement_type
+        }
+
+        groups_replacement_types = {
+            replacement_type.decode("utf-8")
+            for groups_replacement_types_result in groups_replacement_types_results
+            for replacement_type in groups_replacement_types_result
+        }
+
+        replacement_types = groups_replacement_types.union(
+            needs_final_replacement_types
+        )
+
+        latest_replacement_time = cls._process_latest_replacement(
+            needs_final, needs_final_result, latest_exclude_groups_result
+        )
+
+        flags = cls(
+            needs_final, exclude_groups, replacement_types, latest_replacement_time
+        )
+        return flags
+
+    @staticmethod
+    def _query_redis(
+        project_ids: Set[int],
+        state_name: Optional[ReplacerState],
+        p: StrictClusterPipeline,
+    ) -> None:
+        """
+        Builds Redis calls in the pipeline p to get all necessary replacements
+        data for the given set of project ids.
+
+        All queried data has been previously set in setter functions
+        above this class.
+        """
+        needs_final_keys_and_type_keys = [
+            ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
+                project_id, state_name
+            )
+            for project_id in project_ids
+        ]
+
+        for needs_final_key, _ in needs_final_keys_and_type_keys:
+            p.get(needs_final_key)
+
+        exclude_groups_keys_and_types = [
+            ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
+                project_id, state_name
+            )
+            for project_id in project_ids
+        ]
+
+        ProjectsQueryFlags._remove_stale_and_load_new_sorted_set_data(
+            p,
+            [groups_key for groups_key, _ in exclude_groups_keys_and_types],
+        )
+
+        for _, needs_final_type_key in needs_final_keys_and_type_keys:
+            p.get(needs_final_type_key)
+
+        ProjectsQueryFlags._remove_stale_and_load_new_sorted_set_data(
+            p, [type_key for _, type_key in exclude_groups_keys_and_types]
+        )
+
+        # retrieve the latest timestamp for any exclude groups replacement
+        for exclude_groups_key, _ in exclude_groups_keys_and_types:
+            p.zrevrange(
+                exclude_groups_key,
+                0,
+                0,
+                withscores=True,
+            )
+
+    @staticmethod
+    def _remove_stale_and_load_new_sorted_set_data(
+        p: StrictClusterPipeline, keys: List[str]
+    ) -> None:
+        """
+        Remove stale data per key according to TTL.
+        Get latest data per key.
+
+        Split across two loops to avoid intertwining Redis calls and
+        consequentially, their results.
+        """
+        now = time.time()
+
+        for key in keys:
+            p.zremrangebyscore(key, float("-inf"), now - settings.REPLACER_KEY_TTL)
+        for key in keys:
+            p.zrevrangebyscore(key, float("inf"), now - settings.REPLACER_KEY_TTL)
+
+    @staticmethod
+    def _process_latest_replacement(
+        needs_final: bool,
+        needs_final_result: List[Any],
+        latest_exclude_groups_result: List[Any],
+    ) -> Optional[datetime]:
+        """
+        Process the relevant replacements data to look for the latest timestamp
+        any replacement occured.
+        """
+        latest_replacements = set()
+        if needs_final:
+            latest_need_final_replacement_times = [
+                # Backwards compatibility: Before it was simply "True" at each key,
+                # now it's the timestamp at which the key was added.
+                float(timestamp)
+                for timestamp in needs_final_result
+                if timestamp and timestamp != b"True"
+            ]
+            if latest_need_final_replacement_times:
+                latest_replacements.add(max(latest_need_final_replacement_times))
+
+        for latest_exclude_groups in latest_exclude_groups_result:
+            if latest_exclude_groups:
+                [(_, timestamp)] = latest_exclude_groups
+                latest_replacements.add(timestamp)
+
+        return (
+            datetime.fromtimestamp(max(latest_replacements))
+            if latest_replacements
+            else None
+        )
+
+    @staticmethod
+    def _build_project_needs_final_key_and_type_key(
+        project_id: int, state_name: Optional[ReplacerState]
+    ) -> Tuple[str, str]:
+        key = f"project_needs_final:{f'{state_name.value}:' if state_name else ''}{project_id}"
+        return key, f"{key}-type"
+
+    @staticmethod
+    def _build_project_exclude_groups_key_and_type_key(
+        project_id: int, state_name: Optional[ReplacerState]
+    ) -> Tuple[str, str]:
+        key = f"project_exclude_groups:{f'{state_name.value}:' if state_name else ''}{project_id}"
+        return key, f"{key}-type"
+
+    @staticmethod
+    def _truncate_group_id_replacement_set(
+        p: StrictClusterPipeline, key: str, now: float, max_group_ids_exclude: int
+    ) -> None:
+        # remove group id deletions that should have been merged by now
+        p.zremrangebyscore(key, -1, now - settings.REPLACER_KEY_TTL)
+
+        # remove group id deletions that exceed the maximum number of deletions
+        # snuba's query processor will put in a query.
+        #
+        # Add +2 because:
+        #
+        # - ranges are exclusive in redis (apparently)
+        # - such that the query processor will recognize that we exceeded the limit
+        #   and fall back to FINAL (because the set doesn't contain all group ids to
+        #   exclude anymore)
+        p.zremrangebyrank(key, 0, -(2 * max_group_ids_exclude + 2))

--- a/snuba/datasets/storages/errors.py
+++ b/snuba/datasets/storages/errors.py
@@ -1,7 +1,7 @@
 from snuba import util
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.errors_replacer import ErrorsReplacer
 from snuba.datasets.processors.errors_processor import ErrorsProcessor
+from snuba.datasets.replacements.errors_replacer import ErrorsReplacer
 from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.errors_common import (

--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -9,7 +9,7 @@ from snuba.clickhouse.query_dsl.accessors import (
     get_object_ids_in_query_ast,
     get_time_range,
 )
-from snuba.datasets.errors_replacer import ProjectsQueryFlags
+from snuba.datasets.replacements.projects_query_flags import ProjectsQueryFlags
 from snuba.query.conditions import not_in_condition
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.physical import ClickhouseQueryProcessor

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -26,7 +26,7 @@ from snuba.clusters.cluster import (
     ClickhouseCluster,
     ClickhouseNode,
 )
-from snuba.datasets.errors_replacer import Replacement as ErrorReplacement
+from snuba.datasets.replacements.errors_replacer import Replacement as ErrorReplacement
 from snuba.datasets.storage import WritableTableStorage
 from snuba.processor import InvalidMessageVersion
 from snuba.redis import RedisClientKey, get_redis_client

--- a/tests/datasets/storages/processors/test_replaced_groups.py
+++ b/tests/datasets/storages/processors/test_replaced_groups.py
@@ -6,10 +6,7 @@ import pytest
 from snuba import state
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.query import Query as ClickhouseQuery
-from snuba.datasets.errors_replacer import (
-    set_project_exclude_groups,
-    set_project_needs_final,
-)
+from snuba.datasets.replacements.projects_query_flags import ProjectsQueryFlags
 from snuba.processor import ReplacementType
 from snuba.query.conditions import BooleanFunctions
 from snuba.query.data_source.simple import Table
@@ -132,7 +129,7 @@ def test_with_turbo(query: ClickhouseQuery) -> None:
 
 
 def test_without_turbo_with_projects_needing_final(query: ClickhouseQuery) -> None:
-    set_project_needs_final(
+    ProjectsQueryFlags.set_project_needs_final(
         2,
         ReplacerState.ERRORS,
         ReplacementType.EXCLUDE_GROUPS,  # Arbitrary replacement type, no impact on tests
@@ -157,7 +154,7 @@ def test_without_turbo_without_projects_needing_final(query: ClickhouseQuery) ->
 
 def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
     state.set_config("max_group_ids_exclude", 5)
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -192,7 +189,7 @@ def test_not_many_groups_to_exclude(query: ClickhouseQuery) -> None:
 
 def test_too_many_groups_to_exclude(query: ClickhouseQuery) -> None:
     state.set_config("max_group_ids_exclude", 2)
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -221,7 +218,7 @@ def test_query_overlaps_replacements_processor(
 
     # overlaps replacement and should be final due to too many groups to exclude
     state.set_config("max_group_ids_exclude", 2)
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -249,7 +246,7 @@ def test_single_no_replacements(query_with_single_group_id: ClickhouseQuery) -> 
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [105, 106, 107],
         ReplacerState.ERRORS,
@@ -273,7 +270,7 @@ def test_single_too_many_exclude(query_with_single_group_id: ClickhouseQuery) ->
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -300,7 +297,7 @@ def test_single_not_too_many_exclude(
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -327,7 +324,7 @@ def test_multiple_disjoint_replaced(
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [110, 120, 130],
         ReplacerState.ERRORS,
@@ -353,7 +350,7 @@ def test_multiple_fewer_exclude_than_queried(
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [101],
         ReplacerState.ERRORS,
@@ -380,7 +377,7 @@ def test_multiple_too_many_excludes(
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -408,7 +405,7 @@ def test_multiple_not_too_many_excludes(
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -432,7 +429,7 @@ def test_no_groups_not_too_many_excludes(query: ClickhouseQuery) -> None:
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,
@@ -456,7 +453,7 @@ def test_no_groups_too_many_excludes(query: ClickhouseQuery) -> None:
     """
     enforcer = PostReplacementConsistencyEnforcer("project_id", ReplacerState.ERRORS)
 
-    set_project_exclude_groups(
+    ProjectsQueryFlags.set_project_exclude_groups(
         2,
         [100, 101, 102],
         ReplacerState.ERRORS,

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -13,7 +13,7 @@ from snuba import replacer, settings
 from snuba.clickhouse import DATETIME_FORMAT
 from snuba.clickhouse.optimize.optimize import run_optimize
 from snuba.clusters.cluster import ClickhouseClientSettings
-from snuba.datasets import errors_replacer
+from snuba.datasets.replacements import errors_replacer
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.processor import ReplacementType

--- a/tests/replacer/test_cluster_replacements.py
+++ b/tests/replacer/test_cluster_replacements.py
@@ -8,7 +8,7 @@ from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters import cluster
 from snuba.clusters.cluster import ClickhouseNode
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.errors_replacer import NEEDS_FINAL, LegacyReplacement
+from snuba.datasets.replacements.errors_replacer import NEEDS_FINAL, LegacyReplacement
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.processor import ReplacementType

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -14,8 +14,7 @@ from arroyo.types import BrokerValue, Message, Partition, Topic
 from snuba import replacer, settings
 from snuba.clickhouse.optimize.optimize import run_optimize
 from snuba.clusters.cluster import ClickhouseClientSettings
-from snuba.datasets import errors_replacer
-from snuba.datasets.errors_replacer import ProjectsQueryFlags
+from snuba.datasets.replacements.projects_query_flags import ProjectsQueryFlags
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.processor import ReplacementType
@@ -205,14 +204,14 @@ class TestReplacer:
         p = redis_client.pipeline()
 
         exclude_groups_keys = [
-            errors_replacer.ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
+            ProjectsQueryFlags._build_project_exclude_groups_key_and_type_key(
                 project_id, ReplacerState.ERRORS
             )
             for project_id in project_ids
         ]
 
         project_needs_final_keys = [
-            errors_replacer.ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
+            ProjectsQueryFlags._build_project_needs_final_key_and_type_key(
                 project_id, ReplacerState.ERRORS
             )
             for project_id in project_ids
@@ -293,7 +292,7 @@ class TestReplacer:
 
     def test_query_time_flags_project(self) -> None:
         """
-        Tests errors_replacer.set_project_needs_final()
+        Tests ProjectsQueryFlags.set_project_needs_final()
 
         ReplacementType's are arbitrary, just need to show up in
         getter appropriately once set.
@@ -304,14 +303,14 @@ class TestReplacer:
             project_ids, ReplacerState.ERRORS
         ) == ProjectsQueryFlags(False, set(), set(), None)
 
-        errors_replacer.set_project_needs_final(
+        ProjectsQueryFlags.set_project_needs_final(
             100, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
         assert ProjectsQueryFlags.load_from_redis(
             project_ids, ReplacerState.ERRORS
         ) == ProjectsQueryFlags(False, set(), set(), None)
 
-        errors_replacer.set_project_needs_final(
+        ProjectsQueryFlags.set_project_needs_final(
             1, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
         flags = ProjectsQueryFlags.load_from_redis(project_ids, ReplacerState.ERRORS)
@@ -325,7 +324,7 @@ class TestReplacer:
             {ReplacementType.EXCLUDE_GROUPS},
         )
 
-        errors_replacer.set_project_needs_final(
+        ProjectsQueryFlags.set_project_needs_final(
             2, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
         flags = ProjectsQueryFlags.load_from_redis(project_ids, ReplacerState.ERRORS)
@@ -341,17 +340,17 @@ class TestReplacer:
 
     def test_query_time_flags_groups(self) -> None:
         """
-        Tests errors_replacer.set_project_exclude_groups()
+        Tests ProjectsQueryFlags.set_project_exclude_groups()
 
         ReplacementType's are arbitrary, just need to show up in
         getter appropriately once set.
         """
         redis_client.flushdb()
         project_ids = [4, 5, 6]
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             4, [1, 2], ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             5, [3, 4], ReplacerState.ERRORS, ReplacementType.START_MERGE
         )
         flags = ProjectsQueryFlags.load_from_redis(project_ids, ReplacerState.ERRORS)
@@ -365,13 +364,13 @@ class TestReplacer:
             {ReplacementType.EXCLUDE_GROUPS, ReplacementType.START_MERGE},
         )
 
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             4, [1, 2], ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             5, [3, 4], ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             6, [5, 6], ReplacerState.ERRORS, ReplacementType.START_UNMERGE
         )
 
@@ -416,7 +415,7 @@ class TestReplacer:
         redis_client.flushdb()
         project_id = 256
         for i in range(10):
-            errors_replacer.set_project_exclude_groups(
+            ProjectsQueryFlags.set_project_exclude_groups(
                 project_id,
                 [i],
                 ReplacerState.ERRORS,
@@ -430,7 +429,7 @@ class TestReplacer:
 
         project_id = 5
 
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             project_id,
             list(range(10)),
             ReplacerState.ERRORS,
@@ -444,8 +443,8 @@ class TestReplacer:
 
     def test_query_time_flags_project_and_groups(self) -> None:
         """
-        Tests errors_replacer.set_project_needs_final() and
-        errors_replacer.set_project_exclude_groups() work together as expected.
+        Tests ProjectsQueryFlags.set_project_needs_final() and
+        ProjectsQueryFlags.set_project_exclude_groups() work together as expected.
 
         ReplacementType's are arbitrary, just need to show up in
         getter appropriately once set.
@@ -453,10 +452,10 @@ class TestReplacer:
         redis_client.flushdb()
         project_ids = [7, 8, 9]
 
-        errors_replacer.set_project_needs_final(
+        ProjectsQueryFlags.set_project_needs_final(
             7, ReplacerState.ERRORS, ReplacementType.EXCLUDE_GROUPS
         )
-        errors_replacer.set_project_exclude_groups(
+        ProjectsQueryFlags.set_project_exclude_groups(
             7, [1, 2], ReplacerState.ERRORS, ReplacementType.START_MERGE
         )
         flags = ProjectsQueryFlags.load_from_redis(project_ids, ReplacerState.ERRORS)


### PR DESCRIPTION
### Overview
- `ProjectsQueryFlags` is a huge class and concept, and although tied to the errors_replacer, it should probably reside in its own module and not `errors_replacer.py`
- Also, it seems strange that `errors_replacer.py` resides in the main `snuba/datasets/` directory while the `snuba/datasets/replacements/` directory is empty, and the replacer isn't a dataset
     - Moved `errors_replacer.py` into that directory and created a new file for `ProjectsQueryFlags` in the same directory

For context, `ProjectsQueryFlags` is the abstraction we use on top of Redis to handle setting and getting replacement data for projects.