### PR TITLE
feat(DC): ReplacerProcessor Registered + JSON Schema'd + Built

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -271,6 +271,24 @@ STORAGE_SCHEMA = {
 }
 
 
+def register1(property_name: str, class_name: str, description: str) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": {
+            property_name: {
+                "type": "string",
+                "description": description,
+            },
+            "args": {
+                "type": "object",
+                "description": f"Key/value mappings required to instantiate {class_name} class.",
+            },  # args are a flexible dict
+        },
+        "required": [property_name],
+        "additionalProperties": False,
+    }
+
+
 def registered_class_schema(
     property_name: str, class_name: str, description: str
 ) -> dict[str, Any]:
@@ -316,7 +334,7 @@ STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA = registered_class_schema(
     "ConditionChecker",
     "Name of ConditionChecker class config key. Responsible for running final checks on a query to ensure that transformations haven't impacted/removed conditions required for security reasons.",
 )
-
+BRUH = register1("processor", "ReplacerProcessor", "name")
 
 ENTITY_QUERY_PROCESSOR = {
     "type": "object",
@@ -435,6 +453,7 @@ V1_WRITABLE_STORAGE_SCHEMA = {
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
         "query_splitters": STORAGE_QUERY_SPLITTERS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
+        "replacer_processor": BRUH,
         "writer_options": {
             "type": "object",
             "description": "Extra Clickhouse fields that are used for consumer writes",

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -64,8 +64,8 @@ def build_storage_from_config(
         ).from_kwargs(**config[REPLACER_PROCESSOR].get("args", {}))
         if REPLACER_PROCESSOR in config
         else {}
-        # TODO: Rest of writable storage optional args
     )
+    # TODO: Rest of writable storage optional args
     return WritableTableStorage(**storage_kwargs)
 
 

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -44,6 +44,7 @@ MANDATORY_CONDITION_CHECKERS = "mandatory_condition_checkers"
 WRITER_OPTIONS = "writer_options"
 SUBCRIPTION_SCHEDULER_MODE = "subscription_scheduler_mode"
 DLQ_POLICY = "dlq_policy"
+REPLACER_PROCESSOR = "replacer_processor"
 
 
 def build_storage_from_config(
@@ -57,12 +58,13 @@ def build_storage_from_config(
     storage_kwargs[WRITER_OPTIONS] = (
         config[WRITER_OPTIONS] if WRITER_OPTIONS in config else {}
     )
-    storage_kwargs["replacer_processor"] = (
+    storage_kwargs[REPLACER_PROCESSOR] = (
         ReplacerProcessor.get_from_name(
-            config["replacer_processor"]["processor"]
-        ).from_kwargs(**config["replacer_processor"].get("args", {}))
-        if "replacer_processor" in config
+            config[REPLACER_PROCESSOR]["processor"]
+        ).from_kwargs(**config[REPLACER_PROCESSOR].get("args", {}))
+        if REPLACER_PROCESSOR in config
         else {}
+        # TODO: Rest of writable storage optional args
     )
     return WritableTableStorage(**storage_kwargs)
 

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -24,6 +24,7 @@ from snuba.datasets.table_storage import (
     build_kafka_stream_loader_from_settings,
 )
 from snuba.processor import MessageProcessor
+from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.util import PartSegment
 from snuba.utils.registered_class import InvalidConfigKeyError
@@ -55,6 +56,13 @@ def build_storage_from_config(
     storage_kwargs[STREAM_LOADER] = build_stream_loader(config[STREAM_LOADER])
     storage_kwargs[WRITER_OPTIONS] = (
         config[WRITER_OPTIONS] if WRITER_OPTIONS in config else {}
+    )
+    storage_kwargs["replacer_processor"] = (
+        ReplacerProcessor.get_from_name(
+            config["replacer_processor"]["processor"]
+        ).from_kwargs(**config["replacer_processor"].get("args", {}))
+        if "replacer_processor" in config
+        else {}
     )
     return WritableTableStorage(**storage_kwargs)
 

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -96,6 +96,13 @@ def _deep_compare_storages(old: Storage, new: Storage) -> None:
             old.get_table_writer().get_schema().get_columns()
             == new.get_table_writer().get_schema().get_columns()
         )
+        old_rp = old.get_table_writer().get_replacer_processor()
+        new_rp = new.get_table_writer().get_replacer_processor()
+        if old_rp or new_rp:
+            assert old_rp is not None and new_rp is not None
+            assert old_rp.get_schema() == new_rp.get_schema()
+            assert old_rp.config_key() == new_rp.config_key()
+            assert old_rp.get_state() == new_rp.get_state()
         _compare_stream_loaders(
             old.get_table_writer().get_stream_loader(),
             new.get_table_writer().get_stream_loader(),


### PR DESCRIPTION
### Overview
Support for `replacer_processor` argument of `WritableTableStorage` requires a couple updates to DC stuff:
- `ReplacerProcessor` needs to be a `RegisteredClass`
    - Assigning the metaclass `RegisteredClass` enables a class to be referenced by name
    - This is required in order for Errors config to be parsed correctly and have the replacer processor picked up
- JSON Schema for Storage needs to be updated to accept `replacer_processor` param
- `storage_builder` needs to be updated to build a storage with a ReplacerProcessor if defined in a config