### PR TITLE
ref: Rewrite the KafkaConsumerWithCommitLog as a strategy

### DIFF
--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -1,7 +1,19 @@
+import time
 from abc import abstractmethod
-from typing import Callable, Mapping, Optional, Protocol, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Mapping,
+    MutableMapping,
+    NamedTuple,
+    Optional,
+    Protocol,
+    TypeVar,
+)
 
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka.commit import CommitCodec
+from arroyo.commit import Commit as CommitLogCommit
 from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.processing.strategies.collect import CollectStep, ParallelCollectStep
 from arroyo.processing.strategies.commit import CommitOffsets
@@ -13,7 +25,10 @@ from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
 )
 from arroyo.processing.strategies.filter import FilterStep
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
-from arroyo.types import Commit, Message, Partition
+from arroyo.types import Commit, Message, Partition, Position, Topic
+from confluent_kafka import KafkaError
+from confluent_kafka import Message as ConfluentMessage
+from confluent_kafka import Producer as ConfluentProducer
 
 TPayload = TypeVar("TPayload")
 TProcessed = TypeVar("TProcessed")
@@ -28,6 +43,83 @@ class StreamMessageFilter(Protocol[TPayload]):
     @abstractmethod
     def should_drop(self, message: Message[TPayload]) -> bool:
         raise NotImplementedError
+
+
+PRODUCE_FREQUENCY_SEC = 1.0
+
+
+class ProduceCommitLog(ProcessingStrategy[Any]):
+    def __init__(
+        self,
+        producer: ConfluentProducer,
+        commit_log_topic: Topic,
+        group_id: str,
+        commit: Commit,
+    ) -> None:
+        self.__producer = producer
+        self.__commit_log_topic = commit_log_topic
+        self.__group_id = group_id
+        self.__commit_codec = CommitCodec()
+        self.__commit = commit
+
+        # Record offsets to be produced to the commit log
+        self.__offsets_to_produce: MutableMapping[Partition, Position] = {}
+        self.__last_flush_time = time.time()
+
+    def poll(self) -> None:
+        self.__flush()
+        self.__producer.poll(0.0)
+
+    def __commit_message_delivery_callback(
+        self, error: Optional[KafkaError], message: ConfluentMessage
+    ) -> None:
+        if error is not None:
+            raise Exception(error.str())
+
+    def __flush(self, force: bool = False) -> None:
+        if not force and time.time() - self.__last_flush_time < PRODUCE_FREQUENCY_SEC:
+            return
+
+        self.__commit(self.__offsets_to_produce)
+
+        for partition, position in self.__offsets_to_produce.items():
+            commit = CommitLogCommit(
+                self.__group_id, partition, position.offset, position.timestamp
+            )
+
+            payload = self.__commit_codec.encode(commit)
+
+            self.__producer.produce(
+                self.__commit_log_topic.name,
+                key=payload.key,
+                value=payload.value,
+                headers=payload.headers,
+                on_delivery=self.__commit_message_delivery_callback,
+            )
+
+        self.__offsets_to_produce.clear()
+
+    def submit(self, message: Message[Any]) -> None:
+        self.__offsets_to_produce.update(message.committable)
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self.__flush(force=True)
+
+        messages: int = self.__producer.flush(*[timeout] if timeout is not None else [])
+        if messages > 0:
+            raise TimeoutError(f"{messages} commit log messages pending delivery")
+
+
+class CommitLogConfig(NamedTuple):
+    producer: ConfluentProducer
+    topic: Topic
+    group_id: str
 
 
 class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
@@ -72,6 +164,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         ] = None,
         parallel_collect: bool = False,
         parallel_collect_timeout: float = 10.0,
+        commit_log_config: Optional[CommitLogConfig] = None,
     ) -> None:
         self.__prefilter = prefilter
         self.__dead_letter_queue_policy_creator = dead_letter_queue_policy_creator
@@ -98,6 +191,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self.__initialize_parallel_transform = initialize_parallel_transform
         self.__parallel_collect = parallel_collect
         self.__parallel_collect_timeout = parallel_collect_timeout
+        self.__commit_log_config = commit_log_config
 
     def __should_accept(self, message: Message[TPayload]) -> bool:
         assert self.__prefilter is not None
@@ -108,10 +202,21 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         commit: Commit,
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[TPayload]:
+        commit_strategy: ProcessingStrategy[Any]
+        if self.__commit_log_config is not None:
+            commit_strategy = ProduceCommitLog(
+                self.__commit_log_config.producer,
+                self.__commit_log_config.topic,
+                self.__commit_log_config.group_id,
+                commit,
+            )
+        else:
+            commit_strategy = CommitOffsets(commit)
+
         collect = (
             ParallelCollectStep(
                 self.__collector,
-                CommitOffsets(commit),
+                commit_strategy,
                 self.__max_batch_size,
                 self.__max_batch_time,
                 self.__parallel_collect_timeout,
@@ -119,7 +224,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
             if self.__parallel_collect
             else CollectStep(
                 self.__collector,
-                CommitOffsets(commit),
+                commit_strategy,
                 self.__max_batch_size,
                 self.__max_batch_time,
             )

--- a/tests/consumers/test_strategy_factory.py
+++ b/tests/consumers/test_strategy_factory.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+from typing import Any
+from unittest.mock import Mock, patch
+
+from arroyo.types import BrokerValue, Message, Partition, Topic
+
+from snuba.consumers.strategy_factory import ProduceCommitLog
+
+
+@patch("time.time")
+def test_produce_commit_log(time_mock: Any) -> None:
+    start = datetime(2022, 12, 12)
+    time_mock.return_value = start.timestamp()
+
+    producer = Mock()
+    main_topic = Topic("main-topic")
+    partition = Partition(main_topic, 0)
+    now = datetime.now()
+    commit_log_topic = Topic("commit-log")
+    commit_func = Mock()
+    strategy = ProduceCommitLog(
+        producer, commit_log_topic, "errors-consumer-group", commit_func
+    )
+
+    strategy.submit(Message(BrokerValue(0, partition, 1, now)))
+
+    assert commit_func.call_count == 0
+    assert producer.produce.call_count == 0
+
+    # Advance time by 1 second
+    now = start + timedelta(seconds=1)
+    time_mock.return_value = now.timestamp()
+
+    strategy.poll()
+    assert commit_func.call_count == 1
+    assert producer.produce.call_count == 1


### PR DESCRIPTION
The ``KafkaConsumerWithCommitLog`` was a huge hack that essentially moved what should be part of the processing strategy logic (produce and commit) into the consumer code instead to be executed post strategy.

The main issue with this (in addition to be a bit against the library's design) is that it required a big change to Arroyo's interface to support - instead of committing simply an offset and it's partition, we need to now pass the original message timestamp all the way through the commit interface unnecessarily.... just because of this consumer. This makes every other consumer (where committing never needs the timestamp) more complicated.

This is the first step towards deprecating the commit log consumer, and simplifying committing offsets in Arroyo. It removes the KafkaConsumerWithCommitLog from the main Snuba consumer. It will be removed from the multistorage consumer as a follow up.