### PR TITLE
ref: Rewrite Snuba replacer to not use batch processing strategy

### DIFF
--- a/snuba/cli/replacer.py
+++ b/snuba/cli/replacer.py
@@ -86,7 +86,7 @@ def replacer(
 
     from arroyo import Topic, configure_metrics
     from arroyo.backends.kafka import KafkaConsumer
-    from arroyo.commit import IMMEDIATE
+    from arroyo.commit import ONCE_PER_SECOND
     from arroyo.processing import StreamProcessor
 
     from snuba.replacer import ReplacerStrategyFactory, ReplacerWorker
@@ -130,7 +130,7 @@ def replacer(
             max_batch_size=max_batch_size,
             max_batch_time=max_batch_time_ms,
         ),
-        IMMEDIATE,
+        ONCE_PER_SECOND,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import time
 from abc import ABC, abstractmethod
@@ -9,15 +11,12 @@ from typing import Callable, List, Mapping, MutableMapping, Optional, Sequence, 
 
 import simplejson as json
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.processing.strategies import CommitOffsets, RunTask
 from arroyo.processing.strategies.abstract import (
     ProcessingStrategy,
     ProcessingStrategyFactory,
 )
-from arroyo.processing.strategies.batching import (
-    AbstractBatchWorker,
-    BatchProcessingStrategy,
-)
-from arroyo.types import BrokerValue, Message, Partition, Position
+from arroyo.types import BrokerValue, Commit, Message, Partition
 
 from snuba import settings
 from snuba.clickhouse.native import ClickhousePool
@@ -273,10 +272,10 @@ TPayload = TypeVar("TPayload")
 TResult = TypeVar("TResult")
 
 
-class ReplacerStrategyFactory(ProcessingStrategyFactory[TPayload]):
+class ReplacerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     def __init__(
         self,
-        worker: AbstractBatchWorker[TPayload, TResult],
+        worker: ReplacerWorker,
         max_batch_size: int,
         max_batch_time: int,
     ) -> None:
@@ -286,18 +285,20 @@ class ReplacerStrategyFactory(ProcessingStrategyFactory[TPayload]):
 
     def create_with_partitions(
         self,
-        commit: Callable[[Mapping[Partition, Position]], None],
+        commit: Commit,
         partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[TPayload]:
-        return BatchProcessingStrategy(
-            commit,
-            self.__worker,
-            self.__max_batch_size,
-            self.__max_batch_time,
-        )
+    ) -> ProcessingStrategy[KafkaPayload]:
+        def processing_func(message: Message[KafkaPayload]) -> None:
+            processed = self.__worker.process_message(message)
+            batch = [] if processed is None else [processed]
+            return self.__worker.flush_batch(batch)
+
+        commit_offsets: ProcessingStrategy[None] = CommitOffsets(commit)
+
+        return RunTask(processing_func, commit_offsets)
 
 
-class ReplacerWorker(AbstractBatchWorker[KafkaPayload, Replacement]):
+class ReplacerWorker:
     def __init__(
         self,
         storage: WritableTableStorage,


### PR DESCRIPTION
The Batch processing strategy / Abstract batch worker classes are getting deprecated from Arroyo. The Snuba replacer use case does not really even benefit from batch processing since we execute one message at a time. This change swaps in RunTask instead of BatchProcessingStep. I did not make any major changes to the ReplacerWorker code yet, but it could be tackled as a follow up.

