### PR TITLE
migrations UI fixes

### DIFF
--- a/snuba/admin/static/clickhouse_migrations/index.tsx
+++ b/snuba/admin/static/clickhouse_migrations/index.tsx
@@ -100,7 +100,7 @@ function ClickhouseMigrations(props: { api: Client }) {
     executeRealRun(action, force);
   }
 
-  function executeRun(action: Action, dry_run: boolean, force: boolean, cb: (stdout: string) => void ) {
+  function executeRun(action: Action, dry_run: boolean, force: boolean, cb?: (stdout: string) => void ) {
     let req = {
       action: action,
       migration_id: migrationId,
@@ -132,7 +132,7 @@ function ClickhouseMigrations(props: { api: Client }) {
   function executeDryRun(action: Action) {
     console.log("executing dry run !", migrationId, action);
     setHeader(()=> dry_run_header)
-    executeRun(action, true, false, null)
+    executeRun(action, true, false)
     setShowAction(()=> true)
 
   }
@@ -311,8 +311,6 @@ function ClickhouseMigrations(props: { api: Client }) {
           <div style={sqlBox}>
             <p style={textStyle}>
               {header}
-              {/* Raw SQL for running a migration (forwards) or reversing
-              (backwards). Good to do before executing a migration for real. */}
             </p>
             <textarea style={textareaStyle} readOnly value={SQLText} />
           </div>

--- a/snuba/admin/static/clickhouse_migrations/index.tsx
+++ b/snuba/admin/static/clickhouse_migrations/index.tsx
@@ -100,7 +100,8 @@ function ClickhouseMigrations(props: { api: Client }) {
     executeRealRun(action, force);
   }
 
-  function executeRun(action: Action, dry_run: boolean, force: boolean, cb?: (stdout: string) => void ) {
+  function executeRun(action: Action, dry_run: boolean, force: boolean,
+    cb?: (stdout: string, err?: string) => void ) {
     let req = {
       action: action,
       migration_id: migrationId,
@@ -124,8 +125,11 @@ function ClickhouseMigrations(props: { api: Client }) {
         }
       })
       .catch((err) => {
-        console.log(err);
+        console.error(err);
         setSQLText(() => JSON.stringify(err));
+        if (cb) {
+          cb("", JSON.stringify(err))
+        }
       });
   }
 
@@ -134,15 +138,17 @@ function ClickhouseMigrations(props: { api: Client }) {
     setHeader(()=> dry_run_header)
     executeRun(action, true, false)
     setShowAction(()=> true)
-
   }
 
   function executeRealRun(action: Action, force: boolean) {
     console.log("executing real run !", migrationId, action, force);
     setHeader(()=> real_run_header)
-    executeRun(action, false, force, (stdout: string) => {
+    executeRun(action, false, force, (stdout: string, err?: string) => {
       if (stdout.indexOf("migration.completed") > -1) {
         alert(`Migration ${migrationId} ${action} completed successfully`)
+      } else {
+        alert(`Migration ${migrationId} ${action} didn't complete.` +
+              `See run log output. \n\n ${err||""} \n ${stdout}`)
       }
     })
 

--- a/snuba/admin/static/clickhouse_migrations/index.tsx
+++ b/snuba/admin/static/clickhouse_migrations/index.tsx
@@ -20,7 +20,7 @@ function ClickhouseMigrations(props: { api: Client }) {
   const [header, setHeader] = useState<string | null>(null);
   const [show_action, setShowAction] = useState<boolean | null>(false);
 
-  const dry_run_header = "Raw SQL for running a migration (forwards) or reversing \n (backwards). Good to do before executing a migration for real."
+  const dry_run_header = "Dry run SQL output"
   const real_run_header = "Run log output"
 
   const [forwards_dry_run, setFowardsDryRun] = useState<string | null>(null);
@@ -36,7 +36,7 @@ function ClickhouseMigrations(props: { api: Client }) {
     });
   }, []);
 
-  function clearState() {
+  function clearBtnState() {
     setBackwardsDryRun(() => null)
     setFowardsDryRun(() => null)
     setSQLText(() => null);
@@ -45,7 +45,7 @@ function ClickhouseMigrations(props: { api: Client }) {
   function selectGroup(groupName: string) {
     const migrationGroup: MigrationGroupResult = allGroups[groupName];
     setMigrationGroup(() => migrationGroup);
-    clearState()
+    clearBtnState()
     setMigrationId(() => null);
     setShowAction(()=> false)
     refreshStatus(migrationGroup.group);
@@ -53,7 +53,7 @@ function ClickhouseMigrations(props: { api: Client }) {
 
   function selectMigration(migrationId: string) {
     setMigrationId(() => migrationId);
-    clearState()
+    clearBtnState()
     setShowAction(()=> false)
   }
 
@@ -142,6 +142,7 @@ function ClickhouseMigrations(props: { api: Client }) {
 
   function executeRealRun(action: Action, force: boolean) {
     console.log("executing real run !", migrationId, action, force);
+    clearBtnState()
     setHeader(()=> real_run_header)
     executeRun(action, false, force, (stdout: string, err?: string) => {
       if (stdout.indexOf("migration.completed") > -1) {
@@ -299,20 +300,24 @@ function ClickhouseMigrations(props: { api: Client }) {
               <br />
               <button type="button"
                 onClick={() => executeDryRun(Action.Run)}
-                style={buttonStyle}
+                style={forwards_dry_run? selectedButtonStyle : buttonStyle}
               >
                 DRY RUN forwards
               </button>
               <button
                 type="button"
                 onClick={() => executeDryRun(Action.Reverse)}
-                style={buttonStyle}
+                style={backwards_dry_run ? selectedButtonStyle : buttonStyle}
               >
                 DRY RUN backwards
               </button>
             </div>
           )}
         </div>
+        <p>
+        Before executing a migration, do a dry run first. This will generate the raw SQL for running a migration (forwards) or reversing (backwards) a migration so that you can verify it's contents.
+        </p>
+
         {migrationGroup && migrationId && SQLText && (
           <div style={sqlBox}>
             <p style={textStyle}>
@@ -357,6 +362,12 @@ const buttonStyle = {
   padding: "2px 5px",
   marginRight: "10px",
 };
+
+const selectedButtonStyle = {
+  color: "red",
+  padding: "2px 5px",
+  marginRight: "10px",
+}
 
 const textStyle = {
   fontSize: 14,


### PR DESCRIPTION
UI fixes to the migrations tool

1. Makes it clearer what the dry run buttons do
2. Only presents the EXECUTE buttons run/reverse immediately after user has just run the dry run. Reduces risk of user mistakenly clicking forwards run when they are looking at a dry run from reverse.
3. Show a success/fail alert.


https://user-images.githubusercontent.com/1960911/207752692-28f0cfc0-49c8-480f-89aa-61f6d5c0dc35.mov



