### PR TITLE
fix(admin): build bundle outside of arm64 image 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,15 +169,28 @@ jobs:
       # support the image on Docker Hub
       # NOTE: This image has only been tested for local development
       SNUBA_IMAGE: ghcr.io/getsentry/snuba-arm64-dev
+      NODE_VERSION: 19.x
     steps:
       - uses: actions/checkout@v3
         name: Checkout code
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{env.NODE_VERSION}}
       - name: Get branch name
         id: branch
         # strip `refs/heads/` from $GITHUB_REF and replace `/` with `-` so that
         # it can be used as a docker tag
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> "$GITHUB_OUTPUT"
+      # for Arm64, we build the bundle.js outside of docker because inside it is extremely
+      # slow due to emulation.
+      - name: build admin UI
+        run: |
+          # allow copying the bundle to docker image
+          sed -i "s/snuba\/admin\/dist\/bundle.js\*//g" .dockerignore
+          # build bundle
+          cd snuba/admin
+          yarn install
+          yarn run build
 
       - name: enable arm64 building
         run: docker run --rm --privileged tonistiigi/binfmt --install arm64
@@ -201,7 +214,8 @@ jobs:
             -t ${SNUBA_IMAGE}:latest \
             -t ${SNUBA_IMAGE}:${{ steps.branch.outputs.branch }} \
             -t ${SNUBA_IMAGE}:${{ github.sha }} \
-            --load .
+            --load . \
+            --target application
 
       - name: Publish
         # Forks cannot push to the getsentry org

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.8.13
-FROM python:${PYTHON_VERSION}-slim-bullseye AS application
+FROM python:${PYTHON_VERSION}-slim-bullseye AS base
 
 WORKDIR /usr/src/snuba
 
@@ -36,6 +36,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*;
 
 # Install nodejs and yarn and build the admin UI
+FROM base AS build_admin_ui
 ENV NODE_VERSION=19
 COPY ./snuba/admin ./snuba/admin
 RUN set -ex; \
@@ -56,6 +57,7 @@ RUN set -ex; \
 
 # Layer cache is pretty much invalidated here all the time,
 # so try not to do anything heavy beyond here.
+FROM base AS application
 COPY . ./
 RUN set -ex; \
     groupadd -r snuba --gid 1000; \


### PR DESCRIPTION
Building the admin UI within the Arm64 docker image is very slow because GH use emulation. Changes to snuba/admin would invalidate the cache and trigger this slow building. This speeds up the CI by building the bundle.js outside of the docker image and copying the file into the container.