### PR TITLE
fix(discover): DefaultNoneColumnMapper Group By 

### DIFF
--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -314,6 +314,25 @@ class DiscoverEventsEntity(BaseEventsEntity):
         )
 
 
+class DiscoverTransactionsEntity(BaseTransactionsEntity):
+    """
+    Identical to TransactionsEntity except it maps columns and functions present
+    in the events entity to null. This logic will eventually move to Sentry and this
+    entity can be deleted and replaced with the TransactionsEntity directly.
+    """
+
+    def __init__(self) -> None:
+        mappers = transaction_translation_mappers.concat(
+            null_function_translation_mappers
+        )
+        super().__init__(
+            custom_mappers=mappers,
+            custom_validators=[
+                DefaultNoneColumnValidator(default_none_column_mappers(mappers))
+            ],
+        )
+
+
 def default_none_column_mappers(
     mappers: TranslationMappers,
 ) -> list[DefaultNoneColumnMapper]:
@@ -323,18 +342,3 @@ def default_none_column_mappers(
         if isinstance(col_mapper, DefaultNoneColumnMapper)
     ]
     return default_none_column_mappers
-
-
-class DiscoverTransactionsEntity(BaseTransactionsEntity):
-    """
-    Identical to TransactionsEntity except it maps columns and functions present
-    in the events entity to null. This logic will eventually move to Sentry and this
-    entity can be deleted and replaced with the TransactionsEntity directly.
-    """
-
-    def __init__(self) -> None:
-        super().__init__(
-            custom_mappers=transaction_translation_mappers.concat(
-                null_function_translation_mappers
-            )
-        )

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -278,7 +278,7 @@ class DiscoverEntity(Entity):
             writable_storage=None,
             validators=[
                 EntityRequiredColumnValidator({"project_id"}),
-                DefaultNoneColumnValidator(setify(mappers)),
+                DefaultNoneColumnValidator(default_none_column_mappers(mappers)),
             ],
             required_time_column="timestamp",
             subscription_processors=None,
@@ -308,17 +308,21 @@ class DiscoverEventsEntity(BaseEventsEntity):
         mappers = events_translation_mappers.concat(null_function_translation_mappers)
         super().__init__(
             custom_mappers=mappers,
-            custom_validators=[DefaultNoneColumnValidator(setify(mappers))],
+            custom_validators=[
+                DefaultNoneColumnValidator(default_none_column_mappers(mappers))
+            ],
         )
 
 
-def setify(mappers: TranslationMappers) -> set[str]:
-    set_of_default_none_columns: set[str] = set()
-    for col_mapper in mappers.columns:
-        if isinstance(col_mapper, DefaultNoneColumnMapper):
-            for col in col_mapper.columns:
-                set_of_default_none_columns.add(col.name)
-    return set_of_default_none_columns
+def default_none_column_mappers(
+    mappers: TranslationMappers,
+) -> list[DefaultNoneColumnMapper]:
+    default_none_column_mappers = [
+        col_mapper
+        for col_mapper in mappers.columns
+        if isinstance(col_mapper, DefaultNoneColumnMapper)
+    ]
+    return default_none_column_mappers
 
 
 class DiscoverTransactionsEntity(BaseTransactionsEntity):

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1340,7 +1340,6 @@ def _align_max_days_date_align(
 def validate_entities_with_query(
     query: Union[CompositeQuery[QueryEntity], LogicalQuery]
 ) -> None:
-    print("Validating..")
     if isinstance(query, LogicalQuery):
         entity = get_entity(query.get_from_clause().key)
         try:

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1340,6 +1340,7 @@ def _align_max_days_date_align(
 def validate_entities_with_query(
     query: Union[CompositeQuery[QueryEntity], LogicalQuery]
 ) -> None:
+    print("Validating..")
     if isinstance(query, LogicalQuery):
         entity = get_entity(query.get_from_clause().key)
         try:

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1681,6 +1681,31 @@ class TestDiscoverApi(BaseApiTest):
         data = json.loads(response.data)["data"]
         assert len(data) == 11
 
+    def test_group_by_identity_null_column(self) -> None:
+        response = self.post(
+            json.dumps(
+                {
+                    "selected_columns": ["duration"],
+                    "project": [self.project_id],
+                    "dataset": "discover",
+                    "from_date": (self.base_time - self.skew).isoformat(),
+                    "to_date": (self.base_time + self.skew).isoformat(),
+                    "groupby": ["duration"],
+                    "conditions": [
+                        ["project_id", "IN", [self.project_id]],
+                        ["type", "=", "error"],
+                    ],
+                }
+            ),
+            entity="discover",
+        )
+        assert response.status_code == 400
+        error_message = json.loads(response.data)["error"]["message"]
+        assert error_message == (
+            "validation failed for entity discover_events: "
+            "cannot group by column(s) defaulting to None: {'duration'}"
+        )
+
 
 class TestDiscoverAPIEntitySelection(TestDiscoverApi):
     """


### PR DESCRIPTION
### Overview
- If you select AND group by a column which will be set to `identity(NULL)`, we surface a ClickHouse error:
    - `DB::Exception: Size of permutation doesn't match size of column.`
- The query being sent to us isn’t technically wrong, so this shouldn’t cause a 500 error
- It is however, impossible to serve

### Changes
- Introduced a new QueryValidator which just applies the `DefaultNoneColumnMapper` to all columns in a group by condition to catch this case

### Notes
- This ONLY applies to Discover since that is the only entity which should ever use the mapper above


Closes [SNS-1942](https://getsentry.atlassian.net/browse/SNS-1942)