### PR TITLE
feat(devserver): Refactor devserver to use CLI args instead of settings

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -1,12 +1,24 @@
 import click
 
-from snuba import settings
-
 
 @click.command()
 @click.option("--bootstrap/--no-bootstrap", default=True)
 @click.option("--workers/--no-workers", default=True)
-def devserver(*, bootstrap: bool, workers: bool) -> None:
+@click.option("--metrics/--no-metrics", default=False)
+@click.option("--profiles/--no-profiles", default=False)
+@click.option("--replays/--no-replays", default=False)
+@click.option(
+    "--combined-scheduler-executor/--separate-scheduler-executor", default=True
+)
+def devserver(
+    *,
+    bootstrap: bool,
+    workers: bool,
+    metrics: bool,
+    profiles: bool,
+    replays: bool,
+    combined_scheduler_executor: bool
+) -> None:
     "Starts all Snuba processes for local development."
     import os
     import sys
@@ -108,7 +120,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
         ),
     ]
 
-    if settings.SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV:
+    if not combined_scheduler_executor:
         daemons += [
             (
                 "subscriptions-scheduler-events",
@@ -200,7 +212,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
             ),
         ]
 
-    if settings.ENABLE_SENTRY_METRICS_DEV:
+    if metrics:
         daemons += [
             (
                 "metrics-consumer",
@@ -239,8 +251,8 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                 ],
             ),
         ]
-        if settings.ENABLE_METRICS_SUBSCRIPTIONS:
-            if settings.SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV:
+        if metrics:
+            if not combined_scheduler_executor:
                 daemons += [
                     (
                         "subscriptions-scheduler-metrics-counters",
@@ -332,7 +344,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     ),
                 ]
 
-    if settings.ENABLE_PROFILES_CONSUMER:
+    if profiles:
         daemons += [
             (
                 "profiles",
@@ -358,7 +370,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
             ),
         ]
 
-    if settings.ENABLE_REPLAYS_CONSUMER:
+    if replays:
         daemons += [
             (
                 "replays-consumer",

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -249,16 +249,6 @@ TRANSACT_SKIP_CONTEXT_STORE: Mapping[int, Set[str]] = {}
 # Map the Zookeeper path for the replicated merge tree to something else
 CLICKHOUSE_ZOOKEEPER_OVERRIDE: Mapping[str, str] = {}
 
-# Enable Sentry Metrics (used for the snuba metrics consumer)
-ENABLE_SENTRY_METRICS_DEV = os.environ.get("ENABLE_SENTRY_METRICS_DEV", False)
-
-# Metric Alerts Subscription Options
-ENABLE_METRICS_SUBSCRIPTIONS = os.environ.get("ENABLE_METRICS_SUBSCRIPTIONS", False)
-
-SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV = os.environ.get(
-    "SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS_DEV", False
-)
-
 # Subscriptions scheduler buffer size
 SUBSCRIPTIONS_DEFAULT_BUFFER_SIZE = 10000
 SUBSCRIPTIONS_ENTITY_BUFFER_SIZE: Mapping[str, int] = {}  # (entity name, buffer size)
@@ -269,12 +259,6 @@ TRANSACTIONS_DIRECT_TO_READONLY_REFERRERS: Set[str] = set()
 # rather than using materialized views
 WRITE_METRICS_AGG_DIRECTLY = False
 ENABLED_MATERIALIZATION_VERSION = 4
-
-# Enable profiles ingestion
-ENABLE_PROFILES_CONSUMER = os.environ.get("ENABLE_PROFILES_CONSUMER", False)
-
-# Enable replays ingestion
-ENABLE_REPLAYS_CONSUMER = os.environ.get("ENABLE_REPLAYS_CONSUMER", False)
 
 MAX_ROWS_TO_CHECK_FOR_SIMILARITY = 1000
 


### PR DESCRIPTION
Our settings is getting very polluted with random settings for the devserver. None of this is relevant except for in the devserver anyway. This moves them to CLI args.

The following settings have been removed:
- ENABLE_SENTRY_METRICS_DEV
- ENABLE_METRICS_SUBSCRIPTIONS
- SEPARATE_SCHEDULER_EXECUTOR_SUBSCRIPTIONS
- ENABLE_PROFILES_CONSUMER
- ENABLE_REPLAYS_CONSUMER
