### PR TITLE
feat: Deprecate the KafkaConsumerWithCommitLog

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -25,6 +25,8 @@ from typing import (
 
 import rapidjson
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.backends.kafka.commit import CommitCodec
+from arroyo.commit import Commit as CommitLogCommit
 from arroyo.processing.strategies import FilterStep
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
@@ -37,7 +39,10 @@ from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
 from arroyo.types import BrokerValue, Commit, Message, Partition, Topic
+from confluent_kafka import KafkaError
+from confluent_kafka import Message as ConfluentMessage
 from confluent_kafka import Producer as ConfluentKafkaProducer
+from confluent_kafka import Producer as ConfluentProducer
 
 from snuba.clickhouse.http import JSONRow, JSONRowEncoder, ValuesRowEncoder
 from snuba.consumers.strategy_factory import ConsumerStrategyFactory
@@ -59,6 +64,14 @@ from snuba.utils.streams.configuration_builder import build_kafka_producer_confi
 from snuba.writer import BatchWriter
 
 logger = logging.getLogger("snuba.consumer")
+
+commit_codec = CommitCodec()
+
+
+class CommitLogConfig(NamedTuple):
+    producer: ConfluentProducer
+    topic: Topic
+    group_id: str
 
 
 class BytesInsertBatch(NamedTuple):
@@ -226,9 +239,15 @@ class ProcessedMessageBatchWriter(
         self,
         insert_batch_writer: InsertBatchWriter,
         replacement_batch_writer: Optional[ProcessingStep[ReplacementBatch]] = None,
+        # If commit log config is passed, we will produce to the commit log topic
+        # upon closing each batch.
+        commit_log_config: Optional[CommitLogConfig] = None,
     ) -> None:
         self.__insert_batch_writer = insert_batch_writer
         self.__replacement_batch_writer = replacement_batch_writer
+        self.__commit_log_config = commit_log_config
+        self.__commit_codec = CommitCodec()
+        self.__offsets_to_produce: MutableMapping[Partition, Tuple[int, datetime]] = {}
 
         self.__closed = False
 
@@ -258,6 +277,18 @@ class ProcessedMessageBatchWriter(
         else:
             raise TypeError("unexpected payload type")
 
+        assert isinstance(message.value, BrokerValue)
+        self.__offsets_to_produce[message.value.partition] = (
+            message.value.offset,
+            message.value.timestamp,
+        )
+
+    def __commit_message_delivery_callback(
+        self, error: Optional[KafkaError], message: ConfluentMessage
+    ) -> None:
+        if error is not None:
+            raise Exception(error.str())
+
     def close(self) -> None:
         self.__closed = True
 
@@ -265,6 +296,21 @@ class ProcessedMessageBatchWriter(
 
         if self.__replacement_batch_writer is not None:
             self.__replacement_batch_writer.close()
+
+        if self.__commit_log_config is not None:
+            for partition, (offset, timestamp) in self.__offsets_to_produce.items():
+                payload = self.__commit_codec.encode(
+                    CommitLogCommit(
+                        self.__commit_log_config.group_id, partition, offset, timestamp
+                    )
+                )
+                self.__commit_log_config.producer.produce(
+                    self.__commit_log_config.topic.name,
+                    key=payload.key,
+                    value=payload.value,
+                    headers=payload.headers,
+                    on_delivery=self.__commit_message_delivery_callback,
+                )
 
     def terminate(self) -> None:
         self.__closed = True
@@ -307,6 +353,7 @@ def build_batch_writer(
     metrics: MetricsBackend,
     replacements_producer: Optional[ConfluentKafkaProducer] = None,
     replacements_topic: Optional[Topic] = None,
+    commit_log_config: Optional[CommitLogConfig] = None,
     slice_id: Optional[int] = None,
 ) -> Callable[[], ProcessedMessageBatchWriter]:
 
@@ -335,7 +382,7 @@ def build_batch_writer(
             replacement_batch_writer = None
 
         return ProcessedMessageBatchWriter(
-            insert_batch_writer, replacement_batch_writer
+            insert_batch_writer, replacement_batch_writer, commit_log_config
         )
 
     return build_writer

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -12,7 +12,11 @@ from arroyo.utils.profiler import ProcessingStrategyProfilerWrapperFactory
 from arroyo.utils.retries import BasicRetryPolicy, RetryPolicy
 from confluent_kafka import KafkaError, KafkaException, Producer
 
-from snuba.consumers.consumer import build_batch_writer, process_message
+from snuba.consumers.consumer import (
+    CommitLogConfig,
+    build_batch_writer,
+    process_message,
+)
 from snuba.consumers.strategy_factory import KafkaConsumerStrategyFactory
 from snuba.datasets.slicing import validate_passed_slice
 from snuba.datasets.storages.factory import get_writable_storage
@@ -24,9 +28,6 @@ from snuba.utils.streams.configuration_builder import (
     build_kafka_consumer_configuration,
     build_kafka_producer_configuration,
     get_default_kafka_configuration,
-)
-from snuba.utils.streams.kafka_consumer_with_commit_log import (
-    KafkaConsumerWithCommitLog,
 )
 
 logger = logging.getLogger(__name__)
@@ -212,18 +213,10 @@ class ConsumerBuilder:
                 }
             )
 
-        if self.commit_log_topic is None:
-            consumer = KafkaConsumer(
-                configuration,
-                commit_retry_policy=self.__commit_retry_policy,
-            )
-        else:
-            consumer = KafkaConsumerWithCommitLog(
-                configuration,
-                producer=self.producer,
-                commit_log_topic=self.commit_log_topic,
-                commit_retry_policy=self.__commit_retry_policy,
-            )
+        consumer = KafkaConsumer(
+            configuration,
+            commit_retry_policy=self.__commit_retry_policy,
+        )
 
         return StreamProcessor(consumer, self.raw_topic, strategy_factory, IMMEDIATE)
 
@@ -235,6 +228,13 @@ class ConsumerBuilder:
         stream_loader = table_writer.get_stream_loader()
 
         processor = stream_loader.get_processor()
+
+        if self.commit_log_topic:
+            commit_log_config = CommitLogConfig(
+                self.producer, self.commit_log_topic, self.group_id
+            )
+        else:
+            commit_log_config = None
 
         strategy_factory: ProcessingStrategyFactory[
             KafkaPayload
@@ -251,6 +251,7 @@ class ConsumerBuilder:
                 ),
                 replacements_topic=self.replacements_topic,
                 slice_id=slice_id,
+                commit_log_config=commit_log_config,
             ),
             max_batch_size=self.max_batch_size,
             max_batch_time=self.max_batch_time_ms / 1000.0,


### PR DESCRIPTION
Another take at killing the KafkaConsumerWithCommitLog. This implementation moves the part that produces offsets to the commit log topic into the collect step.

For context, the previous take on it was https://github.com/getsentry/snuba/pull/3511/ but this other approach doesn't work well. Since Collect/ParallelCollect does not pass any output to the next step, it must be done within this processing step itself.

This change is needed as Arroyo will no longer pass message timestamps through to the commit callback function via `Position`. It is wasteful, affects performance and only existed to support this particular use case (writing part of the strategy logic in the consumer) which is not really a valid one.