### PR TITLE
feat(admin): Show dist nodes hosts

### DIFF
--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -18,7 +18,7 @@ Storage = TypedDict(
         "local_table_name": str,
         "local_nodes": Sequence[Node],
         "dist_nodes": Sequence[Node],
-        "query_node": Node,
+        "query_node": Optional[Node],
     },
 )
 

--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -13,7 +13,12 @@ Node = TypedDict("Node", {"host": str, "port": int})
 
 Storage = TypedDict(
     "Storage",
-    {"storage_name": str, "local_table_name": str, "local_nodes": Sequence[Node]},
+    {
+        "storage_name": str,
+        "local_table_name": str,
+        "local_nodes": Sequence[Node],
+        "dist_nodes": Sequence[Node],
+    },
 )
 
 
@@ -26,16 +31,27 @@ def _get_local_table_name(storage_key: StorageKey) -> str:
         return "badcluster"
 
 
-def _get_local_nodes(storage_key: StorageKey) -> Sequence[Node]:
+def _get_nodes(storage_key: StorageKey, local: bool = True) -> Sequence[Node]:
     try:
         storage = get_storage(storage_key)
+        cluster = storage.get_cluster()
         return [
             {"host": node.host_name, "port": node.port}
-            for node in storage.get_cluster().get_local_nodes()
+            for node in (
+                cluster.get_local_nodes() if local else cluster.get_distributed_nodes()
+            )
         ]
     except (AssertionError, KeyError, UndefinedClickhouseCluster):
         # If cluster_name is not defined just return an empty list
         return []
+
+
+def _get_local_nodes(storage_key: StorageKey) -> Sequence[Node]:
+    return _get_nodes(storage_key, local=True)
+
+
+def _get_dist_nodes(storage_key: StorageKey) -> Sequence[Node]:
+    return _get_nodes(storage_key, local=False)
 
 
 def get_storage_info() -> Sequence[Storage]:
@@ -44,6 +60,7 @@ def get_storage_info() -> Sequence[Storage]:
             "storage_name": storage_key.value,
             "local_table_name": _get_local_table_name(storage_key),
             "local_nodes": _get_local_nodes(storage_key),
+            "dist_nodes": _get_dist_nodes(storage_key),
         }
         for storage_key in sorted(
             get_all_storage_keys(), key=lambda storage_key: storage_key.value

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -81,6 +81,35 @@ function QueryDisplay(props: {
     window.navigator.clipboard.writeText(text);
   }
 
+  function getHosts(nodeData: ClickhouseNodeData[]) : JSX.Element[]{
+    let node_info = nodeData.find((el) => el.storage_name === query.storage)!;
+    // populate the hosts entries marking distributed hosts that are not also local
+    if (node_info){
+      let local_hosts = node_info.local_nodes.map((node) => (
+              <option
+                key={`${node.host}:${node.port}`}
+                value={`${node.host}:${node.port}`}
+              >
+                {node.host}:{node.port}
+              </option>
+            ))
+      let dist_hosts = node_info.dist_nodes
+          .filter((node)=>!node_info.local_nodes.includes(node))
+          .map((node) => (
+              <option
+                key={`${node.host}:${node.port}`}
+                value={`${node.host}:${node.port}`}
+              >
+                {node.host}:{node.port} (distributed)
+              </option>
+            ))
+
+      return local_hosts.concat(dist_hosts)
+    }
+    return []
+
+  }
+
   return (
     <div>
       <form>
@@ -116,16 +145,7 @@ function QueryDisplay(props: {
               <option disabled value="">
                 Select a host
               </option>
-              {nodeData
-                .find((el) => el.storage_name === query.storage)
-                ?.local_nodes.map((node) => (
-                  <option
-                    key={`${node.host}:${node.port}`}
-                    value={`${node.host}:${node.port}`}
-                  >
-                    {node.host}:{node.port}
-                  </option>
-                ))}
+              {getHosts(nodeData)}
             </select>
           </div>
           <div>

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -103,9 +103,10 @@ function QueryDisplay(props: {
                 {node.host}:{node.port} (distributed)
               </option>
             ))
+      let hosts = local_hosts.concat(dist_hosts)
       let query_node = node_info.query_node
-
-      return local_hosts.concat(dist_hosts).concat(
+      if (query_node){
+        hosts.push(
           (<option
             key={`${query_node.host}:${query_node.port}`}
             value={`${query_node.host}:${query_node.port}`}
@@ -114,6 +115,8 @@ function QueryDisplay(props: {
           </option>
           )
         )
+      }
+      return hosts
     }
     return []
 

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -103,8 +103,17 @@ function QueryDisplay(props: {
                 {node.host}:{node.port} (distributed)
               </option>
             ))
+      let query_node = node_info.query_node
 
-      return local_hosts.concat(dist_hosts)
+      return local_hosts.concat(dist_hosts).concat(
+          (<option
+            key={`${query_node.host}:${query_node.port}`}
+            value={`${query_node.host}:${query_node.port}`}
+          >
+            {query_node.host}:{query_node.port} (query node)
+          </option>
+          )
+        )
     }
     return []
 

--- a/snuba/admin/static/clickhouse_queries/types.tsx
+++ b/snuba/admin/static/clickhouse_queries/types.tsx
@@ -7,6 +7,7 @@ type ClickhouseNodeData = {
   storage_name: string;
   local_table_name: string;
   local_nodes: ClickhouseNode[];
+  dist_nodes: ClickhouseNode[];
 };
 
 type QueryRequest = {

--- a/snuba/admin/static/clickhouse_queries/types.tsx
+++ b/snuba/admin/static/clickhouse_queries/types.tsx
@@ -8,6 +8,7 @@ type ClickhouseNodeData = {
   local_table_name: string;
   local_nodes: ClickhouseNode[];
   dist_nodes: ClickhouseNode[];
+  query_node: ClickhouseNode
 };
 
 type QueryRequest = {

--- a/test_distributed_migrations/conftest.py
+++ b/test_distributed_migrations/conftest.py
@@ -39,8 +39,8 @@ def pytest_configure() -> None:
             default=lambda x: list(x) if isinstance(x, set) else x.__dict__,
         ),
     )
-    print("waiting 30 seconds for clickhouse to start")
-    time.sleep(30)  # wait for clickhouse to start
+    print("waiting 10 seconds for clickhouse to start")
+    time.sleep(10)  # wait for clickhouse to start
 
     for cluster_node in settings.CLUSTERS:
         clickhouse_cluster = ClickhouseCluster(

--- a/test_distributed_migrations/test_get_nodes.py
+++ b/test_distributed_migrations/test_get_nodes.py
@@ -1,0 +1,13 @@
+from snuba.admin.clickhouse.nodes import _get_dist_nodes, _get_local_nodes
+from snuba.datasets.storages.storage_key import StorageKey
+
+
+def test_get_local_and_distributed_nodes() -> None:
+    # test we get the right nodes when dist and local have different hosts
+    assert sorted(_get_local_nodes(StorageKey.ERRORS), key=lambda n: n["host"]) == [
+        {"host": "clickhouse-02", "port": 9000},
+        {"host": "clickhouse-03", "port": 9000},
+    ]
+    assert _get_dist_nodes(StorageKey.ERRORS) == [
+        {"host": "clickhouse-query", "port": 9000}
+    ]


### PR DESCRIPTION
The dist nodes do not show up as hosts for the system queries tab. This usually isn't an issue locally because the dist hosts are the same a local hosts, but for distributed setups where the two are different, it means we cant run system queries on the dist hosts.

### Before:
The system queries tab would only show local hosts

### After:
The system queries tab shows dist hosts if they are not already included in the local hosts

### Blast Radius
Frontend JSX and `/clickhouse_nodes` admin endpoint.
