### PR TITLE
feat(migration): conditionally auto-run migration based on env var

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -237,10 +237,11 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {
     "profiles",
     "functions",
     "test_migration",
+    "search_issues",
 }
 
 if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
-    SKIPPED_MIGRATION_GROUPS.add("search_issues")
+    SKIPPED_MIGRATION_GROUPS.remove("search_issues")
 
 
 MAX_RESOLUTION_FOR_JITTER = 60

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -237,8 +237,11 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {
     "profiles",
     "functions",
     "test_migration",
-    "search_issues",
 }
+
+if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
+    SKIPPED_MIGRATION_GROUPS.add("search_issues")
+
 
 MAX_RESOLUTION_FOR_JITTER = 60
 


### PR DESCRIPTION
This PR is mostly needed as a stop-gap since we don't have the production infra setup yet for the table yet, but we still want to be able to reference the dataset in sentry CI and dev.