### PR TITLE
fix(issue-platform): Fix `search_issues_processor` to handle event_id and group_id

### DIFF
--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -116,6 +116,7 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
         fields: MutableMapping[str, Any] = {
             "organization_id": event["organization_id"],
             "project_id": event["project_id"],
+            "event_id": event["event_id"],
             "search_title": event_occurrence_data["issue_title"],
             "primary_hash": ensure_uuid(event["primary_hash"]),
             "fingerprint": fingerprints,
@@ -137,14 +138,13 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
 
         return [
             {
-                "group_id": group_id,
+                "group_id": event["group_id"],
                 **fields,
                 "message_timestamp": metadata.timestamp,
                 "retention_days": retention_days,
                 "partition": metadata.partition,
                 "offset": metadata.offset,
             }
-            for group_id in event["group_ids"]
         ]
 
     def process_message(

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -117,7 +117,7 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
         fields: MutableMapping[str, Any] = {
             "organization_id": event["organization_id"],
             "project_id": event["project_id"],
-            "event_id": event["event_id"],
+            "event_id": ensure_uuid(event["event_id"]),
             "search_title": event_occurrence_data["issue_title"],
             "primary_hash": ensure_uuid(event["primary_hash"]),
             "fingerprint": fingerprints,

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -59,6 +59,7 @@ class SearchIssueEvent(TypedDict):
     # issue-related
     organization_id: int
     project_id: int
+    event_id: str
     group_id: int  # backwards compatibility
     group_ids: Sequence[int]
     primary_hash: str

--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -28,7 +28,8 @@ class TestSearchIssuesMessageProcessor:
             {
                 "project_id": 1,
                 "organization_id": 2,
-                "group_ids": (3,),
+                "group_id": 3,
+                "event_id": str(uuid.uuid4()),
                 "retention_days": 90,
                 "primary_hash": str(uuid.uuid4()),
                 "data": {
@@ -73,7 +74,8 @@ class TestSearchIssuesMessageProcessor:
                 {
                     "project_id": 1,
                     "organization_id": 2,
-                    "group_ids": (3,),
+                    "group_id": 3,
+                    "event_id": str(uuid.uuid4()),
                     "retention_days": 90,
                     "data": {
                         "received": datetime.now().timestamp(),

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -59,7 +59,8 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         evt: MutableMapping[str, Any] = dict(
             organization_id=1,
             project_id=2,
-            group_ids=[3],
+            event_id=str(uuid.uuid4().hex),
+            group_id=3,
             primary_hash=str(uuid.uuid4().hex),
             data={"received": now.timestamp()},
             occurrence_data=dict(
@@ -108,7 +109,8 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             {
                 "project_id": 1,
                 "organization_id": 2,
-                "group_ids": [3],
+                "event_id": str(uuid.uuid4()),
+                "group_id": 3,
                 "retention_days": 90,
                 "primary_hash": str(uuid.uuid4()),
                 "data": {

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -100,7 +100,7 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             }
         ]
 
-    def test_test_evenstream_endpoint(self) -> None:
+    def test_eventstream_endpoint(self) -> None:
         now = datetime.now()
 
         event = (


### PR DESCRIPTION
We don't pass `group_ids` for occurrences. Fixing the processor to expect `group_id`, and also to write the `event_id` to the table.
