### PR TITLE
feat: Skip invalid offset ranges

### DIFF
--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -148,9 +148,10 @@ class CommitLogTickConsumer(Consumer[Tick]):
                 time_interval = Interval(
                     previous_message.orig_message_ts, commit.orig_message_ts
                 )
+                offset_interval = Interval(previous_message.offset, commit.offset)
             except InvalidRangeError:
                 logger.warning(
-                    "Could not construct valid time interval between %r and %r!",
+                    "Could not construct valid interval between %r and %r!",
                     previous_message,
                     MessageDetails(commit.offset, commit.orig_message_ts),
                     exc_info=True,
@@ -160,7 +161,7 @@ class CommitLogTickConsumer(Consumer[Tick]):
                 result = BrokerValue(
                     Tick(
                         commit.partition.index,
-                        Interval(previous_message.offset, commit.offset),
+                        offset_interval,
                         time_interval,
                     ).time_shift(self.__time_shift),
                     value.partition,


### PR DESCRIPTION
We had an incident at Sentry (inc-276) caused by the fact that there was an offset/timestamps in the incorrect order in one of the consumers. We are supposed to be catching and ignoring these in the subscriptions scheduler.

We were already handling invalid time intervals, but we forgot to include handling for invalid offset intervals.