### PR TITLE
feat(DC): Deleted Column mandatory condition

### DIFF
--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -90,6 +90,7 @@ schema:
     ]
   local_table_name: discover_local
   dist_table_name: discover_dist
+  not_deleted_mandatory_condition: deleted
 query_processors:
   - processor: MappingColumnPromoter
     args:

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -15,6 +15,10 @@ TYPE_NULLABLE_INTEGER = {"type": ["integer", "null"]}
 TYPE_NULLABLE_STRING = {"type": ["string", "null"]}
 
 
+def string_with_description(description: str) -> dict[str, str]:
+    return {**TYPE_STRING, "description": description}
+
+
 FUNCTION_CALL_SCHEMA = {
     "type": "object",
     "properties": {
@@ -245,6 +249,12 @@ SCHEMA_SCHEMA = {
             "type": "string",
             "description": "The distributed table name in distributed ClickHouse",
         },
+        "not_deleted_mandatory_condition": string_with_description(
+            "The name of the column flagging a deletion, eg `deleted` column in Errors. "
+            "Defining this column here will ensure any query served by this storage "
+            "explicitly filters out any 'deleted' rows. Should only be used for storages "
+            "supporting deletion replacement."
+        ),
         "partition_format": {
             "type": "array",
             "items": {"type": "string"},

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -90,6 +90,10 @@ def _deep_compare_storages(old: Storage, new: Storage) -> None:
 
     if isinstance(schema_old, TableSchema) and isinstance(schema_new, TableSchema):
         assert schema_old.get_table_name() == schema_new.get_table_name()
+        assert (
+            schema_old.get_data_source().get_mandatory_conditions()
+            == schema_new.get_data_source().get_mandatory_conditions()
+        )
 
     if isinstance(old, WritableTableStorage) and isinstance(new, WritableTableStorage):
         assert (


### PR DESCRIPTION
### Overview
- Dataset Config doesn't support the `mandatory_conditions` field in storages
- This is currently only used to modify queries to certain storages so that they don't respond with deleted entries
- This is necessary for Errors (and Discover ❗)
