### PR TITLE
fix: Ensure commit log producer is flushed

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -332,6 +332,12 @@ class ProcessedMessageBatchWriter(
 
             self.__replacement_batch_writer.join(timeout)
 
+        # XXX: This adds a blocking call when each batch is joined. Ideally we would only
+        # call proudcer.flush() when the consumer / strategy is actually being shut down but
+        # the CollectStep that this is called from does not allow us to hook into that easily.
+        if self.__commit_log_config:
+            self.__commit_log_config.producer.flush()
+
 
 json_row_encoder = JSONRowEncoder()
 


### PR DESCRIPTION
We need to ensure the producer is flushed during the consumer shutdown process.This fix flushes the commit log producer on each batch. It does add a blocking operation on each batch. Ideally it would only be performed when the consumer is actually shutting down but the current design of the consumer (and use of the CollectStep) does not allow us to easily hook into that. Given the size of batches is fairly large, i think this flush is non problematic.

This is a fix for SNUBA-30Y firing during deployment.