### PR TITLE
fix(init): don't return in the with block

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -63,7 +63,7 @@ class SnubaCLI(click.MultiCommand):
             init_time = time.perf_counter() - start
             metrics.timing("snuba_init_time", init_time)
             logger.info(f"Snuba initialization took {init_time}s")
-            return ns[actual_command_name]
+        return ns[actual_command_name]
 
 
 @click.command(cls=SnubaCLI)


### PR DESCRIPTION
I have a suspicion that the sentry sdk and click are interacting in weird ways. Try this to see if the transaction is labeled properly