### PR TITLE
ci: Update self-hosted e2e to pull from GCB and push to DockerHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,16 +363,26 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: Checkout snuba
-        uses: actions/checkout@v2
-
-      - name: Pull snuba CI images
+      - name: Pull the test image
+        id: image_pull
+        env:
+          SNUBA_TEST_IMAGE: us.gcr.io/sentryio/snuba:${{ github.event.pull_request.head.sha || github.sha }} 
         run: |
-          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || docker pull ghcr.io/getsentry/snuba-ci:latest
+          echo "We poll for the Snuba Docker image that the GCB build produces until it succeeds or this job times out."
+          if [[ -z "$SNUBA_TEST_IMAGE" ]]; then
+              echo "The SNUBA_TEST_IMAGE needs to be set" 1>&2
+              exit 1
+          fi
+          echo "Polling for $SNUBA_TEST_IMAGE"
+          until docker pull "$SNUBA_TEST_IMAGE" 2>/dev/null; do
+              sleep 10
+          done
+          echo "snuba-test-image-name=$SNUBA_TEST_IMAGE" >> "$GITHUB_OUTPUT"
+
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@5bbd3d6725bbe4bf5cc12f8a3291ce87df6a891f
+        uses: getsentry/action-self-hosted-e2e-tests@ethanhs/test-dockerhub-push
         with:
           project_name: snuba
-          local_image: ghcr.io/getsentry/snuba-ci:${{ github.sha }}
           docker_repo: ghcr.io/getsentry/snuba
-          # TODO: add docker tag to build for
+          local_image: ${{ steps.image_pull.outputs.snuba-test-image-name }}
+          docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,38 +365,10 @@ jobs:
     steps:
       - name: Checkout Snuba
         uses: actions/checkout@v3
-      - name: Pull the test image
-        id: image_pull
-        env:
-          SNUBA_TEST_IMAGE: us.gcr.io/sentryio/snuba:${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          echo "We poll for the Snuba Docker image that the GCB build produces until it succeeds or this job times out."
-          if [[ -z "$SNUBA_TEST_IMAGE" ]]; then
-              echo "The SNUBA_TEST_IMAGE needs to be set" 1>&2
-              exit 1
-          fi
-          echo "Polling for $SNUBA_TEST_IMAGE"
-          until docker pull "$SNUBA_TEST_IMAGE" 2>/dev/null; do
-              sleep 10
-          done
-          echo "snuba-test-image-name=$SNUBA_TEST_IMAGE" >> "$GITHUB_OUTPUT"
-      - name: Get short SHA for docker tag
-        id: short_sha
-        shell: bash
-        run: |
-          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
-          if [[ -z "$SHORT_SHA" ]]; then
-            echo "Short SHA empty? Re-running rev-parse."
-            git rev-parse --short "$GITHUB_SHA"
-          else
-            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
-          fi
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@c2ceda76ac951188056325d6670178592ecfa1e7
+        uses: getsentry/action-self-hosted-e2e-tests@ethanhs/add-img-build
         with:
           project_name: snuba
           docker_repo: getsentry/snuba
-          local_image: ${{ steps.image_pull.outputs.snuba-test-image-name }}
+          image_url: us.gcr.io/sentryio/snuba:${{ github.event.pull_request.head.sha || github.sha }}
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
-          full_sha: ${GITHUB_SHA}
-          short_sha: ${{ steps.short_sha.outputs.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,17 @@ jobs:
               sleep 10
           done
           echo "snuba-test-image-name=$SNUBA_TEST_IMAGE" >> "$GITHUB_OUTPUT"
-
+      - name: Get short SHA for docker tag
+        id: short_sha
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          if [[ -z "$SHORT_SHA" ]]; then
+            echo "Short SHA empty? Re-running rev-parse."
+            git rev-parse --short "$GITHUB_SHA"
+          else
+            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          fi
       - name: Run Sentry self-hosted e2e CI
         uses: getsentry/action-self-hosted-e2e-tests@ethanhs/test-dockerhub-push
         with:
@@ -388,3 +398,5 @@ jobs:
           docker_repo: getsentry/snuba
           local_image: ${{ steps.image_pull.outputs.snuba-test-image-name }}
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+          full_sha: ${GITHUB_SHA}
+          short_sha: ${{ steps.short_sha.outputs.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,10 +363,12 @@ jobs:
     continue-on-error: true
 
     steps:
+      - name: Checkout Snuba
+        uses: actions/checkout@v3
       - name: Pull the test image
         id: image_pull
         env:
-          SNUBA_TEST_IMAGE: us.gcr.io/sentryio/snuba:${{ github.event.pull_request.head.sha || github.sha }} 
+          SNUBA_TEST_IMAGE: us.gcr.io/sentryio/snuba:${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           echo "We poll for the Snuba Docker image that the GCB build produces until it succeeds or this job times out."
           if [[ -z "$SNUBA_TEST_IMAGE" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,7 @@ jobs:
             echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           fi
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@ethanhs/test-dockerhub-push
+        uses: getsentry/action-self-hosted-e2e-tests@c2ceda76ac951188056325d6670178592ecfa1e7
         with:
           project_name: snuba
           docker_repo: getsentry/snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@ethanhs/add-img-build
+        uses: getsentry/action-self-hosted-e2e-tests@697a3ca95a72f93e3a1ebdb8f967be38d1f029f6
         with:
           project_name: snuba
           docker_repo: getsentry/snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,6 @@ jobs:
         uses: getsentry/action-self-hosted-e2e-tests@ethanhs/test-dockerhub-push
         with:
           project_name: snuba
-          docker_repo: ghcr.io/getsentry/snuba
+          docker_repo: getsentry/snuba
           local_image: ${{ steps.image_pull.outputs.snuba-test-image-name }}
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}


### PR DESCRIPTION
This PR:
a) Pulls the snuba image from Google Cloud Build so that the images that are pushed can be scanned, and b) Enables pushing of the images to DockerHub, so that tests run in GCB can be replaced with the Github Action here
