### PR TITLE
ref(multistorage-consumer): Stop using ConsumerStrategyFactory

### DIFF
--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -15,22 +15,21 @@ from arroyo.processing.strategies.filter import FilterStep
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
 from arroyo.types import Commit, Message, Partition
 
-TPayload = TypeVar("TPayload")
 TProcessed = TypeVar("TProcessed")
 
 
-class StreamMessageFilter(Protocol[TPayload]):
+class StreamMessageFilter(Protocol):
     """
     A filter over messages coming from a stream. Can be used to pre filter
     messages during consumption but potentially for other use cases as well.
     """
 
     @abstractmethod
-    def should_drop(self, message: Message[TPayload]) -> bool:
+    def should_drop(self, message: Message[KafkaPayload]) -> bool:
         raise NotImplementedError
 
 
-class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
+class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
     """
     Do not use for new consumers.
     This is deprecated and will be removed in a future version.
@@ -58,8 +57,8 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
 
     def __init__(
         self,
-        prefilter: Optional[StreamMessageFilter[TPayload]],
-        process_message: Callable[[Message[TPayload]], TProcessed],
+        prefilter: Optional[StreamMessageFilter],
+        process_message: Callable[[Message[KafkaPayload]], TProcessed],
         collector: Callable[[], ProcessingStrategy[TProcessed]],
         max_batch_size: int,
         max_batch_time: float,
@@ -99,7 +98,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self.__parallel_collect = parallel_collect
         self.__parallel_collect_timeout = parallel_collect_timeout
 
-    def __should_accept(self, message: Message[TPayload]) -> bool:
+    def __should_accept(self, message: Message[KafkaPayload]) -> bool:
         assert self.__prefilter is not None
         return not self.__prefilter.should_drop(message)
 
@@ -107,7 +106,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
         self,
         commit: Commit,
         partitions: Mapping[Partition, int],
-    ) -> ProcessingStrategy[TPayload]:
+    ) -> ProcessingStrategy[KafkaPayload]:
         collect = (
             ParallelCollectStep(
                 self.__collector,
@@ -127,7 +126,7 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
 
         transform_function = self.__process_message
 
-        strategy: ProcessingStrategy[TPayload]
+        strategy: ProcessingStrategy[KafkaPayload]
         if self.__processes is None:
             strategy = TransformStep(transform_function, collect)
         else:
@@ -156,12 +155,3 @@ class ConsumerStrategyFactory(ProcessingStrategyFactory[TPayload]):
             )
 
         return strategy
-
-
-class KafkaConsumerStrategyFactory(ConsumerStrategyFactory[KafkaPayload]):
-    """
-    Do not use for new consumers.
-    This is deprecated and will be removed in a future version.
-    """
-
-    pass


### PR DESCRIPTION
The KafkaConusmerStrategyFactory is supposed to get deprecated. This change refactors the multistorage consumer to stop using it there. It also removes the need for the generic `ConsumerStrategyFactory` which previously needed to be generic so it could take a MultistorageKafkaPayload instead of a KafkaPayload in the multistorage scenario.

Soon we will be adding a new processing step for payload decoding and schema validation - this will happen between the DLQ and the rest of the message processing steps.

This refactor will make it easier to introduce the decoder/validator as it needs to happen in different places in the main consumer vs the multistorage consumer.