### PR TITLE
ref: Remove "kafka_messages_to_skip" config

### DIFF
--- a/tests/state/test_state.py
+++ b/tests/state/test_state.py
@@ -1,15 +1,11 @@
 import random
 import time
 from collections import ChainMap
-from datetime import datetime
 from functools import partial
 
 import pytest
-from arroyo.backends.kafka import KafkaPayload
-from arroyo.types import BrokerValue, Partition, Topic
 
 from snuba import state
-from snuba.consumers.consumer import skip_kafka_message
 from snuba.state import MismatchedTypeException, safe_dumps
 
 
@@ -103,35 +99,6 @@ class TestState:
         assert rand1 == rand()
         time.sleep(0.1)
         assert rand1 != rand()
-
-    def test_skip_kafka_message(self) -> None:
-        state.set_config(
-            "kafka_messages_to_skip", "[snuba-test-lol:1:2,snuba-test-yeet:0:1]"
-        )
-        assert skip_kafka_message(
-            BrokerValue(
-                KafkaPayload(None, b"", []),
-                Partition(Topic("snuba-test-lol"), 1),
-                2,
-                datetime.now(),
-            )
-        )
-        assert skip_kafka_message(
-            BrokerValue(
-                KafkaPayload(None, b"", []),
-                Partition(Topic("snuba-test-yeet"), 0),
-                1,
-                datetime.now(),
-            )
-        )
-        assert not skip_kafka_message(
-            BrokerValue(
-                KafkaPayload(None, b"", []),
-                Partition(Topic("snuba-test-lol"), 2),
-                1,
-                datetime.now(),
-            )
-        )
 
 
 def test_safe_dumps():


### PR DESCRIPTION
Removes the ability to skip Kafka messages via config. This functionality was never used, and shouldn't ever be (invalid messages should be handled via dlqs) not this mechanism.

The motivations to remove this are to:
- remove unnecessary complexity that is never used
- align the consumer and multistorage consumer implementations which will be merged together soon
- make it easier to provide a shared decoder/schema validator implementation for both single storage and multistorage consumer