### PR TITLE
feat(consumer): Remove the --cooperative-rebalancing option

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -113,13 +113,6 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
-# TODO: For testing alternate rebalancing strategies. To be eventually removed.
-@click.option(
-    "--cooperative-rebalancing",
-    is_flag=True,
-    default=False,
-    help="Use cooperative-sticky partition assignment strategy",
-)
 def consumer(
     *,
     raw_events_topic: Optional[str],
@@ -141,7 +134,6 @@ def consumer(
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
     profile_path: Optional[str] = None,
-    cooperative_rebalancing: bool = False,
 ) -> None:
 
     setup_logging(log_level)
@@ -189,7 +181,6 @@ def consumer(
         stats_callback=stats_callback,
         parallel_collect=parallel_collect,
         slice_id=slice_id,
-        cooperative_rebalancing=cooperative_rebalancing,
     )
 
     consumer = consumer_builder.build_base_consumer(slice_id)

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -106,13 +106,6 @@ logger = logging.getLogger(__name__)
     type=int,
 )
 @click.option("--log-level")
-# TODO: For testing alternate rebalancing strategies. To be eventually removed.
-@click.option(
-    "--cooperative-rebalancing",
-    is_flag=True,
-    default=False,
-    help="Use cooperative-sticky partition assignment strategy",
-)
 def multistorage_consumer(
     storage_names: Sequence[str],
     raw_events_topic: Optional[str],
@@ -130,7 +123,6 @@ def multistorage_consumer(
     input_block_size: Optional[int],
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
-    cooperative_rebalancing: bool = False,
 ) -> None:
 
     DEFAULT_BLOCK_SIZE = int(32 * 1e6)
@@ -222,9 +214,6 @@ def multistorage_consumer(
         queued_min_messages=queued_min_messages,
         bootstrap_servers=bootstrap_server,
     )
-
-    if cooperative_rebalancing is True:
-        consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
     metrics = MetricsWrapper(
         environment.metrics,

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -76,13 +76,6 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     type=int,
     help="Skip execution if timestamp is beyond this threshold compared to the system time",
 )
-# TODO: For testing alternate rebalancing strategies. To be eventually removed.
-@click.option(
-    "--cooperative-rebalancing",
-    is_flag=True,
-    default=False,
-    help="Use cooperative-sticky partition assignment strategy",
-)
 def subscriptions_executor(
     *,
     dataset_name: str,
@@ -94,7 +87,6 @@ def subscriptions_executor(
     no_strict_offset_reset: bool,
     log_level: Optional[str],
     stale_threshold_seconds: Optional[int],
-    cooperative_rebalancing: bool,
 ) -> None:
     """
     The subscription's executor consumes scheduled subscriptions from the scheduled
@@ -152,7 +144,6 @@ def subscriptions_executor(
         not no_strict_offset_reset,
         metrics,
         stale_threshold_seconds,
-        cooperative_rebalancing,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -73,7 +73,6 @@ class ConsumerBuilder:
         stats_callback: Optional[Callable[[str], None]] = None,
         commit_retry_policy: Optional[RetryPolicy] = None,
         profile_path: Optional[str] = None,
-        cooperative_rebalancing: bool = False,
     ) -> None:
         self.storage = get_writable_storage(storage_key)
         self.bootstrap_servers = kafka_params.bootstrap_servers
@@ -155,7 +154,6 @@ class ConsumerBuilder:
         self.output_block_size = processing_params.output_block_size
         self.__profile_path = profile_path
         self.__parallel_collect = parallel_collect
-        self.__cooperative_rebalancing = cooperative_rebalancing
 
         if commit_retry_policy is None:
             commit_retry_policy = BasicRetryPolicy(
@@ -196,9 +194,6 @@ class ConsumerBuilder:
             queued_max_messages_kbytes=self.queued_max_messages_kbytes,
             queued_min_messages=self.queued_min_messages,
         )
-
-        if self.__cooperative_rebalancing is True:
-            configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
         stats_collection_frequency_ms = get_config(
             f"stats_collection_freq_ms_{self.group_id}",

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -81,7 +81,6 @@ def build_executor_consumer(
     strict_offset_reset: Optional[bool],
     metrics: MetricsBackend,
     stale_threshold_seconds: Optional[int],
-    cooperative_rebalancing: bool = False,
 ) -> StreamProcessor[KafkaPayload]:
     # Validate that a valid dataset/entity pair was passed in
     dataset = get_dataset(dataset_name)
@@ -154,9 +153,6 @@ def build_executor_consumer(
                 "stats_cb": stats_callback,
             }
         )
-
-    if cooperative_rebalancing is True:
-        consumer_configuration["partition.assignment.strategy"] = "cooperative-sticky"
 
     return StreamProcessor(
         KafkaConsumer(consumer_configuration),


### PR DESCRIPTION
Co-operative rebalancing never quite worked with the way we write our consumers and is not very compatible with Arroyo. Let's remove the option since we never want to run this.

Eventually we might want to try this again but will probably have to wait for https://cwiki.apache.org/confluence/display/KAFKA/KIP-848%3A+The+Next+Generation+of+the+Consumer+Rebalance+Protocol being implemented in Kafka which will be some time away.
