### PR TITLE
fix(CI): autorun migrations in sentry CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,6 +361,7 @@ jobs:
             -e REDIS_HOST=sentry_redis \
             -e REDIS_PORT=6379 \
             -e REDIS_DB=1 \
+            -e ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES=1 \
             --name sentry_snuba \
             --network sentry \
             snuba-test


### PR DESCRIPTION
Search issues migrations have to be enabled explicitly. This PR does that. Without it, CI breaks when running sentry tests against the snuba