### PR TITLE
build bundle outside of arm64 image. attempt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,15 +169,28 @@ jobs:
       # support the image on Docker Hub
       # NOTE: This image has only been tested for local development
       SNUBA_IMAGE: ghcr.io/getsentry/snuba-arm64-dev
+      NODE_VERSION: 19.x
     steps:
       - uses: actions/checkout@v3
         name: Checkout code
-
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{env.NODE_VERSION}}
       - name: Get branch name
         id: branch
         # strip `refs/heads/` from $GITHUB_REF and replace `/` with `-` so that
         # it can be used as a docker tag
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> "$GITHUB_OUTPUT"
+      # for Arm64, we build the bundle.js outside of docker because inside it is extremely
+      # slow due to emulation.
+      - name: build admin UI
+        run: |
+          # allow copying the bundle to docker image
+          sed -i "s/snuba\/admin\/dist\/bundle.js\*//g" .dockerignore
+          # build bundle
+          cd snuba/admin
+          yarn install
+          yarn run build
 
       - name: enable arm64 building
         run: docker run --rm --privileged tonistiigi/binfmt --install arm64
@@ -196,6 +209,7 @@ jobs:
           docker buildx create --name arm64-builder --use
           docker buildx build --platform linux/arm64 \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg BUILD_BASE=base \
             --cache-from ${SNUBA_IMAGE}:latest \
             --cache-from ${SNUBA_IMAGE}:${{ steps.branch.outputs.branch }} \
             -t ${SNUBA_IMAGE}:latest \

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -11,10 +11,25 @@ jobs:
     env:
       IMG_CACHE: ghcr.io/getsentry/snuba:${{ matrix.arch }}-latest
       IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
+      BUILD_BASE: ${{ matrix.arch == 'arm64' && 'base' || 'build_admin_ui' }}
+      NODE_VERSION: 19.x
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{env.NODE_VERSION}}
+      if: matrix.arch == 'arm64'
     - run: docker run --rm --privileged tonistiigi/binfmt --install arm64
       if: matrix.arch == 'arm64'
+    - name: build admin UI
+      if: matrix.arch == 'arm64'
+      run: |
+        # allow copying the bundle to docker image
+        sed -i "s/snuba\/admin\/dist\/bundle.js\*//g" .dockerignore
+        # build bundle
+        cd snuba/admin
+        yarn install
+        yarn run build
     - name: build
       run: |
         set -euxo pipefail
@@ -25,6 +40,7 @@ jobs:
         docker buildx build \
             "${args[@]}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg BUILD_BASE="$BUILD_BASE" \
             --platform linux/${{ matrix.arch }} \
             --tag "$IMG_VERSIONED" \
             --target application \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG PYTHON_VERSION=3.8.13
-FROM python:${PYTHON_VERSION}-slim-bullseye AS application
+ARG BUILD_BASE=build_admin_ui
+FROM python:${PYTHON_VERSION}-slim-bullseye AS base
 
 WORKDIR /usr/src/snuba
 
@@ -36,6 +37,7 @@ RUN set -ex; \
     rm -rf /var/lib/apt/lists/*;
 
 # Install nodejs and yarn and build the admin UI
+FROM base AS build_admin_ui
 ENV NODE_VERSION=19
 COPY ./snuba/admin ./snuba/admin
 RUN set -ex; \
@@ -56,6 +58,7 @@ RUN set -ex; \
 
 # Layer cache is pretty much invalidated here all the time,
 # so try not to do anything heavy beyond here.
+FROM $BUILD_BASE AS application
 COPY . ./
 RUN set -ex; \
     groupadd -r snuba --gid 1000; \


### PR DESCRIPTION
Follow up fixes to #3514 . Makes docker build the admin UI along with the image by default by using the `build_admin_ui` layer as the default base.  This fixes issues where the CI would mistakenly skip building the UI. 

Optionally, specifying the arg `BUILD_BASE=base`  will use the base layer without the UI. This is useful for steps like building the arm64 image where building the UI within the docker image can take a long time.
