### PR TITLE
fix(settings): Fix SASL defaults

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -180,9 +180,9 @@ BROKER_CONFIG: Mapping[str, Any] = {
     "ssl.ca.location": os.environ.get("KAFKA_SSL_CA_PATH", ""),
     "ssl.certificate.location": os.environ.get("KAFKA_SSL_CERT_PATH", ""),
     "ssl.key.location": os.environ.get("KAFKA_SSL_KEY_PATH", ""),
-    "sasl.mechanism": os.environ.get("KAFKA_SASL_MECHANISM", "GSSAPI"),
-    "sasl.username": os.environ.get("KAFKA_SASL_USERNAME", ""),
-    "sasl.password": os.environ.get("KAFKA_SASL_PASSWORD", ""),
+    "sasl.mechanism": os.environ.get("KAFKA_SASL_MECHANISM", None),
+    "sasl.username": os.environ.get("KAFKA_SASL_USERNAME", None),
+    "sasl.password": os.environ.get("KAFKA_SASL_PASSWORD", None),
 }
 
 # Mapping of default Kafka topic name to custom names


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/snuba/pull/3551. Since the default security.protocol is set to plaintext, default sasl.username, sasl.password and sasl.mechanism should all be None.