### PR TITLE
feat: Consumer schema validation, take 2

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -110,6 +110,7 @@ logger = logging.getLogger(__name__)
     "--output-block-size",
     type=int,
 )
+@click.option("--validate-schema", is_flag=True, default=False)
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
@@ -133,6 +134,7 @@ def consumer(
     input_block_size: Optional[int],
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
+    validate_schema: bool,
     profile_path: Optional[str] = None,
 ) -> None:
 
@@ -179,6 +181,7 @@ def consumer(
         metrics=metrics,
         profile_path=profile_path,
         stats_callback=stats_callback,
+        validate_schema=validate_schema,
         parallel_collect=parallel_collect,
         slice_id=slice_id,
     )

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -38,6 +38,7 @@ from arroyo.processing.strategies.dead_letter_queue import (
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
+from arroyo.processing.strategies.decoder import JsonCodec
 from arroyo.types import BrokerValue, Commit, Message, Partition, Topic
 from confluent_kafka import KafkaError
 from confluent_kafka import Message as ConfluentMessage
@@ -543,12 +544,17 @@ def __invalid_kafka_message(
 
 
 def process_message(
-    processor: MessageProcessor, consumer_group: str, message: Message[KafkaPayload]
+    processor: MessageProcessor,
+    consumer_group: str,
+    codec: JsonCodec,
+    validate: bool,
+    message: Message[KafkaPayload],
 ) -> Union[None, BytesInsertBatch, ReplacementBatch]:
     assert isinstance(message.value, BrokerValue)
     try:
+        decoded = codec.decode(message.payload.value, validate=validate)
         result = processor.process_message(
-            rapidjson.loads(message.payload.value),
+            decoded,
             KafkaMessageMetadata(
                 message.value.offset,
                 message.value.partition.index,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -8,7 +8,6 @@ from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategyFactory
-from arroyo.processing.strategies.decoder import JsonCodec
 from arroyo.utils.profiler import ProcessingStrategyProfilerWrapperFactory
 from arroyo.utils.retries import BasicRetryPolicy, RetryPolicy
 from confluent_kafka import KafkaError, KafkaException, Producer
@@ -18,7 +17,6 @@ from snuba.consumers.consumer import (
     build_batch_writer,
     process_message,
 )
-from snuba.consumers.schemas import get_schema
 from snuba.consumers.strategy_factory import KafkaConsumerStrategyFactory
 from snuba.datasets.slicing import validate_passed_slice
 from snuba.datasets.storages.factory import get_writable_storage
@@ -226,7 +224,7 @@ class ConsumerBuilder:
         table_writer = self.storage.get_table_writer()
         stream_loader = table_writer.get_stream_loader()
 
-        json_codec = JsonCodec(get_schema(stream_loader.get_default_topic_spec().topic))
+        logical_topic = stream_loader.get_default_topic_spec().topic
 
         processor = stream_loader.get_processor()
 
@@ -245,7 +243,7 @@ class ConsumerBuilder:
                 process_message,
                 processor,
                 self.consumer_group,
-                json_codec,
+                logical_topic,
                 self.__validate_schema,
             ),
             collector=build_batch_writer(

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -8,6 +8,7 @@ from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategyFactory
+from arroyo.processing.strategies.decoder import JsonCodec
 from arroyo.utils.profiler import ProcessingStrategyProfilerWrapperFactory
 from arroyo.utils.retries import BasicRetryPolicy, RetryPolicy
 from confluent_kafka import KafkaError, KafkaException, Producer
@@ -17,6 +18,7 @@ from snuba.consumers.consumer import (
     build_batch_writer,
     process_message,
 )
+from snuba.consumers.schemas import get_schema
 from snuba.consumers.strategy_factory import KafkaConsumerStrategyFactory
 from snuba.datasets.slicing import validate_passed_slice
 from snuba.datasets.storages.factory import get_writable_storage
@@ -72,6 +74,7 @@ class ConsumerBuilder:
         slice_id: Optional[int],
         stats_callback: Optional[Callable[[str], None]] = None,
         commit_retry_policy: Optional[RetryPolicy] = None,
+        validate_schema: bool = False,
         profile_path: Optional[str] = None,
     ) -> None:
         self.storage = get_writable_storage(storage_key)
@@ -169,6 +172,7 @@ class ConsumerBuilder:
             )
 
         self.__commit_retry_policy = commit_retry_policy
+        self.__validate_schema = validate_schema
 
     def __build_consumer(
         self,
@@ -222,6 +226,8 @@ class ConsumerBuilder:
         table_writer = self.storage.get_table_writer()
         stream_loader = table_writer.get_stream_loader()
 
+        json_codec = JsonCodec(get_schema(stream_loader.get_default_topic_spec().topic))
+
         processor = stream_loader.get_processor()
 
         if self.commit_log_topic:
@@ -236,7 +242,11 @@ class ConsumerBuilder:
         ] = KafkaConsumerStrategyFactory(
             prefilter=stream_loader.get_pre_filter(),
             process_message=functools.partial(
-                process_message, processor, self.consumer_group
+                process_message,
+                processor,
+                self.consumer_group,
+                json_codec,
+                self.__validate_schema,
             ),
             collector=build_batch_writer(
                 table_writer,

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -1,4 +1,6 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
+
+from arroyo.processing.strategies.decoder import JsonCodec
 
 from snuba.utils.streams.topics import Topic
 
@@ -12,3 +14,13 @@ def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
 
     """
     return None
+
+
+_cache: MutableMapping[Topic, JsonCodec] = {}
+
+
+def get_json_codec(topic: Topic) -> JsonCodec:
+    if topic not in _cache:
+        _cache[topic] = JsonCodec(get_schema(topic))
+
+    return _cache[topic]

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -1,0 +1,14 @@
+from typing import Any, Mapping, Optional
+
+from snuba.utils.streams.topics import Topic
+
+
+def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
+    """
+    This is a placeholder. Eventually the schema will be fetched from the
+    sentry-kafka-topics library when it gets published.
+
+    This function returns either the schema if it is defined, or None if not.
+
+    """
+    return None

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -667,7 +667,10 @@ if application.debug or application.testing:
         assert storage is not None
 
         if type_ == "insert":
+            from arroyo.processing.strategies.decoder import JsonCodec
+
             from snuba.consumers.consumer import build_batch_writer, process_message
+            from snuba.consumers.schemas import get_schema
             from snuba.consumers.strategy_factory import KafkaConsumerStrategyFactory
 
             table_writer = storage.get_table_writer()
@@ -676,10 +679,19 @@ if application.debug or application.testing:
             def commit(offsets: Mapping[Partition, int], force: bool = False) -> None:
                 pass
 
+            json_codec = JsonCodec(
+                get_schema(stream_loader.get_default_topic_spec().topic)
+            )
+            validate_schema = True
+
             strategy = KafkaConsumerStrategyFactory(
                 stream_loader.get_pre_filter(),
                 functools.partial(
-                    process_message, stream_loader.get_processor(), "consumer_grouup"
+                    process_message,
+                    stream_loader.get_processor(),
+                    "consumer_grouup",
+                    json_codec,
+                    validate_schema,
                 ),
                 build_batch_writer(table_writer, metrics=metrics),
                 max_batch_size=1,

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -667,10 +667,7 @@ if application.debug or application.testing:
         assert storage is not None
 
         if type_ == "insert":
-            from arroyo.processing.strategies.decoder import JsonCodec
-
             from snuba.consumers.consumer import build_batch_writer, process_message
-            from snuba.consumers.schemas import get_schema
             from snuba.consumers.strategy_factory import KafkaConsumerStrategyFactory
 
             table_writer = storage.get_table_writer()
@@ -679,9 +676,6 @@ if application.debug or application.testing:
             def commit(offsets: Mapping[Partition, int], force: bool = False) -> None:
                 pass
 
-            json_codec = JsonCodec(
-                get_schema(stream_loader.get_default_topic_spec().topic)
-            )
             validate_schema = True
 
             strategy = KafkaConsumerStrategyFactory(
@@ -690,7 +684,7 @@ if application.debug or application.testing:
                     process_message,
                     stream_loader.get_processor(),
                     "consumer_grouup",
-                    json_codec,
+                    stream_loader.get_default_topic_spec().topic,
                     validate_schema,
                 ),
                 build_batch_writer(table_writer, metrics=metrics),

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, call
 
 import pytest
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.processing.strategies.decoder import JsonCodec
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from snuba.clusters.cluster import ClickhouseClientSettings
@@ -68,7 +69,9 @@ def test_streaming_consumer_strategy() -> None:
 
     factory = KafkaConsumerStrategyFactory(
         None,
-        functools.partial(process_message, processor, "consumer_group"),
+        functools.partial(
+            process_message, processor, "consumer_group", JsonCodec(), False
+        ),
         write_step,
         max_batch_size=10,
         max_batch_time=60,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock, call
 
 import pytest
 from arroyo.backends.kafka import KafkaPayload
-from arroyo.processing.strategies.decoder import JsonCodec
 from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from snuba.clusters.cluster import ClickhouseClientSettings
@@ -26,6 +25,7 @@ from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storage import Storage
 from snuba.processor import InsertBatch, ReplacementBatch
 from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.utils.streams.topics import Topic as SnubaTopic
 from tests.assertions import assert_changes
 from tests.backends.confluent_kafka import FakeConfluentKafkaProducer
 from tests.backends.metrics import TestingMetricsBackend, Timing
@@ -70,7 +70,7 @@ def test_streaming_consumer_strategy() -> None:
     factory = KafkaConsumerStrategyFactory(
         None,
         functools.partial(
-            process_message, processor, "consumer_group", JsonCodec(), False
+            process_message, processor, "consumer_group", SnubaTopic.EVENTS, False
         ),
         write_step,
         max_batch_size=10,


### PR DESCRIPTION
Same as https://github.com/getsentry/snuba/pull/3553 but instead of passing JsonCodec to the `process_message` function we are now passing the topic instead.

The previous implementation caused consumers to crash if multiprocessing was used (INC-279 / SNUBA-316) as JsonCodec cannot be pickled in order to pass to subprocesses. The new implementation loads the JsonCodec once in each subprocess and only passes the topic to the `process_message` function so the correct codec and schema can be loaded.