### PR TITLE
feat(ops): allow disabled entities for storage sets that are not in use

### DIFF
--- a/snuba/datasets/entities/factory.py
+++ b/snuba/datasets/entities/factory.py
@@ -60,28 +60,34 @@ class _EntityFactory(ConfigComponentFactory[Entity, EntityKey]):
         from snuba.datasets.entities.sessions import OrgSessionsEntity, SessionsEntity
         from snuba.datasets.entities.transactions import TransactionsEntity
 
+        entity_map_pre_execute = {
+            EntityKey.DISCOVER: DiscoverEntity,
+            EntityKey.EVENTS: EventsEntity,
+            EntityKey.GROUPASSIGNEE: GroupAssigneeEntity,
+            EntityKey.GROUPEDMESSAGE: GroupedMessageEntity,
+            EntityKey.OUTCOMES: OutcomesEntity,
+            EntityKey.OUTCOMES_RAW: OutcomesRawEntity,
+            EntityKey.SESSIONS: SessionsEntity,
+            EntityKey.ORG_SESSIONS: OrgSessionsEntity,
+            EntityKey.TRANSACTIONS: TransactionsEntity,
+            EntityKey.DISCOVER_TRANSACTIONS: DiscoverTransactionsEntity,
+            EntityKey.DISCOVER_EVENTS: DiscoverEventsEntity,
+            EntityKey.METRICS_SETS: MetricsSetsEntity,
+            EntityKey.METRICS_COUNTERS: MetricsCountersEntity,
+            EntityKey.ORG_METRICS_COUNTERS: OrgMetricsCountersEntity,
+            EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity,
+            EntityKey.PROFILES: ProfilesEntity,
+            EntityKey.FUNCTIONS: FunctionsEntity,
+            EntityKey.REPLAYS: ReplaysEntity,
+            EntityKey.GENERIC_METRICS_SETS: GenericMetricsSetsEntity,
+            EntityKey.GENERIC_METRICS_DISTRIBUTIONS: GenericMetricsDistributionsEntity,
+        }
+
         self._entity_map.update(
             {
-                EntityKey.DISCOVER: DiscoverEntity(),
-                EntityKey.EVENTS: EventsEntity(),
-                EntityKey.GROUPASSIGNEE: GroupAssigneeEntity(),
-                EntityKey.GROUPEDMESSAGE: GroupedMessageEntity(),
-                EntityKey.OUTCOMES: OutcomesEntity(),
-                EntityKey.OUTCOMES_RAW: OutcomesRawEntity(),
-                EntityKey.SESSIONS: SessionsEntity(),
-                EntityKey.ORG_SESSIONS: OrgSessionsEntity(),
-                EntityKey.TRANSACTIONS: TransactionsEntity(),
-                EntityKey.DISCOVER_TRANSACTIONS: DiscoverTransactionsEntity(),
-                EntityKey.DISCOVER_EVENTS: DiscoverEventsEntity(),
-                EntityKey.METRICS_SETS: MetricsSetsEntity(),
-                EntityKey.METRICS_COUNTERS: MetricsCountersEntity(),
-                EntityKey.ORG_METRICS_COUNTERS: OrgMetricsCountersEntity(),
-                EntityKey.METRICS_DISTRIBUTIONS: MetricsDistributionsEntity(),
-                EntityKey.PROFILES: ProfilesEntity(),
-                EntityKey.FUNCTIONS: FunctionsEntity(),
-                EntityKey.REPLAYS: ReplaysEntity(),
-                EntityKey.GENERIC_METRICS_SETS: GenericMetricsSetsEntity(),
-                EntityKey.GENERIC_METRICS_DISTRIBUTIONS: GenericMetricsDistributionsEntity(),
+                k: v()
+                for (k, v) in entity_map_pre_execute.items()
+                if k.value not in settings.DISABLED_ENTITIES
             }
         )
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -47,6 +47,7 @@ ADMIN_ALLOWED_MIGRATION_GROUPS = {
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 
 DEFAULT_DATASET_NAME = "events"
+DISABLED_ENTITIES: Set[str] = set()
 DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options


### PR DESCRIPTION
Add a new config that lets us disable entity loading when we want to disable storage sets temporarily.

We want to remove the `cdc` and `sessions` storage sets for ops changes, but that causes the validation on EntityFactory loading to fail

```
 File "/Users/oliver/workplace/snuba/snuba/datasets/schemas/tables.py", line 92, in get_table_name
    if get_cluster(self.__storage_set_key).is_single_node()
  File "/Users/oliver/workplace/snuba/snuba/clusters/cluster.py", line 482, in get_cluster
    raise UndefinedClickhouseCluster(
snuba.clusters.cluster.UndefinedClickhouseCluster: StorageSetKey.CDC is not defined in the CLUSTERS setting for this environment
```

even if the dataset is in `DISABLED_DATASETS`. This is because initialize_snuba is loading entities first: 
https://github.com/getsentry/snuba/blob/afcfb2a76f65492a5c9df90ef391db7d617e7c70/snuba/core/initialize.py#L32-L43
https://github.com/getsentry/snuba/blob/a6a41eff612a5bbf2d086d7ddaffd2a36995466c/snuba/datasets/entities/factory.py#L67-L72

I tested locally that with the relevant entities disabled we can remove the storage sets `cdc` and `sessions` and `snuba api` will start without the above error