### PR TITLE
docs(schema): why do we promote tags?

### DIFF
--- a/docs/source/clickhouse/schema_design.rst
+++ b/docs/source/clickhouse/schema_design.rst
@@ -1,0 +1,27 @@
+ClickHouse Schema Design Best Practices
+=======================================
+
+Columns based on dictionary data
+--------------------------------
+
+ClickHouse is a columnar datastore, and it loads columns on-demand based on the columns referenced
+in the query (both the columns ``SELECT``ed and those part of the ``WHERE`` clause). Commonly,
+a data schema contains a flexible key:value pair mapping (for example: tags) and stores that
+data in a column that contains two ``Nested`` arrays where the first array contains the keys
+of the dictionary and the second array contains the values. This works well when
+your dataset design gives you the ability to filter based on other attributes to a small
+number of rows and the flexibility of completely arbitrary keys and values are a real requirement.
+Often, however, a ClickHouse user is interested in rows that contain a specific tag key or a
+specific ``key=value`` pair and in this case one is often best-served by creating a top-level
+column and duplicating (we often call it "promoting" in code) the data.
+
+This is more efficient on two dimensions:
+
+1. A dictionary style-column can be arbitrarily sized and, especially if you know you will often only
+need a single value from the dictionary, it may be that just returning
+this column in your results blows up the size of your **query results** result in-memory. It also can
+exhaust the cache and in that manner slow down other unrelated queries.
+
+2. Queries that filter based on an array column have to load the entire column into memory
+in order to do filtering. This makes it more difficult and expensive for the query planner to build
+indexing on the presence of a key.

--- a/docs/source/clickhouse/schema_design.rst
+++ b/docs/source/clickhouse/schema_design.rst
@@ -4,9 +4,13 @@ ClickHouse Schema Design Best Practices
 Columns based on dictionary data
 --------------------------------
 
-ClickHouse is a columnar datastore, and it loads columns on-demand based on the columns referenced
-in the query (both the columns ``SELECT``ed and those part of the ``WHERE`` clause). Commonly,
-a data schema contains a flexible key:value pair mapping (for example: tags) and stores that
+ClickHouse is a columnar datastore, and at run-time it loads columns on-demand
+based on the columns referenced in the query (both the columns ``SELECT`` ed
+and those part of the ``WHERE`` clause). The ability to store different columns independently
+and not load them for every row for every query is part of the performance advantage that
+ClickHouse provides over a traditional RDBMBS (like PostgreSQL).
+
+Commonly, a data schema contains a flexible key:value pair mapping (for example: tags) and stores that
 data in a column that contains two ``Nested`` arrays where the first array contains the keys
 of the dictionary and the second array contains the values. This works well when
 your dataset design gives you the ability to filter based on other attributes to a small
@@ -15,13 +19,12 @@ Often, however, a ClickHouse user is interested in rows that contain a specific 
 specific ``key=value`` pair and in this case one is often best-served by creating a top-level
 column and duplicating (we often call it "promoting" in code) the data.
 
-This is more efficient on two dimensions:
+This duplication is more performance-efficient on two dimensions:
 
 1. A dictionary style-column can be arbitrarily sized and, especially if you know you will often only
-need a single value from the dictionary, it may be that just returning
-this column in your results blows up the size of your **query results** result in-memory. It also can
-exhaust the cache and in that manner slow down other unrelated queries.
-
+   need a single value from the dictionary, it may be that just returning
+   this column in your results blows up the amount of data that has to be processed, aggregated
+   and serialized in-memory. It also can exhaust the cache and in that manner slow down other unrelated queries.
 2. Queries that filter based on an array column have to load the entire column into memory
-in order to do filtering. This makes it more difficult and expensive for the query planner to build
-indexing on the presence of a key.
+   in order to do filtering. This makes it more difficult and expensive for the query planner to build
+   indexing on the presence of a key.

--- a/docs/source/clickhouse/schema_design.rst
+++ b/docs/source/clickhouse/schema_design.rst
@@ -10,7 +10,7 @@ and those part of the ``WHERE`` clause). The ability to store different columns 
 and not load them for every row for every query is part of the performance advantage that
 ClickHouse provides over a traditional RDBMBS (like PostgreSQL).
 
-Commonly, a data schema contains a flexible key:value pair mapping (for example: tags) and stores that
+Commonly, a data schema contains a flexible key:value pair mapping (canonically: ``tags``) and stores that
 data in a column that contains two ``Nested`` arrays where the first array contains the keys
 of the dictionary and the second array contains the values. This works well when
 your dataset design gives you the ability to filter based on other attributes to a small
@@ -25,6 +25,11 @@ This duplication is more performance-efficient on two dimensions:
    need a single value from the dictionary, it may be that just returning
    this column in your results blows up the amount of data that has to be processed, aggregated
    and serialized in-memory. It also can exhaust the cache and in that manner slow down other unrelated queries.
-2. Queries that filter based on an array column have to load the entire column into memory
-   in order to do filtering. This makes it more difficult and expensive for the query planner to build
-   indexing on the presence of a key.
+2. Queries that filter based on an array column may have to load the entire column into memory
+   in order to do filtering. Adding a new index on top of a top-level column is a more
+   straightforward operation that guarantees more consistent performance outcomes vs. iterating
+   over an array
+
+..
+   # (TODO: add some information to the above section about how we have
+   done indexes on arrays, and when that might be appropriate)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,3 +17,4 @@ Contents:
    migrations/modes
    contributing/environment
    clickhouse/death_queries
+   clickhouse/schema_design


### PR DESCRIPTION
wanted to document the rationale behind why you see "promotion" throughout Snuba as it's come up a couple times for me recently

https://github.com/getsentry/snuba/pull/3571/files#r1062820314