### PR TITLE
Pick up self-hosted CI bugfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@4ff2dbfdd5c986a4670efaa16d82e460598359eb
+        uses: getsentry/action-self-hosted-e2e-tests@ade3e646ffc3b6a765cfa18ec4ca720f710cb53d
         with:
           project_name: snuba
           docker_repo: getsentry/snuba


### PR DESCRIPTION
Picks up https://github.com/getsentry/action-self-hosted-e2e-tests/pull/3.