### PR TITLE
fix: Change DefaultNoneColumnMapper to use a normal set

### DIFF
--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -140,23 +140,24 @@ class ArgumentMapper(SnubaClickhouseMapper[Argument, Argument]):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass
 class DefaultNoneColumnMapper(ColumnMapper):
     """
-    This maps a list of column names to None (NULL in SQL) as it is done
-    in the discover column_expr method today. It should not be used for
-    any other reason or use case, thus it should not be moved out of
-    the discover dataset file.
+    This takes a list of flattened column names and maps them to None (NULL in SQL) as it is done in the discover column_expr method today.
+    It should not be used for any other reason or use case, thus it should not be moved out of the discover dataset file.
     """
 
-    columns: set[str]
+    column_names: list[str]
+
+    def __post_init__(self) -> None:
+        self.columns = set(self.column_names)
 
     def attempt_map(
         self,
         expression: Column,
         children_translator: SnubaClickhouseStrictTranslator,
     ) -> Optional[FunctionCall]:
-        if expression.column_name in self.columns:
+        if expression.column_name in self.column_names:
             return identity(
                 Literal(None, None),
                 expression.alias

--- a/snuba/clickhouse/translators/snuba/allowed.py
+++ b/snuba/clickhouse/translators/snuba/allowed.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, Set, Type, TypeVar, Union, cast
 
-from snuba.clickhouse.columns import ColumnSet
 from snuba.clickhouse.translators.snuba import SnubaClickhouseStrictTranslator
 from snuba.datasets.plans.translator.mapper import ExpressionMapper
 from snuba.query.dsl import identity
@@ -148,7 +149,7 @@ class DefaultNoneColumnMapper(ColumnMapper):
     the discover dataset file.
     """
 
-    columns: ColumnSet
+    columns: set[str]
 
     def attempt_map(
         self,

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -123,7 +123,7 @@ TRANSACTIONS_COLUMNS = ColumnSet(
 
 
 events_translation_mappers = TranslationMappers(
-    columns=[DefaultNoneColumnMapper({c.flattened for c in TRANSACTIONS_COLUMNS})],
+    columns=[DefaultNoneColumnMapper([c.flattened for c in TRANSACTIONS_COLUMNS])],
     functions=[DefaultNoneFunctionMapper({"apdex", "failure_rate"})],
     subscriptables=[DefaultNoneSubscriptMapper({"measurements", "span_op_breakdowns"})],
 )
@@ -131,7 +131,7 @@ events_translation_mappers = TranslationMappers(
 transaction_translation_mappers = TranslationMappers(
     columns=[
         ColumnToLiteral(None, "group_id", 0),
-        DefaultNoneColumnMapper({c.flattened for c in EVENTS_COLUMNS}),
+        DefaultNoneColumnMapper([c.flattened for c in EVENTS_COLUMNS]),
     ],
     functions=[DefaultNoneFunctionMapper({"isHandled", "notHandled"})],
 )

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -123,7 +123,7 @@ TRANSACTIONS_COLUMNS = ColumnSet(
 
 
 events_translation_mappers = TranslationMappers(
-    columns=[DefaultNoneColumnMapper(TRANSACTIONS_COLUMNS)],
+    columns=[DefaultNoneColumnMapper({c.flattened for c in TRANSACTIONS_COLUMNS})],
     functions=[DefaultNoneFunctionMapper({"apdex", "failure_rate"})],
     subscriptables=[DefaultNoneSubscriptMapper({"measurements", "span_op_breakdowns"})],
 )
@@ -131,7 +131,7 @@ events_translation_mappers = TranslationMappers(
 transaction_translation_mappers = TranslationMappers(
     columns=[
         ColumnToLiteral(None, "group_id", 0),
-        DefaultNoneColumnMapper(EVENTS_COLUMNS),
+        DefaultNoneColumnMapper({c.flattened for c in EVENTS_COLUMNS}),
     ],
     functions=[DefaultNoneFunctionMapper({"isHandled", "notHandled"})],
 )


### PR DESCRIPTION
Dataset configuration doesn't support complex objects for registered classes
like this. In order for the discover entity to be migration to YAML, there needs
to be a different way to initialize this class that can be encoded in YAML.

This mapper is checking if a column name exists in the ColumnSet. That check
compares against the flattened column name stored in the ColumnSet. This can be
achieved by comparing to a normal set instead of a ColumnSet.

### Blast Radius

This should only concern anyone who works with the Discover entity. 
Also, nothing should change when this is merged.