### PR TITLE
feat: Change settings.TOPIC_PARTITION_COUNTS to use logical topic name

### DIFF
--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -59,10 +59,7 @@ class KafkaTopicSpec:
 
     @property
     def partitions_number(self) -> int:
-        # TODO: This references the actual topic name for backward compatibility.
-        # It should be changed to the logical name for consistency with KAFKA_TOPIC_MAP
-        # and KAFKA_BROKER_CONFIG
-        return settings.TOPIC_PARTITION_COUNTS.get(self.topic_name, 1)
+        return settings.TOPIC_PARTITION_COUNTS.get(self.__topic.value, 1)
 
     @property
     def replication_factor(self) -> int:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -228,7 +228,7 @@ TURBO_SAMPLE_RATE = 0.1
 PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 PRETTY_FORMAT_EXPRESSIONS = True
 
-TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (topic name, # of partitions)
+TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (logical topic name, # of partitions)
 
 COLUMN_SPLIT_MIN_COLS = 6
 COLUMN_SPLIT_MAX_LIMIT = 1000


### PR DESCRIPTION
TOPIC_PARTITION_COUNTS configuration was unintuitive because (unlike all the other Kafka settings) it referenced the physical topic name and not the logical topic name.

This brings it in line with the way the other settings like KAFKA_TOPIC_MAP, KAFKA_BROKER_CONFIG, LOGICAL_PARTITION_MAPPING, etc, work.
