### PR TITLE
bump search_issues storage occurrence_type_id int size

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -16,7 +16,7 @@ schema:
       { name: primary_hash, type: UUID },
       { name: fingerprint, type: Array, args: { inner_type: { type: String } } },
       { name: occurrence_id, type: UUID },
-      { name: occurrence_type_id, type: UInt, args: { size: 8 } },
+      { name: occurrence_type_id, type: UInt, args: { size: 16 } },
       { name: detection_timestamp, type: DateTime },
 
       { name: event_id, type: UUID, args: { schema_modifiers: [ nullable ] } },


### PR DESCRIPTION
Bumps `search_issues` storage `occurrence_type_id` int size from 6 to 12. Migration for this has already been merged https://github.com/getsentry/snuba/pull/3575