### PR TITLE
fix(config) Support join relationships in configuration

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -442,6 +442,50 @@ ENTITY_SUBSCRIPTION_VALIDATORS = {
     },
 }
 
+ENTITY_JOIN_RELATIONSHIPS = {
+    "type": "object",
+    "patternProperties": {
+        "^.*$": {
+            "type": "object",
+            "description": "The join relationship. The key for this relationship is how the relationship is specified in queries (`MATCH x -[key]-> y`)",
+            "properties": {
+                "rhs_entity": {
+                    "type": "string",
+                    "description": "The entity key of the rhs entity to join with",
+                },
+                "columns": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "prefixItems": [
+                            {"type": "string"},
+                            {"type": "string"},
+                        ],
+                    },
+                    "description": "A sequence of tuples of columns to join on, in the form (left, right)",
+                },
+                "join_type": {
+                    "type": "string",
+                    "description": "The type of join that can be performed (either 'left' or 'inner'",
+                },
+                "equivalences": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "prefixItems": [
+                            {"type": "string"},
+                            {"type": "string"},
+                        ],
+                    },
+                    "description": "Tracking columns in the two entities that are not part of the join key but are still equivalent",
+                },
+            },
+            "required": ["rhs_entity", "columns", "join_type"],
+            "additionalProperties": False,
+        },
+    },
+}
+
 # Full schemas:
 
 V1_WRITABLE_STORAGE_SCHEMA = {
@@ -512,6 +556,7 @@ V1_ENTITY_SCHEMA = {
                 "description": "Name of a ReadableStorage class which provides an abstraction to read from a table or a view in ClickHouse"
             },
         },
+        "join_relationships": ENTITY_JOIN_RELATIONSHIPS,
         "writable_storage": {
             "type": ["string", "null"],
             "description": "Name of a WritableStorage class which provides an abstraction to write to a table in ClickHouse",

--- a/tests/datasets/configuration/entity_join_relationships.yaml
+++ b/tests/datasets/configuration/entity_join_relationships.yaml
@@ -1,0 +1,38 @@
+version: v1
+kind: entity
+name: groupassignee_test
+
+schema:
+  [
+    { name: offset, type: UInt, args: { size: 64 } },
+    { name: record_deleted, type: UInt, args: { size: 8 } },
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: group_id, type: UInt, args: { size: 64 } },
+    { name: date_added, type: DateTime, args: { schema_modifiers: [nullable] } },
+    { name: user_id, type: UInt, args: { size: 64, schema_modifiers: [nullable] } },
+    { name: team_id, type: UInt, args: { size: 64, schema_modifiers: [nullable] } },
+  ]
+
+readable_storage: groupassignees
+writable_storage: groupassignees
+storage_selector:
+  selector: DefaultQueryStorageSelector
+
+query_processors:
+  - processor: BasicFunctionsProcessor
+  - processor: ProjectRateLimiterProcessor
+    args:
+      project_column: project_id
+
+join_relationships:
+  owns:
+    rhs_entity: events
+    join_type: left
+    columns:
+      - [project_id, project_id]
+      - [group_id, group_id]
+    equivalences:
+      - [offset, offset]
+
+validators: []
+required_time_column: test

--- a/tests/datasets/configuration/test_entity_loader.py
+++ b/tests/datasets/configuration/test_entity_loader.py
@@ -91,7 +91,7 @@ class TestEntityConfiguration(ConfigurationTest):
 
         assert config_entity.get_data_model() == py_entity.get_data_model()
 
-    def test_entity_loader_for_enitity_with_column_mappers(self) -> None:
+    def test_entity_loader_for_entity_with_column_mappers(self) -> None:
         pluggable_entity = build_entity_from_config(
             "tests/datasets/configuration/entity_with_column_mappers.yaml"
         )
@@ -149,3 +149,22 @@ class TestEntityConfiguration(ConfigurationTest):
         )
         entity_validators = set(pluggable_entity.get_validators())
         assert len(entity_validators) == len(pluggable_entity._get_builtin_validators())
+
+    def test_entity_loader_join_relationships(self) -> None:
+        pluggable_entity = build_entity_from_config(
+            "tests/datasets/configuration/entity_join_relationships.yaml"
+        )
+        relationships = pluggable_entity.get_all_join_relationships()
+        assert len(relationships) == 1
+        rel = pluggable_entity.get_join_relationship("owns")
+        assert rel is not None
+        assert rel.rhs_entity.value == "events"
+        assert rel.join_type.value == "LEFT"
+        assert len(rel.columns) == 2
+        assert rel.columns[0][0] == "project_id"
+        assert rel.columns[0][1] == "project_id"
+        assert rel.columns[1][0] == "group_id"
+        assert rel.columns[1][1] == "group_id"
+        assert len(rel.equivalences) == 1
+        assert rel.equivalences[0][0] == "offset"
+        assert rel.equivalences[0][1] == "offset"

--- a/tests/datasets/entities/test_entity_key.py
+++ b/tests/datasets/entities/test_entity_key.py
@@ -8,9 +8,11 @@ def test_entity_key() -> None:
     initialize_entity_factory()
     with pytest.raises(AttributeError):
         EntityKey.NON_EXISTENT_ENTITY
-    assert REGISTERED_ENTITY_KEYS == {
-        "GENERIC_METRICS_DISTRIBUTIONS": "generic_metrics_distributions",
-        "GENERIC_METRICS_SETS": "generic_metrics_sets",
-        "TRANSACTIONS": "transactions",
-        "SEARCH_ISSUES": "search_issues",
-    }
+
+    assert (
+        REGISTERED_ENTITY_KEYS["GENERIC_METRICS_DISTRIBUTIONS"]
+        == "generic_metrics_distributions"
+    )
+    assert REGISTERED_ENTITY_KEYS["GENERIC_METRICS_SETS"] == "generic_metrics_sets"
+    assert REGISTERED_ENTITY_KEYS["TRANSACTIONS"] == "transactions"
+    assert REGISTERED_ENTITY_KEYS["SEARCH_ISSUES"] == "search_issues"


### PR DESCRIPTION
Add support to the schemas to allow entities to specify join relationships.
Also add a test for the join relationship parser.

Since CDC is a deprecated feature, there was a discussion about whether we should support joins in config, since CDC is the only user of them. But I don't think we want to eliminate support for joins entirely, so I decided to add support for the relationships. Perhaps in the future someone will want joins and we will be ready.