### PR TITLE
chore(eventstream): Fix eventstream dev api to return 500s when there is an error

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -280,7 +280,6 @@ def handle_invalid_query(exception: InvalidQueryException) -> Response:
 @application.errorhandler(InternalServerError)
 def handle_internal_server_error(exception: InternalServerError) -> Response:
     original = getattr(exception, "original_exception", None)
-    print("internal server error", exception)
 
     if original is None:
         return Response(

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -714,7 +714,7 @@ if application.debug or application.testing:
             # TODO: This is a temporary workaround so that we return a more useful error when
             # attempting to write to a dataset where the migration hasn't been run. This should be
             # no longer necessary once we have more advanced dataset management in place.
-            raise InternalServerError(e)
+            raise InternalServerError(str(e), original_exception=e)
 
         return ("ok", 200, {"Content-Type": "text/plain"})
 


### PR DESCRIPTION
When we have an error here (for example, due to a dataset not existing) we end up with an obscure connection error in sentry. Explicitly raising an `InternalServerError` causes a 500 to be returned.
