### PR TITLE
feat(issue-platform): add mappers so discover queries can work with search_issues dataset

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -91,6 +91,63 @@ translation_mappers:
         from_col_name: "timestamp"
         to_table_name:
         to_col_name: "client_timestamp"
+    - mapper: ColumnToColumn
+      args:
+        from_table_name:
+        from_col_name: "message"
+        to_table_name:
+        to_col_name: "search_title"
+    - mapper: ColumnToColumn
+      args:
+        from_table_name:
+        from_col_name: "title"
+        to_table_name:
+        to_col_name: "search_title"
+    - mapper: ColumnToIPAddress
+      args:
+        from_table_name:
+        from_col_name: "ip_address"
+        to_function_name: "coalesce"
+    - mapper: ColumnToNullIf
+      args:
+        from_table_name:
+        from_col_name: "user"
+    - mapper: ColumnToColumn
+      args:
+        from_table_name:
+        from_col_name: "username"
+        to_table_name:
+        to_col_name: "user_name"
+    - mapper: ColumnToColumn
+      args:
+        from_table_name:
+        from_col_name: "email"
+        to_table_name:
+        to_col_name: "user_email"
+    - mapper: ColumnToMapping
+      args:
+        from_table_name:
+        from_col_name: "geo_country_code"
+        to_nested_col_table_name:
+        to_nested_col_name: "contexts"
+        to_nested_mapping_key: "geo.country_code"
+        nullable: True
+    - mapper: ColumnToMapping
+      args:
+        from_table_name:
+        from_col_name: "geo_region"
+        to_nested_col_table_name:
+        to_nested_col_name: "contexts"
+        to_nested_mapping_key: "geo.region"
+        nullable: True
+    - mapper: ColumnToMapping
+      args:
+        from_table_name:
+        from_col_name: "geo_city"
+        to_nested_col_table_name:
+        to_nested_col_name: "contexts"
+        to_nested_mapping_key: "geo.city"
+        nullable: True
   subscriptables:
     - mapper: SubscriptableMapper
       args:


### PR DESCRIPTION
Basically mirrors the DiscoverEntity column mappers from here:
https://github.com/getsentry/snuba/blob/fa65895b0d6d62d5cb7003455ff994864d0339da/snuba/datasets/entities/discover.py#L195