### PR TITLE
fix(migrations): make outcomes schema match SaaS SNS-1992

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -172,7 +172,8 @@ class OutcomesLoader(DirectoryLoader):
             "0004_outcomes_matview_additions",
             "0005_outcomes_ttl",
             "0006_outcomes_add_size_col",
-            "0007_outcomes_add_indexes_and_codecs",
+            "0007_outcomes_add_event_id_ttl_codec",
+            "0008_outcomes_add_indexes",
         ]
 
 

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -171,6 +171,8 @@ class OutcomesLoader(DirectoryLoader):
             "0003_outcomes_add_category_and_quantity",
             "0004_outcomes_matview_additions",
             "0005_outcomes_ttl",
+            "0006_outcomes_add_size_col",
+            "0007_outcomes_add_indexes_and_codecs",
         ]
 
 

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -68,7 +68,9 @@ def _validate_add_col_or_create_table(
             )
 
 
-def _validate_drop(dist_op: SqlOperation, local_ops: Sequence[SqlOperation]) -> None:
+def _validate_drop_col(
+    dist_op: SqlOperation, local_ops: Sequence[SqlOperation]
+) -> None:
     if isinstance(dist_op, (DropColumn)):
         if any(_conflicts_ops(local_op, dist_op) for local_op in local_ops):
             raise InvalidMigrationOrderError(
@@ -87,7 +89,7 @@ def _validate_order_old(
     """
     if local_first:
         for dist_op in dist_ops:
-            _validate_drop(dist_op, local_ops)
+            _validate_drop_col(dist_op, local_ops)
     else:
         for local_op in local_ops:
             _validate_add_col_or_create_table(local_op, dist_ops)
@@ -112,7 +114,7 @@ def _validate_order_new(
                     _validate_add_col_or_create_table(op, dist_ops_before)
             elif isinstance(op, DropColumn):
                 if op.target == OperationTarget.DISTRIBUTED:
-                    _validate_drop(op, local_ops_before)
+                    _validate_drop_col(op, local_ops_before)
 
 
 def validate_migration_order(migration: ClickhouseNodeMigration) -> None:

--- a/snuba/migrations/validator.py
+++ b/snuba/migrations/validator.py
@@ -111,7 +111,8 @@ def _validate_order_new(
                 if op.target == OperationTarget.LOCAL:
                     _validate_add_col_or_create_table(op, dist_ops_before)
             elif isinstance(op, DropColumn):
-                _validate_drop(op, local_ops_before)
+                if op.target == OperationTarget.DISTRIBUTED:
+                    _validate_drop(op, local_ops_before)
 
 
 def validate_migration_order(migration: ClickhouseNodeMigration) -> None:

--- a/snuba/snuba_migrations/outcomes/0003_outcomes_add_category_and_quantity.py
+++ b/snuba/snuba_migrations/outcomes/0003_outcomes_add_category_and_quantity.py
@@ -71,25 +71,25 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
                 storage_set=StorageSetKey.OUTCOMES,
                 table_name="outcomes_raw_dist",
                 column=Column("quantity", UInt(32)),
-                after=None,
+                after="reason",
             ),
             operations.AddColumn(
                 storage_set=StorageSetKey.OUTCOMES,
                 table_name="outcomes_raw_dist",
                 column=Column("category", UInt(8)),
-                after=None,
+                after="timestamp",
             ),
             operations.AddColumn(
                 storage_set=StorageSetKey.OUTCOMES,
                 table_name="outcomes_hourly_dist",
                 column=Column("quantity", UInt(64)),
-                after=None,
+                after="reason",
             ),
             operations.AddColumn(
                 storage_set=StorageSetKey.OUTCOMES,
                 table_name="outcomes_hourly_dist",
                 column=Column("category", UInt(8)),
-                after=None,
+                after="timestamp",
             ),
         ]
 

--- a/snuba/snuba_migrations/outcomes/0006_outcomes_add_size_col.py
+++ b/snuba/snuba_migrations/outcomes/0006_outcomes_add_size_col.py
@@ -10,7 +10,7 @@ class Migration(migration.ClickhouseNodeMigration):
     Adds back (again) the size, bytes_received columns to match schema in SaaS
     """
 
-    blocking = True
+    blocking = False
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [

--- a/snuba/snuba_migrations/outcomes/0006_outcomes_add_size_col.py
+++ b/snuba/snuba_migrations/outcomes/0006_outcomes_add_size_col.py
@@ -17,13 +17,13 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.AddColumn(
                 StorageSetKey.OUTCOMES,
                 "outcomes_raw_local",
-                Column("size", UInt(64)),
+                Column("size", UInt(32)),
                 target=operations.OperationTarget.LOCAL,
             ),
             operations.AddColumn(
                 StorageSetKey.OUTCOMES,
                 "outcomes_raw_dist",
-                Column("size", UInt(64)),
+                Column("size", UInt(32)),
                 target=operations.OperationTarget.DISTRIBUTED,
             ),
             operations.AddColumn(

--- a/snuba/snuba_migrations/outcomes/0006_outcomes_add_size_col.py
+++ b/snuba/snuba_migrations/outcomes/0006_outcomes_add_size_col.py
@@ -1,0 +1,69 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds back (again) the size, bytes_received columns to match schema in SaaS
+    """
+
+    blocking = True
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                Column("size", UInt(64)),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_dist",
+                Column("size", UInt(64)),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.AddColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_hourly_local",
+                Column("bytes_received", UInt(64)),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_hourly_dist",
+                Column("bytes_received", UInt(64)),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_dist",
+                "size",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                "size",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_hourly_dist",
+                "size",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_hourly_local",
+                "size",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/outcomes/0007_outcomes_add_event_id_ttl_codec.py
+++ b/snuba/snuba_migrations/outcomes/0007_outcomes_add_event_id_ttl_codec.py
@@ -8,11 +8,10 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 class Migration(migration.ClickhouseNodeMigration):
     """
-    Adds indexes and codecs to match schema in SaaS. Clickhouse 20 doesn't
-    support adding codecs to key columns, so we don't add codecs to timestamp.
+    Adds TTL and codec to event_id column to match schema in SaaS
     """
 
-    blocking = True
+    blocking = False
 
     def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
@@ -30,25 +29,7 @@ class Migration(migration.ClickhouseNodeMigration):
                     ),
                 ),
                 target=operations.OperationTarget.LOCAL,
-            ),
-            operations.AddIndex(
-                StorageSetKey.OUTCOMES,
-                "outcomes_raw_local",
-                index_name="minmax_key_id",
-                index_expression="key_id",
-                index_type="minmax",
-                granularity=1,
-                target=operations.OperationTarget.LOCAL,
-            ),
-            operations.AddIndex(
-                StorageSetKey.OUTCOMES,
-                "outcomes_raw_local",
-                index_name="minmax_outcome",
-                index_expression="outcome",
-                index_type="minmax",
-                granularity=1,
-                target=operations.OperationTarget.LOCAL,
-            ),
+            )
         ]
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
@@ -60,17 +41,5 @@ class Migration(migration.ClickhouseNodeMigration):
                 "outcomes_raw_local",
                 Column("event_id", UUID(Modifiers(nullable=True))),
                 target=operations.OperationTarget.LOCAL,
-            ),
-            operations.DropIndex(
-                StorageSetKey.OUTCOMES,
-                "outcomes_raw_local",
-                index_name="minmax_key_id",
-                target=operations.OperationTarget.LOCAL,
-            ),
-            operations.DropIndex(
-                StorageSetKey.OUTCOMES,
-                "outcomes_raw_local",
-                index_name="minmax_outcome",
-                target=operations.OperationTarget.LOCAL,
-            ),
+            )
         ]

--- a/snuba/snuba_migrations/outcomes/0007_outcomes_add_indexes_and_codecs.py
+++ b/snuba/snuba_migrations/outcomes/0007_outcomes_add_indexes_and_codecs.py
@@ -8,8 +8,8 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 class Migration(migration.ClickhouseNodeMigration):
     """
-    Adds indexes and codecs to match schema in SaaS.
-    Clickhouse 20 doesn't support adding codecs to key columns, so we don't add codecs to span_id and event_id.
+    Adds indexes and codecs to match schema in SaaS. Clickhouse 20 doesn't
+    support adding codecs to key columns, so we don't add codecs to timestamp.
     """
 
     blocking = True
@@ -19,8 +19,16 @@ class Migration(migration.ClickhouseNodeMigration):
             operations.ModifyColumn(
                 StorageSetKey.OUTCOMES,
                 "outcomes_raw_local",
-                Column("event_id", UUID(Modifiers(nullable=True, codecs=["LZ4HC(0)"]))),
-                ttl_month=("timestamp", 1),
+                Column(
+                    "event_id",
+                    UUID(
+                        Modifiers(
+                            nullable=True,
+                            codecs=["LZ4HC(0)"],
+                            ttl="timestamp + toIntervalDay(30)",
+                        )
+                    ),
+                ),
                 target=operations.OperationTarget.LOCAL,
             ),
             operations.AddIndex(

--- a/snuba/snuba_migrations/outcomes/0007_outcomes_add_indexes_and_codecs.py
+++ b/snuba/snuba_migrations/outcomes/0007_outcomes_add_indexes_and_codecs.py
@@ -1,0 +1,79 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column, DateTime
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds indexes and codecs to match schema in SaaS
+    """
+
+    blocking = True
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                Column(
+                    "timestamp", DateTime(Modifiers(codecs=["DoubleDelta", "ZSTD(1)"]))
+                ),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.ModifyColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                Column("event_id", UUID(Modifiers(nullable=True, codecs=["LZ4HC(0)"]))),
+                ttl_month=("timestamp", 1),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.AddIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_key_id",
+                index_expression="key_id",
+                index_type="minmax",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.AddIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_outcome",
+                index_expression="outcome",
+                index_type="minmax",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                Column("timestamp", DateTime()),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.ModifyColumn(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                Column("event_id", UUID(Modifiers(nullable=True))),
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_key_id",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_outcome",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]

--- a/snuba/snuba_migrations/outcomes/0008_outcomes_add_indexes.py
+++ b/snuba/snuba_migrations/outcomes/0008_outcomes_add_indexes.py
@@ -1,0 +1,51 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds indexes and codecs to match schema in SaaS. Clickhouse 20 doesn't
+    support adding codecs to key columns, so we don't add codecs to timestamp.
+    """
+
+    blocking = True
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_key_id",
+                index_expression="key_id",
+                index_type="minmax",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.AddIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_outcome",
+                index_expression="outcome",
+                index_type="minmax",
+                granularity=1,
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_key_id",
+                target=operations.OperationTarget.LOCAL,
+            ),
+            operations.DropIndex(
+                StorageSetKey.OUTCOMES,
+                "outcomes_raw_local",
+                index_name="minmax_outcome",
+                target=operations.OperationTarget.LOCAL,
+            ),
+        ]

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -145,6 +145,16 @@ class TestValidateMigrations:
             "",
         ),
         (
+            False,
+            False,
+            [drop_col_local_op, drop_col_local_op],
+            [],
+            [],
+            [drop_col_dist_op, drop_col_dist_op],
+            does_not_raise(),
+            "",
+        ),
+        (
             True,
             True,
             [create_local_op, add_col_local_op],


### PR DESCRIPTION
This migrations attempts to make the outcomes tables match what's in sass. 
1. It fixes some of the past migrations to display columns in a consistent order with SaaS. Functionally, this make no difference but allows the diff tool to more easily highlight changes.
2. Add back size, bytes received cols to match SaaS schema
3. Add indexes and codecs to match SaaS schema

Also fixes a bug where the validator was overly aggressive when checking for order errors.
