### PR TITLE
ref(migrations): Simplfy policies and status checks

### DIFF
--- a/snuba/admin/clickhouse/migration_checks.py
+++ b/snuba/admin/clickhouse/migration_checks.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import List, Mapping, Optional, Sequence, Tuple, Union
 
-from snuba.admin.migrations_policies import get_migration_group_polices
 from snuba.migrations.groups import MigrationGroup, get_group_loader
+from snuba.migrations.policies import MigrationPolicy
 from snuba.migrations.runner import MigrationDetails, MigrationKey, Runner
 from snuba.migrations.status import Status
 
@@ -157,85 +157,48 @@ class StatusChecker(Checker):
         return ReverseResult(True)
 
 
-class PolicyChecker(Checker):
-    """
-    The PolicyChecker validates whether you can run or
-    reverse a migration based on the policy for the
-    migration's group.
-
-    Policies are defined in the ADMIN_ALLOWED_MIGRATION_GROUPS
-    setting.
-    """
-
-    def can_run(self, migration_key: MigrationKey) -> RunResult:
-        if get_migration_group_polices()[migration_key.group.value].can_run(
-            migration_key
-        ):
-            return RunResult(True)
-        else:
-            return RunResult(False, RunReason.RUN_POLICY)
-
-    def can_reverse(self, migration_key: MigrationKey) -> ReverseResult:
-        if get_migration_group_polices()[migration_key.group.value].can_reverse(
-            migration_key
-        ):
-            return ReverseResult(True)
-        else:
-            return ReverseResult(False, ReverseReason.REVERSE_POLICY)
-
-
-def do_checks(
-    checkers: Sequence[Checker], migration_key: MigrationKey
-) -> Tuple[RunResult, ReverseResult]:
-    """
-    Execute the can_run and can_reverse functionality
-    for the checkers.
-
-    Returns the failed Result(s) for the first
-    check to fail in the sequence, otherwise returns
-    a passing Result.
-    """
-
-    assert len(checkers) >= 1
-
-    for checker in checkers:
-        run_result = checker.can_run(migration_key)
-        if not run_result.allowed:
-            break
-
-    for checker in checkers:
-        reverse_result = checker.can_reverse(migration_key)
-        if not reverse_result.allowed:
-            break
-
-    return run_result, reverse_result
-
-
-def run_migration_checks_for_groups(
-    allowed_groups: Sequence[MigrationGroup], runner: Runner
+def run_migration_checks_and_policies(
+    group_policies: Mapping[str, MigrationPolicy], runner: Runner
 ) -> Sequence[Tuple[MigrationGroup, Sequence[MigrationData]]]:
     """
-    Gets the statuses of all the migrations within each group
-    listed in the allowed_groups and runs the StatusChecker
-    and PolicyChecker (in that order) for said migrations.
+    Runs the policies for the given groups in addition to status
+    checks for all groups.
 
     Returns the results of those checks along with the statuses
     for the migrations.
     """
     group_results: List[Tuple[MigrationGroup, Sequence[MigrationData]]] = []
 
-    for group, migrations in runner.show_all([g.value for g in allowed_groups]):
-
+    for group, migrations in runner.show_all([g for g in group_policies.keys()]):
         migration_ids: List[MigrationData] = []
 
         status_checker = StatusChecker(group, migrations)
-        policy_checker = PolicyChecker()
+        policy = group_policies[group.value]
 
-        checkers = [status_checker, policy_checker]
+        def do_checking(
+            migration_key: MigrationKey,
+        ) -> Tuple[RunResult, ReverseResult]:
+            run_result = status_checker.can_run(migration_key)
+            reverse_result = status_checker.can_reverse(migration_key)
+
+            if run_result.allowed:
+                run_result = (
+                    RunResult(True)
+                    if policy.can_run(migration_key)
+                    else RunResult(False, RunReason.RUN_POLICY)
+                )
+            if reverse_result.allowed:
+                reverse_result = (
+                    ReverseResult(True)
+                    if policy.can_reverse(migration_key)
+                    else ReverseResult(False, ReverseReason.REVERSE_POLICY)
+                )
+
+            return run_result, reverse_result
 
         for details in migrations:
-            run_result, reverse_result = do_checks(
-                checkers, MigrationKey(group, details.migration_id)
+            run_result, reverse_result = do_checking(
+                MigrationKey(group, details.migration_id)
             )
             migration_ids.append(
                 MigrationData(

--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -8,7 +8,7 @@ from flask import Response, jsonify, make_response, request
 from snuba import settings
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.policies import MigrationPolicy
-from snuba.migrations.runner import MigrationKey
+from snuba.migrations.runner import MigrationKey, get_active_migration_groups
 
 
 def get_migration_group_polices() -> Dict[str, MigrationPolicy]:
@@ -17,9 +17,13 @@ def get_migration_group_polices() -> Dict[str, MigrationPolicy]:
     ADMIN_ALLOWED_MIGRATION_GROUPS setting. If a group is not defined
     it means no access at all to that group through admin.
     """
+    allowed_groups = {
+        group.value: settings.ADMIN_ALLOWED_MIGRATION_GROUPS[group.value]
+        for group in get_active_migration_groups()
+    }
     return {
         group_name: MigrationPolicy.class_from_name(policy_name)()
-        for group_name, policy_name in settings.ADMIN_ALLOWED_MIGRATION_GROUPS.items()
+        for group_name, policy_name in allowed_groups.items()
     }
 
 

--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -17,13 +17,17 @@ def get_migration_group_polices() -> Dict[str, MigrationPolicy]:
     ADMIN_ALLOWED_MIGRATION_GROUPS setting. If a group is not defined
     it means no access at all to that group through admin.
     """
-    allowed_groups = {
-        group.value: settings.ADMIN_ALLOWED_MIGRATION_GROUPS[group.value]
+    allowed_groups = [
+        group.value
         for group in get_active_migration_groups()
-    }
+        if group.value in settings.ADMIN_ALLOWED_MIGRATION_GROUPS
+    ]
+
     return {
-        group_name: MigrationPolicy.class_from_name(policy_name)()
-        for group_name, policy_name in allowed_groups.items()
+        group_name: MigrationPolicy.class_from_name(
+            settings.ADMIN_ALLOWED_MIGRATION_GROUPS[group_name]
+        )()
+        for group_name in allowed_groups
     }
 
 

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -144,7 +144,7 @@ def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
         response = admin_api.post(
             f"/migrations/invalid_but_allowed_group/{action}/0001_migrations"
         )
-        assert response.status_code == 500
+        assert response.status_code == 403
 
         with patch.object(Runner, method) as mock_run_migration:
             response = admin_api.post(f"/migrations/system/{action}/0001_migrations")


### PR DESCRIPTION
**context:**
Policies are no longer going to be defined in settings, but rather by the roles added https://github.com/getsentry/snuba/pull/3522. Actually using the roles to get the policies is done in https://github.com/getsentry/snuba/pull/3618 but I wanted to simplify the code a bit in order to make that change more manageable. 

**changes:**
* removal of the `PolicyChecker` class - it made more sense to get the group policies in the API endpoint since we'll need the user to do so. 
* contain all the checking logic within `run_migration_checks_and_policies` - I think ultimately this makes it simpler to read and understand