### PR TITLE
Add migration to make discover use merge engine instead of distributed

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -154,6 +154,7 @@ class DiscoverLoader(DirectoryLoader):
             "0005_discover_fix_transaction_name",
             "0006_discover_add_trace_id",
             "0007_discover_add_span_id",
+            "0008_discover_fix_dist_table",
         ]
 
 

--- a/snuba/snuba_migrations/discover/0008_discover_fix_dist_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_dist_table.py
@@ -1,0 +1,98 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import (
+    UUID,
+    Array,
+    Column,
+    DateTime,
+    IPv4,
+    IPv6,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+columns: List[Column[Modifiers]] = [
+    Column("event_id", UUID()),
+    Column("project_id", UInt(64)),
+    Column("type", String(Modifiers(low_cardinality=True))),
+    Column("timestamp", DateTime()),
+    Column("platform", String(Modifiers(low_cardinality=True))),
+    Column("environment", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("release", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("dist", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("transaction_name", String(Modifiers(low_cardinality=True))),
+    Column("message", String()),
+    Column("title", String()),
+    Column("user", String()),
+    Column("user_hash", UInt(64)),
+    Column("user_id", String(Modifiers(nullable=True))),
+    Column("user_name", String(Modifiers(nullable=True))),
+    Column("user_email", String(Modifiers(nullable=True))),
+    Column("ip_address_v4", IPv4(Modifiers(nullable=True))),
+    Column("ip_address_v6", IPv6(Modifiers(nullable=True))),
+    Column("sdk_name", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("sdk_version", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("http_method", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("http_referer", String(Modifiers(nullable=True))),
+    Column("tags", Nested([("key", String()), ("value", String())])),
+    Column("_tags_hash_map", Array(UInt(64))),
+    Column("contexts", Nested([("key", String()), ("value", String())])),
+    Column("trace_id", UUID(Modifiers(nullable=True))),
+    Column("span_id", UInt(64, Modifiers(nullable=True))),
+    Column("deleted", UInt(8)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = True
+    """
+    Fixes the discover table to be a merge table of the errors and transactions tables to match SaaS.
+    This migration first drops the existing dist table then replaces it with one with the correct engine.
+    """
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name="discover_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.CreateTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name="discover_dist_new",
+                columns=columns,
+                engine=table_engines.Merge(
+                    table_name_regex="^errors_dist$|^transactions_dist$"
+                ),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.RenameTable(
+                storage_set=StorageSetKey.DISCOVER,
+                old_table_name="discover_dist_new",
+                new_table_name="discover_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name="discover_dist",
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.CreateTable(
+                storage_set=StorageSetKey.DISCOVER,
+                table_name="discover_dist",
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="discover_local",
+                    sharding_key=None,
+                ),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]


### PR DESCRIPTION
This migration fixes the discover dist table to use the merge engine. In order to change the engine, we drop the current dist table and replace it with a new one with the correct engine.