### PR TITLE
ci: Update self-hosted e2e action to add sentry-cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@05a7e7994f8f713cbb9e353a9fd5f5952ed6c015
+        uses: getsentry/action-self-hosted-e2e-tests@20b5170d3b59d8b44ee5327d64b31d6b6b5aa34f
         with:
           project_name: snuba
           docker_repo: getsentry/snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@ade3e646ffc3b6a765cfa18ec4ca720f710cb53d
+        uses: getsentry/action-self-hosted-e2e-tests@05a7e7994f8f713cbb9e353a9fd5f5952ed6c015
         with:
           project_name: snuba
           docker_repo: getsentry/snuba


### PR DESCRIPTION
This bumps the action ref to https://github.com/getsentry/action-self-hosted-e2e-tests/commit/20b5170d3b59d8b44ee5327d64b31d6b6b5aa34f, which introduces sentry-cli, a new dependency of our integration tests.