### PR TITLE
fix(DC) ColumnToIPAddress mapper needing unnecessary parameters

### DIFF
--- a/snuba/clickhouse/translators/snuba/mappers.py
+++ b/snuba/clickhouse/translators/snuba/mappers.py
@@ -114,9 +114,7 @@ class ColumnToIPAddress(ColumnToFunction):
     TODO: Can remove when we support dynamic expression parsing in config
     """
 
-    def __init__(
-        self, from_table_name: str, from_col_name: str, to_function_name: str
-    ) -> None:
+    def __init__(self, from_table_name: Optional[str], from_col_name: str) -> None:
         to_function_params: Tuple[FunctionCallExpr, ...] = (
             FunctionCallExpr(
                 None,
@@ -129,9 +127,7 @@ class ColumnToIPAddress(ColumnToFunction):
                 (ColumnExpr(None, None, "ip_address_v6"),),
             ),
         )
-        super().__init__(
-            from_table_name, from_col_name, to_function_name, to_function_params
-        )
+        super().__init__(from_table_name, from_col_name, "coalesce", to_function_params)
 
 
 @dataclass(frozen=True)

--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -89,7 +89,6 @@ storages:
           args:
             from_table_name:
             from_col_name: "ip_address"
-            to_function_name: "coalesce"
         - mapper: ColumnToNullIf
           args:
             from_table_name:

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -142,7 +142,6 @@ storages:
                   {
                     from_table_name,
                     from_col_name: "ip_address",
-                    to_function_name: "coalesce",
                   },
               },
               {

--- a/snuba/datasets/entities/events.py
+++ b/snuba/datasets/entities/events.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 
 from snuba.clickhouse.translators.snuba.mappers import (
     ColumnToColumn,
-    ColumnToFunction,
+    ColumnToIPAddress,
     ColumnToMapping,
     SubscriptableMapper,
 )
@@ -18,7 +18,6 @@ from snuba.datasets.storages.factory import get_storage, get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.pipeline.simple_pipeline import SimplePipelineBuilder
 from snuba.query.data_source.join import JoinRelationship, JoinType
-from snuba.query.expressions import Column, FunctionCall
 from snuba.query.processors.logical import LogicalQueryProcessor
 from snuba.query.processors.logical.basic_functions import BasicFunctionsProcessor
 from snuba.query.processors.logical.handled_functions import HandledFunctionsProcessor
@@ -49,23 +48,7 @@ errors_translators = TranslationMappers(
         ColumnToMapping(None, "release", None, "tags", "sentry:release"),
         ColumnToMapping(None, "dist", None, "tags", "sentry:dist"),
         ColumnToMapping(None, "user", None, "tags", "sentry:user"),
-        ColumnToFunction(
-            None,
-            "ip_address",
-            "coalesce",
-            (
-                FunctionCall(
-                    None,
-                    "IPv4NumToString",
-                    (Column(None, None, "ip_address_v4"),),
-                ),
-                FunctionCall(
-                    None,
-                    "IPv6NumToString",
-                    (Column(None, None, "ip_address_v6"),),
-                ),
-            ),
-        ),
+        ColumnToIPAddress(None, "ip_address"),
         ColumnToColumn(None, "transaction", None, "transaction_name"),
         ColumnToColumn(None, "username", None, "user_name"),
         ColumnToColumn(None, "email", None, "user_email"),

--- a/tests/datasets/configuration/entity_with_column_mappers.yaml
+++ b/tests/datasets/configuration/entity_with_column_mappers.yaml
@@ -20,7 +20,6 @@ storages:
           args:
             from_table_name:
             from_col_name: ip_address
-            to_function_name: coalesce
         -
           mapper: ColumnToNullIf
           args:
@@ -71,7 +70,6 @@ storages:
           args:
             from_table_name:
             from_col_name: ip_address
-            to_function_name: coalesce
         -
           mapper: ColumnToNullIf
           args:


### PR DESCRIPTION
We shouldn't need to specify the argument for this purpose built translation mapper. 

(CI should fail at first commit because this should break stuff))