### PR TITLE
fix(outcomes): Add TTL to outcomes dataset

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -167,6 +167,7 @@ class OutcomesLoader(DirectoryLoader):
             "0002_outcomes_remove_size_and_bytes",
             "0003_outcomes_add_category_and_quantity",
             "0004_outcomes_matview_additions",
+            "0005_outcomes_ttl",
         ]
 
 

--- a/snuba/snuba_migrations/outcomes/0005_outcomes_ttl.py
+++ b/snuba/snuba_migrations/outcomes/0005_outcomes_ttl.py
@@ -1,0 +1,34 @@
+from typing import Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyTableTTL(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_raw_local",
+                reference_column="timestamp",
+                ttl_days=30,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.ModifyTableTTL(
+                storage_set=StorageSetKey.OUTCOMES,
+                table_name="outcomes_hourly_local",
+                reference_column="timestamp",
+                ttl_days=90,
+                target=OperationTarget.LOCAL,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        """
+        Removing a TTL is not supported by Clickhouse version 20.3. So there is
+        no backwards migration.
+        """
+        return []


### PR DESCRIPTION
Since there is no TTL on the outcomes dataset, the storage size can grow unbounded. This PR adds a TTL of 30 days for the raw tables and 90 days for the aggregate tables.
