### PR TITLE
feat(config): Migrate GroupedMessage and GroupAssignee Entities to YAML

### DIFF
--- a/snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml
+++ b/snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml
@@ -1,0 +1,35 @@
+version: v1
+kind: entity
+name: groupassignee
+
+schema:
+  [
+    { name: offset, type: UInt, args: { size: 64 } },
+    { name: record_deleted, type: UInt, args: { size: 8 } },
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: group_id, type: UInt, args: { size: 64 } },
+    { name: date_added, type: DateTime, args: { schema_modifiers: [nullable] } },
+    { name: user_id, type: UInt, args: { size: 64, schema_modifiers: [nullable] } },
+    { name: team_id, type: UInt, args: { size: 64, schema_modifiers: [nullable] } },
+  ]
+
+storages:
+  - storage: groupassignees
+    is_writable: true
+storage_selector:
+  selector: DefaultQueryStorageSelector
+
+query_processors:
+  - processor: BasicFunctionsProcessor
+  - processor: ProjectRateLimiterProcessor
+    args:
+      project_column: project_id
+validators: []
+required_time_column: null
+join_relationships:
+  owns:
+    rhs_entity: events
+    join_type: left
+    columns:
+      - [project_id, project_id]
+      - [group_id, group_id]

--- a/snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml
+++ b/snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml
@@ -1,0 +1,37 @@
+version: v1
+kind: entity
+name: groupedmessage
+
+schema:
+  [
+    { name: offset, type: UInt, args: { size: 64 } },
+    { name: record_deleted, type: UInt, args: { size: 8 } },
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: id, type: UInt, args: { size: 64 } },
+    { name: status, type: UInt, args: { schema_modifiers: [nullable], size: 8 } },
+    { name: last_seen, type: DateTime, args: { schema_modifiers: [nullable] } },
+    { name: first_seen, type: DateTime, args: { schema_modifiers: [nullable] } },
+    { name: active_at, type: DateTime, args: { schema_modifiers: [nullable] } },
+    { name: first_release_id, type: UInt, args: { schema_modifiers: [nullable], size: 64 } },
+  ]
+
+storages:
+  - storage: groupedmessages
+    is_writable: true
+storage_selector:
+  selector: DefaultQueryStorageSelector
+
+query_processors:
+  - processor: BasicFunctionsProcessor
+  - processor: ProjectRateLimiterProcessor
+    args:
+      project_column: project_id
+validators: []
+required_time_column: null
+join_relationships:
+  groups:
+    rhs_entity: events
+    join_type: left
+    columns:
+      - [project_id, project_id]
+      - [id, group_id]

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -645,10 +645,8 @@ V1_ENTITY_SCHEMA = {
             "description": "The validation logic used on the ClickHouse query",
         },
         "required_time_column": {
-            **TYPE_STRING,
-            **{
-                "description": "The name of the required time column specifed in schema"
-            },
+            "type": ["string", "null"],
+            "description": "The name of the required time column specifed in schema",
         },
         "partition_key_column_name": {
             "type": ["string", "null"],

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -48,7 +48,7 @@ class PluggableEntity(Entity):
     query_processors: Sequence[LogicalQueryProcessor]
     columns: Sequence[Column[SchemaModifiers]]
     validators: Sequence[QueryValidator]
-    required_time_column: str
+    required_time_column: Optional[str]
     storage_selector: QueryStorageSelector
     join_relationships: Mapping[str, JoinRelationship] = field(default_factory=dict)
     function_call_validators: Mapping[str, FunctionCallValidator] = field(

--- a/tests/datasets/configuration/test_entity_loader.py
+++ b/tests/datasets/configuration/test_entity_loader.py
@@ -13,6 +13,7 @@ from snuba.clickhouse.translators.snuba.mappers import (
 from snuba.datasets.configuration.entity_builder import build_entity_from_config
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entity import Entity
+from snuba.datasets.factory import reset_dataset_factory
 from snuba.datasets.pluggable_entity import PluggableEntity
 from snuba.query.expressions import Column, FunctionCall, Literal
 from tests.datasets.configuration.utils import ConfigurationTest
@@ -25,24 +26,23 @@ def get_object_in_list_by_class(object_list: Any, object_class: Any) -> Any:
     return None
 
 
-class TestEntityConfiguration(ConfigurationTest):
-    def test_bad_configuration_broken_query_processor(self) -> None:
-        with pytest.raises(JsonSchemaValueException):
-            build_entity_from_config(
-                "tests/datasets/configuration/broken_entity_bad_query_processor.yaml"
-            )
+class TestEntityConfigurationComparison(ConfigurationTest):
+    """
+    This test compare the YAML config files to the Python ones.
+    This test suite is only useful as we translate entities to YAML.
+    Once all the entities are YAML and the Python ones are removed this
+    test suite can also be removed.
+    """
 
-    def test_bad_configuration_broken_validator(self) -> None:
-        with pytest.raises(JsonSchemaValueException):
-            build_entity_from_config(
-                "tests/datasets/configuration/broken_entity_positional_validator_args.yaml"
-            )
+    def setup_class(self) -> None:
+        reset_dataset_factory()
 
-    def test_config_matches_python_definition(self) -> None:
+        from snuba.datasets.cdc.groupassignee_entity import GroupAssigneeEntity
+        from snuba.datasets.cdc.groupedmessage_entity import GroupedMessageEntity
         from snuba.datasets.entities.generic_metrics import GenericMetricsSetsEntity
         from snuba.datasets.entities.transactions import TransactionsEntity
 
-        test_data = [
+        self.test_data = [
             (
                 "snuba/datasets/configuration/generic_metrics/entities/sets.yaml",
                 GenericMetricsSetsEntity,
@@ -53,9 +53,17 @@ class TestEntityConfiguration(ConfigurationTest):
                 TransactionsEntity,
                 EntityKey.TRANSACTIONS,
             ),
+            (
+                "snuba/datasets/configuration/groupassignee/entities/groupassignee.yaml",
+                GroupAssigneeEntity,
+                EntityKey.GROUPASSIGNEE,
+            ),
+            (
+                "snuba/datasets/configuration/groupedmessage/entities/groupedmessage.yaml",
+                GroupedMessageEntity,
+                EntityKey.GROUPEDMESSAGE,
+            ),
         ]
-        for test in test_data:
-            self._config_matches_python_definition(*test)  # type: ignore
 
     def _config_matches_python_definition(
         self, config_path: str, entity: Type[Entity], entity_key: EntityKey
@@ -89,6 +97,24 @@ class TestEntityConfiguration(ConfigurationTest):
         assert config_entity.required_time_column == py_entity.required_time_column
 
         assert config_entity.get_data_model() == py_entity.get_data_model()
+
+    def test_config_matches_python_definition(self) -> None:
+        for test in self.test_data:
+            self._config_matches_python_definition(*test)  # type: ignore
+
+
+class TestEntityConfiguration(ConfigurationTest):
+    def test_bad_configuration_broken_query_processor(self) -> None:
+        with pytest.raises(JsonSchemaValueException):
+            build_entity_from_config(
+                "tests/datasets/configuration/broken_entity_bad_query_processor.yaml"
+            )
+
+    def test_bad_configuration_broken_validator(self) -> None:
+        with pytest.raises(JsonSchemaValueException):
+            build_entity_from_config(
+                "tests/datasets/configuration/broken_entity_positional_validator_args.yaml"
+            )
 
     def test_entity_loader_for_entity_with_column_mappers(self) -> None:
         pluggable_entity = build_entity_from_config(


### PR DESCRIPTION
GroupedMessage and GroupAssignee entities had YAML versions created and added to
their existing datasets. The two entities are now being loaded from config
instead of Python.

`required_time_column` can now be set to `null`. The field is still required in
the schema since that is the main case. These entities are a special case.

There is now a test in the entity loader that is similar to the storages test
that compares entities to their Python version. As we migrate entities we should
update that test. Once our migration is done we can delete that test entirely.