### PR TITLE
fix(DC): Make sure storage selectors are imported automatically

### DIFF
--- a/snuba/datasets/configuration/entity_builder.py
+++ b/snuba/datasets/configuration/entity_builder.py
@@ -14,7 +14,7 @@ from snuba.datasets.configuration.json_schema import ENTITY_VALIDATORS
 from snuba.datasets.configuration.loader import load_configuration_data
 from snuba.datasets.configuration.utils import parse_columns
 from snuba.datasets.entities.entity_key import register_entity_key
-from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelector
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entity_subscriptions.processors import EntitySubscriptionProcessor
 from snuba.datasets.entity_subscriptions.validators import EntitySubscriptionValidator
 from snuba.datasets.pluggable_entity import PluggableEntity

--- a/snuba/datasets/entities/metrics.py
+++ b/snuba/datasets/entities/metrics.py
@@ -20,9 +20,9 @@ from snuba.clickhouse.translators.snuba.mappers import (
     SubscriptableMapper,
 )
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entities.storage_selectors.selector import (
     DefaultQueryStorageSelector,
-    QueryStorageSelector,
     SimpleQueryStorageSelector,
 )
 from snuba.datasets.entity import Entity

--- a/snuba/datasets/entities/storage_selectors/__init__.py
+++ b/snuba/datasets/entities/storage_selectors/__init__.py
@@ -1,0 +1,38 @@
+import os
+from abc import ABC, abstractmethod
+from typing import List, Type, cast
+
+from snuba.datasets.storage import EntityStorageConnection
+from snuba.query.logical import Query
+from snuba.query.query_settings import QuerySettings
+from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
+
+
+class QueryStorageSelector(ABC, metaclass=RegisteredClass):
+    """
+    The component provided by a dataset and used at the beginning of the
+    execution of a query to pick the storage query should be executed onto.
+    """
+
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
+
+    @classmethod
+    def get_from_name(cls, name: str) -> Type["QueryStorageSelector"]:
+        return cast(Type["QueryStorageSelector"], cls.class_from_name(name))
+
+    @abstractmethod
+    def select_storage(
+        self,
+        query: Query,
+        query_settings: QuerySettings,
+        storage_connections: List[EntityStorageConnection],
+    ) -> EntityStorageConnection:
+        raise NotImplementedError
+
+
+import_submodules_in_directory(
+    os.path.dirname(os.path.realpath(__file__)),
+    "snuba.datasets.entities.storage_selectors",
+)

--- a/snuba/datasets/entities/storage_selectors/errors.py
+++ b/snuba/datasets/entities/storage_selectors/errors.py
@@ -1,7 +1,7 @@
 from typing import List
 
 from snuba import state
-from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelector
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.storage import (
     EntityStorageConnection,
     EntityStorageConnectionNotFound,

--- a/snuba/datasets/entities/storage_selectors/selector.py
+++ b/snuba/datasets/entities/storage_selectors/selector.py
@@ -1,39 +1,14 @@
-from abc import ABC, abstractmethod
-from typing import List, Type, cast
+from typing import List
 
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.storage import EntityStorageConnection, ReadableTableStorage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.logical import Query
 from snuba.query.query_settings import QuerySettings
-from snuba.utils.registered_class import RegisteredClass
 
 
 class QueryStorageSelectorError(Exception):
     pass
-
-
-class QueryStorageSelector(ABC, metaclass=RegisteredClass):
-    """
-    The component provided by a dataset and used at the beginning of the
-    execution of a query to pick the storage query should be executed onto.
-    """
-
-    @classmethod
-    def config_key(cls) -> str:
-        return cls.__name__
-
-    @classmethod
-    def get_from_name(cls, name: str) -> Type["QueryStorageSelector"]:
-        return cast(Type["QueryStorageSelector"], cls.class_from_name(name))
-
-    @abstractmethod
-    def select_storage(
-        self,
-        query: Query,
-        query_settings: QuerySettings,
-        storage_connections: List[EntityStorageConnection],
-    ) -> EntityStorageConnection:
-        raise NotImplementedError
 
 
 class DefaultQueryStorageSelector(QueryStorageSelector):

--- a/snuba/datasets/entities/storage_selectors/sessions.py
+++ b/snuba/datasets/entities/storage_selectors/sessions.py
@@ -3,7 +3,7 @@ from typing import List
 
 from snuba import environment
 from snuba.clickhouse.query_dsl.accessors import get_time_range
-from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelector
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.storage import (
     EntityStorageConnection,
     EntityStorageConnectionNotFound,

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -5,10 +5,8 @@ import sentry_sdk
 from snuba import state
 from snuba.clickhouse.query import Query
 from snuba.clusters.cluster import ClickhouseCluster
-from snuba.datasets.entities.storage_selectors.selector import (
-    QueryStorageSelector,
-    QueryStorageSelectorError,
-)
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
+from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelectorError
 from snuba.datasets.plans.cluster_selector import ColumnBasedStorageSliceSelector
 from snuba.datasets.plans.query_plan import (
     ClickhouseQueryPlan,

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -4,7 +4,7 @@ from typing import Any, List, Mapping, Optional, Sequence
 from snuba.clickhouse.columns import Column
 from snuba.datasets.entities.entity_data_model import EntityColumnSet
 from snuba.datasets.entities.entity_key import EntityKey
-from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelector
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entity import Entity
 from snuba.datasets.entity_subscriptions.processors import EntitySubscriptionProcessor
 from snuba.datasets.entity_subscriptions.validators import EntitySubscriptionValidator

--- a/tests/datasets/entities/storage_selectors/test_errors.py
+++ b/tests/datasets/entities/storage_selectors/test_errors.py
@@ -5,8 +5,8 @@ import pytest
 from snuba import state
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.events import errors_translators
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entities.storage_selectors.errors import ErrorsQueryStorageSelector
-from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelector
 from snuba.datasets.factory import get_dataset
 from snuba.datasets.storage import (
     EntityStorageConnection,

--- a/tests/datasets/entities/storage_selectors/test_selector.py
+++ b/tests/datasets/entities/storage_selectors/test_selector.py
@@ -8,9 +8,9 @@ from snuba.clickhouse.translators.snuba.mappers import (
 )
 from snuba.clickhouse.translators.snuba.mapping import TranslationMappers
 from snuba.datasets.dataset import Dataset
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entities.storage_selectors.selector import (
     DefaultQueryStorageSelector,
-    QueryStorageSelector,
     QueryStorageSelectorError,
     SimpleQueryStorageSelector,
 )

--- a/tests/datasets/entities/storage_selectors/test_sessions.py
+++ b/tests/datasets/entities/storage_selectors/test_sessions.py
@@ -7,7 +7,7 @@ from snuba.datasets.entities.sessions import (
     sessions_hourly_translators,
     sessions_raw_translators,
 )
-from snuba.datasets.entities.storage_selectors.selector import QueryStorageSelector
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entities.storage_selectors.sessions import (
     SessionsQueryStorageSelector,
 )

--- a/tests/datasets/plans/test_storage_plan_builder.py
+++ b/tests/datasets/plans/test_storage_plan_builder.py
@@ -7,10 +7,10 @@ from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.datasets.dataset import Dataset
 from snuba.datasets.entities.events import errors_translators
+from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.entities.storage_selectors.errors import ErrorsQueryStorageSelector
 from snuba.datasets.entities.storage_selectors.selector import (
     DefaultQueryStorageSelector,
-    QueryStorageSelector,
 )
 from snuba.datasets.entities.transactions import transaction_translator
 from snuba.datasets.factory import get_dataset


### PR DESCRIPTION
Converting sessions and errors entities is not possible until the storage selectors can be referenced from config. This only works now because only the default ones are used in config