### PR TITLE
ref: Remove runtime config override for stale-threshold-sec

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -126,13 +126,6 @@ def subscriptions_executor(
         )
     )
 
-    # TODO: Consider removing and always passing via CLI.
-    # If a value provided via config, it overrides the one provided via CLI.
-    # This is so we can quickly change this in an emergency.
-    stale_threshold_seconds = state.get_config(
-        f"subscriptions_stale_threshold_sec_{dataset_name}", stale_threshold_seconds
-    )
-
     processor = build_executor_consumer(
         dataset_name,
         entity_names,


### PR DESCRIPTION
--stale-threshold-sec should be passed via the CLI, remove the runtime override for this value
