### PR TITLE
feat(api-abuse): Add triggered rate limiter name to Querylog stats

### DIFF
--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -107,6 +107,7 @@ def _get_bucket_key(prefix: str, bucket: str, shard_id: int) -> str:
 def rate_limit(
     rate_limit_params: RateLimitParameters,
 ) -> Iterator[Optional[RateLimitStats]]:
+    print("entered rate limit context manager")
     """
     A context manager for rate limiting that allows for limiting based on:
         * a rolling-window per-second rate

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -107,7 +107,6 @@ def _get_bucket_key(prefix: str, bucket: str, shard_id: int) -> str:
 def rate_limit(
     rate_limit_params: RateLimitParameters,
 ) -> Iterator[Optional[RateLimitStats]]:
-    print("entered rate limit context manager")
     """
     A context manager for rate limiting that allows for limiting based on:
         * a rolling-window per-second rate

--- a/tests/datasets/test_querylog_processor.py
+++ b/tests/datasets/test_querylog_processor.py
@@ -67,7 +67,11 @@ def test_simple() -> None:
                 sql_anonymized="select event_id from sentry_dist sample 0.1 prewhere project_id in ($I) limit 50, 100",
                 start_timestamp=datetime.utcnow() - timedelta(days=3),
                 end_timestamp=datetime.utcnow(),
-                stats={"sample": 10, "error_code": 386},
+                stats={
+                    "sample": 10,
+                    "error_code": 386,
+                    "triggered_rate_limiter": "test_rate_limiter",
+                },
                 status=QueryStatus.SUCCESS,
                 profile=ClickhouseQueryProfile(
                     time_range=10,
@@ -117,7 +121,9 @@ def test_simple() -> None:
                 "clickhouse_queries.status": ["success"],
                 "clickhouse_queries.trace_id": [str(uuid.UUID("b" * 32))],
                 "clickhouse_queries.duration_ms": [42],
-                "clickhouse_queries.stats": ['{"error_code": 386, "sample": 10}'],
+                "clickhouse_queries.stats": [
+                    '{"error_code": 386, "sample": 10, "triggered_rate_limiter": "test_rate_limiter"}'
+                ],
                 "clickhouse_queries.final": [0],
                 "clickhouse_queries.cache_hit": [0],
                 "clickhouse_queries.sample": [10.0],


### PR DESCRIPTION
## Overview
Currently, the snuba querylog contains `status` which specifies whether a query was rate-limited or not. However, it does not specify which rate limiter was applied. This PR is responsible for adding that into `stats`.

## After State
Querylog contains a new key `triggered_rate_limiter` in `stats` when a rate limiter is applied to a query.

## Testing
Tested locally to ensure messages produced to querylog topics are correct and contain accurate fields.