### PR TITLE
feat(api-abuse): Add timing metrics for table_concurrent

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -313,6 +313,16 @@ def _record_rate_limit_metrics(
                 else "default",
             },
         )
+        metrics.timing(
+            name="table_concurrent_",
+            value=table_rate_limit_stats.concurrent,
+            tags={
+                "table": stats.get("clickhouse_table", ""),
+                "cache_partition": reader.cache_partition_id
+                if reader.cache_partition_id
+                else "default",
+            },
+        )
 
 
 def _apply_thread_quota_to_clickhouse_query_settings(

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -314,7 +314,7 @@ def _record_rate_limit_metrics(
             },
         )
         metrics.timing(
-            name="table_concurrent_",
+            name="table_concurrent_hist",
             value=table_rate_limit_stats.concurrent,
             tags={
                 "table": stats.get("clickhouse_table", ""),


### PR DESCRIPTION
## Overview
Currently, the `table_concurrent` metric is a gauge in Datadog. As a result, the agent only submits the last reported number of the metric in a given time interval. Since we want a more accurate representation of the maximum concurrent queries that hit our tables, we should change this to a `metric.timing`.

## After State
A new `table_concurrent_` metric is added to get a more accurate maximum overt time.