### PR TITLE
fix(codecov) Change codecov notifier to send after at least 2 builds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ codecov:
   # until all of these are done, we don't want a faulty
   # codecov report
   notify:
-      after_n_builds: 3
+      after_n_builds: 2
 coverage:
   status:
     project:


### PR DESCRIPTION
Since the codecov.yml was added, Codecov does not notify (comment report on PR) anymore. This PR reduces `after_n_builds` to `2` so it will post after only 2 of our test CI steps.