### PR TITLE
ref(DC): Add FixedString field to configuration

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -152,6 +152,17 @@ NUMBER_SCHEMA = make_column_schema(
     },
 )
 
+FIXED_STRING_SCHEMA = make_column_schema(
+    column_type={"enum": ["FixedString"]},
+    args={
+        "type": "object",
+        "properties": {
+            "length": {"type": "number"},
+        },
+        "additionalProperties": False,
+    },
+)
+
 
 NO_ARG_SCHEMA = make_column_schema(
     column_type={"enum": ["String", "DateTime", "UUID", "IPv4", "IPv6"]},
@@ -184,6 +195,7 @@ AGGREGATE_FUNCTION_SCHEMA = make_column_schema(
 
 SIMPLE_COLUMN_SCHEMAS = [
     NUMBER_SCHEMA,
+    FIXED_STRING_SCHEMA,
     NO_ARG_SCHEMA,
     AGGREGATE_FUNCTION_SCHEMA,
 ]

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -22,7 +22,14 @@ from snuba.clickhouse.columns import (
 from snuba.datasets.plans.splitters import QuerySplitStrategy
 from snuba.query.processors.condition_checkers import ConditionChecker
 from snuba.query.processors.physical import ClickhouseQueryProcessor
-from snuba.utils.schemas import UUID, AggregateFunction, ColumnType, IPv4, IPv6
+from snuba.utils.schemas import (
+    UUID,
+    AggregateFunction,
+    ColumnType,
+    FixedString,
+    IPv4,
+    IPv6,
+)
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.topics import Topic
 
@@ -149,6 +156,8 @@ def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:
             [__parse_column_type(c) for c in col["args"]["arg_types"]],
             modifiers,
         )
+    elif col["type"] == "FixedString":
+        column_type = FixedString(col["args"]["length"], modifiers)
     assert column_type is not None
     return column_type
 

--- a/tests/datasets/configuration/entity_with_fixed_string.yaml
+++ b/tests/datasets/configuration/entity_with_fixed_string.yaml
@@ -8,7 +8,7 @@ schema:
   args:
     length: 420
 - name: project_id
-  type: uint
+  type: UInt
   args:
     size: 64
 - name: primary_hash

--- a/tests/datasets/configuration/entity_with_fixed_string.yaml
+++ b/tests/datasets/configuration/entity_with_fixed_string.yaml
@@ -1,0 +1,28 @@
+version: v1
+kind: entity
+name: fixedstring
+
+schema:
+- name: event_id
+  type: FixedString
+  args:
+    length: 420
+- name: project_id
+  type: uint
+  args:
+    size: 64
+- name: primary_hash
+  type: FixedString
+  args:
+    length: 69
+    schema_modifiers:
+    - nullable
+
+storages:
+- storage: discover
+  is_writable: false
+required_time_column: event_id
+storage_selector:
+  selector: DefaultQueryStorageSelector
+query_processors: []
+validators: []

--- a/tests/datasets/configuration/test_entity_loader.py
+++ b/tests/datasets/configuration/test_entity_loader.py
@@ -26,6 +26,11 @@ def get_object_in_list_by_class(object_list: Any, object_class: Any) -> Any:
 
 
 class TestEntityConfiguration(ConfigurationTest):
+    def test_entity_loader_fixed_string(self) -> None:
+        build_entity_from_config(
+            "tests/datasets/configuration/entity_with_fixed_string.yaml"
+        )
+
     def test_bad_configuration_broken_query_processor(self) -> None:
         with pytest.raises(JsonSchemaValueException):
             build_entity_from_config(

--- a/tests/datasets/configuration/test_entity_loader.py
+++ b/tests/datasets/configuration/test_entity_loader.py
@@ -27,9 +27,13 @@ def get_object_in_list_by_class(object_list: Any, object_class: Any) -> Any:
 
 class TestEntityConfiguration(ConfigurationTest):
     def test_entity_loader_fixed_string(self) -> None:
-        build_entity_from_config(
+        entity = build_entity_from_config(
             "tests/datasets/configuration/entity_with_fixed_string.yaml"
         )
+        columns = list(entity.get_data_model())
+        assert len(columns) == 3
+        assert columns[0].type.length == 420  # type: ignore
+        assert columns[2].type.length == 69  # type: ignore
 
     def test_bad_configuration_broken_query_processor(self) -> None:
         with pytest.raises(JsonSchemaValueException):


### PR DESCRIPTION
The discover Entity contains `FixedString` fields which do not exist in the configuration grammar right now

* update the grammar
* update the parser

**Blast Radius**
No existing entities should be affected

**Feedback Desired**
Is there a better place to put the test that I don't know about?