### PR TITLE
ref(copy-tables): fix regex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ api-tests:
 	SNUBA_SETTINGS=test pytest -vv tests/*_api.py
 
 backend-typing:
-	mypy snuba tests --strict --config-file mypy.ini --exclude 'tests/datasets|tests/query|tests/state|tests/snapshots|tests/clickhouse|tests/test_split.py'
+	mypy snuba tests --strict --config-file mypy.ini --exclude 'tests/datasets|tests/query|tests/state|tests/snapshots|tests/clickhouse|tests/test_split.py|tests/test_copy_tables.py'
 
 install-python-dependencies:
 	pip uninstall -qqy uwsgi  # pip doesn't do well with swapping drop-ins

--- a/scripts/copy_tables.py
+++ b/scripts/copy_tables.py
@@ -20,6 +20,11 @@ def _get_client(
     )
 
 
+def get_regex_match(curr_create_table_statement: str) -> str:
+    match = re.search("\/clickhouse([a-z\/\-{}_]*)", curr_create_table_statement)
+    return match.group(0)
+
+
 def verify_zk_replica_path(
     source_client: Client,
     curr_create_table_statement: str,
@@ -43,8 +48,8 @@ def verify_zk_replica_path(
         f"SELECT replica_path FROM system.replicas where table = '{table}'"
     )
 
-    match = re.search("\/clickhouse(.*,)", curr_create_table_statement)
-    create_table_path = match.group(0)[:-2].replace("{shard}", source_shard)
+    match = get_regex_match(curr_create_table_statement)
+    create_table_path = match.replace("{shard}", source_shard)
 
     built_replica_path = f"{create_table_path}/replicas/{source_replica}"
 

--- a/tests/test_copy_tables.py
+++ b/tests/test_copy_tables.py
@@ -1,0 +1,22 @@
+import pytest
+from scripts import copy_tables
+
+
+@pytest.mark.parametrize(
+    "table_statement, expected_match",
+    [
+        (
+            "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/transactions-{shard}/transactions_local', '{replica}', deleted)",
+            "/clickhouse/tables/transactions-{shard}/transactions_local",
+        ),
+        (
+            "ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/transactions-{shard}/transactions_local', '{replica}')",
+            "/clickhouse/tables/transactions-{shard}/transactions_local",
+        ),
+    ],
+)
+def test_copy_tables_regex(table_statement: str, expected_match: str) -> None:
+    """
+    Verify that the regex for extracting the zk path works as expected
+    """
+    assert copy_tables.get_regex_match(table_statement) == expected_match


### PR DESCRIPTION
The old regex did not account for some of the cases that have come up and cause mismatch errors when running the copy-tables script

I changed the name to `copy_tables` since it didn't like `from scripts import copy-tables` but if someone knows a way around that I can change back