### PR TITLE
ref(config) Migrate Outcomes and OutcomesRaw entities to YAML

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -644,6 +644,10 @@ V1_ENTITY_SCHEMA = {
             "items": ENTITY_VALIDATOR,
             "description": "The validation logic used on the ClickHouse query",
         },
+        "validate_data_model": {
+            "type": ["string", "null"],
+            "description": "The level at which mismatched functions and columns when querying the entity should be logged",
+        },
         "required_time_column": {
             **TYPE_STRING,
             **{

--- a/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
+++ b/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
@@ -1,0 +1,45 @@
+version: v1
+kind: entity
+name: outcomes
+schema:
+  [
+    { name: org_id, type: UInt, args: { size: 64 } },
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: key_id, type: UInt, args: { size: 64 } },
+    { name: timestamp, type: DateTime },
+    { name: outcome, type: UInt, args: { size: 8 } },
+    { name: reason, type: String },
+    { name: quantity, type: UInt, args: { size: 64 } },
+    { name: category, type: UInt, args: { size: 8 } },
+    { name: times_seen, type: UInt, args: { size: 64 } },
+    { name: time, type: DateTime },
+  ]
+
+required_time_column: timestamp
+storages:
+- storage: outcomes_hourly
+  is_writable: false
+- storage: outcomes_raw
+  is_writable: true
+storage_selector:
+  selector: SimpleQueryStorageSelector
+  args:
+    storage: outcomes_hourly
+query_processors:
+- processor: BasicFunctionsProcessor
+- processor: TimeSeriesProcessor
+  args:
+    time_group_columns:
+      time: timestamp
+    time_parse_columns:
+    - timestamp
+- processor: ReferrerRateLimiterProcessor
+- processor: OrganizationRateLimiterProcessor
+  args:
+    org_column: org_id
+validators:
+- validator: EntityRequiredColumnValidator
+  args:
+    required_filter_columns:
+    - org_id
+validate_data_model: warn

--- a/snuba/datasets/configuration/outcomes/entities/outcomes_raw.yaml
+++ b/snuba/datasets/configuration/outcomes/entities/outcomes_raw.yaml
@@ -1,0 +1,46 @@
+version: v1
+kind: entity
+name: outcomes_raw
+schema:
+  [
+    { name: org_id, type: UInt, args: { size: 64 } },
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: key_id, type: UInt, args: { size: 64, schema_modifiers: [nullable] } },
+    { name: timestamp, type: DateTime },
+    { name: outcome, type: UInt, args: { size: 8 } },
+    { name: reason, type: String, args: { schema_modifiers: [nullable] } },
+    { name: event_id, type: UUID, args: { schema_modifiers: [nullable] } },
+    { name: quantity, type: UInt, args: { size: 32 } },
+    { name: category, type: UInt, args: { size: 8 } },
+    { name: time, type: DateTime },
+  ]
+
+required_time_column: timestamp
+storages:
+- storage: outcomes_raw
+  is_writable: false
+storage_selector:
+  selector: DefaultQueryStorageSelector
+query_processors:
+- processor: BasicFunctionsProcessor
+- processor: TimeSeriesProcessor
+  args:
+    time_group_columns:
+      time: timestamp
+    time_parse_columns:
+    - timestamp
+- processor: ReferrerRateLimiterProcessor
+- processor: OrganizationRateLimiterProcessor
+  args:
+    org_column: org_id
+- processor: ProjectReferrerRateLimiter
+  args:
+    project_column: project_id
+- processor: ResourceQuotaProcessor
+  args:
+    project_field: project_id
+validators:
+- validator: EntityRequiredColumnValidator
+  args:
+    required_filter_columns:
+    - org_id

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -50,6 +50,7 @@ class PluggableEntity(Entity):
     validators: Sequence[QueryValidator]
     required_time_column: str
     storage_selector: QueryStorageSelector
+    validate_data_model: ColumnValidationMode = ColumnValidationMode.DO_NOTHING
     join_relationships: Mapping[str, JoinRelationship] = field(default_factory=dict)
     function_call_validators: Mapping[str, FunctionCallValidator] = field(
         default_factory=dict
@@ -63,7 +64,7 @@ class PluggableEntity(Entity):
     def _get_builtin_validators(self) -> Sequence[QueryValidator]:
         return [
             EntityContainsColumnsValidator(
-                EntityColumnSet(self.columns), ColumnValidationMode.DO_NOTHING
+                EntityColumnSet(self.columns), self.validate_data_model
             )
         ]
 

--- a/tests/datasets/configuration/test_entity_loader.py
+++ b/tests/datasets/configuration/test_entity_loader.py
@@ -40,6 +40,8 @@ class TestEntityConfiguration(ConfigurationTest):
 
     def test_config_matches_python_definition(self) -> None:
         from snuba.datasets.entities.generic_metrics import GenericMetricsSetsEntity
+        from snuba.datasets.entities.outcomes import OutcomesEntity
+        from snuba.datasets.entities.outcomes_raw import OutcomesRawEntity
         from snuba.datasets.entities.transactions import TransactionsEntity
 
         test_data = [
@@ -53,6 +55,16 @@ class TestEntityConfiguration(ConfigurationTest):
                 TransactionsEntity,
                 EntityKey.TRANSACTIONS,
             ),
+            (
+                "snuba/datasets/configuration/outcomes/entities/outcomes.yaml",
+                OutcomesEntity,
+                EntityKey.OUTCOMES,
+            ),
+            (
+                "snuba/datasets/configuration/outcomes/entities/outcomes_raw.yaml",
+                OutcomesRawEntity,
+                EntityKey.OUTCOMES_RAW,
+            ),
         ]
         for test in test_data:
             self._config_matches_python_definition(*test)  # type: ignore
@@ -63,32 +75,40 @@ class TestEntityConfiguration(ConfigurationTest):
         config_entity = build_entity_from_config(config_path)
         py_entity = entity()  # type: ignore
 
-        assert isinstance(config_entity, PluggableEntity)
-        assert config_entity.entity_key == entity_key
+        assert isinstance(config_entity, PluggableEntity), entity_key.value
+        assert config_entity.entity_key == entity_key, entity_key.value
 
         assert len(config_entity.get_query_processors()) == len(
             py_entity.get_query_processors()
-        )
+        ), entity_key.value
         for (config_qp, py_qp) in zip(
             config_entity.get_query_processors(), py_entity.get_query_processors()
         ):
             assert (
                 config_qp.__class__ == py_qp.__class__
-            ), "query processor mismatch between configuration-loaded sets and python-defined"
+            ), f"{entity_key.value}: query processor mismatch between configuration-loaded sets and python-defined"
 
-        assert len(config_entity.get_validators()) == len(py_entity.get_validators())
+        assert len(config_entity.get_validators()) == len(
+            py_entity.get_validators()
+        ), entity_key.value
         for (config_v, py_v) in zip(
             config_entity.get_validators(), py_entity.get_validators()
         ):
             assert (
                 config_v.__class__ == py_v.__class__
-            ), "validator mismatch between configuration-loaded sets and python-defined"
-            assert config_v.__dict__ == py_v.__dict__
+            ), f"{entity_key.value}: validator mismatch between configuration-loaded sets and python-defined"
+            assert config_v.__dict__ == py_v.__dict__, entity_key.value
 
-        assert config_entity.get_all_storages() == py_entity.get_all_storages()
-        assert config_entity.required_time_column == py_entity.required_time_column
+        assert (
+            config_entity.get_all_storages() == py_entity.get_all_storages()
+        ), entity_key.value
+        assert (
+            config_entity.required_time_column == py_entity.required_time_column
+        ), entity_key.value
 
-        assert config_entity.get_data_model() == py_entity.get_data_model()
+        assert (
+            config_entity.get_data_model() == py_entity.get_data_model()
+        ), entity_key.value
 
     def test_entity_loader_for_entity_with_column_mappers(self) -> None:
         pluggable_entity = build_entity_from_config(


### PR DESCRIPTION
Generated using the pyentity_2_yaml.py script.

Changes:

The outcomes entity is using the `EntityContainsColumnsValidator` at the warn
level, so the `validate_data_model` is now part of the entity schema to define
that.

Also changed the test to output which entity actually failed an assertion.