### PR TITLE
feat: Tag invalid messages for DLQ with `invalid_message`: `true`

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Sequence
 
 import click
 import rapidjson
+import sentry_sdk
 from arroyo import configure_metrics
 
 from snuba import environment, settings
@@ -136,6 +137,7 @@ def consumer(
     setup_sentry()
     logger.info("Consumer Starting")
     storage_key = StorageKey(storage_name)
+    sentry_sdk.set_tag("storage", storage_name)
 
     metrics_tags = {
         "group": consumer_group,

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 import rapidjson
+import sentry_sdk
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.backends.kafka.commit import CommitCodec
 from arroyo.commit import Commit as CommitLogCommit
@@ -566,6 +567,7 @@ def process_message(
             ),
         )
     except Exception as err:
+        sentry_sdk.set_tag("invalid_message", "true")
         logger.error(err, exc_info=True)
         raise InvalidMessages(
             [__invalid_kafka_message(message.value, consumer_group, err)]

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -567,8 +567,9 @@ def process_message(
             ),
         )
     except Exception as err:
-        sentry_sdk.set_tag("invalid_message", "true")
-        logger.warning(err, exc_info=True)
+        with sentry_sdk.push_scope() as scope:
+            scope.set_tag("invalid_message", "true")
+            logger.warning(err, exc_info=True)
         raise InvalidMessages(
             [__invalid_kafka_message(message.value, consumer_group, err)]
         ) from err

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -568,7 +568,7 @@ def process_message(
         )
     except Exception as err:
         sentry_sdk.set_tag("invalid_message", "true")
-        logger.error(err, exc_info=True)
+        logger.warning(err, exc_info=True)
         raise InvalidMessages(
             [__invalid_kafka_message(message.value, consumer_group, err)]
         ) from err

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -570,9 +570,9 @@ def process_message(
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("invalid_message", "true")
             logger.warning(err, exc_info=True)
-        raise InvalidMessages(
-            [__invalid_kafka_message(message.value, consumer_group, err)]
-        ) from err
+            raise InvalidMessages(
+                [__invalid_kafka_message(message.value, consumer_group, err)]
+            ) from err
 
     if isinstance(result, InsertBatch):
         return BytesInsertBatch(


### PR DESCRIPTION
This allows us to better route Sentry errors to relevant teams based on tags.

The storage name is also tagged on the Snuba consumer so we can filter by consumers for monitoring.