### PR TITLE
ref(admin): Add in fetching GCP roles

### DIFF
--- a/snuba/admin/gcp_roles.py
+++ b/snuba/admin/gcp_roles.py
@@ -1,0 +1,43 @@
+from collections import defaultdict
+from typing import List, MutableMapping
+
+import googleapiclient.discovery
+
+# not sure if both of these are needed...
+from google.oauth2 import service_account
+
+GCP_PROJECT_ID = 123455789  # todo move to a setting
+GCP_USER_ROLES: MutableMapping[str, List[str]] = defaultdict(list)
+
+
+def set_google_roles() -> None:
+    """
+    Using the GCP cloud resource manager API, request the list
+    of bindings (roles to users) and use those mappings to populate
+    GCP_USER_ROLES for the project specified by the GCP_PROJECT_ID.
+
+    Every call to this function will refresh the GCP_USER_ROLES.
+    """
+    # is this needed? can we get creds a diff way?
+    credentials = service_account.Credentials.from_service_account_file(
+        filename="search-and-storage-7de40f318ea6.json",
+        scopes=["https://www.googleapis.com/auth/cloud-platform"],
+    )
+    service = googleapiclient.discovery.build(
+        "cloudresourcemanager", "v1", credentials=credentials
+    )
+
+    # https://cloud.google.com/resource-manager/reference/rest/v1/projects/getIamPolicy
+    # will return an instance of a gcp policy, example payload:
+    # https://cloud.google.com/resource-manager/reference/rest/Shared.Types/Policy
+    response = (
+        service.projects().getIamPolicy(resource=GCP_PROJECT_ID, body={}).execute()
+    )
+
+    GCP_USER_ROLES.clear()
+    for binding in response["bindings"]:
+        role = binding["role"].split("roles/")[1]
+        for member in binding["members"]:
+            _, email = member.split(":")
+            # TODO: handle group email e.g. team-sns@sentry.io
+            GCP_USER_ROLES[email].append(role)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -33,6 +33,7 @@ ADMIN_URL = os.environ.get("ADMIN_URL", "http://localhost:1219")
 ADMIN_AUTH_PROVIDER = "NOOP"
 ADMIN_AUTH_JWT_AUDIENCE = ""
 
+ADMIN_GCP_PROJECT_ID = os.environ.get("ADMIN_GCP_PROJECT_ID")
 # Migrations Groups that are allowed to be managed
 # in the snuba admin tool.
 ADMIN_ALLOWED_MIGRATION_GROUPS = {


### PR DESCRIPTION
**context:**:
A little bit ago, I added roles in the snuba admin tooling: https://github.com/getsentry/snuba/pull/3522. Right now, set all those roles on a user:https://github.com/getsentry/snuba/blob/154cd213f3b9fdff41b2f7b98e311b4bd6e46b18/snuba/admin/auth.py#L39
We want to be able to assign different roles to different users, and we've decided we can use GCP roles to do that.

My hope is to create roles in GCP with identical names as the ones listed in `DEFAULT_ROLES` (these are not the end all be all for which roles, but just wanted to have a couple to start). And then by grabbing the roles from a user that is authenticated via google's auth, we can assign the admin roles appropriately. 

e.g user `meredith@sentry.io` has a custom GCP role `roles/MigrationsLimitedExecutor`, from that I should be able to assign the admin role with the name `MigrationsLimitedExecutor` on the `AdminUser` for `meredith@sentry.io`


Since the cloud resource manager API would be fetching all the role bindings for an entire project, we could just store that in memory (just the clickhouse migration ones) instead of fetching every time we check a user. We could decide when to refresh so that bindings are up to date. 