### PR TITLE
remove yarn ppa and instead install yarn off npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,16 +42,17 @@ ENV NODE_VERSION=19
 COPY ./snuba/admin ./snuba/admin
 RUN set -ex; \
     apt-get update && \
-    apt-get install -y curl gnupg --no-install-recommends && \
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get install -y curl --no-install-recommends && \
     curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - &&\
     apt-get update && \
-    apt-get install -y yarn nodejs --no-install-recommends && \
+    apt-get install -y nodejs --no-install-recommends && \
+    npm install --global yarn && \
     cd snuba/admin && \
     yarn install && \
     yarn run build && \
     yarn cache clean && \
+    npm cache clean --force && \
+    npm uninstall -g yarn && \
     rm -rf node_modules && \
     apt-get purge -y --auto-remove yarn curl nodejs gnupg && \
     rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/yarn.list


### PR DESCRIPTION
There a bug where our yarn key has expired and is causing self-hosted tests to fail because the docker cache is not invalidated to refresh. This will make it so that we install yarn directly via npm and don't rely on caching the yarn key to fetch from ppa.