### PR TITLE
feat(replays): Extract sample rates from the replay contexts object

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -70,12 +70,6 @@ class ReplaysProcessor(DatasetMessageProcessor):
         processed["replay_type"] = maybe(
             to_enum(["session", "error"]), replay_event.get("replay_type")
         )
-        processed["error_sample_rate"] = maybe(
-            float, replay_event.get("error_sample_rate")
-        )
-        processed["session_sample_rate"] = maybe(
-            float, replay_event.get("session_sample_rate")
-        )
 
         # Archived can only be 1 or null.
         processed["is_archived"] = (
@@ -144,6 +138,12 @@ class ReplaysProcessor(DatasetMessageProcessor):
         processed["device_brand"] = maybe(to_string, device_context.get("brand"))
         processed["device_family"] = maybe(to_string, device_context.get("family"))
         processed["device_model"] = maybe(to_string, device_context.get("model"))
+
+        replay = contexts.get("replay", {})
+        processed["error_sample_rate"] = maybe(float, replay.get("error_sample_rate"))
+        processed["session_sample_rate"] = maybe(
+            float, replay.get("session_sample_rate")
+        )
 
     def _process_sdk(
         self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -102,8 +102,6 @@ class ReplayEvent:
             "type": "replay_event",
             "replay_id": self.replay_id,
             "replay_type": self.replay_type,
-            "error_sample_rate": self.error_sample_rate,
-            "session_sample_rate": self.session_sample_rate,
             "segment_id": self.segment_id,
             "tags": {"customtag": "is_set", "transaction": self.title},
             "urls": self.urls,
@@ -131,6 +129,10 @@ class ReplayEvent:
                     "op": "pageload",
                     "span_id": "affa5649681a1eeb",
                     "trace_id": "23eda6cd4b174ef8a51f0096df3bfdd1",
+                },
+                "replay": {
+                    "error_sample_rate": self.error_sample_rate,
+                    "session_sample_rate": self.session_sample_rate,
                 },
                 "os": {
                     "name": self.os_name,


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/260

The SDK team has determined that the `contexts` object is the more appropriate place for these fields to live. Therefore, we can remove the old access pattern and replace it with one that knows to look inside the `contexts` object for these values.