### PR TITLE
ref(migrations): allow reverting completed non-blocking migrations

### DIFF
--- a/snuba/migrations/policies.py
+++ b/snuba/migrations/policies.py
@@ -75,7 +75,7 @@ class NonBlockingMigrationsPolicy(MigrationPolicy):
 
         if status == Status.COMPLETED and timestamp:
             oldest_allowed_timestamp = datetime.now() + timedelta(
-                minutes=-MAX_REVERT_TIME_WINDOW_HRS
+                hours=-MAX_REVERT_TIME_WINDOW_HRS
             )
             if timestamp >= oldest_allowed_timestamp:
                 return False if migration.blocking else True

--- a/snuba/migrations/policies.py
+++ b/snuba/migrations/policies.py
@@ -6,7 +6,7 @@ from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
 from snuba.utils.registered_class import RegisteredClass
 
-MAX_REVERT_TIME_WINDOW_MINS = 20
+MAX_REVERT_TIME_WINDOW_HRS = 24
 
 
 class MigrationPolicy(ABC, metaclass=RegisteredClass):
@@ -75,7 +75,7 @@ class NonBlockingMigrationsPolicy(MigrationPolicy):
 
         if status == Status.COMPLETED and timestamp:
             oldest_allowed_timestamp = datetime.now() + timedelta(
-                minutes=-MAX_REVERT_TIME_WINDOW_MINS
+                minutes=-MAX_REVERT_TIME_WINDOW_HRS
             )
             if timestamp >= oldest_allowed_timestamp:
                 return False if migration.blocking else True

--- a/snuba/migrations/policies.py
+++ b/snuba/migrations/policies.py
@@ -4,9 +4,8 @@ from datetime import datetime, timedelta
 from snuba.migrations.groups import get_group_loader
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.migrations.status import Status
+from snuba.settings import MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS
 from snuba.utils.registered_class import RegisteredClass
-
-MAX_REVERT_TIME_WINDOW_HRS = 24
 
 
 class MigrationPolicy(ABC, metaclass=RegisteredClass):
@@ -75,7 +74,7 @@ class NonBlockingMigrationsPolicy(MigrationPolicy):
 
         if status == Status.COMPLETED and timestamp:
             oldest_allowed_timestamp = datetime.now() + timedelta(
-                hours=-MAX_REVERT_TIME_WINDOW_HRS
+                hours=-MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS
             )
             if timestamp >= oldest_allowed_timestamp:
                 return False if migration.blocking else True

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -43,6 +43,7 @@ ADMIN_ALLOWED_MIGRATION_GROUPS = {
     "replays": "NonBlockingMigrationsPolicy",
     "test_migration": "AllMigrationsPolicy",
 }
+MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS = 24
 
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)
 

--- a/tests/migrations/test_policies.py
+++ b/tests/migrations/test_policies.py
@@ -110,7 +110,7 @@ class TestMigrationPolicies:
         "snuba.migrations.runner.Runner.get_status",
         return_value=(
             Status.COMPLETED,
-            datetime.now() + timedelta(minutes=-(MAX_REVERT_TIME_WINDOW_HRS - 5)),
+            datetime.now() + timedelta(hours=-(MAX_REVERT_TIME_WINDOW_HRS - 5)),
         ),
     )
     def test_completed_migration_reverse(self, mock_get_status: Mock) -> None:

--- a/tests/migrations/test_policies.py
+++ b/tests/migrations/test_policies.py
@@ -6,7 +6,6 @@ import pytest
 
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.policies import (
-    MAX_REVERT_TIME_WINDOW_HRS,
     AllMigrationsPolicy,
     MigrationPolicy,
     NoMigrationsPolicy,
@@ -14,6 +13,7 @@ from snuba.migrations.policies import (
 )
 from snuba.migrations.runner import MigrationKey
 from snuba.migrations.status import Status
+from snuba.settings import MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS
 
 POLICIES: Mapping[str, MigrationPolicy] = {
     "no_migrations": NoMigrationsPolicy(),
@@ -97,12 +97,18 @@ class TestMigrationPolicies:
         return_value=(Status.IN_PROGRESS, None),
     )
     def test_pending_migration_reverse(self, mock_get_status: Mock) -> None:
+        """
+        The NonBlockingMigrationsPolicy allows pending, non-blocking migrations
+        to be reversed. Blocking migrations, even pending ones, are still not
+        allowed under this policy.
+        """
+        # non-blocking migration
         migration_key = MigrationKey(
             MigrationGroup("events"), "0016_drop_legacy_events"
         )
         assert NonBlockingMigrationsPolicy().can_reverse(migration_key) == True
 
-        # if forward migration was blocking, reverse not allowed even when pending
+        # blocking migration
         migration_key = code_migration_key()
         assert NonBlockingMigrationsPolicy().can_reverse(migration_key) == False
 
@@ -110,16 +116,24 @@ class TestMigrationPolicies:
         "snuba.migrations.runner.Runner.get_status",
         return_value=(
             Status.COMPLETED,
-            datetime.now() + timedelta(hours=-(MAX_REVERT_TIME_WINDOW_HRS - 5)),
+            datetime.now()
+            + timedelta(hours=-(MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS - 5)),
         ),
     )
     def test_completed_migration_reverse(self, mock_get_status: Mock) -> None:
+        """
+        The NonBlockingMigrationsPolicy allows reversing a migration if it was
+        completed within the hours set by MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS.
+
+        However, if a migration is blocking, regardless of whether it was in the
+        allowed time range, we don't allow reversing.
+        """
+        # non-blocking migration
         migration_key = MigrationKey(
             MigrationGroup("events"), "0016_drop_legacy_events"
         )
         assert NonBlockingMigrationsPolicy().can_reverse(migration_key) == True
 
-        # if forward migration was blocking, reverse not allowed even when
-        # within the max time limit to
+        # blocking migration
         migration_key = code_migration_key()
         assert NonBlockingMigrationsPolicy().can_reverse(migration_key) == False

--- a/tests/migrations/test_policies.py
+++ b/tests/migrations/test_policies.py
@@ -6,7 +6,7 @@ import pytest
 
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.policies import (
-    MAX_REVERT_TIME_WINDOW_MINS,
+    MAX_REVERT_TIME_WINDOW_HRS,
     AllMigrationsPolicy,
     MigrationPolicy,
     NoMigrationsPolicy,
@@ -110,7 +110,7 @@ class TestMigrationPolicies:
         "snuba.migrations.runner.Runner.get_status",
         return_value=(
             Status.COMPLETED,
-            datetime.now() + timedelta(minutes=-(MAX_REVERT_TIME_WINDOW_MINS - 5)),
+            datetime.now() + timedelta(minutes=-(MAX_REVERT_TIME_WINDOW_HRS - 5)),
         ),
     )
     def test_completed_migration_reverse(self, mock_get_status: Mock) -> None:


### PR DESCRIPTION
**context**
Currently our non blocking migration policy allows users to revert migrations that are pending. However, there may be a case where a migration ran successfully and completed, but there may be a valid reason to revert. 

This PR adds an arbitrary time limit of 20 minutes to revert once completed. I figured 20 minutes would be enough time to assess whether the impact of a migration would necessitate a revert.