### PR TITLE
fix(search-issues): Remove hardcoded key in consumer cli

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -47,7 +47,6 @@ logger = logging.getLogger(__name__)
     "storage_name",
     type=click.Choice(
         [storage_key.value for storage_key in get_writable_storage_keys()]
-        + ["search_issues"]
     ),
     help="The storage to target",
     required=True,


### PR DESCRIPTION
This was fixed in https://github.com/getsentry/snuba/pull/3502. We do not need this hardcoded key anymore.

### Testing
Ran `snuba consumer --storage search_issues --auto-offset-reset earliest` locally.