### PR TITLE
fix(health) Fix extra data in storage set error

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -469,10 +469,8 @@ def get_cluster(
         if res is None:
             raise UndefinedClickhouseCluster(
                 f"{(storage_set_key, slice_id)} is not defined in the SLICED_CLUSTERS setting for this environment",
-                extra_data={
-                    "storage_set_key_not_defined": storage_set_key,
-                    "slice_id": slice_id,
-                },
+                storage_set_key_not_defined=storage_set_key.value,
+                slice_id=slice_id,
             )
 
     else:
@@ -481,6 +479,6 @@ def get_cluster(
         if res is None:
             raise UndefinedClickhouseCluster(
                 f"{storage_set_key} is not defined in the CLUSTERS setting for this environment",
-                extra_data={"storage_set_key_not_defined": storage_set_key},
+                storage_set_key_not_defined=storage_set_key.value,
             )
     return res

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -170,7 +170,13 @@ def check_clickhouse(
 
     except UndefinedClickhouseCluster as err:
         if metric_tags is not None and isinstance(err.extra_data, dict):
-            metric_tags.update(err.extra_data)
+            # Be a little defensive here, since it's not always obvious this extra data
+            # is being passed to metrics, and we might want non-string values in the
+            # exception data.
+            for k, v in err.extra_data.items():
+                if isinstance(v, str):
+                    metric_tags[k] = v
+
         logger.error(err)
         return False
 

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Sequence
 from unittest import mock
 
@@ -69,3 +71,17 @@ def test_bad_dataset_fails_healthcheck(
     # the bad dataset is enabled and not experimental, therefore the healthcheck
     # should fail
     assert not check_clickhouse(ignore_experimental=True)
+
+
+@mock.patch(
+    "snuba.web.views.get_enabled_dataset_names",
+    return_value=["events"],
+)
+@mock.patch("snuba.clusters.cluster._get_storage_set_cluster_map", return_value={})
+def test_dataset_undefined_storage_set(
+    mock1: mock.MagicMock, mock2: mock.MagicMock
+) -> None:
+    metrics_tags: dict[str, str] = {}
+    assert not check_clickhouse(ignore_experimental=True, metric_tags=metrics_tags)
+    for v in metrics_tags.values():
+        assert isinstance(v, str)


### PR DESCRIPTION
When an `UndefinedClickhouseCluster` exception was raised sometimes it was
adding extra data to the error. That would be fine except that extra data is
being passed into metrics tags which expect a certain format. Change the error
to correctly pass extra data so it gets propagated to the metric tags correctly.

Fixes https://sentry.io/organizations/sentry/issues/3899535676