### PR TITLE
fix(profiling): Profile id only on transaction dataset

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -249,6 +249,11 @@ schema:
       type: String,
       args: { schema_modifiers: [nullable] },
     },
+    {
+      name: profile_id,
+      type: UUID,
+      args: { schema_modifiers: [nullable] },
+    },
   ]
 required_time_column: timestamp
 storages:
@@ -274,6 +279,7 @@ storages:
               - spans.exclusive_time_32
               - group_ids
               - app_start_type
+              - profile_id
         - mapper: ColumnToLiteral
           args:
             from_table_name: null

--- a/snuba/datasets/entities/discover.py
+++ b/snuba/datasets/entities/discover.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 from snuba.clickhouse.columns import (
+    UUID,
     Array,
     ColumnSet,
     DateTime,
@@ -118,6 +119,7 @@ TRANSACTIONS_COLUMNS = ColumnSet(
         ),
         ("group_ids", Array(UInt(64, Modifiers(nullable=True)))),
         ("app_start_type", String(Modifiers(nullable=True))),
+        ("profile_id", UUID(Modifiers(nullable=True))),
     ]
 )
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -190,6 +190,7 @@ def get_raw_transaction(span_id: str | None = None) -> Mapping[str, Any]:
     unique = "100"
     primary_hash = md5(unique.encode("utf-8")).hexdigest()
     app_start_type = "warm.prewarmed"
+    profile_id = uuid.UUID("046852d2-4483-455c-8c44-f0c8fbf496f9")
 
     return {
         "project_id": PROJECT_ID,
@@ -231,6 +232,7 @@ def get_raw_transaction(span_id: str | None = None) -> Mapping[str, Any]:
                 },
                 "device": {"online": True, "charging": True, "model_id": "Galaxy"},
                 "app": {"start_type": app_start_type},
+                "profile": {"profile_id": profile_id.hex},
             },
             "measurements": {
                 "lcp": {"value": 32.129},

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -664,6 +664,38 @@ class TestSnQLApi(BaseApiTest):
         assert len(data) == 1
         assert data[0]["count"] == 1
 
+    @pytest.mark.parametrize(
+        "url, entity",
+        [
+            pytest.param("/transactions/snql", "transactions", id="transactions"),
+            pytest.param(
+                "/discover/snql", "discover_transactions", id="discover_transactions"
+            ),
+        ],
+    )
+    def test_profile_id(self, url: str, entity: str) -> None:
+        response = self.post(
+            url,
+            data=json.dumps(
+                {
+                    "query": f"""
+                    MATCH ({entity})
+                    SELECT profile_id AS profile_id
+                    WHERE
+                        finish_ts >= toDateTime('{self.base_time.isoformat()}') AND
+                        finish_ts < toDateTime('{self.next_time.isoformat()}') AND
+                        project_id IN tuple({self.project_id})
+                    LIMIT 10
+                    """
+                }
+            ),
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)["data"]
+        assert len(data) == 1
+        assert data[0]["profile_id"] == "046852d24483455c8c44f0c8fbf496f9"
+
     def test_attribution_tags(self) -> None:
         response = self.post(
             "/events/snql",


### PR DESCRIPTION
When querying the profile_id, make sure it only uses the transactions dataset in this case.

Fixes SNUBA-31S