### PR TITLE
fix(admin): remove the execute role for the default user

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -114,10 +114,6 @@ DEFAULT_ROLES = [
         actions={ExecuteNoneAction(list(MIGRATIONS_RESOURCES.values()))},
     ),
     Role(
-        name="MigrationsLimitedExecutor",
-        actions={ExecuteNonBlockingAction(list(MIGRATIONS_RESOURCES.values()))},
-    ),
-    Role(
         name="TestMigrationsExecutor",
         actions={ExecuteAllAction([MIGRATIONS_RESOURCES["test_migration"]])},
     ),


### PR DESCRIPTION

Removes the execute-non-blocking action from the default user. This  will make all migrations in the snuba admin tool readonly except from the TestMigration by default.