### PR TITLE
chore(oncall): add timing to healthcheck

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -423,7 +423,7 @@ def health() -> Response:
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
     metrics.timing(
-        "healthcheck_timing", time.time() - start, tags={"thorough": str(thorough)}
+        "healthcheck.latency", time.time() - start, tags={"thorough": str(thorough)}
     )
     return Response(json.dumps(body), status, {"Content-Type": "application/json"})
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -392,7 +392,7 @@ def config_changes() -> RespTuple:
 
 @application.route("/health")
 def health() -> Response:
-
+    start = time.time()
     down_file_exists = check_down_file_exists()
     thorough = http_request.args.get("thorough", False)
 
@@ -422,7 +422,9 @@ def health() -> Response:
 
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
-
+    metrics.timing(
+        "healthcheck_timing", time.time() - start, tags={"thorough": str(thorough)}
+    )
     return Response(json.dumps(body), status, {"Content-Type": "application/json"})
 
 


### PR DESCRIPTION
We have some pods failing the readinessprobe. My hypothesis is that it is happening because the healthcheck is taking too long. This gives us more information on its operation