### PR TITLE
fix(profiling): Broken discover events test missing profile_id

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover_events.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_events.yaml
@@ -282,6 +282,7 @@ storages:
               - spans.exclusive_time_32
               - group_ids
               - app_start_type
+              - profile_id
       subscriptables:
         - mapper: SubscriptableMapper
           args:
@@ -405,6 +406,7 @@ storages:
               - spans.exclusive_time_32
               - group_ids
               - app_start_type
+              - profile_id
       subscriptables:
         - mapper: SubscriptableMapper
           args:


### PR DESCRIPTION
This dataset config was added after the previous PR was opened but before it was merged.