### PR TITLE
fix(search-issues): rebuild search_issues dataset with a version column to support replacements in the future

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -327,6 +327,7 @@ class SearchIssuesLoader(DirectoryLoader):
             "0001_search_issues",
             "0002_search_issues_add_tags_hash_map",
             "0003_search_issues_modify_occurrence_type_id_size",
+            "0004_rebuild_search_issues_with_version",
         ]
 
 

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -113,7 +113,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="search_issues_dist_new",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="errors_local",
+                    local_table_name="search_issues_dist_new",
                     sharding_key="cityHash64(occurrence_id)",
                 ),
                 target=OperationTarget.DISTRIBUTED,

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -50,7 +50,7 @@ columns: List[Column[Modifiers]] = [
     Column("contexts", Nested([("key", String()), ("value", String())])),
     Column("http_method", String(Modifiers(nullable=True, low_cardinality=True))),
     Column("http_referer", String(Modifiers(nullable=True))),
-    Column("version", UInt(8)),
+    Column("deleted", UInt(8)),
     Column("message_timestamp", DateTime()),
     Column("partition", UInt(16)),
     Column("offset", UInt(64)),
@@ -77,7 +77,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
                     order_by="(project_id, toStartOfDay(receive_timestamp), primary_hash, cityHash64(occurrence_id))",
-                    version_column="version",
+                    version_column="deleted",
                     partition_by="(retention_days, toMonday(receive_timestamp))",
                     sample_by="cityHash64(occurrence_id)",
                     settings={"index_granularity": "8192"},

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -130,7 +130,7 @@ class Migration(migration.ClickhouseNodeMigration):
             ),
             operations.DropTable(
                 storage_set=StorageSetKey.SEARCH_ISSUES,
-                table_name="search_issues_dist_new",
+                table_name="search_issues_dist",
                 target=OperationTarget.DISTRIBUTED,
             ),
             operations.RenameTable(

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -62,8 +62,8 @@ class Migration(migration.ClickhouseNodeMigration):
     """
     This migration rebuilds the search_issues table by collapsing all migrations from 0001-0003 into a single migration
     and adding the following changes:
-    - add version column to support replacements
-    - modify ReplacingMergeTree engine to use the new version column
+    - add a `deleted` column to support replacements
+    - modify ReplacingMergeTree engine to use the new `deleted` column
     """
 
     blocking = False

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -113,7 +113,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="search_issues_dist_new",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="search_issues_dist_new",
+                    local_table_name="search_issues_local",
                     sharding_key="cityHash64(occurrence_id)",
                 ),
                 target=OperationTarget.DISTRIBUTED,

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -1,0 +1,156 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import (
+    UUID,
+    Array,
+    Column,
+    DateTime,
+    IPv4,
+    IPv6,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import TAGS_HASH_MAP_COLUMN
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+columns: List[Column[Modifiers]] = [
+    Column("organization_id", UInt(64)),
+    Column("project_id", UInt(64)),
+    Column("group_id", UInt(64)),
+    Column("search_title", String()),
+    Column("primary_hash", UUID()),
+    Column("fingerprint", Array(String())),
+    Column("occurrence_id", UUID()),
+    Column("occurrence_type_id", UInt(16)),
+    Column("detection_timestamp", DateTime()),
+    Column("event_id", UUID(Modifiers(nullable=True))),
+    Column("trace_id", UUID(Modifiers(nullable=True))),
+    Column("platform", String(Modifiers(low_cardinality=True))),
+    Column("environment", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("release", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("dist", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("receive_timestamp", DateTime()),
+    Column("client_timestamp", DateTime()),
+    Column("tags", Nested([("key", String()), ("value", String())])),
+    Column("user", String(Modifiers(nullable=True))),
+    Column(
+        "user_hash", UInt(64, Modifiers(nullable=True, materialized="cityHash64(user)"))
+    ),
+    Column("user_id", String(Modifiers(nullable=True))),
+    Column("user_name", String(Modifiers(nullable=True))),
+    Column("user_email", String(Modifiers(nullable=True))),
+    Column("ip_address_v4", IPv4(Modifiers(nullable=True))),
+    Column("ip_address_v6", IPv6(Modifiers(nullable=True))),
+    Column("sdk_name", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("sdk_version", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("contexts", Nested([("key", String()), ("value", String())])),
+    Column("http_method", String(Modifiers(nullable=True, low_cardinality=True))),
+    Column("http_referer", String(Modifiers(nullable=True))),
+    Column("http_referer", String(Modifiers(nullable=True))),
+    Column("version", String(Modifiers(nullable=True, low_cardinality=True))),
+    Column("message_timestamp", DateTime()),
+    Column("partition", UInt(16)),
+    Column("offset", UInt(64)),
+    Column("retention_days", UInt(16)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    This migration rebuilds the search_issues table by collapsing all migrations from 0001-0003 into a single migration
+    and adding the following changes:
+    - add version column to support replacements
+    - modify ReplacingMergeTree engine to use the new version column
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            # local first
+            operations.CreateTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_local_new",
+                columns=columns,
+                engine=table_engines.ReplacingMergeTree(
+                    order_by="(project_id, toStartOfDay(receive_timestamp), primary_hash, cityHash64(occurrence_id))",
+                    version_column="version",
+                    partition_by="(retention_days, toMonday(receive_timestamp))",
+                    sample_by="cityHash64(occurrence_id)",
+                    settings={"index_granularity": "8192"},
+                    storage_set=StorageSetKey.SEARCH_ISSUES,
+                    ttl="receive_timestamp + toIntervalDay(retention_days)",
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_local_new",
+                column=Column(
+                    "_tags_hash_map",
+                    Array(UInt(64), Modifiers(materialized=TAGS_HASH_MAP_COLUMN)),
+                ),
+                after="tags.value",
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_local_new",
+                target=OperationTarget.LOCAL,
+            ),
+            operations.RenameTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                old_table_name="search_issues_local_new",
+                new_table_name="search_issues_local",
+                target=OperationTarget.LOCAL,
+            ),
+            # dist second
+            operations.CreateTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_dist_new",
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="errors_local",
+                    sharding_key="cityHash64(occurrence_id)",
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.AddColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_dist_new",
+                column=Column(
+                    "_tags_hash_map",
+                    Array(UInt(64), Modifiers(materialized=TAGS_HASH_MAP_COLUMN)),
+                ),
+                after="tags.value",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name="search_issues_dist_new",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.RenameTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                old_table_name="search_issues_dist_new",
+                new_table_name="search_issues_dist",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name=params[0],
+                target=params[1],
+            )
+            for params in [
+                ("search_issues_dist_new", OperationTarget.DISTRIBUTED),
+                ("search_issues_local_new", OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
+++ b/snuba/snuba_migrations/search_issues/0004_rebuild_search_issues_with_version.py
@@ -50,8 +50,7 @@ columns: List[Column[Modifiers]] = [
     Column("contexts", Nested([("key", String()), ("value", String())])),
     Column("http_method", String(Modifiers(nullable=True, low_cardinality=True))),
     Column("http_referer", String(Modifiers(nullable=True))),
-    Column("http_referer", String(Modifiers(nullable=True))),
-    Column("version", String(Modifiers(nullable=True, low_cardinality=True))),
+    Column("version", UInt(8)),
     Column("message_timestamp", DateTime()),
     Column("partition", UInt(16)),
     Column("offset", UInt(64)),
@@ -99,7 +98,7 @@ class Migration(migration.ClickhouseNodeMigration):
             ),
             operations.DropTable(
                 storage_set=StorageSetKey.SEARCH_ISSUES,
-                table_name="search_issues_local_new",
+                table_name="search_issues_local",
                 target=OperationTarget.LOCAL,
             ),
             operations.RenameTable(


### PR DESCRIPTION
We wanna rebuild the search_issues table to include a `deleted` column required for replacements. 

This table is only present in local and dev environments so its ok to drop the table and rebuild.

I tested this locally and didn't encounter any issues.