### PR TITLE
ref(migrations): Add replays role [DO NOT MERGE YET]

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -114,6 +114,10 @@ DEFAULT_ROLES = [
         actions={ExecuteNoneAction(list(MIGRATIONS_RESOURCES.values()))},
     ),
     Role(
+        name="ReplaysNonBlockingMigrations",
+        actions={ExecuteNonBlockingAction([MIGRATIONS_RESOURCES["replays"]])},
+    ),
+    Role(
         name="TestMigrationsExecutor",
         actions={ExecuteAllAction([MIGRATIONS_RESOURCES["test_migration"]])},
     ),


### PR DESCRIPTION
**context**
The concept of admin roles was added in https://github.com/getsentry/snuba/pull/3522. As we add more migration groups to the snuba admin tooling, we can add more roles. 


Datasets (and their corresponding migration groups) that existed in production prior to the admin tooling have to make sure that the migration status table in matches the state of production for that group. Only then can we add more permissive roles for those migration groups.

Replays is an example of a group needs that vetting. This PR can only be merged once the migration table is up to date.
