### PR TITLE
feat(oncall): add envoy specific healthcheck endpoint

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -390,6 +390,21 @@ def config_changes() -> RespTuple:
     )
 
 
+@application.route("/health_envoy")
+def health_envoy() -> Response:
+    down_file_exists = check_down_file_exists()
+
+    body: Mapping[str, Union[str, bool]]
+    if not down_file_exists:
+        status = 200
+    else:
+        status = 503
+
+    if status != 200:
+        metrics.increment("healthcheck_envoy_failed")
+    return Response(json.dumps({}), status, {"Content-Type": "application/json"})
+
+
 @application.route("/health")
 def health() -> Response:
     start = time.time()

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -392,6 +392,15 @@ def config_changes() -> RespTuple:
 
 @application.route("/health_envoy")
 def health_envoy() -> Response:
+    """K8s can decide to shut down the pod, at which point it will write the down file.
+    This down file signals that we have to drain the pod, and not accept any new traffic.
+    In SaaS, envoy is the thing that will decided to route traffic to this node or not. It
+    uses this endpoint to make that decision.
+
+    This differs from the generic health endpoint because the pod can still be healthy
+    but just not accepting traffic. That way k8s will not restart it until it is drained
+    """
+
     down_file_exists = check_down_file_exists()
 
     body: Mapping[str, Union[str, bool]]

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -1,7 +1,9 @@
 import logging
 from typing import Any
+from unittest import mock
 
 import pytest
+from flask.testing import FlaskClient
 
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.parser.exceptions import ParsingException
@@ -21,6 +23,13 @@ invalid_query_exception_test_cases = [
 ]
 
 
+@pytest.fixture
+def snuba_api() -> FlaskClient:
+    from snuba.web.views import application
+
+    return application.test_client()
+
+
 @pytest.mark.parametrize(
     "exception, expected_log_level", invalid_query_exception_test_cases
 )
@@ -32,3 +41,11 @@ def test_handle_invalid_query(
         _ = handle_invalid_query(exception)
         for record in caplog.records:
             assert record.levelname == expected_log_level
+
+
+def test_check_envoy_health(snuba_api):
+    response = snuba_api.get("/health_envoy")
+    assert response.status_code == 200
+    with mock.patch("snuba.web.views.check_down_file_exists", return_value=True):
+        response = snuba_api.get("/health_envoy")
+        assert response.status_code == 503

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -43,7 +43,7 @@ def test_handle_invalid_query(
             assert record.levelname == expected_log_level
 
 
-def test_check_envoy_health(snuba_api):
+def test_check_envoy_health(snuba_api: FlaskClient) -> None:
     response = snuba_api.get("/health_envoy")
     assert response.status_code == 200
     with mock.patch("snuba.web.views.check_down_file_exists", return_value=True):


### PR DESCRIPTION
We are currently conflating two different healthchecks as one. There's the healthcheck that envoy uses to not send traffic to the pod while it's draining, and the healthcheck that k8s uses to know whether to restart the pod. Currently those are the same thing.

The hypothesis is that if we have them as two separate endpoints, we will stop getting erroneous restarts by k8s of the snuba API