### PR TITLE
fix(consumer): Separate out producers in consumer_builder

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -189,3 +189,4 @@ def consumer(
     signal.signal(signal.SIGTERM, handler)
 
     consumer.run()
+    consumer_builder.flush()

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -114,8 +114,7 @@ class ConsumerBuilder:
             else:
                 self.replacements_topic = None
 
-        if self.replacements_topic is not None:
-            assert replacement_topic_spec is not None
+        if replacement_topic_spec is not None:
             self.replacements_producer = Producer(
                 build_kafka_producer_configuration(
                     replacement_topic_spec.topic,
@@ -141,8 +140,7 @@ class ConsumerBuilder:
             else:
                 self.commit_log_topic = None
 
-        if self.commit_log_topic is not None:
-            assert commit_log_topic_spec is not None
+        if commit_log_topic_spec is not None:
             self.commit_log_producer = Producer(
                 build_kafka_producer_configuration(
                     commit_log_topic_spec.topic,
@@ -271,11 +269,7 @@ class ConsumerBuilder:
             collector=build_batch_writer(
                 table_writer,
                 metrics=self.metrics,
-                replacements_producer=(
-                    self.replacements_producer
-                    if self.replacements_topic is not None
-                    else None
-                ),
+                replacements_producer=self.replacements_producer,
                 replacements_topic=self.replacements_topic,
                 slice_id=slice_id,
                 commit_log_config=commit_log_config,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -92,15 +92,6 @@ class ConsumerBuilder:
             topic, slice_id, bootstrap_servers=kafka_params.bootstrap_servers
         )
         logger.info(f"librdkafka log level: {self.broker_config.get('log_level', 6)}")
-        self.producer_broker_config = build_kafka_producer_configuration(
-            topic,
-            slice_id,
-            bootstrap_servers=kafka_params.bootstrap_servers,
-            override_params={
-                "partitioner": "consistent",
-                "message.max.bytes": 50000000,  # 50MB, default is 1MB
-            },
-        )
 
         stream_loader = self.storage.get_table_writer().get_stream_loader()
 
@@ -112,10 +103,10 @@ class ConsumerBuilder:
             self.raw_topic = Topic(default_topic_spec.get_physical_topic_name(slice_id))
 
         self.replacements_topic: Optional[Topic]
+        replacement_topic_spec = stream_loader.get_replacement_topic_spec()
         if kafka_params.replacements_topic is not None:
             self.replacements_topic = Topic(kafka_params.replacements_topic)
         else:
-            replacement_topic_spec = stream_loader.get_replacement_topic_spec()
             if replacement_topic_spec is not None:
                 self.replacements_topic = Topic(
                     replacement_topic_spec.get_physical_topic_name(slice_id)
@@ -123,12 +114,26 @@ class ConsumerBuilder:
             else:
                 self.replacements_topic = None
 
+        if self.replacements_topic is not None:
+            assert replacement_topic_spec is not None
+            self.replacements_producer = Producer(
+                build_kafka_producer_configuration(
+                    replacement_topic_spec.topic,
+                    bootstrap_servers=kafka_params.bootstrap_servers,
+                    override_params={
+                        "partitioner": "consistent",
+                        "message.max.bytes": 50000000,  # 50MB, default is 1MB)
+                    },
+                )
+            )
+        else:
+            self.replacements_producer = None
+
         self.commit_log_topic: Optional[Topic]
+        commit_log_topic_spec = stream_loader.get_commit_log_topic_spec()
         if kafka_params.commit_log_topic is not None:
             self.commit_log_topic = Topic(kafka_params.commit_log_topic)
-
         else:
-            commit_log_topic_spec = stream_loader.get_commit_log_topic_spec()
             if commit_log_topic_spec is not None:
                 self.commit_log_topic = Topic(
                     commit_log_topic_spec.get_physical_topic_name(slice_id)
@@ -136,12 +141,18 @@ class ConsumerBuilder:
             else:
                 self.commit_log_topic = None
 
+        if self.commit_log_topic is not None:
+            assert commit_log_topic_spec is not None
+            self.commit_log_producer = Producer(
+                build_kafka_producer_configuration(
+                    commit_log_topic_spec.topic,
+                    bootstrap_servers=kafka_params.bootstrap_servers,
+                ),
+            )
+        else:
+            self.commit_log_producer = None
+
         self.stats_callback = stats_callback
-
-        # XXX: This can result in a producer being built in cases where it's
-        # not actually required.
-        self.producer = Producer(self.producer_broker_config)
-
         self.metrics = metrics
         self.max_batch_size = max_batch_size
         self.max_batch_time_ms = max_batch_time_ms
@@ -241,7 +252,7 @@ class ConsumerBuilder:
 
         if self.commit_log_topic:
             commit_log_config = CommitLogConfig(
-                self.producer, self.commit_log_topic, self.group_id
+                self.commit_log_producer, self.commit_log_topic, self.group_id
             )
         else:
             commit_log_config = None
@@ -261,7 +272,9 @@ class ConsumerBuilder:
                 table_writer,
                 metrics=self.metrics,
                 replacements_producer=(
-                    self.producer if self.replacements_topic is not None else None
+                    self.replacements_producer
+                    if self.replacements_topic is not None
+                    else None
                 ),
                 replacements_topic=self.replacements_topic,
                 slice_id=slice_id,
@@ -283,6 +296,10 @@ class ConsumerBuilder:
             )
 
         return strategy_factory
+
+    def flush(self) -> None:
+        if self.replacements_producer:
+            self.replacements_producer.flush()
 
     def build_base_consumer(
         self, slice_id: Optional[int] = None

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock
 import pytest
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
-from confluent_kafka import Producer
 
 from snuba import environment
 from snuba.consumers.consumer_builder import (
@@ -56,10 +55,10 @@ consumer_builder = ConsumerBuilder(
 
 optional_kafka_params = KafkaParameters(
     raw_topic="raw",
-    replacements_topic="replacements",
+    replacements_topic="event-replacements",
     bootstrap_servers=["cli.server:9092", "cli2.server:9092"],
     group_id=consumer_group_name,
-    commit_log_topic="commit_log",
+    commit_log_topic="snuba-commit-log",
     auto_offset_reset="earliest",
     strict_offset_reset=False,
     queued_max_messages_kbytes=1,
@@ -104,10 +103,6 @@ def test_consumer_builder_non_optional_attributes(con_build) -> None:  # type: i
 
     assert con_build.broker_config is not None
 
-    assert con_build.producer_broker_config is not None
-
-    assert isinstance(con_build.producer, Producer)
-
     assert isinstance(con_build.metrics, MetricsBackend)
 
     assert con_build.max_batch_size == 3
@@ -126,8 +121,11 @@ def test_consumer_builder_optional_attributes(con_build) -> None:  # type: ignor
     # are passed in, stronger checks are performed
     # in a separate test below
 
-    consumer_builder.replacements_topic
-    consumer_builder.commit_log_topic
+    con_build.replacements_topic
+    con_build.commit_log_topic
+
+    con_build.replacements_producer
+    con_build.commit_log_producer
 
     con_build.bootstrap_servers
     con_build.strict_offset_reset


### PR DESCRIPTION
https://github.com/getsentry/snuba/pull/3626 (third time's the charm?)

This time, the Producers are configured using the logical/default topic name, which is derived from the topic spec, regardless of whether there is a topic override being passed in. 