### PR TITLE
ref(logging) Don't log full exception trace for rate limit errors

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -519,10 +519,10 @@ def dataset_query(
                 "type": "rate-limited",
                 "message": str(cause),
             }
-            logger.warning(
-                str(cause),
-                exc_info=True,
-            )
+            # Capture the warning and log the error separately, to avoid
+            # cluttering the logs with stack traces when this happens
+            util.capture_warning()
+            logger.warning(str(cause))
         elif isinstance(cause, ClickhouseError):
             status = get_http_status_for_clickhouse_error(cause)
             details = {


### PR DESCRIPTION
Currently in order to send rate limit errors to Sentry, the LoggingIntegration
is used, which requires logging the exception.

This generally works fine, since we want the exception to be in the logs as well
as in Sentry.

However with rate limit exceptions, they tend to have many layers of tracebacks,
which results in multiple lines being logged for a single error, and an error
that having the traceback isn't useful in logs.

Add a new utlity that sends a warning to Sentry. This is a manual workaround.
Use that workaround to send the warning event to Sentry, but just log the
message without the full stack trace.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
