### PR TITLE
fix(admin): initialize snuba in admin

### DIFF
--- a/snuba/admin/wsgi.py
+++ b/snuba/admin/wsgi.py
@@ -3,4 +3,7 @@ from snuba.environment import setup_logging, setup_sentry
 setup_logging()
 setup_sentry()
 
+from snuba.core.initialize import initialize_snuba
+
+initialize_snuba()
 from snuba.admin.views import application  # noqa


### PR DESCRIPTION
We removed some of the hardcoded enums so now we have to make sure the storages are there when we start admin