### PR TITLE
fix(cli): Allow more options for datasets and entities for subscription consumers

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -31,16 +31,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     "entity_names",
     required=True,
     multiple=True,
-    type=click.Choice(
-        [
-            EntityKey.EVENTS.value,
-            EntityKey.TRANSACTIONS.value,
-            EntityKey.METRICS_COUNTERS.value,
-            EntityKey.METRICS_SETS.value,
-            EntityKey.GENERIC_METRICS_SETS.value,
-            EntityKey.GENERIC_METRICS_DISTRIBUTIONS.value,
-        ]
-    ),
+    type=click.Choice([entity_key.value for entity_key in EntityKey]),
     help="The entity to target.",
 )
 @click.option(

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -10,6 +10,7 @@ from snuba import environment, state
 from snuba.attribution.log import flush_attribution_producer
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
+from snuba.datasets.factory import get_enabled_dataset_names
 from snuba.environment import setup_logging, setup_sentry
 from snuba.subscriptions.combined_scheduler_executor import (
     build_scheduler_executor_consumer,
@@ -24,7 +25,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     "--dataset",
     "dataset_name",
     required=True,
-    type=click.Choice(["events", "transactions", "metrics", "sessions"]),
+    type=click.Choice(get_enabled_dataset_names()),
     help="The dataset to target.",
 )
 @click.option(
@@ -32,9 +33,7 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     "entity_names",
     required=True,
     multiple=True,
-    type=click.Choice(
-        ["events", "transactions", "metrics_counters", "metrics_sets", "sessions"]
-    ),
+    type=click.Choice([entity_key.value for entity_key in EntityKey]),
     help="The entity to target.",
 )
 @click.option(


### PR DESCRIPTION
The subscritpion consumers should dynamically pick up the list of allowed datasets and entities. With the current approach, one would need to manually change the list of CLI options which can cause pod crashloops.

### Tests
Validated that the CLI help option shows all entities and datasets

`
Options:
  --entity [events|groups|metrics_sets|org_metrics_counters|metrics_distributions|metrics_counters|discover_events|groupedmessage|groupassignee|discover|discover_transactions|outcomes|outcomes_raw|transactions|sessions|org_sessions|replays|functions|profiles|search_issues|generic_metrics_distributions|generic_metrics_counters|generic_metrics_sets]
                                  The entity to target  [required]
  --consumer-group TEXT           Consumer group used for consuming the commit
                                  log topic.
  --followed-consumer-group TEXT  Name of the consumer group to follow
                                  [required]
  --auto-offset-reset [error|earliest|latest]
                                  Kafka consumer auto offset reset.
  --no-strict-offset-reset        Forces the kafka consumer auto offset reset.
  --schedule-ttl INTEGER
  --slice-id INTEGER              The slice id for the corresponding storage
                                  to the given entity
  --log-level TEXT                Logging level to use.
  --delay-seconds INTEGER
  --stale-threshold-seconds INTEGER
                                  Skip scheduling if timestamp is beyond this
                                  threshold compared to the system time
  --help                          Show this message and exit.
`