### PR TITLE
feat(rust-consumer): Parse storage yaml into Storage struct

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -20,3 +20,5 @@ cadence = "0.29.0"
 lazy_static = "1.4.0"
 parking_lot = "0.10.0"
 rand="0.8.5"
+serde = { version = "1.0", features = ["derive"]}
+serde_yaml = "0.9"

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -2,7 +2,6 @@ pub mod backends;
 pub mod processing;
 pub mod types;
 pub mod utils;
-pub mod storage;
 
 #[cfg(test)]
 mod tests {

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -2,6 +2,7 @@ pub mod backends;
 pub mod processing;
 pub mod types;
 pub mod utils;
+pub mod storage;
 
 #[cfg(test)]
 mod tests {

--- a/rust_snuba/src/main.rs
+++ b/rust_snuba/src/main.rs
@@ -1,3 +1,5 @@
+pub mod storage;
+
 fn main() {
     println!("Hello, world!");
 }

--- a/rust_snuba/src/storage.rs
+++ b/rust_snuba/src/storage.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct StorageKeys {
+    key: String,
+    set_key: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Schema {
+    local_table_name: String,
+    dist_table_name: String,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Processor {
+    name: String
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct StreamLoader {
+    processor: Processor,
+    default_topic: String
+}
+
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Storage {
+    version: String,
+    kind: String,
+    name: String,
+    schema: Schema,
+    storage: StorageKeys,
+    stream_loader: StreamLoader
+}
+
+impl Storage {
+    // Loads storage from yaml file
+    pub fn load(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let f = File::open(path)?;
+        let d: Storage = serde_yaml::from_reader(f)?;
+        Ok(d)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_load_storage() {
+        use super::*;
+
+        let storage_yaml_path = "../snuba/datasets/configuration/querylog/storages/querylog.yaml";
+
+        let storage = Storage::load(storage_yaml_path).unwrap();
+
+        assert_eq!(storage.name, "querylog");
+        assert_eq!(storage.storage.key, "querylog");
+        assert_eq!(storage.storage.set_key, "querylog");
+        assert_eq!(storage.schema.local_table_name, "querylog_local");
+        assert_eq!(storage.schema.dist_table_name, "querylog_dist");
+        assert_eq!(storage.stream_loader.default_topic, "snuba-queries");
+    }
+}


### PR DESCRIPTION
Adds a Storage struct which can be loaded via a storage yaml file