### PR TITLE
feat(admin): allow querylog to be queried by more threads

### DIFF
--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -1,3 +1,4 @@
+from snuba import state
 from snuba.admin.audit_log.querylog import audit_log
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
@@ -39,5 +40,9 @@ def __run_querylog_query(query: str) -> ClickhouseResult:
     connection = get_ro_query_node_connection(
         StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERY
     )
-    query_result = connection.execute(query=query, with_column_types=True)
+    query_result = connection.execute(
+        query=query,
+        with_column_types=True,
+        settings={"max_threads": state.get_config("admin.querylog_threads", 4)},
+    )
     return query_result

--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -13,6 +13,10 @@ from snuba.datasets.storages.storage_key import StorageKey
 _MAX_CH_THREADS = 4
 
 
+class BadThreadsValue(Exception):
+    pass
+
+
 @audit_log
 def run_querylog_query(query: str, user: str) -> ClickhouseResult:
     """
@@ -43,7 +47,9 @@ def _get_clickhouse_threads() -> int:
         )
     except ValueError:
         # in case the config is set incorrectly
-        return _MAX_CH_THREADS
+        raise BadThreadsValue(
+            f"{config_threads} is not a valid configuration option for Clickhouse `max_threads`"
+        )
 
 
 def __run_querylog_query(query: str) -> ClickhouseResult:

--- a/tests/admin/clickhouse/test_querylog.py
+++ b/tests/admin/clickhouse/test_querylog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from snuba import state
@@ -12,6 +14,6 @@ from snuba.admin.clickhouse.querylog import _MAX_CH_THREADS, _get_clickhouse_thr
         pytest.param("invalid_value", _MAX_CH_THREADS, id="invalid_value"),
     ],
 )
-def test_get_clickhouse_threads(config_val, expected_threads) -> None:
-    state.set_config("admin.querylog_threads", config_val)
+def test_get_clickhouse_threads(config_val: str | int, expected_threads: int) -> None:
+    state.set_config("admin.querylog_threads", str(config_val))
     assert _get_clickhouse_threads() == expected_threads

--- a/tests/admin/clickhouse/test_querylog.py
+++ b/tests/admin/clickhouse/test_querylog.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from typing import Type
+
 import pytest
 
 from snuba import state
-from snuba.admin.clickhouse.querylog import _MAX_CH_THREADS, _get_clickhouse_threads
+from snuba.admin.clickhouse.querylog import (
+    _MAX_CH_THREADS,
+    BadThreadsValue,
+    _get_clickhouse_threads,
+)
 
 
 @pytest.mark.parametrize(
@@ -11,9 +17,22 @@ from snuba.admin.clickhouse.querylog import _MAX_CH_THREADS, _get_clickhouse_thr
     [
         pytest.param(2, 2, id="normal"),
         pytest.param(5, _MAX_CH_THREADS, id="over max"),
-        pytest.param("invalid_value", _MAX_CH_THREADS, id="invalid_value"),
     ],
 )
 def test_get_clickhouse_threads(config_val: str | int, expected_threads: int) -> None:
     state.set_config("admin.querylog_threads", str(config_val))
     assert _get_clickhouse_threads() == expected_threads
+
+
+@pytest.mark.parametrize(
+    "config_val, error",
+    [
+        pytest.param("invalid_value", BadThreadsValue, id="invalid_value"),
+    ],
+)
+def test_get_clickhouse_threads_error(
+    config_val: str | int, error: Type[Exception]
+) -> None:
+    state.set_config("admin.querylog_threads", str(config_val))
+    with pytest.raises(error):
+        _get_clickhouse_threads()

--- a/tests/admin/clickhouse/test_querylog.py
+++ b/tests/admin/clickhouse/test_querylog.py
@@ -1,0 +1,17 @@
+import pytest
+
+from snuba import state
+from snuba.admin.clickhouse.querylog import _MAX_CH_THREADS, _get_clickhouse_threads
+
+
+@pytest.mark.parametrize(
+    "config_val, expected_threads",
+    [
+        pytest.param(2, 2, id="normal"),
+        pytest.param(5, _MAX_CH_THREADS, id="over max"),
+        pytest.param("invalid_value", _MAX_CH_THREADS, id="invalid_value"),
+    ],
+)
+def test_get_clickhouse_threads(config_val, expected_threads):
+    state.set_config("admin.querylog_threads", config_val)
+    assert _get_clickhouse_threads() == expected_threads

--- a/tests/admin/clickhouse/test_querylog.py
+++ b/tests/admin/clickhouse/test_querylog.py
@@ -12,6 +12,6 @@ from snuba.admin.clickhouse.querylog import _MAX_CH_THREADS, _get_clickhouse_thr
         pytest.param("invalid_value", _MAX_CH_THREADS, id="invalid_value"),
     ],
 )
-def test_get_clickhouse_threads(config_val, expected_threads):
+def test_get_clickhouse_threads(config_val, expected_threads) -> None:
     state.set_config("admin.querylog_threads", config_val)
     assert _get_clickhouse_threads() == expected_threads


### PR DESCRIPTION
There are many useful querylog queries which we cannot do because we only have one thread to query the querylog with. Up the max_threads to 4 but make it runtime configurable.

NOTE:

I'm not sure how to test this to know that it works as expected (except for deploying it). It seems like you can pass anything you want into the `settings` dict, and have max_threads be any value and the query will still succeed. Would love some guidance on this if anyone has ideas.