### PR TITLE
ref(migrations): Make ADMIN_ALLOWED_MIGRATION_GROUPS a set

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -72,10 +72,8 @@ class ExecuteNoneAction(MigrationAction):
     pass
 
 
-# todo, shoudln't need .keys() once ADMIN_ALLOWED_MIGRATION_GROUPS is a set not dict
 MIGRATIONS_RESOURCES = {
-    group: MigrationResource(group)
-    for group in settings.ADMIN_ALLOWED_MIGRATION_GROUPS.keys()
+    group: MigrationResource(group) for group in settings.ADMIN_ALLOWED_MIGRATION_GROUPS
 }
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -47,6 +47,7 @@ ADMIN_ALLOWED_MIGRATION_GROUPS = {
     "profiles",
     "functions",
     "replays",
+    "search_issues",
     "test_migration",
 }
 MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS = 24

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -42,12 +42,12 @@ ADMIN_IAM_POLICY_FILE = os.environ.get(
 # Migrations Groups that are allowed to be managed
 # in the snuba admin tool.
 ADMIN_ALLOWED_MIGRATION_GROUPS = {
-    "system": "NonBlockingMigrationsPolicy",
-    "generic_metrics": "NonBlockingMigrationsPolicy",
-    "profiles": "NonBlockingMigrationsPolicy",
-    "functions": "NonBlockingMigrationsPolicy",
-    "replays": "NonBlockingMigrationsPolicy",
-    "test_migration": "AllMigrationsPolicy",
+    "system",
+    "generic_metrics",
+    "profiles",
+    "functions",
+    "replays",
+    "test_migration",
 }
 MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS = 24
 

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -132,9 +132,9 @@ def test_list_migration_status(admin_api: FlaskClient) -> None:
 @patch(
     "snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS",
     {
-        "system": "AllMigrationsPolicy",
-        "generic_metrics": "NoMigrationsPolicy",
-        "events": "NonBlockingMigrationsPolicy",
+        "system",
+        "generic_metrics",
+        "events",
     },
 )
 def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:


### PR DESCRIPTION
The policies are handle via roles, instead of from `ADMIN_ALLOWED_MIGRATION_GROUPS`