### PR TITLE
feat(replays): add replay_id to transactions table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -139,6 +139,7 @@ class TransactionsLoader(DirectoryLoader):
             "0018_transactions_add_profile_id",
             "0019_transactions_add_indexes_and_context_hash",
             "0020_transactions_add_codecs",
+            "0021_transactions_add_replay_id",
         ]
 
 

--- a/snuba/snuba_migrations/transactions/0021_transactions_add_replay_id.py
+++ b/snuba/snuba_migrations/transactions/0021_transactions_add_replay_id.py
@@ -1,0 +1,40 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name=table_name,
+                column=Column("replay_id", UUID(Modifiers(nullable=True))),
+                after="profile_id",
+                target=target,
+            )
+            for table_name, target in [
+                ("transactions_local", OperationTarget.LOCAL),
+                ("transactions_dist", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.TRANSACTIONS,
+                table_name=table_name,
+                column_name="replay_id",
+                target=target,
+            )
+            for table_name, target in [
+                ("transactions_dist", OperationTarget.DISTRIBUTED),
+                ("transactions_local", OperationTarget.LOCAL),
+            ]
+        ]


### PR DESCRIPTION
As per https://github.com/getsentry/rfcs/blob/main/text/0048-move-replayid-out-of-tags.md, this pull request adds a `replay_id` column to the transactions table. 