### PR TITLE
feat(replays): add replay_id to errors table

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -110,6 +110,7 @@ class EventsLoader(DirectoryLoader):
             "0016_drop_legacy_events",
             "0017_errors_add_indexes",
             "0018_errors_ro_add_tags_hash_map",
+            "0019_add_replay_id_column",
         ]
 
 

--- a/snuba/snuba_migrations/events/0019_add_replay_id_column.py
+++ b/snuba/snuba_migrations/events/0019_add_replay_id_column.py
@@ -21,7 +21,7 @@ class Migration(migration.ClickhouseNodeMigration):
             )
             for table_name, target in [
                 ("errors_local", OperationTarget.LOCAL),
-                ("transactions_dist", OperationTarget.DISTRIBUTED),
+                ("errors_dist", OperationTarget.DISTRIBUTED),
             ]
         ]
 

--- a/snuba/snuba_migrations/events/0019_add_replay_id_column.py
+++ b/snuba/snuba_migrations/events/0019_add_replay_id_column.py
@@ -34,7 +34,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 target=target,
             )
             for table_name, target in [
-                ("errors_local", OperationTarget.LOCAL),
                 ("errors_dist", OperationTarget.DISTRIBUTED),
+                ("errors_local", OperationTarget.LOCAL),
             ]
         ]

--- a/snuba/snuba_migrations/events/0019_add_replay_id_column.py
+++ b/snuba/snuba_migrations/events/0019_add_replay_id_column.py
@@ -1,0 +1,40 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name=table_name,
+                column=Column("replay_id", UUID(Modifiers(nullable=True))),
+                after="modules.version",
+                target=target,
+            )
+            for table_name, target in [
+                ("errors_local", OperationTarget.LOCAL),
+                ("transactions_dist", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.EVENTS,
+                table_name=table_name,
+                column_name="replay_id",
+                target=target,
+            )
+            for table_name, target in [
+                ("errors_local", OperationTarget.LOCAL),
+                ("errors_dist", OperationTarget.DISTRIBUTED),
+            ]
+        ]


### PR DESCRIPTION
As per https://github.com/getsentry/rfcs/blob/main/text/0048-move-replayid-out-of-tags.md, this pull request adds a replay_id column to the errors table. 

I'm not sure how `ERRORS_RO` is used, and if its needed in this migration, but not doing anything with it now.