### PR TITLE
migrations: add custom search issues role

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -119,9 +119,14 @@ ROLES = {
         name="TestMigrationsExecutor",
         actions={ExecuteAllAction([MIGRATIONS_RESOURCES["test_migration"]])},
     ),
+    "SearchIssuesExecutor": Role(
+        name="SearchIssuesExecutor",
+        actions={ExecuteNonBlockingAction([MIGRATIONS_RESOURCES["search_issues"]])},
+    ),
 }
 
 DEFAULT_ROLES = [
     ROLES["MigrationsReader"],
     ROLES["TestMigrationsExecutor"],
+    ROLES["SearchIssuesExecutor"],
 ]

--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -11,6 +11,15 @@
       },
       {
         "members": [
+          "user:fpacifici@sentry.io",
+          "user:meredith@sentry.io",
+          "user:nikhar.saxena@sentry.io",
+          "user:dalitso.banda@sentry.io"
+        ],
+        "role": "roles/SearchIssuesExecutor"
+      },
+      {
+        "members": [
           "group:team-sns@sentry.io"
         ],
         "role": "roles/MigrationsReader"


### PR DESCRIPTION
Adds custom role to allow running the search issue migrations by default. This is part of the effort to run search issue with the migrations tool.  Follows up #3720
