### PR TITLE
feat(replays): Remove experimental flag

### DIFF
--- a/snuba/datasets/configuration/replays/dataset.yaml
+++ b/snuba/datasets/configuration/replays/dataset.yaml
@@ -2,7 +2,7 @@ version: v1
 kind: dataset
 name: replays
 
-is_experimental: true
+is_experimental: false
 
 entities:
   - replays


### PR DESCRIPTION
Removes the experimental flag from replays before the Monday launch.