### PR TITLE
ref(consumer): Separate out a get_logical_topics function in multistorage consumer

### DIFF
--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -255,7 +255,7 @@ def multistorage_consumer(
     processor.run()
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConsumerConfig:
     logical_raw_topic: Topic
     logical_commit_log_topic: Optional[Topic]


### PR DESCRIPTION
This is the second mini step. There is scattered topic validation throughout the multistorage consumer which checks for and ensures that there is only one topic or one dead letter policy in a multistorage context. 

This PR pulls out those validations into a single function and reduces a bit of repetition. With this PR we can also predict some of the small refactors we will need to get multistorage consumer to look a bit more like ConsumerBuilder. In the next step(s), we can move some pieces of code around to get a `get_consumer` and a `build_streaming_strategy_factory` function like ConsumerBuilder has.