### PR TITLE
feat(DC): Add support for Enum column type

### DIFF
--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -193,11 +193,32 @@ AGGREGATE_FUNCTION_SCHEMA = make_column_schema(
     },
 )
 
+ENUM_SCHEMA = make_column_schema(
+    column_type={"const": "Enum"},
+    args={
+        "type": "object",
+        "properties": {
+            "values": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "items": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                    ],
+                },
+            },
+        },
+        "additionalProperties": False,
+    },
+)
+
 SIMPLE_COLUMN_SCHEMAS = [
     NUMBER_SCHEMA,
     FIXED_STRING_SCHEMA,
     NO_ARG_SCHEMA,
     AGGREGATE_FUNCTION_SCHEMA,
+    ENUM_SCHEMA,
 ]
 
 # Array inner types are the same as normal column types except they don't have a name

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -13,6 +13,7 @@ from snuba.clickhouse.columns import (
     Array,
     Column,
     DateTime,
+    Enum,
     Float,
     Nested,
     SchemaModifiers,
@@ -158,6 +159,8 @@ def __parse_column_type(col: dict[str, Any]) -> ColumnType[SchemaModifiers]:
         )
     elif col["type"] == "FixedString":
         column_type = FixedString(col["args"]["length"], modifiers)
+    elif col["type"] == "Enum":
+        column_type = Enum(col["args"]["values"], modifiers)
     assert column_type is not None
     return column_type
 

--- a/tests/datasets/configuration/test_storage_loader.py
+++ b/tests/datasets/configuration/test_storage_loader.py
@@ -8,6 +8,7 @@ from snuba.clickhouse.columns import (
     Array,
     Column,
     DateTime,
+    Enum,
     Float,
     Nested,
     SchemaModifiers,
@@ -101,6 +102,14 @@ query_processors:
                     "schema_modifiers": ["readonly"],
                 },
             },
+            {
+                "name": "enum_col",
+                "type": "Enum",
+                "args": {
+                    "values": [("success", 0), ("error", 1), ("pending", 2)],
+                    "schema_modifiers": ["nullable"],
+                },
+            },
         ]
 
         expected_python_columns = [
@@ -117,6 +126,13 @@ query_processors:
             Column(
                 "double_array_col",
                 Array(Array(UInt(64)), SchemaModifiers(nullable=False, readonly=True)),
+            ),
+            Column(
+                "enum_col",
+                Enum(
+                    [("success", 0), ("error", 1), ("pending", 2)],
+                    SchemaModifiers(nullable=True, readonly=False),
+                ),
             ),
         ]
 


### PR DESCRIPTION
This PR is responsible for adding support for specifying `Enum` column types in configuration. This schema type was already supported in python components and just needed to be moved over to config.