### PR TITLE
ref: bump timeout slightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   config-validation:
     name: "Dataset Config Validation"
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     steps:
       - uses: actions/checkout@v3
         name: Checkout code


### PR DESCRIPTION
this was within ~10% of failing and so github sometimes reports it as both a pass and a failure at the same time