### PR TITLE
fix: Rename consumer group tag

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -139,7 +139,7 @@ def consumer(
     sentry_sdk.set_tag("storage", storage_name)
 
     metrics_tags = {
-        "group": consumer_group,
+        "consumer_group": consumer_group,
         "storage": storage_key.value,
     }
 


### PR DESCRIPTION
`group` was removed at Sentry since it's too high cardinality, rename to `consumer_group`
