### PR TITLE
ref(schemas): Add basic generic-metrics message schema

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -105,7 +105,6 @@ logger = logging.getLogger(__name__)
     "--output-block-size",
     type=int,
 )
-@click.option("--validate-schema", is_flag=True, default=False)
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
@@ -128,7 +127,6 @@ def consumer(
     input_block_size: Optional[int],
     output_block_size: Optional[int],
     log_level: Optional[str] = None,
-    validate_schema: bool,
     profile_path: Optional[str] = None,
 ) -> None:
 
@@ -176,7 +174,6 @@ def consumer(
         metrics=metrics,
         profile_path=profile_path,
         stats_callback=stats_callback,
-        validate_schema=validate_schema,
         slice_id=slice_id,
     )
 

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import random
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -551,13 +552,15 @@ def process_message(
     processor: MessageProcessor,
     consumer_group: str,
     snuba_logical_topic: SnubaTopic,
-    validate: bool,
+    validate: float,
     message: Message[KafkaPayload],
 ) -> Union[None, BytesInsertBatch, ReplacementBatch]:
     assert isinstance(message.value, BrokerValue)
     try:
         codec = get_json_codec(snuba_logical_topic)
-        decoded = codec.decode(message.payload.value, validate=validate)
+        decoded = codec.decode(
+            message.payload.value, validate=random.random() < validate
+        )
         result = processor.process_message(
             decoded,
             KafkaMessageMetadata(

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -72,7 +72,6 @@ class ConsumerBuilder:
         slice_id: Optional[int],
         stats_callback: Optional[Callable[[str], None]] = None,
         commit_retry_policy: Optional[RetryPolicy] = None,
-        validate_schema: bool = False,
         profile_path: Optional[str] = None,
     ) -> None:
         self.storage = get_writable_storage(storage_key)
@@ -178,7 +177,6 @@ class ConsumerBuilder:
             )
 
         self.__commit_retry_policy = commit_retry_policy
-        self.__validate_schema = validate_schema
 
     def __build_consumer(
         self,
@@ -264,7 +262,7 @@ class ConsumerBuilder:
                 processor,
                 self.consumer_group,
                 logical_topic,
-                self.__validate_schema,
+                float(get_config("validate_schema", 0) or 0.0),
             ),
             collector=build_batch_writer(
                 table_writer,

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -4,6 +4,62 @@ from arroyo.processing.strategies.decoder import JsonCodec
 
 from snuba.utils.streams.topics import Topic
 
+_HARDCODED_SCHEMAS: Mapping[Topic, Mapping[str, Any]] = {
+    Topic.GENERIC_METRICS: {
+        "$schema": "http://json-schema.org/draft-06/schema#",
+        "$ref": "#/definitions/Main",
+        "definitions": {
+            "Main": {
+                "type": "object",
+                "additionalProperties": False,
+                "properties": {
+                    "use_case_id": {"type": "string"},
+                    "org_id": {"type": "integer"},
+                    "project_id": {"type": "integer"},
+                    "metric_id": {"type": "integer"},
+                    "type": {"type": "string"},
+                    "timestamp": {"type": "integer"},
+                    "tags": {"$ref": "#/definitions/IntToInt"},
+                    "value": {"type": "array", "items": {"type": "number"}},
+                    "retention_days": {"type": "integer"},
+                    "mapping_meta": {"$ref": "#/definitions/MappingMeta"},
+                },
+                "required": [
+                    "mapping_meta",
+                    "metric_id",
+                    "org_id",
+                    "project_id",
+                    "retention_days",
+                    "tags",
+                    "timestamp",
+                    "type",
+                    "use_case_id",
+                    "value",
+                ],
+                "title": "Main",
+            },
+            "MappingMeta": {
+                "type": "object",
+                "additionalProperties": False,
+                "patternProperties": {
+                    "^[chdfr]$": {"$ref": "#/definitions/IntToString"}
+                },
+                "title": "MappingMeta",
+            },
+            "IntToInt": {
+                "type": "object",
+                "patternProperties": {"^[0-9]$": {"type": "integer"}},
+                "title": "IntToInt",
+            },
+            "IntToString": {
+                "type": "object",
+                "patternProperties": {"^[0-9]$": {"type": "string"}},
+                "title": "IntToString",
+            },
+        },
+    }
+}
+
 
 def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
     """
@@ -13,7 +69,7 @@ def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
     This function returns either the schema if it is defined, or None if not.
 
     """
-    return None
+    return _HARDCODED_SCHEMAS.get(topic)
 
 
 _cache: MutableMapping[Topic, JsonCodec] = {}


### PR DESCRIPTION
I used https://app.quicktype.io/ to infer a schema from some example
messages, and edited the schema manually to be actually correct.

I verified its contents with some sample messages in local development.
It would be better if we had a way to run schema validation against all
existing test payloads we have checked in. But typically those test
payloads exist as part of tests that directly invoke the
dataset-specific processor.

Also remove a CLI flag and replace it with a runtime config sample rate
setting. We are unsure about the performance impact and stability of schema
validation, and this will allow us to sample a few messages to get metrics from
prod + turn down to zero quickly if the consumer starts rejecting messages
incorrectly.

