### PR TITLE
fix(admin): allow strings in select statements on system queries

### DIFF
--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -36,7 +36,7 @@ SYSTEM_QUERY_RE = re.compile(
         ^ # Start
         (SELECT|select)
         \s
-        (?P<select_statement>[\w\s,()*+\-\/]+|\*)
+        (?P<select_statement>[\w\s\',()*+\-\/]+|\*)
         \s
         (FROM|from)
         \s

--- a/tests/admin/test_system_queries.py
+++ b/tests/admin/test_system_queries.py
@@ -16,6 +16,7 @@ from snuba.admin.clickhouse.system_queries import validate_system_query
         "SELECT * FROM system.clusters WHERE cluster == 'my_cluster'",  # where clause
         "SELECT * FROM system.clusters WHERE toInt32(shard_num) == 1",  # where clause with fn
         "SELECT * FROM system.clusters LIMIT 100",  # limit
+        "SELECT empty('str') FROM system.clusters LIMIT 100",  # literal str params
     ],
 )
 def test_valid_system_query(sql_query: str) -> None:


### PR DESCRIPTION
The regex does not currently allow literal strings in select statements. Add it to the regex