### PR TITLE
OPS-2789: add search issues consumer to freight

### DIFF
--- a/.freight.yml
+++ b/.freight.yml
@@ -79,6 +79,8 @@ steps:
         name: profiling-functions-consumer
       - image: us.gcr.io/sentryio/snuba:{sha}
         name: replays-consumer
+      - image: us.gcr.io/sentryio/snuba:{sha}
+        name: search-issues-consumer
   - kind: KubernetesCronJob
     selector:
       label_selector: service=snuba


### PR DESCRIPTION
Confirming the consumer deployment name:
```
% k get deploy | grep search-issues
snuba-search-issues-consumer-production                                     1/1       1            1           26h
```

Didn't add to `stable` since it's still in testing.