### PR TITLE
feat(search-issues): alias isHandled and notHandled functions to None

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -142,6 +142,12 @@ storages:
             from_column_name: contexts
             to_nested_col_table:
             to_nested_col_name: contexts
+      functions:
+        - mapper: DefaultNoneFunctionMapper
+          args:
+            function_names:
+              - isHandled
+              - notHandled
 
 storage_selector:
   selector: DefaultQueryStorageSelector


### PR DESCRIPTION
Handle queries to this dataset that use `isHandled` and `notHandled` function names. For our use case, we don't have stacktraces to parse out so just return nothing.