### PR TITLE
feat(replays): Default event_hash when segment_id is null

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -161,7 +161,11 @@ class ReplaysProcessor(DatasetMessageProcessor):
     def _process_event_hash(
         self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict
     ) -> None:
-        processed["event_hash"] = segment_id_to_event_hash(replay_event["segment_id"])
+        event_hash = replay_event.get("event_hash")
+        if event_hash is None:
+            event_hash = segment_id_to_event_hash(replay_event["segment_id"])
+
+        processed["event_hash"] = event_hash
 
     def process_message(
         self, message: Mapping[Any, Any], metadata: KafkaMessageMetadata

--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -161,14 +161,7 @@ class ReplaysProcessor(DatasetMessageProcessor):
     def _process_event_hash(
         self, processed: MutableMapping[str, Any], replay_event: ReplayEventDict
     ) -> None:
-        # event_hash is used to uniquely identify a row within a replay
-        # for our segment updates we'll simply hash the segment_id
-        # for future additions, we'll use whatever unique identifier (e.g. event_id)
-        # as the input to the hash
-
-        segment_id_bytes = force_bytes(str((replay_event["segment_id"])))
-        segment_hash = md5(segment_id_bytes).hexdigest()
-        processed["event_hash"] = to_uuid(segment_hash)
+        processed["event_hash"] = segment_id_to_event_hash(replay_event["segment_id"])
 
     def process_message(
         self, message: Mapping[Any, Any], metadata: KafkaMessageMetadata
@@ -209,6 +202,19 @@ class ReplaysProcessor(DatasetMessageProcessor):
 
 T = TypeVar("T")
 U = TypeVar("U")
+
+
+def segment_id_to_event_hash(segment_id: int | None) -> str:
+    if segment_id is None:
+        # Rows with null segment_id fields are considered "out of band" meaning they do not
+        # originate from the SDK and do not relate to a specific segment.
+        #
+        # For example: archive requests.
+        return str(uuid.uuid4().hex)
+    else:
+        segment_id_bytes = force_bytes(str(segment_id))
+        segment_hash = md5(segment_id_bytes).hexdigest()
+        return to_uuid(segment_hash)
 
 
 def default(default: Callable[[], T], value: T | None) -> T:

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -390,17 +390,17 @@ class TestReplaysProcessor:
         message = ReplayEvent.empty_set()
 
         processed_batch = ReplaysProcessor().process_message(message.serialize(), meta)
-        assert isinstance(processed_batch, InsertBatch)
+        assert isinstance(processed_batch, InsertBatch)  # required for type checker
         received = processed_batch.rows[0]
-        assert isinstance(received, dict)
+        assert isinstance(received, dict)  # required for type checker
         received_event_hash = received.pop("event_hash")
 
         expected = message.build_result(meta)
-        assert isinstance(expected, dict)
+        assert isinstance(expected, dict)  # required for type checker
         expected_event_hash = expected.pop("event_hash")
 
-        assert received == expected
-        assert received_event_hash != expected_event_hash
+        assert received == expected  # all fields are identical except event_hash
+        assert received_event_hash != expected_event_hash  # hash is random
 
     def test_process_message_invalid_segment_id(self) -> None:
         meta = KafkaMessageMetadata(


### PR DESCRIPTION
The primary-key of the replays table includes segment_id as a component.  When segment_id is null we need to provide a default event_hash value to prevent row merges.  Previously `None` was coerced to a UUID which was deterministic.