### PR TITLE
fix(admin): clear host and port when storage is changed

### DIFF
--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -39,7 +39,7 @@ function QueryDisplay(props: {
       // clear old host port
       delete prevQuery.host
       delete prevQuery.port
-      
+
       return {
         ...prevQuery,
         storage: storage,
@@ -101,7 +101,7 @@ function QueryDisplay(props: {
           .filter((node)=>!node_info.local_nodes.includes(node))
           .map((node) => (
               <option
-                key={`${node.host}:${node.port}`}
+                key={`${node.host}:${node.port} dist`}
                 value={`${node.host}:${node.port}`}
               >
                 {node.host}:{node.port} (distributed)
@@ -112,7 +112,7 @@ function QueryDisplay(props: {
       if (query_node){
         hosts.push(
           (<option
-            key={`${query_node.host}:${query_node.port}`}
+            key={`${query_node.host}:${query_node.port} query`}
             value={`${query_node.host}:${query_node.port}`}
           >
             {query_node.host}:{query_node.port} (query node)

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -36,6 +36,10 @@ function QueryDisplay(props: {
 
   function selectStorage(storage: string) {
     setQuery((prevQuery) => {
+      // clear old host port
+      delete prevQuery.host
+      delete prevQuery.port
+      
       return {
         ...prevQuery,
         storage: storage,


### PR DESCRIPTION
Fix a ui bug where where the host and port were not updated after changing storage and queries could be sent to wrong host.