### PR TITLE
fix(oncall): error on non-existent columns

### DIFF
--- a/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
+++ b/snuba/datasets/configuration/outcomes/entities/outcomes.yaml
@@ -42,4 +42,3 @@ validators:
   args:
     required_filter_columns:
     - org_id
-validate_data_model: warn

--- a/snuba/datasets/configuration/replays/entities/replays.yaml
+++ b/snuba/datasets/configuration/replays/entities/replays.yaml
@@ -76,4 +76,3 @@ validators:
     args:
       required_filter_columns:
         - project_id
-validate_data_model: warn

--- a/snuba/datasets/configuration/sessions/entities/sessions.yaml
+++ b/snuba/datasets/configuration/sessions/entities/sessions.yaml
@@ -233,7 +233,6 @@ storages:
     - mapper: SessionsRawUsersErroredMapper
 storage_selector:
   selector: SessionsQueryStorageSelector
-validate_data_model: warn
 query_processors:
 - processor: BasicFunctionsProcessor
 - processor: TimeSeriesProcessor

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -50,7 +50,7 @@ class PluggableEntity(Entity):
     validators: Sequence[QueryValidator]
     required_time_column: Optional[str]
     storage_selector: QueryStorageSelector
-    validate_data_model: ColumnValidationMode = ColumnValidationMode.DO_NOTHING
+    validate_data_model: ColumnValidationMode = ColumnValidationMode.ERROR
     join_relationships: Mapping[str, JoinRelationship] = field(default_factory=dict)
     function_call_validators: Mapping[str, FunctionCallValidator] = field(
         default_factory=dict

--- a/tests/datasets/validation/test_entity_contains_columns_validator.py
+++ b/tests/datasets/validation/test_entity_contains_columns_validator.py
@@ -1,0 +1,58 @@
+import pytest
+
+from snuba.datasets.configuration.entity_builder import build_entity_from_config
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Entity as QueryEntity
+from snuba.query.exceptions import InvalidQueryException
+from snuba.query.expressions import Column
+from snuba.query.logical import Query as LogicalQuery
+from snuba.query.validation.validators import (
+    ColumnValidationMode,
+    EntityContainsColumnsValidator,
+)
+
+entity_contains_columns_tests = [
+    pytest.param(
+        "tests/datasets/configuration/entity_with_fixed_string.yaml",
+        id="Validate Entity Columns",
+    )
+]
+
+
+@pytest.mark.parametrize("config_path", entity_contains_columns_tests)
+def test_outcomes_columns_validation(config_path: str) -> None:
+    entity = build_entity_from_config(config_path)
+
+    query_entity = QueryEntity(entity.entity_key, entity.get_data_model())
+
+    bad_query = LogicalQuery(
+        query_entity,
+        selected_columns=[
+            SelectedExpression("asdf", Column("_snuba_asdf", None, "asdf")),
+            *[
+                SelectedExpression(
+                    column.name, Column(f"_snuba_{column.name}", None, column.name)
+                )
+                for column in entity.get_data_model().columns
+            ],
+        ],
+    )
+
+    good_query = LogicalQuery(
+        query_entity,
+        selected_columns=[
+            SelectedExpression(
+                column.name, Column(f"_snuba_{column.name}", None, column.name)
+            )
+            for column in entity.get_data_model().columns
+        ],
+    )
+
+    validator = EntityContainsColumnsValidator(
+        entity.get_data_model(), validation_mode=ColumnValidationMode.ERROR
+    )
+
+    with pytest.raises(InvalidQueryException):
+        validator.validate(bad_query)
+
+    validator.validate(good_query)

--- a/tests/datasets/validation/test_entity_contains_columns_validator.py
+++ b/tests/datasets/validation/test_entity_contains_columns_validator.py
@@ -4,7 +4,7 @@ from snuba.datasets.configuration.entity_builder import build_entity_from_config
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidQueryException
-from snuba.query.expressions import Column
+from snuba.query.expressions import Column, FunctionCall
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.validation.validators import (
     ColumnValidationMode,
@@ -56,3 +56,29 @@ def test_outcomes_columns_validation(config_path: str) -> None:
         validator.validate(bad_query)
 
     validator.validate(good_query)
+
+
+@pytest.mark.parametrize("config_path", entity_contains_columns_tests)
+def test_in_where_clause_and_function(config_path):
+    entity = build_entity_from_config(config_path)
+
+    query_entity = QueryEntity(entity.entity_key, entity.get_data_model())
+
+    bad_query = LogicalQuery(
+        query_entity,
+        selected_columns=[
+            *[
+                SelectedExpression(
+                    column.name, Column(f"_snuba_{column.name}", None, column.name)
+                )
+                for column in entity.get_data_model().columns
+            ],
+        ],
+        condition=FunctionCall(None, "f1", (Column(None, None, "bad_column"),)),
+    )
+    validator = EntityContainsColumnsValidator(
+        entity.get_data_model(), validation_mode=ColumnValidationMode.ERROR
+    )
+
+    with pytest.raises(InvalidQueryException):
+        validator.validate(bad_query)

--- a/tests/datasets/validation/test_entity_validation.py
+++ b/tests/datasets/validation/test_entity_validation.py
@@ -11,11 +11,7 @@ from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.expressions import Column, Expression, FunctionCall, Literal
 from snuba.query.logical import Query as LogicalQuery
-from snuba.query.validation.validators import (
-    ColumnValidationMode,
-    EntityContainsColumnsValidator,
-    EntityRequiredColumnValidator,
-)
+from snuba.query.validation.validators import EntityRequiredColumnValidator
 
 required_column_tests = [
     pytest.param(
@@ -124,44 +120,3 @@ def test_entity_required_column_validation_failure(
     validator = EntityRequiredColumnValidator(["project_id"])
     with pytest.raises(InvalidQueryException):
         validator.validate(query)
-
-
-entity_contains_columns_tests = [
-    pytest.param(
-        EntityKey.OUTCOMES,
-        id="Validate Outcomes Entity Columns",
-    )
-]
-
-
-@pytest.mark.parametrize("key", entity_contains_columns_tests)
-def test_outcomes_columns_validation(key: EntityKey) -> None:
-    entity = get_entity(key)
-
-    query_entity = QueryEntity(key, entity.get_data_model())
-
-    bad_query = LogicalQuery(
-        query_entity,
-        selected_columns=[
-            SelectedExpression("asdf", Column("_snuba_asdf", None, "asdf")),
-        ],
-    )
-
-    good_query = LogicalQuery(
-        query_entity,
-        selected_columns=[
-            SelectedExpression(
-                column.name, Column(f"_snuba_{column.name}", None, column.name)
-            )
-            for column in entity.get_data_model().columns
-        ],
-    )
-
-    validator = EntityContainsColumnsValidator(
-        entity.get_data_model(), validation_mode=ColumnValidationMode.ERROR
-    )
-
-    with pytest.raises(InvalidQueryException):
-        validator.validate(bad_query)
-
-    validator.validate(good_query)


### PR DESCRIPTION
Queries get sent to us with non-existent columns in them. No need to let those queries get all the way to clickhouse. Turn on the `EntityContainsColumnsValidator` to `ERROR` for all entities by default.

As part of this I moved the test for this validator to its own file and decoupled it from the outcomes entity (it now uses its a test configuration entity)