### PR TITLE
fix: Fix a few bugs with message schema validation

### DIFF
--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -262,7 +262,6 @@ class ConsumerBuilder:
                 processor,
                 self.consumer_group,
                 logical_topic,
-                float(get_config(f"validate_schema_{logical_topic.name}", 0) or 0.0),
             ),
             collector=build_batch_writer(
                 table_writer,

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -5,7 +5,7 @@ from arroyo.processing.strategies.decoder.json import JsonCodec
 from snuba.utils.streams.topics import Topic
 
 _HARDCODED_SCHEMAS: Mapping[Topic, Mapping[str, Any]] = {
-    Topic.GENERIC_METRICS: {
+    Topic.METRICS: {
         "$schema": "http://json-schema.org/draft-2020-12/schema#",
         "$ref": "#/definitions/Main",
         "definitions": {

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -713,8 +713,6 @@ if application.debug or application.testing:
                 ) -> None:
                     pass
 
-                validate_schema = True
-
                 strategy = KafkaConsumerStrategyFactory(
                     stream_loader.get_pre_filter(),
                     functools.partial(
@@ -722,7 +720,6 @@ if application.debug or application.testing:
                         stream_loader.get_processor(),
                         "consumer_grouup",
                         stream_loader.get_default_topic_spec().topic,
-                        validate_schema,
                     ),
                     build_batch_writer(table_writer, metrics=metrics),
                     max_batch_size=1,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -72,7 +72,7 @@ def test_streaming_consumer_strategy() -> None:
     factory = KafkaConsumerStrategyFactory(
         None,
         functools.partial(
-            process_message, processor, "consumer_group", SnubaTopic.EVENTS, 0.0
+            process_message, processor, "consumer_group", SnubaTopic.EVENTS
         ),
         write_step,
         max_batch_size=10,


### PR DESCRIPTION
* The defined schema was not for the generic-metrics topic, but for the
  metrics topic. An important difference is that the tag values are
  strings!

* The config was not reloaded dynamically, only on consumer start

* Validation errors crashed the consumers, but in this stage we don't
  want that

