### PR TITLE
fix(issue-platform): use the same consumer group as sentry devserver

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -409,6 +409,7 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
                     "--auto-offset-reset=latest",
                     "--log-level=debug",
                     "--storage=search_issues",
+                    "--consumer-group=generic_events_group",
                 ],
             ),
         ]


### PR DESCRIPTION
Related to this PR https://github.com/getsentry/sentry/pull/44846/files#diff-b7d8e2b4479e5aa536d95992ae00a4a667372de290d42fc9caf12efa42ebb707R64