### PR TITLE
fix(issue-platform): wrap log(0) function calls with 0 value

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -161,6 +161,7 @@ query_processors:
     args:
       project_field: project_id
   - processor: TagsExpanderProcessor
+  - processor: BasicFunctionsProcessor
 
 validators:
   - validator: EntityRequiredColumnValidator


### PR DESCRIPTION
Replaces any function calls for `log(x) = -inf` with a value of 0.

Fixes SNUBA-32N