### PR TITLE
feat(issue-platform): add commit log topic when processing search_issue events

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -84,6 +84,7 @@ stream_loader:
   processor:
     name: SearchIssuesMessageProcessor
   default_topic: generic-events
+  commit_log_topic: snuba-generic-events-commit-log
   dlq_policy:
     type: produce
     args: [ snuba-dead-letter-generic-events ]

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -60,6 +60,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "profiles-call-tree",
         "ingest-replay-events",
         "generic-events",
+        "snuba-generic-events-commit-log",
         "snuba-replay-events",
         "snuba-dead-letter-replays",
         "snuba-generic-metrics",

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -49,6 +49,7 @@ class Topic(Enum):
     )
     GENERIC_METRICS_COUNTERS_COMMIT_LOG = "snuba-generic-metrics-counters-commit-log"
     GENERIC_EVENTS = "generic-events"
+    GENERIC_EVENTS_COMMIT_LOG = "snuba-generic-events-commit-log"
 
     ATTRIBUTION = "snuba-attribution"
     DEAD_LETTER_METRICS = "snuba-dead-letter-metrics"


### PR DESCRIPTION
Brings these changes back https://github.com/getsentry/snuba/pull/3767 which was reverted since we didn't have this https://github.com/getsentry/ops/pull/6162 merged in yet. 

The commit log should be fully ready in prod, but gonna hold off merging this until we get the green light from OPS, just getting this ready.