### PR TITLE
Add `loadbalancer-outcomes` to the list of valid topics

### DIFF
--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -39,6 +39,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "cdc",
         "snuba-metrics",
         "outcomes",
+        "loadbalancer-outcomes",
         "ingest-sessions",
         "snuba-queries",
         "scheduled-subscriptions-events",


### PR DESCRIPTION
I'd like to temporarily override the cluster for `loadbalancer-outcomes` topic via `KAFKA_BROKER_CONFIG`. However, according to [this logic](https://github.com/getsentry/snuba/blob/master/snuba/settings/validation.py#L80-L82) it would fail currently, because this topic is missing from `topic_names`.