### PR TITLE
fix(oncall): validate metrics counters tag condition

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
@@ -120,6 +120,8 @@ validators:
   - validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["org_id", "project_id"]
+  - validator: TagConditionValidator
+    args: {}
 required_time_column: timestamp
 partition_key_column_name: org_id
 subscription_processors:

--- a/snuba/datasets/configuration/metrics/entities/metrics_counters.yaml
+++ b/snuba/datasets/configuration/metrics/entities/metrics_counters.yaml
@@ -105,6 +105,8 @@ validators:
   - validator: GranularityValidator
     args:
       minimum: 10
+  - validator: TagConditionValidator
+    args: {}
 
 subscription_processors:
   - processor: AddColumnCondition


### PR DESCRIPTION
Had a bunch of queries come in to sentry that triggered an alert because non-string keys were being used on tags