### PR TITLE
cd: sentry releases fixes take 2

### DIFF
--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -60,7 +60,7 @@ pipelines:
                               - script: |
                                     sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
                                     sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
-                                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e release
+                                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
                                     sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
                       deploy:
                           timeout: 1200

--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -62,7 +62,7 @@ pipelines:
                               - script: |
                                     sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
                                     sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
-                                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e release
+                                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
                                     sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
                       deploy:
                           timeout: 1200


### PR DESCRIPTION
1. release name is `production`, not `release`
2. got 403's while trying to set-commits - i've since update the token with the relevant permissions. The reason this failed was freight, which handles snuba releases, uses a sufficiently permissioned token, and so far with our token we have not needed to set-commits till now