### PR TITLE
feat(CapMan): `NO_LIMIT` keyword to skip limiting

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -164,7 +164,7 @@ class SubscriptionData:
         custom_processing.append(partial(self.add_conditions, timestamp, offset))
 
         request = build_request(
-            {"query": self.query},
+            {"query": self.query, "tenant_ids": {"NO_LIMIT": 1}},
             parse_snql_query,
             SubscriptionQuerySettings,
             schema,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -217,6 +217,8 @@ def record_missing_tenant_ids(request: Request) -> None:
     metric will be removed once all API calls from Sentry do include this info.
     """
     if tenant_ids := request.attribution_info.tenant_ids:
+        if "NO_LIMIT" in tenant_ids:
+            return
         if "referrer" not in tenant_ids or "organization_id" not in tenant_ids:
             metrics.increment(
                 "request_without_tenant_ids", tags={"referrer": request.referrer}


### PR DESCRIPTION
All this does is skip counting towards the metric for now, maybe this can become a keyword used to ignore or at least request skipping allocation management for certain requests