### PR TITLE
fix(CapMan): Subscriptions have no org IDs

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -164,7 +164,13 @@ class SubscriptionData:
         custom_processing.append(partial(self.add_conditions, timestamp, offset))
 
         request = build_request(
-            {"query": self.query},
+            {
+                "query": self.query,
+                "tenant_ids": {
+                    "organization_id": "<subscriptions>",
+                    "referrer": referrer,
+                },
+            },
             parse_snql_query,
             SubscriptionQuerySettings,
             schema,


### PR DESCRIPTION
- Refactoring subscriptions to include organization IDs for the queries would be a huge task
- Setting the organization id as a placeholder string for now, can be changed if we decide to figure out how to add org IDs to subscriptions