### PR TITLE
ref(CapMan): remove execute_query_strategy variable

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -81,6 +81,11 @@ class RedisCache(Cache[TValue]):
         timeout: int,
         timer: Optional[Timer] = None,
     ) -> TValue:
+        # in case something is wrong with redis, we want to be able to
+        # disable the read_through_cache but still serve traffic.
+        if get_config("read_through_cache.short_circuit", 0):
+            return function()
+
         # This method is designed with the following goals in mind:
         # 1. The value generation function is only executed when no value
         # already exists for the key.

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -668,14 +668,8 @@ def raw_query(
         trace_id,
     )
 
-    execute_query_strategy = (
-        execute_query_with_query_id
-        if state.get_config("use_readthrough_query_cache", 1)
-        else execute_query_with_caching
-    )
-
     try:
-        result = execute_query_strategy(
+        result = execute_query_with_query_id(
             clickhouse_query,
             query_settings,
             formatted_query,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1837,6 +1837,7 @@ class TestApi(SimpleAPITest):
 
     def test_consistent(self, disable_query_cache: Callable[..., Any]) -> None:
         state.set_config("consistent_override", "test_override=0;another=0.5")
+        state.set_config("read_through_cache.short_circuit", 1)
         query = json.dumps(
             {
                 "project": 2,


### PR DESCRIPTION
in order to make room for capacity management, we have to understand how db_query.py works. As part of that process, I realized that we had dead code in this file `execute_query_with_caching` has not been used since 2020 and we're not going to use it again.

@untitaker actually tried to remove this in #3372 but tests were failing. 

### Significant changes

added a short circuit option to the readthrough cache. This was done for the following reasons:

1. The test that was failing was failing because it was hitting the readthrough cache, which never hit the `execute_query` function, thus never setting the `consistent` flag in the results. 
2. We had a single tenant incident where we wanted to disable the reathrough cache and were not able to so I figured it was fine to add it. This way if we lose redis for a consistent amount of time we can just pass the queries right through.