### PR TITLE
rust: add simple transform and produce strategy example

### DIFF
--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -48,7 +48,8 @@ impl ProcessingStrategy<KafkaPayload> for Noop {
 
 
 
-fn main() {
+#[tokio::main]
+async fn main() {
     struct ReverseStringAndProduceStrategyFactory {
         config: KafkaConfig,
         topic: Topic,

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -49,19 +49,19 @@ impl ProcessingStrategy<KafkaPayload> for Noop {
 
 
 fn main() {
-    struct HashPasswordAndProduceStrategyFactory {
+    struct ReverseStringAndProduceStrategyFactory {
         config: KafkaConfig,
         topic: Topic,
     }
-    impl ProcessingStrategyFactory<KafkaPayload> for HashPasswordAndProduceStrategyFactory {
+    impl ProcessingStrategyFactory<KafkaPayload> for ReverseStringAndProduceStrategyFactory {
         fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
             let producer = KafkaProducer::new(self.config.clone());
             let topic = TopicOrPartition::Topic(self.topic.clone());
-            let hash_password_and_produce_strategy = Transform {
+            let reverse_string_and_produce_strategy = Transform {
                 function: reverse_string,
                 next_step: Box::new(Produce::new(producer, Box::new(Noop {}), topic ))
             };
-            Box::new(hash_password_and_produce_strategy)
+            Box::new(reverse_string_and_produce_strategy)
         }
     }
 
@@ -76,7 +76,7 @@ fn main() {
 
     let consumer = Box::new(KafkaConsumer::new(config.clone()));
     let mut processor = StreamProcessor::new(consumer,
-        Box::new(HashPasswordAndProduceStrategyFactory {
+        Box::new(ReverseStringAndProduceStrategyFactory {
                             config: config.clone(),
                             topic: Topic { name: "test_out".to_string() }
                          }));

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -1,0 +1,88 @@
+// An example of using the Transform and Produce strategies together.
+// inspired by https://github.com/getsentry/arroyo/blob/main/examples/transform_and_produce/script.py
+// This creates a consumer that reads from a topic test_in, reverses the string message,
+// and then produces it to topic test_out.
+extern crate rust_arroyo;
+
+use rdkafka::message::ToBytes;
+use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::producer::KafkaProducer;
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::backends::kafka::KafkaConsumer;
+use rust_arroyo::processing::strategies::produce::Produce;
+use rust_arroyo::processing::strategies::transform::Transform;
+use rust_arroyo::processing::strategies::{
+    CommitRequest, MessageRejected, ProcessingStrategy, ProcessingStrategyFactory, InvalidMessage,
+};
+use rust_arroyo::processing::StreamProcessor;
+use rust_arroyo::types::{Message, Topic, TopicOrPartition};
+use std::time::Duration;
+
+fn reverse_string(value: KafkaPayload) -> Result<KafkaPayload, InvalidMessage> {
+    let payload = value.payload.unwrap();
+    let str_payload = std::str::from_utf8(&payload).unwrap();
+    let result_str = str_payload.chars().rev().collect::<String>();
+
+    println!("transforming value: {:?} -> {:?}", str_payload, &result_str);
+
+    let result = KafkaPayload {
+        payload: Some(result_str.to_bytes().to_vec()),
+        ..value
+    };
+    Ok(result)
+}
+struct Noop {}
+impl ProcessingStrategy<KafkaPayload> for Noop {
+    fn poll(&mut self) -> Option<CommitRequest> {
+        None
+    }
+    fn submit(&mut self, _message: Message<KafkaPayload>) -> Result<(), MessageRejected> {
+        Ok(())
+    }
+    fn close(&mut self) {}
+    fn terminate(&mut self) {}
+    fn join(&mut self, _timeout: Option<Duration>) -> Option<CommitRequest> {
+        None
+    }
+}
+
+
+
+fn main() {
+    struct HashPasswordAndProduceStrategyFactory {
+        config: KafkaConfig,
+        topic: Topic,
+    }
+    impl ProcessingStrategyFactory<KafkaPayload> for HashPasswordAndProduceStrategyFactory {
+        fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+            let producer = KafkaProducer::new(self.config.clone());
+            let topic = TopicOrPartition::Topic(self.topic.clone());
+            let hash_password_and_produce_strategy = Transform {
+                function: reverse_string,
+                next_step: Box::new(Produce::new(producer, Box::new(Noop {}), topic ))
+            };
+            Box::new(hash_password_and_produce_strategy)
+        }
+    }
+
+    let config = KafkaConfig::new_consumer_config(
+        vec!["0.0.0.0:9092".to_string()],
+        "my_group".to_string(),
+        "latest".to_string(),
+        false,
+        None,
+    );
+
+
+    let consumer = Box::new(KafkaConsumer::new(config.clone()));
+    let mut processor = StreamProcessor::new(consumer,
+        Box::new(HashPasswordAndProduceStrategyFactory {
+                            config: config.clone(),
+                            topic: Topic { name: "test_out".to_string() }
+                         }));
+    processor.subscribe(Topic {
+        name: "test_in".to_string(),
+    });
+    println!("running processor. transforming from test_in to test_out");
+    processor.run();
+}

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 pub mod noop;
 pub mod transform;
+pub mod produce;
 
 #[derive(Debug, Clone)]
 pub struct MessageRejected;

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -17,8 +17,6 @@ use std::time::{Duration, Instant};
 
 
 pub struct ProduceFuture {
-    // pub producer: &'a KafkaProducer,
-    // destination: &'a TopicOrPartition,
     pub producer: Arc<KafkaProducer>,
     destination: Arc<TopicOrPartition>,
     payload: KafkaPayload,

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -58,8 +58,7 @@ impl ProcessingStrategy<KafkaPayload>
 {
     fn poll(&mut self) -> Option<CommitRequest> {
         while !self.queue.is_empty(){
-            let message_fut = self.queue.pop_front();
-            let (message, _produce_fut) = message_fut.unwrap();
+            let (message, produce_fut) = self.queue.pop_front().unwrap();
             self.next_step.poll();
             self.next_step.submit(message).unwrap()
         }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -1,0 +1,160 @@
+
+use log::warn;
+use crate::backends::Producer;
+use crate::backends::kafka::producer::KafkaProducer;
+use crate::backends::kafka::types::KafkaPayload;
+use crate::processing::strategies::{
+    CommitRequest, MessageRejected, ProcessingStrategy,
+};
+use crate::types::{Message, TopicOrPartition};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+pub struct Produce<TPayload: Clone + Send + Sync> {
+    pub producer: KafkaProducer,
+    pub next_step: Box<dyn ProcessingStrategy<TPayload>>,
+    queue: VecDeque<Message<TPayload>>,
+    topic: TopicOrPartition,
+    closed: bool,
+    max_queue_size: usize,
+}
+
+// TODO: make the queue store futures
+// TODO: make this generic
+impl Produce<KafkaPayload> {
+    pub fn new(producer: KafkaProducer, next_step: Box<dyn ProcessingStrategy<KafkaPayload>>, topic:TopicOrPartition) -> Self {
+        Produce {
+            producer,
+            next_step,
+            queue: VecDeque::new(),
+            topic,
+            closed: false,
+            max_queue_size: 1000,
+        }
+    }
+}
+
+impl ProcessingStrategy<KafkaPayload>
+    for Produce<KafkaPayload>
+{
+    fn poll(&mut self) -> Option<CommitRequest> {
+        while !self.queue.is_empty(){
+            let message = self.queue.pop_front();
+            self.next_step.poll();
+            self.next_step.submit(message.unwrap()).unwrap()
+        }
+        return None
+    }
+
+    fn submit(&mut self, message: Message<KafkaPayload>) -> Result<(), MessageRejected> {
+        if self.queue.len() >= self.max_queue_size {
+            return Err(MessageRejected)
+        }
+        print!("Producing message: {:?}", &message.payload.payload);
+        self.producer.produce(&self.topic, &message.payload);
+        self.producer.flush();
+        self.queue.push_back(message);
+        return Ok(());
+    }
+
+    fn close(&mut self) {
+        self.closed = true;
+    }
+
+    fn terminate(&mut self) {
+        self.closed = true;
+        self.next_step.terminate()
+    }
+
+    fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
+        let start = Instant::now();
+        let mut remaining: Option<Duration> = None;
+
+        while !self.queue.is_empty(){
+            if let Some(timeout) = timeout {
+                remaining = Some(timeout - start.elapsed());
+                if remaining.unwrap() <= Duration::from_secs(0) {
+                    warn!("Timeout reached while waiting for the queue to be empty");
+                    break;
+                }
+            }
+            let message = self.queue.pop_front();
+            self.next_step.poll();
+            self.next_step.submit(message.unwrap()).unwrap();
+
+        }
+
+        self.next_step.close();
+        self.next_step.join(remaining);
+        return None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Produce;
+    use crate::backends::kafka::config::KafkaConfig;
+    use crate::backends::kafka::producer::KafkaProducer;
+    use crate::backends::kafka::types::KafkaPayload;
+    use crate::processing::strategies::{
+        CommitRequest, MessageRejected, ProcessingStrategy,
+    };
+    use crate::types::{Message, Partition, Topic, TopicOrPartition};
+    use chrono::Utc;
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    #[test]
+    fn test_produce() {
+        let config = KafkaConfig::new_consumer_config(
+            vec!["localhost:9092".to_string()],
+            "my_group".to_string(),
+            "latest".to_string(),
+            false,
+            None,
+        );
+
+        let partition = Partition {
+            topic: Topic {
+                name: "test".to_string(),
+            },
+            index: 0,
+        };
+
+        struct Noop {}
+        impl ProcessingStrategy<KafkaPayload> for Noop {
+            fn poll(&mut self) -> Option<CommitRequest> {
+                None
+            }
+            fn submit(&mut self, _message: Message<KafkaPayload>) -> Result<(), MessageRejected> {
+                Ok(())
+            }
+            fn close(&mut self) {}
+            fn terminate(&mut self) {}
+            fn join(&mut self, _timeout: Option<Duration>) -> Option<CommitRequest> {
+                None
+            }
+        }
+
+        let producer: KafkaProducer = KafkaProducer::new(config);
+
+        let mut strategy: Produce<KafkaPayload> = Produce {
+            next_step: Box::new(Noop {}),
+            producer: producer,
+            queue: VecDeque::new(),
+            topic: TopicOrPartition::Topic(partition.topic.clone()),
+            closed: false,
+            max_queue_size: 1000,
+        };
+
+        let payload_str = "hello world".to_string().as_bytes().to_vec();
+        strategy
+            .submit(Message::new(
+                partition,
+                0,
+                KafkaPayload { key: None, headers: None, payload: Some(payload_str) },
+                Utc::now(),
+            ))
+            .unwrap();
+    }
+}


### PR DESCRIPTION
Adds the produce strategy and a simple transform -> produce example. 

The produce strategy is an arroyo strategy that produces messages on a given topic.