### PR TITLE
ref(ratelimit): Create separate namespace if config redis for rate limit keys

### DIFF
--- a/snuba/query/processors/physical/table_rate_limit.py
+++ b/snuba/query/processors/physical/table_rate_limit.py
@@ -3,8 +3,11 @@ from typing import Optional
 from snuba.clickhouse.query import Query
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.query_settings import QuerySettings
-from snuba.state import get_configs
-from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitParameters
+from snuba.state.rate_limit import (
+    TABLE_RATE_LIMIT_NAME,
+    RateLimitParameters,
+    get_rate_limit_config,
+)
 
 
 class TableRateLimit(ClickhouseQueryProcessor):
@@ -18,11 +21,9 @@ class TableRateLimit(ClickhouseQueryProcessor):
 
     def process_query(self, query: Query, query_settings: QuerySettings) -> None:
         table_name = query.get_from_clause().table_name
-        (per_second, concurr) = get_configs(
-            [
-                (f"table_per_second_limit_{table_name}{self.__suffix}", 5000),
-                (f"table_concurrent_limit_{table_name}{self.__suffix}", 1000),
-            ]
+        (per_second, concurr) = get_rate_limit_config(
+            (f"table_per_second_limit_{table_name}{self.__suffix}", 5000),
+            (f"table_concurrent_limit_{table_name}{self.__suffix}", 1000),
         )
 
         rate_limit = RateLimitParameters(

--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from functools import partial
 from typing import (
     Any,
-    Callable,
     Iterable,
     Mapping,
     Optional,
+    Protocol,
     Sequence,
     SupportsFloat,
     Tuple,
@@ -42,6 +42,7 @@ config_history_hash = "snuba-config-history"
 config_changes_list = "snuba-config-changes"
 config_changes_list_limit = 25
 queries_list = "snuba-queries"
+rate_limit_config_hash = "snuba-ratelimit-config:"
 
 # Rate Limiting and Deduplication
 
@@ -106,22 +107,31 @@ def get_rates(bucket: str, rollup: int = 60) -> Sequence[Any]:
 # Runtime Configuration
 
 
+class ConfigKeyCallable(Protocol):  # Necessary for typing the memoize
+    def __call__(self, config_key: str = config_hash) -> Any:
+        pass
+
+
 class memoize:
     """
-    Simple expiring memoizer for functions with no args.
+    Simple expiring memoizer for state functions that takes a config key.
     """
 
     def __init__(self, timeout: int = 1) -> None:
         self.timeout = timeout
-        self.saved = None
-        self.at = 0.0
+        self.saved: dict[str, Any] = {}
+        self.at: dict[str, float] = {}
 
-    def __call__(self, func: Callable[[], Any]) -> Callable[[], Any]:
-        def wrapper() -> Any:
+    def __call__(self, func: ConfigKeyCallable) -> ConfigKeyCallable:
+        def wrapper(config_key: str = config_hash) -> Any:
             now = time.time()
-            if now > self.at + self.timeout or self.saved is None:
-                self.saved, self.at = func(), now
-            return self.saved
+            at = self.at.get(config_key, 0.0)
+            if now > at + self.timeout or config_key not in self.saved:
+                self.saved[config_key], self.at[config_key] = (
+                    func(config_key=config_key),
+                    now,
+                )
+            return self.saved[config_key]
 
         return wrapper
 
@@ -147,12 +157,12 @@ def set_config(
     value: Optional[Any],
     user: Optional[str] = None,
     force: bool = False,
+    config_key: str = config_hash,
 ) -> None:
     value = get_typed_value(value)
     enc_value = "{}".format(value).encode("utf-8") if value is not None else None
-
     try:
-        enc_original_value = rds.hget(config_hash, key)
+        enc_original_value = rds.hget(config_key, key)
         if enc_original_value is not None and value is not None:
             original_value = get_typed_value(enc_original_value.decode("utf-8"))
             if value == original_value and type(value) == type(original_value):
@@ -164,10 +174,10 @@ def set_config(
         change_record = (time.time(), user, enc_original_value, enc_value)
         p = rds.pipeline()
         if value is None:
-            p.hdel(config_hash, key)
+            p.hdel(config_key, key)
             p.hdel(config_history_hash, key)
         else:
-            p.hset(config_hash, key, enc_value)
+            p.hset(config_key, key, enc_value)
             p.hset(config_history_hash, key, json.dumps(change_record))
         p.lpush(config_changes_list, json.dumps((key, change_record)))
         p.ltrim(config_changes_list, 0, config_changes_list_limit)
@@ -183,31 +193,36 @@ def set_config(
 
 
 def set_configs(
-    values: Mapping[str, Optional[Any]], user: Optional[str] = None, force: bool = False
+    values: Mapping[str, Optional[Any]],
+    user: Optional[str] = None,
+    force: bool = False,
+    config_key: str = config_hash,
 ) -> None:
     for k, v in values.items():
-        set_config(k, v, user=user, force=force)
+        set_config(k, v, user=user, force=force, config_key=config_key)
 
 
-def get_config(key: str, default: Optional[Any] = None) -> Optional[Any]:
-    return get_all_configs().get(key, default)
+def get_config(
+    key: str, default: Optional[Any] = None, config_key: str = config_hash
+) -> Optional[Any]:
+    return get_all_configs(config_key=config_key).get(key, default)
 
 
 def get_configs(
-    key_defaults: Iterable[Tuple[str, Optional[Any]]]
+    key_defaults: Iterable[Tuple[str, Optional[Any]]], config_key: str = config_hash
 ) -> Sequence[Optional[Any]]:
-    all_confs = get_all_configs()
+    all_confs = get_all_configs(config_key=config_key)
     return [all_confs.get(k, d) for k, d in key_defaults]
 
 
-def get_all_configs() -> Mapping[str, Optional[Any]]:
-    return {k: v for k, v in get_raw_configs().items()}
+def get_all_configs(config_key: str = config_hash) -> Mapping[str, Optional[Any]]:
+    return {k: v for k, v in get_raw_configs(config_key=config_key).items()}
 
 
 @memoize(settings.CONFIG_MEMOIZE_TIMEOUT)
-def get_raw_configs() -> Mapping[str, Optional[Any]]:
+def get_raw_configs(config_key: str = config_hash) -> Mapping[str, Optional[Any]]:
     try:
-        all_configs = rds.hgetall(config_hash)
+        all_configs = rds.hgetall(config_key)
         configs = {
             k.decode("utf-8"): get_typed_value(v.decode("utf-8"))
             for k, v in all_configs.items()
@@ -225,12 +240,14 @@ def get_raw_configs() -> Mapping[str, Optional[Any]]:
         return {}
 
 
-def delete_config(key: str, user: Optional[Any] = None) -> None:
-    set_config(key, None, user=user)
+def delete_config(
+    key: str, user: Optional[Any] = None, config_key: str = config_hash
+) -> None:
+    set_config(key, None, user=user, config_key=config_key)
 
 
-def get_uncached_config(key: str) -> Optional[Any]:
-    value = rds.hget(config_hash, key.encode("utf-8"))
+def get_uncached_config(key: str, config_key: str = config_hash) -> Optional[Any]:
+    value = rds.hget(config_key, key.encode("utf-8"))
     if value is not None:
         return get_typed_value(value.decode("utf-8"))
     return None

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 import time
@@ -6,11 +8,13 @@ from collections import ChainMap, namedtuple
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from dataclasses import dataclass
 from types import TracebackType
+from typing import Any
 from typing import ChainMap as TypingChainMap
 from typing import Iterator, MutableMapping, Optional, Sequence, Type
 
 from snuba import environment, state
 from snuba.redis import RedisClientKey, get_redis_client
+from snuba.state import get_configs, set_config
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.serializable_exception import SerializableException
 
@@ -25,6 +29,57 @@ TABLE_RATE_LIMIT_NAME = "table"
 metrics = MetricsWrapper(environment.metrics, "api")
 
 rds = get_redis_client(RedisClientKey.RATE_LIMITER)
+
+
+def get_rate_limit_config(
+    per_second: tuple[str, float | None], concurrent: tuple[str, int | None]
+) -> tuple[Any, Any]:
+    """
+    This function to encapsulate how rate limit keys are fetched from Redis, since
+    that is conceptually a different process from fetching normal config keys.
+
+    It currently also contains logic to read from both the new namespace and the old one,
+    until everything is properly migrated.
+
+    First step: read from the old and new namespace. If the new namespace is different from
+    the old, copy the value from old to new. Return the values from the old namespace.
+    """
+    ps_name, per_second_default = per_second
+    ct_name, concurrent_default = concurrent
+
+    # Dual read
+    # if the value in new doesn't match value from old, copy over
+    old_per_second, old_concurrent = get_configs([(ps_name, None), (ct_name, None)])
+    new_per_second, new_concurrent = get_configs(
+        [(ps_name, None), (ct_name, None)], config_key=state.rate_limit_config_hash
+    )
+
+    # This handles deletes as well, since writing None deletes the key
+    if old_per_second != new_per_second:
+        set_rate_limit_config(ps_name, old_per_second)
+    if old_concurrent != new_concurrent:
+        set_rate_limit_config(ct_name, old_concurrent)
+
+    found_per_second = (
+        old_per_second if old_per_second is not None else per_second_default
+    )
+    found_concurrent = (
+        old_concurrent if old_concurrent is not None else concurrent_default
+    )
+
+    return (found_per_second, found_concurrent)
+
+
+def set_rate_limit_config(bucket: str, value: float | int | None) -> None:
+    """
+    This function to encapsulate how rate limit keys are set in Redis, since
+    that is conceptually a different process from fetching normal config keys.
+    """
+    set_config(
+        bucket,
+        value,
+        config_key=state.rate_limit_config_hash,
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/query/processors/test_org_rate_limiter.py
+++ b/tests/query/processors/test_org_rate_limiter.py
@@ -102,3 +102,33 @@ def test_org_rate_limit_processor_overridden(
     assert rate_limiter.bucket == str(org_id)
     assert rate_limiter.per_second_limit == 5
     assert rate_limiter.concurrent_limit == 10
+
+
+def test_namespaced_rate_limit() -> None:
+    query = Query(
+        QueryEntity(EntityKey.EVENTS, EntityColumnSet([])),
+        selected_columns=[SelectedExpression("column2", Column(None, None, "column2"))],
+        condition=binary_condition(
+            ConditionFunctions.EQ,
+            Column("_snuba_org_id", None, "org_id"),
+            Literal(None, 1),
+        ),
+    )
+    org_id = 1
+    settings = HTTPQuerySettings()
+    ps_key = f"org_per_second_limit_{org_id}"
+    ct_key = f"org_concurrent_limit_{org_id}"
+    state.set_config(ps_key, 5)
+    state.set_config(ct_key, 10)
+
+    OrganizationRateLimiterProcessor("org_id").process_query(query, settings)
+
+    ps_found = state.get_uncached_config(
+        ps_key, config_key=state.rate_limit_config_hash
+    )
+    ct_found = state.get_uncached_config(
+        ct_key, config_key=state.rate_limit_config_hash
+    )
+
+    assert ps_found == 5
+    assert ct_found == 10

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -80,7 +80,6 @@ class TestMetricsApiCounters(BaseApiTest):
             WritableTableStorage,
             get_entity(EntityKey.METRICS_COUNTERS).get_writable_storage(),
         )
-        print(self.storage.get_storage_key())
         self.generate_counters()
 
     def teardown_method(self, test_method: Any) -> None:


### PR DESCRIPTION
Motivation:

Currently all of the configuration for rate limiting is done alongside other
runtime configuration. This was fine when not much rate limiting was done, but
now rate limit keys are the dominant keys in the configuration tool.

Ultimately there should be a separate tool for configuring rate limiting. That
simplifies the user interface and allows product owners access to rate limits
without having to grant access to configuration in general.

Blast Radius:

This change adds a new config key hash to redis to store the rate limiting keys.
This still uses the configuration mechanism under the hood, largely to leverage
the audit log that state changes allow.

This is step one of the migration process, doing dual read/writes on the keys
when they are accessed. This will be followed up with a migration to move all
the old keys over automatically.

Notes:

The new rate limit keys will not show up in the config tool, so follow up
changes will be added to expose them.