### PR TITLE
feat(rust-consumer): Add yaml settings file

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -14,4 +14,6 @@ path = "src/bin/consumer/querylog_consumer.rs"
 
 [dependencies]
 rust_arroyo = { path = "./rust_arroyo" }
+serde = { version = "1.0", features = ["derive"]}
+serde_yaml = "0.9"
 tokio = { version = "1.19.2", features = ["full"] }

--- a/rust_snuba/src/main.rs
+++ b/rust_snuba/src/main.rs
@@ -1,0 +1,1 @@
+mod settings;

--- a/rust_snuba/src/settings.rs
+++ b/rust_snuba/src/settings.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fs::File;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Cluster {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+    pub http_port: u16,
+    pub storage_sets: Vec<String>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct Settings {
+    pub clusters: Vec<Cluster>,
+    pub broker_config: HashMap<String, Option<String>>,
+}
+
+impl Settings {
+    pub fn load(path: &str) -> Result<Self, Box<dyn Error>> {
+        let f = File::open(path)?;
+        let d: Settings = serde_yaml::from_reader(f)?;
+        Ok(d)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_load_settings() {
+        use super::*;
+
+        let settings_yaml_path = "../rust_snuba/src/settings/default.yaml";
+
+        let settings = Settings::load(settings_yaml_path).unwrap();
+
+        let all_storage_sets: Vec<String> = [
+            "cdc",
+            "discover",
+            "events",
+            "events_ro",
+            "metrics",
+            "migrations",
+            "outcomes",
+            "querylog",
+            "sessions",
+            "transactions",
+            "profiles",
+            "functions",
+            "replays",
+            "generic_metrics_sets",
+            "generic_metrics_distributions",
+            "search_issues",
+            "generic_metrics_counters",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        assert_eq!(
+            settings.clusters,
+            vec![Cluster {
+                host: "127.0.0.1".to_string(),
+                port: 9000,
+                user: "default".to_string(),
+                password: "".to_string(),
+                http_port: 8123,
+                storage_sets: all_storage_sets,
+            }]
+        );
+
+        assert_eq!(
+            settings.broker_config["bootstrap.servers"],
+            Some("127.0.0.1:9092".to_string())
+        );
+    }
+}

--- a/rust_snuba/src/settings/default.yaml
+++ b/rust_snuba/src/settings/default.yaml
@@ -1,0 +1,34 @@
+clusters:
+  - host: 127.0.0.1
+    port: 9000
+    user: default
+    password: ""
+    http_port: 8123
+    storage_sets:
+      - "cdc"
+      - "discover"
+      - "events"
+      - "events_ro"
+      - "metrics"
+      - "migrations"
+      - "outcomes"
+      - "querylog"
+      - "sessions"
+      - "transactions"
+      - "profiles"
+      - "functions"
+      - "replays"
+      - "generic_metrics_sets"
+      - "generic_metrics_distributions"
+      - "search_issues"
+      - "generic_metrics_counters"
+
+broker_config:
+  bootstrap.servers: 127.0.0.1:9092
+  security.protocol: plaintext
+  ssl.ca.location: ""
+  ssl.certificate.location: ""
+  ssl.key.location: ""
+  sasl.mechanism: null
+  sasl.username: null
+  sasl.password: null


### PR DESCRIPTION
Adds a yaml file with the minimal settings needed to run the Rust consumer (the Kafka broker config and the ClickHouse cluster mapping).

These values are essentially duplicated from the Python settings file. If Rust and Python code were being run side by side, these would need to be kept in sync. Though since only consumers would ever be in Rust, not every setting will be duplicated here, just a few.

An alternative approach would be to attempt to load the Python file in Rust so that the values would be defined only once. This option was not pursued as it is messier and likely not the right long term direction for settings anyway. It has been a long time goal in Snuba to move away from the Python specific settings to something language agnostic that is easier for end users (including open source users) to configure. For this reason, I wanted to propose starting fresh with yaml settings rather than attempting to share the Python ones.
