### PR TITLE
feat(querylog): Support for query interpolation in Querylog query editor

### DIFF
--- a/snuba/admin/clickhouse/predefined_querylog_queries.py
+++ b/snuba/admin/clickhouse/predefined_querylog_queries.py
@@ -14,11 +14,11 @@ class QueryByID(QuerylogQuery):
     """Find a query by its ID"""
 
     sql = """
-    SELECT <fields>
+    SELECT {{fields}}
     FROM querylog_local
-    WHERE has(clickhouse_queries.query_id, '<UUID>')
+    WHERE has(clickhouse_queries.query_id, '{{UUID}}')
     AND timestamp > (now() - 60)
-    AND timestamp < toDateTime('<time>')
+    AND timestamp < toDateTime('{{time}}')
 
     """
 
@@ -29,7 +29,7 @@ class SQLQueriesForRequestID(QuerylogQuery):
     sql = """
     SELECT arrayJoin(clickhouse_queries.sql)
     FROM querylog_local
-    WHERE request_id = '<UUID>'
+    WHERE request_id = '{{UUID}}'
     AND timestamp > (now() - 60)
     AND timestamp < now()
     ORDER BY timestamp ASC
@@ -47,7 +47,7 @@ class DurationForReferrerByProject(QuerylogQuery):
             arrayJoin(projects) as projects,
             sum(duration_ms) AS c
         FROM querylog_local
-        WHERE referrer = '<referrer>'
+        WHERE referrer = '{{referrer}}'
         AND time > (now() - (1 * 3600))
         AND time < now()
         GROUP BY
@@ -73,8 +73,8 @@ class BytesScannedForReferrerByProject(QuerylogQuery):
             arrayJoin(projects) as projects,
             sum(arraySum(clickhouse_queries.bytes_scanned)) AS c
         FROM querylog_local
-        WHERE referrer = '<referrer>'
-        AND time > (now() - (<duration>))
+        WHERE referrer = '{{referrer}}'
+        AND time > (now() - ({{duration}}))
         AND time < now()
         GROUP BY
             projects,
@@ -99,8 +99,8 @@ class QueryDurationForReferrerByProject(QuerylogQuery):
             arrayJoin(projects) as projects,
             sum(arraySum(clickhouse_queries.duration_ms)) AS c
         FROM querylog_local
-        WHERE referrer = '<referrer>'
-        AND time > (now() - (<duration>))
+        WHERE referrer = '{{referrer}}'
+        AND time > (now() - ({{duration}}))
         AND time < now()
         GROUP BY
             projects,
@@ -123,17 +123,17 @@ class BeforeAfterBytesScannedComparison(QuerylogQuery):
     (
         SELECT referrer, sum(arrayReduce('sum', clickhouse_queries.bytes_scanned)) as after_scanned
         FROM querylog_local
-        WHERE timestamp >= toDateTime('<after_scanned_duration_start>')
-        AND timestamp <= toDateTime('<after_scanned_duration_end>')
-        AND dataset IN ('<dataset>')
+        WHERE timestamp >= toDateTime('{{after_scanned_duration_start}}')
+        AND timestamp <= toDateTime('{{after_scanned_duration_end}}')
+        AND dataset IN ('{{dataset}}')
         GROUP BY referrer
     ) `after` LEFT OUTER JOIN
     (
         SELECT referrer, sum(arrayReduce('sum', clickhouse_queries.bytes_scanned)) as before_scanned
         FROM querylog_local
-        WHERE timestamp >= toDateTime('<before_scanned_duration_start>')
-        AND timestamp <= toDateTime('<before_scanned_duration_end>')
-        AND dataset IN ('<dataset>')
+        WHERE timestamp >= toDateTime('{{before_scanned_duration_start}}')
+        AND timestamp <= toDateTime('{{before_scanned_duration_end}}')
+        AND dataset IN ('{{dataset}}')
         GROUP BY referrer
     ) `before` USING referrer
     ORDER BY pct_diff DESC
@@ -150,17 +150,17 @@ class BeforeAfterDurationComparison(QuerylogQuery):
     (
         SELECT referrer, sum(arrayReduce('sum', clickhouse_queries.duration_ms)) as after_duration
         FROM querylog_local
-        WHERE timestamp >= toDateTime('<after_duration_start>')
-        AND timestamp <= toDateTime('<after_duration_end>')
-        AND dataset IN ('<dataset>')
+        WHERE timestamp >= toDateTime('{{after_duration_start}}')
+        AND timestamp <= toDateTime('{{after_duration_end}}')
+        AND dataset IN ('{{dataset}}')
         GROUP BY referrer
     ) `after` LEFT OUTER JOIN
     (
         SELECT referrer, sum(arrayReduce('sum', clickhouse_queries.duration_ms)) as before_duration
         FROM querylog_local
-        WHERE timestamp >= toDateTime('<before_duartion_start>')
-        AND timestamp <= toDateTime('<before_duartion_end>')
-        AND dataset IN ('<dataset>')
+        WHERE timestamp >= toDateTime('{{before_duartion_start}}')
+        AND timestamp <= toDateTime('{{before_duartion_end}}')
+        AND dataset IN ('{{dataset}}')
         GROUP BY referrer
     ) `before` USING referrer
     ORDER BY pct_diff DESC

--- a/snuba/admin/clickhouse/predefined_querylog_queries.py
+++ b/snuba/admin/clickhouse/predefined_querylog_queries.py
@@ -125,7 +125,7 @@ class BeforeAfterBytesScannedComparison(QuerylogQuery):
         FROM querylog_local
         WHERE timestamp >= toDateTime('<after_scanned_duration_start>')
         AND timestamp <= toDateTime('<after_scanned_duration_end>')
-        AND dataset IN (<dataset>)
+        AND dataset IN ('<dataset>')
         GROUP BY referrer
     ) `after` LEFT OUTER JOIN
     (
@@ -133,7 +133,7 @@ class BeforeAfterBytesScannedComparison(QuerylogQuery):
         FROM querylog_local
         WHERE timestamp >= toDateTime('<before_scanned_duration_start>')
         AND timestamp <= toDateTime('<before_scanned_duration_end>')
-        AND dataset IN (<dataset>)
+        AND dataset IN ('<dataset>')
         GROUP BY referrer
     ) `before` USING referrer
     ORDER BY pct_diff DESC
@@ -152,7 +152,7 @@ class BeforeAfterDurationComparison(QuerylogQuery):
         FROM querylog_local
         WHERE timestamp >= toDateTime('<after_duration_start>')
         AND timestamp <= toDateTime('<after_duration_end>')
-        AND dataset IN (<dataset>)
+        AND dataset IN ('<dataset>')
         GROUP BY referrer
     ) `after` LEFT OUTER JOIN
     (
@@ -160,7 +160,7 @@ class BeforeAfterDurationComparison(QuerylogQuery):
         FROM querylog_local
         WHERE timestamp >= toDateTime('<before_duartion_start>')
         AND timestamp <= toDateTime('<before_duartion_end>')
-        AND dataset IN (<dataset>)
+        AND dataset IN ('<dataset>')
         GROUP BY referrer
     ) `before` USING referrer
     ORDER BY pct_diff DESC

--- a/snuba/admin/package.json
+++ b/snuba/admin/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@jest/globals": "^29.4.3",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "jest": "^29.4.3",
     "jest-environment-jsdom": "^29.5.0",
     "ts-jest": "^29.0.5",

--- a/snuba/admin/static/query_editor.tsx
+++ b/snuba/admin/static/query_editor.tsx
@@ -96,17 +96,17 @@ function QueryEditor(props: {
       setters.push(
         <div key={paramName}>
           <div>
-            <label>{`Parameter: ${paramName.match(variableRegex)?.[1]}`}</label>
+            <label>
+              {paramName.match(variableRegex)?.[1]}
+              <br />
+              <textarea
+                value={queryParamValues[paramName]}
+                onChange={(evt) => {
+                  updateQueryParameter(paramName, evt.target.value);
+                }}
+              />
+            </label>
           </div>
-          <div>
-            <label>{`Value:`}</label>
-          </div>
-          <textarea
-            value={queryParamValues[paramName]}
-            onChange={(evt) => {
-              updateQueryParameter(paramName, evt.target.value);
-            }}
-          />
           <hr />
         </div>
       );

--- a/snuba/admin/static/query_editor.tsx
+++ b/snuba/admin/static/query_editor.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState, ReactElement } from "react";
+
+type PredefinedQuery = {
+  name: string;
+  queryTemplate: string;
+  description?: string;
+};
+
+function QueryEditor(props: {
+  onQueryUpdate: (query: string) => void;
+  predefinedQueries?: Array<PredefinedQuery>;
+}) {
+  const [queryTemplate, setQueryTemplate] = useState<string>("");
+  const [queryParams, setQueryParams] = useState<Map<string, string>>(
+    new Map<string, string>()
+  );
+  const [query, setQuery] = useState<string>("");
+  const [predefinedQuery, setPredefinedQuery] = useState<
+    PredefinedQuery | undefined
+  >(undefined);
+
+  useEffect(() => {
+    applyQueryTemplate();
+  }, [queryTemplate, queryParams]);
+
+  function updateQueryTemplate(template: string) {
+    setQueryTemplate((_) => template);
+    let paramNames = new Set(template.match(/{{{([a-zA-Z0-9_]+)}}}/g));
+    setQueryParams((queryParams) => {
+      queryParams.forEach((_, key: string) => {
+        if (!paramNames.has(key)) {
+          queryParams.delete(key);
+        }
+      });
+      paramNames.forEach((paramName) => {
+        if (!queryParams.has(paramName)) {
+          queryParams.set(paramName, "");
+        }
+      });
+      return queryParams;
+    });
+  }
+
+  function updateQueryParameter(key: string, value: string) {
+    setQueryParams((queryParams) => {
+      return new Map(queryParams.set(key, value));
+    });
+  }
+
+  function applyQueryTemplate() {
+    let sql = queryTemplate;
+    queryParams.forEach((value, key) => {
+      if (value) {
+        sql = sql.replace(new RegExp(key, "g"), value);
+      }
+    });
+    setQuery(sql);
+    props.onQueryUpdate(sql);
+  }
+
+  function renderParameterSetters() {
+    let setters: Array<ReactElement> = [];
+    queryParams.forEach((value, key) => {
+      setters.push(
+        <div key={key}>
+          <div>
+            <label>{`Parameter: ${key.match(/{{{(.*?)}}}/)?.[1]}`}</label>
+          </div>
+          <div>
+            <label>{`Value:`}</label>
+          </div>
+          <textarea
+            value={value}
+            onChange={(evt) => {
+              updateQueryParameter(key, evt.target.value);
+            }}
+          />
+          <hr />
+        </div>
+      );
+    });
+    return setters;
+  }
+
+  function renderPredefinedQueriesSelector() {
+    return (
+      <div>
+        <label>Query template: </label>
+        <select
+          value={predefinedQuery?.name ?? "undefined"}
+          onChange={(evt) => {
+            let selectedPredefinedQuery = props?.predefinedQueries?.find(
+              (predefinedQuery) => predefinedQuery.name == evt.target.value
+            );
+            setPredefinedQuery(selectedPredefinedQuery);
+            updateQueryTemplate(selectedPredefinedQuery?.queryTemplate ?? "");
+          }}
+        >
+          <option value={"undefined"}>Custom query template</option>
+          {props.predefinedQueries?.map((predefinedQuery) => (
+            <option key={predefinedQuery.name} value={predefinedQuery.name}>
+              {predefinedQuery.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  return (
+    <form>
+      {renderPredefinedQueriesSelector()}
+      {predefinedQuery?.description ? (
+        <p>{predefinedQuery?.description}</p>
+      ) : null}
+      <textarea
+        value={queryTemplate || ""}
+        placeholder={"Edit your queries here"}
+        style={{ width: "100%", height: 140 }}
+        onChange={(evt) => {
+          setPredefinedQuery(undefined);
+          updateQueryTemplate(evt.target.value);
+        }}
+      />
+      {renderParameterSetters()}
+      <textarea
+        disabled={true}
+        placeholder={"Edit your queries in the text fields above"}
+        style={{ width: "100%", height: 140 }}
+        value={query}
+      ></textarea>
+    </form>
+  );
+}
+
+export default QueryEditor;

--- a/snuba/admin/static/query_editor.tsx
+++ b/snuba/admin/static/query_editor.tsx
@@ -19,7 +19,7 @@ function QueryEditor(props: {
     PredefinedQuery | undefined
   >(undefined);
 
-  const variableRegex = /<([a-zA-Z0-9_]+)>/;
+  const variableRegex = /{{([a-zA-Z0-9_]+)}}/;
   const textAreaStyle = { width: "100%", height: 140 };
 
   useEffect(() => {
@@ -123,7 +123,7 @@ function QueryEditor(props: {
       <textarea
         value={queryTemplate || ""}
         placeholder={
-          "Edit your queries here, add '<>' around substrings you wish to replace"
+          "Edit your queries here, add '{{ }}' around substrings you wish to replace, e.g. {{ label }}"
         }
         style={textAreaStyle}
         onChange={(evt) => {

--- a/snuba/admin/static/query_editor.tsx
+++ b/snuba/admin/static/query_editor.tsx
@@ -89,10 +89,17 @@ function QueryEditor(props: {
             setSelectedPredefinedQuery(selectedPredefinedQuery);
             setQueryTemplate(selectedPredefinedQuery?.sql ?? "");
           }}
+          data-testid="select"
         >
-          <option value={"undefined"}>Custom query</option>
+          <option value={"undefined"} data-testid="select-option">
+            Custom query
+          </option>
           {props.predefinedQueryOptions?.map((predefinedQuery) => (
-            <option key={predefinedQuery.name} value={predefinedQuery.name}>
+            <option
+              key={predefinedQuery.name}
+              value={predefinedQuery.name}
+              data-testid="select-option"
+            >
               {predefinedQuery.name}
             </option>
           ))}
@@ -115,6 +122,7 @@ function QueryEditor(props: {
                 onChange={(evt) => {
                   updateQueryParameter(paramName, evt.target.value);
                 }}
+                data-testid="parameter-value"
               />
             </label>
           </div>
@@ -141,6 +149,7 @@ function QueryEditor(props: {
           setSelectedPredefinedQuery(undefined);
           setQueryTemplate(evt.target.value);
         }}
+        data-testid="text-area-input"
       />
       {renderParameterSetters()}
       <textarea
@@ -148,6 +157,7 @@ function QueryEditor(props: {
         placeholder={"The final query you send to snuba will be here"}
         style={textAreaStyle}
         value={query}
+        data-testid="text-area-output"
       ></textarea>
     </form>
   );

--- a/snuba/admin/static/querylog/index.tsx
+++ b/snuba/admin/static/querylog/index.tsx
@@ -3,6 +3,7 @@ import Client from "../api_client";
 import { Table } from "../table";
 import QueryDisplay from "./query_display";
 import { QuerylogResult, PredefinedQuery } from "./types";
+import QueryEditor from "../query_editor";
 
 function QuerylogQueries(props: { api: Client }) {
   const [predefinedQuery, setPredefinedQuery] =
@@ -54,6 +55,26 @@ function QuerylogQueries(props: { api: Client }) {
 
   return (
     <div>
+      <QueryEditor
+        onQueryUpdate={function (query: string): void {}}
+        predefinedQueries={[
+          {
+            name: "a",
+            queryTemplate: `
+SELECT x as {{{alias}}}
+FROM {{{table}}}
+WHERE {{{alias}}} < {{{value}}}`,
+            description: "Description for a, what does a do?",
+          },
+          {
+            name: "b",
+            queryTemplate: `
+I'm too lazy to come up with more queries {{{alias}}} {{{hello}}}
+{{{alias}}} {{{qwert}}}`,
+            description: "Description for b, same as a",
+          },
+        ]}
+      ></QueryEditor>
       <div>
         <form>
           <select
@@ -72,11 +93,6 @@ function QuerylogQueries(props: { api: Client }) {
           </select>
         </form>
       </div>
-      {QueryDisplay({
-        api: props.api,
-        resultDataPopulator: tablePopulator,
-        predefinedQuery: predefinedQuery,
-      })}
     </div>
   );
 }

--- a/snuba/admin/static/querylog/index.tsx
+++ b/snuba/admin/static/querylog/index.tsx
@@ -3,11 +3,8 @@ import Client from "../api_client";
 import { Table } from "../table";
 import QueryDisplay from "./query_display";
 import { QuerylogResult, PredefinedQuery } from "./types";
-import QueryEditor from "../query_editor";
 
 function QuerylogQueries(props: { api: Client }) {
-  const [predefinedQuery, setPredefinedQuery] =
-    useState<PredefinedQuery | null>(null);
   const [predefinedQueryOptions, setPredefinedQueryOptions] = useState<
     PredefinedQuery[]
   >([]);
@@ -32,19 +29,6 @@ function QuerylogQueries(props: { api: Client }) {
     );
   }
 
-  function updatePredefinedQuery(queryName: string) {
-    const selectedQuery = predefinedQueryOptions.find(
-      (query) => query.name === queryName
-    );
-    if (selectedQuery) {
-      setPredefinedQuery(() => {
-        return {
-          ...selectedQuery,
-        };
-      });
-    }
-  }
-
   function formatSQL(sql: string) {
     const formatted = sql
       .split("\n")
@@ -55,44 +39,11 @@ function QuerylogQueries(props: { api: Client }) {
 
   return (
     <div>
-      <QueryEditor
-        onQueryUpdate={function (query: string): void {}}
-        predefinedQueries={[
-          {
-            name: "a",
-            queryTemplate: `
-SELECT x as {{{alias}}}
-FROM {{{table}}}
-WHERE {{{alias}}} < {{{value}}}`,
-            description: "Description for a, what does a do?",
-          },
-          {
-            name: "b",
-            queryTemplate: `
-I'm too lazy to come up with more queries {{{alias}}} {{{hello}}}
-{{{alias}}} {{{qwert}}}`,
-            description: "Description for b, same as a",
-          },
-        ]}
-      ></QueryEditor>
-      <div>
-        <form>
-          <select
-            value={predefinedQuery?.name || ""}
-            onChange={(evt) => updatePredefinedQuery(evt.target.value)}
-            style={selectStyle}
-          >
-            <option disabled value="">
-              Select a predefined query
-            </option>
-            {predefinedQueryOptions.map((option: PredefinedQuery) => (
-              <option key={option.name} value={option.name}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </form>
-      </div>
+      {QueryDisplay({
+        api: props.api,
+        resultDataPopulator: tablePopulator,
+        predefinedQueryOptions: predefinedQueryOptions,
+      })}
     </div>
   );
 }

--- a/snuba/admin/static/querylog/query_display.tsx
+++ b/snuba/admin/static/querylog/query_display.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import Client from "../api_client";
-import { QueryResult } from "../clickhouse_queries/types";
 import { Collapse } from "../collapse";
+import QueryEditor from "../query_editor";
 
 import { QuerylogRequest, QuerylogResult, PredefinedQuery } from "./types";
 
@@ -10,18 +10,12 @@ type QueryState = Partial<QuerylogRequest>;
 function QueryDisplay(props: {
   api: Client;
   resultDataPopulator: (queryResult: QuerylogResult) => JSX.Element;
-  predefinedQuery: PredefinedQuery | null;
+  predefinedQueryOptions: Array<PredefinedQuery>;
 }) {
   const [query, setQuery] = useState<QueryState>({});
   const [queryResultHistory, setQueryResultHistory] = useState<
     QuerylogResult[]
   >([]);
-
-  useEffect(() => {
-    if (props.predefinedQuery) {
-      setQuery({ sql: props.predefinedQuery.sql });
-    }
-  }, [props.predefinedQuery]);
 
   function updateQuerySql(sql: string) {
     setQuery((prevQuery) => {
@@ -76,36 +70,36 @@ function QueryDisplay(props: {
 
   return (
     <div>
-      <form>
-        <h2>Construct a Querylog Query</h2>
-        <div style={queryDescription}>{props.predefinedQuery?.description}</div>
+      <h2>Construct a Querylog Query</h2>
+      <QueryEditor
+        onQueryUpdate={(sql) => {
+          updateQuerySql(sql);
+        }}
+        predefinedQueryOptions={props.predefinedQueryOptions}
+      />
+      <div style={executeActionsStyle}>
         <div>
-          <TextArea value={query.sql || ""} onChange={updateQuerySql} />
+          <button
+            onClick={(evt) => {
+              evt.preventDefault();
+              executeQuery();
+            }}
+            style={executeButtonStyle}
+            disabled={!query.sql}
+          >
+            Execute Query
+          </button>
+          <button
+            onClick={(evt) => {
+              evt.preventDefault();
+              getQuerylogSchema();
+            }}
+            style={executeButtonStyle}
+          >
+            View Querylog Schema
+          </button>
         </div>
-        <div style={executeActionsStyle}>
-          <div>
-            <button
-              onClick={(evt) => {
-                evt.preventDefault();
-                executeQuery();
-              }}
-              style={executeButtonStyle}
-              disabled={!query.sql}
-            >
-              Execute Query
-            </button>
-            <button
-              onClick={(evt) => {
-                evt.preventDefault();
-                getQuerylogSchema();
-              }}
-              style={executeButtonStyle}
-            >
-              View Querylog Schema
-            </button>
-          </div>
-        </div>
-      </form>
+      </div>
       <div>
         <h2>Query results</h2>
         {queryResultHistory.map((queryResult, idx) => {

--- a/snuba/admin/static/tests/query_editor.spec.tsx
+++ b/snuba/admin/static/tests/query_editor.spec.tsx
@@ -1,0 +1,106 @@
+import React from "react";
+import { it, expect, describe, jest, afterEach } from "@jest/globals";
+import { cleanup, render } from "@testing-library/react";
+import { generateQuery, mergeQueryParamValues } from "../query_editor";
+import userEvent from "@testing-library/user-event";
+import QueryEditor from "../query_editor";
+
+describe("Query editor", () => {
+  afterEach(cleanup);
+  describe("when generating queries", () => {
+    it("should replace all instances of parameter name when it has a non-empty parameter value", () => {
+      let queryTemplate = "{{key}}_{{value}}_{{key}}_{{value}}";
+      let queryParamValues = {
+        "{{key}}": "theActualKey",
+        "{{value}}": "theActualValue",
+      };
+
+      expect(generateQuery(queryTemplate, queryParamValues)).toBe(
+        "theActualKey_theActualValue_theActualKey_theActualValue"
+      );
+    });
+    it("should not replace any instances of parameter name when it has an empty parameter value", () => {
+      let queryTemplate = "{{key}}_{{value}}_{{key}}_{{value}}";
+      let queryParamValues = {
+        "{{key}}": "",
+        "{{value}}": "theActualValue",
+      };
+
+      expect(generateQuery(queryTemplate, queryParamValues)).toBe(
+        "{{key}}_theActualValue_{{key}}_theActualValue"
+      );
+    });
+  });
+  describe("when new parameters are given", () => {
+    it("should keep existing values if parameter name already exist", () => {
+      let newQueryParams = new Set(["a", "b", "c"]);
+      let oldQueryParamValues = {
+        a: "a_val",
+        c: "c_val",
+      };
+
+      expect(
+        mergeQueryParamValues(newQueryParams, oldQueryParamValues)
+      ).toStrictEqual({
+        a: "a_val",
+        b: "",
+        c: "c_val",
+      });
+    });
+  });
+  describe("when rendered", () => {
+    describe("with predefinedQueries", () => {
+      const predefinedQueries = [
+        {
+          name: "query_1",
+          sql: "query_1_sql {{label_1}} {{label_2}}",
+          description: "descripton for query 1",
+        },
+        {
+          name: "query_2",
+          sql: "query_2_sql {{label_1}}",
+          description: "descripton for query 2",
+        },
+      ];
+      let mockOnQueryUpdate = jest.fn<(query: string) => {}>();
+      it("should show right number of predefined queries in drop down menu", () => {
+        let { getAllByTestId } = render(
+          <QueryEditor
+            onQueryUpdate={mockOnQueryUpdate}
+            predefinedQueryOptions={predefinedQueries}
+          />
+        );
+        expect(getAllByTestId("select-option")).toHaveLength(
+          predefinedQueries.length + 1
+        );
+      });
+      it("should invoke callback when predefined query is selected", async () => {
+        const user = userEvent.setup();
+        let { getByTestId } = render(
+          <QueryEditor
+            onQueryUpdate={mockOnQueryUpdate}
+            predefinedQueryOptions={predefinedQueries}
+          />
+        );
+        predefinedQueries.forEach(async (predefinedQuery) => {
+          await user.selectOptions(getByTestId("select"), predefinedQuery.name);
+          expect(mockOnQueryUpdate).lastCalledWith(predefinedQuery.sql);
+        });
+      });
+      it("should show query and description when predefined query selected", async () => {
+        const user = userEvent.setup();
+        let { getByTestId, getByText } = render(
+          <QueryEditor
+            onQueryUpdate={mockOnQueryUpdate}
+            predefinedQueryOptions={predefinedQueries}
+          />
+        );
+        predefinedQueries.forEach(async (predefinedQuery) => {
+          await user.selectOptions(getByTestId("select"), predefinedQuery.name);
+          expect(getByText(predefinedQuery.description)).toBeTruthy();
+          expect(getByText(predefinedQuery.sql)).toBeTruthy();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Overview
Changes to the ClickHouse Querylog page in the Snuba admin console allow users and authors of predefined queries to define labels and its corresponding values in their queries.
<img width="720" alt="image" src="https://user-images.githubusercontent.com/14865283/222234584-660b76ce-c92f-4b92-a44b-edb21106cbaa.png">


### Changes
- Added new component `QueryEditor`

Closes [SNS-1931](https://getsentry.atlassian.net/browse/SNS-1931)

[SNS-1931]: https://getsentry.atlassian.net/browse/SNS-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ