### PR TITLE
fix(gocd): Automatically deploy after CI passes

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -47,8 +47,6 @@ pipelines:
                                     sentryio \
                                     "us.gcr.io/sentryio/snuba"
             - deploy:
-                  approval:
-                      type: manual
                   fetch_materials: true
                   jobs:
                       create-sentry-release:


### PR DESCRIPTION
There's a real discussion to be had as to which behavior is better, but
this is currently closer to how Freight behaved.
