### PR TITLE
ref(migrations): add reverse-in-progress cmd

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -175,6 +175,49 @@ def reverse(
 
 
 @migrations.command()
+@click.option("--group", help="Migration group")
+@click.option("--fake", is_flag=True)
+@click.option("--dry-run", is_flag=True)
+@click.option(
+    "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
+)
+def reverse_in_progress(
+    fake: bool,
+    dry_run: bool,
+    group: Optional[str] = None,
+    log_level: Optional[str] = None,
+) -> None:
+    """
+    Reverses a single migration.
+
+    --force is required to reverse an already completed migration.
+    --fake marks a migration as reversed without doing anything.
+    """
+    setup_logging(log_level)
+    if not dry_run:
+        check_clickhouse_connections()
+    runner = Runner()
+
+    migration_group = MigrationGroup(group) if group else None
+
+    if dry_run:
+        runner.reverse_in_progress(group=migration_group, dry_run=True)
+        return
+
+    try:
+        if fake:
+            click.confirm(
+                "This will mark the migration as not started without actually reversing it. Your database may be in an invalid state. Are you sure?",
+                abort=True,
+            )
+        runner.reverse_in_progress(group=migration_group, fake=fake)
+    except MigrationError as e:
+        raise click.ClickException(str(e))
+
+    click.echo("Finished reversing in progress migrations")
+
+
+@migrations.command()
 @click.option(
     "--type", "node_type", type=click.Choice(["local", "dist"]), required=True
 )

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -188,10 +188,11 @@ def reverse_in_progress(
     log_level: Optional[str] = None,
 ) -> None:
     """
-    Reverses a single migration.
+    Reverses any in progress migrations for all migration groups.
+    If group is specified, only reverse in progress migrations for
+    that group.
 
-    --force is required to reverse an already completed migration.
-    --fake marks a migration as reversed without doing anything.
+    --fake marks migrations as reversed without doing anything.
     """
     setup_logging(log_level)
     if not dry_run:

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -302,7 +302,7 @@ class Runner:
             return migration_status.get(migration_key, Status.NOT_STARTED)
 
         if group:
-            migration_groups = [group]
+            migration_groups: Sequence[MigrationGroup] = [group]
         else:
             migration_groups = get_active_migration_groups()
 
@@ -313,7 +313,7 @@ class Runner:
                 status = get_status(migration_key)
                 if status == Status.IN_PROGRESS:
                     return migration_key
-            return
+            return None
 
         for group in migration_groups:
             migration_key = get_in_progress_migration(group)

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -284,8 +284,17 @@ class Runner:
             self._reverse_migration_impl(migration_key)
 
     def reverse_in_progress(
-        self, fake: bool = False, group: Optional[MigrationGroup] = None
+        self,
+        fake: bool = False,
+        group: Optional[MigrationGroup] = None,
+        dry_run: bool = False,
     ) -> None:
+        """
+        Reverse migrations that are stuck in progress. This can be done
+        for all migrations groups or for a select migration group. There
+        will be at most one in-progress migration per group since you
+        can't move forward if a migration is in-progress.
+        """
 
         migration_status = self._get_migration_status()
 
@@ -312,10 +321,10 @@ class Runner:
                 if fake:
                     self._update_migration_status(migration_key, Status.NOT_STARTED)
                 else:
-                    print(f"[{group}]: reversing {migration_key}")
-                    self._reverse_migration_impl(migration_key)
+                    logger.info(f"[{group}]: reversing {migration_key}")
+                    self._reverse_migration_impl(migration_key, dry_run=dry_run)
             else:
-                print(f"[{group}]: no in progress migrations found")
+                logger.info(f"[{group}]: no in progress migrations found")
 
     def _reverse_migration_impl(
         self, migration_key: MigrationKey, *, dry_run: bool = False


### PR DESCRIPTION
**context**
We want to automate migrations in our deployment process. The command we plan to use is the one that runs any migrations that have not been already run. We are not doing this for blocking migrations, only non-blocking, so we do not want to use the `--force` flag.

```
snuba migrations migrate
```

If for some reason something goes wrong during the attempted migrations, we will need to rollback. Currently reversing is only possible to do one migration at a time and you need both the `migration_id` and the `group`. To make things easier in CI/CD, we'd like a way to reverse any migrations that are "stuck" in-progress.  Hence, the reverse in progress cmd.

```
snuba migrations reverse-in-progress
```

**what about completed migrations that need to be reversed?**
As of right now, that will not be handled in an automated way, this will have to been done through the admin tooling. In the future we may add a separate pipeline to run blocking migrations in a more automated way.