### PR TITLE
feat(profiling): Set origin timestamp to measure ingestion duration

### DIFF
--- a/snuba/datasets/processors/functions_processor.py
+++ b/snuba/datasets/processors/functions_processor.py
@@ -73,4 +73,4 @@ class FunctionsMessageProcessor(DatasetMessageProcessor):
         if max_depth_reached:
             metrics.increment("max_depth_reached")
 
-        return InsertBatch(list(functions.values()), None)
+        return InsertBatch(list(functions.values()), timestamp)

--- a/snuba/datasets/processors/profiles_processor.py
+++ b/snuba/datasets/processors/profiles_processor.py
@@ -40,7 +40,7 @@ class ProfilesMessageProcessor(DatasetMessageProcessor):
         except KeyError:
             metrics.increment("missing_field")
             return None
-        return InsertBatch([processed], None)
+        return InsertBatch([processed], received)
 
 
 def _normalize_legacy_format(
@@ -67,7 +67,7 @@ def _normalize_legacy_format(
         "platform": message["platform"],
         "profile_id": str(UUID(message["profile_id"])),
         "project_id": message["project_id"],
-        "received": datetime.utcfromtimestamp(message["received"]),
+        "received": received,
         "retention_days": retention_days,
         "trace_id": str(UUID(message["trace_id"])),
         "transaction_id": str(UUID(message["transaction_id"])),

--- a/tests/datasets/test_functions_processor.py
+++ b/tests/datasets/test_functions_processor.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Mapping, Optional, Sequence
 
 from snuba.consumers.types import KafkaMessageMetadata
@@ -74,10 +74,11 @@ class TestFunctionsProcessor:
             offset=1, partition=2, timestamp=datetime(1970, 1, 1)
         )
 
+        now = datetime.now(timezone.utc)
         message = ProfileCallTreeEvent(
             project_id=22,
             profile_id="a" * 32,
-            timestamp=0,
+            timestamp=now.timestamp(),
             transaction_name="vroom-vroom",
             call_trees={
                 "259": [
@@ -147,7 +148,7 @@ class TestFunctionsProcessor:
             "profile_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
             "project_id": 22,
             "transaction_name": "vroom-vroom",
-            "timestamp": datetime(1970, 1, 1),
+            "timestamp": now.replace(tzinfo=None),
             "platform": "cocoa",
             "environment": "prod",
             "release": "7.14.0 (1)",
@@ -195,4 +196,4 @@ class TestFunctionsProcessor:
 
         assert FunctionsMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch(batch, None)
+        ) == InsertBatch(batch, datetime.utcfromtimestamp(message.timestamp))

--- a/tests/datasets/test_profiles_processor.py
+++ b/tests/datasets/test_profiles_processor.py
@@ -139,7 +139,9 @@ class TestProfilesProcessor:
         )
         assert ProfilesMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)], message.received)
+        ) == InsertBatch(
+            [message.build_result(meta)], datetime.utcfromtimestamp(message.received)
+        )
 
     def test_missing_symbols(self) -> None:
         meta = KafkaMessageMetadata(
@@ -208,4 +210,6 @@ class TestProfilesProcessor:
         )
         assert ProfilesMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)], message.received)
+        ) == InsertBatch(
+            [message.build_result(meta)], datetime.utcfromtimestamp(message.received)
+        )

--- a/tests/datasets/test_profiles_processor.py
+++ b/tests/datasets/test_profiles_processor.py
@@ -139,19 +139,15 @@ class TestProfilesProcessor:
         )
         assert ProfilesMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)], None)
+        ) == InsertBatch([message.build_result(meta)], message.received)
 
     def test_missing_symbols(self) -> None:
         meta = KafkaMessageMetadata(
             offset=1, partition=0, timestamp=datetime(1970, 1, 1)
         )
         message = ProfileEvent(
-            organization_id=123456789,
-            project_id=987654321,
-            transaction_id=str(uuid.uuid4()),
-            received=datetime.utcnow().timestamp(),
-            profile_id=str(uuid.uuid4()),
             android_api_level=None,
+            architecture="aarch64",
             device_classification="high",
             device_locale="fr_FR",
             device_manufacturer="Pierre",
@@ -159,17 +155,21 @@ class TestProfilesProcessor:
             device_os_build_number="13",
             device_os_name="PierreOS",
             device_os_version="47",
-            architecture="aarch64",
             duration_ns=1234567890,
             environment="production",
-            platform="pierre",
-            trace_id=str(uuid.uuid4()),
-            transaction_name="lets-get-ready-to-party",
-            version_name="v42.0.0",
-            version_code="1337",
-            retention_days=30,
-            partition=meta.partition,
             offset=meta.offset,
+            organization_id=123456789,
+            partition=meta.partition,
+            platform="pierre",
+            profile_id=str(uuid.uuid4()),
+            project_id=987654321,
+            received=datetime.utcnow().timestamp(),
+            retention_days=30,
+            trace_id=str(uuid.uuid4()),
+            transaction_id=str(uuid.uuid4()),
+            transaction_name="lets-get-ready-to-party",
+            version_code="1337",
+            version_name="v42.0.0",
         )
         payload = message.serialize()
         del payload["profile_id"]
@@ -181,12 +181,8 @@ class TestProfilesProcessor:
             offset=0, partition=0, timestamp=datetime(1970, 1, 1)
         )
         message = ProfileEvent(
-            organization_id=123456789,
-            project_id=987654321,
-            transaction_id=str(uuid.uuid4()),
-            received=datetime.utcnow().timestamp(),
-            profile_id=str(uuid.uuid4()),
             android_api_level=None,
+            architecture="aarch64",
             device_classification="high",
             device_locale="fr_FR",
             device_manufacturer="Pierre",
@@ -194,18 +190,22 @@ class TestProfilesProcessor:
             device_os_build_number="13",
             device_os_name="PierreOS",
             device_os_version="47",
-            architecture="aarch64",
             duration_ns=1234567890,
             environment="production",
-            platform="pierre",
-            trace_id=str(uuid.uuid4()),
-            transaction_name="lets-get-ready-to-party",
-            version_name="v42.0.0",
-            version_code="1337",
-            retention_days=30,
-            partition=meta.partition,
             offset=meta.offset,
+            organization_id=123456789,
+            partition=meta.partition,
+            platform="pierre",
+            profile_id=str(uuid.uuid4()),
+            project_id=987654321,
+            received=datetime.utcnow().timestamp(),
+            retention_days=30,
+            trace_id=str(uuid.uuid4()),
+            transaction_id=str(uuid.uuid4()),
+            transaction_name="lets-get-ready-to-party",
+            version_code="1337",
+            version_name="v42.0.0",
         )
         assert ProfilesMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)], None)
+        ) == InsertBatch([message.build_result(meta)], message.received)


### PR DESCRIPTION
In order to measure out ingestion time SLO, we need to pass the origin timestamp to `InsertBatch`.