### PR TITLE
(chore): Bump self-hosted-e2e-test action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@627c9b50cb168c546ed6e2c461dae76d5d0c7cdb
+        uses: getsentry/action-self-hosted-e2e-tests@77805295ebff8a603def5970e18743ded72cb304
         with:
           project_name: snuba
           docker_repo: getsentry/snuba


### PR DESCRIPTION
Bumps action commit sha to fail test suite properly from typo fix here:
https://github.com/getsentry/action-self-hosted-e2e-tests/pull/7