### PR TITLE
ref(db_query): remove uncompressed cache 'optimization'

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import logging
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial, reduce
+from functools import partial
 from hashlib import md5
 from threading import Lock
-from typing import Any, Mapping, MutableMapping, Optional, Set, Union, cast
+from typing import Any, Mapping, MutableMapping, Optional, Union, cast
 
 import rapidjson
 import sentry_sdk
@@ -21,11 +21,8 @@ from snuba.clickhouse.formatter.query import format_query_anonymized
 from snuba.clickhouse.query import Query
 from snuba.clickhouse.query_dsl.accessors import get_time_range_estimate
 from snuba.clickhouse.query_profiler import generate_profile
-from snuba.query import ProcessableQuery
 from snuba.query.composite import CompositeQuery
-from snuba.query.data_source.join import IndividualNode, JoinClause, JoinVisitor
 from snuba.query.data_source.simple import Table
-from snuba.query.data_source.visitor import DataSourceVisitor
 from snuba.query.query_settings import QuerySettings
 from snuba.querylog.query_metadata import (
     ClickhouseQueryMetadata,
@@ -97,90 +94,6 @@ cache_partitions_lock = Lock()
 logger = logging.getLogger("snuba.query")
 
 
-class ReferencedColumnsCounter(
-    DataSourceVisitor[None, Table], JoinVisitor[None, Table]
-):
-    """
-    Traverse a potentially composite data source tree for a query
-    and count the physical Clickhouse columns referenced.
-
-    Since get_all_ast_referenced_columns only returns the columns
-    referenced directly by a query (ignoring subqueries), we need
-    to traverse each node of the data source structure individually.
-    """
-
-    def __init__(self) -> None:
-        # When we have a join node that references a table directly
-        # instead of a subquery we pick the columns list from the
-        # query that contains that join. So when visiting the join
-        # node we signal that the enclosing query has to count the
-        # columns for that join node.
-        self.__incomplete_tables: MutableMapping[str, str] = {}
-        # Analysed tables with their columns list
-        self.__complete_tables: MutableMapping[str, Set[str]] = {}
-
-    def count_columns(self) -> int:
-        return reduce(
-            lambda total, table: total + len(self.__complete_tables[table]),
-            self.__complete_tables,
-            0,
-        )
-
-    def _visit_simple_source(self, data_source: Table) -> None:
-        return
-
-    def _visit_join(self, data_source: JoinClause[Table]) -> None:
-        self.visit_join_clause(data_source)
-
-    def _visit_simple_query(self, data_source: ProcessableQuery[Table]) -> None:
-        table = data_source.get_from_clause().table_name
-        columns = set(
-            (
-                # Skip aliases when counting columns
-                c.column_name
-                for c in data_source.get_all_ast_referenced_columns()
-            )
-        )
-
-        if table in self.__complete_tables:
-            self.__complete_tables[table] |= columns
-        else:
-            self.__complete_tables[table] = columns
-
-    def _visit_composite_query(self, data_source: CompositeQuery[Table]) -> None:
-        self.visit(data_source.get_from_clause())
-        if self.__incomplete_tables:
-            # This case means that we ran into a join node that referenced
-            # a table directly. So that table, with its alias is in the
-            # incomplete tables mapping and we count all the columns this
-            # query references from there.
-            for _, table in self.__incomplete_tables.items():
-                if table not in self.__complete_tables:
-                    self.__complete_tables[table] = set()
-            for c in data_source.get_all_ast_referenced_columns():
-                if (
-                    c.table_name is not None
-                    and c.table_name in self.__incomplete_tables
-                ):
-                    self.__complete_tables[self.__incomplete_tables[c.table_name]].add(
-                        c.column_name
-                    )
-            self.__incomplete_tables = {}
-
-    def visit_individual_node(self, node: IndividualNode[Table]) -> None:
-        if isinstance(node.data_source, Table):
-            # This is an individual table in a join. So we signal that the
-            # enclosing query needs to count the columns that reference this
-            # table.
-            self.__incomplete_tables[node.alias] = node.data_source.table_name
-        else:
-            self.visit(node.data_source)
-
-    def visit_join_clause(self, node: JoinClause[Table]) -> None:
-        node.left_node.accept(self)
-        node.right_node.accept(self)
-
-
 def update_query_metadata_and_stats(
     query: Query,
     sql: str,
@@ -242,15 +155,6 @@ def execute_query(
     """
     Execute a query and return a result.
     """
-    # Experiment, if we are going to grab more than X columns worth of data,
-    # don't use uncompressed_cache in ClickHouse.
-    uc_max = state.get_config("uncompressed_cache_max_cols", 5)
-    assert isinstance(uc_max, int)
-    column_counter = ReferencedColumnsCounter()
-    column_counter.visit(clickhouse_query.get_from_clause())
-    if column_counter.count_columns() > uc_max:
-        clickhouse_query_settings["use_uncompressed_cache"] = 0
-
     # Force query to use the first shard replica, which
     # should have synchronously received any cluster writes
     # before this query is run.

--- a/tests/web/test_tables_collector.py
+++ b/tests/web/test_tables_collector.py
@@ -17,7 +17,6 @@ from snuba.query.data_source.join import (
 )
 from snuba.query.data_source.simple import Table
 from snuba.query.expressions import Column, FunctionCall, Literal
-from snuba.web.db_query import ReferencedColumnsCounter
 
 ERRORS_SCHEMA = ColumnSet(
     [
@@ -66,7 +65,6 @@ SIMPLE_QUERY = ClickhouseQuery(
 TEST_CASES = [
     pytest.param(
         SIMPLE_QUERY,
-        3,
         {"errors_local"},
         True,
         0.1,
@@ -82,7 +80,6 @@ TEST_CASES = [
                 )
             ],
         ),
-        3,
         {"errors_local"},
         True,
         None,
@@ -115,7 +112,6 @@ TEST_CASES = [
                 SelectedExpression("message", Column("message", "groups", "message")),
             ],
         ),
-        5,  # 3 from errors and 2 from groups
         {"errors_local", "groups_local"},
         True,
         None,
@@ -125,19 +121,15 @@ TEST_CASES = [
 
 
 @pytest.mark.parametrize(
-    "query, expected_cols, expected_tables, expected_final, expected_sampling",
+    "query, expected_tables, expected_final, expected_sampling",
     TEST_CASES,
 )
 def test_count_columns(
     query: Union[ClickhouseQuery, CompositeQuery[Table]],
-    expected_cols: int,
     expected_tables: Set[str],
     expected_final: bool,
     expected_sampling: Optional[float],
 ) -> None:
-    counter = ReferencedColumnsCounter()
-    counter.visit(query)
-    assert counter.count_columns() == expected_cols
 
     tables_collector = TablesCollector()
     tables_collector.visit(query)


### PR DESCRIPTION
This experiment was made three years ago. I turned the `uncompressed_cache_max_cols` to 100 to see if it would affect the query performance in any way. There is no significant difference with this optimization being turned on or off:

https://app.datadoghq.com/notebook/4927786/volo-mar-03-2023-10-28

According to [this presentation](https://presentations.clickhouse.com/meetup60/overview-of-caching.pdf) clickhouse will automatically disable the uncompressed cache for large queries anyways.

