### PR TITLE
feat(admin): Add front-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,10 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout code
       - name: Set up and run tests through yarn
-        run: make test-admin
+        run: cd snuba/admin && yarn install && yarn run test --coverage
+      - name: Upload to codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
   sentry:
     needs: [snuba-image]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,16 @@ jobs:
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
+  admin-tests:
+    needs: [linting]
+    name: Front end tests for snuba admin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout code
+      - name: Set up and run tests through yarn
+        run: make test-admin
+
   sentry:
     needs: [snuba-image]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ setup-git:
 
 test:
 	SNUBA_SETTINGS=test pytest -vv tests -v -m "not ci_only"
-	cd snuba/admin && yarn install && yarn run test
 
 test-distributed-migrations:
 	docker build . -t snuba-test
@@ -56,6 +55,7 @@ watch-admin:
 
 test-admin:
 	cd snuba/admin && yarn install && yarn run test
+	SNUBA_SETTINGS=test pytest -vv tests/admin/
 
 validate-configs:
 	python3 snuba/validate_configs.py

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ setup-git:
 
 test:
 	SNUBA_SETTINGS=test pytest -vv tests -v -m "not ci_only"
+	cd snuba/admin && yarn install && yarn run test
 
 test-distributed-migrations:
 	docker build . -t snuba-test
@@ -52,6 +53,9 @@ build-admin:
 
 watch-admin:
 	cd snuba/admin && yarn install && yarn run watch
+
+test-admin:
+	cd snuba/admin && yarn install && yarn run test
 
 validate-configs:
 	python3 snuba/validate_configs.py

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ codecov:
   # do not notify until at least 3 builds
   # have been uploaded from the CI pipeline
   # we upload artifacts from 'test',
-  # 'test_distributed', 'test_distributed_migrations'
-  # until all of these are done, we don't want a faulty
-  # codecov report
+  # 'test_distributed', 'test_distributed_migrations',
+  # and 'admin-tests' until all of these are done,
+  # we don't want a faulty codecov report
   notify:
-      after_n_builds: 3
+      after_n_builds: 4
 coverage:
   status:
     project:

--- a/snuba/admin/jest.config.js
+++ b/snuba/admin/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/snuba/admin/package.json
+++ b/snuba/admin/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "webpack --config webpack.config.js --mode production",
-    "watch": "webpack --config webpack.config.js --mode development --watch"
+    "watch": "webpack --config webpack.config.js --mode development --watch",
+    "test": "jest"
   },
   "dependencies": {
     "@types/react": "^18.0.20",
@@ -14,6 +15,11 @@
     "typescript": "^4.8.3"
   },
   "devDependencies": {
+    "@jest/globals": "^29.4.3",
+    "@testing-library/react": "^14.0.0",
+    "jest": "^29.4.3",
+    "jest-environment-jsdom": "^29.5.0",
+    "ts-jest": "^29.0.5",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
   }

--- a/snuba/admin/static/tests/kafka/index.spec.tsx
+++ b/snuba/admin/static/tests/kafka/index.spec.tsx
@@ -1,0 +1,32 @@
+import TopicData from "../../kafka/index";
+import Client from "../../api_client";
+import React from "react";
+import { it, expect, jest, afterEach } from "@jest/globals";
+import { render, act, waitFor } from "@testing-library/react";
+import { KafkaTopicData } from "../../kafka/types";
+
+it("should display data fetched from API when rendering", async () => {
+  let data = [
+    {
+      key: "My_Key_1",
+      user: "My_User_1",
+      timestamp: 0,
+    },
+    {
+      key: "My_Key_2",
+      user: "My_User_2",
+      timestamp: 1,
+    },
+  ];
+  let mockClient = {
+    ...Client(),
+    getKafkaData: jest
+      .fn<() => Promise<KafkaTopicData[]>>()
+      .mockResolvedValueOnce(data),
+  };
+
+  let { getByText } = render(<TopicData api={mockClient} />);
+
+  await waitFor(() => expect(mockClient.getKafkaData).toBeCalledTimes(1));
+  expect(getByText(JSON.stringify(data))).toBeTruthy();
+});


### PR DESCRIPTION
### Overview
Add tests for the front end components within snuba through [jest](https://jestjs.io/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).


### Changes
- Update `package.json` to include new dev dependencies
- Add new github job [`admin-tests`](https://github.com/getsentry/snuba/actions/runs/4349199836/jobs/7598600464) to github actions
- Add `jest.config.js` for jest configerations
- Add sample test for `KafkaTopicData`