### PR TITLE
fix(profiling): Use correct field as origin timestamp for functions

### DIFF
--- a/snuba/datasets/processors/functions_processor.py
+++ b/snuba/datasets/processors/functions_processor.py
@@ -73,4 +73,9 @@ class FunctionsMessageProcessor(DatasetMessageProcessor):
         if max_depth_reached:
             metrics.increment("max_depth_reached")
 
-        return InsertBatch(list(functions.values()), timestamp)
+        received = message.get("received")
+
+        return InsertBatch(
+            list(functions.values()),
+            datetime.utcfromtimestamp(received) if received else None,
+        )

--- a/tests/datasets/test_functions_processor.py
+++ b/tests/datasets/test_functions_processor.py
@@ -49,7 +49,7 @@ class ProfileCallTreeEvent:
     os_name: str
     os_version: str
     retention_days: int
-    received: int
+    received: Optional[int]
 
     def serialize(self) -> Mapping[str, Any]:
         return {


### PR DESCRIPTION
We're currently using the client's timestamp (start of the profile) for the origin timestamp and it's producing wild results (like suggesting we took 11 days to ingest some values).

It'd be better to use the timestamp taken from Kafka when we ingest the message. We started forwarding that value recently in https://github.com/getsentry/vroom/pull/190.