### PR TITLE
feat(replays): Add bloom filter index to replay_id column

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -196,6 +196,7 @@ class ReplaysLoader(DirectoryLoader):
             "0006_add_is_archived_column",
             "0007_add_replay_type_column",
             "0008_add_sample_rate",
+            "0009_add_index_to_replay_id",
         ]
 
 

--- a/snuba/snuba_migrations/replays/0009_add_index_to_replay_id.py
+++ b/snuba/snuba_migrations/replays/0009_add_index_to_replay_id.py
@@ -1,0 +1,34 @@
+from typing import Iterator, Sequence
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(forward_columns_iter())
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(backward_columns_iter())
+
+
+def forward_columns_iter() -> Iterator[operations.SqlOperation]:
+    yield operations.AddIndex(
+        storage_set=StorageSetKey.REPLAYS,
+        table_name="replays_local",
+        index_name="bf_replay_id",
+        index_expression="replay_id",
+        index_type="bloom_filter()",
+        granularity=1,
+    )
+
+
+def backward_columns_iter() -> Iterator[operations.SqlOperation]:
+    yield operations.DropIndex(
+        storage_set=StorageSetKey.REPLAYS,
+        table_name="replays_local",
+        index_name="bf_replay_id",
+        target=operations.OperationTarget.LOCAL,
+    )

--- a/snuba/snuba_migrations/replays/0009_add_index_to_replay_id.py
+++ b/snuba/snuba_migrations/replays/0009_add_index_to_replay_id.py
@@ -22,6 +22,7 @@ def forward_columns_iter() -> Iterator[operations.SqlOperation]:
         index_expression="replay_id",
         index_type="bloom_filter()",
         granularity=1,
+        target=operations.OperationTarget.LOCAL,
     )
 
 


### PR DESCRIPTION
Intended to improve the performance of replay-details pages.

This addition was tested locally against a dataset of 10 million replays.  Multiple strategies were tested.  The bloom filter consistently returned the best results (on read).  I did not test write performance.  However, I did not notice significant regression when ingesting 10M records.