### PR TITLE
feat(consumer): Support passing commit log and replacements bootstrap servers

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -49,7 +49,17 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--bootstrap-server",
     multiple=True,
-    help="Kafka bootstrap server to use.",
+    help="Kafka bootstrap server to use for consuming.",
+)
+@click.option(
+    "--commit-log-bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use to produce the commit log.",
+)
+@click.option(
+    "--replacement-bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use to produce replacements.",
 )
 @click.option(
     "--slice-id",
@@ -116,6 +126,8 @@ def consumer(
     commit_log_topic: Optional[str],
     consumer_group: str,
     bootstrap_server: Sequence[str],
+    commit_log_bootstrap_server: Sequence[str],
+    replacement_bootstrap_server: Sequence[str],
     slice_id: Optional[int],
     max_batch_size: int,
     max_batch_time_ms: int,
@@ -158,6 +170,8 @@ def consumer(
             raw_topic=raw_events_topic,
             replacements_topic=replacements_topic,
             bootstrap_servers=bootstrap_server,
+            commit_log_bootstrap_servers=commit_log_bootstrap_server,
+            replacements_bootstrap_servers=replacement_bootstrap_server,
             group_id=consumer_group,
             commit_log_topic=commit_log_topic,
             auto_offset_reset=auto_offset_reset,

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -30,6 +30,8 @@ consumer_builder = ConsumerBuilder(
         raw_topic=None,
         replacements_topic=None,
         bootstrap_servers=None,
+        commit_log_bootstrap_servers=None,
+        replacements_bootstrap_servers=None,
         group_id=consumer_group_name,
         commit_log_topic=None,
         auto_offset_reset="earliest",
@@ -56,6 +58,8 @@ optional_kafka_params = KafkaParameters(
     raw_topic="raw",
     replacements_topic="event-replacements",
     bootstrap_servers=["cli.server:9092", "cli2.server:9092"],
+    commit_log_bootstrap_servers=["cli.server:9092", "cli2.server:9092"],
+    replacements_bootstrap_servers=["cli.server:9092", "cli2.server:9092"],
     group_id=consumer_group_name,
     commit_log_topic="snuba-commit-log",
     auto_offset_reset="earliest",
@@ -100,8 +104,6 @@ def test_consumer_builder_non_optional_attributes(con_build) -> None:  # type: i
 
     assert isinstance(con_build.raw_topic, Topic)
 
-    assert con_build.broker_config is not None
-
     assert isinstance(con_build.metrics, MetricsBackend)
 
     assert con_build.max_batch_size == 3
@@ -126,7 +128,6 @@ def test_consumer_builder_optional_attributes(con_build) -> None:  # type: ignor
     con_build.replacements_producer
     con_build.commit_log_producer
 
-    con_build.bootstrap_servers
     con_build.strict_offset_reset
     con_build.processes
     con_build.input_block_size


### PR DESCRIPTION
Currently --bootstrap-servers is applied to the main topic being consumed as well as the commit log and replacements topic produced onto.

We are currently moving some topics between clusters. This limitation is inconvenient as it forces all topics to be moved in one hit instead of allowing topics to ever reside on different brokers.