### PR TITLE
fix: Suppress irrelevant exception

### DIFF
--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -16,6 +16,8 @@ def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
     """
     try:
         return sentry_kafka_schemas.get_schema(topic.value)["schema"]
+    except sentry_kafka_schemas.SchemaNotFound:
+        return None
     except Exception as err:
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("snuba_logical_topic", topic.name)


### PR DESCRIPTION
After the latest changes to this file, we started reporting warnings on
startup when we tried to load schemas for all topics that had none
defined.


Fix SNUBA-33H



<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
