### PR TITLE
feat(subscriptions): Support passing --bootstrap-server via CLI

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -133,6 +133,7 @@ def subscriptions_executor(
         dataset_name,
         entity_names,
         consumer_group,
+        bootstrap_server,
         slice_id,
         producer,
         total_concurrent_queries,

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -40,6 +40,16 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Consumer group used for consuming the scheduled subscription topic/s.",
 )
 @click.option(
+    "--bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use for consuming.",
+)
+@click.option(
+    "--result-bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use for producing subscription results.",
+)
+@click.option(
     "--slice-id",
     help="The slice to load scheduled queries from",
 )
@@ -71,6 +81,8 @@ def subscriptions_executor(
     dataset_name: str,
     entity_names: Sequence[str],
     consumer_group: str,
+    bootstrap_server: Sequence[str],
+    result_bootstrap_server: Sequence[str],
     slice_id: Optional[int],
     total_concurrent_queries: int,
     auto_offset_reset: str,
@@ -112,6 +124,7 @@ def subscriptions_executor(
     producer = KafkaProducer(
         build_kafka_producer_configuration(
             result_topic_spec.topic,
+            bootstrap_servers=result_bootstrap_server,
             override_params={"partitioner": "consistent"},
         )
     )

--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -1,7 +1,7 @@
 import logging
 import signal
 from contextlib import closing
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import click
 from arroyo import configure_metrics
@@ -38,6 +38,16 @@ logger = logging.getLogger(__name__)
     help="Name of the consumer group to follow",
 )
 @click.option(
+    "--bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use for consuming.",
+)
+@click.option(
+    "--scheduled-bootstrap-server",
+    multiple=True,
+    help="Kafka bootstrap server to use for producing scheduled messages.",
+)
+@click.option(
     "--auto-offset-reset",
     default="error",
     type=click.Choice(["error", "earliest", "latest"]),
@@ -67,6 +77,8 @@ def subscriptions_scheduler(
     entity_name: str,
     consumer_group: str,
     followed_consumer_group: str,
+    bootstrap_server: Sequence[str],
+    scheduled_bootstrap_server: Sequence[str],
     auto_offset_reset: str,
     no_strict_offset_reset: bool,
     schedule_ttl: int,
@@ -148,6 +160,7 @@ def subscriptions_scheduler(
         build_kafka_producer_configuration(
             scheduled_topic_spec.topic,
             slice_id,
+            bootstrap_servers=scheduled_bootstrap_server,
             override_params={"partitioner": "consistent"},
         )
     )
@@ -156,6 +169,7 @@ def subscriptions_scheduler(
         entity_name,
         consumer_group,
         followed_consumer_group,
+        bootstrap_server,
         producer,
         auto_offset_reset,
         not no_strict_offset_reset,

--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -74,6 +74,7 @@ def build_executor_consumer(
     dataset_name: str,
     entity_names: Sequence[str],
     consumer_group: str,
+    bootstrap_servers: Sequence[str],
     slice_id: Optional[int],
     producer: Producer[KafkaPayload],
     total_concurrent_queries: int,
@@ -128,6 +129,7 @@ def build_executor_consumer(
     consumer_configuration = build_kafka_consumer_configuration(
         SnubaTopic(physical_scheduled_topic),
         consumer_group,
+        bootstrap_servers=bootstrap_servers,
         auto_offset_reset=auto_offset_reset,
         strict_offset_reset=strict_offset_reset,
     )

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -215,6 +215,7 @@ class SchedulerBuilder:
         entity_name: str,
         consumer_group: str,
         followed_consumer_group: str,
+        bootstrap_servers: Sequence[str],
         producer: Producer[KafkaPayload],
         auto_offset_reset: str,
         strict_offset_reset: Optional[bool],
@@ -251,6 +252,7 @@ class SchedulerBuilder:
 
         self.__consumer_group = consumer_group
         self.__followed_consumer_group = followed_consumer_group
+        self.__bootstrap_servers = bootstrap_servers
         self.__producer = producer
         self.__auto_offset_reset = auto_offset_reset
         self.__strict_offset_reset = strict_offset_reset
@@ -288,6 +290,7 @@ class SchedulerBuilder:
             self.__commit_log_topic_spec.topic,
             self.__consumer_group,
             self.__slice_id,
+            bootstrap_servers=self.__bootstrap_servers,
             auto_offset_reset=self.__auto_offset_reset,
             strict_offset_reset=self.__strict_offset_reset,
         )

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -105,6 +105,7 @@ def test_executor_consumer() -> None:
         dataset_name,
         [entity_name],
         consumer_group,
+        [],
         None,
         result_producer,
         2,

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -83,6 +83,7 @@ def test_scheduler_consumer() -> None:
         entity_name,
         str(uuid.uuid1().hex),
         "events",
+        [],
         mock_scheduler_producer,
         "latest",
         False,


### PR DESCRIPTION
Similar to https://github.com/getsentry/snuba/pull/3827

We are moving topics around and need a way to easily override these temporarily as we will have 2 subscriptions pipelines running side by side.