### PR TITLE
ref: Bump sentry-kafka-schemas to 0.0.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.7.1
-sentry-kafka-schemas==0.0.3
+sentry-kafka-schemas==0.0.4
 sentry-relay==0.8.19
 sentry-sdk==1.16.0
 simplejson==3.17.6


### PR DESCRIPTION
This introduces the types necessary for #3812 to land.
