### PR TITLE
test: Run all consumers' message processors against examples

### DIFF
--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -88,23 +88,7 @@ class ReplacementType(str, Enum):
     EXCLUDE_GROUPS = "exclude_groups"
 
 
-REPLACEMENT_EVENT_TYPES = frozenset(
-    [
-        ReplacementType.START_DELETE_GROUPS,
-        ReplacementType.START_MERGE,
-        ReplacementType.START_UNMERGE,
-        ReplacementType.START_DELETE_TAG,
-        ReplacementType.END_DELETE_GROUPS,
-        ReplacementType.END_MERGE,
-        ReplacementType.END_UNMERGE,
-        ReplacementType.END_DELETE_TAG,
-        ReplacementType.TOMBSTONE_EVENTS,
-        ReplacementType.EXCLUDE_GROUPS,
-        ReplacementType.REPLACE_GROUP,
-        ReplacementType.START_UNMERGE_HIERARCHICAL,
-        ReplacementType.END_UNMERGE_HIERARCHICAL,
-    ]
-)
+REPLACEMENT_EVENT_TYPES = frozenset(ReplacementType.__members__.values())
 
 
 class InsertEvent(TypedDict):

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -101,6 +101,8 @@ REPLACEMENT_EVENT_TYPES = frozenset(
         ReplacementType.TOMBSTONE_EVENTS,
         ReplacementType.EXCLUDE_GROUPS,
         ReplacementType.REPLACE_GROUP,
+        ReplacementType.START_UNMERGE_HIERARCHICAL,
+        ReplacementType.END_UNMERGE_HIERARCHICAL,
     ]
 )
 

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -7,6 +7,7 @@ from hashlib import md5
 from typing import (
     Any,
     Dict,
+    FrozenSet,
     Iterable,
     MutableMapping,
     NamedTuple,
@@ -88,7 +89,9 @@ class ReplacementType(str, Enum):
     EXCLUDE_GROUPS = "exclude_groups"
 
 
-REPLACEMENT_EVENT_TYPES = frozenset(ReplacementType.__members__.values())
+REPLACEMENT_EVENT_TYPES: FrozenSet[ReplacementType] = frozenset(
+    ReplacementType.__members__.values()
+)
 
 
 class InsertEvent(TypedDict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,9 @@ def pytest_configure() -> None:
 
     setup_sentry()
 
+
+@pytest.fixture(scope="session")
+def create_databases():
     for cluster in settings.CLUSTERS:
         clickhouse_cluster = ClickhouseCluster(
             host=cluster["host"],
@@ -55,7 +58,7 @@ def pytest_configure() -> None:
 
 
 @pytest.fixture(autouse=True)
-def run_migrations() -> Iterator[None]:
+def run_migrations(create_databases) -> Iterator[None]:
     from snuba.migrations.runner import Runner
 
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def pytest_configure() -> None:
 
 
 @pytest.fixture(scope="session")
-def create_databases():
+def create_databases() -> None:
     for cluster in settings.CLUSTERS:
         clickhouse_cluster = ClickhouseCluster(
             host=cluster["host"],
@@ -58,7 +58,7 @@ def create_databases():
 
 
 @pytest.fixture(autouse=True)
-def run_migrations(create_databases) -> Iterator[None]:
+def run_migrations(create_databases: None) -> Iterator[None]:
     from snuba.migrations.runner import Runner
 
     try:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,14 @@
 from datetime import date, datetime
 
+import pytest
+
 from snuba.clickhouse.escaping import escape_alias, escape_identifier
 from snuba.util import escape_literal
+
+
+@pytest.fixture
+def run_migrations():
+    pass
 
 
 def test_escape() -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -7,7 +7,7 @@ from snuba.util import escape_literal
 
 
 @pytest.fixture
-def run_migrations():
+def run_migrations() -> None:
     pass
 
 


### PR DESCRIPTION
sentry-kafka-schemas is supposed to contain more and more examples over
time for all kafka topics. Run those examples against the relevant snuba
consumers.
