### PR TITLE
ref(admin): add CreateTableQuery predefined queries

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -10,17 +10,6 @@ class SystemQuery(PreDefinedQuery, metaclass=RegisteredClass):
         return cls.__name__
 
 
-class CreateTableQuery(SystemQuery):
-    """Show the current state of the schema by looking at the create_table_query"""
-
-    sql = """
-    SELECT
-        create_table_query
-    FROM system.tables
-    WHERE database not in ('system')
-    """
-
-
 class CurrentMerges(SystemQuery):
     """Currently executing merges"""
 
@@ -31,6 +20,17 @@ class CurrentMerges(SystemQuery):
         progress,
         result_part_name
     FROM system.merges
+    """
+
+
+class CreateTableQuery(SystemQuery):
+    """Show the current state of the schema by looking at the create_table_query"""
+
+    sql = """
+    SELECT
+        create_table_query
+    FROM system.tables
+    WHERE database not in ('system')
     """
 
 

--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -10,6 +10,17 @@ class SystemQuery(PreDefinedQuery, metaclass=RegisteredClass):
         return cls.__name__
 
 
+class CreateTableQuery(SystemQuery):
+    """Show the current state of the schema by looking at the create_table_query"""
+
+    sql = """
+    SELECT
+        create_table_query
+    FROM system.tables
+    WHERE database not in ('system')
+    """
+
+
 class CurrentMerges(SystemQuery):
     """Currently executing merges"""
 


### PR DESCRIPTION
This query is useful for investigations for migrations and just in general when you want to see that current schema for a table in production