### PR TITLE
fix(querylog): enable readonly 2 for querylog

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -69,13 +69,16 @@ def get_ro_node_connection(
 
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
-        ClickhouseClientSettings.TRACING,
+        ClickhouseClientSettings.QUERY_AND_SETTINGS,
     }, "admin can only use QUERY or TRACING ClickhouseClientSettings"
 
     if client_settings == ClickhouseClientSettings.QUERY:
         username = settings.CLICKHOUSE_READONLY_USER
         password = settings.CLICKHOUSE_READONLY_PASSWORD
     else:
+        # renamed the ClickhouseClientSettings.TRACING to
+        # ClickhouseClientSettings.QUERY_AND_SETTINGS but didnt
+        # want to have to change these settings in ops
         username = settings.CLICKHOUSE_TRACE_USER
         password = settings.CLICKHOUSE_TRACE_PASSWORD
 

--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -37,7 +37,7 @@ def __run_querylog_query(query: str) -> ClickhouseResult:
     query and does not validate/sanitize query or response data.
     """
     connection = get_ro_query_node_connection(
-        StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERY
+        StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERY_AND_SETTINGS
     )
     query_result = connection.execute(query=query, with_column_types=True)
     return query_result

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -23,8 +23,15 @@ def _run_sql_query_on_host(
     """
     Run the SQL query. It should be validated before getting to this point
     """
+    if storage_name == "querylog":
+        # we want to be able to change settings for the querylog which
+        # requires readonly: 2 so we must use QUERY_AND_SETTINGS
+        settings = ClickhouseClientSettings.QUERY_AND_SETTINGS
+    else:
+        settings = ClickhouseClientSettings.QUERY
+
     connection = get_ro_node_connection(
-        clickhouse_host, clickhouse_port, storage_name, ClickhouseClientSettings.QUERY
+        clickhouse_host, clickhouse_port, storage_name, settings
     )
     query_result = connection.execute(query=sql, with_column_types=True)
 

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -10,7 +10,7 @@ def run_query_and_get_trace(storage_name: str, query: str) -> ClickhouseResult:
     validate_ro_query(query)
 
     connection = get_ro_query_node_connection(
-        storage_name, ClickhouseClientSettings.TRACING
+        storage_name, ClickhouseClientSettings.QUERY_AND_SETTINGS
     )
     query_result = connection.execute(query=query, capture_trace=True)
     return query_result

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -60,7 +60,7 @@ class ClickhouseClientSettings(Enum):
     )
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
-    TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
+    QUERY_AND_SETTINGS = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(
         {
             # Replacing existing rows requires reconstructing the entire tuple


### PR DESCRIPTION
**context**
This PR https://github.com/getsentry/ops/pull/6099 was applied today and I started seeing the same error when I tried to run system queries for the querylog or when I tried to use the querylog - see [SNUBA-342](https://sentry.sentry.io/issues/3988451086/?project=300688&query=is%3Aunresolved+is%3Aunassigned+level%3Aerror+lastSeen%3A-24h&referrer=issue-stream).

What seems to be happening is that we set the user to have `readonly=2`, but when we are making the query we set `readonly=1` and clickhouse does not allow the `readyonly` setting to be changed when you have the `readonly=2` setting https://clickhouse.com/docs/en/operations/settings/constraints-on-settings/

**TRACING -> QUERY_AND_SETTINGS**
Since the tracing setting already has `readonly=2` I decided to just rename that setting to be more general - you can query things AND set settings (like `max_threads` in the case of querylog). Since we only are enabling `readonly=2` for the querylog, I had to specifically setting for system queries for that storage. 

**do we even need the readonly=2 on the query if we have it on the user?**
I'm not 100% but a follow up would be to try to remove it and see if it works, just didn't want to include that in this PR since I think we may need more investigation/testing for that.
