### PR TITLE
Revert "fix(querylog): enable readonly 2 for querylog"

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -69,16 +69,13 @@ def get_ro_node_connection(
 
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
-        ClickhouseClientSettings.QUERY_AND_SETTINGS,
+        ClickhouseClientSettings.TRACING,
     }, "admin can only use QUERY or TRACING ClickhouseClientSettings"
 
     if client_settings == ClickhouseClientSettings.QUERY:
         username = settings.CLICKHOUSE_READONLY_USER
         password = settings.CLICKHOUSE_READONLY_PASSWORD
     else:
-        # renamed the ClickhouseClientSettings.TRACING to
-        # ClickhouseClientSettings.QUERY_AND_SETTINGS but didnt
-        # want to have to change these settings in ops
         username = settings.CLICKHOUSE_TRACE_USER
         password = settings.CLICKHOUSE_TRACE_PASSWORD
 

--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -37,7 +37,7 @@ def __run_querylog_query(query: str) -> ClickhouseResult:
     query and does not validate/sanitize query or response data.
     """
     connection = get_ro_query_node_connection(
-        StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERY_AND_SETTINGS
+        StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERY
     )
     query_result = connection.execute(query=query, with_column_types=True)
     return query_result

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -23,15 +23,8 @@ def _run_sql_query_on_host(
     """
     Run the SQL query. It should be validated before getting to this point
     """
-    if storage_name == "querylog":
-        # we want to be able to change settings for the querylog which
-        # requires readonly: 2 so we must use QUERY_AND_SETTINGS
-        settings = ClickhouseClientSettings.QUERY_AND_SETTINGS
-    else:
-        settings = ClickhouseClientSettings.QUERY
-
     connection = get_ro_node_connection(
-        clickhouse_host, clickhouse_port, storage_name, settings
+        clickhouse_host, clickhouse_port, storage_name, ClickhouseClientSettings.QUERY
     )
     query_result = connection.execute(query=sql, with_column_types=True)
 

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -10,7 +10,7 @@ def run_query_and_get_trace(storage_name: str, query: str) -> ClickhouseResult:
     validate_ro_query(query)
 
     connection = get_ro_query_node_connection(
-        storage_name, ClickhouseClientSettings.QUERY_AND_SETTINGS
+        storage_name, ClickhouseClientSettings.TRACING
     )
     query_result = connection.execute(query=query, capture_trace=True)
     return query_result

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -60,7 +60,7 @@ class ClickhouseClientSettings(Enum):
     )
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
-    QUERY_AND_SETTINGS = ClickhouseClientSettingsType({"readonly": 2}, None)
+    TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(
         {
             # Replacing existing rows requires reconstructing the entire tuple


### PR DESCRIPTION
Reverts getsentry/snuba#3847

This didn't help at all, but also cabin doesn't even have the `trace_readonly` user, so this change probably wouldn't have worked anyway