### PR TITLE
ref(admin): dont use tracing user for querylog and remove readonly=2

### DIFF
--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -70,15 +70,16 @@ def get_ro_node_connection(
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
         ClickhouseClientSettings.QUERY_AND_SETTINGS,
-    }, "admin can only use QUERY or TRACING ClickhouseClientSettings"
+        ClickhouseClientSettings.TRACING,
+    }, "admin can only use QUERY/QUERY_AND_SETTINGS or TRACING ClickhouseClientSettings"
 
-    if client_settings == ClickhouseClientSettings.QUERY:
+    if (
+        client_settings == ClickhouseClientSettings.QUERY
+        or client_settings == ClickhouseClientSettings.QUERY_AND_SETTINGS
+    ):
         username = settings.CLICKHOUSE_READONLY_USER
         password = settings.CLICKHOUSE_READONLY_PASSWORD
     else:
-        # renamed the ClickhouseClientSettings.TRACING to
-        # ClickhouseClientSettings.QUERY_AND_SETTINGS but didnt
-        # want to have to change these settings in ops
         username = settings.CLICKHOUSE_TRACE_USER
         password = settings.CLICKHOUSE_TRACE_PASSWORD
 

--- a/snuba/admin/clickhouse/common.py
+++ b/snuba/admin/clickhouse/common.py
@@ -69,13 +69,13 @@ def get_ro_node_connection(
 
     assert client_settings in {
         ClickhouseClientSettings.QUERY,
-        ClickhouseClientSettings.QUERY_AND_SETTINGS,
+        ClickhouseClientSettings.QUERYLOG,
         ClickhouseClientSettings.TRACING,
-    }, "admin can only use QUERY/QUERY_AND_SETTINGS or TRACING ClickhouseClientSettings"
+    }, "admin can only use QUERY, QUERYLOG, or TRACING ClickhouseClientSettings"
 
     if (
         client_settings == ClickhouseClientSettings.QUERY
-        or client_settings == ClickhouseClientSettings.QUERY_AND_SETTINGS
+        or client_settings == ClickhouseClientSettings.QUERYLOG
     ):
         username = settings.CLICKHOUSE_READONLY_USER
         password = settings.CLICKHOUSE_READONLY_PASSWORD

--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -37,7 +37,7 @@ def __run_querylog_query(query: str) -> ClickhouseResult:
     query and does not validate/sanitize query or response data.
     """
     connection = get_ro_query_node_connection(
-        StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERY_AND_SETTINGS
+        StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERYLOG
     )
     query_result = connection.execute(query=query, with_column_types=True)
     return query_result

--- a/snuba/admin/clickhouse/system_queries.py
+++ b/snuba/admin/clickhouse/system_queries.py
@@ -24,9 +24,11 @@ def _run_sql_query_on_host(
     Run the SQL query. It should be validated before getting to this point
     """
     if storage_name == "querylog":
-        # we want to be able to change settings for the querylog which
-        # requires readonly: 2 so we must use QUERY_AND_SETTINGS
-        settings = ClickhouseClientSettings.QUERY_AND_SETTINGS
+        # querylog readonly user profile has readonly=2 set, but if you try
+        # and set readonly=2 as part of the request this will error since
+        # clickhouse doesn't let you set readonly setting if readonly=2 in
+        # the current settings https://github.com/ClickHouse/ClickHouse/blob/20.7/src/Access/SettingsConstraints.cpp#L243-L249
+        settings = ClickhouseClientSettings.QUERYLOG
     else:
         settings = ClickhouseClientSettings.QUERY
 

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -10,7 +10,7 @@ def run_query_and_get_trace(storage_name: str, query: str) -> ClickhouseResult:
     validate_ro_query(query)
 
     connection = get_ro_query_node_connection(
-        storage_name, ClickhouseClientSettings.QUERY_AND_SETTINGS
+        storage_name, ClickhouseClientSettings.TRACING
     )
     query_result = connection.execute(query=query, capture_trace=True)
     return query_result

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -61,6 +61,7 @@ class ClickhouseClientSettings(Enum):
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
     QUERY_AND_SETTINGS = ClickhouseClientSettingsType({"readonly": 2}, None)
+    TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(
         {
             # Replacing existing rows requires reconstructing the entire tuple

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -60,7 +60,7 @@ class ClickhouseClientSettings(Enum):
     )
     OPTIMIZE = ClickhouseClientSettingsType({}, settings.OPTIMIZE_QUERY_TIMEOUT)
     QUERY = ClickhouseClientSettingsType({"readonly": 1}, None)
-    QUERY_AND_SETTINGS = ClickhouseClientSettingsType({"readonly": 2}, None)
+    QUERYLOG = ClickhouseClientSettingsType({}, None)
     TRACING = ClickhouseClientSettingsType({"readonly": 2}, None)
     REPLACE = ClickhouseClientSettingsType(
         {


### PR DESCRIPTION
So cabin doesn't actually have the `trace_readonly` user which makes https://github.com/getsentry/snuba/pull/3847 wrong. 

~However, I think we should be able to use the same user and just change the settings (to be `readonly=2` for the querylog)~
Actually that might still cause issues due to https://github.com/ClickHouse/ClickHouse/blob/20.7/src/Access/SettingsConstraints.cpp#L243-L249 so I'm actually removing it for the querylog together, the settings will just be empty
