### PR TITLE
feat(tx_processor): write replay_id as top level column

### DIFF
--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -50,6 +50,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         "sentry:release",
         "sentry:user",
         "sentry:dist",
+        "replay_id",
     }
 
     def __extract_timestamp(self, field: int) -> Tuple[datetime, int]:
@@ -157,6 +158,16 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         )
         processed["environment"] = promoted_tags.get("environment")
         processed["user"] = promoted_tags.get("sentry:user", "")
+
+        replay_id = promoted_tags.get("replay_id")
+        if replay_id:
+            try:
+                processed["replay_id"] = str(uuid.UUID(replay_id))
+            except ValueError:
+                # replay_id as a tag is not guarenteed to be UUID (user could set value in theory)
+                # so simply continue if not UUID.
+                pass
+
         processed["dist"] = _unicodify(
             promoted_tags.get("sentry:dist", event_dict["data"].get("dist")),
         )
@@ -258,6 +269,18 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
             profile_id = profile_context.get("profile_id")
             if profile_id is not None:
                 processed["profile_id"] = str(uuid.UUID(profile_id))
+
+        replay_context = contexts.get("replay")
+        if replay_context is not None:
+            replay_id = replay_context.get("replay_id")
+            if replay_id is not None:
+                replay_id_uuid = uuid.UUID(replay_id)
+
+                processed["replay_id"] = str(replay_id_uuid)
+                # remove this after 90 days or we shift query conditions based on timestamp
+                processed["tags.key"].append("replay_id")
+                # the tag value should not have dashes in it so we use .hex
+                processed["tags.value"].append(replay_id_uuid.hex)
 
         sanitized_contexts = self._sanitize_contexts(processed, event_dict)
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(
@@ -402,10 +425,12 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         if app_ctx is not None:
             app_ctx.pop("start_type", None)
 
-        # The profile_id is promoted as a column, so no need to store it
+        # The profile_id and replay_id are promoted as columns, so no need to store them
         # again in the context array
         profile_ctx = sanitized_context.get("profile", {})
         profile_ctx.pop("profile_id", None)
+        replay_ctx = sanitized_context.get("replay", {})
+        replay_ctx.pop("replay_id", None)
 
         skipped_contexts = settings.TRANSACT_SKIP_CONTEXT_STORE.get(
             processed["project_id"], set()

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -50,7 +50,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         "sentry:release",
         "sentry:user",
         "sentry:dist",
-        "replay_id",
+        "replayId",
     }
 
     def __extract_timestamp(self, field: int) -> Tuple[datetime, int]:
@@ -159,7 +159,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         processed["environment"] = promoted_tags.get("environment")
         processed["user"] = promoted_tags.get("sentry:user", "")
 
-        replay_id = promoted_tags.get("replay_id")
+        replay_id = promoted_tags.get("replayId")
         if replay_id:
             try:
                 processed["replay_id"] = str(uuid.UUID(replay_id))
@@ -275,12 +275,13 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
             replay_id = replay_context.get("replay_id")
             if replay_id is not None:
                 replay_id_uuid = uuid.UUID(replay_id)
-
                 processed["replay_id"] = str(replay_id_uuid)
+
                 # remove this after 90 days or we shift query conditions based on timestamp
-                processed["tags.key"].append("replay_id")
-                # the tag value should not have dashes in it so we use .hex
-                processed["tags.value"].append(replay_id_uuid.hex)
+                if "replayId" not in processed["tags.key"]:
+                    processed["tags.key"].append("replayId")
+                    # the tag value should not have dashes in it so we use .hex
+                    processed["tags.value"].append(replay_id_uuid.hex)
 
         sanitized_contexts = self._sanitize_contexts(processed, event_dict)
         processed["contexts.key"], processed["contexts.value"] = extract_extra_contexts(

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -42,6 +42,7 @@ class TransactionEvent:
     app_start_type: str = "warm"
     has_app_ctx: bool = True
     profile_id: Optional[str] = None
+    replay_id: Optional[str] = None
 
     def get_app_context(self) -> Optional[Mapping[str, str]]:
         if self.has_app_ctx:
@@ -53,6 +54,11 @@ class TransactionEvent:
         if self.profile_id is None:
             return None
         return {"profile_id": self.profile_id}
+
+    def get_replay_context(self) -> Optional[Mapping[str, str]]:
+        if self.replay_id is None:
+            return None
+        return {"replay_id": self.replay_id}
 
     def serialize(self) -> Tuple[int, str, Mapping[str, Any]]:
         return (
@@ -153,6 +159,7 @@ class TransactionEvent:
                         "app": self.get_app_context(),
                         "experiments": {"test1": 1, "test2": 2},
                         "profile": self.get_profile_context(),
+                        "replay": self.get_replay_context(),
                     },
                     "tags": [
                         ["sentry:release", self.release],
@@ -266,6 +273,10 @@ class TransactionEvent:
 
         if self.profile_id is not None:
             ret["profile_id"] = str(uuid.UUID(self.profile_id))
+        if self.replay_id is not None:
+            ret["replay_id"] = str(uuid.UUID(self.replay_id))
+            ret["tags.key"].append("replay_id")
+            ret["tags.value"].append(self.replay_id)
 
         return ret
 
@@ -304,6 +315,7 @@ class TestTransactionsProcessor:
             geo={"country_code": "XY", "region": "fake_region", "city": "fake_city"},
             transaction_source="url",
             profile_id="046852d24483455c8c44f0c8fbf496f9",
+            replay_id="d2731f8ed8934c6fa5253e450915aa12",
         )
 
     def test_skip_non_transactions(self) -> None:
@@ -412,3 +424,34 @@ class TestTransactionsProcessor:
             message.serialize(), meta
         ) == InsertBatch([message.build_result(meta)], None)
         settings.TRANSACT_SKIP_CONTEXT_STORE = old_skip_context
+
+    def test_replay_id_as_tag(self) -> None:
+        settings.TRANSACT_SKIP_CONTEXT_STORE = {1: {"experiments"}}
+
+        message = self.__get_transaction_event()
+        payload = message.serialize()
+        # replays will only ever have the context set, or the tag set, not both
+        # this will be guarenteed on the sdk / relay
+
+        # regardless, we should write both the tag and the top level field
+
+        payload[2]["data"]["tags"].append(
+            ["replay_id", "d2731f8ed8934c6fa5253e450915aa12"]
+        )
+        del payload[2]["data"]["contexts"]["replay"]
+
+        meta = KafkaMessageMetadata(
+            offset=1, partition=2, timestamp=datetime(1970, 1, 1)
+        )
+        result = message.build_result(meta)
+
+        # when the replay_id is sent as a tag instead of a context,
+        # the order in which it's placed in the tags list is different
+        result["tags.key"].remove("replay_id")
+        result["tags.value"].remove("d2731f8ed8934c6fa5253e450915aa12")
+        result["tags.key"].insert(1, "replay_id")
+        result["tags.value"].insert(1, "d2731f8ed8934c6fa5253e450915aa12")
+
+        assert TransactionsMessageProcessor().process_message(
+            payload, meta
+        ) == InsertBatch([result], None)


### PR DESCRIPTION
We're deprecating sending replay_id as a tag (https://github.com/getsentry/rfcs/blob/rfc/escalating-issues/text/0048-move-replayid-out-of-tags.md)

This PR modifies the transactions processor to:

- [x] if the replay_id is sent as a tag (replayId), then set the top level value on the processed dict so the replay_id column is written.
    - [x] ensure the replay_id is a valid UUID before setting the top level value, as current replayId tags are not validated
- [x] if the replay_id is sent as a context, then set the top level value, and write it as a tag as well

we can remove the dual writing once we conditionally query on the new column based on date and only write the column



Task: https://github.com/getsentry/team-replay/issues/32
Epic: https://github.com/getsentry/replay-backend/issues/248

Relies on a change to relay to validate the replay context, which i'll be putting up shortly.



