### PR TITLE
feat: Share Python settings with Rust and add Rust consumer entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ snuba.egg-info/
 node_modules
 .vscode/*.log
 snuba/admin/dist/bundle.js*
+tmp/

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -9,7 +9,7 @@ members = ["rust_arroyo"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]
-name = "querylog_consumer"
+name = "consumer"
 path = "src/bin/consumer/querylog_consumer.rs"
 
 [dependencies]

--- a/snuba/cli/optimize.py
+++ b/snuba/cli/optimize.py
@@ -98,7 +98,7 @@ def optimize(
     )
 
     # add 1 hour to make the redis TTL past the optimize job cuttoff time
-    cutoff_time = last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
+    cutoff_time = last_midnight + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
     redis_expire_time = cutoff_time + timedelta(hours=1)
     logger.info(f"Cutoff time: {str(cutoff_time)}")
     logger.info(f"redis_expire_time time: {str(redis_expire_time)}")

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -1,0 +1,31 @@
+import os
+
+import click
+
+from snuba.datasets.storages.factory import get_writable_storage_keys
+from snuba.settings.utils import write_settings_to_json
+
+RUST_ENVIRONMENT = os.environ.get("RUST_ENVIRONMENT", "debug")
+RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
+
+
+@click.command()
+@click.option(
+    "--storage",
+    "storage_name",
+    type=click.Choice(
+        [storage_key.value for storage_key in get_writable_storage_keys()]
+    ),
+    help="The storage to target",
+    required=True,
+)
+def rust_consumer(
+    *,
+    storage_name: str,
+) -> None:
+    """
+    Experimental alternative to`snuba consumer`
+    """
+    settings_path = write_settings_to_json()
+
+    os.execv(RUST_PATH, ["--storage", storage_name, "--settings-path", settings_path])

--- a/snuba/clickhouse/optimize/optimize_scheduler.py
+++ b/snuba/clickhouse/optimize/optimize_scheduler.py
@@ -45,14 +45,14 @@ class OptimizeScheduler:
         self.__last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
             hour=0, minute=0, second=0, microsecond=0
         )
-        self.__parallel_start_time = (
-            self.__last_midnight + settings.PARALLEL_OPTIMIZE_JOB_START_TIME
+        self.__parallel_start_time = self.__last_midnight + timedelta(
+            hours=settings.PARALLEL_OPTIMIZE_JOB_START_TIME
         )
-        self.__parallel_end_time = (
-            self.__last_midnight + settings.PARALLEL_OPTIMIZE_JOB_END_TIME
+        self.__parallel_end_time = self.__last_midnight + timedelta(
+            hours=settings.PARALLEL_OPTIMIZE_JOB_END_TIME
         )
-        self.__full_job_end_time = (
-            self.__last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME
+        self.__full_job_end_time = self.__last_midnight + timedelta(
+            hours=settings.OPTIMIZE_JOB_CUTOFF_TIME
         )
 
     @staticmethod
@@ -122,7 +122,8 @@ class OptimizeScheduler:
         if self.__parallel == 1:
             return OptimizationSchedule(
                 partitions=[self.sort_partitions(partitions)],
-                cutoff_time=self.__last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME,
+                cutoff_time=self.__last_midnight
+                + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME),
             )
         else:
             if current_time < self.__parallel_start_time:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from datetime import timedelta
 from pathlib import Path
 from typing import (
     Any,
@@ -12,10 +11,16 @@ from typing import (
     Set,
     Tuple,
     TypedDict,
-    TypeVar,
 )
 
 from snuba.settings.validation import validate_settings
+
+# All settings must be uppercased, have a default value and cannot start with _.
+# The Rust consumer relies on this to create a JSON file from the evaluated settings
+# upon startup with any variables in this module that conform to this format.
+# Similarly, variables that are not supposed to be settings for override/export should not
+# follow this convention otherwise they will be included in the JSON.
+# Sets will be converted to arrays.
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
 LOG_FORMAT = "%(asctime)s %(message)s"
@@ -134,8 +139,6 @@ REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD")
 REDIS_DB = int(os.environ.get("REDIS_DB", 1))
 REDIS_INIT_MAX_RETRIES = 3
 REDIS_REINITIALIZE_STEPS = 10
-
-T = TypeVar("T")
 
 
 class RedisClusters(TypedDict):
@@ -302,17 +305,17 @@ ENABLE_ISSUE_OCCURRENCE_CONSUMER = os.environ.get(
 
 MAX_ROWS_TO_CHECK_FOR_SIMILARITY = 1000
 
-# Start time from UTC 00:00:00 after which we are allowed to run optimize
-# jobs in parallel.
-PARALLEL_OPTIMIZE_JOB_START_TIME = timedelta(hours=0)
+# Start time in hours from UTC 00:00:00 after which we are allowed to run
+# optimize jobs in parallel.
+PARALLEL_OPTIMIZE_JOB_START_TIME = 0
 
 # Cutoff time from UTC 00:00:00 to stop running optimize jobs in
 # parallel to avoid running in parallel when peak traffic starts.
-PARALLEL_OPTIMIZE_JOB_END_TIME = timedelta(hours=9)
+PARALLEL_OPTIMIZE_JOB_END_TIME = 9
 
 # Cutoff time from UTC 00:00:00 to stop running optimize jobs to
 # avoid spilling over to the next day.
-OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
+OPTIMIZE_JOB_CUTOFF_TIME = 23
 OPTIMIZE_QUERY_TIMEOUT = 4 * 60 * 60  # 4 hours
 # sleep time to wait for a merge to complete
 OPTIMIZE_BASE_SLEEP_TIME = 300  # 5 mins
@@ -335,7 +338,7 @@ ENTITY_CONFIG_FILES_GLOB = f"{CONFIG_FILES_PATH}/**/entities/*.yaml"
 DATASET_CONFIG_FILES_GLOB = f"{CONFIG_FILES_PATH}/**/dataset.yaml"
 
 # Counter utility class window size in minutes
-COUNTER_WINDOW_SIZE = timedelta(minutes=10)
+COUNTER_WINDOW_SIZE_MINUTES = 10
 
 
 # Slicing Configuration

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -1,5 +1,4 @@
 import os
-from datetime import timedelta
 from typing import Set
 
 TESTING = True
@@ -29,7 +28,7 @@ REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms
 ENFORCE_RETENTION = True
 
 # Ignore optimize job cut off time for tests
-OPTIMIZE_JOB_CUTOFF_TIME = timedelta(days=1)
+OPTIMIZE_JOB_CUTOFF_TIME = 24
 
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 0
 

--- a/snuba/settings/utils.py
+++ b/snuba/settings/utils.py
@@ -1,0 +1,50 @@
+import json
+import os
+from typing import Any, MutableMapping
+
+from snuba import settings
+
+
+def write_settings_to_json() -> str:
+    """
+    Write settings to json file, return the file path.
+    """
+    settings_json = get_settings_json()
+
+    tmp_dir = os.path.join(settings.ROOT_REPO_PATH, "tmp")
+    file_path = os.path.join(tmp_dir, "settings.json")
+
+    if not os.path.exists(tmp_dir):
+        os.makedirs(tmp_dir)
+
+    with open(file_path, "w") as f:
+        f.write(settings_json)
+
+    return file_path
+
+
+def get_settings_json() -> str:
+    settings_vars = [
+        setting for setting in dir(settings) if is_settings_variable(setting)
+    ]
+
+    settings_json: MutableMapping[str, Any] = {}
+
+    for setting in settings_vars:
+        settings_json[setting] = getattr(settings, setting)
+
+    return json.dumps(settings_json, indent=4, cls=SetEncoder)
+
+
+def is_settings_variable(name: str) -> bool:
+    if name.startswith("_"):
+        return False
+
+    return name.upper() == name
+
+
+class SetEncoder(json.JSONEncoder):
+    def default(self, obj: Any) -> Any:
+        if isinstance(obj, set):
+            return list(obj)
+        return json.JSONEncoder.default(self, obj)

--- a/snuba/utils/bucket_timer.py
+++ b/snuba/utils/bucket_timer.py
@@ -34,12 +34,14 @@ class Bucket:
 
 Buckets = MutableMapping[datetime, MutableMapping[int, timedelta]]
 
+COUNTER_WINDOW_SIZE = timedelta(minutes=settings.COUNTER_WINDOW_SIZE_MINUTES)
+
 
 class Counter:
     """
     The Counter class is used to track time spent on some activity (e.g. processing a replacement) for a project.
     To accomplish this, the `record_time_spent()` function captures some processing time range and splits it by a per
-    minute resolution (Bucket). The buckets older than settings.COUNTER_WINDOW_SIZE are trimmed. Finally, the `get_bucket_totals_exceeding_limit()`
+    minute resolution (Bucket). The buckets older than COUNTER_WINDOW_SIZE are trimmed. Finally, the `get_bucket_totals_exceeding_limit()`
     function returns all project ids who's total processing time has exceeded self.limit.
     """
 
@@ -49,11 +51,11 @@ class Counter:
 
         percentage = state.get_config("project_quota_time_percentage", 1.0)
         assert isinstance(percentage, float)
-        self.limit = settings.COUNTER_WINDOW_SIZE * percentage
+        self.limit = COUNTER_WINDOW_SIZE * percentage
 
     def __trim_expired_buckets(self, now: datetime) -> None:
         current_minute = floor_minute(now)
-        window_start = current_minute - settings.COUNTER_WINDOW_SIZE
+        window_start = current_minute - COUNTER_WINDOW_SIZE
         new_buckets: Buckets = {}
         for min, dict in self.buckets.items():
             if min >= window_start:

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -259,7 +259,9 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     tracker.update_all_partitions([dummy_partition])
 
     with freeze_time(
-        last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(minutes=15)
+        last_midnight
+        + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
+        + timedelta(minutes=15)
     ):
         scheduler = OptimizeScheduler(2)
         with pytest.raises(OptimizedSchedulerTimeout):

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -99,7 +99,7 @@ test_data = [
             None,
         ),
         last_midnight
-        + settings.PARALLEL_OPTIMIZE_JOB_START_TIME
+        + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_START_TIME)
         + timedelta(minutes=30),
         id="transactions parallel",
     ),
@@ -239,7 +239,7 @@ def test_optimize_partitions_raises_exception_with_cutoff_time() -> None:
     Tests that a JobTimeoutException is raised when a cutoff time is reached.
     """
     prev_job_cutoff_time = settings.OPTIMIZE_JOB_CUTOFF_TIME
-    settings.OPTIMIZE_JOB_CUTOFF_TIME = timedelta(hours=23)
+    settings.OPTIMIZE_JOB_CUTOFF_TIME = 23
     storage = get_writable_storage(StorageKey.ERRORS)
     cluster = storage.get_cluster()
     clickhouse_pool = cluster.get_query_connection(ClickhouseClientSettings.OPTIMIZE)

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -63,7 +63,7 @@ test_data = [
             None,
         ),
         last_midnight
-        + settings.PARALLEL_OPTIMIZE_JOB_START_TIME
+        + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_START_TIME)
         + timedelta(minutes=30),
         id="errors parallel",
     ),

--- a/tests/clickhouse/optimize/test_optimize_scheduler.py
+++ b/tests/clickhouse/optimize/test_optimize_scheduler.py
@@ -185,7 +185,7 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
                         "(90,'2022-06-08')",
                     ]
                 ],
-                last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME,
+                last_midnight + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME),
             ),
             id="non parallel",
         ),
@@ -198,7 +198,7 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
                 "(90,'2022-06-27')",
             ],
             last_midnight
-            + settings.PARALLEL_OPTIMIZE_JOB_START_TIME
+            + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_START_TIME)
             - timedelta(minutes=30),
             OptimizationSchedule(
                 [
@@ -209,7 +209,8 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
                         "(30,'2022-06-08')",
                     ]
                 ],
-                last_midnight + settings.PARALLEL_OPTIMIZE_JOB_START_TIME,
+                last_midnight
+                + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_START_TIME),
             ),
             id="parallel before parallel start",
         ),
@@ -217,11 +218,12 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
             2,
             ["(90,'2022-03-28')", "(90,'2022-03-21')"],
             last_midnight
-            + settings.PARALLEL_OPTIMIZE_JOB_END_TIME
+            + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_END_TIME)
             - timedelta(minutes=30),
             OptimizationSchedule(
                 [["(90,'2022-03-28')"], ["(90,'2022-03-21')"]],
-                last_midnight + settings.PARALLEL_OPTIMIZE_JOB_END_TIME,
+                last_midnight
+                + timedelta(hours=settings.PARALLEL_OPTIMIZE_JOB_END_TIME),
                 [0, settings.OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES],
             ),
             id="parallel before parallel end",
@@ -229,10 +231,12 @@ last_midnight = (datetime.now() + timedelta(minutes=10)).replace(
         pytest.param(
             2,
             ["(90,'2022-03-28')", "(90,'2022-03-21')"],
-            last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME - timedelta(minutes=30),
+            last_midnight
+            + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
+            - timedelta(minutes=30),
             OptimizationSchedule(
                 [["(90,'2022-03-28')", "(90,'2022-03-21')"]],
-                last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME,
+                last_midnight + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME),
             ),
             id="parallel before final cutoff",
         ),
@@ -253,7 +257,9 @@ def test_get_next_schedule(
 def test_get_next_schedule_raises_exception() -> None:
     optimize_scheduler = OptimizeScheduler(parallel=1)
     with freeze_time(
-        last_midnight + settings.OPTIMIZE_JOB_CUTOFF_TIME + timedelta(minutes=20)
+        last_midnight
+        + timedelta(hours=settings.OPTIMIZE_JOB_CUTOFF_TIME)
+        + timedelta(minutes=20)
     ):
         with pytest.raises(OptimizedSchedulerTimeout):
             optimize_scheduler.get_next_schedule(

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 from copy import deepcopy
 from typing import Any, Dict
 from unittest.mock import patch
@@ -7,6 +8,7 @@ import pytest
 
 from snuba import settings
 from snuba.settings import validation
+from snuba.settings.utils import get_settings_json
 from snuba.settings.validation import (
     InvalidTopicError,
     validate_settings,
@@ -127,3 +129,15 @@ def test_validation_catches_unmapped_topic_pair() -> None:
         validate_slicing_settings(all_settings)
 
     del sliced_topics[("events", 1)]
+
+
+def test_json_serializable() -> None:
+    # Settings file can be serialized
+    settings_json = get_settings_json()
+
+    # Convert json back to python object
+    settings_py = json.loads(settings_json)
+
+    assert settings_py["TESTING"] == True
+    # Set got turned to a list
+    assert settings_py["PROJECT_STACKTRACE_BLACKLIST"] == []


### PR DESCRIPTION
Alt to https://github.com/getsentry/snuba/pull/3802

I prefer this approach at least in the short term as it keeps the settings in Rust aligned with the Python version. It requires more minimal changes to the Python settings than the other option: only that the timedelta types need to change as these are not easily json serializable. Whether Python settings should ultimately move to yaml is a larger, more consequential topic - let's not try to solve it within the Rust consumer prototype.

The Rust consumer entrypoint loads the Python settings, writes the json file and replaces the current process with the Rust program passing the path to the JSON file through to the Rust consumer.
