### PR TITLE
feat(Querylog): Organization ID from `tenant_ids`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.7.1
-sentry-kafka-schemas==0.0.6
+sentry-kafka-schemas==0.0.8
 sentry-relay==0.8.19
 sentry-sdk==1.16.0
 simplejson==3.17.6

--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -156,9 +156,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
             "referrer": message["request"]["referrer"] or "",
             "dataset": message["dataset"],
             "projects": message.get("projects") or [],
-            # TODO: This column is empty for now, we plan to use it soon as we
-            # will start to write org IDs into events and allow querying by org.
-            "organization": None,
+            "organization": message.get("organization"),
             **self.__extract_query_list(message["query_list"]),
         }
         self._remove_invalid_data(processed)

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -224,7 +224,7 @@ class SnubaQueryMetadata:
     def to_dict(self) -> Dict[str, Any]:
         start = int(self.start_timestamp.timestamp()) if self.start_timestamp else None
         end = int(self.end_timestamp.timestamp()) if self.end_timestamp else None
-        return {
+        request_dict = {
             "request": {
                 "id": self.request.id,
                 "body": self.request.original_body,
@@ -245,6 +245,11 @@ class SnubaQueryMetadata:
             "projects": list(self.projects),
             "snql_anonymized": self.snql_anonymized,
         }
+
+        if org_id := self.request.attribution_info.tenant_ids.get("organization_id"):
+            request_dict["organization"] = org_id
+
+        return request_dict
 
     @property
     def status(self) -> QueryStatus:


### PR DESCRIPTION
### Overview
- There currently exists an `organization` field in the Querylog schema which seemingly has no data in any Querylog entry
- We now have Org ID in each request for >90% (and growing) of requests coming from Sentry via `tenant_ids`

### Changes
- Updated the `record_query()` function to now pass in Org ID if it exists in the Snuba Request