### PR TITLE
feat(schemas): Partially type the data in querylog producer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.7.1
-sentry-kafka-schemas==0.0.6
+sentry-kafka-schemas==0.0.7
 sentry-relay==0.8.19
 sentry-sdk==1.16.0
 simplejson==3.17.6

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Mapping, MutableSequence, Optional, Set
+from typing import Any, Dict, MutableSequence, Optional, Set
 
 from clickhouse_driver.errors import ErrorCodes
+from sentry_kafka_schemas.schema_types import snuba_queries_v1
 
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.request import Request
@@ -135,7 +136,7 @@ class FilterProfile:
     # Filters on non optimized mapping columns like tags/contexts
     mapping_cols: Columnset
 
-    def to_dict(self) -> Mapping[str, Any]:
+    def to_dict(self) -> snuba_queries_v1.ClickhouseQueryProfileWhereProfile:
         return {
             "columns": sorted(self.columns),
             "mapping_cols": sorted(self.mapping_cols),
@@ -162,7 +163,7 @@ class ClickhouseQueryProfile:
     # Columns in arrayjoin statements
     array_join_cols: Columnset
 
-    def to_dict(self) -> Mapping[str, Any]:
+    def to_dict(self) -> snuba_queries_v1.ClickhouseQueryProfile:
         return {
             "time_range": self.time_range,
             "table": self.table,
@@ -180,14 +181,14 @@ class ClickhouseQueryMetadata:
     sql_anonymized: str
     start_timestamp: Optional[datetime]
     end_timestamp: Optional[datetime]
-    stats: Mapping[str, Any]
+    stats: Dict[str, Any]
     status: QueryStatus
     request_status: Status
     profile: ClickhouseQueryProfile
     trace_id: Optional[str] = None
-    result_profile: Optional[Mapping[str, Any]] = None
+    result_profile: Optional[Dict[str, Any]] = None
 
-    def to_dict(self) -> Mapping[str, Any]:
+    def to_dict(self) -> snuba_queries_v1.QueryMetadata:
         start = int(self.start_timestamp.timestamp()) if self.start_timestamp else None
         end = int(self.end_timestamp.timestamp()) if self.end_timestamp else None
         return {

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -6,7 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from hashlib import md5
 from threading import Lock
-from typing import Any, Mapping, MutableMapping, Optional, Union, cast
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Union, cast
 
 import rapidjson
 import sentry_sdk
@@ -102,13 +102,13 @@ def update_query_metadata_and_stats(
     query: Query,
     sql: str,
     timer: Timer,
-    stats: MutableMapping[str, Any],
+    stats: Dict[str, Any],
     query_metadata: SnubaQueryMetadata,
     query_settings: Mapping[str, Any],
     trace_id: Optional[str],
     status: QueryStatus,
     request_status: Status,
-    profile_data: Optional[Mapping[str, Any]] = None,
+    profile_data: Optional[Dict[str, Any]] = None,
     error_code: Optional[int] = None,
     triggered_rate_limiter: Optional[str] = None,
 ) -> MutableMapping[str, Any]:


### PR DESCRIPTION
It cannot be fully typed yet as schema is not correct. The SLO fields are marked as part of the `clickhouse_query` in the schema but are at the top level in the producer code.
