### PR TITLE
feat(rust-consumer): Forward Python Cli args to Rust

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -10,8 +10,11 @@ members = ["rust_arroyo"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [[bin]]
 name = "consumer"
-path = "src/bin/consumer/querylog_consumer.rs"
+path = "src/consumer.rs"
 
 [dependencies]
 rust_arroyo = { path = "./rust_arroyo" }
 tokio = { version = "1.19.2", features = ["full"] }
+clap = { version = "4.1.8", features = ["derive"] }
+log = "0.4"
+env_logger = "0.10.0"

--- a/rust_snuba/src/bin/consumer/querylog_consumer.rs
+++ b/rust_snuba/src/bin/consumer/querylog_consumer.rs
@@ -1,4 +1,0 @@
-#[tokio::main]
-async fn main() {
-    unimplemented!("hello!");
-}

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,0 +1,22 @@
+use clap::Parser;
+use log;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    storage: String,
+
+    #[arg(long)]
+    settings_path: String,
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let args = Args::parse();
+    log::warn!(
+        "Starting consumer for {} with settings at {}",
+        args.storage,
+        args.settings_path,
+    );
+}

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -19,13 +19,21 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
     help="The storage to target",
     required=True,
 )
-def rust_consumer(
-    *,
-    storage_name: str,
-) -> None:
+@click.option(
+    "--log-level",
+    "log_level",
+    type=click.Choice(["error", "warn", "info", "debug", "trace"]),
+    help="Logging level to use.",
+    default="error",
+)
+def rust_consumer(*, storage_name: str, log_level: str) -> None:
     """
     Experimental alternative to`snuba consumer`
     """
     settings_path = write_settings_to_json()
 
-    os.execv(RUST_PATH, ["--storage", storage_name, "--settings-path", settings_path])
+    os.execve(
+        RUST_PATH,
+        ["--", "--storage", storage_name, "--settings-path", settings_path],
+        {"RUST_LOG": log_level},
+    )


### PR DESCRIPTION
Add Rust consumer argument parsing. Add --log-level to the Python CLI and pass it to the Rust process.
