### PR TITLE
fix(issue-platform): map timestamp to receive_timestamp

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -72,7 +72,7 @@ storages:
             from_table_name:
             from_col_name: "timestamp"
             to_table_name:
-            to_col_name: "client_timestamp"
+            to_col_name: "receive_timestamp"
         - mapper: ColumnToColumn
           args:
             from_table_name:


### PR DESCRIPTION
Primary key on this table is actually `receive_timestamp` so we should be querying on `receive_timestamp` instead of `client_timestamp`.