### PR TITLE
feat(rust-consumer): Multistorage consumer

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -6,7 +6,7 @@ mod settings;
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long)]
-    storage: String,
+    storage: Vec<String>,
 
     #[arg(long)]
     settings_path: String,
@@ -17,7 +17,7 @@ async fn main() {
     env_logger::init();
     let args = Args::parse();
     log::info!(
-        "Starting consumer for {} with settings at {}",
+        "Starting consumer for {:?} with settings at {}",
         args.storage,
         args.settings_path,
     );

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -19,7 +19,7 @@ use rust_snuba::storages;
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long)]
-    storage: Vec<String>,
+    storages: Vec<String>,
 
     #[arg(long)]
     settings_path: String,
@@ -81,16 +81,20 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
 async fn main() {
     env_logger::init();
     let args = Args::parse();
+
+    // TODO: Support multiple storages
+    let first_storage = args.storages[0].clone();
+
     log::info!(
         "Starting consumer for {:?} with settings at {}",
-        args.storage,
+        first_storage,
         args.settings_path,
     );
     let settings = settings::Settings::load_from_json(&args.settings_path).unwrap();
     log::info!("Loaded settings: {settings:?}");
 
     let storage_registry = storages::StorageRegistry::load_all(&settings).unwrap();
-    let storage = storage_registry.get(&args.storage).unwrap();
+    let storage = storage_registry.get(&first_storage).unwrap();
 
     struct ConsumerStrategyFactory {
         config: KafkaConfig,

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -1,4 +1,5 @@
 import os
+from typing import Sequence
 
 import click
 
@@ -12,11 +13,12 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
 @click.command()
 @click.option(
     "--storage",
-    "storage_name",
+    "storage_names",
     type=click.Choice(
         [storage_key.value for storage_key in get_writable_storage_keys()]
     ),
     help="The storage to target",
+    multiple=True,
     required=True,
 )
 @click.option(
@@ -26,14 +28,19 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
     help="Logging level to use.",
     default="error",
 )
-def rust_consumer(*, storage_name: str, log_level: str) -> None:
+def rust_consumer(*, storage_names: Sequence[str], log_level: str) -> None:
     """
     Experimental alternative to`snuba consumer`
     """
     settings_path = write_settings_to_json()
 
+    rust_consumer_args = ["--", "--settings-path", settings_path]
+
+    for storage_name in storage_names:
+        rust_consumer_args.extend(["--storage", storage_name])
+
     os.execve(
         RUST_PATH,
-        ["--", "--storage", storage_name, "--settings-path", settings_path],
+        rust_consumer_args,
         {"RUST_LOG": log_level},
     )


### PR DESCRIPTION
In Python we have separate consumer and multistorage consumer implementations. Since there is a lot of divergence between them, bringing them together has been a long and ongoing process. In Rust, we only want to support one implementation.

