### PR TITLE
wip: Scaffolding for generic Rust consumer

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -13,10 +13,14 @@ name = "consumer"
 path = "src/consumer.rs"
 
 [dependencies]
+anyhow = "1.0.69"
+clap = { version = "4.1.8", features = ["std", "derive"], default_features = false }
 rust_arroyo = { path = "./rust_arroyo" }
+serde_yaml = "0.9.19"
 tokio = { version = "1.19.2", features = ["full"] }
-clap = { version = "4.1.8", features = ["derive"] }
 log = "0.4"
 env_logger = "0.10.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0" }
+glob = "0.3.1"
+pyo3 = { version = "0.18.1", features = ["auto-initialize"] }

--- a/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/config.rs
@@ -13,10 +13,14 @@ impl KafkaConfig {
     ) -> Self {
         let mut config_map = HashMap::new();
         config_map.insert("bootstrap.servers".to_string(), bootstrap_servers.join(","));
-
         let config = Self { config_map };
-
         apply_override_params(config, override_params)
+    }
+
+    pub fn new_config_from_raw(override_params: HashMap<String, String>) -> Self {
+        let mut config_map = HashMap::new();
+        let config = Self { config_map };
+        apply_override_params(config, Some(override_params))
     }
 
     pub fn new_consumer_config(

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,7 +1,8 @@
 use clap::Parser;
 use log;
 
-mod settings;
+use rust_snuba::settings;
+use rust_snuba::storages;
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -22,5 +23,8 @@ async fn main() {
         args.settings_path,
     );
     let settings = settings::Settings::load_from_json(&args.settings_path).unwrap();
-    log::info!("Loaded settings: {:?}", settings);
+    log::info!("Loaded settings: {settings:?}");
+
+    let storage_registry = storages::StorageRegistry::load_all(&settings).unwrap();
+    let storage = storage_registry.get(&args.storage);
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,6 +1,18 @@
 use clap::Parser;
 use log;
 
+use rust_arroyo::backends::kafka::config::KafkaConfig;
+use rust_arroyo::backends::kafka::producer::KafkaProducer;
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::backends::kafka::KafkaConsumer;
+use rust_arroyo::processing::strategies::transform::Transform;
+use rust_arroyo::processing::strategies::{
+    CommitRequest, MessageRejected, ProcessingStrategy, ProcessingStrategyFactory, InvalidMessage,
+};
+use rust_arroyo::processing::StreamProcessor;
+use rust_arroyo::types::{Message, Topic, TopicOrPartition};
+use std::time::Duration;
+
 use rust_snuba::settings;
 use rust_snuba::storages;
 
@@ -11,6 +23,58 @@ struct Args {
 
     #[arg(long)]
     settings_path: String,
+}
+
+struct Noop {}
+impl<T> ProcessingStrategy<T> for Noop where T: Clone {
+    fn poll(&mut self) -> Option<CommitRequest> {
+        None
+    }
+    fn submit(&mut self, _message: Message<T>) -> Result<(), MessageRejected> {
+        Ok(())
+    }
+    fn close(&mut self) {}
+    fn terminate(&mut self) {}
+    fn join(&mut self, _timeout: Option<Duration>) -> Option<CommitRequest> {
+        None
+    }
+}
+
+#[derive(Clone)]
+struct ClickhouseInsert {}
+
+struct PythonTransformStep {
+    pub next_step: Box<dyn ProcessingStrategy<ClickhouseInsert>>,
+}
+
+impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
+    fn poll(&mut self) -> Option<CommitRequest> {
+        self.next_step.poll()
+    }
+
+    fn submit(&mut self, message: Message<KafkaPayload>) -> Result<(), MessageRejected> {
+        log::info!("processing message");
+        let transformed = ClickhouseInsert {};
+
+        self.next_step.submit(Message {
+            partition: message.partition,
+            offset: message.offset,
+            payload: transformed,
+            timestamp: message.timestamp,
+        })
+    }
+
+    fn close(&mut self) {
+        self.next_step.close()
+    }
+
+    fn terminate(&mut self) {
+        self.next_step.terminate()
+    }
+
+    fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
+        self.next_step.join(timeout)
+    }
 }
 
 #[tokio::main]
@@ -26,5 +90,35 @@ async fn main() {
     log::info!("Loaded settings: {settings:?}");
 
     let storage_registry = storages::StorageRegistry::load_all(&settings).unwrap();
-    let storage = storage_registry.get(&args.storage);
+    let storage = storage_registry.get(&args.storage).unwrap();
+
+    struct ConsumerStrategyFactory {
+        config: KafkaConfig,
+    }
+    impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
+        fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+            let transform_step = PythonTransformStep {
+                next_step: Box::new(Noop {}),
+            };
+            Box::new(transform_step)
+        }
+    }
+
+    let broker_config = settings.get_broker_config(&storage.stream_loader.default_topic)
+        .iter()
+        .filter_map(|(k, v)| Some((k.to_owned(), v.as_ref()?.to_owned())))
+        .collect();
+    let config = KafkaConfig::new_config_from_raw(broker_config);
+
+    let consumer = Box::new(KafkaConsumer::new(config.clone()));
+    let mut processor = StreamProcessor::new(
+        consumer,
+        Box::new(ConsumerStrategyFactory { config })
+    );
+
+    processor.subscribe(Topic {
+        name: settings.kafka_topic_map.get(&storage.stream_loader.default_topic).unwrap_or(&storage.stream_loader.default_topic).to_owned(),
+    });
+
+    processor.run().unwrap();
 }

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod settings;
+pub mod storages;

--- a/rust_snuba/src/settings.rs
+++ b/rust_snuba/src/settings.rs
@@ -19,6 +19,7 @@ pub struct Settings {
     pub clusters: Vec<Cluster>,
     pub broker_config: HashMap<String, Option<String>>,
     pub config_files_path: String,
+    pub storage_config_files_glob: String,
 }
 
 impl Settings {

--- a/rust_snuba/src/settings.rs
+++ b/rust_snuba/src/settings.rs
@@ -17,15 +17,23 @@ pub struct Cluster {
 #[serde(rename_all = "UPPERCASE")]
 pub struct Settings {
     pub clusters: Vec<Cluster>,
-    pub broker_config: HashMap<String, Option<String>>,
+    pub broker_config: BrokerConfig,
+    pub kafka_broker_config: HashMap<String, BrokerConfig>,
     pub config_files_path: String,
     pub storage_config_files_glob: String,
+    pub kafka_topic_map: HashMap<String, String>,
 }
+
+pub type BrokerConfig = HashMap<String, Option<String>>;
 
 impl Settings {
     pub fn load_from_json(path: &str) -> Result<Self, Box<dyn std::error::Error>> {
         let f = File::open(path)?;
         let d: Settings = serde_json::from_reader(f)?;
         Ok(d)
+    }
+
+    pub fn get_broker_config(&self, topic: &str) -> &BrokerConfig {
+        self.kafka_broker_config.get(topic).unwrap_or(&self.broker_config)
     }
 }

--- a/rust_snuba/src/storages.rs
+++ b/rust_snuba/src/storages.rs
@@ -1,0 +1,80 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+
+use crate::settings::{Settings};
+
+use serde::Deserialize;
+use anyhow::{Error, bail, Context};
+
+#[derive(Deserialize)]
+#[serde(tag = "kind")]
+pub enum StorageConfig {
+    #[serde(rename = "readable_storage")]
+    ReadableStorage {},
+    #[serde(rename = "cdc_storage")]
+    CdcStorage {},
+    #[serde(rename = "writable_storage")]
+    WritableStorage(WritableStorageConfig)
+}
+
+#[derive(Deserialize)]
+pub struct WritableStorageConfig {
+    pub name: String,
+    pub stream_loader: StreamLoaderConfig,
+    pub schema: SchemaConfig,
+    #[serde(default)]
+    pub writer_options: WriterOptions,
+}
+
+#[derive(Deserialize, Default)]
+#[serde(default)]
+pub struct WriterOptions {
+    pub input_format_skip_unknown_fields: u8,
+}
+
+#[derive(Deserialize)]
+pub struct SchemaConfig {
+    pub local_table_name: String,
+    pub dist_table_name: String,
+}
+
+#[derive(Deserialize)]
+pub struct StreamLoaderConfig {
+    pub processor: ProcessorConfig,
+    pub default_topic: String,
+}
+
+#[derive(Deserialize)]
+pub struct ProcessorConfig {
+    name: String
+}
+
+pub struct StorageRegistry {
+    storages: BTreeMap<String, WritableStorageConfig>,
+}
+
+impl StorageRegistry {
+    pub fn load_all(settings: &Settings) -> Result<StorageRegistry, Error> {
+        let mut rv = StorageRegistry {
+            storages: BTreeMap::new()
+        };
+
+        for entry in glob::glob(&settings.storage_config_files_glob)? {
+            let entry = entry?;
+            let file = File::open(entry.as_path()).with_context(|| format!("Failed to load file {entry:?}"))?;
+            let storage: StorageConfig = serde_yaml::from_reader(file).with_context(|| format!("Failed to load file {entry:?}"))?;
+
+            if let StorageConfig::WritableStorage(writable_storage) = storage {
+                if let Some(other_storage) = rv.storages.insert(writable_storage.name.clone(), writable_storage) {
+                    bail!("Duplicate storage {}", other_storage.name);
+                }
+            }
+        }
+
+        Ok(rv)
+    }
+
+    pub fn get(&self, key: &str) -> Option<&WritableStorageConfig> {
+        self.storages.get(key)
+    }
+}

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -24,7 +24,7 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
     "log_level",
     type=click.Choice(["error", "warn", "info", "debug", "trace"]),
     help="Logging level to use.",
-    default="error",
+    default="info",
 )
 def rust_consumer(*, storage_name: str, log_level: str) -> None:
     """

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -47,6 +47,16 @@ def rust_consumer(*, storage_name: str, log_level: str) -> None:
     # ideally the config passed to rust would contain physical topic name, the
     # right kafka broker config and clickhouse cluster to use, and nothing
     # else.
+    #
+    # there is an argument for keeping it as-is, and that is if we need to read
+    # the storage yaml at compile-time, to do code generation. It might be
+    # necessary if we want to define import paths for Rust message processors
+    # in yaml, e.g.:
+    #
+    # stream_loader:
+    #   processor:
+    #     python_name: snuba.processors.QuerylogProcessor
+    #     rust_name: rust_snuba::processors::QuerylogProcessor
 
     os.execve(
         RUST_PATH,

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -35,5 +35,5 @@ def rust_consumer(*, storage_name: str, log_level: str) -> None:
     os.execve(
         RUST_PATH,
         ["--", "--storage", storage_name, "--settings-path", settings_path],
-        {"RUST_LOG": log_level},
+        {"RUST_LOG": log_level, **os.environ},
     )

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -32,6 +32,22 @@ def rust_consumer(*, storage_name: str, log_level: str) -> None:
     """
     settings_path = write_settings_to_json()
 
+    # TODO: compile minimal consumer config here, and pass it down to rust
+    # code, instead of having rust code read the storage yaml. Incomplete list
+    # of things that are unimplemented:
+    #
+    # - slices
+    # - multi-storage consumer
+    # - consumer group (?)
+    # - topic cli arg
+    # - interaction between BROKER_CONFIG + KAFKA_TOPIC_MAP +
+    # KAFKA_BROKER_CONFIG had to be reimplemented. But does it match the Python
+    # impl?
+    #
+    # ideally the config passed to rust would contain physical topic name, the
+    # right kafka broker config and clickhouse cluster to use, and nothing
+    # else.
+
     os.execve(
         RUST_PATH,
         ["--", "--storage", storage_name, "--settings-path", settings_path],


### PR DESCRIPTION
Currently crashes with:

```
$ RUST_BACKTRACE=1 snuba rust-consumer --storage querylog
2023-03-15 15:55:06,869 Initializing Snuba...
2023-03-15 15:55:09,273 Snuba initialization took 2.404892279s
[2023-03-15T14:55:09Z INFO  consumer] Starting consumer for querylog with settings at /Users/untitaker/projects/snuba/tmp/settings.json
[2023-03-15T14:55:09Z INFO  consumer] Loaded settings: Settings { clusters: [Cluster { host: "127.0.0.1", port: 9000, user: "default", password: "", http_port: 8123, storage_sets: ["cdc", "querylog", "search_issues", "migrations", "functions", "transactions", "events", "generic_metrics_distributions", "discover", "events_ro", "sessions", "outcomes", "profiles", "replays", "generic_metrics_counters", "generic_metrics_sets", "metrics"] }], broker_config: {"ssl.certificate.location": Some(""), "ssl.key.location": Some(""), "bootstrap.servers": Some("127.0.0.1:9092"), "security.protocol": Some("plaintext"), "sasl.mechanism": None, "sasl.username": None, "sasl.password": None, "ssl.ca.location": Some("")}, kafka_broker_config: {}, config_files_path: "/Users/untitaker/projects/snuba/snuba/datasets/configuration", storage_config_files_glob: "/Users/untitaker/projects/snuba/snuba/datasets/configuration/**/storages/*.yaml", kafka_topic_map: {} }
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: PollError', src/consumer.rs:123:21
stack backtrace:
   0: rust_begin_unwind
             at /rustc/2c8cc343237b8f7d5a3c3703e3a87f2eb2c54a74/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/2c8cc343237b8f7d5a3c3703e3a87f2eb2c54a74/library/core/src/panicking.rs:64:14
   2: core::result::unwrap_failed
             at /rustc/2c8cc343237b8f7d5a3c3703e3a87f2eb2c54a74/library/core/src/result.rs:1790:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/2c8cc343237b8f7d5a3c3703e3a87f2eb2c54a74/library/core/src/result.rs:1112:23
   4: consumer::main::{{closure}}
             at ./rust_snuba/src/consumer.rs:123:5
   5: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/park.rs:283:63
   6: tokio::runtime::coop::with_budget
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/coop.rs:107:5
   7: tokio::runtime::coop::budget
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/coop.rs:73:5
   8: tokio::runtime::park::CachedParkThread::block_on
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/park.rs:283:31
   9: tokio::runtime::context::BlockingRegionGuard::block_on
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/context.rs:315:13
  10: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/scheduler/multi_thread/mod.rs:66:9
  11: tokio::runtime::runtime::Runtime::block_on
             at /Users/untitaker/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.26.0/src/runtime/runtime.rs:304:45
  12: consumer::main
             at ./rust_snuba/src/consumer.rs:123:5
  13: core::ops::function::FnOnce::call_once
             at /rustc/2c8cc343237b8f7d5a3c3703e3a87f2eb2c54a74/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
