### PR TITLE
fix(rust-consumer): Remove auto-initialize feature

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -23,4 +23,4 @@ env_logger = "0.10.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = { version = "1.0" }
 glob = "0.3.1"
-pyo3 = { version = "0.18.1", features = ["auto-initialize"] }
+pyo3 = { version = "0.18.1"}


### PR DESCRIPTION
Requires PYTHON_CONFIGURE_OPTS="--enable-shared" to build

