### PR TITLE
feat: Start building the config for Rust consumer

### DIFF
--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -23,6 +23,10 @@ struct Args {
 
     #[arg(long)]
     settings_path: String,
+
+    #[arg(long)]
+    config_path: String,
+
 }
 
 struct Noop {}

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -19,7 +19,7 @@ use rust_snuba::storages;
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long)]
-    storages: Vec<String>,
+    storage: Vec<String>,
 
     #[arg(long)]
     settings_path: String,
@@ -87,7 +87,7 @@ async fn main() {
     let args = Args::parse();
 
     // TODO: Support multiple storages
-    let first_storage = args.storages[0].clone();
+    let first_storage = args.storage[0].clone();
 
     log::info!(
         "Starting consumer for {:?} with settings at {}",

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -6,7 +6,7 @@ mod settings;
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long)]
-    storage: String,
+    storage: Vec<String>,
 
     #[arg(long)]
     settings_path: String,
@@ -17,7 +17,7 @@ async fn main() {
     env_logger::init();
     let args = Args::parse();
     log::info!(
-        "Starting consumer for {} with settings at {}",
+        "Starting consumer for {:?} with settings at {}",
         args.storage,
         args.settings_path,
     );

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -19,7 +19,7 @@ use rust_snuba::storages;
 #[derive(Parser, Debug)]
 struct Args {
     #[arg(long)]
-    storage: Vec<String>,
+    storages: Vec<String>,
 
     #[arg(long)]
     settings_path: String,
@@ -81,16 +81,20 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
 async fn main() {
     env_logger::init();
     let args = Args::parse();
+
+    // TODO: Support multiple storages
+    let first_storage = args.storages[0].clone();
+
     log::info!(
         "Starting consumer for {:?} with settings at {}",
-        args.storage,
+        first_storage,
         args.settings_path,
     );
     let settings = settings::Settings::load_from_json(&args.settings_path).unwrap();
     log::info!("Loaded settings: {settings:?}");
 
     let storage_registry = storages::StorageRegistry::load_all(&settings).unwrap();
-    let storage = storage_registry.get(&args.storage).unwrap();
+    let storage = storage_registry.get(&first_storage).unwrap();
 
     struct ConsumerStrategyFactory {
         config: KafkaConfig,

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -122,8 +122,6 @@ def rust_consumer(
         consumer_config_path,
     ]
 
-    rust_consumer_args = ["--", "--settings-path", settings_path]
-
     for storage_name in storage_names:
         rust_consumer_args.extend(["--storage", storage_name])
 

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -1,4 +1,5 @@
 import os
+from typing import Sequence
 
 import click
 
@@ -12,11 +13,12 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
 @click.command()
 @click.option(
     "--storage",
-    "storage_name",
+    "storage_names",
     type=click.Choice(
         [storage_key.value for storage_key in get_writable_storage_keys()]
     ),
     help="The storage to target",
+    multiple=True,
     required=True,
 )
 @click.option(
@@ -26,14 +28,19 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
     help="Logging level to use.",
     default="error",
 )
-def rust_consumer(*, storage_name: str, log_level: str) -> None:
+def rust_consumer(*, storage_names: Sequence[str], log_level: str) -> None:
     """
     Experimental alternative to`snuba consumer`
     """
     settings_path = write_settings_to_json()
 
+    rust_consumer_args = ["--", "--settings-path", settings_path]
+
+    for storage_name in storage_names:
+        rust_consumer_args.extend(["--storage", storage_name])
+
     os.execve(
         RUST_PATH,
-        ["--", "--storage", storage_name, "--settings-path", settings_path],
+        rust_consumer_args,
         {"RUST_LOG": log_level},
     )

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -1,10 +1,18 @@
+import json
 import os
-from typing import Sequence
+from dataclasses import asdict, dataclass
+from typing import Optional, Sequence
 
 import click
 
-from snuba.datasets.storages.factory import get_writable_storage_keys
-from snuba.settings.utils import write_settings_to_json
+from snuba import settings
+from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.storages.factory import (
+    get_writable_storage,
+    get_writable_storage_keys,
+)
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.settings.utils import get_settings_json
 
 RUST_ENVIRONMENT = os.environ.get("RUST_ENVIRONMENT", "debug")
 RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
@@ -22,44 +30,97 @@ RUST_PATH = f"rust_snuba/target/{RUST_ENVIRONMENT}/consumer"
     required=True,
 )
 @click.option(
+    "--consumer-group",
+    help="Consumer group use for consuming the raw events topic.",
+    required=True,
+)
+@click.option("--raw-events-topic", help="Topic to consume raw events from.")
+@click.option(
+    "--commit-log-topic",
+    help="Topic for committed offsets to be written to, triggering post-processing task(s)",
+)
+@click.option(
+    "--replacements-topic",
+    help="Topic to produce replacement messages info.",
+)
+@click.option(
+    "--bootstrap-server",
+    "bootstrap_servers",
+    multiple=True,
+    help="Kafka bootstrap server to use for consuming.",
+)
+@click.option(
+    "--commit-log-bootstrap-server",
+    "commit_log_bootstrap_servers",
+    multiple=True,
+    help="Kafka bootstrap server to use to produce the commit log.",
+)
+@click.option(
+    "--replacement-bootstrap-server",
+    "replacement_bootstrap_servers",
+    multiple=True,
+    help="Kafka bootstrap server to use to produce replacements.",
+)
+@click.option(
+    "--slice-id",
+    "slice_id",
+    type=int,
+    help="The slice id for the storage",
+)
+@click.option(
     "--log-level",
     "log_level",
     type=click.Choice(["error", "warn", "info", "debug", "trace"]),
     help="Logging level to use.",
     default="info",
 )
-def rust_consumer(*, storage_names: Sequence[str], log_level: str) -> None:
+def rust_consumer(
+    *,
+    storage_names: Sequence[str],
+    consumer_group: str,
+    raw_events_topic: Optional[str],
+    commit_log_topic: Optional[str],
+    replacements_topic: Optional[str],
+    bootstrap_servers: Sequence[str],
+    commit_log_bootstrap_servers: Sequence[str],
+    replacement_bootstrap_servers: Sequence[str],
+    slice_id: Optional[int],
+    log_level: str,
+) -> None:
     """
     Experimental alternative to`snuba consumer`
     """
-    # TODO: compile minimal consumer config here, and pass it down to rust
-    # code, instead of having rust code read the storage yaml. Incomplete list
-    # of things that are unimplemented:
-    #
-    # - slices
-    # - multi-storage consumer
-    # - consumer group (?)
-    # - topic cli arg
-    # - interaction between BROKER_CONFIG + KAFKA_TOPIC_MAP +
-    # KAFKA_BROKER_CONFIG had to be reimplemented. But does it match the Python
-    # impl?
-    #
-    # ideally the config passed to rust would contain physical topic name, the
-    # right kafka broker config and clickhouse cluster to use, and nothing
-    # else.
-    #
-    # there is an argument for keeping it as-is, and that is if we need to read
-    # the storage yaml at compile-time, to do code generation. It might be
-    # necessary if we want to define import paths for Rust message processors
-    # in yaml, e.g.:
+
+    settings_data = get_settings_json()
+    settings_path = write_file_to_tmp_directory(settings_data, "settings.json")
+
+    # TODO: Consumer config is still missing some stuff needed by the Rust consumer, e.g.:
     #
     # stream_loader:
     #   processor:
     #     python_name: snuba.processors.QuerylogProcessor
 
-    settings_path = write_settings_to_json()
+    consumer_config = resolve_consumer_config(
+        storage_names=storage_names,
+        raw_topic=raw_events_topic,
+        commit_log_topic=commit_log_topic,
+        replacements_topic=replacements_topic,
+        bootstrap_servers=bootstrap_servers,
+        commit_log_bootstrap_servers=commit_log_bootstrap_servers,
+        replacement_bootstrap_servers=replacement_bootstrap_servers,
+        slice_id=slice_id,
+    )
+    consumer_config_path = write_file_to_tmp_directory(
+        json.dumps(asdict(consumer_config)), "consumer_config.json"
+    )
 
-    rust_consumer_args = ["--", "--settings-path", settings_path]
+    rust_consumer_args = [
+        "--",
+        "--settings-path",
+        settings_path,
+        "--config-path",
+        consumer_config_path,
+    ]
 
     for storage_name in storage_names:
         rust_consumer_args.extend(["--storage", storage_name])
@@ -69,3 +130,175 @@ def rust_consumer(*, storage_names: Sequence[str], log_level: str) -> None:
         rust_consumer_args,
         {"RUST_LOG": log_level},
     )
+
+
+@dataclass(frozen=True)
+class ClickhouseClusterConfig:
+    host: str
+    port: int
+    user: str
+    password: str
+    database: str
+
+
+@dataclass(frozen=True)
+class StorageConfig:
+    name: str
+    clickhouse_cluster: ClickhouseClusterConfig
+
+
+@dataclass(frozen=True)
+class RustConsumerConfig:
+    """
+    Already resolved configuration for the Rust consumer
+    """
+
+    storages: Sequence[StorageConfig]
+    raw_topic: str
+    commit_log_topic: Optional[str]
+    replacements_topic: Optional[str]
+
+
+def resolve_consumer_config(
+    *,
+    storage_names: Sequence[str],
+    raw_topic: Optional[str],
+    commit_log_topic: Optional[str],
+    replacements_topic: Optional[str],
+    bootstrap_servers: Sequence[str],
+    commit_log_bootstrap_servers: Sequence[str],
+    replacement_bootstrap_servers: Sequence[str],
+    slice_id: Optional[int],
+) -> RustConsumerConfig:
+    """
+    Resolves the ClickHouse cluster and Kafka brokers, and the physical topic name
+    to be passed to the Rust consumer. We don't want to duplicate the cluster
+    resolution code in Rust.
+    """
+
+    storages = {
+        storage_name: get_writable_storage(StorageKey(storage_name))
+        for storage_name in storage_names
+    }
+
+    validate_storages([*storages.values()])
+
+    stream_loader = storages[storage_names[0]].get_table_writer().get_stream_loader()
+
+    resolved_raw_topic: str
+    if raw_topic is not None:
+        resolved_raw_topic = raw_topic
+    else:
+        resolved_raw_topic = (
+            stream_loader.get_default_topic_spec().get_physical_topic_name(slice_id)
+        )
+
+    resolved_commit_log_topic: Optional[str]
+    commit_log_topic_spec = stream_loader.get_commit_log_topic_spec()
+
+    if commit_log_topic_spec is None:
+        if commit_log_topic is not None:
+            raise ValueError("Commit log not supported for this storage")
+        resolved_commit_log_topic = None
+    elif commit_log_topic is not None:
+        resolved_commit_log_topic = commit_log_topic
+    else:
+        resolved_commit_log_topic = commit_log_topic_spec.get_physical_topic_name(
+            slice_id
+        )
+
+    resolved_replacements_topic: Optional[str]
+    replacements_topic_spec = stream_loader.get_replacement_topic_spec()
+
+    if replacements_topic_spec is None:
+        if replacements_topic is not None:
+            raise ValueError("Commit log not supported for this storage")
+
+        resolved_replacements_topic = None
+    elif commit_log_topic is not None:
+        resolved_commit_log_topic = replacements_topic
+    else:
+        resolved_commit_log_topic = replacements_topic_spec.get_physical_topic_name(
+            slice_id
+        )
+
+    # TODO: Temporarily hardcoded. To be properly resolved based on the storage set.
+    hardcoded_clickhouse_cluster = ClickhouseClusterConfig(
+        host="127.0.0.1", port=9000, user="default", password="", database="default"
+    )
+
+    return RustConsumerConfig(
+        storages=[
+            StorageConfig(
+                name=storage_name, clickhouse_cluster=hardcoded_clickhouse_cluster
+            )
+            for (storage_name, storage) in storages.items()
+        ],
+        raw_topic=resolved_raw_topic,
+        commit_log_topic=resolved_commit_log_topic,
+        replacements_topic=resolved_replacements_topic,
+    )
+
+
+def validate_storages(storages: Sequence[WritableTableStorage]) -> None:
+    """
+    Validates that storage combination is valid based on topic definitions
+    """
+    assert (
+        len(
+            set(
+                [
+                    storage.get_table_writer()
+                    .get_stream_loader()
+                    .get_default_topic_spec()
+                    for storage in storages
+                ]
+            )
+        )
+        < 2
+    ), "All storages must have the same default topic spec"
+
+    assert (
+        len(
+            set(
+                [
+                    storage.get_table_writer()
+                    .get_stream_loader()
+                    .get_commit_log_topic_spec()
+                    for storage in storages
+                ]
+            )
+        )
+        < 2
+    ), "All storages must have the same commit log topic spec"
+
+    assert (
+        len(
+            set(
+                [
+                    storage.get_table_writer()
+                    .get_stream_loader()
+                    .get_replacement_topic_spec()
+                    for storage in storages
+                ]
+            )
+        )
+        < 2
+    ), "All storages must have the same replacement topic spec"
+
+
+def write_file_to_tmp_directory(data: str, filename: str) -> str:
+    """
+    Write data to json file, return the file path.
+    """
+
+    tmp_dir = os.path.join(settings.ROOT_REPO_PATH, "tmp")
+    file_path = os.path.join(tmp_dir, filename)
+
+    if not os.path.exists(tmp_dir):
+        os.makedirs(tmp_dir)
+
+    with open(file_path, "w") as f:
+        f.write(data)
+
+    return file_path

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -33,6 +33,9 @@ class KafkaTopicSpec:
     def __init__(self, topic: Topic) -> None:
         self.__topic = topic
 
+    def __hash__(self) -> int:
+        return hash(self.__topic)
+
     @property
     def topic(self) -> Topic:
         return self.__topic


### PR DESCRIPTION
We don't want to reimplement the slice/cluster resolution in Rust, call it in Python when the Rust consumer starts and write it in a file for Rust.

This is currently incomplete, there are some additional fields we need to add here such as the reference to the message processor.
