### PR TITLE
fix(replays): set transaction as empty string instead of null

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -334,7 +334,7 @@ class Tag:
 
     @classmethod
     def empty_set(cls) -> Tag:
-        return cls([], [], None)
+        return cls([], [], "")
 
 
 def process_tags_object(value: Any) -> Tag:
@@ -346,7 +346,7 @@ def process_tags_object(value: Any) -> Tag:
 
     keys = []
     values = []
-    transaction = None
+    transaction = ""
 
     for key, value in tags:
         # Keys and values are stored as optional strings regardless of their input type.

--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -353,7 +353,7 @@ def process_tags_object(value: Any) -> Tag:
         parsed_key, parsed_value = to_string(key), maybe(to_string, value)
 
         if key == "transaction":
-            transaction = parsed_value
+            transaction = parsed_value or ""
         elif parsed_value is not None:
             keys.append(parsed_key)
             values.append(parsed_value)

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -604,7 +604,7 @@ class TestReplaysProcessor:
         assert tags.values == []
 
         tags = process_tags_object({"hello": "world"})
-        assert tags.transaction is None
+        assert tags.transaction == ""
         assert tags.keys == ["hello"]
         assert tags.values == ["world"]
 
@@ -621,19 +621,19 @@ class TestReplaysProcessor:
         assert tags.values == []
 
         tags = process_tags_object([("hello", "world")])
-        assert tags.transaction is None
+        assert tags.transaction == ""
         assert tags.keys == ["hello"]
         assert tags.values == ["world"]
 
         tags = process_tags_object([("hello", "world", "!")])
-        assert tags.transaction is None
+        assert tags.transaction == ""
         assert tags.keys == []
         assert tags.values == []
 
         # Empty
 
         tags = process_tags_object(None)
-        assert tags.transaction is None
+        assert tags.transaction == ""
         assert tags.keys == []
         assert tags.values == []
 

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -69,7 +69,7 @@ class ReplayEvent:
             event_hash=None,
             error_sample_rate=0,
             session_sample_rate=0,
-            title=None,
+            title="",
             error_ids=[],
             trace_ids=[],
             segment_id=None,

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -69,7 +69,7 @@ class ReplayEvent:
             event_hash=None,
             error_sample_rate=0,
             session_sample_rate=0,
-            title="",
+            title=None,
             error_ids=[],
             trace_ids=[],
             segment_id=None,
@@ -218,7 +218,7 @@ class ReplayEvent:
             "device_model": self.device_model,
             "tags.key": ["customtag"],
             "tags.value": ["is_set"],
-            "title": self.title,
+            "title": self.title or "",
             "sdk_name": "sentry.python",
             "sdk_version": "0.9.0",
             "retention_days": 30,
@@ -604,7 +604,7 @@ class TestReplaysProcessor:
         assert tags.values == []
 
         tags = process_tags_object({"hello": "world"})
-        assert tags.transaction == ""
+        assert tags.transaction is None
         assert tags.keys == ["hello"]
         assert tags.values == ["world"]
 
@@ -621,19 +621,19 @@ class TestReplaysProcessor:
         assert tags.values == []
 
         tags = process_tags_object([("hello", "world")])
-        assert tags.transaction == ""
+        assert tags.transaction is None
         assert tags.keys == ["hello"]
         assert tags.values == ["world"]
 
         tags = process_tags_object([("hello", "world", "!")])
-        assert tags.transaction == ""
+        assert tags.transaction is None
         assert tags.keys == []
         assert tags.values == []
 
         # Empty
 
         tags = process_tags_object(None)
-        assert tags.transaction == ""
+        assert tags.transaction is None
         assert tags.keys == []
         assert tags.values == []
 


### PR DESCRIPTION
on clickhouse 20 it seems that we have to specify an empty string for `title` as it is a non-nullable column. On newer versions of clickhouse this does not cause problems, but we were seeing issues in self-hosted. Sentry employees did not see this as generally everyone is on an M1 and uses clickhouse 21.

In CI we run clickhouse 20, but we also do not have adequate test coverage for actual DB insertion, and this is something i plan to follow up on. additionally, we don't use this column anywhere so i'm thinking we should plan on removing it / deprecating it.

Solves https://github.com/getsentry/self-hosted/issues/2002