### PR TITLE
feat(rust-arroyo): Get rid of `Position`

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -7,12 +7,12 @@ use rust_arroyo::processing::strategies::{
     CommitRequest, MessageRejected, ProcessingStrategy, ProcessingStrategyFactory,
 };
 use rust_arroyo::processing::StreamProcessor;
-use rust_arroyo::types::{Message, Partition, Position, Topic};
+use rust_arroyo::types::{Message, Partition, Topic};
 use std::collections::HashMap;
 use std::time::Duration;
 
 struct TestStrategy {
-    partitions: HashMap<Partition, Position>,
+    partitions: HashMap<Partition, u64>,
 }
 impl ProcessingStrategy<KafkaPayload> for TestStrategy {
     fn poll(&mut self) -> Option<CommitRequest> {
@@ -34,10 +34,7 @@ impl ProcessingStrategy<KafkaPayload> for TestStrategy {
         println!("SUBMIT {}", message);
         self.partitions.insert(
             message.partition,
-            Position {
-                offset: message.offset,
-                timestamp: message.timestamp,
-            },
+            message.offset,
         );
         Ok(())
     }

--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -4,7 +4,7 @@ use super::Consumer as ArroyoConsumer;
 use super::ConsumerError;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::types::Message as ArroyoMessage;
-use crate::types::{Partition, Position, Topic};
+use crate::types::{Partition, Topic};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
@@ -144,7 +144,7 @@ pub struct KafkaConsumer {
     config: KafkaConfig,
     state: KafkaConsumerState,
     offsets: Arc<Mutex<HashMap<Partition, u64>>>,
-    staged_offsets: HashMap<Partition, Position>,
+    staged_offsets: HashMap<Partition, u64>,
 }
 
 impl KafkaConsumer {
@@ -266,7 +266,7 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
 
     fn stage_positions(
         &mut self,
-        positions: HashMap<Partition, Position>,
+        positions: HashMap<Partition, u64>,
     ) -> Result<(), ConsumerError> {
         for (partition, position) in positions {
             self.staged_offsets.insert(partition, position);
@@ -274,14 +274,14 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
         Ok(())
     }
 
-    fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerError> {
+    fn commit_positions(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError> {
         self.state.assert_consuming_state()?;
 
         let mut topic_map = HashMap::new();
-        for (partition, position) in self.staged_offsets.iter() {
+        for (partition, offset) in self.staged_offsets.iter() {
             topic_map.insert(
                 (partition.topic.name.clone(), partition.index as i32),
-                Offset::from_raw(position.offset as i64),
+                Offset::from_raw(*offset as i64),
             );
         }
 
@@ -311,7 +311,7 @@ mod tests {
     use super::{AssignmentCallbacks, KafkaConsumer};
     use crate::backends::kafka::config::KafkaConfig;
     use crate::backends::Consumer;
-    use crate::types::{Partition, Position, Topic};
+    use crate::types::{Partition, Topic};
     use chrono::Utc;
     use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
     use rdkafka::client::DefaultClientContext;
@@ -425,10 +425,7 @@ mod tests {
 
         let positions = HashMap::from([(
             Partition { topic, index: 0 },
-            Position {
-                offset: 100,
-                timestamp: Utc::now(),
-            },
+            100,
         )]);
 
         consumer.stage_positions(positions.clone()).unwrap();

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -1,7 +1,7 @@
 pub mod broker;
 
 use super::{AssignmentCallbacks, Consumer, ConsumerError};
-use crate::types::{Message, Partition, Position, Topic};
+use crate::types::{Message, Partition, Topic};
 use broker::LocalBroker;
 use std::collections::HashSet;
 use std::collections::{HashMap, VecDeque};
@@ -20,7 +20,7 @@ struct SubscriptionState {
     topics: Vec<Topic>,
     callbacks: Option<Box<dyn AssignmentCallbacks>>,
     offsets: HashMap<Partition, u64>,
-    staged_positions: HashMap<Partition, Position>,
+    staged_positions: HashMap<Partition, u64>,
     last_eof_at: HashMap<Partition, u64>,
 }
 
@@ -235,7 +235,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
 
     fn stage_positions(
         &mut self,
-        positions: HashMap<Partition, Position>,
+        positions: HashMap<Partition, u64>,
     ) -> Result<(), ConsumerError> {
         if self.closed {
             return Err(ConsumerError::ConsumerClosed);
@@ -256,7 +256,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
         Ok(())
     }
 
-    fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerError> {
+    fn commit_positions(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError> {
         if self.closed {
             return Err(ConsumerError::ConsumerClosed);
         }
@@ -264,7 +264,7 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
 
         let offsets = positions
             .iter()
-            .map(|(part, position)| (part.clone(), position.offset))
+            .map(|(part, offset)| (part.clone(), offset.clone()))
             .collect();
         self.broker.commit(&self.group, offsets);
         self.subscription_state.staged_positions.clear();
@@ -299,7 +299,7 @@ mod tests {
     use crate::backends::local::broker::LocalBroker;
     use crate::backends::storages::memory::MemoryMessageStorage;
     use crate::backends::Consumer;
-    use crate::types::{Partition, Position, Topic};
+    use crate::types::{Partition, Topic};
     use crate::utils::clock::SystemClock;
     use chrono::Utc;
     use std::collections::{HashMap, HashSet};
@@ -569,10 +569,7 @@ mod tests {
                 topic: topic2.clone(),
                 index: 0,
             },
-            Position {
-                offset: 100,
-                timestamp: Utc::now(),
-            },
+            100,
         )]);
         let stage_result = consumer.stage_positions(positions.clone());
         assert!(stage_result.is_ok());
@@ -587,10 +584,7 @@ mod tests {
                 topic: topic2,
                 index: 1,
             },
-            Position {
-                offset: 100,
-                timestamp: Utc::now(),
-            },
+            100
         )]);
 
         let stage_result = consumer.stage_positions(invalid_positions);

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -1,4 +1,4 @@
-use super::types::{Message, Partition, Position, Topic, TopicOrPartition};
+use super::types::{Message, Partition, Topic, TopicOrPartition};
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use thiserror::Error;
@@ -143,12 +143,12 @@ pub trait Consumer<'a, TPayload: Clone> {
     /// moves in reverse.)
     fn stage_positions(
         &mut self,
-        positions: HashMap<Partition, Position>,
+        positions: HashMap<Partition, u64>,
     ) -> Result<(), ConsumerError>;
 
     /// Commit staged offsets. The return value of this method is a mapping
     /// of streams with their committed offsets as values.
-    fn commit_positions(&mut self) -> Result<HashMap<Partition, Position>, ConsumerError>;
+    fn commit_positions(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError>;
 
     fn close(&mut self);
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -217,7 +217,7 @@ mod tests {
     use crate::backends::local::broker::LocalBroker;
     use crate::backends::local::LocalConsumer;
     use crate::backends::storages::memory::MemoryMessageStorage;
-    use crate::types::{Message, Partition, Position, Topic};
+    use crate::types::{Message, Partition, Topic};
     use crate::utils::clock::SystemClock;
     use std::collections::HashMap;
     use std::time::Duration;
@@ -234,10 +234,7 @@ mod tests {
                 Some(message) => Some(CommitRequest {
                     positions: HashMap::from([(
                         message.partition.clone(),
-                        Position {
-                            offset: message.offset,
-                            timestamp: message.timestamp,
-                        },
+                        message.offset,
                     )]),
                 }),
             }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -1,4 +1,4 @@
-use crate::types::{Message, Partition, Position};
+use crate::types::{Message, Partition};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -14,7 +14,7 @@ pub struct InvalidMessage;
 /// Signals that we need to commit offsets
 #[derive(Debug, Clone, PartialEq)]
 pub struct CommitRequest {
-    pub positions: HashMap<Partition, Position>,
+    pub positions: HashMap<Partition, u64>,
 }
 
 /// A processing strategy defines how a stream processor processes messages

--- a/rust_snuba/rust_arroyo/src/types/mod.rs
+++ b/rust_snuba/rust_arroyo/src/types/mod.rs
@@ -35,12 +35,6 @@ pub enum TopicOrPartition {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Position {
-    pub offset: u64,
-    pub timestamp: DateTime<Utc>,
-}
-
-#[derive(Clone, Debug, PartialEq)]
 pub struct Message<T: Clone> {
     pub partition: Partition,
     pub offset: u64,


### PR DESCRIPTION
`Position` struct is no longer needed. It was a hack used for the legacy Snuba consumer, and has been removed in Python Arroyo: https://github.com/getsentry/arroyo/pull/165. We are removing it here to bring the two libraries in line.
