### PR TITLE
ref: Include rust_arroyo in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,4 @@ snuba.egg-info/
 .github/
 snuba/admin/dist/bundle.js*
 */node_modules
+rust_snuba/target/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           docker buildx create --name arm64-builder --use
           docker buildx build --platform linux/arm64 \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --build-arg BUILD_BASE=base \
+            --build-arg SHOULD_BUILD_ADMIN_UI=false \
             --cache-from ${SNUBA_IMAGE}:latest \
             --cache-from ${SNUBA_IMAGE}:${{ steps.branch.outputs.branch }} \
             -t ${SNUBA_IMAGE}:latest \

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN set -ex; \
     cd ./rust_snuba/; \
     export PATH="$HOME/.cargo/bin/:$PATH"; \
     # use git CLI to avoid OOM on ARM64
-    echo -e "[net]\ngit-fetch-with-cli = true" > $CARGO_HOME/config; \
+    echo -e "[net]\ngit-fetch-with-cli = true" > ~/.cargo/config; \
     maturin build --release --compatibility linux --locked --strip
 
 # Install nodejs and yarn and build the admin UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,8 @@ RUN set -ex; \
     cd ./rust_snuba/; \
     export PATH="$HOME/.cargo/bin/:$PATH"; \
     # use git CLI to avoid OOM on ARM64
-    echo -e "[net]\ngit-fetch-with-cli = true" > ~/.cargo/config; \
+    echo '[net]' > ~/.cargo/config; \
+    echo 'git-fetch-with-cli = true' >> ~/.cargo/config; \
     maturin build --release --compatibility linux --locked --strip
 
 # Install nodejs and yarn and build the admin UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex; \
     \
     buildDeps=' \
         curl \
+        git \
         gcc \
         libc6-dev \
         liblz4-dev \
@@ -73,6 +74,8 @@ RUN set -ex; \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain $RUST_TOOLCHAIN  --profile minimal -y; \
     cd ./rust_snuba/; \
     export PATH="$HOME/.cargo/bin/:$PATH"; \
+    # use git CLI to avoid OOM on ARM64
+    echo -e "[net]\ngit-fetch-with-cli = true" > $CARGO_HOME/config; \
     maturin build --release --compatibility linux --locked --strip
 
 # Install nodejs and yarn and build the admin UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ RUN set -ex; \
     # use git CLI to avoid OOM on ARM64
     echo '[net]' > ~/.cargo/config; \
     echo 'git-fetch-with-cli = true' >> ~/.cargo/config; \
+    echo '[registries.crates-io]' >> ~/.cargo/config; \
+    echo 'protocol = "sparse"' >> ~/.cargo/config' \
     maturin build --release --compatibility linux --locked --strip
 
 # Install nodejs and yarn and build the admin UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN set -ex; \
 FROM base AS application
 COPY . ./
 COPY --from=build_rust_snuba /usr/src/snuba/rust_snuba/target/wheels/ /tmp/rust_wheels/
-COPY --from=build_admin_ui /usr/src/snuba/snuba/admin/ ./snuba/admin/
+COPY --from=build_admin_ui /usr/src/snuba/snuba/admin/dist/bundle.js* ./snuba/admin/dist/
 RUN set -ex; \
     groupadd -r snuba --gid 1000; \
     useradd -r -g snuba --uid 1000 snuba; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.8.13
-ARG BUILD_BASE=build_admin_ui
+ARG SHOULD_BUILD_ADMIN_UI=true
 
 FROM python:${PYTHON_VERSION}-slim-bullseye as build_base
 WORKDIR /usr/src/snuba
@@ -81,6 +81,7 @@ ENV NODE_VERSION=19
 
 COPY ./snuba/admin ./snuba/admin
 RUN set -ex; \
+    [ "$SHOULD_BUILD_ADMIN_UI" = "true" ] || exit 0; \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN set -ex; \
     echo '[net]' > ~/.cargo/config; \
     echo 'git-fetch-with-cli = true' >> ~/.cargo/config; \
     echo '[registries.crates-io]' >> ~/.cargo/config; \
-    echo 'protocol = "sparse"' >> ~/.cargo/config' \
+    echo 'protocol = "sparse"' >> ~/.cargo/config; \
     maturin build --release --compatibility linux --locked --strip
 
 # Install nodejs and yarn and build the admin UI

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,9 +95,9 @@ RUN set -ex; \
 # Layer cache is pretty much invalidated here all the time,
 # so try not to do anything heavy beyond here.
 FROM base AS application
+COPY . ./
 COPY --from=build_rust_snuba /usr/src/snuba/rust_snuba/target/wheels/ /tmp/rust_wheels/
 COPY --from=build_admin_ui /usr/src/snuba/snuba/admin/ ./snuba/admin/
-COPY . ./
 RUN set -ex; \
     groupadd -r snuba --gid 1000; \
     useradd -r -g snuba --uid 1000 snuba; \

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ backend-typing:
 
 install-python-dependencies:
 	pip uninstall -qqy uwsgi  # pip doesn't do well with swapping drop-ins
+	pip install `grep ^-- requirements.txt` -r requirements-build.txt
 	pip install `grep ^-- requirements.txt` -e .
 	pip install `grep ^-- requirements.txt` -r requirements-test.txt
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
         "-f",
         "./Dockerfile",
       ]
-    timeout: 180s
+    timeout: 1200s
   # Unit tests
   - name: "gcr.io/$PROJECT_ID/docker-compose"
     id: unit-tests

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,3 @@
+--index-url https://pypi.devinfra.sentry.io/simple
+
+maturin==0.14.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ python-jose[cryptography]==3.3.0
 jsonschema==4.16.0
 fastjsonschema==2.16.2
 Markdown==3.4.1
-maturin==0.14.15
 packaging==21.3
 # Do not update parsimonious, there is a performance issue in newer versions
 parsimonious==0.8.1

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -87,7 +87,7 @@ impl ProcessingStrategy<KafkaPayload>
         let produce_fut = ProduceFuture {
             producer: Arc::clone(&self.producer),
             destination: Arc::clone(&self.topic),
-            payload: message.payload.clone(),
+            payload: message.payload().clone(),
             completed: false,
         };
         // spawn the future


### PR DESCRIPTION
This will allow us to run `snuba rust-consumer` from docker.

The build now happens in roughly four steps:

1. Initialize `build_base` layer, which contains common debian packages we need
  to have around for building everything else + requirements-build.txt

2. Then, based on `build_base`, there are _three_ build stages that (at
  least on my machine) run in parallel:

   * `base` is just `build_base` with requirements.txt + additional runtime
     deps installed, and all the build dependencies stripped out.

   * `build_admin_ui` is `build_base` with JS dependencies installed, and
    the admin UI built

   * `build_rust_snuba` is `build_base` with Rust installed, and the
    `rust_snuba` package built.

3. Based on `base`, `application` is built. Build artifacts from
   `build_admin_ui` and `build_rust_snuba` are selectively copied into
   the container. The entire git repo is copied into the container so
   that `snuba`-the-python-package can be installed.

4. The `testing` image is built from `application` as before.

The main changes are in step 2, which used to be synchronous
installation of additional runtime dependencies + admin UI build.
