### PR TITLE
fix(admin): Avoid get_local and get_dist nodes for discover in admin

### DIFF
--- a/snuba/admin/clickhouse/nodes.py
+++ b/snuba/admin/clickhouse/nodes.py
@@ -40,12 +40,20 @@ def _get_nodes(storage_key: StorageKey, local: bool = True) -> Sequence[Node]:
     try:
         storage = get_storage(storage_key)
         cluster = storage.get_cluster()
-        return [
-            {"host": node.host_name, "port": node.port}
-            for node in (
-                cluster.get_local_nodes() if local else cluster.get_distributed_nodes()
-            )
-        ]
+        if storage_key == StorageKey.DISCOVER:
+            # Discover does not follow typical cluster pattern.
+            # The get_nodes cluster methods would result in an error because
+            # discover is not a single node, but also does not belong to any cluster.
+            return []
+        else:
+            return [
+                {"host": node.host_name, "port": node.port}
+                for node in (
+                    cluster.get_local_nodes()
+                    if local
+                    else cluster.get_distributed_nodes()
+                )
+            ]
     except (AssertionError, KeyError, UndefinedClickhouseCluster) as e:
         logger.warning(str(e), storage_key=storage_key.value, local=local)
         return []


### PR DESCRIPTION
The Discover dataset is now exposed in snuba admin tracing tool. However, in production, the discover dataset does not follow the typical snuba cluster pattern. Internally, the discover cluster identifies itself as a non-single node, but is not part of a cluster. 

As a result, this [check](https://github.com/getsentry/snuba/blob/c7d920648a24d2f66c0248cf91423b33ba110f60/snuba/clusters/cluster.py#L325) will always fail for discover. To make this work in admin, we could either refactor `ClickhouseCluster` to work with discover, or we can just update the admin API to accommodate for this one-off case which is what this PR does.