### PR TITLE
ref: Rename positions to offsets everywhere

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/mod.rs
@@ -265,17 +265,17 @@ impl<'a> ArroyoConsumer<'a, KafkaPayload> for KafkaConsumer {
         Ok(())
     }
 
-    fn stage_positions(
+    fn stage_offsets(
         &mut self,
-        positions: HashMap<Partition, u64>,
+        offsets: HashMap<Partition, u64>,
     ) -> Result<(), ConsumerError> {
-        for (partition, position) in positions {
-            self.staged_offsets.insert(partition, position);
+        for (partition, offset) in offsets {
+            self.staged_offsets.insert(partition, offset);
         }
         Ok(())
     }
 
-    fn commit_positions(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError> {
+    fn commit_offsets(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError> {
         self.state.assert_consuming_state()?;
 
         let mut topic_map = HashMap::new();
@@ -429,7 +429,7 @@ mod tests {
             100,
         )]);
 
-        consumer.stage_positions(positions.clone()).unwrap();
+        consumer.stage_offsets(positions.clone()).unwrap();
 
         // Wait until the consumer got an assignment
         for _ in 0..10 {
@@ -441,7 +441,7 @@ mod tests {
             sleep(Duration::from_millis(200));
         }
 
-        let res = consumer.commit_positions().unwrap();
+        let res = consumer.commit_offsets().unwrap();
         assert_eq!(res, positions);
         consumer.unsubscribe().unwrap();
         consumer.close();

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -233,30 +233,30 @@ impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload>
         unimplemented!("Seek is not implemented");
     }
 
-    fn stage_positions(
+    fn stage_offsets(
         &mut self,
-        positions: HashMap<Partition, u64>,
+        offsets: HashMap<Partition, u64>,
     ) -> Result<(), ConsumerError> {
         if self.closed {
             return Err(ConsumerError::ConsumerClosed);
         }
         let assigned_partitions: HashSet<&Partition> =
             self.subscription_state.offsets.keys().collect();
-        let requested_partitions: HashSet<&Partition> = positions.keys().collect();
+        let requested_partitions: HashSet<&Partition> = offsets.keys().collect();
         let diff = requested_partitions.difference(&assigned_partitions);
 
         if diff.count() > 0 {
             return Err(ConsumerError::UnassignedPartition);
         }
-        for (partition, position) in positions {
+        for (partition, offset) in offsets {
             self.subscription_state
                 .staged_positions
-                .insert(partition, position);
+                .insert(partition, offset);
         }
         Ok(())
     }
 
-    fn commit_positions(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError> {
+    fn commit_offsets(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError> {
         if self.closed {
             return Err(ConsumerError::ConsumerClosed);
         }
@@ -571,10 +571,10 @@ mod tests {
             },
             100,
         )]);
-        let stage_result = consumer.stage_positions(positions.clone());
+        let stage_result = consumer.stage_offsets(positions.clone());
         assert!(stage_result.is_ok());
 
-        let offsets = consumer.commit_positions();
+        let offsets = consumer.commit_offsetes();
         assert!(offsets.is_ok());
         assert_eq!(offsets.unwrap(), positions);
 
@@ -587,7 +587,7 @@ mod tests {
             100
         )]);
 
-        let stage_result = consumer.stage_positions(invalid_positions);
+        let stage_result = consumer.stage_offsets(invalid_positions);
         assert!(stage_result.is_err());
     }
 }

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -63,8 +63,8 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// up where it left off" after restarting, or that another consumer in the
 /// same group doesn't read messages that have been processed by another
 /// consumer within the same group during a rebalance operation, positions must
-/// be regularly committed by calling ``commit_positions`` after they have been
-/// staged with ``stage_positions``. Offsets are not staged or committed
+/// be regularly committed by calling ``commit_offsets`` after they have been
+/// staged with ``stage_offsets``. Offsets are not staged or committed
 /// automatically!
 ///
 /// During rebalance operations, working offsets are rolled back to the
@@ -141,14 +141,14 @@ pub trait Consumer<'a, TPayload: Clone> {
     /// Stage offsets to be committed. If an offset has already been staged
     /// for a given partition, that offset is overwritten (even if the offset
     /// moves in reverse.)
-    fn stage_positions(
+    fn stage_offsets(
         &mut self,
         positions: HashMap<Partition, u64>,
     ) -> Result<(), ConsumerError>;
 
     /// Commit staged offsets. The return value of this method is a mapping
     /// of streams with their committed offsets as values.
-    fn commit_positions(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError>;
+    fn commit_offsets(&mut self) -> Result<HashMap<Partition, u64>, ConsumerError>;
 
     fn close(&mut self);
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -139,8 +139,8 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
                 match commit_request {
                     None => {}
                     Some(request) => {
-                        self.consumer.stage_positions(request.positions).unwrap();
-                        self.consumer.commit_positions().unwrap();
+                        self.consumer.stage_offsets(request.positions).unwrap();
+                        self.consumer.commit_offsets().unwrap();
                     }
                 };
 


### PR DESCRIPTION
Follw up to https://github.com/getsentry/snuba/pull/3883.

commit_positions and stage_positions should be called commit_offsets/ stage_offset like in Python's Arroyo library.
