### PR TITLE
feat(DRS): add file for self hosted settings

### DIFF
--- a/snuba/settings/settings_self_hosted.py
+++ b/snuba/settings/settings_self_hosted.py
@@ -1,0 +1,19 @@
+import os
+
+env = os.environ.get
+
+DEBUG = env("DEBUG", "0").lower() in ("1", "true")
+
+DEFAULT_RETENTION_DAYS = env("SENTRY_EVENT_RETENTION_DAYS", 90)
+
+REDIS_HOST = env("REDIS_HOST", "127.0.0.1")
+REDIS_PORT = int(env("REDIS_PORT", 6379))
+REDIS_PASSWORD = env("REDIS_PASSWORD")
+REDIS_DB = int(env("REDIS_DB", 1))
+USE_REDIS_CLUSTER = False
+
+# Dogstatsd Options
+DOGSTATSD_HOST = env("DOGSTATSD_HOST")
+DOGSTATSD_PORT = env("DOGSTATSD_PORT")
+
+SENTRY_DSN = env("SENTRY_DSN")


### PR DESCRIPTION
### Overview
In order for a snuba environment to determine which snuba readiness state it supports, we need a settings file for each environment to specify its supported states. Currently, [self-hosted](https://github.com/getsentry/self-hosted/blob/b1fda9a55203e3f28a3d02e1056213449b7cff45/docker-compose.yml#L89) uses `SNUBA_SETTINGS: docker`.  This PR is responsible for creating a new file called `settings_self_hosted.py` to house the new `SUPPORTED_STATES` flag specific to self-hosted as specified in the Dataset Readiness State proposal. The contents of this file is a copy of `settings_docker.py` for now.

### Blast Radius
No changes will occur until the self-hosted repo is updated to use this new file.