### PR TITLE
feat(CI): add check to detect migrations changes coupled with others

### DIFF
--- a/.github/workflows/ddl-changes.yml
+++ b/.github/workflows/ddl-changes.yml
@@ -34,3 +34,6 @@ jobs:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           migration: "./snuba/migrations/groups.py"
           cmd: python scripts/ddl-changes.py
+      - name: Check migrations are not coupled with other changes
+        run: |
+          SNUBA_SETTINGS=test_distributed python scripts/check-migrations.py

--- a/gocd/pipelines/snuba-sns-test.yaml
+++ b/gocd/pipelines/snuba-sns-test.yaml
@@ -24,6 +24,18 @@ pipelines:
                 branch: master
                 destination: snuba
         stages:
+            - checks:
+                  approval:
+                      type: manual
+                  fetch_materials: true
+                  jobs:
+                      checks-migrations:
+                          timeout: 1800
+                          elastic_profile_id: snuba
+                          tasks:
+                              - script: |
+                                    deploy_sha=`python scripts/fetch_service_refs.py --pipeline "deploy-snuba-sns-test"` && \
+                                    python scripts/check-migrations.py --to $deploy_sha
             - deploy:
                   fetch_materials: true
                   jobs:

--- a/gocd/pipelines/snuba-sns-test.yaml
+++ b/gocd/pipelines/snuba-sns-test.yaml
@@ -15,6 +15,7 @@ pipelines:
             GKE_REGION: us-central1
             GKE_CLUSTER_ZONE: a
             GKE_BASTION_ZONE: a
+            MIGRATIONS_READINESS: complete
         group: snuba
         lock_behavior: unlockWhenFinished
         materials:
@@ -108,7 +109,7 @@ pipelines:
                                     --label-selector="service=snuba-admin" \
                                     --container-name="snuba-admin" \
                                     "snuba-migrate" "ghcr.io/getsentry/snuba-ci:${GO_REVISION_SNUBA_REPO}" \
-                                    -- snuba migrations migrate --force
+                                    -- snuba migrations migrate -r ${MIGRATIONS_READINESS}
                               - plugin:
                                     options:
                                         script: |

--- a/gocd/pipelines/snuba-sns-test.yaml
+++ b/gocd/pipelines/snuba-sns-test.yaml
@@ -20,7 +20,7 @@ pipelines:
         materials:
             snuba_repo:
                 git: https://github.com/getsentry/snuba.git
-                shallow_clone: true
+                shallow_clone: false
                 branch: master
                 destination: snuba
         stages:
@@ -34,8 +34,8 @@ pipelines:
                           elastic_profile_id: snuba
                           tasks:
                               - script: |
-                                    deploy_sha=`python scripts/fetch_service_refs.py --pipeline "deploy-snuba-sns-test"` && \
-                                    python scripts/check-migrations.py --to $deploy_sha
+                                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba-sns-test"` && \
+                                    snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
             - deploy:
                   fetch_materials: true
                   jobs:

--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -2,23 +2,37 @@
 import argparse
 import subprocess
 from shutil import ExecError
+from typing import Sequence
 
 """
 This script is meant to be run in CI to check that migrations changes are
 not coupled with other changes.
 """
 
+# changes to these files here are allowed to be coupled with migrations
+ALLOWED_MIGRATIONS_GLOBS = [
+    "snuba/migrations/groups.py",
+    "tests",
+    "test_distributed_migrations",
+    "test_initialization",
+    "docs",
+    "*.md",
+]
+
+# changes to files here are migrations changes
+MIGRATIONS_GLOBS = ["snuba/snuba_migrations/*/[0-9]*.py"]
+
 
 class CoupledMigrations(Exception):
     pass
 
 
-def _get_migration_changes(workdir: str = ".", to: str = "origin/master") -> str:
-    return _get_changes("snuba/snuba_migrations/*/[0-9]*.py", workdir, to)
+def _get_migration_changes(workdir: str, to: str) -> str:
+    return _get_changes(MIGRATIONS_GLOBS, workdir, to)
 
 
-def _get_changes(glob: str, workdir: str = ".", to: str = "origin/master") -> str:
-    migrations_changes = subprocess.run(
+def _get_changes(globs: Sequence[str], workdir: str, to: str) -> str:
+    changes = subprocess.run(
         [
             "git",
             "diff",
@@ -26,23 +40,24 @@ def _get_changes(glob: str, workdir: str = ".", to: str = "origin/master") -> st
             "--name-only",
             to,
             "--",
-            glob,
+            *globs,
+            *[f":(exclude){allowed}" for allowed in ALLOWED_MIGRATIONS_GLOBS],
         ],
         stdout=subprocess.PIPE,
         text=True,
         cwd=workdir,
     )
-    if migrations_changes.returncode != 0:
-        raise ExecError(migrations_changes.stdout)
+    if changes.returncode != 0:
+        raise ExecError(changes.stdout)
     else:
-        return migrations_changes.stdout
+        return changes.stdout
 
 
 def main(to: str = "origin/master", workdir: str = ".") -> None:
     migrations_changes = _get_migration_changes(workdir, to)
     has_migrations = len(migrations_changes.splitlines()) > 0
     if has_migrations:
-        all_changes = _get_changes("*", workdir, to)
+        all_changes = _get_changes(["*"], workdir, to)
         if all_changes != migrations_changes:
             raise CoupledMigrations(
                 f"Migration changes are coupled with other changes.\n\nMigrations changes: \n{migrations_changes}\n\nAll changes: \n{all_changes}"

--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -18,12 +18,6 @@ def _get_migration_changes(workdir: str = ".", to: str = "origin/master") -> str
 
 
 def _get_changes(glob: str, workdir: str = ".", to: str = "origin/master") -> str:
-
-    # deep fetch to make sure we have the history
-    # subprocess.run(["git", "fetch", "--unshallow", "1000"], cwd=workdir, check=True)
-    print("orginal to", to)
-    to = "8c07121fc38b443524c8d88e1559f8095f97c3b1"
-    print("glob", glob)
     migrations_changes = subprocess.run(
         [
             "git",

--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -1,0 +1,55 @@
+"""
+This script is meant to be run in CI to check that migrations changes are
+not coupled with other changes.
+"""
+
+
+import argparse
+import subprocess
+from shutil import ExecError
+
+
+class CoupledMigrations(Exception):
+    pass
+
+
+def _get_migration_changes(to: str = "origin/master") -> str:
+    return _get_changes("snuba/snuba_migrations/*/[0-9]*.py", to)
+
+
+def _get_changes(glob: str, to: str = "origin/master") -> str:
+    migrations_changes = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--diff-filter=AM",
+            "--name-only",
+            to,
+            "--",
+            glob,
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if migrations_changes.returncode != 0:
+        raise ExecError(migrations_changes.stdout)
+    else:
+        return migrations_changes.stdout
+
+
+def main(to: str = "origin/master") -> None:
+    migrations_changes = _get_migration_changes(to)
+    has_migrations = len(migrations_changes.splitlines()) > 0
+    if has_migrations:
+        all_changes = _get_changes("*", to)
+        if all_changes != migrations_changes:
+            raise CoupledMigrations(
+                f"Migration changes are coupled with other changes.\n\nMigrations changes: \n{migrations_changes}\n\nAll changes: \n{all_changes}"
+            )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--to", default="origin/master")
+    args = parser.parse_args()
+    main(args.to)

--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -1,23 +1,29 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+from shutil import ExecError
+
 """
 This script is meant to be run in CI to check that migrations changes are
 not coupled with other changes.
 """
 
 
-import argparse
-import subprocess
-from shutil import ExecError
-
-
 class CoupledMigrations(Exception):
     pass
 
 
-def _get_migration_changes(to: str = "origin/master") -> str:
-    return _get_changes("snuba/snuba_migrations/*/[0-9]*.py", to)
+def _get_migration_changes(workdir: str = ".", to: str = "origin/master") -> str:
+    return _get_changes("snuba/snuba_migrations/*/[0-9]*.py", workdir, to)
 
 
-def _get_changes(glob: str, to: str = "origin/master") -> str:
+def _get_changes(glob: str, workdir: str = ".", to: str = "origin/master") -> str:
+
+    # deep fetch to make sure we have the history
+    # subprocess.run(["git", "fetch", "--unshallow", "1000"], cwd=workdir, check=True)
+    print("orginal to", to)
+    to = "8c07121fc38b443524c8d88e1559f8095f97c3b1"
+    print("glob", glob)
     migrations_changes = subprocess.run(
         [
             "git",
@@ -30,6 +36,7 @@ def _get_changes(glob: str, to: str = "origin/master") -> str:
         ],
         stdout=subprocess.PIPE,
         text=True,
+        cwd=workdir,
     )
     if migrations_changes.returncode != 0:
         raise ExecError(migrations_changes.stdout)
@@ -37,11 +44,11 @@ def _get_changes(glob: str, to: str = "origin/master") -> str:
         return migrations_changes.stdout
 
 
-def main(to: str = "origin/master") -> None:
-    migrations_changes = _get_migration_changes(to)
+def main(to: str = "origin/master", workdir: str = ".") -> None:
+    migrations_changes = _get_migration_changes(workdir, to)
     has_migrations = len(migrations_changes.splitlines()) > 0
     if has_migrations:
-        all_changes = _get_changes("*", to)
+        all_changes = _get_changes("*", workdir, to)
         if all_changes != migrations_changes:
             raise CoupledMigrations(
                 f"Migration changes are coupled with other changes.\n\nMigrations changes: \n{migrations_changes}\n\nAll changes: \n{all_changes}"
@@ -51,5 +58,6 @@ def main(to: str = "origin/master") -> None:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--to", default="origin/master")
+    parser.add_argument("--workdir", default=".")
     args = parser.parse_args()
-    main(args.to)
+    main(args.to, args.workdir)

--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -12,6 +12,9 @@ from typing import Any, Dict, Optional
 
 GO_SERVER_URL = os.environ["GO_SERVER_URL"]
 
+# the maximum number of times to fetch the pipeline history
+MAX_FETCHES = 100
+
 
 def pipeline_passed(pipeline: Dict[str, Any]) -> bool:
     # stage["result"] isn't populated if it isn't run
@@ -29,8 +32,9 @@ def main(pipeline_name: str = "deploy-snuba", repo: str = "snuba") -> int:
             """
         )
     fetch_url: Optional[str] = f"{GO_SERVER_URL}/api/pipelines/{pipeline_name}/history"
-
-    while fetch_url:
+    fetches = 0
+    while fetch_url and fetches < MAX_FETCHES:
+        fetches += 1
         req = urllib.request.Request(
             fetch_url,
             headers={

--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -10,9 +10,7 @@ import urllib.error
 import urllib.request
 from typing import Any, Dict, Optional
 
-GO_SERVER_URL = os.environ.get(
-    "GO_SERVER_URL", "http://gocd-server.gocd.svc.cluster.local:8153/go"
-)
+GO_SERVER_URL = os.environ["GO_SERVER_URL"]
 
 
 def pipeline_passed(pipeline: Dict[str, Any]) -> bool:

--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict
+
+
+def pipeline_passed(pipeline: Dict[str, Any]) -> bool:
+    # stage["result"] isn't populated if it isn't run
+    # the other possible statuses are Unknown (not run yet), Cancelled, Failed
+    return all(stage["status"] == "Passed" for stage in pipeline["stages"])
+
+
+# print the most recent passing sha for a repo
+def main(pipeline_name: str = "deploy-snuba", repo: str = "snuba") -> int:
+    GOCD_ACCESS_TOKEN = os.environ.get("GOCD_ACCESS_TOKEN")
+    if not GOCD_ACCESS_TOKEN:
+        raise SystemExit(
+            """
+            GOCD_ACCESS_TOKEN not set. It should be an access token belonging to bot@sentry.io.
+            """
+        )
+
+    req = urllib.request.Request(
+        f"http://gocd-server.gocd.svc.cluster.local:8153/go/api/pipelines/{pipeline_name}/history",
+        headers={
+            "Accept": "application/vnd.go.cd.v1+json",
+            "Authorization": f"bearer {GOCD_ACCESS_TOKEN}",
+        },
+    )
+    try:
+        resp = urllib.request.urlopen(req)
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"Failed to fetch pipeline history:\n{e.read().decode()}")
+    data = json.loads(resp.read())
+
+    rev = None
+    for pipeline in sorted(
+        data["pipelines"], key=lambda _: int(_["counter"]), reverse=True
+    ):
+        # Look at the most recent passing pipeline,
+        # and get its deployment revision for the main material.
+        if pipeline_passed(pipeline):
+
+            for r in pipeline["build_cause"]["material_revisions"]:
+                # example material description format... `in` is good enough
+                # 'URL: git@github.com:getsentry/devinfra-example-service.git, Branch: main'
+                if (
+                    f"git@github.com:getsentry/{repo}.git"
+                    in r["material"]["description"]
+                ):
+                    rev = r["modifications"][0]["revision"]
+                    break
+                elif (
+                    f"https://github.com/getsentry/{repo}.git"
+                    in r["material"]["description"]
+                ):
+                    rev = r["modifications"][0]["revision"]
+                    break
+    if rev is None:
+        raise SystemExit(f"Couldn't find {repo} in {pipeline}")
+    print(rev)
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pipeline", default="deploy-snuba")
+    parser.add_argument("--repo", default="snuba")
+    args = parser.parse_args()
+    main(args.pipeline, args.repo)

--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -54,7 +54,6 @@ def main(pipeline_name: str = "deploy-snuba", repo: str = "snuba") -> int:
             fetch_url = data["_links"]["next"]["href"]
         else:
             fetch_url = None
-        print([x["counter"] for x in data["pipelines"]], file=sys.stderr)
         rev = None
 
         for pipeline in sorted(


### PR DESCRIPTION
There's an ongoing effort to make migrations run in a more automated manner. As such, there's a need to add some guardrails to check that migrations aren't coupled with other code changes. This makes them more easily reversible if something goes wrong during when apply a migration.

This PR checks that when changes are made to migrations (in `snuba_migrations`), no other files outside the `snuba_migrations` are touched. It adds two scripts to run in CI:

* `check_migrations.py` :  a script that diff HEAD with a given sha and throws a `CoupledMigrations` exceptions if the diff has a mixture of migrations and non-migrations changes. 
* `fetch_service_ref.py` :  a script that uses the GoCD REST api to fetch the most recent successfully deployed sha from the GoCD pipeline. 


To first test this, we are adding it to the `snuba-sns-test.yaml` for test deployments, then in a follow up PR will will add it to the main gocd pipeline.