### PR TITLE
feat(DRS): Add SUPPORTED_STATES settings in dev and self-hosted

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 from typing import (
     Any,
-    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -263,7 +262,7 @@ if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
     SKIPPED_MIGRATION_GROUPS.remove("search_issues")
 
 # Dataset readiness states supported in this environment
-SUPPORTED_STATES: List[str] = ["deprecate", "limited", "partial", "complete"]
+SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 
 MAX_RESOLUTION_FOR_JITTER = 60
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 from typing import (
     Any,
+    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -261,6 +262,8 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {
 if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
     SKIPPED_MIGRATION_GROUPS.remove("search_issues")
 
+# Dataset readiness states supported in this environment
+SUPPORTED_STATES: List[str] = ["deprecate", "limited", "partial", "complete"]
 
 MAX_RESOLUTION_FOR_JITTER = 60
 

--- a/snuba/settings/settings_self_hosted.py
+++ b/snuba/settings/settings_self_hosted.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import Set
 
 env = os.environ.get
 
@@ -18,6 +18,6 @@ DOGSTATSD_HOST = env("DOGSTATSD_HOST")
 DOGSTATSD_PORT = env("DOGSTATSD_PORT")
 
 # Dataset readiness states supported in this environment
-SUPPORTED_STATES: List[str] = ["complete"]
+SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 
 SENTRY_DSN = env("SENTRY_DSN")

--- a/snuba/settings/settings_self_hosted.py
+++ b/snuba/settings/settings_self_hosted.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 
 env = os.environ.get
 
@@ -15,5 +16,8 @@ USE_REDIS_CLUSTER = False
 # Dogstatsd Options
 DOGSTATSD_HOST = env("DOGSTATSD_HOST")
 DOGSTATSD_PORT = env("DOGSTATSD_PORT")
+
+# Dataset readiness states supported in this environment
+SUPPORTED_STATES: List[str] = ["complete"]
 
 SENTRY_DSN = env("SENTRY_DSN")

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Set
+from typing import Set
 
 TESTING = True
 
@@ -13,7 +13,7 @@ USE_RESULT_CACHE = True
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 
 SKIPPED_MIGRATION_GROUPS: Set[str] = set()
-SUPPORTED_STATES: List[str] = ["deprecate", "limited", "partial", "complete"]
+SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 ENABLE_DEV_FEATURES = True
 
 # Sometimes we want the raw structure of an expression

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -1,5 +1,5 @@
 import os
-from typing import Set
+from typing import List, Set
 
 TESTING = True
 
@@ -13,6 +13,7 @@ USE_RESULT_CACHE = True
 SENTRY_DSN = os.getenv("SENTRY_DSN")
 
 SKIPPED_MIGRATION_GROUPS: Set[str] = set()
+SUPPORTED_STATES: List[str] = ["deprecate", "limited", "partial", "complete"]
 ENABLE_DEV_FEATURES = True
 
 # Sometimes we want the raw structure of an expression


### PR DESCRIPTION
### Overview
This PR is responsible for adding `SUPPORTED_STATES` settings in dev and self-hosted settings files. Right now, there are four states: `deprecate`, `limited`, `partial`, and `complete`. These readiness states map to snuba specific environments within Sentry are used to determine which storages and migrations groups are available within an environment.

### Blast Radius
These settings will not do anything after being merged because Dataset Readiness States have not been implemented yet. Side note, the rollout for readiness states will be control by a runtime config and updated for less critical datasets first.