### PR TITLE
fix: Update build arguments to no longer build admin UI for ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,7 @@ jobs:
           docker buildx build --platform linux/arm64 \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg SHOULD_BUILD_ADMIN_UI=false \
+            --build-arg SHOULD_BUILD_RUST=false \
             --cache-from ${SNUBA_IMAGE}:latest \
             --cache-from ${SNUBA_IMAGE}:${{ steps.branch.outputs.branch }} \
             -t ${SNUBA_IMAGE}:latest \

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       IMG_CACHE: ghcr.io/getsentry/snuba:${{ matrix.arch }}-latest
       IMG_VERSIONED: ghcr.io/getsentry/snuba:${{ matrix.arch }}-${{ github.sha }}
-      BUILD_BASE: ${{ matrix.arch == 'arm64' && 'base' || 'build_admin_ui' }}
+      SHOULD_BUILD_ADMIN_UI: ${{ matrix.arch == 'arm64' && 'false' || 'true' }}
       NODE_VERSION: 19.x
     steps:
     - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
         docker buildx build \
             "${args[@]}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --build-arg BUILD_BASE="$BUILD_BASE" \
+            --build-arg SHOULD_BUILD_ADMIN_UI="$SHOULD_BUILD_ADMIN_UI" \
             --platform linux/${{ matrix.arch }} \
             --tag "$IMG_VERSIONED" \
             --target application \

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -41,6 +41,7 @@ jobs:
             "${args[@]}" \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
             --build-arg SHOULD_BUILD_ADMIN_UI="$SHOULD_BUILD_ADMIN_UI" \
+            --build-arg SHOULD_BUILD_RUST=false \
             --platform linux/${{ matrix.arch }} \
             --tag "$IMG_VERSIONED" \
             --target application \


### PR DESCRIPTION
This build arg was changed recently to be a bit more explicit

also get rid of rust in all github docker (ghcr) images for now, caching somehow doesn't work. we only need it on google cloud build, where caching works fine