### PR TITLE
fix(tests): initialize snuba before tests run

### DIFF
--- a/snuba/datasets/configuration/loader.py
+++ b/snuba/datasets/configuration/loader.py
@@ -13,8 +13,8 @@ def load_configuration_data(path: str, validators: dict[str, Any]) -> dict[str, 
     """
     with sentry_sdk.start_span(op="load_and_validate") as span:
         span.set_tag("file", path)
-        file = open(path)
-        config = safe_load(file)
+        with open(path) as file:
+            config = safe_load(file)
         assert isinstance(config, dict)
         validators[config["kind"]](config)
         span.description = config["name"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from snuba_sdk.legacy import json_to_snql
 
 from snuba import settings, state
 from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseCluster
+from snuba.core.initialize import initialize_snuba
 from snuba.datasets.factory import reset_dataset_factory
 from snuba.datasets.schemas.tables import WritableTableSchema
 from snuba.datasets.storages.factory import get_all_storage_keys, get_storage
@@ -23,6 +24,7 @@ def pytest_configure() -> None:
     ), "settings.TESTING is False, try `SNUBA_SETTINGS=test` or `make test`"
 
     setup_sentry()
+    initialize_snuba()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
if tests are run in isolation which depend on the entity factory, they will not have initialized them and get an AttributeError

Also fix an unclosed file warning