### PR TITLE
ci: Bump test_distributed timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
     needs: [linting, snuba-image]
     name: Tests and code coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 60
     strategy:
       matrix:
         snuba_settings:


### PR DESCRIPTION
I took a look and the timeouts didn't start recently, so not sure what's
going on. We have some other PRs lined up for speed improvements at
least.
