### PR TITLE
fix: Also do not build Rust for the arm64 CI image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
         run: |
           docker build . \
             -t snuba-test \
+            --build-arg SHOULD_BUILD_RUST=false \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
             --cache-from ghcr.io/getsentry/snuba-ci:latest \


### PR DESCRIPTION
I believe this image is dead and should be removed entirely, but for now
let's not build Rust inside of it
