### PR TITLE
ref(migrations): run multiple migrations through a specifc migration id

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -59,7 +59,11 @@ def list() -> None:
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
 def migrate(
-    group: str, through: str, force: bool, fake: bool, log_level: Optional[str] = None
+    group: Optional[str],
+    through: str,
+    force: bool,
+    fake: bool,
+    log_level: Optional[str] = None,
 ) -> None:
     """
     If group is specified, runs all the migrations for a group (including any pending

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -51,13 +51,15 @@ def list() -> None:
 
 
 @migrations.command()
+@click.argument("group", default="all")
+@click.argument("through", default="all")
 @click.option("--force", is_flag=True)
-@click.option("--group", help="Migration group")
+@click.option("--fake", is_flag=True)
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
 def migrate(
-    force: bool, group: Optional[str] = None, log_level: Optional[str] = None
+    group: str, through: str, force: bool, fake: bool, log_level: Optional[str] = None
 ) -> None:
     """
     If group is specified, runs all the migrations for a group (including any pending
@@ -71,11 +73,13 @@ def migrate(
     runner = Runner()
 
     try:
-        if group is not None:
+        if group != "all":
             migration_group = MigrationGroup(group)
         else:
+            if through != "all":
+                raise click.ClickException("Need migration group")
             migration_group = None
-        runner.run_all(force=force, group=migration_group)
+        runner.run_all(through=through, force=force, fake=fake, group=migration_group)
     except MigrationError as e:
         raise click.ClickException(str(e))
 

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -51,7 +51,7 @@ def list() -> None:
 
 
 @migrations.command()
-@click.argument("group", default="all")
+@click.option("-g", "--group", default=None)
 @click.argument("through", default="all")
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
@@ -73,7 +73,7 @@ def migrate(
     runner = Runner()
 
     try:
-        if group != "all":
+        if group:
             migration_group = MigrationGroup(group)
         else:
             if through != "all":

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -174,6 +174,8 @@ class Runner:
         use_through = False if through == "all" else True
 
         def migration_exists(through: str) -> bool:
+            # (todo) make sure there is only one that could match
+            # aka `00` isn't valid since all the migrations could match that
             for migration_key in pending_migrations:
                 if migration_key.migration_id.startswith(through):
                     return True

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -196,7 +196,11 @@ class Runner:
                     raise MigrationError("Requires force to run blocking migrations")
 
         for migration_key in pending_migrations:
-            self._run_migration_impl(migration_key, force=force)
+            if fake:
+                self._update_migration_status(migration_key, Status.COMPLETED)
+            else:
+                self._run_migration_impl(migration_key, force=force)
+
             if use_through and migration_key.migration_id.startswith(through):
                 logger.info(f"Ran through: {migration_key.migration_id}")
                 break

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -256,6 +256,7 @@ def test_run_all_using_through() -> None:
         == []
     )
 
+
 @pytest.mark.clickhouse_db
 def test_reverse_all() -> None:
     runner = Runner()

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -238,9 +238,22 @@ def test_run_all_using_through() -> None:
         # no migration id matches
         runner.run_all(force=True, group=group, through="9999")
 
-    runner.run_all(force=True, group=group, through="0003")
+    runner.run_all(force=True, group=group, through="0002")
     assert len(runner._get_pending_migrations_for_group(group=group)) == (
-        all_generic_metrics - 3
+        all_generic_metrics - 2
+    )
+
+    # Running with --fake
+    # (generic_metric_sets_aggregation_mv was added in 0003)
+    runner.run_all(force=True, group=group, through="0003", fake=True)
+    connection = get_cluster(StorageSetKey.GENERIC_METRICS_SETS).get_query_connection(
+        ClickhouseClientSettings.MIGRATE
+    )
+    assert (
+        connection.execute(
+            "SHOW TABLES LIKE 'generic_metric_sets_aggregation_mv'"
+        ).results
+        == []
     )
 
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
Specifying the group and prefix will migration through that migration (includes the matching migration)

this should also work for `--fake`

```shell
12:35 $ snuba migrations migrate -g generic_metrics 0012
2023-03-24 12:35:29,689 Initializing Snuba...
2023-03-24 12:35:31,869 Snuba initialization took 2.181490815s
2023-03-24 12:35:31,895 Running migration: 0012_counters_mv
2023-03-24 12:35:31,957 Finished: 0012_counters_mv
2023-03-24 12:35:31,965 Ran through: 0012_counters_mv
Finished running migrations
```


If the migration is already run or the arg doesn't match, get an error
```shell
12:34 $ snuba migrations migrate -g generic_metrics 0011
2023-03-24 12:35:23,842 Initializing Snuba...
2023-03-24 12:35:26,178 Snuba initialization took 2.337297151s
Error: No pending migration matching: 0011
```

```
12:28 $ snuba migrations migrate -g generic_metrics 0089
2023-03-24 12:34:41,059 Initializing Snuba...
2023-03-24 12:34:43,528 Snuba initialization took 2.470212598s
Error: No migration matching: 0089
```


