### PR TITLE
skip checking undefined nodes

### DIFF
--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -6,7 +6,12 @@ from typing import Sequence
 from packaging import version
 
 from snuba.clickhouse.native import ClickhousePool
-from snuba.clusters.cluster import CLUSTERS, ClickhouseClientSettings, ClickhouseNode
+from snuba.clusters.cluster import (
+    CLUSTERS,
+    ClickhouseClientSettings,
+    ClickhouseNode,
+    UndefinedClickhouseCluster,
+)
 from snuba.clusters.storage_sets import DEV_STORAGE_SETS
 from snuba.datasets.storages.factory import get_all_storage_keys, get_storage
 from snuba.datasets.storages.storage_key import StorageKey
@@ -80,7 +85,10 @@ def check_for_inactive_replicas() -> None:
 
     for storage_key in storage_keys:
         storage = get_storage(storage_key)
-        cluster = storage.get_cluster()
+        try:
+            cluster = storage.get_cluster()
+        except UndefinedClickhouseCluster:
+            continue
 
         query_node = cluster.get_query_node()
         if storage_key == StorageKey.DISCOVER:


### PR DESCRIPTION
Some storages like CDC dont have defined clusters in prod. Skip checking them.
