### PR TITLE
fix(migrations): add passing in yes to migrations cli prompt for headless cli running

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -88,6 +88,7 @@ def migrate(
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
 @click.option("--dry-run", is_flag=True)
+@click.option("--yes", is_flag=True)
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
@@ -97,6 +98,7 @@ def run(
     force: bool,
     fake: bool,
     dry_run: bool,
+    yes: bool,
     log_level: Optional[str] = None,
 ) -> None:
     """
@@ -120,7 +122,7 @@ def run(
         return
 
     try:
-        if fake:
+        if fake and not yes:
             click.confirm(
                 "This will mark the migration as completed without actually running it. Your database may be in an invalid state. Are you sure?",
                 abort=True,
@@ -138,6 +140,7 @@ def run(
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
 @click.option("--dry-run", is_flag=True)
+@click.option("--yes", is_flag=True)
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
@@ -147,6 +150,7 @@ def reverse(
     force: bool,
     fake: bool,
     dry_run: bool,
+    yes: bool,
     log_level: Optional[str] = None,
 ) -> None:
     """
@@ -168,7 +172,7 @@ def reverse(
         return
 
     try:
-        if fake:
+        if fake and not yes:
             click.confirm(
                 "This will mark the migration as not started without actually reversing it. Your database may be in an invalid state. Are you sure?",
                 abort=True,
@@ -184,12 +188,14 @@ def reverse(
 @click.option("--group", help="Migration group")
 @click.option("--fake", is_flag=True)
 @click.option("--dry-run", is_flag=True)
+@click.option("--yes", is_flag=True)
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
 def reverse_in_progress(
     fake: bool,
     dry_run: bool,
+    yes: bool,
     group: Optional[str] = None,
     log_level: Optional[str] = None,
 ) -> None:
@@ -213,7 +219,7 @@ def reverse_in_progress(
         return
 
     try:
-        if fake:
+        if fake and not yes:
             click.confirm(
                 "This will mark the migration as not started without actually reversing it. Your database may be in an invalid state. Are you sure?",
                 abort=True,


### PR DESCRIPTION
allow passing `--yes` to the migrations fake prompt so we can run in headless mode. Needed for k8s jobs