### PR TITLE
ref(outcomes): Use python types from sentry-kafka-schemas for OutcomesProcessor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.7.1
-sentry-kafka-schemas==0.0.11
+sentry-kafka-schemas==0.0.13
 sentry-relay==0.8.19
 sentry-sdk==1.16.0
 simplejson==3.17.6

--- a/snuba/datasets/processors/outcomes_processor.py
+++ b/snuba/datasets/processors/outcomes_processor.py
@@ -1,7 +1,8 @@
 import uuid
 from datetime import datetime
-from typing import Any, Mapping, Optional
+from typing import Optional
 
+from sentry_kafka_schemas.schema_types.outcomes_v1 import Outcome
 from sentry_relay import DataCategory
 
 from snuba import environment, settings
@@ -38,32 +39,34 @@ CLIENT_DISCARD_REASONS = frozenset(
 
 class OutcomesProcessor(DatasetMessageProcessor):
     def process_message(
-        self, value: Mapping[str, Any], metadata: KafkaMessageMetadata
+        self, outcome: Outcome, metadata: KafkaMessageMetadata
     ) -> Optional[ProcessedMessage]:
-        assert isinstance(value, dict)
-        v_uuid = value.get("event_id")
-        reason = value.get("reason")
+        assert isinstance(outcome, dict)
+        v_uuid = outcome.get("event_id")
+        reason = outcome.get("reason")
 
         # relays let arbitrary outcome reasons through do the topic.  We
         # reject undesired values only in the processor so that we can
         # add new ones without having to update relays through the entire
         # chain.
-        if value["outcome"] == OUTCOME_CLIENT_DISCARD:
+        if outcome["outcome"] == OUTCOME_CLIENT_DISCARD:
             if reason is not None and reason not in CLIENT_DISCARD_REASONS:
                 reason = None
 
         if (
-            value["outcome"] != OUTCOME_ABUSE
+            outcome["outcome"] != OUTCOME_ABUSE
         ):  # we dont care about abuse outcomes for these metrics
-            if "category" not in value:
+            if "category" not in outcome:
                 metrics.increment("missing_category")
-            if "quantity" not in value:
+            if "quantity" not in outcome:
                 metrics.increment("missing_quantity")
 
         message = None
         try:
             timestamp = _ensure_valid_date(
-                datetime.strptime(value["timestamp"], settings.PAYLOAD_DATETIME_FORMAT),
+                datetime.strptime(
+                    outcome["timestamp"], settings.PAYLOAD_DATETIME_FORMAT
+                ),
             )
         except Exception:
             metrics.increment("bad_outcome_timestamp")
@@ -71,13 +74,13 @@ class OutcomesProcessor(DatasetMessageProcessor):
 
         try:
             message = {
-                "org_id": value.get("org_id", 0),
-                "project_id": value.get("project_id", 0),
-                "key_id": value.get("key_id"),
+                "org_id": outcome.get("org_id", 0),
+                "project_id": outcome.get("project_id", 0),
+                "key_id": outcome.get("key_id"),
                 "timestamp": timestamp,
-                "outcome": value["outcome"],
-                "category": value.get("category", DataCategory.ERROR),
-                "quantity": value.get("quantity", 1),
+                "outcome": outcome["outcome"],
+                "category": outcome.get("category", DataCategory.ERROR),
+                "quantity": outcome.get("quantity", 1),
                 "reason": _unicodify(reason),
                 "event_id": str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
             }


### PR DESCRIPTION
### Overview
Added schema validation for outcome and use `Outcome` python type hint for OutcomesProcessor