### PR TITLE
feat(admin): add system query for inactive replicas and show error msgs

### DIFF
--- a/snuba/admin/clickhouse/predefined_system_queries.py
+++ b/snuba/admin/clickhouse/predefined_system_queries.py
@@ -81,3 +81,30 @@ class PartSizeWithinPartition(SystemQuery):
         bytes_on_disk > 1000000
     ORDER BY bytes_on_disk DESC
     """
+
+
+class InactiveReplicas(SystemQuery):
+    """
+    Checks for inactive replicas by querying for active_replicas < total_replicas.
+    Also checks if total_replicas < 2 as this is likely an indication
+    that a replica is not configured correctly.
+
+    Shows the replica path of the current replica. To get the replica paths of the
+    inactive replicas you need to inspect the system.zookeeper table.
+
+    """
+
+    sql = """
+    SELECT
+        total_replicas,
+        active_replicas,
+        replica_path,
+        last_queue_update,
+        zookeeper_exception,
+        is_leader,
+        is_readonly
+    FROM system.replicas
+    WHERE
+        active_replicas < total_replicas
+        OR total_replicas < 2
+    """

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -40,7 +40,7 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.migrations.connect import check_for_inactive_replicas
-from snuba.migrations.errors import MigrationError
+from snuba.migrations.errors import InactiveClickhouseReplica, MigrationError
 from snuba.migrations.groups import MigrationGroup
 from snuba.migrations.runner import MigrationKey, Runner
 from snuba.query.exceptions import InvalidQueryException
@@ -218,6 +218,11 @@ def run_or_reverse_migration(group: str, action: str, migration_id: str) -> Resp
         logger.error(err, exc_info=True)
         return make_response(
             jsonify({"error": "clickhouse error: " + err.message}), 400
+        )
+    except InactiveClickhouseReplica as err:
+        logger.error(err, exc_info=True)
+        return make_response(
+            jsonify({"error": "inactive replicas error: " + err.message}), 400
         )
 
 


### PR DESCRIPTION
Follow up to #3861 

Add a system query to get the replica counts as we use this often. Also allows the admin tool to show the inactive replica error when detected.