### PR TITLE
feat: Produce generic metrics subscription results on single topic (#…

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
@@ -58,7 +58,7 @@ stream_loader:
   commit_log_topic: snuba-generic-metrics-counters-commit-log
   subscription_scheduler_mode: global
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-counters
-  subscription_result_topic: generic-metrics-counters-subscription-results
+  subscription_result_topic: generic-metrics-subscription-results
   dlq_policy:
     type: produce
     args: [snuba-dead-letter-generic-metrics]

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -58,7 +58,7 @@ stream_loader:
   commit_log_topic: snuba-generic-metrics-distributions-commit-log
   subscription_scheduler_mode: global
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-distributions
-  subscription_result_topic: generic-metrics-distributions-subscription-results
+  subscription_result_topic: generic-metrics-subscription-results
   dlq_policy:
     type: produce
     args: [snuba-dead-letter-generic-metrics]

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -58,7 +58,7 @@ stream_loader:
   commit_log_topic: snuba-generic-metrics-sets-commit-log
   subscription_scheduler_mode: global
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-sets
-  subscription_result_topic: generic-metrics-sets-subscription-results
+  subscription_result_topic: generic-metrics-subscription-results
   dlq_policy:
     type: produce
     args: [snuba-dead-letter-generic-metrics]


### PR DESCRIPTION
Bringing back https://github.com/getsentry/snuba/pull/3899

Previously we were missing https://github.com/getsentry/ops/pull/6461. Now the prod change is applied, let's give it another shot.