### PR TITLE
feat: DLQ performance test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
-sentry-arroyo[json]==2.7.1
+sentry-arroyo[json]==2.8.0
 sentry-kafka-schemas==0.0.18
 sentry-relay==0.8.19
 sentry-sdk==1.18.0

--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -2,7 +2,13 @@ from abc import abstractmethod
 from typing import Callable, Mapping, Optional, Protocol, Union
 
 from arroyo.backends.kafka import KafkaPayload
-from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory
+from arroyo.processing.strategies import (
+    FilterStep,
+    ProcessingStrategy,
+    ProcessingStrategyFactory,
+    Reduce,
+    RunTaskInThreads,
+)
 from arroyo.processing.strategies.commit import CommitOffsets
 from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
     DeadLetterQueue,
@@ -10,9 +16,6 @@ from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
 from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
     DeadLetterQueuePolicy,
 )
-from arroyo.processing.strategies.filter import FilterStep
-from arroyo.processing.strategies.reduce import Reduce
-from arroyo.processing.strategies.run_task import RunTaskInThreads
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
 from arroyo.types import BaseValue, Commit, FilteredPayload, Message, Partition
 


### PR DESCRIPTION
We want to check if the DLQ proposal in Arroyo is viable by testing the performance impact on Snuba in production.

There are no functional changes here, however if the runtime config `run_dlq_test_{storage_name}` is set, the consumer for that storage will start buffering messages as would be needed for the DLQ.

Note that this config is only checked once upon start up of the consumer so a deploy is needed for the runtime config value to take effect.
