### PR TITLE
feat(API): log failed `/health`

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -379,6 +379,7 @@ def health() -> Response:
 
     if status != 200:
         metrics.increment("healthcheck_failed", tags=metric_tags)
+        logger.error(f"Snuba health check failed! Tags: {metric_tags}")
     metrics.timing(
         "healthcheck.latency", time.time() - start, tags={"thorough": str(thorough)}
     )


### PR DESCRIPTION
### Overview
- We're seeing a lot of pod restarts for Snuba API but the ddog metric doesn't seem to align, it's possible the metric isn't being emitted
- Adds an error log on any failed `/health` call to try and gain more observability on the issue via logs