### PR TITLE
feat(admin): Bytes scanned + Request duration by Org pre-defined queries

### DIFF
--- a/snuba/admin/clickhouse/predefined_querylog_queries.py
+++ b/snuba/admin/clickhouse/predefined_querylog_queries.py
@@ -251,7 +251,7 @@ class DurationForReferrerByOrganizations(QuerylogQuery):
             organization
         FROM querylog_local
         WHERE referrer = '{{referrer}}'
-        AND time > (now() - (1 * 3600))
+        AND time > (now() - ({{duration}}))
         AND time < now()
         GROUP BY
             organization,


### PR DESCRIPTION
### Overview
- Adds the following pre-defined queries to Querylog:
    - Most bytes scanned for referrer by organization
    - Highest cumulative request duration for referrer by organization