### PR TITLE
fix: Add error message when replacement is dropped

### DIFF
--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -402,6 +402,9 @@ def _build_group_replacement(
     txn = message.data.get("transaction_id")
     if txn:
         if txn in SEEN_MERGE_TXN_CACHE:
+            logger.error(
+                "Skipping duplicate group replacement", extra={"project_id": project_id}
+            )
             return None
         else:
             SEEN_MERGE_TXN_CACHE.append(txn)


### PR DESCRIPTION
We want to know if this actually is still happening since it was
originally conceived in https://github.com/getsentry/snuba/commit/67618adbf987560274b40fa35a6a8b579130ea3a#diff-efbe37619db8bd83053dfc7e8eecf1ec37700b2d5078eb8ad6a5e462ac93605aR112-R119

If not, we could get rid of transaction_id as a concept in replacements
