### PR TITLE
ref(ci): add auto labeling for migrations

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+migrations:
+- snuba/group_loader.py
+- snuba/snuba_migrations/**/*
+- snuba/migrations/system_migrations/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
I want it to be easy to see what PRs are migrations, so adding an auto labeler for the files that you'd need to touch to create a migration. 

**Note:** A change in this PR https://github.com/getsentry/snuba/pull/3960/ changes the file structure for migrations so the files below are to match the file structure in the linked PR, so we should merge this after