### PR TITLE
fix: Subscription result data

### DIFF
--- a/snuba/subscriptions/codecs.py
+++ b/snuba/subscriptions/codecs.py
@@ -49,8 +49,6 @@ class SubscriptionTaskResultEncoder(Encoder[KafkaPayload, SubscriptionTaskResult
                 "result": {
                     "data": result["data"],
                     "meta": result["meta"],
-                    "profile": result["profile"],
-                    "trace_output": result["trace_output"],
                 },
                 "timestamp": value.task.timestamp.isoformat(),
                 "entity": entity.value,

--- a/tests/subscriptions/test_codecs.py
+++ b/tests/subscriptions/test_codecs.py
@@ -164,7 +164,7 @@ def test_subscription_task_result_encoder() -> None:
         task_result.task.task.subscription.identifier
     )
     assert payload["request"] == request.original_body
-    assert payload["result"] == result
+    assert payload["result"]["data"] == result["data"]
     assert payload["timestamp"] == task_result.task.timestamp.isoformat()
     assert payload["entity"] == EntityKey.EVENTS.value
 
@@ -247,7 +247,7 @@ def test_metrics_subscription_task_result_encoder(
         task_result.task.task.subscription.identifier
     )
     assert payload["request"] == request.original_body
-    assert payload["result"] == result
+    assert payload["result"]["data"] == result["data"]
     assert payload["timestamp"] == task_result.task.timestamp.isoformat()
     assert payload["entity"] == entity_key.value
 


### PR DESCRIPTION
`trace_output` and `profile` are internal Snuba things. Sentry does nothing with them and they are not required by the schema. Let's not produce this data unnecessarily.