### PR TITLE
fix(migrations): Enable profiles, functions and search-issues migrations in dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,6 @@ jobs:
             -e REDIS_HOST=sentry_redis \
             -e REDIS_PORT=6379 \
             -e REDIS_DB=1 \
-            -e ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES=1 \
             --name sentry_snuba \
             --network sentry \
             snuba-test

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -250,14 +250,8 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 # Migrations for skipped groups will not be run.
 SKIPPED_MIGRATION_GROUPS: Set[str] = {
     "querylog",
-    "profiles",
-    "functions",
     "test_migration",
-    "search_issues",
 }
-
-if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
-    SKIPPED_MIGRATION_GROUPS.remove("search_issues")
 
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}


### PR DESCRIPTION
### Overview
This PR is responsible for enabling migrations for profiles, functions, and search-issues to run in local ClickHouse. We already run these migrations in production.