### PR TITLE
fix(functions): Remove is_experimental flag for functions dataset

### DIFF
--- a/snuba/datasets/configuration/functions/dataset.yaml
+++ b/snuba/datasets/configuration/functions/dataset.yaml
@@ -2,7 +2,7 @@ version: v1
 kind: dataset
 name: functions
 
-is_experimental: true
+is_experimental: false
 
 entities:
   - functions


### PR DESCRIPTION
Turns off `is_experimental` for `functions` dataset. This will enable ClickHouse health-checks in production.