### PR TITLE
fix(scheduler) Increase producer buffer size

### DIFF
--- a/snuba/subscriptions/scheduler_processing_strategy.py
+++ b/snuba/subscriptions/scheduler_processing_strategy.py
@@ -401,7 +401,7 @@ class ProduceScheduledSubscriptionMessage(ProcessingStrategy[CommittableTick]):
         self.__queue = ScheduledSubscriptionQueue()
 
         # Not a hard max
-        self.__max_buffer_size = 10000
+        self.__max_buffer_size = 80000
 
     def poll(self) -> None:
         # Remove completed tasks from the queue and raise if an exception occurred.


### PR DESCRIPTION
librdkafka producer buffer is 100k messages.
We limit ourselves. to 10k by mistake.
This increases that limit.