### PR TITLE
feat(DRS): Use readiness_states in health-checks and active migration groups

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -88,3 +88,7 @@ _REGISTERED_MIGRATION_GROUPS = {
 
 def get_group_loader(group: MigrationGroup) -> GroupLoader:
     return _REGISTERED_MIGRATION_GROUPS[group].loader
+
+
+def get_readiness_state(group: MigrationGroup) -> ReadinessState:
+    return _REGISTERED_MIGRATION_GROUPS[group].readiness_state

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -261,6 +261,8 @@ if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
 
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
+READINESS_STATE_MIGRATION_GROUPS_ENABLED: set[str] = set()
+READINESS_STATE_STORAGES_ENABLED: set[str] = set()
 
 MAX_RESOLUTION_FOR_JITTER = 60
 


### PR DESCRIPTION
### Overview
This PR is responsible for updating `get_active_migration_groups()` and `check_clickhouse()` functions to use readiness_states to determine:
1. Whether or not a health-check should be executed 
2. Whether or not a migration group is active

The roll-out process is controlled by two new settings variables called `READINESS_STATE_MIGRATION_GROUPS_ENABLED: set[str]` and `READINESS_STATE_STORAGES_ENABLED: set[str]`.
If the storage or migration group exists in these sets, then use the readiness_state to determine whether or not the health-check or migration group is active. If not, then use the existing system (is_experimental and SKIPPED_MIGRATION_GROUPS). The goal is to incrementally roll this out to all storages and migration groups. Once this is completely rolled out and there is parity across all environments, we can deprecate the old settings. More details in [Dataset Readiness State Rollout Plan](https://www.notion.so/sentry/Dataset-Readiness-State-Rollout-Plan-d38deffe77534856a4e4f4a3b0cfb110?pvs=4#7c8bd102fbd2467ca40df7029a29e448).

### Blast Radius
This change impacts all storage health-checks and how migrations_groups are loaded. Supposedly, there should be no change until we add to `READINESS_STATE_MIGRATION_GROUPS_ENABLED` and `READINESS_STATE_STORAGES_ENABLED`