### PR TITLE
Pin fossa action to commit

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Enforce License Compliance'
-        uses: getsentry/action-enforce-license-compliance@main
+        uses: getsentry/action-enforce-license-compliance@693b4f5a92ea8629db875f0226b05e8af43c95ae
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Let's pin license compliance scanning to a commit. This is done in `sentry` and `getsentry`. Example: https://github.com/getsentry/sentry/blob/2430ab615a525b69558f523ae80612043465bab8/.github/workflows/enforce-license-compliance.yml

This will turn off the license compliance until it is bumped manually, seems reasonable to do for snuba since merging and deploying fast can be super important here