### PR TITLE
fix(CI): skip checking groups loader for migration changes

### DIFF
--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -12,6 +12,7 @@ not coupled with other changes.
 # changes to these files here are allowed to be coupled with migrations
 ALLOWED_MIGRATIONS_GLOBS = [
     "snuba/migrations/groups.py",
+    "snuba/migrations/group_loader.py",
     "tests",
     "test_distributed_migrations",
     "test_initialization",


### PR DESCRIPTION
Skip checking groups_loader.py for coupled migrations changes since this is a file that is also updated with migrations.
