### PR TITLE
fix(ci): diff only new changes

### DIFF
--- a/.github/workflows/ddl-changes.yml
+++ b/.github/workflows/ddl-changes.yml
@@ -12,10 +12,12 @@ jobs:
         name: Checkout master for diffing
         with:
           ref: master
+          fetch-depth: 20
       - uses: actions/checkout@v3
         name: Checkout HEAD of code that may have migration changes
         with:
           clean: false
+          fetch-depth: 20
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8

--- a/.github/workflows/ddl-changes.yml
+++ b/.github/workflows/ddl-changes.yml
@@ -12,12 +12,12 @@ jobs:
         name: Checkout master for diffing
         with:
           ref: master
-          fetch-depth: 20
+          fetch-depth: 200
       - uses: actions/checkout@v3
         name: Checkout HEAD of code that may have migration changes
         with:
           clean: false
-          fetch-depth: 20
+          fetch-depth: 200
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8

--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -39,7 +39,7 @@ def _get_changes(globs: Sequence[str], workdir: str, to: str) -> str:
             "diff",
             "--diff-filter=AM",
             "--name-only",
-            to,
+            f"{to}...",
             "--",
             *globs,
             *[f":(exclude){allowed}" for allowed in ALLOWED_MIGRATIONS_GLOBS],


### PR DESCRIPTION
Use 3 dots to only diff new changes relative to master when checking migrations conflicts. This avoids having to rebase everytime.