### PR TITLE
feat(CapMan): AllocationPolicy for Errors

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -225,6 +225,14 @@ schema:
   local_table_name: errors_local
   dist_table_name: errors_dist_ro
   not_deleted_mandatory_condition: deleted
+allocation_policy:
+  name: ErrorsAllocationPolicy
+  args:
+    storage_set_key: events_ro
+    required_tenant_types:
+      - organzation_id
+      - referrer
+
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import os
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any, cast
 
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.state import get_config
-from snuba.utils.registered_class import RegisteredClass
+from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
 from snuba.utils.serializable_exception import SerializableException
 from snuba.web import QueryException, QueryResult
 
@@ -204,4 +205,8 @@ class PassthroughPolicy(AllocationPolicy):
 
 DEFAULT_PASSTHROUGH_POLICY = PassthroughPolicy(
     StorageSetKey("default.no_storage_set_key"), required_tenant_types=[]
+)
+
+import_submodules_in_directory(
+    os.path.dirname(os.path.realpath(__file__)), "snuba.query.allocation_policies"
 )

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -10,7 +10,7 @@ from snuba import settings
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.state import get_config
 from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
-from snuba.utils.serializable_exception import SerializableException
+from snuba.utils.serializable_exception import JsonSerializable, SerializableException
 from snuba.web import QueryException, QueryResult
 
 logger = logging.getLogger("snuba.query.allocation_policy_base")
@@ -55,11 +55,13 @@ class AllocationPolicyViolation(SerializableException):
         )
 
     @property
-    def quota_allowance(self):
-        return self.extra_data.get("quota_allowance", {})
+    def quota_allowance(self) -> dict[str, JsonSerializable]:
+        return cast(
+            "dict[str, JsonSerializable]", self.extra_data.get("quota_allowance", {})
+        )
 
     @property
-    def explanation(self) -> dict[str, Any]:
+    def explanation(self) -> dict[str, JsonSerializable]:
         return self.extra_data.get("quota_allowance", {}).get("explanation", {})  # type: ignore
 
     def __str__(self) -> str:

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -55,6 +55,10 @@ class AllocationPolicyViolation(SerializableException):
         )
 
     @property
+    def quota_allowance(self):
+        return self.extra_data.get("quota_allowance", {})
+
+    @property
     def explanation(self) -> dict[str, Any]:
         return self.extra_data.get("quota_allowance", {}).get("explanation", {})  # type: ignore
 

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any, cast
 
+from snuba import settings
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.state import get_config
 from snuba.utils.registered_class import RegisteredClass, import_submodules_in_directory
@@ -172,6 +173,8 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
             logger.exception(
                 "Allocation policy failed to get quota allowance, this is a bug, fix it"
             )
+            if settings.RAISE_ON_ALLOCATION_POLICY_FAILURES:
+                raise
             return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids)
         if not allowance.can_run:
             raise AllocationPolicyViolation.from_args(tenant_ids, allowance)
@@ -192,6 +195,8 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
             logger.exception(
                 "Allocation policy failed to update quota balance, this is a bug, fix it"
             )
+            if settings.RAISE_ON_ALLOCATION_POLICY_FAILURES:
+                raise
 
     @abstractmethod
     def _update_quota_balance(

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -136,6 +136,7 @@ class ErrorsAllocationPolicy(AllocationPolicy):
                     tags={
                         "storage_set_key": self._storage_set_key.value,
                         "is_enforced": str(is_enforced),
+                        "referrer": str(tenant_ids.get("referrer", "no_referrer")),
                     },
                 )
                 if is_enforced:

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -127,7 +127,7 @@ class ErrorsAllocationPolicy(AllocationPolicy):
                                 # reacts to such changes
                                 window_seconds=self.WINDOW_SECONDS,
                                 granularity_seconds=self.WINDOW_GRANULARITY_SECONDS,
-                                limit=int(org_limit_bytes_scanned),  # type: ignore
+                                limit=int(org_limit_bytes_scanned),
                                 prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
                             )
                         ],

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -50,7 +50,7 @@ class ErrorsAllocationPolicy(AllocationPolicy):
     WINDOW_SECONDS = 10 * 60
     WINDOW_GRANULARITY_SECONDS = 60
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._rate_limiter = RedisSlidingWindowRateLimiter()
 
@@ -70,7 +70,7 @@ class ErrorsAllocationPolicy(AllocationPolicy):
             return False, "no organization_id for referrer {tenant_ids['referrer']}"
         return True, ""
 
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]):
+    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
         # TODO: This kind of killswitch should just be included with every allocation policy
         is_active = get_config(f"{self.rate_limit_prefix}.is_active", True)
         is_enforced = get_config(f"{self.rate_limit_prefix}.is_enforced", False)

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -163,7 +163,7 @@ class ErrorsAllocationPolicy(AllocationPolicy):
         self._rate_limiter.use_quotas(
             [
                 RequestedQuota(
-                    "{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                    f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
                     bytes_scanned,
                     [
                         Quota(

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from snuba import environment
+from snuba.clusters.storage_sets import StorageSetKey
 from snuba.query.allocation_policies import (
     DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicy,
@@ -50,8 +51,13 @@ class ErrorsAllocationPolicy(AllocationPolicy):
     WINDOW_SECONDS = 10 * 60
     WINDOW_GRANULARITY_SECONDS = 60
 
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(
+        self,
+        storage_set_key: StorageSetKey,
+        required_tenant_types: list[str],
+        **kwargs: str,
+    ) -> None:
+        super().__init__(storage_set_key, required_tenant_types)
         self._rate_limiter = RedisSlidingWindowRateLimiter()
 
     @property

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 
+from snuba import environment
 from snuba.query.allocation_policies import (
     DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicy,
@@ -16,9 +17,39 @@ from snuba.state.sliding_windows import (
     RedisSlidingWindowRateLimiter,
     RequestedQuota,
 )
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+metrics = MetricsWrapper(environment.metrics, "errors_allocation_policy")
+
+
+# A hardcoded list of referrers which do not have an organization_id associated with them
+# purposefully not in config because we don't want that to be easily changeable
+_ORG_LESS_REFERRERS = set(
+    [
+        "weekly_reports.outcomes",
+        "reports.key_errors",
+        "weekly_reports.key_transactions.this_week",
+        "weekly_reports.key_transactions.last_week",
+        "dynamic_sampling.distribution.fetch_projects_with_count_per_root_total_volumes",
+        "reports.key_performance_issues",
+        "dynamic_sampling.counters.fetch_projects_with_count_per_transaction_volumes",
+        "dynamic_sampling.counters.fetch_projects_with_transaction_totals",
+        "migration.backfill_perf_issue_events_issue_platform",
+        "api.vroom",
+        "replays.query.download_replay_segments",
+        "outcomes.timeseries",
+        "release_monitor.fetch_projects_with_recent_sessions",
+        "https://snuba-admin.getsentry.net/",
+        "reprocessing2.start_group_reprocessing",
+    ]
+)
 
 
 class ErrorsAllocationPolicy(AllocationPolicy):
+
+    WINDOW_SECONDS = 10 * 60
+    WINDOW_GRANULARITY_SECONDS = 60
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._rate_limiter = RedisSlidingWindowRateLimiter()
@@ -27,32 +58,73 @@ class ErrorsAllocationPolicy(AllocationPolicy):
     def rate_limit_prefix(self) -> str:
         return self.__class__.__name__
 
+    def _are_tenant_ids_valid(
+        self, tenant_ids: dict[str, str | int]
+    ) -> tuple[bool, str]:
+        if "referrer" not in tenant_ids:
+            return False, "no referrer"
+        if (
+            "organization_id" not in tenant_ids
+            and tenant_ids.get("referrer", None) not in _ORG_LESS_REFERRERS
+        ):
+            return False, "no organization_id for referrer {tenant_ids['referrer']}"
+        return True, ""
+
     def _get_quota_allowance(self, tenant_ids: dict[str, str | int]):
         is_active = get_config(f"{self.rate_limit_prefix}.is_active", True)
         # TODO: This kind of killswitch should just be included with every allocation policy
         if not is_active:
             return DEFAULT_PASSTHROUGH_POLICY._get_quota_allowance(tenant_ids)
-        # TODO: figure out shit
-        org_scan_limit = get_config(f"{self.rate_limit_prefix}.org_scan_limit", 10000)
+        ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
+        if not ids_are_valid:
+            metrics.increment(
+                "db_request_rejected",
+                tags={"storage_set_key": self._storage_set_key.value},
+            )
+            return QuotaAllowance(
+                can_run=False, max_threads=0, explanation={"reason": why}
+            )
+        # TODO: figure out an actually good number
+        if "organization_id" in tenant_ids:
+            org_scan_limit = get_config(
+                f"{self.rate_limit_prefix}.org_scan_limit", 10000
+            )
 
-        self._rate_limiter.check_within_quotas(
-            [
-                RequestedQuota(
-                    self.rate_limit_prefix,
-                    # request a big number because we don't know how much we actually
-                    # will use in this query. this doesn't use up any quota
-                    int(1e10),
-                    [
-                        Quota(
-                            window_seconds=(15 * 60),
-                            granularity_seconds=60,
-                            limit=int(org_scan_limit),  # type: ignore
-                            prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
-                        )
-                    ],
-                ),
-            ]
-        )
+            timestamp, granted_quotas = self._rate_limiter.check_within_quotas(
+                [
+                    RequestedQuota(
+                        self.rate_limit_prefix,
+                        # request a big number because we don't know how much we actually
+                        # will use in this query. this doesn't use up any quota, we just want to know how much is left
+                        int(1e10),
+                        [
+                            Quota(
+                                # TODO: Make window configurable but I don't know exactly how the rate limiter
+                                # reacts to such changes
+                                window_seconds=self.WINDOW_SECONDS,
+                                granularity_seconds=self.WINDOW_GRANULARITY_SECONDS,
+                                limit=int(org_scan_limit),  # type: ignore
+                                prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                            )
+                        ],
+                    ),
+                ]
+            )
+            num_threads = 8
+            explanation = {}
+            granted_quota = granted_quotas[0]
+            if granted_quota.granted <= 0:
+                metrics.increment(
+                    "db_request_throttled",
+                    tags={"storage_set_key": self._storage_set_key.value},
+                )
+                if get_config(f"{self.rate_limit_prefix}.is_enforced", True):
+                    num_threads = 1
+                    explanation[
+                        "reason"
+                    ] = f"organization {tenant_ids['organization_id']} is over the bytes scanned limit of {org_scan_limit}"
+
+            return QuotaAllowance(True, num_threads, explanation)
         return QuotaAllowance(True, 8, {})
 
     def _update_quota_balance(
@@ -64,9 +136,10 @@ class ErrorsAllocationPolicy(AllocationPolicy):
             return
         query_result = result_or_error.query_result
         assert query_result is not None
-        bytes_scanned = query_result.result["profile"]["bytes"]
+        bytes_scanned = query_result.result["profile"]["bytes"]  # type: ignore
         if not bytes_scanned:
             logging.error("No bytes scanned in query_result")
+            return
         org_scan_limit = get_config(f"{self.rate_limit_prefix}.org_scan_limit", 10000)
         # we can assume that the requested quota was granted (because it was)
         # we just need to update the quota with however many bytes were consumed
@@ -77,8 +150,8 @@ class ErrorsAllocationPolicy(AllocationPolicy):
                     bytes_scanned,
                     [
                         Quota(
-                            window_seconds=(15 * 60),
-                            granularity_seconds=60,
+                            window_seconds=self.WINDOW_SECONDS,
+                            granularity_seconds=self.WINDOW_GRANULARITY_SECONDS,
                             limit=int(org_scan_limit),  # type: ignore
                             prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
                         )
@@ -92,5 +165,5 @@ class ErrorsAllocationPolicy(AllocationPolicy):
                     reached_quotas=[],
                 )
             ],
-            timestamp=time.time(),
+            timestamp=int(time.time()),
         )

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+import time
+
+from snuba.query.allocation_policies import (
+    DEFAULT_PASSTHROUGH_POLICY,
+    AllocationPolicy,
+    QueryResultOrError,
+    QuotaAllowance,
+)
+from snuba.state import get_config
+from snuba.state.sliding_windows import (
+    GrantedQuota,
+    Quota,
+    RedisSlidingWindowRateLimiter,
+    RequestedQuota,
+)
+
+
+class ErrorsAllocationPolicy(AllocationPolicy):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._rate_limiter = RedisSlidingWindowRateLimiter()
+
+    @property
+    def rate_limit_prefix(self) -> str:
+        return self.__class__.__name__
+
+    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]):
+        is_active = get_config(f"{self.rate_limit_prefix}.is_active", True)
+        # TODO: This kind of killswitch should just be included with every allocation policy
+        if not is_active:
+            return DEFAULT_PASSTHROUGH_POLICY._get_quota_allowance(tenant_ids)
+        # TODO: figure out shit
+        org_scan_limit = get_config(f"{self.rate_limit_prefix}.org_scan_limit", 10000)
+
+        self._rate_limiter.check_within_quotas(
+            [
+                RequestedQuota(
+                    self.rate_limit_prefix,
+                    # request a big number because we don't know how much we actually
+                    # will use in this query. this doesn't use up any quota
+                    int(1e10),
+                    [
+                        Quota(
+                            window_seconds=(15 * 60),
+                            granularity_seconds=60,
+                            limit=int(org_scan_limit),  # type: ignore
+                            prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                        )
+                    ],
+                ),
+            ]
+        )
+        return QuotaAllowance(True, 8, {})
+
+    def _update_quota_balance(
+        self,
+        tenant_ids: dict[str, str | int],
+        result_or_error: QueryResultOrError,
+    ) -> None:
+        if result_or_error.error:
+            return
+        query_result = result_or_error.query_result
+        assert query_result is not None
+        bytes_scanned = query_result.result["profile"]["bytes"]
+        if not bytes_scanned:
+            logging.error("No bytes scanned in query_result")
+        org_scan_limit = get_config(f"{self.rate_limit_prefix}.org_scan_limit", 10000)
+        # we can assume that the requested quota was granted (because it was)
+        # we just need to update the quota with however many bytes were consumed
+        self._rate_limiter.use_quotas(
+            [
+                RequestedQuota(
+                    "{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                    bytes_scanned,
+                    [
+                        Quota(
+                            window_seconds=(15 * 60),
+                            granularity_seconds=60,
+                            limit=int(org_scan_limit),  # type: ignore
+                            prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                        )
+                    ],
+                )
+            ],
+            grants=[
+                GrantedQuota(
+                    "{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                    granted=bytes_scanned,
+                    reached_quotas=[],
+                )
+            ],
+            timestamp=time.time(),
+        )

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -240,6 +240,12 @@ TURBO_SAMPLE_RATE = 0.1
 PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 PRETTY_FORMAT_EXPRESSIONS = True
 
+# By default, allocation policies won't block requests from going through in a production
+# environment to not cause incidents unnecessarily. If something goes wrong with allocation
+# policy code, the request will still be able to go through (but it will create a dangerous
+# situation eventually)
+RAISE_ON_ALLOCATION_POLICY_FAILURES = False
+
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (logical topic name, # of partitions)
 
 COLUMN_SPLIT_MIN_COLS = 6

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -21,6 +21,8 @@ ENABLE_DEV_FEATURES = True
 # to explore the unrefined Expression structure
 PRETTY_FORMAT_EXPRESSIONS = True
 
+RAISE_ON_ALLOCATION_POLICY_FAILURES = True
+
 # override replacer threshold to write to redis every time a replacement message is consumed
 REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms
 

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -21,6 +21,9 @@ ENABLE_DEV_FEATURES = True
 # to explore the unrefined Expression structure
 PRETTY_FORMAT_EXPRESSIONS = True
 
+# By default, allocation policies won't block requests from going through in a production
+# environment to not cause incidents unnecessarily. But if you're testing the policy, it
+# should fail on bad code
 RAISE_ON_ALLOCATION_POLICY_FAILURES = True
 
 # override replacer threshold to write to redis every time a replacement message is consumed

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -706,7 +706,9 @@ def db_query(
         quota_allowance = allocation_policy.get_quota_allowance(
             attribution_info.tenant_ids
         )
+        stats["quota_allowance"] = quota_allowance.to_dict()
     except AllocationPolicyViolation as e:
+        stats["quota_allowance"] = e.quota_allowance
         raise QueryException.from_args(
             "Query cannot be run due to allocation policy",
             extra={"stats": stats, "sql": formatted_query.get_sql(), "experiments": {}},

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -7,6 +7,7 @@ from snuba.query.allocation_policies import (
     DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicyViolation,
     PassthroughPolicy,
+    QueryResultOrError,
     QuotaAllowance,
 )
 from snuba.state import set_config
@@ -51,3 +52,27 @@ def test_raises_on_false_can_run():
         RejectingEverythingAllocationPolicy(
             StorageSetKey("something"), []
         ).get_quota_allowance({})
+
+
+def test_passes_through_on_error() -> None:
+    class BadlyWrittenAllocationPolicy(PassthroughPolicy):
+        def _get_quota_allowance(
+            self, tenant_ids: dict[str, str | int]
+        ) -> QuotaAllowance:
+            raise AttributeError("You messed up!")
+
+        def _update_quota_balance(
+            self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
+        ) -> None:
+            raise ValueError("you messed up AGAIN")
+
+    # should not raise even though the implementation is buggy
+    assert (
+        BadlyWrittenAllocationPolicy(StorageSetKey("something"), [])
+        .get_quota_allowance({})
+        .can_run
+    )
+
+    BadlyWrittenAllocationPolicy(StorageSetKey("something"), []).update_quota_balance(
+        None, None
+    )  # type: ignore

--- a/tests/query/allocation_policies/test_errors_allocation_policy.py
+++ b/tests/query/allocation_policies/test_errors_allocation_policy.py
@@ -11,7 +11,7 @@ from snuba.query.allocation_policies.errors_allocation_policy import (
     _ORG_LESS_REFERRERS,
     ErrorsAllocationPolicy,
 )
-from snuba.state import get_config, set_config
+from snuba.state import set_config
 from snuba.web import QueryResult
 
 ORG_SCAN_LIMIT = 1000
@@ -127,7 +127,6 @@ def test_enforcement_switch(policy) -> None:
         ),
     )
     set_config(f"{policy.rate_limit_prefix}.is_enforced", False)
-    assert not get_config(f"{policy.rate_limit_prefix}.is_enforced", True)
     allowance = policy.get_quota_allowance(tenant_ids)
     # policy not enforced
     assert allowance.max_threads == MAX_THREAD_NUMBER

--- a/tests/query/allocation_policies/test_errors_allocation_policy.py
+++ b/tests/query/allocation_policies/test_errors_allocation_policy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.query.allocation_policies import (
+    AllocationPolicyViolation,
+    QueryResultOrError,
+)
+from snuba.query.allocation_policies.errors_allocation_policy import (
+    _ORG_LESS_REFERRERS,
+    ErrorsAllocationPolicy,
+)
+from snuba.state import get_config, set_config
+from snuba.web import QueryResult
+
+ORG_SCAN_LIMIT = 1000
+
+
+@pytest.fixture(scope="function")
+def policy():
+    policy = ErrorsAllocationPolicy(
+        storage_set_key=StorageSetKey("errors"),
+        required_tenant_types=["referrer", "organization_id"],
+    )
+    return policy
+
+
+def _configure_policy(policy):
+    set_config(f"{policy.rate_limit_prefix}.is_active", True)
+    set_config(f"{policy.rate_limit_prefix}.is_enforced", True)
+    set_config(f"{policy.rate_limit_prefix}.org_scan_limit", ORG_SCAN_LIMIT)
+
+
+@pytest.mark.redis_db
+def test_consume_quota(policy: ErrorsAllocationPolicy) -> None:
+    # 1. if you scan the limit of bytes, you get throttled to one thread
+    _configure_policy(policy)
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    allowance = policy.get_quota_allowance(tenant_ids)
+    assert allowance.can_run
+    assert allowance.max_threads == 8
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    allowance = policy.get_quota_allowance(tenant_ids)
+    assert allowance.can_run
+    assert allowance.max_threads == 1
+
+
+@pytest.mark.redis_db
+def test_org_isolation(policy) -> None:
+    _configure_policy(policy)
+
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    different_tenant_ids: dict[str, int | str] = {
+        "organization_id": 1235,
+        "referrer": "some_referrer",
+    }
+    allowance = policy.get_quota_allowance(different_tenant_ids)
+    assert allowance.max_threads == 8
+
+
+@pytest.mark.redis_db
+def test_killswitch(policy) -> None:
+    set_config(f"{policy.rate_limit_prefix}.is_active", False)
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    allowance = policy.get_quota_allowance(tenant_ids)
+    # policy is not active so no change
+    assert allowance.max_threads == 8
+
+
+@pytest.mark.redis_db
+def test_enforcement_switch(policy) -> None:
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    set_config(f"{policy.rate_limit_prefix}.is_enforced", False)
+    assert not get_config(f"{policy.rate_limit_prefix}.is_enforced", True)
+    allowance = policy.get_quota_allowance(tenant_ids)
+    # policy not enforced
+    assert allowance.max_threads == 8
+
+
+@pytest.mark.redis_db
+def test_reject_queries_without_tenant_ids(policy) -> None:
+    _configure_policy(policy)
+    with pytest.raises(AllocationPolicyViolation):
+        policy.get_quota_allowance(tenant_ids={"organization_id": 1234})
+    with pytest.raises(AllocationPolicyViolation):
+        policy.get_quota_allowance(tenant_ids={"referrer": "bloop"})
+    # These should not fail because we know they don't have an org id
+    for referrer in _ORG_LESS_REFERRERS:
+        policy.get_quota_allowance(tenant_ids={"referrer": referrer})

--- a/tests/query/allocation_policies/test_errors_allocation_policy.py
+++ b/tests/query/allocation_policies/test_errors_allocation_policy.py
@@ -31,7 +31,7 @@ def policy():
 def _configure_policy(policy):
     set_config(f"{policy.rate_limit_prefix}.is_active", True)
     set_config(f"{policy.rate_limit_prefix}.is_enforced", True)
-    set_config(f"{policy.rate_limit_prefix}.org_scan_limit", ORG_SCAN_LIMIT)
+    set_config(f"{policy.rate_limit_prefix}.org_limit_bytes_scanned", ORG_SCAN_LIMIT)
     set_config(
         f"{policy.rate_limit_prefix}.throttled_thread_number", THROTTLED_THREAD_NUMBER
     )

--- a/tests/query/allocation_policies/test_errors_allocation_policy.py
+++ b/tests/query/allocation_policies/test_errors_allocation_policy.py
@@ -61,6 +61,12 @@ def test_consume_quota(policy: ErrorsAllocationPolicy) -> None:
     allowance = policy.get_quota_allowance(tenant_ids)
     assert allowance.can_run
     assert allowance.max_threads == THROTTLED_THREAD_NUMBER
+    assert allowance.explanation == {
+        "reason": f"organization 123 is over the bytes scanned limit of {ORG_SCAN_LIMIT}",
+        "is_enforced": True,
+        "granted_quota": 0,
+        "limit": ORG_SCAN_LIMIT,
+    }
 
 
 @pytest.mark.redis_db

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -176,6 +176,7 @@ def test_db_query_success() -> None:
         trace_id="trace_id",
         robust=False,
     )
+    assert stats["quota_allowance"] == dict(can_run=True, max_threads=8, explanation={})
     assert len(query_metadata_list) == 1
     assert result.extra["stats"] == stats
     assert result.extra["sql"] is not None
@@ -256,6 +257,11 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
                 robust=False,
             )
         cause = excinfo.value.__cause__
+        assert stats["quota_allowance"] == dict(
+            can_run=False,
+            max_threads=0,
+            explanation={"reason": "policy rejects all queries"},
+        )
         assert isinstance(cause, AllocationPolicyViolation)
         assert cause.extra_data["quota_allowance"]["explanation"]["reason"] == "policy rejects all queries"  # type: ignore
 

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -15,7 +15,6 @@ from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query import SelectedExpression
 from snuba.query.allocation_policies import (
-    DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicy,
     AllocationPolicyViolation,
     QueryResultOrError,
@@ -126,17 +125,16 @@ def test_apply_thread_quota(
 
 
 def _build_test_query(
-    select_expression: str,
-    allocation_policy: AllocationPolicy = DEFAULT_PASSTHROUGH_POLICY,
+    select_expression: str, allocation_policy: AllocationPolicy | None = None
 ) -> tuple[ClickhouseQuery, Storage, AttributionInfo]:
-    storage = get_storage(StorageKey("errors"))
+    storage = get_storage(StorageKey("errors_ro"))
     return (
         ClickhouseQuery(
             from_clause=Table(
                 storage.get_schema().get_data_source().get_table_name(),  # type: ignore
                 schema=storage.get_schema().get_columns(),
                 final=False,
-                allocation_policy=allocation_policy,
+                allocation_policy=allocation_policy or storage.get_allocation_policy(),
             ),
             selected_columns=[
                 SelectedExpression(
@@ -148,7 +146,7 @@ def _build_test_query(
         storage,
         AttributionInfo(
             app_id=AppID(key="key"),
-            tenant_ids={},
+            tenant_ids={"referrer": "something", "organization_id": 1234},
             referrer="something",
             team=None,
             feature=None,


### PR DESCRIPTION
This PR introduces the first iteration of the allocation policy for the errors storage

### The Policy

For every organization, keep track of how many bytes they've scanned in the last 10 minutes, when they reach a limit, throttle them to one thread

### How to turn it on/off

In runtime config:

```
# completely bypasses the code path
SET ErrorsAllocationPolicy.is_active 0
```


```
# code runs and emits metrics but no action is taken
SET ErrorsAllocationPolicy.is_enforced 0
```

```
# how many bytes the org can scan in ten minutes before being throttled
SET ErrorsAllocationPolicy.org_scan_limit 42069
```

### Intent

This is not meant to be the final policy, this is just a quick way to get something working end to end and then iterate on it. Most of this code will be rewritten