### PR TITLE
feat: Use new DLQ from Arroyo

### DIFF
--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -292,7 +292,7 @@ def multistorage_consumer(
         resolved_topic = Topic(dlq_topic_spec.get_physical_topic_name(slice_id))
 
         dlq_policy = DlqPolicy(
-            KafkaDlqProducer(dlq_producer, resolved_topic), DlqLimit()
+            KafkaDlqProducer(dlq_producer, resolved_topic), DlqLimit(), None
         )
     else:
         dlq_policy = None

--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -1,18 +1,16 @@
 import logging
 import signal
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import click
 import rapidjson
 from arroyo import Topic, configure_metrics
-from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.commit import IMMEDIATE
+from arroyo.dlq import DlqLimit, DlqPolicy, KafkaDlqProducer
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategyFactory
-from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
-    DeadLetterQueuePolicy,
-)
 from arroyo.utils.profiler import ProcessingStrategyProfilerWrapperFactory
 from confluent_kafka import Producer as ConfluentKafkaProducer
 
@@ -21,6 +19,7 @@ from snuba.consumers.consumer import (
     CommitLogConfig,
     MultistorageConsumerProcessingStrategyFactory,
 )
+from snuba.datasets.configuration.utils import DlqConfig
 from snuba.datasets.slicing import validate_passed_slice
 from snuba.datasets.storage import WritableTableStorage
 from snuba.datasets.storages.factory import (
@@ -28,6 +27,7 @@ from snuba.datasets.storages.factory import (
     get_writable_storage_keys,
 )
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.environment import setup_logging, setup_sentry
 from snuba.state import get_config
 from snuba.utils.metrics.backends.abstract import MetricsBackend
@@ -253,13 +253,15 @@ def multistorage_consumer(
 
         assert consumer_config.logical_commit_log_topic is not None
 
-        producer = ConfluentKafkaProducer(
+        commit_log_producer = ConfluentKafkaProducer(
             build_kafka_producer_configuration(
                 SnubaTopic(consumer_config.logical_commit_log_topic.name)
             )
         )
 
-        commit_log_config = CommitLogConfig(producer, commit_log, consumer_group)
+        commit_log_config = CommitLogConfig(
+            commit_log_producer, commit_log, consumer_group
+        )
 
     strategy_factory = build_multistorage_streaming_strategy_factory(
         writable_storages,
@@ -271,17 +273,32 @@ def multistorage_consumer(
         metrics,
         commit_log_config,
         replacements,
-        consumer_config.dead_letter_policy,
         slice_id,
         profile_path,
     )
 
     configure_metrics(StreamMetricsAdapter(metrics))
+
+    dlq_config = consumer_config.dlq_config
+
+    if dlq_config is not None:
+        dlq_producer = KafkaProducer(
+            build_kafka_producer_configuration(
+                dlq_config.topic,
+                slice_id,
+            )
+        )
+        dlq_topic_spec = KafkaTopicSpec(dlq_config.topic)
+        resolved_topic = Topic(dlq_topic_spec.get_physical_topic_name(slice_id))
+
+        dlq_policy = DlqPolicy(
+            KafkaDlqProducer(dlq_producer, resolved_topic), DlqLimit()
+        )
+    else:
+        dlq_policy = None
+
     processor = StreamProcessor(
-        consumer,
-        topic,
-        strategy_factory,
-        IMMEDIATE,
+        consumer, topic, strategy_factory, IMMEDIATE, dlq_policy=dlq_policy
     )
 
     def handler(signum: int, frame: Any) -> None:
@@ -297,7 +314,7 @@ class ConsumerConfig:
     logical_raw_topic: Topic
     logical_commit_log_topic: Optional[Topic]
     logical_replacements_topic: Optional[Topic]
-    dead_letter_policy: Optional[Callable[[], DeadLetterQueuePolicy]]
+    dlq_config: Optional[DlqConfig]
 
 
 def get_consumer_config(
@@ -330,10 +347,7 @@ def get_consumer_config(
         if spec is not None
     }
 
-    dead_letter_policies = {
-        stream_loader.get_dead_letter_queue_policy_creator()
-        for stream_loader in stream_loaders
-    }
+    dlq_configs = {stream_loader.get_dlq_config() for stream_loader in stream_loaders}
 
     # XXX: The ``StreamProcessor`` only supports a single topic at this time,
     # but is easily modified. The topic routing in the processing strategy is a
@@ -358,13 +372,11 @@ def get_consumer_config(
 
     # Only one dead letter policy is supported. All storages must share the same
     # dead letter policy creator
-    dead_letter_policy_creator = dead_letter_policies.pop()
-    if dead_letter_policies:
+    dlq_config = dlq_configs.pop()
+    if dlq_config:
         raise ValueError("only one dead letter policy is supported")
 
-    return ConsumerConfig(
-        topic, commit_log_topic, replacement_topic, dead_letter_policy_creator
-    )
+    return ConsumerConfig(topic, commit_log_topic, replacement_topic, dlq_config)
 
 
 def build_multistorage_streaming_strategy_factory(
@@ -377,7 +389,6 @@ def build_multistorage_streaming_strategy_factory(
     metrics: MetricsBackend,
     commit_log_config: Optional[CommitLogConfig],
     replacements: Optional[Topic],
-    dead_letter_policy: Optional[Callable[[], DeadLetterQueuePolicy]],
     slice_id: Optional[int],
     profile_path: Optional[str],
 ) -> ProcessingStrategyFactory[KafkaPayload]:
@@ -392,7 +403,6 @@ def build_multistorage_streaming_strategy_factory(
         input_block_size=input_block_size,
         output_block_size=output_block_size,
         metrics=metrics,
-        dead_letter_policy_creator=dead_letter_policy,
         slice_id=slice_id,
         commit_log_config=commit_log_config,
         replacements=replacements,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -247,7 +247,7 @@ class ConsumerBuilder:
             resolved_topic = Topic(dlq_topic_spec.get_physical_topic_name(slice_id))
 
             dlq_policy = DlqPolicy(
-                KafkaDlqProducer(dlq_producer, resolved_topic), DlqLimit()
+                KafkaDlqProducer(dlq_producer, resolved_topic), DlqLimit(), None
             )
         else:
             dlq_policy = None

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from typing import Callable, Optional, Sequence
 
 from arroyo import Topic
-from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.backends.kafka import KafkaConsumer, KafkaPayload, KafkaProducer
 from arroyo.commit import IMMEDIATE
-from arroyo.dlq import DlqLimit, DlqPolicy, NoopDlqProducer
+from arroyo.dlq import DlqLimit, DlqPolicy, KafkaDlqProducer
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategyFactory
 from arroyo.utils.profiler import ProcessingStrategyProfilerWrapperFactory
@@ -23,6 +23,7 @@ from snuba.consumers.strategy_factory import KafkaConsumerStrategyFactory
 from snuba.datasets.slicing import validate_passed_slice
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.datasets.table_storage import KafkaTopicSpec
 from snuba.environment import setup_sentry
 from snuba.state import get_config
 from snuba.utils.metrics import MetricsBackend
@@ -77,8 +78,6 @@ class ConsumerBuilder:
         commit_retry_policy: Optional[RetryPolicy] = None,
         profile_path: Optional[str] = None,
     ) -> None:
-        self.__run_dlq_test = get_config(f"dlq_test_{storage_key.value}") == 1
-
         self.storage = get_writable_storage(storage_key)
         self.__kafka_params = kafka_params
         self.consumer_group = kafka_params.group_id
@@ -189,13 +188,10 @@ class ConsumerBuilder:
         slice_id: Optional[int] = None,
     ) -> StreamProcessor[KafkaPayload]:
 
+        stream_loader = self.storage.get_table_writer().get_stream_loader()
+
         # retrieves the default logical topic
-        topic = (
-            self.storage.get_table_writer()
-            .get_stream_loader()
-            .get_default_topic_spec()
-            .topic
-        )
+        topic = stream_loader.get_default_topic_spec().topic
 
         configuration = build_kafka_consumer_configuration(
             topic,
@@ -238,9 +234,23 @@ class ConsumerBuilder:
             commit_retry_policy=self.__commit_retry_policy,
         )
 
-        dlq_policy = None
-        if self.__run_dlq_test:
-            dlq_policy = DlqPolicy(NoopDlqProducer(), DlqLimit(), None)
+        dlq_config = stream_loader.get_dlq_config()
+
+        if dlq_config is not None:
+            dlq_producer = KafkaProducer(
+                build_kafka_producer_configuration(
+                    dlq_config.topic,
+                    slice_id,
+                )
+            )
+            dlq_topic_spec = KafkaTopicSpec(dlq_config.topic)
+            resolved_topic = Topic(dlq_topic_spec.get_physical_topic_name(slice_id))
+
+            dlq_policy = DlqPolicy(
+                KafkaDlqProducer(dlq_producer, resolved_topic), DlqLimit()
+            )
+        else:
+            dlq_policy = None
 
         return StreamProcessor(
             consumer, self.raw_topic, strategy_factory, IMMEDIATE, dlq_policy=dlq_policy
@@ -288,7 +298,6 @@ class ConsumerBuilder:
             input_block_size=self.input_block_size,
             output_block_size=self.output_block_size,
             initialize_parallel_transform=setup_sentry,
-            dead_letter_queue_policy_creator=stream_loader.get_dead_letter_queue_policy_creator(),
         )
 
         if self.__profile_path is not None:

--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -10,12 +10,6 @@ from arroyo.processing.strategies import (
     RunTaskInThreads,
 )
 from arroyo.processing.strategies.commit import CommitOffsets
-from arroyo.processing.strategies.dead_letter_queue.dead_letter_queue import (
-    DeadLetterQueue,
-)
-from arroyo.processing.strategies.dead_letter_queue.policies.abstract import (
-    DeadLetterQueuePolicy,
-)
 from arroyo.processing.strategies.transform import ParallelTransformStep, TransformStep
 from arroyo.types import BaseValue, Commit, FilteredPayload, Message, Partition
 
@@ -73,12 +67,8 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         input_block_size: Optional[int],
         output_block_size: Optional[int],
         initialize_parallel_transform: Optional[Callable[[], None]] = None,
-        dead_letter_queue_policy_creator: Optional[
-            Callable[[], DeadLetterQueuePolicy]
-        ] = None,
     ) -> None:
         self.__prefilter = prefilter
-        self.__dead_letter_queue_policy_creator = dead_letter_queue_policy_creator
         self.__process_message = process_message
         self.__collector = collector
 
@@ -160,13 +150,5 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
         if self.__prefilter is not None:
             strategy = FilterStep(self.__should_accept, strategy)
-
-        if self.__dead_letter_queue_policy_creator is not None:
-            # The DLQ Policy is instantiated here so it gets the correct
-            # metrics singleton in the init function of the policy
-            # It also ensures any producer/consumer is recreated on rebalance
-            strategy = DeadLetterQueue(
-                strategy, self.__dead_letter_queue_policy_creator()
-            )
 
         return strategy

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -10,7 +10,7 @@ from snuba.datasets.cdc.row_processors import CdcRowProcessor
 from snuba.datasets.configuration.json_schema import STORAGE_VALIDATORS
 from snuba.datasets.configuration.loader import load_configuration_data
 from snuba.datasets.configuration.utils import (
-    generate_policy_creator,
+    generate_dlq_config,
     get_mandatory_condition_checkers,
     get_query_processors,
     get_query_splitters,
@@ -185,8 +185,8 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
         else None
     )
     subscription_result_topic = __get_topic(loader_config, "subscription_result_topic")
-    dead_letter_queue_policy_creator = (
-        generate_policy_creator(loader_config[DLQ_POLICY])
+    dlq_config = (
+        generate_dlq_config(loader_config[DLQ_POLICY])
         if DLQ_POLICY in loader_config and loader_config[DLQ_POLICY] is not None
         else None
     )
@@ -200,7 +200,7 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
         subscription_scheduler_mode,
         subscription_scheduled_topic,
         subscription_result_topic,
-        dead_letter_queue_policy_creator,
+        dlq_config,
     )
 
 

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any
 
 import pytest
-from arroyo.processing.strategies.dead_letter_queue import (
-    DeadLetterQueuePolicy,
-    ProduceInvalidMessagePolicy,
-)
 from fastjsonschema.exceptions import JsonSchemaValueException
 
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.datasets.configuration.storage_builder import (
-    STORAGE_VALIDATORS,
-    build_stream_loader,
-)
+from snuba.datasets.configuration.json_schema import STORAGE_VALIDATORS
+from snuba.datasets.configuration.storage_builder import build_stream_loader
 from snuba.datasets.configuration.utils import DlqConfig, generate_dlq_config
 from snuba.datasets.message_filters import KafkaHeaderSelectFilter
 from snuba.datasets.processors import DatasetMessageProcessor

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -14,10 +14,7 @@ from snuba.datasets.configuration.storage_builder import (
     STORAGE_VALIDATORS,
     build_stream_loader,
 )
-from snuba.datasets.configuration.utils import (
-    DlqConfig,
-    generate_dlq_config,
-)
+from snuba.datasets.configuration.utils import DlqConfig, generate_dlq_config
 from snuba.datasets.message_filters import KafkaHeaderSelectFilter
 from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.datasets.processors.generic_metrics_processor import (


### PR DESCRIPTION
Depends on https://github.com/getsentry/snuba/pull/4003

These are the Snuba changes needed once https://github.com/getsentry/arroyo/pull/202 lands.

Also fixes a bug where the DLQ topic name is not resolved from the logical to physical names or to the correct slice if the storage is sliced.

I kept the DLQ policy definitions in the storage yaml files unchanged, we may want to revisit at some later stage