### PR TITLE
fix: update validation from org_countries for granularity

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/org_counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/org_counters.yaml
@@ -86,4 +86,4 @@ query_processors:
 validators:
   - validator: GranularityValidator
     args:
-      minimum: 3600
+      minimum: 60


### PR DESCRIPTION
This PR synchronize validation for org_countries for granularity,

Based on:

https://github.com/getsentry/snuba/blob/51062e0cf93e5dd54fd596a276a774af71f8b197/snuba/datasets/configuration/generic_metrics/entities/org_counters.yaml#L59-L64

Some more detailed context where we use it:

In Dynamic sampling we use query for last 5 mins to calibrate dynamic sampling rules, so we need granularity=60, otherwise we'll see a validation error: 

```
E   sentry.utils.snuba.SnubaError: validation failed for entity generic_org_metrics_counters: granularity must be multiple of 3600
```