### PR TITLE
feat(profiling): Add new columns to raw functions table

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -270,7 +270,7 @@ class FunctionsLoader(DirectoryLoader):
         super().__init__("snuba.snuba_migrations.functions")
 
     def get_migrations(self) -> Sequence[str]:
-        return ["0001_functions"]
+        return ["0001_functions", "0002_add_new_columns_to_raw_functions"]
 
 
 class GenericMetricsLoader(DirectoryLoader):

--- a/snuba/snuba_migrations/functions/0002_add_new_columns_to_raw_functions.py
+++ b/snuba/snuba_migrations/functions/0002_add_new_columns_to_raw_functions.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+@dataclass(frozen=True)
+class NewColumn:
+    column: Column[Modifiers]
+    after: str
+
+
+UNKNOWN_SPAN_STATUS = 2
+
+new_columns: Sequence[NewColumn] = [
+    NewColumn(column=Column("function", String()), after="name"),
+    NewColumn(column=Column("module", String()), after="package"),
+    NewColumn(
+        column=Column("dist", String(Modifiers(nullable=True, low_cardinality=True))),
+        after="release",
+    ),
+    NewColumn(
+        column=Column("transaction_op", String(Modifiers(low_cardinality=True))),
+        after="dist",
+    ),
+    NewColumn(
+        column=Column(
+            "transaction_status", UInt(8, Modifiers(default=str(UNKNOWN_SPAN_STATUS)))
+        ),
+        after="transaction_op",
+    ),
+    NewColumn(
+        column=Column(
+            "http_method", String(Modifiers(nullable=True, low_cardinality=True))
+        ),
+        after="transaction_status",
+    ),
+    NewColumn(
+        column=Column(
+            "browser_name", String(Modifiers(nullable=True, low_cardinality=True))
+        ),
+        after="http_method",
+    ),
+    NewColumn(
+        column=Column("device_classification", UInt(8)),
+        after="browser_name",
+    ),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set = StorageSetKey.FUNCTIONS
+
+    local_raw_table = "functions_raw_local"
+    dist_raw_table = "functions_raw_dist"
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set,
+                table_name=table_name,
+                column=new_column.column,
+                after=new_column.after,
+                target=target,
+            )
+            for table_name, target in [
+                (self.local_raw_table, OperationTarget.LOCAL),
+                (self.dist_raw_table, OperationTarget.DISTRIBUTED),
+            ]
+            for new_column in new_columns
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set,
+                table_name=table_name,
+                column_name=new_column.column.name,
+                target=target,
+            )
+            for table_name, target in [
+                (self.dist_raw_table, OperationTarget.DISTRIBUTED),
+                (self.local_raw_table, OperationTarget.LOCAL),
+            ]
+            for new_column in new_columns
+        ]


### PR DESCRIPTION
This adds some new columns to the raw functions table that we want to explore the cardinality of. These columns were chosen based on the same columns the metrics datasets had chosen plus some profiling specific ones. This will be used to create a new materialization from the findings. And any high cardinality columns will be removed.