### PR TITLE
feat(search-issues) add optional transaction_duration column

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -306,4 +306,5 @@ class SearchIssuesLoader(DirectoryLoader):
             "0004_rebuild_search_issues_with_version",
             "0005_search_issues_v2",
             "0006_add_subtitle_culprit_level_resource_id",
+            "0007_add_transaction_duration",
         ]

--- a/snuba/snuba_migrations/search_issues/0007_add_transaction_duration.py
+++ b/snuba/snuba_migrations/search_issues/0007_add_transaction_duration.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import UInt
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.SEARCH_ISSUES,
+                table_name=params[0],
+                column=Column(
+                    "transaction_duration",
+                    UInt(32),
+                ),
+                after="http_referer",
+                target=params[1],
+            )
+            for params in [
+                ("search_issues_local_v2", OperationTarget.LOCAL),
+                ("search_issues_dist_v2", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                StorageSetKey.SEARCH_ISSUES,
+                table_name=params[0],
+                column_name="transaction_duration",
+                target=params[1],
+            )
+            for params in [
+                ("search_issues_dist_v2", OperationTarget.DISTRIBUTED),
+                ("search_issues_local_v2", OperationTarget.LOCAL),
+            ]
+        ]


### PR DESCRIPTION
We missed this column when reviewing what's required to display Issue events for this dataset. Including it now and defaulting it to 0 value.