### PR TITLE
feat(search-issues): process transaction_duration values

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -59,6 +59,7 @@ schema:
       type: String,
       args: { schema_modifiers: [ nullable ] },
     },
+    { name: transaction_duration, type: UInt, args: { size: 32 } },
 
     { name: message_timestamp, type: DateTime },
     { name: partition, type: UInt, args: { size: 16 } },

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -50,6 +50,7 @@ schema:
       { name: contexts.value, type: Array, args: { inner_type: { type: String } } },
       { name: http_method, type: String, args: { schema_modifiers: [ nullable ] } },
       { name: http_referer, type: String, args: { schema_modifiers: [ nullable ] } },
+      { name: transaction_duration, type: UInt, args: { size: 32 } },
 
       { name: message_timestamp, type: DateTime },
       { name: partition, type: UInt, args: { size: 16 } },

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -55,6 +55,7 @@ class IssueOccurrenceData(TypedDict, total=False):
     level: str
     resource_id: Optional[str]
     detection_time: float
+    transaction_duration: Optional[int]
 
 
 class IssueEventData(TypedDict, total=False):
@@ -237,6 +238,9 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
             "receive_timestamp": receive_timestamp,
             "client_timestamp": client_timestamp,
             "platform": event["platform"],
+            "transaction_duration": event_occurrence_data.get("transaction_duration")
+            if event_occurrence_data.get("transaction_duration")
+            else 0,
         }
 
         # optional fields

--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -388,6 +388,24 @@ class TestSearchIssuesMessageProcessor:
             with pytest.raises(ValueError):
                 self.process_message(message_base)
 
+    def test_extract_transaction_duration(self, message_base):
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert insert_row["transaction_duration"] == 0
+
+        message_base["occurrence_data"]["transaction_duration"] = None
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert insert_row["transaction_duration"] == 0
+
+        message_base["occurrence_data"]["transaction_duration"] = 1000
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert insert_row["transaction_duration"] == 1000
+
     def test_ensure_uuid(self):
         with pytest.raises(ValueError):
             ensure_uuid("not_a_uuid")


### PR DESCRIPTION
2nd step for adding `transaction_duration` to the dataset. Related to this PR: https://github.com/getsentry/snuba/pull/4007

Essentially a copy-past of what's being done in `transactions_processor` https://github.com/getsentry/snuba/blob/9fba7cfbd50f22e7ad0bb3607e0cb089e29d9fdb/snuba/datasets/processors/transactions_processor.py#L116-L135

Pulls out `start_timestamp` and `timestamp` from the event data dictionary to calculate the difference in milliseconds for a transactions, `transaction_duration`, defaulting to 0. 