### PR TITLE
DO NOT MERGE: experiment(oncall): sleep before init

### DIFF
--- a/snuba/web/wsgi.py
+++ b/snuba/web/wsgi.py
@@ -1,8 +1,12 @@
+import time
+
 from snuba.core.initialize import initialize_snuba
 from snuba.environment import setup_logging, setup_sentry
 
 setup_logging()
 setup_sentry()
 initialize_snuba()
+print("sleepin")
+time.sleep(100)
 
 from snuba.web.views import application  # noqa


### PR DESCRIPTION
This can repro the slow start issues we're seeing in production.

Process:

1. start `snuba api`
2. in a different window `curl localhost:1218/health`
3. See the healthcheck hang