### PR TITLE
feat(CI): add migrations check to main pipeline

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -17,7 +17,7 @@ pipelines:
         materials:
             snuba_repo:
                 git: git@github.com:getsentry/snuba.git
-                shallow_clone: true
+                shallow_clone: false
                 branch: master
                 destination: snuba
         stages:
@@ -47,7 +47,7 @@ pipelines:
                                     sentryio \
                                     "us.gcr.io/sentryio/snuba"
                               - script: |
-                                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba-sns-test"` && \
+                                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"` && \
                                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
             - deploy:
                   fetch_materials: true

--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -46,6 +46,9 @@ pipelines:
                                     ${GO_REVISION_SNUBA_REPO} \
                                     sentryio \
                                     "us.gcr.io/sentryio/snuba"
+                              - script: |
+                                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba-sns-test"` && \
+                                    snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
             - deploy:
                   fetch_materials: true
                   jobs:

--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -19,7 +19,11 @@ MAX_FETCHES = 100
 def pipeline_passed(pipeline: Dict[str, Any]) -> bool:
     # stage["result"] isn't populated if it isn't run
     # the other possible statuses are Unknown (not run yet), Cancelled, Failed
-    return all(stage["status"] == "Passed" for stage in pipeline["stages"])
+    return all(
+        stage["status"] == "Passed"
+        for stage in pipeline["stages"]
+        if stage["name"] != "migrate"
+    )
 
 
 # print the most recent passing sha for a repo


### PR DESCRIPTION

We've tested the migrations check on the test pipeline. This PR transfers it to the main pipeline.

The check compares against the last deployed commit to check that there are not too many undeployed migrations commits stacked up . We are ignoring migrations status for now.