### PR TITLE
feat(CI): add a manually triggered migrations stage to main gocd

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -12,6 +12,7 @@ pipelines:
             GKE_BASTION_ZONE: b
             # Required for checkruns.
             GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
+            MIGRATIONS_READINESS: complete
         group: snuba
         lock_behavior: unlockWhenFinished
         materials:
@@ -114,3 +115,35 @@ pipelines:
                                     --type="cronjob" \
                                     --container-name="cleanup" \
                                     --container-name="optimize"
+
+            - migrate:
+                  approval:
+                      type: manual
+                  fetch_materials: true
+                  jobs:
+                      migrate:
+                          timeout: 1200
+                          elastic_profile_id: snuba
+                          tasks:
+                              - script: |
+                                    /devinfra/scripts/k8s/k8stunnel \
+                                    && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                                    --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                                    --label-selector="service=snuba-admin" \
+                                    --container-name="snuba-admin" \
+                                    "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                                    -- snuba migrations migrate -r ${MIGRATIONS_READINESS}
+                              - plugin:
+                                    options:
+                                        script: |
+                                            /devinfra/scripts/k8s/k8stunnel \
+                                            && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                                            --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                                            --label-selector="service=snuba-admin" \
+                                            --container-name="snuba-admin" \
+                                            "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                                            -- snuba migrations reverse-in-progress
+                                    run_if: failed
+                                    configuration:
+                                        id: script-executor
+                                        version: 1


### PR DESCRIPTION
To be merged after #4013 

 This add a manually triggered migrate stage to the main gocd. We have been testing this pipeline in the test cluster. At the moment it needs to be manually triggered and only runs for migrations in the "complete" readiness state.