### PR TITLE
feat(CapMan): Errors Allocation Policy V0 (fixed)

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -228,6 +228,13 @@ schema:
     - retention_days
     - date
   not_deleted_mandatory_condition: deleted
+allocation_policy:
+  name: ErrorsAllocationPolicy
+  args:
+    storage_set_key: events_ro
+    required_tenant_types:
+      - organzation_id
+      - referrer
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -225,6 +225,14 @@ schema:
   local_table_name: errors_local
   dist_table_name: errors_dist_ro
   not_deleted_mandatory_condition: deleted
+allocation_policy:
+  name: ErrorsAllocationPolicy
+  args:
+    storage_set_key: events_ro
+    required_tenant_types:
+      - organzation_id
+      - referrer
+
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -119,6 +119,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
     **GOTCHAS**
     -----------
 
+    * Because allocation policies are attached to query objects, they have to be pickleable. Don't put non-pickleable members onto the allocation policy
     * At time of writing (29-03-2023), not all allocation policy decisions are made in the allocation policy,
         rate limiters are still applied in the query pipeline, those should be moved into an allocation policy as they
         are also policy decisions

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -168,6 +168,10 @@ class ErrorsAllocationPolicy(AllocationPolicy):
             return
         if result_or_error.error:
             return
+        ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
+        if not ids_are_valid:
+            # we already logged the reason before the query
+            return
         query_result = result_or_error.query_result
         assert query_result is not None
         bytes_scanned = query_result.result.get("profile", {}).get("bytes", None)  # type: ignore

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, cast
+
+from snuba import environment
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.query.allocation_policies import (
+    DEFAULT_PASSTHROUGH_POLICY,
+    AllocationPolicy,
+    QueryResultOrError,
+    QuotaAllowance,
+)
+from snuba.state import get_config
+from snuba.state.sliding_windows import (
+    GrantedQuota,
+    Quota,
+    RedisSlidingWindowRateLimiter,
+    RequestedQuota,
+)
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+metrics = MetricsWrapper(environment.metrics, "errors_allocation_policy")
+
+
+# A hardcoded list of referrers which do not have an organization_id associated with them
+# purposefully not in config because we don't want that to be easily changeable
+_ORG_LESS_REFERRERS = set(
+    [
+        "subscription_executor",
+        "weekly_reports.outcomes",
+        "reports.key_errors",
+        "weekly_reports.key_transactions.this_week",
+        "weekly_reports.key_transactions.last_week",
+        "dynamic_sampling.distribution.fetch_projects_with_count_per_root_total_volumes",
+        "reports.key_performance_issues",
+        "dynamic_sampling.counters.fetch_projects_with_count_per_transaction_volumes",
+        "dynamic_sampling.counters.fetch_projects_with_transaction_totals",
+        "migration.backfill_perf_issue_events_issue_platform",
+        "api.vroom",
+        "replays.query.download_replay_segments",
+        "release_monitor.fetch_projects_with_recent_sessions",
+        "https://snuba-admin.getsentry.net/",
+        "reprocessing2.start_group_reprocessing",
+    ]
+)
+
+UNREASONABLY_LARGE_NUMBER_OF_BYTES_SCANNED_PER_QUERY = int(1e10)
+
+
+class ErrorsAllocationPolicy(AllocationPolicy):
+
+    WINDOW_SECONDS = 10 * 60
+    WINDOW_GRANULARITY_SECONDS = 60
+
+    def __init__(
+        self,
+        storage_set_key: StorageSetKey,
+        required_tenant_types: list[str],
+        **kwargs: str,
+    ) -> None:
+        super().__init__(storage_set_key, required_tenant_types)
+        self._rate_limiter = RedisSlidingWindowRateLimiter()
+
+    @property
+    def rate_limit_prefix(self) -> str:
+        return self.__class__.__name__
+
+    def _are_tenant_ids_valid(
+        self, tenant_ids: dict[str, str | int]
+    ) -> tuple[bool, str]:
+        if "referrer" not in tenant_ids:
+            return False, "no referrer"
+        if (
+            "organization_id" not in tenant_ids
+            and tenant_ids.get("referrer", None) not in _ORG_LESS_REFERRERS
+        ):
+            return False, f"no organization_id for referrer {tenant_ids['referrer']}"
+        return True, ""
+
+    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+        # TODO: This kind of killswitch should just be included with every allocation policy
+        is_active = cast(bool, get_config(f"{self.rate_limit_prefix}.is_active", True))
+        is_enforced = cast(
+            bool, get_config(f"{self.rate_limit_prefix}.is_enforced", False)
+        )
+        throttled_thread_number = cast(
+            int, get_config(f"{self.rate_limit_prefix}.throttled_thread_number", 1)
+        )
+        max_threads = cast(int, get_config("query_settings/max_threads", 8))
+        if not is_active:
+            return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids)
+        ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
+        if not ids_are_valid:
+            metrics.increment(
+                "db_request_rejected",
+                tags={
+                    "storage_set_key": self._storage_set_key.value,
+                    "is_enforced": str(is_enforced),
+                },
+            )
+            if is_enforced:
+                return QuotaAllowance(
+                    can_run=False, max_threads=0, explanation={"reason": why}
+                )
+        if "organization_id" in tenant_ids:
+            org_limit_bytes_scanned = cast(
+                int,
+                get_config(
+                    # TODO: figure out an actually good number
+                    f"{self.rate_limit_prefix}.org_limit_bytes_scanned",
+                    10000,
+                ),
+            )
+
+            timestamp, granted_quotas = self._rate_limiter.check_within_quotas(
+                [
+                    RequestedQuota(
+                        self.rate_limit_prefix,
+                        # request a big number because we don't know how much we actually
+                        # will use in this query. this doesn't use up any quota, we just want to know how much is left
+                        UNREASONABLY_LARGE_NUMBER_OF_BYTES_SCANNED_PER_QUERY,
+                        [
+                            Quota(
+                                # TODO: Make window configurable but I don't know exactly how the rate limiter
+                                # reacts to such changes
+                                window_seconds=self.WINDOW_SECONDS,
+                                granularity_seconds=self.WINDOW_GRANULARITY_SECONDS,
+                                limit=int(org_limit_bytes_scanned),
+                                prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                            )
+                        ],
+                    ),
+                ]
+            )
+            num_threads = max_threads
+            explanation: dict[str, Any] = {}
+            granted_quota = granted_quotas[0]
+            if granted_quota.granted <= 0:
+                metrics.increment(
+                    "db_request_throttled",
+                    tags={
+                        "storage_set_key": self._storage_set_key.value,
+                        "is_enforced": str(is_enforced),
+                        "referrer": str(tenant_ids.get("referrer", "no_referrer")),
+                    },
+                )
+                explanation[
+                    "reason"
+                ] = f"organization {tenant_ids['organization_id']} is over the bytes scanned limit of {org_limit_bytes_scanned}"
+                explanation["is_enforced"] = is_enforced
+                explanation["granted_quota"] = granted_quota.granted
+                explanation["limit"] = org_limit_bytes_scanned
+
+                if is_enforced:
+                    num_threads = throttled_thread_number
+
+            return QuotaAllowance(True, num_threads, explanation)
+        return QuotaAllowance(True, max_threads, {})
+
+    def _update_quota_balance(
+        self,
+        tenant_ids: dict[str, str | int],
+        result_or_error: QueryResultOrError,
+    ) -> None:
+        if not get_config(f"{self.rate_limit_prefix}.is_active", True):
+            return
+        if result_or_error.error:
+            return
+        query_result = result_or_error.query_result
+        assert query_result is not None
+        bytes_scanned = query_result.result["profile"]["bytes"]  # type: ignore
+        if not bytes_scanned:
+            logging.error("No bytes scanned in query_result")
+            return
+        org_limit_bytes_scanned = get_config(
+            f"{self.rate_limit_prefix}.org_limit_bytes_scanned", 10000
+        )
+        # we can assume that the requested quota was granted (because it was)
+        # we just need to update the quota with however many bytes were consumed
+        self._rate_limiter.use_quotas(
+            [
+                RequestedQuota(
+                    f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                    bytes_scanned,
+                    [
+                        Quota(
+                            window_seconds=self.WINDOW_SECONDS,
+                            granularity_seconds=self.WINDOW_GRANULARITY_SECONDS,
+                            limit=int(org_limit_bytes_scanned),  # type: ignore
+                            prefix_override=f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                        )
+                    ],
+                )
+            ],
+            grants=[
+                GrantedQuota(
+                    f"{self.rate_limit_prefix}-organization_id-{tenant_ids['organization_id']}",
+                    granted=bytes_scanned,
+                    reached_quotas=[],
+                )
+            ],
+            timestamp=int(time.time()),
+        )

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -240,6 +240,12 @@ TURBO_SAMPLE_RATE = 0.1
 PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 PRETTY_FORMAT_EXPRESSIONS = True
 
+# By default, allocation policies won't block requests from going through in a production
+# environment to not cause incidents unnecessarily. If something goes wrong with allocation
+# policy code, the request will still be able to go through (but it will create a dangerous
+# situation eventually)
+RAISE_ON_ALLOCATION_POLICY_FAILURES = False
+
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}  # (logical topic name, # of partitions)
 
 COLUMN_SPLIT_MIN_COLS = 6

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -21,6 +21,11 @@ ENABLE_DEV_FEATURES = True
 # to explore the unrefined Expression structure
 PRETTY_FORMAT_EXPRESSIONS = True
 
+# By default, allocation policies won't block requests from going through in a production
+# environment to not cause incidents unnecessarily. But if you're testing the policy, it
+# should fail on bad code
+RAISE_ON_ALLOCATION_POLICY_FAILURES = True
+
 # override replacer threshold to write to redis every time a replacement message is consumed
 REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -706,7 +706,9 @@ def db_query(
         quota_allowance = allocation_policy.get_quota_allowance(
             attribution_info.tenant_ids
         )
+        stats["quota_allowance"] = quota_allowance.to_dict()
     except AllocationPolicyViolation as e:
+        stats["quota_allowance"] = e.quota_allowance
         raise QueryException.from_args(
             "Query cannot be run due to allocation policy",
             extra={"stats": stats, "sql": formatted_query.get_sql(), "experiments": {}},

--- a/tests/pipeline/test_composite_planner.py
+++ b/tests/pipeline/test_composite_planner.py
@@ -21,7 +21,6 @@ from snuba.pipeline.composite import (
     CompositeQueryPlanner,
 )
 from snuba.query import SelectedExpression
-from snuba.query.allocation_policies import PassthroughPolicy
 from snuba.query.composite import CompositeQuery
 from snuba.query.conditions import (
     BooleanFunctions,
@@ -61,7 +60,7 @@ events_table_name = events_storage.get_table_writer().get_schema().get_table_nam
 events_table = Table(
     events_table_name,
     events_storage.get_schema().get_columns(),
-    allocation_policy=PassthroughPolicy(StorageSetKey("events"), []),
+    allocation_policy=events_storage.get_allocation_policy(),
     final=False,
     sampling_rate=None,
     mandatory_conditions=events_storage.get_schema()
@@ -79,7 +78,7 @@ assert isinstance(groups_schema, TableSchema)
 groups_table = Table(
     groups_schema.get_table_name(),
     groups_schema.get_columns(),
-    allocation_policy=PassthroughPolicy(StorageSetKey("cdc"), []),
+    allocation_policy=groups_storage.get_allocation_policy(),
     final=False,
     sampling_rate=None,
     mandatory_conditions=groups_schema.get_data_source().get_mandatory_conditions(),

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
 from snuba.clusters.storage_sets import StorageSetKey
@@ -7,6 +9,7 @@ from snuba.query.allocation_policies import (
     DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicyViolation,
     PassthroughPolicy,
+    QueryResultOrError,
     QuotaAllowance,
 )
 from snuba.state import set_config
@@ -51,3 +54,38 @@ def test_raises_on_false_can_run():
         RejectingEverythingAllocationPolicy(
             StorageSetKey("something"), []
         ).get_quota_allowance({})
+
+
+def test_passes_through_on_error() -> None:
+    class BadlyWrittenAllocationPolicy(PassthroughPolicy):
+        def _get_quota_allowance(
+            self, tenant_ids: dict[str, str | int]
+        ) -> QuotaAllowance:
+            raise AttributeError("You messed up!")
+
+        def _update_quota_balance(
+            self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
+        ) -> None:
+            raise ValueError("you messed up AGAIN")
+
+    with pytest.raises(AttributeError):
+        BadlyWrittenAllocationPolicy(
+            StorageSetKey("something"), []
+        ).get_quota_allowance({})
+
+    with pytest.raises(ValueError):
+        BadlyWrittenAllocationPolicy(StorageSetKey("something"), []).update_quota_balance(None, None)  # type: ignore
+
+    # should not raise even though the implementation is buggy (this is the production setting)
+    with mock.patch("snuba.settings.RAISE_ON_ALLOCATION_POLICY_FAILURES", False):
+        assert (
+            BadlyWrittenAllocationPolicy(StorageSetKey("something"), [])
+            .get_quota_allowance({})
+            .can_run
+        )
+
+        BadlyWrittenAllocationPolicy(
+            StorageSetKey("something"), []
+        ).update_quota_balance(
+            None, None  # type: ignore
+        )

--- a/tests/query/allocation_policies/test_errors_allocation_policy.py
+++ b/tests/query/allocation_policies/test_errors_allocation_policy.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import pytest
+
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.query.allocation_policies import (
+    AllocationPolicyViolation,
+    QueryResultOrError,
+)
+from snuba.query.allocation_policies.errors_allocation_policy import (
+    _ORG_LESS_REFERRERS,
+    ErrorsAllocationPolicy,
+)
+from snuba.state import set_config
+from snuba.web import QueryResult
+
+ORG_SCAN_LIMIT = 1000
+THROTTLED_THREAD_NUMBER = 1
+MAX_THREAD_NUMBER = 400
+
+
+@pytest.fixture(scope="function")
+def policy():
+    policy = ErrorsAllocationPolicy(
+        storage_set_key=StorageSetKey("errors"),
+        required_tenant_types=["referrer", "organization_id"],
+    )
+    return policy
+
+
+def _configure_policy(policy):
+    set_config(f"{policy.rate_limit_prefix}.is_active", True)
+    set_config(f"{policy.rate_limit_prefix}.is_enforced", True)
+    set_config(f"{policy.rate_limit_prefix}.org_limit_bytes_scanned", ORG_SCAN_LIMIT)
+    set_config(
+        f"{policy.rate_limit_prefix}.throttled_thread_number", THROTTLED_THREAD_NUMBER
+    )
+    set_config("query_settings/max_threads", MAX_THREAD_NUMBER)
+
+
+@pytest.mark.redis_db
+def test_consume_quota(policy: ErrorsAllocationPolicy) -> None:
+    # 1. if you scan the limit of bytes, you get throttled to one thread
+    _configure_policy(policy)
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    allowance = policy.get_quota_allowance(tenant_ids)
+    assert allowance.can_run
+    assert allowance.max_threads == MAX_THREAD_NUMBER
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    allowance = policy.get_quota_allowance(tenant_ids)
+    assert allowance.can_run
+    assert allowance.max_threads == THROTTLED_THREAD_NUMBER
+    assert allowance.explanation == {
+        "reason": f"organization 123 is over the bytes scanned limit of {ORG_SCAN_LIMIT}",
+        "is_enforced": True,
+        "granted_quota": 0,
+        "limit": ORG_SCAN_LIMIT,
+    }
+
+
+@pytest.mark.redis_db
+def test_org_isolation(policy) -> None:
+    _configure_policy(policy)
+
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    different_tenant_ids: dict[str, int | str] = {
+        "organization_id": 1235,
+        "referrer": "some_referrer",
+    }
+    allowance = policy.get_quota_allowance(different_tenant_ids)
+    assert allowance.max_threads == MAX_THREAD_NUMBER
+
+
+@pytest.mark.redis_db
+def test_killswitch(policy) -> None:
+    _configure_policy(policy)
+    set_config(f"{policy.rate_limit_prefix}.is_active", False)
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    allowance = policy.get_quota_allowance(tenant_ids)
+    # policy is not active so no change
+    assert allowance.max_threads == MAX_THREAD_NUMBER
+
+
+@pytest.mark.redis_db
+def test_enforcement_switch(policy) -> None:
+    _configure_policy(policy)
+    tenant_ids: dict[str, int | str] = {
+        "organization_id": 123,
+        "referrer": "some_referrer",
+    }
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}}, extra={}
+            ),
+            error=None,
+        ),
+    )
+    set_config(f"{policy.rate_limit_prefix}.is_enforced", False)
+    allowance = policy.get_quota_allowance(tenant_ids)
+    # policy not enforced
+    assert allowance.max_threads == MAX_THREAD_NUMBER
+
+
+@pytest.mark.redis_db
+def test_reject_queries_without_tenant_ids(policy) -> None:
+    _configure_policy(policy)
+    with pytest.raises(AllocationPolicyViolation):
+        policy.get_quota_allowance(tenant_ids={"organization_id": 1234})
+    with pytest.raises(AllocationPolicyViolation):
+        policy.get_quota_allowance(tenant_ids={"referrer": "bloop"})
+    # These should not fail because we know they don't have an org id
+    for referrer in _ORG_LESS_REFERRERS:
+        policy.get_quota_allowance(tenant_ids={"referrer": referrer})

--- a/tests/query/allocation_policies/test_pickleability.py
+++ b/tests/query/allocation_policies/test_pickleability.py
@@ -1,0 +1,15 @@
+import pickle
+
+from snuba.datasets.storages.factory import get_all_storage_keys, get_storage
+
+
+def test_policies_are_pickleable() -> None:
+    # * allocation policies will eventually become part of the Table object which queries are run against
+    # * that table object is part of the query
+    # * we need the query object to be deepcopy-able
+    # * to deepcopy an object, all of its members must be pickleable
+
+    # this test makes sure that any allocation policy defined on a storage is in fact pickleable
+    for key in get_all_storage_keys():
+        storage = get_storage(key)
+        pickle.dumps(storage.get_allocation_policy())

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1161,29 +1161,6 @@ class TestSnQLApi(BaseApiTest):
             == "validation failed for entity discover: invalid tag condition on 'tags[count]': array literal 419 must be a string"
         )
 
-    def test_split_bullshit(self) -> None:
-        response = self.post(
-            "/discover/snql",
-            data=json.dumps(
-                {
-                    "legacy": True,
-                    "query": """MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE
-timestamp >= toDateTime('2023-01-13T21:50:02.960807') AND timestamp < toDateTime('2023-04-13T21:50:03.957655') AND project_id IN tuple(6641999) AND project_id IN tuple(6641999) ORDER BY timestamp DESC, event_id DESC LIMIT 101 OFFSET 0""",
-                    "dataset": "events",
-                    "app_id": "legacy",
-                    "tenant_ids": {
-                        "organization_id": 74868,
-                        "referrer": "api.project-events",
-                    },
-                    "parent_api": "/api/0/projects/{organization_slug}/{project_slug}/events/",
-                }
-            ),
-        )
-
-        assert (
-            response.status_code == 200
-        )  # TODO: This should be a 400, and will change once we can properly categorise these errors
-
     def test_datetime_condition_types(self) -> None:
         response = self.post(
             "/discover/snql",

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1161,6 +1161,29 @@ class TestSnQLApi(BaseApiTest):
             == "validation failed for entity discover: invalid tag condition on 'tags[count]': array literal 419 must be a string"
         )
 
+    def test_split_bullshit(self) -> None:
+        response = self.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "legacy": True,
+                    "query": """MATCH (events) SELECT event_id, group_id, project_id, timestamp WHERE
+timestamp >= toDateTime('2023-01-13T21:50:02.960807') AND timestamp < toDateTime('2023-04-13T21:50:03.957655') AND project_id IN tuple(6641999) AND project_id IN tuple(6641999) ORDER BY timestamp DESC, event_id DESC LIMIT 101 OFFSET 0""",
+                    "dataset": "events",
+                    "app_id": "legacy",
+                    "tenant_ids": {
+                        "organization_id": 74868,
+                        "referrer": "api.project-events",
+                    },
+                    "parent_api": "/api/0/projects/{organization_slug}/{project_slug}/events/",
+                }
+            ),
+        )
+
+        assert (
+            response.status_code == 200
+        )  # TODO: This should be a 400, and will change once we can properly categorise these errors
+
     def test_datetime_condition_types(self) -> None:
         response = self.post(
             "/discover/snql",


### PR DESCRIPTION
Same as #3999 except we make sure the allocation policy is pickleable (and all future allocation policies are pickleable)


### The Policy

For every organization, keep track of how many bytes they've scanned in the last 10 minutes, when they reach a limit, throttle them to one thread

### How to turn it on/off

In runtime config:

```
# completely bypasses the code path
SET ErrorsAllocationPolicy.is_active 0
```


```
# code runs and emits metrics but no action is taken
SET ErrorsAllocationPolicy.is_enforced 0
```

```
# how many bytes the org can scan in ten minutes before being throttled
SET ErrorsAllocationPolicy.org_scan_limit 42069
```

### Intent

This is not meant to be the final policy, this is just a quick way to get something working end to end and then iterate on it. Most of this code will be rewritten