### PR TITLE
ref: Dispatch replacements based on get_replacement_type

### DIFF
--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -609,7 +609,6 @@ class MergeReplacement(Replacement):
 
     all_columns: Sequence[FlattenedColumn]
 
-
     @classmethod
     def parse_message(
         cls,
@@ -811,7 +810,6 @@ class UnmergeHierarchicalReplacement(Replacement):
 
     all_columns: Sequence[FlattenedColumn]
     state_name: ReplacerState
-
 
     @classmethod
     def parse_message(

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -1060,14 +1060,17 @@ class DeleteTagReplacement(Replacement):
 
 _REPLACEMENT_BY_TYPE: Mapping[ReplacementType, Type[Replacement]] = dict(
     (cls.get_replacement_type(), cls)
-    for cls in [
-        DeleteGroupsReplacement,
-        MergeReplacement,
-        UnmergeGroupsReplacement,
-        UnmergeHierarchicalReplacement,
-        DeleteTagReplacement,
-        TombstoneEventsReplacement,
-        ReplaceGroupReplacement,
-        ExcludeGroupsReplacement,
-    ]
+    for cls in cast(
+        Sequence[Type[Replacement]],
+        [
+            DeleteGroupsReplacement,
+            MergeReplacement,
+            UnmergeGroupsReplacement,
+            UnmergeHierarchicalReplacement,
+            DeleteTagReplacement,
+            TombstoneEventsReplacement,
+            ReplaceGroupReplacement,
+            ExcludeGroupsReplacement,
+        ],
+    )
 )

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -1006,6 +1006,7 @@ class DeleteTagReplacement(Replacement):
     def get_project_id(self) -> int:
         return self.project_id
 
+    @classmethod
     def get_replacement_type(cls) -> ReplacementType:
         return ReplacementType.END_DELETE_TAG
 

--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -18,6 +18,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -91,16 +92,19 @@ class ReplacementContext:
 
 
 class Replacement(ReplacementBase):
+    @classmethod
+    @abstractmethod
+    def parse_message(
+        cls, message: ReplacementMessage[Any], context: ReplacementContext
+    ) -> Optional[Replacement]:
+        raise NotImplementedError()
+
     @abstractmethod
     def get_query_time_flags(self) -> Optional[QueryTimeFlags]:
         raise NotImplementedError()
 
     @abstractmethod
     def get_project_id(self) -> int:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_replacement_type(self) -> ReplacementType:
         raise NotImplementedError()
 
     @abstractmethod
@@ -195,44 +199,10 @@ class ErrorsReplacer(ReplacerProcessor[Replacement]):
             ReplacementType.START_DELETE_TAG,
         ):
             return None
-        elif type_ == ReplacementType.END_DELETE_GROUPS:
-            processed = DeleteGroupsReplacement.parse_message(
-                cast(ReplacementMessage[EndDeleteGroupsMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.END_MERGE:
-            processed = MergeReplacement.parse_message(
-                cast(ReplacementMessage[EndMergeMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.END_UNMERGE:
-            processed = UnmergeGroupsReplacement.parse_message(
-                cast(ReplacementMessage[EndUnmergeMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.END_UNMERGE_HIERARCHICAL:
-            processed = UnmergeHierarchicalReplacement.parse_message(
-                cast(ReplacementMessage[EndUnmergeHierarchicalMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.END_DELETE_TAG:
-            processed = DeleteTagReplacement.parse_message(
-                cast(ReplacementMessage[EndDeleteTagMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.TOMBSTONE_EVENTS:
-            processed = TombstoneEventsReplacement.parse_message(
-                cast(ReplacementMessage[TombstoneEventsMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.REPLACE_GROUP:
-            processed = ReplaceGroupReplacement.parse_message(
-                cast(ReplacementMessage[ReplaceGroupMessageBody], message),
-                self.__replacement_context,
-            )
-        elif type_ == ReplacementType.EXCLUDE_GROUPS:
-            processed = ExcludeGroupsReplacement.parse_message(
-                cast(ReplacementMessage[ExcludeGroupsMessageBody], message),
+        elif type_ in _REPLACEMENT_BY_TYPE:
+
+            processed = _REPLACEMENT_BY_TYPE[type_].parse_message(
+                message,
                 self.__replacement_context,
             )
         else:
@@ -343,7 +313,6 @@ class ReplaceGroupReplacement(Replacement):
     from_timestamp: Optional[str]
     to_timestamp: Optional[str]
     new_group_id: int
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
     all_columns: Sequence[FlattenedColumn]
 
@@ -363,7 +332,6 @@ class ReplaceGroupReplacement(Replacement):
             from_timestamp=message.data.get("from_timestamp"),
             to_timestamp=message.data.get("to_timestamp"),
             new_group_id=message.data["new_group_id"],
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
             all_columns=context.all_columns,
         )
@@ -374,8 +342,9 @@ class ReplaceGroupReplacement(Replacement):
     def get_query_time_flags(self) -> Optional[QueryTimeFlags]:
         return None
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.REPLACE_GROUP
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
@@ -426,7 +395,6 @@ class DeleteGroupsReplacement(Replacement):
     required_columns: Sequence[str]
     timestamp: datetime
     group_ids: Sequence[int]
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -451,7 +419,6 @@ class DeleteGroupsReplacement(Replacement):
             project_id=message.data["project_id"],
             timestamp=timestamp,
             group_ids=group_ids,
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
         )
 
@@ -461,8 +428,9 @@ class DeleteGroupsReplacement(Replacement):
     def get_query_time_flags(self) -> Optional[QueryTimeFlags]:
         return ExcludeGroups(group_ids=self.group_ids)
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.END_DELETE_GROUPS
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
@@ -508,7 +476,6 @@ class TombstoneEventsReplacement(Replacement):
     to_timestamp: Optional[str]
 
     required_columns: Sequence[str]
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -528,7 +495,6 @@ class TombstoneEventsReplacement(Replacement):
             from_timestamp=message.data.get("from_timestamp"),
             to_timestamp=message.data.get("to_timestamp"),
             required_columns=context.required_columns,
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
         )
 
@@ -579,8 +545,9 @@ class TombstoneEventsReplacement(Replacement):
     def get_project_id(self) -> int:
         return self.project_id
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.TOMBSTONE_EVENTS
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
@@ -606,7 +573,6 @@ class ExcludeGroupsReplacement(Replacement):
 
     project_id: int
     group_ids: Sequence[int]
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -621,7 +587,6 @@ class ExcludeGroupsReplacement(Replacement):
         return cls(
             project_id=message.data["project_id"],
             group_ids=message.data["group_ids"],
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
         )
 
@@ -631,8 +596,9 @@ class ExcludeGroupsReplacement(Replacement):
     def get_query_time_flags(self) -> Optional[QueryTimeFlags]:
         return ExcludeGroups(group_ids=self.group_ids)
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.EXCLUDE_GROUPS
 
     def get_insert_query(self, table_name: str) -> Optional[str]:
         return None
@@ -668,7 +634,6 @@ class MergeReplacement(Replacement):
 
     all_columns: Sequence[FlattenedColumn]
 
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -707,7 +672,6 @@ class MergeReplacement(Replacement):
             new_group_id=message.data["new_group_id"],
             timestamp=timestamp,
             all_columns=context.all_columns,
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
         )
 
@@ -752,8 +716,9 @@ class MergeReplacement(Replacement):
     def get_project_id(self) -> int:
         return self.project_id
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.END_MERGE
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
@@ -768,7 +733,6 @@ class UnmergeGroupsReplacement(Replacement):
     project_id: int
     previous_group_id: int
     new_group_id: int
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -795,7 +759,6 @@ class UnmergeGroupsReplacement(Replacement):
             previous_group_id=message.data["previous_group_id"],
             new_group_id=message.data["new_group_id"],
             all_columns=context.all_columns,
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
         )
 
@@ -805,8 +768,9 @@ class UnmergeGroupsReplacement(Replacement):
     def get_query_time_flags(self) -> Optional[QueryTimeFlags]:
         return NeedsFinal()
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.END_UNMERGE
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
@@ -883,7 +847,6 @@ class UnmergeHierarchicalReplacement(Replacement):
     all_columns: Sequence[FlattenedColumn]
     state_name: ReplacerState
 
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -919,7 +882,6 @@ class UnmergeHierarchicalReplacement(Replacement):
             hierarchical_hash=hierarchical_hash,
             all_columns=context.all_columns,
             state_name=context.state_name,
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
             previous_group_id=message.data["previous_group_id"],
             new_group_id=message.data["new_group_id"],
@@ -972,8 +934,9 @@ class UnmergeHierarchicalReplacement(Replacement):
     def get_project_id(self) -> int:
         return self.project_id
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.END_UNMERGE_HIERARCHICAL
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
@@ -988,7 +951,6 @@ class DeleteTagReplacement(Replacement):
     is_promoted: bool
     all_columns: Sequence[FlattenedColumn]
     schema: WritableTableSchema
-    replacement_type: ReplacementType
     replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
@@ -1016,7 +978,6 @@ class DeleteTagReplacement(Replacement):
             is_promoted=is_promoted,
             all_columns=context.all_columns,
             schema=context.schema,
-            replacement_type=message.action_type,
             replacement_message_metadata=message.metadata,
         )
 
@@ -1089,8 +1050,24 @@ class DeleteTagReplacement(Replacement):
     def get_project_id(self) -> int:
         return self.project_id
 
-    def get_replacement_type(self) -> ReplacementType:
-        return self.replacement_type
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        return ReplacementType.END_DELETE_TAG
 
     def get_message_metadata(self) -> ReplacementMessageMetadata:
         return self.replacement_message_metadata
+
+
+_REPLACEMENT_BY_TYPE: Mapping[ReplacementType, Type[Replacement]] = dict(
+    (cls.get_replacement_type(), cls)
+    for cls in [
+        DeleteGroupsReplacement,
+        MergeReplacement,
+        UnmergeGroupsReplacement,
+        UnmergeHierarchicalReplacement,
+        DeleteTagReplacement,
+        TombstoneEventsReplacement,
+        ReplaceGroupReplacement,
+        ExcludeGroupsReplacement,
+    ]
+)

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -39,6 +39,11 @@ class ReplacementMessage(NamedTuple, Generic[T]):
 
 
 class Replacement(ABC):
+    @classmethod
+    @abstractmethod
+    def get_replacement_type(cls) -> ReplacementType:
+        raise NotImplementedError()
+
     @abstractmethod
     def get_insert_query(self, table_name: str) -> Optional[str]:
         raise NotImplementedError()

--- a/tests/replacer/test_cluster_replacements.py
+++ b/tests/replacer/test_cluster_replacements.py
@@ -173,7 +173,8 @@ class DummyReplacement(Replacement):
     def get_query_time_flags(self) -> QueryTimeFlags:
         return NeedsFinal()
 
-    def get_replacement_type(self) -> ReplacementType:
+    @classmethod
+    def get_replacement_type(cls) -> ReplacementType:
         # Arbitrary replacement type, no impact on tests
         return ReplacementType.EXCLUDE_GROUPS
 


### PR DESCRIPTION
Currently we first dispatch to replacement based on type based on a big
if-else statement, then ask the replacement what type it is. Either the
replacement has a say about the ReplacementType or it doesn't, but
we shouldn't use it as a databag for random things we want to
forward to another function.
