### PR TITLE
ref(replacements): Replacements no longer need to carry metadata

### DIFF
--- a/snuba/replacers/errors_replacer.py
+++ b/snuba/replacers/errors_replacer.py
@@ -49,7 +49,6 @@ from snuba.replacers.projects_query_flags import ProjectsQueryFlags
 from snuba.replacers.replacer_processor import Replacement as ReplacementBase
 from snuba.replacers.replacer_processor import (
     ReplacementMessage,
-    ReplacementMessageMetadata,
     ReplacerProcessor,
     ReplacerState,
 )
@@ -101,10 +100,6 @@ class Replacement(ReplacementBase):
 
     @abstractmethod
     def get_replacement_type(self) -> ReplacementType:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
         raise NotImplementedError()
 
     def should_write_every_node(self) -> bool:
@@ -344,7 +339,6 @@ class ReplaceGroupReplacement(Replacement):
     to_timestamp: Optional[str]
     new_group_id: int
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
     all_columns: Sequence[FlattenedColumn]
 
     @classmethod
@@ -364,7 +358,6 @@ class ReplaceGroupReplacement(Replacement):
             to_timestamp=message.data.get("to_timestamp"),
             new_group_id=message.data["new_group_id"],
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
             all_columns=context.all_columns,
         )
 
@@ -376,9 +369,6 @@ class ReplaceGroupReplacement(Replacement):
 
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
-
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
 
     @cached_property
     def _where_clause(self) -> str:
@@ -427,7 +417,6 @@ class DeleteGroupsReplacement(Replacement):
     timestamp: datetime
     group_ids: Sequence[int]
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -452,7 +441,6 @@ class DeleteGroupsReplacement(Replacement):
             timestamp=timestamp,
             group_ids=group_ids,
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
         )
 
     def get_project_id(self) -> int:
@@ -463,9 +451,6 @@ class DeleteGroupsReplacement(Replacement):
 
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
-
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
 
     @cached_property
     def _where_clause(self) -> str:
@@ -509,7 +494,6 @@ class TombstoneEventsReplacement(Replacement):
 
     required_columns: Sequence[str]
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -529,7 +513,6 @@ class TombstoneEventsReplacement(Replacement):
             to_timestamp=message.data.get("to_timestamp"),
             required_columns=context.required_columns,
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
         )
 
     @cached_property
@@ -582,9 +565,6 @@ class TombstoneEventsReplacement(Replacement):
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
 
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
-
 
 @dataclass
 class ExcludeGroupsReplacement(Replacement):
@@ -607,7 +587,6 @@ class ExcludeGroupsReplacement(Replacement):
     project_id: int
     group_ids: Sequence[int]
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -622,7 +601,6 @@ class ExcludeGroupsReplacement(Replacement):
             project_id=message.data["project_id"],
             group_ids=message.data["group_ids"],
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
         )
 
     def get_project_id(self) -> int:
@@ -639,9 +617,6 @@ class ExcludeGroupsReplacement(Replacement):
 
     def get_count_query(self, table_name: str) -> Optional[str]:
         return None
-
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
 
 
 SEEN_MERGE_TXN_CACHE: Deque[str] = deque(maxlen=100)
@@ -669,7 +644,6 @@ class MergeReplacement(Replacement):
     all_columns: Sequence[FlattenedColumn]
 
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -708,7 +682,6 @@ class MergeReplacement(Replacement):
             timestamp=timestamp,
             all_columns=context.all_columns,
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
         )
 
     @cached_property
@@ -755,9 +728,6 @@ class MergeReplacement(Replacement):
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
 
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
-
 
 @dataclass(frozen=True)
 class UnmergeGroupsReplacement(Replacement):
@@ -769,7 +739,6 @@ class UnmergeGroupsReplacement(Replacement):
     previous_group_id: int
     new_group_id: int
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -796,7 +765,6 @@ class UnmergeGroupsReplacement(Replacement):
             new_group_id=message.data["new_group_id"],
             all_columns=context.all_columns,
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
         )
 
     def get_project_id(self) -> int:
@@ -807,9 +775,6 @@ class UnmergeGroupsReplacement(Replacement):
 
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
-
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
 
     @cached_property
     def _where_clause(self) -> str:
@@ -884,7 +849,6 @@ class UnmergeHierarchicalReplacement(Replacement):
     state_name: ReplacerState
 
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -920,7 +884,6 @@ class UnmergeHierarchicalReplacement(Replacement):
             all_columns=context.all_columns,
             state_name=context.state_name,
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
             previous_group_id=message.data["previous_group_id"],
             new_group_id=message.data["new_group_id"],
         )
@@ -975,9 +938,6 @@ class UnmergeHierarchicalReplacement(Replacement):
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
 
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata
-
 
 @dataclass
 class DeleteTagReplacement(Replacement):
@@ -989,7 +949,6 @@ class DeleteTagReplacement(Replacement):
     all_columns: Sequence[FlattenedColumn]
     schema: WritableTableSchema
     replacement_type: ReplacementType
-    replacement_message_metadata: ReplacementMessageMetadata
 
     @classmethod
     def parse_message(
@@ -1017,7 +976,6 @@ class DeleteTagReplacement(Replacement):
             all_columns=context.all_columns,
             schema=context.schema,
             replacement_type=message.action_type,
-            replacement_message_metadata=message.metadata,
         )
 
     @cached_property
@@ -1091,6 +1049,3 @@ class DeleteTagReplacement(Replacement):
 
     def get_replacement_type(self) -> ReplacementType:
         return self.replacement_type
-
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        return self.replacement_message_metadata

--- a/snuba/replacers/replacer_processor.py
+++ b/snuba/replacers/replacer_processor.py
@@ -51,10 +51,6 @@ class Replacement(ABC):
     def should_write_every_node(self) -> bool:
         raise NotImplementedError()
 
-    @abstractmethod
-    def get_message_metadata(self) -> ReplacementMessageMetadata:
-        raise NotImplementedError()
-
 
 R = TypeVar("R", bound=Replacement)
 

--- a/tests/datasets/test_errors_replacer.py
+++ b/tests/datasets/test_errors_replacer.py
@@ -533,7 +533,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         query_args = {
@@ -572,7 +574,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         query_args = {
@@ -608,7 +612,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         query_args = {
@@ -649,7 +655,9 @@ class TestReplacerProcess(BaseTest):
 
         message = (2, ReplacementType.TOMBSTONE_EVENTS, message_kwargs)
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
 
         old_primary_condition = (
             " AND primary_hash = 'e3d704f3-542b-44a6-21eb-ed70dc0efe13'"
@@ -691,7 +699,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         query_args = {
@@ -728,7 +738,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         query_args = {
@@ -769,7 +781,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
 
         query_args = {
             "all_columns": "project_id, timestamp, event_id, platform, environment, release, dist, ip_address_v4, ip_address_v6, user, user_id, user_name, user_email, sdk_name, sdk_version, http_method, http_referer, tags.key, tags.value, contexts.key, contexts.value, transaction_name, span_id, trace_id, partition, offset, message_timestamp, retention_days, deleted, group_id, primary_hash, hierarchical_hashes, received, message, title, culprit, level, location, version, type, exception_stacks.type, exception_stacks.value, exception_stacks.mechanism_type, exception_stacks.mechanism_handled, exception_frames.abs_path, exception_frames.colno, exception_frames.filename, exception_frames.function, exception_frames.lineno, exception_frames.in_app, exception_frames.package, exception_frames.module, exception_frames.stack_level, exception_main_thread, sdk_integrations, modules.name, modules.version",
@@ -808,7 +822,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         query_args = {
@@ -843,7 +859,9 @@ class TestReplacerProcess(BaseTest):
             },
         )
 
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
         query_args = {
             "group_ids": "1, 2, 3",
@@ -879,16 +897,20 @@ class TestReplacerProcess(BaseTest):
                 "datetime": timestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             },
         )
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         set_config("replacements_bypass_projects", f"[{self.project_id + 1}]")
-        replacement = self.replacer.process_message(self._wrap(message))
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is not None
+        _, replacement = meta_and_replacement
         assert replacement is not None
 
         set_config(
             "replacements_bypass_projects", f"[{self.project_id + 1},{self.project_id}]"
         )
-        replacement = self.replacer.process_message(self._wrap(message))
-        assert replacement is None
+        meta_and_replacement = self.replacer.process_message(self._wrap(message))
+        assert meta_and_replacement is None
         delete_config("replacements_bypass_projects")


### PR DESCRIPTION
When writing all those classes I found it kind of annoying that metadata
was a required getter on the interface. Turns out we only do that so we
can access it in a single function somewhere later. Instead, wrap the
replacement in a tuple and store the metadata alongside.
