### PR TITLE
fix(capman): make subscription referrer passthrough

### DIFF
--- a/tests/query/allocation_policies/test_errors_allocation_policy.py
+++ b/tests/query/allocation_policies/test_errors_allocation_policy.py
@@ -173,3 +173,23 @@ def test_passthrough_subscriptions(policy) -> None:
         policy.get_quota_allowance(tenant_ids=tenant_ids).max_threads
         == MAX_THREAD_NUMBER
     )
+
+
+@pytest.mark.redis_db
+def test_org_less_referrers(policy) -> None:
+    _configure_policy(policy)
+    tenant_ids = {"referrer": list(_ORG_LESS_REFERRERS)[0]}
+    assert (
+        policy.get_quota_allowance(tenant_ids=tenant_ids).max_threads
+        == MAX_THREAD_NUMBER
+    )
+    # should not throw
+    policy.update_quota_balance(
+        tenant_ids,
+        QueryResultOrError(
+            query_result=QueryResult(
+                result={"profile": {"bytes": ORG_SCAN_LIMIT}}, extra={}  # type: ignore
+            ),
+            error=None,
+        ),
+    )


### PR DESCRIPTION
It was assumed that subscriptions did not have an organization id attached to them. Turns out it's organization_id=1 for everything.

Make subscriptions queries not have a quota enforced for them (as is done currently with rate limiting)