### PR TITLE
fix: Add killswitch to disable raising of InvalidMessage

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -536,10 +536,10 @@ def process_message(
             scope.set_tag("invalid_message", "true")
             logger.warning(err, exc_info=True)
             value = message.value
-            if state.get_config(f"disable_new_dlq_{snuba_logical_topic.name}", 0):
-                return None
+            if state.get_config(f"enable_new_dlq_{snuba_logical_topic.name}", 0):
+                raise InvalidMessage(value.partition, value.offset) from err
 
-            raise InvalidMessage(value.partition, value.offset) from err
+            return None
 
     if isinstance(result, InsertBatch):
         return BytesInsertBatch(

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -536,6 +536,9 @@ def process_message(
             scope.set_tag("invalid_message", "true")
             logger.warning(err, exc_info=True)
             value = message.value
+            if state.get_config(f"disable_new_dlq_{snuba_logical_topic.name}", 0):
+                return None
+
             raise InvalidMessage(value.partition, value.offset) from err
 
     if isinstance(result, InsertBatch):


### PR DESCRIPTION
That code is a bit brittle, and we should have something to prevent it
from raising.
