### PR TITLE
fix(CI): make the migrations job list status

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -136,7 +136,7 @@ pipelines:
                                     --label-selector="service=snuba-admin" \
                                     --container-name="snuba-admin" \
                                     "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                                    -- snuba migrations migrate -r ${MIGRATIONS_READINESS}
+                                    -- snuba migrations list
                               - plugin:
                                     options:
                                         script: |
@@ -146,7 +146,7 @@ pipelines:
                                             --label-selector="service=snuba-admin" \
                                             --container-name="snuba-admin" \
                                             "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                                            -- snuba migrations reverse-in-progress
+                                            -- snuba migrations list
                                     run_if: failed
                                     configuration:
                                         id: script-executor


### PR DESCRIPTION
Changes the migrations job to list migrations. This is temporary solution to allow us to test the job. Eventually this will be replaced by running the real thing.

