### PR TITLE
fix(admin): show all migrations groups

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Generic, Optional, Sequence, Set, Type, TypeVar
 
 from snuba import settings
+from snuba.migrations.runner import get_active_migration_groups
 
 
 class Category(Enum):
@@ -104,7 +105,8 @@ class ExecuteNoneAction(MigrationAction):
 
 
 MIGRATIONS_RESOURCES = {
-    group: MigrationResource(group) for group in settings.ADMIN_ALLOWED_MIGRATION_GROUPS
+    group.value: MigrationResource(group.value)
+    for group in get_active_migration_groups()
 }
 
 

--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -105,8 +105,11 @@ class ExecuteNoneAction(MigrationAction):
 
 
 MIGRATIONS_RESOURCES = {
-    group.value: MigrationResource(group.value)
-    for group in get_active_migration_groups()
+    **{
+        group.value: MigrationResource(group.value)
+        for group in get_active_migration_groups()
+    },
+    **{group: MigrationResource(group) for group in settings.SKIPPED_MIGRATION_GROUPS},
 }
 
 

--- a/snuba/admin/migrations_policies.py
+++ b/snuba/admin/migrations_policies.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Dict, MutableMapping, Set
 
 from flask import Response, g, jsonify, make_response, request
 
-from snuba import settings
 from snuba.admin.auth_roles import (
     ExecuteAllAction,
     ExecuteNonBlockingAction,
@@ -33,11 +32,7 @@ def get_migration_group_policies(
     roles.
     """
     group_policies: MutableMapping[str, Set[str]] = defaultdict(set)
-    allowed_groups = [
-        group.value
-        for group in get_active_migration_groups()
-        if group.value in settings.ADMIN_ALLOWED_MIGRATION_GROUPS
-    ]
+    allowed_groups = [group.value for group in get_active_migration_groups()]
 
     for role in user.roles:
         for action in role.actions:

--- a/snuba/admin/static/clickhouse_migrations/index.tsx
+++ b/snuba/admin/static/clickhouse_migrations/index.tsx
@@ -29,7 +29,7 @@ function ClickhouseMigrations(props: { api: Client }) {
   useEffect(() => {
     props.api.getAllMigrationGroups().then((res) => {
       let options: GroupOptions = {};
-      res.forEach(
+      res.sort().forEach(
         (group: MigrationGroupResult) => (options[group.group] = group)
       );
       setAllGroups(options);
@@ -165,7 +165,7 @@ function ClickhouseMigrations(props: { api: Client }) {
   function refreshStatus(group: string) {
     props.api.getAllMigrationGroups().then((res) => {
       let options: GroupOptions = {};
-      res.forEach(
+      res.sort().forEach(
         (group: MigrationGroupResult) => (options[group.group] = group)
       );
       setAllGroups(options);

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -44,19 +44,6 @@ ADMIN_IAM_POLICY_FILE = os.environ.get(
     f"{Path(__file__).parent.parent.as_posix()}/admin/iam_policy/iam_policy.json",
 )
 
-# Migrations Groups that are allowed to be managed
-# in the snuba admin tool.
-ADMIN_ALLOWED_MIGRATION_GROUPS = {
-    "system",
-    "generic_metrics",
-    "profiles",
-    "functions",
-    "replays",
-    "search_issues",
-    "test_migration",
-    "events",
-    "transactions",
-}
 MAX_MIGRATIONS_REVERT_TIME_WINDOW_HRS = 24
 
 ENABLE_DEV_FEATURES = os.environ.get("ENABLE_DEV_FEATURES", False)

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -139,14 +139,6 @@ def test_list_migration_status(admin_api: FlaskClient) -> None:
 
 @pytest.mark.clickhouse_db
 @pytest.mark.parametrize("action", ["run", "reverse"])
-@patch(
-    "snuba.settings.ADMIN_ALLOWED_MIGRATION_GROUPS",
-    {
-        "system",
-        "generic_metrics",
-        "events",
-    },
-)
 def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:
 
     method = "run_migration" if action == "run" else "reverse_migration"


### PR DESCRIPTION
Deprecates the `ADMIN_ALLOWED_MIGRATION_GROUPS` list. This list is not needed since we now control access via policy. This allows to show all groups so that migrations status is visible for all. For groups where the migrations policy blocks access , the group is readonly so the user can view its status and dry run it, but cannot execute it.