### PR TITLE
fix(typing) Couple typing errors in cdc tests

### DIFF
--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -172,13 +172,13 @@ class TestGroupassignee:
             [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 55, 32443, tzinfo=pytz.UTC)
         )
         write_processed_messages(self.storage, [ret])
-        ret = (
+        results = (
             self.storage.get_cluster()
             .get_query_connection(ClickhouseClientSettings.QUERY)
             .execute("SELECT * FROM groupassignee_local;")
             .results
         )
-        assert ret[0] == (
+        assert results[0] == (
             42,  # offset
             0,  # deleted
             2,  # project_id

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -237,13 +237,13 @@ class TestGroupedMessage:
             [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
         )
         write_processed_messages(self.storage, [ret])
-        ret = (
+        results = (
             get_cluster(StorageSetKey.EVENTS)
             .get_query_connection(ClickhouseClientSettings.INSERT)
             .execute("SELECT * FROM groupedmessage_local;")
             .results
         )
-        assert ret[0] == (
+        assert results[0] == (
             42,  # offset
             0,  # deleted
             2,  # project_id


### PR DESCRIPTION
Fix typing errors in CDC test that were breaking on master.
