### PR TITLE
ref: Start using FailoverRedis in Snuba

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.10.1
 sentry-kafka-schemas==0.0.28
+sentry-redis-tools==0.1.2
 sentry-relay==0.8.19
 sentry-sdk==1.18.0
 simplejson==3.17.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.10.1
 sentry-kafka-schemas==0.0.28
-sentry-redis-tools==0.1.2
+sentry-redis-tools==0.1.3
 sentry-relay==0.8.19
 sentry-sdk==1.18.0
 simplejson==3.17.6

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -5,13 +5,20 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Iterable, Mapping, TypeVar, Union, cast
 
-from redis.client import StrictRedis
+from sentry_redis_tools.failover_redis import FailoverRedis
+
 from redis.cluster import ClusterNode, NodesManager, RedisCluster
 from redis.exceptions import BusyLoadingError, ConnectionError, RedisClusterException
 from snuba import settings
 from snuba.utils.serializable_exception import SerializableException
 
-RedisClientType = Union[StrictRedis, RedisCluster]
+# We use FailoverRedis as our default redis client for single-node deployments,
+# as its additions to StrictRedis are required to work correctly under GCP
+# memorystore. In case it isn't memorystore, there's not much harm in using
+# FailoverRedis anyway.
+SingleNodeRedis = FailoverRedis
+
+RedisClientType = Union[SingleNodeRedis, RedisCluster]
 
 
 class FailedClusterInitization(SerializableException):
@@ -87,7 +94,7 @@ def _initialize_redis_cluster(config: settings.RedisClusterConfig) -> RedisClien
             reinitialize_steps=config["reinitialize_steps"],
         )
     else:
-        return StrictRedis(
+        return SingleNodeRedis(
             host=config["host"],
             port=config["port"],
             password=config["password"],


### PR DESCRIPTION
There is a class called FailoverRedis in Sentry's sentry.utils that is
supposed to deal with networking errors when GCP memorystore falls over.
Snuba doesn't have an equivalent class, and as a result would be
susceptible to the same failures.

sentry-redis-tools is a new package that contains this code + maybe more
redis-related code in the future. For now, it only contains a copy of
Sentry's FailoverRedis.

Add FailoverRedis and make it the default redis client for everything.

Sentry does NOT use FailoverRedis as the default redis client, but I
believe we should change that as well to prevent incidents like INC-311.
