### PR TITLE
fix(migrations): add the actual run/reverse command to gocd

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -136,7 +136,7 @@ pipelines:
                                     --label-selector="service=snuba-admin" \
                                     --container-name="snuba-admin" \
                                     "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                                    -- snuba migrations list
+                                    -- snuba migrations migrate -r ${MIGRATIONS_READINESS}
                               - plugin:
                                     options:
                                         script: |
@@ -146,7 +146,7 @@ pipelines:
                                             --label-selector="service=snuba-admin" \
                                             --container-name="snuba-admin" \
                                             "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                                            -- snuba migrations list
+                                            -- snuba migrations reverse-in-progress
                                     run_if: failed
                                     configuration:
                                         id: script-executor


### PR DESCRIPTION

We tested the migrations pipeline with the list command and verified that it captures the correct migrations. This now adds the actual run/reverse command to the pipeline.