### PR TITLE
feat(admin): allow querylog to be queried by more threads

### DIFF
--- a/snuba/admin/clickhouse/querylog.py
+++ b/snuba/admin/clickhouse/querylog.py
@@ -1,3 +1,4 @@
+from snuba import state
 from snuba.admin.audit_log.querylog import audit_log
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
@@ -8,6 +9,12 @@ from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.datasets.schemas.tables import TableSchema
 from snuba.datasets.storages.factory import get_storage
 from snuba.datasets.storages.storage_key import StorageKey
+
+_MAX_CH_THREADS = 4
+
+
+class BadThreadsValue(Exception):
+    pass
 
 
 @audit_log
@@ -31,6 +38,20 @@ def describe_querylog_schema() -> ClickhouseResult:
     return __run_querylog_query(f"DESCRIBE TABLE {schema.get_table_name()}")
 
 
+def _get_clickhouse_threads() -> int:
+    config_threads = state.get_config("admin.querylog_threads", _MAX_CH_THREADS)
+    try:
+        return min(
+            int(config_threads) if config_threads is not None else _MAX_CH_THREADS,
+            _MAX_CH_THREADS,
+        )
+    except ValueError:
+        # in case the config is set incorrectly
+        raise BadThreadsValue(
+            f"{config_threads} is not a valid configuration option for Clickhouse `max_threads`"
+        )
+
+
 def __run_querylog_query(query: str) -> ClickhouseResult:
     """
     Runs given Query against Querylog table in ClickHouse. This function assumes valid
@@ -39,5 +60,10 @@ def __run_querylog_query(query: str) -> ClickhouseResult:
     connection = get_ro_query_node_connection(
         StorageKey.QUERYLOG.value, ClickhouseClientSettings.QUERYLOG
     )
-    query_result = connection.execute(query=query, with_column_types=True)
+
+    query_result = connection.execute(
+        query=query,
+        with_column_types=True,
+        settings={"max_threads": _get_clickhouse_threads()},
+    )
     return query_result

--- a/tests/admin/clickhouse/test_querylog.py
+++ b/tests/admin/clickhouse/test_querylog.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Type
+
+import pytest
+
+from snuba import state
+from snuba.admin.clickhouse.querylog import (
+    _MAX_CH_THREADS,
+    BadThreadsValue,
+    _get_clickhouse_threads,
+)
+
+
+@pytest.mark.parametrize(
+    "config_val, expected_threads",
+    [
+        pytest.param(2, 2, id="normal"),
+        pytest.param(5, _MAX_CH_THREADS, id="over max"),
+    ],
+)
+def test_get_clickhouse_threads(config_val: str | int, expected_threads: int) -> None:
+    state.set_config("admin.querylog_threads", str(config_val))
+    assert _get_clickhouse_threads() == expected_threads
+
+
+@pytest.mark.parametrize(
+    "config_val, error",
+    [
+        pytest.param("invalid_value", BadThreadsValue, id="invalid_value"),
+    ],
+)
+def test_get_clickhouse_threads_error(
+    config_val: str | int, error: Type[Exception]
+) -> None:
+    state.set_config("admin.querylog_threads", str(config_val))
+    with pytest.raises(error):
+        _get_clickhouse_threads()

--- a/tests/admin/clickhouse/test_querylog.py
+++ b/tests/admin/clickhouse/test_querylog.py
@@ -19,6 +19,7 @@ from snuba.admin.clickhouse.querylog import (
         pytest.param(5, _MAX_CH_THREADS, id="over max"),
     ],
 )
+@pytest.mark.redis_db
 def test_get_clickhouse_threads(config_val: str | int, expected_threads: int) -> None:
     state.set_config("admin.querylog_threads", str(config_val))
     assert _get_clickhouse_threads() == expected_threads
@@ -30,6 +31,7 @@ def test_get_clickhouse_threads(config_val: str | int, expected_threads: int) ->
         pytest.param("invalid_value", BadThreadsValue, id="invalid_value"),
     ],
 )
+@pytest.mark.redis_db
 def test_get_clickhouse_threads_error(
     config_val: str | int, error: Type[Exception]
 ) -> None:


### PR DESCRIPTION
Since @MeredithAnya applied this:

https://github.com/getsentry/snuba/pull/3849

and we have `readonly=2` [set on the cabin role](https://github.com/getsentry/ops/blob/master/roles/cabin.json#L34), we should be able to specify query threads now and make the querylog queries faster

we're just reapplying https://github.com/getsentry/snuba/pull/3718