### PR TITLE
fix(rust-consumer): Stop spamming the log with messages

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -42,8 +42,8 @@ impl CommitOffsets {
                 .unwrap()
             || force
         {
-            info!("Performing a commit");
             if !self.partitions.is_empty() {
+                info!("Performing a commit {:?}", self.partitions);
                 let ret = Some(CommitRequest {
                     positions: self.partitions.clone(),
                 });


### PR DESCRIPTION
We were logging "performing a commit" on every message even if the commit never actually happens.