### PR TITLE
fix(cli): fix readiness state flag

### DIFF
--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -69,7 +69,7 @@ def list() -> None:
 )
 def migrate(
     group: Optional[str],
-    readiness_state: Optional[ReadinessState],
+    readiness_state: Optional[str],
     through: str,
     force: bool,
     fake: bool,
@@ -98,7 +98,7 @@ def migrate(
             force=force,
             fake=fake,
             group=migration_group,
-            readiness_state=readiness_state,
+            readiness_state=ReadinessState(readiness_state),
         )
     except MigrationError as e:
         raise click.ClickException(str(e))


### PR DESCRIPTION
fix a bug where the cli did not convert the readiness_state flag to an enum
