### PR TITLE
fix: Fix broken rust_snuba import

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,11 +111,13 @@ RUN set -ex; \
     groupadd -r snuba --gid 1000; \
     useradd -r -g snuba --uid 1000 snuba; \
     chown -R snuba:snuba ./; \
-    [ -z "`find -type f /tmp/rust_wheels`" ] || pip install /tmp/rust_wheels/*; \
+    # Ensure that we are always importing the installed rust_snuba wheel, and not the
+    # (basically empty) rust_snuba folder
+    rm -rf ./rust_snuba/; \
+    [ -z "`find /tmp/rust_wheels -type f`" ] || pip install /tmp/rust_wheels/*; \
     rm -rf /tmp/rust_wheels/; \
     pip install -e .; \
-    snuba --help; \
-    python -c 'import rust_snuba'
+    snuba --help
 
 ARG SOURCE_COMMIT
 ENV SNUBA_RELEASE=$SOURCE_COMMIT \


### PR DESCRIPTION
`import rust_snuba` was accidentally importing the folder in the
repository instead of the installed wheel. On top of that, installing
the wheel never happened because the arguments for `find` were in the
wrong order.

Now that that is fixed, we can no longer assume that rust_snuba is
available in all builds, therefore we remove the `import rust_snuba`
sanity check -- not like it helped us catch anything anyway.
