### PR TITLE
fix(search-issue): map transaction and transaction_name column to tags[transaction]

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -134,6 +134,22 @@ storages:
             to_nested_col_name: "contexts"
             to_nested_mapping_key: "geo.city"
             nullable: True
+        - mapper: ColumnToMapping
+          args:
+            from_table_name: null
+            from_col_name: "transaction"
+            to_nested_col_table_name: null
+            to_nested_col_name: "tags"
+            to_nested_mapping_key: "transaction"
+            nullable: true
+        - mapper: ColumnToMapping
+          args:
+            from_table_name: null
+            from_col_name: "transaction_name"
+            to_nested_col_table_name: null
+            to_nested_col_name: "tags"
+            to_nested_mapping_key: "transaction"
+            nullable: true
       subscriptables:
         - mapper: SubscriptableMapper
           args:


### PR DESCRIPTION
Need for issue search.

Is it better to have this as an actual column in the storage? 