### PR TITLE
perf: Allow logging rate of invalid messages to be configured

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -511,8 +511,15 @@ def process_message(
                 try:
                     codec.validate(decoded)
                 except Exception as err:
+                    log_validate_sample_rate = float(
+                        state.get_config(
+                            f"log_validate_schema_{snuba_logical_topic.name}", 0
+                        )
+                        or 0.0
+                    )
                     sentry_sdk.set_tag("invalid_message_schema", "true")
-                    logger.warning(err, exc_info=True)
+                    if random.random() < log_validate_sample_rate:
+                        logger.warning(err, exc_info=True)
 
             # TODO: this is not the most efficient place to emit a metric, but
             # as long as should_validate is behind a sample rate it should be


### PR DESCRIPTION
We suspect excessive logging to Sentry is causing processing of large numbers of invalid messages to be slow. Allow this to be configured with runtime config to test the theory.