### PR TITLE
fix(DRS): Update readiness_state of profiles and functions

### DIFF
--- a/snuba/datasets/configuration/functions/storages/functions.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions.yaml
@@ -4,7 +4,7 @@ name: functions
 storage:
   key: functions
   set_key: functions
-readiness_state: complete
+readiness_state: partial
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/functions/storages/functions_raw.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions_raw.yaml
@@ -4,7 +4,7 @@ name: functions_raw
 storage:
   key: functions_raw
   set_key: functions
-readiness_state: complete
+readiness_state: partial
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/profiles/storages/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/storages/profiles.yaml
@@ -4,7 +4,7 @@ name: profiles
 storage:
   key: profiles
   set_key: profiles
-readiness_state: complete
+readiness_state: partial
 schema:
   columns:
     [

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -114,12 +114,12 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.PROFILES: _MigrationGroup(
         loader=ProfilesLoader(),
         storage_sets_keys={StorageSetKey.PROFILES},
-        readiness_state=ReadinessState.COMPLETE,
+        readiness_state=ReadinessState.PARTIAL,
     ),
     MigrationGroup.FUNCTIONS: _MigrationGroup(
         loader=FunctionsLoader(),
         storage_sets_keys={StorageSetKey.FUNCTIONS},
-        readiness_state=ReadinessState.COMPLETE,
+        readiness_state=ReadinessState.PARTIAL,
     ),
     MigrationGroup.REPLAYS: _MigrationGroup(
         loader=ReplaysLoader(),


### PR DESCRIPTION
### Overview
The storage and migration group's readiness_state for profiles and functions should be `partial` instead of `complete`. This is because they are not available in self-hosted and ST yet. 

### Blast Radius
No affect. The readiness states for these datasets are not set as active in rollout yet.