### PR TITLE
ref(consumers): process kafka headers

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -532,6 +532,7 @@ def process_message(
                 message.value.offset,
                 message.value.partition.index,
                 message.value.timestamp,
+                decoded_headers,
             ),
         )
     except Exception as err:

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -500,6 +500,9 @@ def process_message(
         start = time.time()
 
         decoded = codec.decode(message.payload.value, validate=False)
+        decoded_headers = {
+            header[0]: header[1].decode("utf-8") for header in message.payload.headers
+        }
 
         if should_validate:
             with sentry_sdk.push_scope() as scope:


### PR DESCRIPTION
Need a way to be able to pass headers through to `process_message` in https://github.com/getsentry/snuba/blob/master/snuba/consumers/consumer.py#L526-L532 if we want to use https://github.com/getsentry/sentry/pull/47577