### PR TITLE
ref(consumers): add optional headers to KafkaMessageMetadata

### DIFF
--- a/snuba/consumers/types.py
+++ b/snuba/consumers/types.py
@@ -1,8 +1,9 @@
 from datetime import datetime
-from typing import NamedTuple
+from typing import Mapping, NamedTuple, Optional
 
 
 class KafkaMessageMetadata(NamedTuple):
     offset: int
     partition: int
     timestamp: datetime
+    headers: Optional[Mapping[str, str]] = None


### PR DESCRIPTION
So we want to be able to add a new header, `sentry_received_timestamp` in https://github.com/getsentry/sentry/pull/47577. But in order to use this header in the `process_message`, it would first need to be passed through in 
https://github.com/getsentry/snuba/blob/4e7e95dfd12c6c257dd0202f2d8b038beaf01bc7/snuba/consumers/consumer.py#L533-L540

I have https://github.com/getsentry/snuba/pull/4049 open that would basically decode the headers, but I thought I'd split up the change to the metadata incase we want to do this in a different way that maybe is more involved than what I have here. 

Ultimately the `sentry_received_timestamp` needs to be used in order to pass an `origin_timestamp` to the insert batch like the following: https://github.com/getsentry/snuba/blob/8427b03e514e4891cc490d33ee0aa1461abae766/snuba/datasets/processors/metrics_aggregate_processor.py#L102

