### PR TITLE
fix(ci): gocd set permissions for migrate

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -123,6 +123,9 @@ pipelines:
             - migrate:
                   approval:
                       type: manual
+                      allow_only_on_success: true
+                      roles:
+                        - sns
                   fetch_materials: true
                   jobs:
                       migrate:

--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -125,7 +125,7 @@ pipelines:
                       type: manual
                       allow_only_on_success: true
                       roles:
-                        - sns
+                        - role-deploy-snuba-migrations-operator
                   fetch_materials: true
                   jobs:
                       migrate:


### PR DESCRIPTION
This limits access of the migrate GoCD stage to the `role-deploy-snuba-migrations-operator` google group. Right now members of this group include team-sns