### PR TITLE
build(deps): bump sentry-relay from 0.8.19 to 0.8.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ redis==4.3.4
 sentry-arroyo[json]==2.10.1
 sentry-kafka-schemas==0.0.29
 sentry-redis-tools==0.1.3
-sentry-relay==0.8.19
+sentry-relay==0.8.21
 sentry-sdk==1.18.0
 simplejson==3.17.6
 structlog==22.1.0


### PR DESCRIPTION
Bumping the `sentry-relay` version to stay in sync with latest as we released more data categories.