### PR TITLE
ref(admin): notify slack when migrations err

### DIFF
--- a/snuba/admin/audit_log/action.py
+++ b/snuba/admin/audit_log/action.py
@@ -11,6 +11,8 @@ class AuditLogAction(Enum):
     REVERSED_MIGRATION_STARTED = "reversed.migration.started"
     RAN_MIGRATION_COMPLETED = "ran.migration.completed"
     REVERSED_MIGRATION_COMPLETED = "reversed.migration.completed"
+    RAN_MIGRATION_FAILED = "ran.migration.failed"
+    REVERSED_MIGRATION_FAILED = "reversed.migration.failed"
 
 
 RUNTIME_CONFIG_ACTIONS = [
@@ -24,4 +26,6 @@ MIGRATION_ACTIONS = [
     AuditLogAction.REVERSED_MIGRATION_STARTED,
     AuditLogAction.RAN_MIGRATION_COMPLETED,
     AuditLogAction.REVERSED_MIGRATION_COMPLETED,
+    AuditLogAction.RAN_MIGRATION_FAILED,
+    AuditLogAction.REVERSED_MIGRATION_FAILED,
 ]

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -45,13 +45,30 @@ def build_runtime_config_text(data: Any, action: AuditLogAction) -> Optional[str
 
 
 def build_migration_run_text(data: Any, action: AuditLogAction) -> Optional[str]:
-    if action == AuditLogAction.RAN_MIGRATION_COMPLETED:
+    if action in [
+        AuditLogAction.RAN_MIGRATION_COMPLETED,
+        AuditLogAction.RAN_MIGRATION_FAILED,
+    ]:
         action_text = f":athletic_shoe: ran migration `{data['migration']}`"
-    elif action == AuditLogAction.REVERSED_MIGRATION_COMPLETED:
+    elif action in [
+        AuditLogAction.REVERSED_MIGRATION_COMPLETED,
+        AuditLogAction.REVERSED_MIGRATION_FAILED,
+    ]:
         action_text = f":back: reversed migration `{data['migration']}`"
     else:
         return None
-    return f":warning: *Migration:* \n\n{action_text} (force={data['force']}, fake={data['fake']})"
+
+    text = (
+        f"*Migration:* \n\n{action_text} (force={data['force']}, fake={data['fake']})"
+    )
+
+    if action in [
+        AuditLogAction.REVERSED_MIGRATION_FAILED,
+        AuditLogAction.RAN_MIGRATION_FAILED,
+    ]:
+        return f":bangbang: *[FAILED]* :bangbang: {text}"
+
+    return f":warning: {text}"
 
 
 def build_context(


### PR DESCRIPTION
**context**
currently when running/reversing a migration fails, we just don't send a slack notification (we just log it). This changes that behavior by actually sending a notification when something fails. It will look like the following:

<img width="599" alt="Screenshot 2023-04-20 at 2 53 00 PM" src="https://user-images.githubusercontent.com/15368179/233495958-8dff4e91-f490-4e96-85f6-2298d1184dc6.png">
