### PR TITLE
feat(replays): Ingest null title as null

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -85,7 +85,7 @@ class ReplaysProcessor(DatasetMessageProcessor):
 
         # we have to set title to empty string as it is non-nullable,
         # and on clickhouse 20 this throws an error.
-        processed["title"] = tags.transaction or ""
+        processed["title"] = tags.transaction
         processed["tags.key"] = tags.keys
         processed["tags.value"] = tags.values
 

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -220,7 +220,7 @@ class ReplayEvent:
             "device_model": self.device_model,
             "tags.key": ["customtag"],
             "tags.value": ["is_set"],
-            "title": self.title or "",
+            "title": self.title,
             "sdk_name": "sentry.python",
             "sdk_version": "0.9.0",
             "retention_days": 30,

--- a/tests/test_replays_api.py
+++ b/tests/test_replays_api.py
@@ -104,7 +104,7 @@ class TestReplaysApi(BaseApiTest):
 
         assert data["data"] == [
             {
-                "title": "",
+                "title": None,
                 "user": None,
                 "sdk_name": None,
                 "sdk_version": None,


### PR DESCRIPTION
The `title` column was recently made nullable.  We should ingest title as null so we can properly aggregate the non-null transaction names (stored on the title field).