### PR TITLE
feat(rust): add some metrics backends

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -303,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dogstatsd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4609d1443932a4fcee5d2df820ef0597d039fa4154a5c60f798650a5b4f48e14"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,8 +1364,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ctrlc",
+ "dogstatsd",
  "env_logger 0.10.0",
  "glob",
+ "lazy_static",
  "log",
  "pyo3",
  "rust_arroyo",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -27,3 +27,9 @@ glob = "0.3.1"
 pyo3 = { version = "0.18.1", features = ["chrono", "extension-module"] }
 ctrlc = "3.2.5"
 sentry = "0.31.0"
+
+# these are unofficial libs. haven't validated them yet
+dogstatsd = "0.8.0"
+cadence = "0.29.0"
+
+lazy_static = "1.4.0"

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -28,8 +28,7 @@ pyo3 = { version = "0.18.1", features = ["chrono", "extension-module"] }
 ctrlc = "3.2.5"
 sentry = "0.31.0"
 
-# these are unofficial libs. haven't validated them yet
+# unofficial lib. haven't validated it yet
 dogstatsd = "0.8.0"
-cadence = "0.29.0"
 
 lazy_static = "1.4.0"

--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -62,7 +62,7 @@ impl MetricsClientTrait for MetricsClient {
             match result {
                 Ok(_) => {}
                 Err(_err) => {
-                    println!("Failed to send metric {}: {}", key, _err)
+                    println!("Failed to send metric {key}: {_err}")
                 }
             }
         }
@@ -87,7 +87,7 @@ impl MetricsClientTrait for MetricsClient {
             match result {
                 Ok(_) => {}
                 Err(_err) => {
-                    println!("Failed to send metric {}: {}", key, _err)
+                    println!("Failed to send metric {key}: {_err}")
                 }
             }
         }
@@ -112,7 +112,7 @@ impl MetricsClientTrait for MetricsClient {
             match result {
                 Ok(_) => {}
                 Err(_err) => {
-                    println!("Failed to send metric {}: {}", key, _err)
+                    println!("Failed to send metric {key}: {_err}")
                 }
             }
         }
@@ -136,7 +136,7 @@ impl MetricsClient {
         match result {
             Ok(_) => {}
             Err(_err) => {
-                println!("Failed to send metric with tags: {}", _err)
+                println!("Failed to send metric with tags: {_err}")
             }
         }
     }

--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -210,16 +210,11 @@ mod tests {
     fn test_metrics() {
         init("my_host", "0.0.0.0:8125");
 
-        assert!(!METRICS_CLIENT
-            .read()
-            .clone()
-            .unwrap()
-            .should_sample(Some(0.0)),);
         assert!(METRICS_CLIENT
             .read()
             .clone()
-            .unwrap()
-            .should_sample(Some(1.0)),);
+            .is_some()
+        );
 
         increment(
             "a",

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -2,7 +2,7 @@ mod config;
 mod consumer;
 mod strategies;
 mod types;
-mod utils;
+pub mod utils;
 
 use pyo3::prelude::*;
 

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -2,6 +2,7 @@ mod config;
 mod consumer;
 mod strategies;
 mod types;
+mod utils;
 
 use pyo3::prelude::*;
 

--- a/rust_snuba/src/utils/metrics/backends/abstract_backend.rs
+++ b/rust_snuba/src/utils/metrics/backends/abstract_backend.rs
@@ -1,9 +1,6 @@
 use rust_arroyo::utils::metrics::MetricsClientTrait;
 
 pub trait MetricsBackend: MetricsClientTrait {
-    // fn increment(&self, name: &str, value: i64, tags: &[&str]);
-    // fn gauge(&self, name: &str, value: f64, tags: &[&str]);
-    // fn timing(&self, name: &str, value: i64, tags: &[&str]);
     fn events(
         &self,
         title: &str,
@@ -12,6 +9,4 @@ pub trait MetricsBackend: MetricsClientTrait {
         priority: &str,
         tags: &[&str],
     );
-    // fn counter(&self, name: &str, value: f64, tags: &[&str]) -> Result<(), Error>;
-    // fn histogram(&self, name: &str, value: f64, tags: &[&str]) -> Result<(), Error>;
 }

--- a/rust_snuba/src/utils/metrics/backends/abstract_backend.rs
+++ b/rust_snuba/src/utils/metrics/backends/abstract_backend.rs
@@ -1,0 +1,17 @@
+use rust_arroyo::utils::metrics::MetricsClientTrait;
+
+pub trait MetricsBackend: MetricsClientTrait {
+    // fn increment(&self, name: &str, value: i64, tags: &[&str]);
+    // fn gauge(&self, name: &str, value: f64, tags: &[&str]);
+    // fn timing(&self, name: &str, value: i64, tags: &[&str]);
+    fn events(
+        &self,
+        title: &str,
+        text: &str,
+        alert_type: &str,
+        priority: &str,
+        tags: &[&str],
+    );
+    // fn counter(&self, name: &str, value: f64, tags: &[&str]) -> Result<(), Error>;
+    // fn histogram(&self, name: &str, value: f64, tags: &[&str]) -> Result<(), Error>;
+}

--- a/rust_snuba/src/utils/metrics/backends/datadog.rs
+++ b/rust_snuba/src/utils/metrics/backends/datadog.rs
@@ -43,8 +43,12 @@ impl MetricsClientTrait for DatadogMetricsBackend {
         key: &str,
         value: Option<i64>,
         tags: Option<std::collections::HashMap<&str, &str>>,
-        _sample_rate: Option<f64>,
+        sample_rate: Option<f64>,
     ) {
+        if !self.should_sample(sample_rate) {
+            return;
+        }
+
         let tags_str: Vec<String> = tags.unwrap().iter().map(|(k, v)| format!("{k}:{v}")).collect();
 
         match value {
@@ -70,8 +74,11 @@ impl MetricsClientTrait for DatadogMetricsBackend {
         key: &str,
         value: u64,
         tags: Option<std::collections::HashMap<&str, &str>>,
-        _sample_rate: Option<f64>,
+        sample_rate: Option<f64>,
     ) {
+        if !self.should_sample(sample_rate) {
+            return;
+        }
         let tags_str: Vec<String> = tags.unwrap().iter().map(|(k, v)| format!("{k}:{v}")).collect();
         self.client_sd.gauge(key, value.to_string(), tags_str).unwrap();
     }
@@ -81,8 +88,11 @@ impl MetricsClientTrait for DatadogMetricsBackend {
         key: &str,
         value: u64,
         tags: Option<std::collections::HashMap<&str, &str>>,
-        _sample_rate: Option<f64>,
+        sample_rate: Option<f64>,
     ) {
+        if !self.should_sample(sample_rate) {
+            return;
+        }
         let tags_str: Vec<String> = tags.unwrap().iter().map(|(k, v)| format!("{k}:{v}")).collect();
         self.client_sd.timing(key, value.try_into().unwrap(), tags_str).unwrap();
     }

--- a/rust_snuba/src/utils/metrics/backends/datadog.rs
+++ b/rust_snuba/src/utils/metrics/backends/datadog.rs
@@ -53,13 +53,7 @@ impl MetricsClientTrait for DatadogMetricsBackend {
 
         match value {
             Some(v) => {
-                for _ in 0..v.abs() {
-                    if v < 0 {
-                        self.client_sd.decr(key, &tags_str).unwrap();
-                    } else {
-                        self.client_sd.incr(key, &tags_str).unwrap();
-                    }
-                }
+                self.client_sd.count(key, v, &tags_str).unwrap();
             }
             None => {
                 self.client_sd.incr(key, tags_str).unwrap();

--- a/rust_snuba/src/utils/metrics/backends/datadog.rs
+++ b/rust_snuba/src/utils/metrics/backends/datadog.rs
@@ -1,0 +1,96 @@
+// use crate::utils::metrics::backends::MetricsBackend;
+
+use rust_arroyo::utils::metrics::{gauge, increment, init, time, MetricsClientTrait};
+use dogstatsd;
+use cadence::StatsdClient;
+
+use super::abstract_backend::MetricsBackend;
+pub struct DatadogMetricsBackend {
+    client_sd: dogstatsd::Client,
+    host: String,
+    port: u16,
+    tags: Vec<String>,
+}
+
+impl MetricsBackend for DatadogMetricsBackend {
+    fn events(
+        &self,
+        title: &str,
+        text: &str,
+        alert_type: &str,
+        priority: &str,
+        tags: &[&str],
+    ) {
+        // TODO figure out how to send priority and alert_type
+        self.client_sd.event(title, text, tags );
+    }
+}
+
+
+impl DatadogMetricsBackend {
+    pub fn new(host: String, port: u16 , tags:Vec<String>) -> Self {
+
+        let host_port: String = format!("{}:{}", host, port);
+        let built_options = dogstatsd::OptionsBuilder::new()
+            .to_addr(host_port).build();
+
+        let client = dogstatsd::Client::new(dogstatsd::Options::default()).unwrap();
+        DatadogMetricsBackend {
+            client_sd: client,
+            host,
+            port,
+            tags
+        }
+    }
+}
+
+impl MetricsClientTrait for DatadogMetricsBackend {
+    fn counter(
+        &self,
+        key: &str,
+        value: Option<i64>,
+        tags: Option<std::collections::HashMap<&str, &str>>,
+        sample_rate: Option<f64>,
+    ) {
+        let tags_str: Vec<String> = tags.unwrap().iter().map(|(k, v)| format!("{}:{}", k, v)).collect();
+
+        match value {
+            Some(v) => {
+                for i in 0..v.abs() {
+                    if v < 0 {
+                        self.client_sd.decr(key, &tags_str).unwrap();
+                    } else {
+                        self.client_sd.incr(key, &tags_str).unwrap();
+                    }
+                }
+            }
+            None => {
+                self.client_sd.incr(key, tags_str);
+            }
+        }
+
+
+    }
+
+    fn gauge(
+        &self,
+        key: &str,
+        value: u64,
+        tags: Option<std::collections::HashMap<&str, &str>>,
+        sample_rate: Option<f64>,
+    ) {
+        let tags_str: Vec<String> = tags.unwrap().iter().map(|(k, v)| format!("{}:{}", k, v)).collect();
+        self.client_sd.gauge(key, value.to_string(), tags_str).unwrap();
+    }
+
+    fn time(
+        &self,
+        key: &str,
+        value: u64,
+        tags: Option<std::collections::HashMap<&str, &str>>,
+        sample_rate: Option<f64>,
+    ) {
+        let tags_str: Vec<String> = tags.unwrap().iter().map(|(k, v)| format!("{}:{}", k, v)).collect();
+        self.client_sd.timing(key, value.try_into().unwrap(), tags_str);
+    }
+}

--- a/rust_snuba/src/utils/metrics/backends/mod.rs
+++ b/rust_snuba/src/utils/metrics/backends/mod.rs
@@ -1,0 +1,3 @@
+pub mod datadog;
+pub mod abstract_backend;
+pub mod testing;

--- a/rust_snuba/src/utils/metrics/backends/testing.rs
+++ b/rust_snuba/src/utils/metrics/backends/testing.rs
@@ -35,7 +35,11 @@ impl MetricsBackend for TestingMetricsBackend {
 }
 
 impl MetricsClientTrait for TestingMetricsBackend{
-    fn counter(&self, name: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>, _sample_rate: Option<f64>) {
+    fn counter(&self, name: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+        if !self.should_sample(sample_rate) {
+            return;
+        }
+
         let mut tags_vec = Vec::new();
         if let Some(tags) = tags {
             for (k, v) in tags {
@@ -50,7 +54,10 @@ impl MetricsClientTrait for TestingMetricsBackend{
         });
     }
 
-    fn gauge(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, _sample_rate: Option<f64>) {
+    fn gauge(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+        if !self.should_sample(sample_rate) {
+            return;
+        }
         let mut tags_vec = Vec::new();
         if let Some(tags) = tags {
             for (k, v) in tags {
@@ -66,7 +73,11 @@ impl MetricsClientTrait for TestingMetricsBackend{
         });
     }
 
-    fn time(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, _sample_rate: Option<f64>) {
+    fn time(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+        if !self.should_sample(sample_rate) {
+            return;
+        }
+
         let mut tags_vec = Vec::new();
         if let Some(tags) = tags {
             for (k, v) in tags {

--- a/rust_snuba/src/utils/metrics/backends/testing.rs
+++ b/rust_snuba/src/utils/metrics/backends/testing.rs
@@ -1,0 +1,109 @@
+use std::{collections::HashMap, sync::{Arc, Mutex}};
+
+use rust_arroyo::utils::metrics::MetricsClientTrait;
+
+use super::abstract_backend::MetricsBackend;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    // static ref METRICS_CLIENT: RwLock<Option<Arc<dyn MetricsClientTrait>>> = RwLock::new(None);
+    static ref METRICS: Mutex<HashMap<String, Vec<MetricCall>>> = {
+        let mut m = HashMap::new();
+        Mutex::new(m)
+    };
+}
+// static  METRICS: Arc<HashMap<String, Vec<MetricCall>>> = Arc::new(HashMap::new());
+
+
+pub struct MetricCall {
+    value: String,
+    tags: Vec<String>,
+}
+pub struct TestingMetricsBackend {
+}
+
+impl MetricsBackend for TestingMetricsBackend {
+    fn events(
+        &self,
+        title: &str,
+        text: &str,
+        alert_type: &str,
+        priority: &str,
+        tags: &[&str],
+    ) {
+        todo!()
+    }
+}
+
+impl MetricsClientTrait for TestingMetricsBackend{
+    fn counter(&self, name: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+        let mut tags_vec = Vec::new();
+        if let Some(tags) = tags {
+            for (k, v) in tags {
+                tags_vec.push(format!("{}:{}", k, v));
+            }
+        }
+        let mut metrics_map = METRICS.lock().unwrap();
+        let metric = metrics_map.entry(name.to_string()).or_insert(Vec::new());
+        metric.push(MetricCall {
+            value: value.unwrap().to_string(),
+            tags: tags_vec,
+        });
+    }
+
+    fn gauge(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+        let mut tags_vec = Vec::new();
+        if let Some(tags) = tags {
+            for (k, v) in tags {
+                tags_vec.push(format!("{}:{}", k, v));
+            }
+        }
+        let mut metrics_map = METRICS.lock().unwrap();
+        let metric = metrics_map.entry(name.to_string()).or_insert(Vec::new());
+
+        metric.push(MetricCall {
+            value: value.to_string(),
+            tags: tags_vec,
+        });
+    }
+
+    fn time(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+        let mut tags_vec = Vec::new();
+        if let Some(tags) = tags {
+            for (k, v) in tags {
+                tags_vec.push(format!("{}:{}", k, v));
+            }
+        }
+        let mut metrics_map = METRICS.lock().unwrap();
+        let metric = metrics_map.entry(name.to_string()).or_insert(Vec::new());
+
+        metric.push(MetricCall {
+            value: value.to_string(),
+            tags: tags_vec,
+        });
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rust_arroyo::utils::metrics::{configure_metrics, MetricsClientTrait};
+
+
+    #[test]
+    fn test_testing_backend() {
+        let testing_backend = super::TestingMetricsBackend {};
+
+        let mut tags: HashMap<&str, &str> = HashMap::new();
+        tags.insert("tag1", "value1");
+        tags.insert("tag2", "value2");
+
+        testing_backend.counter("test_counter", Some(1), Some(tags.clone()), None);
+        testing_backend.gauge("test_gauge", 1, Some(tags.clone()), None);
+        testing_backend.time("test_time", 1, Some(tags.clone()), None);
+
+        configure_metrics(testing_backend);
+    }
+}

--- a/rust_snuba/src/utils/metrics/backends/testing.rs
+++ b/rust_snuba/src/utils/metrics/backends/testing.rs
@@ -89,7 +89,9 @@ impl MetricsClientTrait for TestingMetricsBackend{
 mod tests {
     use std::collections::HashMap;
 
-    use rust_arroyo::utils::metrics::{configure_metrics, MetricsClientTrait};
+    use rust_arroyo::utils::metrics::{configure_metrics, MetricsClientTrait, self};
+
+    use crate::utils::metrics::backends::testing::METRICS;
 
 
     #[test]
@@ -103,7 +105,13 @@ mod tests {
         testing_backend.counter("test_counter", Some(1), Some(tags.clone()), None);
         testing_backend.gauge("test_gauge", 1, Some(tags.clone()), None);
         testing_backend.time("test_time", 1, Some(tags.clone()), None);
+        assert!(METRICS.lock().unwrap().contains_key("test_counter"));
+        assert!(METRICS.lock().unwrap().contains_key("test_gauge"));
+        assert!(METRICS.lock().unwrap().contains_key("test_time"));
 
+        // check configure_metrics writes to METRICS
         configure_metrics(testing_backend);
+        metrics::time("c", 30, Some(HashMap::from([("tag3", "value3")])), None);
+        assert!(METRICS.lock().unwrap().contains_key("c"));
     }
 }

--- a/rust_snuba/src/utils/metrics/backends/testing.rs
+++ b/rust_snuba/src/utils/metrics/backends/testing.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::{Arc, Mutex}};
+use std::{collections::HashMap, sync::{Mutex}};
 
 use rust_arroyo::utils::metrics::MetricsClientTrait;
 
@@ -6,80 +6,79 @@ use super::abstract_backend::MetricsBackend;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    // static ref METRICS_CLIENT: RwLock<Option<Arc<dyn MetricsClientTrait>>> = RwLock::new(None);
     static ref METRICS: Mutex<HashMap<String, Vec<MetricCall>>> = {
-        let mut m = HashMap::new();
+        let m = HashMap::new();
         Mutex::new(m)
     };
 }
-// static  METRICS: Arc<HashMap<String, Vec<MetricCall>>> = Arc::new(HashMap::new());
 
 
 pub struct MetricCall {
-    value: String,
-    tags: Vec<String>,
+    _value: String,
+    _tags: Vec<String>,
 }
+
 pub struct TestingMetricsBackend {
 }
 
 impl MetricsBackend for TestingMetricsBackend {
     fn events(
         &self,
-        title: &str,
-        text: &str,
-        alert_type: &str,
-        priority: &str,
-        tags: &[&str],
+        _title: &str,
+        _text: &str,
+        _alert_type: &str,
+        _priority: &str,
+        _tags: &[&str],
     ) {
         todo!()
     }
 }
 
 impl MetricsClientTrait for TestingMetricsBackend{
-    fn counter(&self, name: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+    fn counter(&self, name: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>, _sample_rate: Option<f64>) {
         let mut tags_vec = Vec::new();
         if let Some(tags) = tags {
             for (k, v) in tags {
-                tags_vec.push(format!("{}:{}", k, v));
+                tags_vec.push(format!("{k}:{v}"));
             }
         }
         let mut metrics_map = METRICS.lock().unwrap();
         let metric = metrics_map.entry(name.to_string()).or_insert(Vec::new());
         metric.push(MetricCall {
-            value: value.unwrap().to_string(),
-            tags: tags_vec,
+            _value: value.unwrap().to_string(),
+            _tags: tags_vec,
         });
     }
 
-    fn gauge(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+    fn gauge(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, _sample_rate: Option<f64>) {
         let mut tags_vec = Vec::new();
         if let Some(tags) = tags {
             for (k, v) in tags {
-                tags_vec.push(format!("{}:{}", k, v));
+                tags_vec.push(format!("{k}:{v}"));
             }
         }
         let mut metrics_map = METRICS.lock().unwrap();
         let metric = metrics_map.entry(name.to_string()).or_insert(Vec::new());
 
         metric.push(MetricCall {
-            value: value.to_string(),
-            tags: tags_vec,
+            _value: value.to_string(),
+            _tags: tags_vec,
         });
     }
 
-    fn time(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
+    fn time(&self, name: &str, value: u64, tags: Option<HashMap<&str, &str>>, _sample_rate: Option<f64>) {
         let mut tags_vec = Vec::new();
         if let Some(tags) = tags {
             for (k, v) in tags {
-                tags_vec.push(format!("{}:{}", k, v));
+                tags_vec.push(format!("{k}:{v}"));
             }
         }
         let mut metrics_map = METRICS.lock().unwrap();
         let metric = metrics_map.entry(name.to_string()).or_insert(Vec::new());
 
         metric.push(MetricCall {
-            value: value.to_string(),
-            tags: tags_vec,
+            _value: value.to_string(),
+            _tags: tags_vec,
         });
     }
 

--- a/rust_snuba/src/utils/metrics/mod.rs
+++ b/rust_snuba/src/utils/metrics/mod.rs
@@ -1,3 +1,1 @@
-pub mod metrics;
 pub mod backends;
-pub mod metrics_wrapper;

--- a/rust_snuba/src/utils/metrics/mod.rs
+++ b/rust_snuba/src/utils/metrics/mod.rs
@@ -1,0 +1,3 @@
+pub mod metrics;
+pub mod backends;
+pub mod metrics_wrapper;

--- a/rust_snuba/src/utils/mod.rs
+++ b/rust_snuba/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod metrics;


### PR DESCRIPTION
Switches the metrics client to be a trait and introduces a testing and datadog backend of the metrics client. Datadog is still WIP but this impl uses the dogstatsd library.