### PR TITLE
Adding canary deployments to snuba pipelines

### DIFF
--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -46,9 +46,7 @@ pipelines:
                                     ${GO_REVISION_SNUBA_REPO} \
                                     sentryio \
                                     "us.gcr.io/sentryio/snuba"
-            - deploy:
-                  approval:
-                      type: manual
+            - deploy-canary:
                   fetch_materials: true
                   jobs:
                       create-sentry-release:
@@ -60,6 +58,65 @@ pipelines:
                               - script: |
                                     sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
                                     sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
+                                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary
+                      deploy-canary:
+                          timeout: 1200
+                          elastic_profile_id: snuba
+                          tasks:
+                              - script: |
+                                    /devinfra/scripts/k8s/k8stunnel \
+                                    && /devinfra/scripts/k8s/k8sdeploy.py \
+                                    --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                                    --label-selector="service=snuba,is_canary=true" \
+                                    --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                                    --container-name="api" \
+                                    --container-name="consumer" \
+                                    --container-name="errors-consumer" \
+                                    --container-name="errors-replacer" \
+                                    --container-name="events-subscriptions-executor" \
+                                    --container-name="events-subscriptions-scheduler" \
+                                    --container-name="generic-metrics-counters-consumer" \
+                                    --container-name="generic-metrics-counters-subscriptions-executor" \
+                                    --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                                    --container-name="generic-metrics-distributions-consumer" \
+                                    --container-name="generic-metrics-distributions-subscriptions-executor" \
+                                    --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                                    --container-name="generic-metrics-sets-consumer" \
+                                    --container-name="generic-metrics-sets-subscriptions-executor" \
+                                    --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                                    --container-name="loadbalancer-outcomes-consumer" \
+                                    --container-name="metrics-consumer" \
+                                    --container-name="metrics-counters-subscriptions-scheduler" \
+                                    --container-name="metrics-sets-subscriptions-scheduler" \
+                                    --container-name="metrics-subscriptions-executor" \
+                                    --container-name="outcomes-billing-consumer" \
+                                    --container-name="outcomes-consumer" \
+                                    --container-name="querylog-consumer" \
+                                    --container-name="replacer" \
+                                    --container-name="snuba-admin" \
+                                    --container-name="transactions-consumer-new" \
+                                    --container-name="transactions-subscriptions-executor" \
+                                    --container-name="transactions-subscriptions-scheduler" \
+                                    && /devinfra/scripts/k8s/k8sdeploy.py \
+                                    --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                                    --label-selector="service=snuba,is_canary=true" \
+                                    --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                                    --type="cronjob" \
+                                    --container-name="cleanup" \
+                                    --container-name="optimize"
+                              - script: |
+                                   /devinfra/scripts/canary/canarychecks.py \
+                                     --wait-minutes=5
+            - deploy:
+                  fetch_materials: true
+                  jobs:
+                      create-sentry-release:
+                          environment_variables:
+                              SENTRY_AUTH_TOKEN: "{{SECRET:[devinfra-sentryio][token]}}"
+                          timeout: 300
+                          elastic_profile_id: snuba
+                          tasks:
+                              - script: |
                                     sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
                                     sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
                       deploy:

--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -46,6 +46,9 @@ pipelines:
                                     ${GO_REVISION_SNUBA_REPO} \
                                     sentryio \
                                     "us.gcr.io/sentryio/snuba"
+                              - script: |
+                                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"` && \
+                                    snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
             - deploy-canary:
                   fetch_materials: true
                   jobs:

--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -51,7 +51,7 @@ pipelines:
                               - script: |
                                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"` && \
                                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
-            - deploy:
+            - deploy-canary:
                   fetch_materials: true
                   jobs:
                       create-sentry-release:
@@ -65,6 +65,74 @@ pipelines:
                               - script: |
                                     sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
                                     sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
+                                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary
+                      deploy-canary:
+                          timeout: 1200
+                          elastic_profile_id: snuba
+                          tasks:
+                              - script: |
+                                    /devinfra/scripts/k8s/k8stunnel \
+                                    && /devinfra/scripts/k8s/k8sdeploy.py \
+                                    --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                                    --label-selector="service=snuba,is_canary=true" \
+                                    --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                                    --container-name="api" \
+                                    --container-name="consumer" \
+                                    --container-name="errors-consumer" \
+                                    --container-name="errors-replacer" \
+                                    --container-name="events-subscriptions-executor" \
+                                    --container-name="events-subscriptions-scheduler" \
+                                    --container-name="generic-metrics-counters-consumer" \
+                                    --container-name="generic-metrics-counters-subscriptions-executor" \
+                                    --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                                    --container-name="generic-metrics-distributions-consumer" \
+                                    --container-name="generic-metrics-distributions-subscriptions-executor" \
+                                    --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                                    --container-name="generic-metrics-sets-consumer" \
+                                    --container-name="generic-metrics-sets-subscriptions-executor" \
+                                    --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                                    --container-name="loadbalancer-outcomes-consumer" \
+                                    --container-name="loadtest-errors-consumer" \
+                                    --container-name="loadtest-loadbalancer-outcomes-consumer" \
+                                    --container-name="loadtest-outcomes-consumer" \
+                                    --container-name="loadtest-transactions-consumer" \
+                                    --container-name="metrics-consumer" \
+                                    --container-name="metrics-counters-subscriptions-scheduler" \
+                                    --container-name="metrics-sets-subscriptions-scheduler" \
+                                    --container-name="metrics-subscriptions-executor" \
+                                    --container-name="outcomes-billing-consumer" \
+                                    --container-name="outcomes-consumer" \
+                                    --container-name="profiles-consumer" \
+                                    --container-name="profiling-functions-consumer" \
+                                    --container-name="querylog-consumer" \
+                                    --container-name="replacer" \
+                                    --container-name="replays-consumer" \
+                                    --container-name="search-issues-consumer" \
+                                    --container-name="snuba-admin" \
+                                    --container-name="transactions-consumer-new" \
+                                    --container-name="transactions-subscriptions-executor" \
+                                    --container-name="transactions-subscriptions-scheduler" \
+                                    && /devinfra/scripts/k8s/k8sdeploy.py \
+                                    --label-selector="service=snuba,is_canary=true" \
+                                    --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                                    --type="cronjob" \
+                                    --container-name="cleanup" \
+                                    --container-name="optimize"
+                              - script: |
+                                   /devinfra/scripts/canary/canarychecks.py \
+                                     --wait-minutes=5
+            - deploy:
+                  fetch_materials: true
+                  jobs:
+                      create-sentry-release:
+                          environment_variables:
+                              SENTRY_ORG: sentry
+                              SENTRY_PROJECT: snuba
+                              SENTRY_AUTH_TOKEN: "{{SECRET:[devinfra-sentryio][token]}}"
+                          timeout: 300
+                          elastic_profile_id: snuba
+                          tasks:
+                              - script: |
                                     sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
                                     sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
                       deploy:


### PR DESCRIPTION
With this change, the snuba pipeline will perform the following steps:

1. Deploy new changes to the canary replica
1. Wait for 5 minutes (determined by the canarychecks script flag)
	- NOTE: This delay is intended to give the deployer a chance to check for any early signs of issues and our hope is to add some automated checks to this script in the future (i.e. if any alerts trigger for the canary instances, mark the deploy as a failure)
1. Deploy new changes to all replicas (i.e. canary and primary replicas a.k.a all of prod).

For the snuba stable pipeline is changed to follow the same behavior as above with it's smaller set of container names.