### PR TITLE
(chore) Bump self-hosted-e2e-action pin to limit docker image poll to 10 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
       - name: Checkout Snuba
         uses: actions/checkout@v3
       - name: Run Sentry self-hosted e2e CI
-        uses: getsentry/action-self-hosted-e2e-tests@77805295ebff8a603def5970e18743ded72cb304
+        uses: getsentry/action-self-hosted-e2e-tests@f45ef07793b2cc805a9a9401819f486da449a90a
         with:
           project_name: snuba
           docker_repo: getsentry/snuba


### PR DESCRIPTION
Picks this change up: https://github.com/getsentry/action-self-hosted-e2e-tests/pull/11