### PR TITLE
feat(DRS): Fail queries when storage is unavailable due to readiness state

### DIFF
--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -77,8 +77,8 @@ def __build_readable_storage_kwargs(config: dict[str, Any]) -> dict[str, Any]:
     return {
         STORAGE_KEY: register_storage_key(config[STORAGE]["key"]),
         "storage_set_key": StorageSetKey(config[STORAGE][SET_KEY]),
-        READINESS_STATE: ReadinessState(config[READINESS_STATE]),
         SCHEMA: __build_storage_schema(config),
+        READINESS_STATE: ReadinessState(config[READINESS_STATE]),
         QUERY_PROCESSORS: get_query_processors(
             config[QUERY_PROCESSORS] if QUERY_PROCESSORS in config else []
         ),

--- a/snuba/datasets/entities/storage_selectors/__init__.py
+++ b/snuba/datasets/entities/storage_selectors/__init__.py
@@ -1,6 +1,6 @@
 import os
 from abc import ABC, abstractmethod
-from typing import List, Type, cast
+from typing import Sequence, Type, cast
 
 from snuba.datasets.storage import EntityStorageConnection
 from snuba.query.logical import Query
@@ -27,7 +27,7 @@ class QueryStorageSelector(ABC, metaclass=RegisteredClass):
         self,
         query: Query,
         query_settings: QuerySettings,
-        storage_connections: List[EntityStorageConnection],
+        storage_connections: Sequence[EntityStorageConnection],
     ) -> EntityStorageConnection:
         raise NotImplementedError
 

--- a/snuba/datasets/entities/storage_selectors/errors.py
+++ b/snuba/datasets/entities/storage_selectors/errors.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 
 from snuba import state
 from snuba.datasets.entities.storage_selectors import QueryStorageSelector
@@ -18,7 +18,7 @@ class ErrorsQueryStorageSelector(QueryStorageSelector):
         self,
         query: Query,
         query_settings: QuerySettings,
-        storage_connections: List[EntityStorageConnection],
+        storage_connections: Sequence[EntityStorageConnection],
     ) -> EntityStorageConnection:
         use_readonly_storage = (
             state.get_config("enable_events_readonly_table", False)

--- a/snuba/datasets/entities/storage_selectors/selector.py
+++ b/snuba/datasets/entities/storage_selectors/selector.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Sequence
 
 from snuba.datasets.entities.storage_selectors import QueryStorageSelector
 from snuba.datasets.storage import EntityStorageConnection, ReadableTableStorage
@@ -22,7 +22,7 @@ class DefaultQueryStorageSelector(QueryStorageSelector):
         self,
         query: Query,
         query_settings: QuerySettings,
-        storage_connections: List[EntityStorageConnection],
+        storage_connections: Sequence[EntityStorageConnection],
     ) -> EntityStorageConnection:
         assert len(storage_connections) == 1
         return storage_connections[0]
@@ -40,7 +40,7 @@ class SimpleQueryStorageSelector(QueryStorageSelector):
         self,
         query: Query,
         query_settings: QuerySettings,
-        storage_connections: List[EntityStorageConnection],
+        storage_connections: Sequence[EntityStorageConnection],
     ) -> EntityStorageConnection:
         for storage_connection in storage_connections:
             assert isinstance(storage_connection.storage, ReadableTableStorage)

--- a/snuba/datasets/entities/storage_selectors/sessions.py
+++ b/snuba/datasets/entities/storage_selectors/sessions.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import List
+from typing import Sequence
 
 from snuba import environment
 from snuba.clickhouse.query_dsl.accessors import get_time_range
@@ -25,7 +25,7 @@ class SessionsQueryStorageSelector(QueryStorageSelector):
         self,
         query: Query,
         query_settings: QuerySettings,
-        storage_connections: List[EntityStorageConnection],
+        storage_connections: Sequence[EntityStorageConnection],
     ) -> EntityStorageConnection:
         # If the passed in `query_settings` arg is an instance of `SubscriptionQuerySettings`,
         # then it is a crash rate alert subscription, and hence we decide on whether to use the

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -28,7 +28,6 @@ from snuba.datasets.storage import (
 )
 from snuba.query.allocation_policies import AllocationPolicy
 from snuba.query.data_source.simple import Table
-from snuba.query.exceptions import QueryPlanException
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.processors.physical.conditions_enforcer import (
@@ -184,13 +183,10 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
             assert isinstance(storage, ReadableTableStorage)
             readiness_state = storage.get_readiness_state()
             if readiness_state.value not in snuba_settings.SUPPORTED_STATES:
-                cause = StorageNotAvailable(
-                    f"The selected storage={storage.get_storage_key().value} is not available in this environment yet. To enable it, consider bumping the storage's readiness_state."
+                raise StorageNotAvailable(
+                    StorageNotAvailable.__name__,
+                    f"The selected storage={storage.get_storage_key().value} is not available in this environment yet. To enable it, consider bumping the storage's readiness_state.",
                 )
-                raise QueryPlanException.from_args(
-                    exception_type=StorageNotAvailable.__name__,
-                    message=str(cause),
-                ) from cause
 
         with sentry_sdk.start_span(
             op="build_plan.storage_query_plan_builder", description="translate"

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -181,7 +181,6 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
 
         # Return failure if storage readiness state is not supported in current environment
         if snuba_settings.READINESS_STATE_FAIL_QUERIES:
-            assert isinstance(storage, ReadableTableStorage)
             readiness_state = storage.get_readiness_state()
             if readiness_state.value not in snuba_settings.SUPPORTED_STATES:
                 cause = StorageNotAvailable(

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -28,6 +28,7 @@ from snuba.datasets.storage import (
 )
 from snuba.query.allocation_policies import AllocationPolicy
 from snuba.query.data_source.simple import Table
+from snuba.query.exceptions import QueryPlanException
 from snuba.query.logical import Query as LogicalQuery
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.query.processors.physical.conditions_enforcer import (
@@ -43,7 +44,7 @@ from snuba.utils.metrics.util import with_span
 # dependency is a refactoring of the methods that return RawQueryResult to make them
 # depend on Result + some debug data structure instead. Also It requires removing
 # extra data from the result of the query.
-from snuba.web import QueryException, QueryResult
+from snuba.web import QueryResult
 
 
 class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy[Query]):
@@ -186,14 +187,9 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
                 cause = StorageNotAvailable(
                     f"The selected storage={storage.get_storage_key().value} is not available in this environment yet. To enable it, consider bumping the storage's readiness_state."
                 )
-                raise QueryException.from_args(
+                raise QueryPlanException.from_args(
                     exception_type=StorageNotAvailable.__name__,
                     message=str(cause),
-                    extra={
-                        "stats": {},
-                        "sql": "",
-                        "experiments": {},
-                    },
                 ) from cause
 
         with sentry_sdk.start_span(

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -181,6 +181,7 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
 
         # Return failure if storage readiness state is not supported in current environment
         if snuba_settings.READINESS_STATE_FAIL_QUERIES:
+            assert isinstance(storage, ReadableTableStorage)
             readiness_state = storage.get_readiness_state()
             if readiness_state.value not in snuba_settings.SUPPORTED_STATES:
                 cause = StorageNotAvailable(

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -191,6 +191,7 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
                     "stats": {},
                     "sql": "",
                     "experiments": {},
+                    "exception_type": StorageNotAvailable.__name__,
                 },
             ) from cause
 

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 import sentry_sdk
 
@@ -118,7 +118,7 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
 
     def __init__(
         self,
-        storages: List[EntityStorageConnection],
+        storages: Sequence[EntityStorageConnection],
         selector: QueryStorageSelector,
         post_processors: Optional[Sequence[ClickhouseQueryProcessor]] = None,
         partition_key_column_name: Optional[str] = None,

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -186,12 +186,12 @@ class StorageQueryPlanBuilder(ClickhouseQueryPlanBuilder):
                 f"The selected storage={storage.get_storage_key().value} is not available in this environment yet. To enable it, consider bumping the storage's readiness_state."
             )
             raise QueryException.from_args(
-                str(cause),
+                exception_type=StorageNotAvailable.__name__,
+                message=str(cause),
                 extra={
                     "stats": {},
                     "sql": "",
                     "experiments": {},
-                    "exception_type": StorageNotAvailable.__name__,
                 },
             ) from cause
 

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -16,10 +16,10 @@ from snuba.datasets.schemas.tables import WritableTableSchema, WriteFormat
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.datasets.table_storage import KafkaStreamLoader, TableWriter
 from snuba.query.allocation_policies import AllocationPolicy, PassthroughPolicy
+from snuba.query.exceptions import QueryPlanException
 from snuba.query.processors.condition_checkers import ConditionChecker
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.replacers.replacer_processor import ReplacerProcessor
-from snuba.utils.serializable_exception import SerializableException
 
 
 class Storage(ABC):
@@ -211,5 +211,5 @@ class EntityStorageConnectionNotFound(Exception):
     pass
 
 
-class StorageNotAvailable(SerializableException):
+class StorageNotAvailable(QueryPlanException):
     pass

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -34,9 +34,15 @@ class Storage(ABC):
     for more useful abstractions.
     """
 
-    def __init__(self, storage_set_key: StorageSetKey, schema: Schema):
+    def __init__(
+        self,
+        storage_set_key: StorageSetKey,
+        schema: Schema,
+        readiness_state: ReadinessState,
+    ):
         self.__storage_set_key = storage_set_key
         self.__schema = schema
+        self.__readiness_state = readiness_state
 
     def get_storage_set_key(self) -> StorageSetKey:
         return self.__storage_set_key
@@ -46,6 +52,9 @@ class Storage(ABC):
 
     def get_schema(self) -> Schema:
         return self.__schema
+
+    def get_readiness_state(self) -> ReadinessState:
+        return self.__readiness_state
 
 
 class ReadableStorage(Storage):
@@ -116,26 +125,22 @@ class ReadableTableStorage(ReadableStorage):
         self,
         storage_key: StorageKey,
         storage_set_key: StorageSetKey,
-        readiness_state: ReadinessState,
         schema: Schema,
+        readiness_state: ReadinessState,
         query_processors: Optional[Sequence[ClickhouseQueryProcessor]] = None,
         query_splitters: Optional[Sequence[QuerySplitStrategy]] = None,
         mandatory_condition_checkers: Optional[Sequence[ConditionChecker]] = None,
         allocation_policy: Optional[AllocationPolicy] = None,
     ) -> None:
         self.__storage_key = storage_key
-        self.__readiness_state = readiness_state
         self.__query_processors = query_processors or []
         self.__query_splitters = query_splitters or []
         self.__mandatory_condition_checkers = mandatory_condition_checkers or []
         self.__allocation_policy = allocation_policy
-        super().__init__(storage_set_key, schema)
+        super().__init__(storage_set_key, schema, readiness_state)
 
     def get_storage_key(self) -> StorageKey:
         return self.__storage_key
-
-    def get_readiness_state(self) -> ReadinessState:
-        return self.__readiness_state
 
     def get_query_processors(self) -> Sequence[ClickhouseQueryProcessor]:
         return self.__query_processors
@@ -170,8 +175,8 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         super().__init__(
             storage_key,
             storage_set_key,
-            readiness_state,
             schema,
+            readiness_state,
             query_processors,
             query_splitters,
             mandatory_condition_checkers,

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -205,5 +205,5 @@ class EntityStorageConnectionNotFound(Exception):
     pass
 
 
-class StorageNotFound(Exception):
+class StorageNotAvailable(Exception):
     pass

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -19,6 +19,7 @@ from snuba.query.allocation_policies import AllocationPolicy, PassthroughPolicy
 from snuba.query.processors.condition_checkers import ConditionChecker
 from snuba.query.processors.physical import ClickhouseQueryProcessor
 from snuba.replacers.replacer_processor import ReplacerProcessor
+from snuba.utils.serializable_exception import SerializableException
 
 
 class Storage(ABC):
@@ -205,5 +206,5 @@ class EntityStorageConnectionNotFound(Exception):
     pass
 
 
-class StorageNotAvailable(Exception):
+class StorageNotAvailable(SerializableException):
     pass

--- a/snuba/query/exceptions.py
+++ b/snuba/query/exceptions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from snuba.query.expressions import Expression
 from snuba.utils.serializable_exception import SerializableException
 
@@ -28,3 +30,23 @@ class InvalidExpressionException(ValidationException):
 
 class InvalidGranularityException(InvalidQueryException):
     pass
+
+
+class QueryPlanException(SerializableException):
+    """
+    Common parent class used for exceptions outside the query flow.
+    This includes exceptions from query plan builder.
+    """
+
+    def __init__(
+        self,
+        exception_type: Optional[str] = None,
+        message: Optional[str] = None,
+        should_report: bool = True,
+    ) -> None:
+        self.exception_type = exception_type
+        super().__init__(message, should_report)
+
+    @classmethod
+    def from_args(cls, exception_type: str, message: str) -> "QueryPlanException":
+        return cls(exception_type=exception_type, message=message)

--- a/snuba/querylog/__init__.py
+++ b/snuba/querylog/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Union
 
 import sentry_sdk
 from sentry_sdk import Hub
@@ -9,10 +9,19 @@ from snuba.attribution.log import (
     QueryAttributionData,
     record_attribution,
 )
-from snuba.querylog.query_metadata import QueryStatus, SnubaQueryMetadata, Status
+from snuba.datasets.storage import StorageNotAvailable
+from snuba.query.exceptions import QueryPlanException
+from snuba.querylog.query_metadata import (
+    SLO,
+    QueryStatus,
+    RequestStatus,
+    SnubaQueryMetadata,
+    Status,
+)
 from snuba.request import Request
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.wrapper import MetricsWrapper
+from snuba.web import QueryException, QueryResult
 
 metrics = MetricsWrapper(environment.metrics, "api")
 
@@ -21,29 +30,47 @@ def _record_timer_metrics(
     request: Request,
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
+    result: Union[QueryResult, QueryException, QueryPlanException],
 ) -> None:
     final = str(request.query.get_final())
     referrer = request.referrer or "none"
     app_id = request.attribution_info.app_id.key or "none"
     parent_api = request.attribution_info.parent_api or "none"
+    tags = {
+        "status": query_metadata.status.value,
+        "request_status": query_metadata.request_status.value,
+        "slo": query_metadata.slo.value,
+        "referrer": referrer,
+        "parent_api": parent_api,
+        "final": final,
+        "dataset": query_metadata.dataset,
+        "app_id": app_id,
+    }
+    mark_tags = {
+        "final": final,
+        "referrer": referrer,
+        "parent_api": parent_api,
+        "dataset": query_metadata.dataset,
+    }
+    if isinstance(result, QueryPlanException):
+        # The QueryPlanException is raised outside the query execution flow.
+        # As a result, its status and SLO values are not based on its query_list
+        if result.exception_type == StorageNotAvailable.__name__:
+            tags = {
+                "status": QueryStatus.ERROR.value,
+                "request_status": RequestStatus.INVALID_REQUEST.value,
+                "slo": SLO.FOR.value,
+                "referrer": referrer,
+                "parent_api": parent_api,
+                "final": final,
+                "dataset": query_metadata.dataset,
+                "app_id": app_id,
+            }
+
     timer.send_metrics_to(
         metrics,
-        tags={
-            "status": query_metadata.status.value,
-            "request_status": query_metadata.request_status.value,
-            "slo": query_metadata.slo.value,
-            "referrer": referrer,
-            "parent_api": parent_api,
-            "final": final,
-            "dataset": query_metadata.dataset,
-            "app_id": app_id,
-        },
-        mark_tags={
-            "final": final,
-            "referrer": referrer,
-            "parent_api": parent_api,
-            "dataset": query_metadata.dataset,
-        },
+        tags=tags,
+        mark_tags=mark_tags,
     )
 
 
@@ -62,12 +89,16 @@ def _record_attribution_metrics(
         duration_ms=timing_data["duration_ms"],
         queries=[],
     )
+    query_id = ""
+    if "stats" in extra_data and "query_id" in extra_data["stats"]:
+        query_id = extra_data["stats"]["query_id"]
+
     for q in query_metadata.query_list:
         profile = q.result_profile
         bytes_scanned = profile.get("bytes", 0.0) if profile else 0.0
         attr_query = QueryAttributionData(
             table=q.profile.table,
-            query_id=extra_data["stats"]["query_id"],
+            query_id=query_id,
             bytes_scanned=bytes_scanned,
         )
         attr_data.queries.append(attr_query)
@@ -79,19 +110,23 @@ def record_query(
     request: Request,
     timer: Timer,
     query_metadata: SnubaQueryMetadata,
-    extra_data: Mapping[str, Any],
+    result: Union[QueryResult, QueryException, QueryPlanException],
 ) -> None:
     """
     Records a request after it has been parsed and validated, whether
     we actually ran a query or not.
     """
+
+    extra_data: Mapping[str, Any] = {}
+    if not isinstance(result, QueryPlanException):
+        extra_data = result.extra
     if settings.RECORD_QUERIES:
         # Send to redis
         # We convert this to a dict before passing it to state in order to avoid a
         # circular dependency, where state would depend on the higher level
         # QueryMetadata class
         state.record_query(query_metadata.to_dict())
-        _record_timer_metrics(request, timer, query_metadata)
+        _record_timer_metrics(request, timer, query_metadata, result)
         _record_attribution_metrics(request, query_metadata, extra_data)
         _add_tags(timer, extra_data.get("experiments"), query_metadata)
 

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -279,6 +279,7 @@ class SnubaQueryMetadata:
                     self.top_level_request_status = (
                         query.request_status.status
                     )  # always return the worst case
+                    return self.top_level_request_status
 
             self.top_level_request_status = RequestStatus.SUCCESS
         return self.top_level_request_status

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -207,7 +207,7 @@ class ClickhouseQueryMetadata:
         }
 
 
-@dataclass
+@dataclass(frozen=True)
 class SnubaQueryMetadata:
     """
     Metadata about a Snuba query for recording on the querylog dataset.
@@ -222,9 +222,6 @@ class SnubaQueryMetadata:
     query_list: MutableSequence[ClickhouseQueryMetadata]
     projects: Set[int]
     snql_anonymized: str
-    top_level_status: Optional[QueryStatus] = None
-    top_level_request_status: Optional[RequestStatus] = None
-    top_level_slo: Optional[SLO] = None
 
     def to_dict(self) -> snuba_queries_v1.Querylog:
         start = int(self.start_timestamp.timestamp()) if self.start_timestamp else None
@@ -260,39 +257,28 @@ class SnubaQueryMetadata:
     def status(self) -> QueryStatus:
         # If we do not have any recorded query and we did not specifically log
         # invalid_query, we assume there was an error somewhere.
-        if not self.top_level_status:
-            self.top_level_status = (
-                self.query_list[-1].status if self.query_list else QueryStatus.ERROR
-            )
-        return self.top_level_status
+        return self.query_list[-1].status if self.query_list else QueryStatus.ERROR
 
     @property
     def request_status(self) -> RequestStatus:
         # If we do not have any recorded query and we did not specifically log
         # invalid_query, we assume there was an error somewhere.
-        if not self.top_level_request_status:
-            if not self.query_list:
-                self.top_level_request_status = RequestStatus.ERROR
+        if not self.query_list:
+            return RequestStatus.ERROR
 
-            for query in self.query_list:
-                if query.request_status.status != RequestStatus.SUCCESS:
-                    self.top_level_request_status = (
-                        query.request_status.status
-                    )  # always return the worst case
-                    return self.top_level_request_status
+        for query in self.query_list:
+            if query.request_status.status != RequestStatus.SUCCESS:
+                return query.request_status.status  # always return the worst case
 
-            self.top_level_request_status = RequestStatus.SUCCESS
-        return self.top_level_request_status
+        return RequestStatus.SUCCESS
 
     @property
     def slo(self) -> SLO:
         # If we do not have any recorded query and we did not specifically log
         # invalid_query, we assume there was an error and log it against.
-        if not self.top_level_slo:
-            if not self.query_list:
-                self.top_level_slo = SLO.AGAINST
+        if not self.query_list:
+            return SLO.AGAINST
 
-            # even one error counts the request against
-            failure = any(q.request_status.slo != SLO.FOR for q in self.query_list)
-            self.top_level_slo = SLO.AGAINST if failure else SLO.FOR
-        return self.top_level_slo
+        # even one error counts the request against
+        failure = any(q.request_status.slo != SLO.FOR for q in self.query_list)
+        return SLO.AGAINST if failure else SLO.FOR

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -9,6 +9,7 @@ from clickhouse_driver.errors import ErrorCodes
 from sentry_kafka_schemas.schema_types import snuba_queries_v1
 
 from snuba.clickhouse.errors import ClickhouseError
+from snuba.datasets.storage import StorageNotAvailable
 from snuba.request import Request
 from snuba.state.cache.abstract import ExecutionTimeoutError
 from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitExceeded
@@ -121,6 +122,8 @@ def get_request_status(cause: Exception | None = None) -> Status:
         slo_status = RequestStatus.CACHE_SET_TIMEOUT
     elif isinstance(cause, ExecutionTimeoutError):
         slo_status = RequestStatus.CACHE_WAIT_TIMEOUT
+    elif isinstance(cause, StorageNotAvailable):
+        slo_status = RequestStatus.INVALID_REQUEST
     else:
         slo_status = RequestStatus.ERROR
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -253,7 +253,7 @@ if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
     SKIPPED_MIGRATION_GROUPS.remove("search_issues")
 
 # Dataset readiness states supported in this environment
-SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
+SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial"}
 # [04-18-2023] These two readiness state settings are temporary and used to facilitate the rollout of readiness states.
 # We expect to remove them after all storages and migration groups have been migrated.
 READINESS_STATE_MIGRATION_GROUPS_ENABLED: set[str] = set()

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -258,6 +258,7 @@ SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 # We expect to remove them after all storages and migration groups have been migrated.
 READINESS_STATE_MIGRATION_GROUPS_ENABLED: set[str] = set()
 READINESS_STATE_STORAGES_ENABLED: set[str] = set()
+READINESS_STATE_FAIL_QUERIES: bool = True
 
 MAX_RESOLUTION_FOR_JITTER = 60
 

--- a/snuba/settings/settings_self_hosted.py
+++ b/snuba/settings/settings_self_hosted.py
@@ -19,5 +19,6 @@ DOGSTATSD_PORT = env("DOGSTATSD_PORT")
 
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
+READINESS_STATE_FAIL_QUERIES: bool = False
 
 SENTRY_DSN = env("SENTRY_DSN")

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -10,7 +10,6 @@ class QueryExtraData(TypedDict):
     stats: Mapping[str, Any]
     sql: str
     experiments: Mapping[str, Any]
-    exception_type: str
 
 
 class QueryException(SerializableException):
@@ -22,17 +21,32 @@ class QueryException(SerializableException):
     the cause of the exception.
     """
 
+    def __init__(
+        self,
+        exception_type: str | None = None,
+        message: str | None = None,
+        should_report: bool = True,
+        **extra_data: JsonSerializable,
+    ) -> None:
+        self.exception_type = exception_type
+        super().__init__(message, should_report, **extra_data)
+
     @classmethod
-    def from_args(cls, message: str, extra: QueryExtraData) -> "QueryException":
-        return cls(message=message, extra=cast(JsonSerializable, extra))
+    def from_args(
+        cls, exception_type: str, message: str, extra: QueryExtraData
+    ) -> "QueryException":
+
+        return cls(
+            exception_type=exception_type,
+            message=message,
+            extra=cast(JsonSerializable, extra),
+        )
 
     @property
     def extra(self) -> QueryExtraData:
         extra = self.extra_data.get("extra", None)
         if not extra:
-            return QueryExtraData(
-                stats={}, sql="noquery", experiments={}, exception_type=""
-            )
+            return QueryExtraData(stats={}, sql="noquery", experiments={})
         return cast(QueryExtraData, extra)
 
 

--- a/snuba/web/__init__.py
+++ b/snuba/web/__init__.py
@@ -10,6 +10,7 @@ class QueryExtraData(TypedDict):
     stats: Mapping[str, Any]
     sql: str
     experiments: Mapping[str, Any]
+    exception_type: str
 
 
 class QueryException(SerializableException):
@@ -29,7 +30,9 @@ class QueryException(SerializableException):
     def extra(self) -> QueryExtraData:
         extra = self.extra_data.get("extra", None)
         if not extra:
-            return QueryExtraData(stats={}, sql="noquery", experiments={})
+            return QueryExtraData(
+                stats={}, sql="noquery", experiments={}, exception_type=""
+            )
         return cast(QueryExtraData, extra)
 
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -595,6 +595,7 @@ def _raw_query(
         raise QueryException.from_args(
             # This exception needs to have the message of the cause in it for sentry
             # to pick it up properly
+            cause.__class__.__name__,
             str(cause),
             {
                 "stats": stats,
@@ -710,6 +711,7 @@ def db_query(
     except AllocationPolicyViolation as e:
         stats["quota_allowance"] = e.quota_allowance
         raise QueryException.from_args(
+            AllocationPolicyViolation.__name__,
             "Query cannot be run due to allocation policy",
             extra={"stats": stats, "sql": formatted_query.get_sql(), "experiments": {}},
         ) from e

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -262,7 +262,6 @@ def _dry_run_query_runner(
             "stats": {},
             "sql": formatted_query.get_sql(),
             "experiments": clickhouse_query.get_experiments(),
-            "exception_type": "",
         },
     )
 

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -154,7 +154,7 @@ def update_query_metadata_from_exception(
     exception (due to unsupported readiness_state) is raised very early in the query pipeline and
     does not append to query list. However, it is still counts FOR the SLO.
     """
-    if error.extra.get("exception_type") == StorageNotAvailable.__name__:
+    if error.exception_type == StorageNotAvailable.__name__:
         query_metadata.top_level_status = QueryStatus.ERROR
         query_metadata.top_level_request_status = RequestStatus.INVALID_REQUEST
         query_metadata.top_level_slo = SLO.FOR
@@ -367,12 +367,12 @@ def _format_storage_query_and_run(
         )
 
         raise QueryException.from_args(
+            cause.__class__.__name__,
             str(cause),
             extra=QueryExtraData(
                 stats=stats,
                 sql=formatted_sql,
                 experiments=clickhouse_query.get_experiments(),
-                exception_type=QueryTooLongException.__name__,
             ),
         ) from cause
     with sentry_sdk.start_span(description=formatted_sql, op="db") as span:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -57,7 +57,7 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.datasets.schemas.tables import TableSchema
-from snuba.datasets.storage import ReadableTableStorage, Storage
+from snuba.datasets.storage import ReadableTableStorage, Storage, StorageNotAvailable
 from snuba.query.allocation_policies import AllocationPolicyViolation
 from snuba.query.exceptions import InvalidQueryException
 from snuba.query.query_settings import HTTPQuerySettings
@@ -507,6 +507,12 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
         elif isinstance(cause, Exception):
             details = {
                 "type": "unknown",
+                "message": str(cause),
+            }
+        elif isinstance(cause, StorageNotAvailable):
+            status = 400
+            details = {
+                "type": "storage-not-available",
                 "message": str(cause),
             }
         else:

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -520,12 +520,11 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
             {"Content-Type": "application/json"},
         )
     except QueryPlanException as exception:
-        cause = exception.__cause__
-        if isinstance(cause, StorageNotAvailable):
+        if isinstance(exception, StorageNotAvailable):
             status = 400
             details = {
                 "type": "storage-not-available",
-                "message": str(cause),
+                "message": str(exception.message),
             }
         else:
             raise  # exception should have been chained
@@ -534,7 +533,6 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
             status,
             {"Content-Type": "application/json"},
         )
-
     payload: MutableMapping[str, Any] = {**result.result, "timing": timer.for_json()}
 
     if settings.STATS_IN_RESPONSE or request.query_settings.get_debug():

--- a/tests/datasets/plans/test_storage_plan_builder.py
+++ b/tests/datasets/plans/test_storage_plan_builder.py
@@ -1,4 +1,5 @@
-from typing import List, Optional
+import importlib
+from typing import Any, List, Optional
 
 import pytest
 
@@ -26,6 +27,7 @@ from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query
+from snuba.web import QueryException
 
 errors_translators = TranslationMappers(
     columns=[
@@ -133,3 +135,42 @@ def test_storage_query_plan_builder(
         ):
             correct_policy_assigned = True
     assert correct_policy_assigned
+
+
+@pytest.fixture(scope="function")
+def temp_settings() -> Any:
+    from snuba import settings
+
+    yield settings
+    importlib.reload(settings)
+
+
+def test_storage_unavailable_error_in_plan_builder(temp_settings: Any) -> None:
+    snql_query = """
+        MATCH (events)
+        SELECT col1
+        WHERE tags_key IN tuple('t1', 't2')
+            AND timestamp >= toDateTime('2021-01-01T00:00:00')
+            AND timestamp < toDateTime('2021-01-02T00:00:00')
+            AND project_id = 1
+    """
+    dataset = get_dataset("events")
+    storage_connections = get_entity(EntityKey.EVENTS).get_all_storage_connections()
+    selector = ErrorsQueryStorageSelector()
+    query_plan_builder = StorageQueryPlanBuilder(
+        storages=storage_connections,
+        selector=selector,
+        partition_key_column_name=None,
+    )
+    query, _ = parse_snql_query(str(snql_query), dataset)
+
+    temp_settings.SUPPORTED_STATES = {}  # remove all supported states
+
+    assert isinstance(query, Query)
+    with pytest.raises(
+        QueryException,
+        match="The selected storage=errors is not available in this environment yet. To enable it, consider bumping the storage's readiness_state.",
+    ):
+        query_plan_builder.build_and_rank_plans(
+            query=query, settings=HTTPQuerySettings(referrer="r")
+        )

--- a/tests/datasets/plans/test_storage_plan_builder.py
+++ b/tests/datasets/plans/test_storage_plan_builder.py
@@ -24,10 +24,10 @@ from snuba.datasets.plans.query_plan import ClickhouseQueryPlan
 from snuba.datasets.plans.storage_plan_builder import StorageQueryPlanBuilder
 from snuba.datasets.storage import EntityStorageConnection
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.exceptions import QueryPlanException
 from snuba.query.logical import Query
 from snuba.query.query_settings import HTTPQuerySettings
 from snuba.query.snql.parser import parse_snql_query
-from snuba.web import QueryException
 
 errors_translators = TranslationMappers(
     columns=[
@@ -168,7 +168,7 @@ def test_storage_unavailable_error_in_plan_builder(temp_settings: Any) -> None:
 
     assert isinstance(query, Query)
     with pytest.raises(
-        QueryException,
+        QueryPlanException,
         match="The selected storage=errors is not available in this environment yet. To enable it, consider bumping the storage's readiness_state.",
     ):
         query_plan_builder.build_and_rank_plans(

--- a/tests/web/test_query_exception.py
+++ b/tests/web/test_query_exception.py
@@ -6,6 +6,7 @@ from snuba.web import QueryException
 
 def test_printable() -> None:
     e = QueryException.from_args(
+        "generic exception type",
         "the cause was coming from inside the house!",
         {"stats": {}, "sql": "fdsfsdaf", "experiments": {}},
     )

--- a/tests/web/test_results.py
+++ b/tests/web/test_results.py
@@ -29,7 +29,9 @@ TEST_CASES = [
                     },
                 ],
             ),
-            extra=QueryExtraData(stats={}, sql="...", experiments={}),
+            extra=QueryExtraData(
+                stats={}, sql="...", experiments={}, exception_type=""
+            ),
         ),
         QueryResult(
             result=Result(
@@ -43,7 +45,9 @@ TEST_CASES = [
                     {"event_id": "sdf", "duration": 321, "message": "msg2"},
                 ],
             ),
-            extra=QueryExtraData(stats={}, sql="...", experiments={}),
+            extra=QueryExtraData(
+                stats={}, sql="...", experiments={}, exception_type=""
+            ),
         ),
         {
             "_snuba_event_id": ["event_id"],
@@ -78,7 +82,9 @@ TEST_CASES = [
                     "_snuba_message": "",
                 },
             ),
-            extra=QueryExtraData(stats={}, sql="...", experiments={}),
+            extra=QueryExtraData(
+                stats={}, sql="...", experiments={}, exception_type=""
+            ),
         ),
         QueryResult(
             result=Result(
@@ -93,7 +99,9 @@ TEST_CASES = [
                 ],
                 totals={"event_id": "", "duration": 223, "message": ""},
             ),
-            extra=QueryExtraData(stats={}, sql="...", experiments={}),
+            extra=QueryExtraData(
+                stats={}, sql="...", experiments={}, exception_type=""
+            ),
         ),
         {
             "_snuba_event_id": ["event_id"],
@@ -123,7 +131,9 @@ TEST_CASES = [
                     },
                 ],
             ),
-            extra=QueryExtraData(stats={}, sql="...", experiments={}),
+            extra=QueryExtraData(
+                stats={}, sql="...", experiments={}, exception_type=""
+            ),
         ),
         QueryResult(
             result=Result(
@@ -145,7 +155,9 @@ TEST_CASES = [
                     },
                 ],
             ),
-            extra=QueryExtraData(stats={}, sql="...", experiments={}),
+            extra=QueryExtraData(
+                stats={}, sql="...", experiments={}, exception_type=""
+            ),
         ),
         {"_snuba_event_id": ["event_id"]},
         id="Incomplete mapping",

--- a/tests/web/test_results.py
+++ b/tests/web/test_results.py
@@ -29,9 +29,7 @@ TEST_CASES = [
                     },
                 ],
             ),
-            extra=QueryExtraData(
-                stats={}, sql="...", experiments={}, exception_type=""
-            ),
+            extra=QueryExtraData(stats={}, sql="...", experiments={}),
         ),
         QueryResult(
             result=Result(
@@ -45,9 +43,7 @@ TEST_CASES = [
                     {"event_id": "sdf", "duration": 321, "message": "msg2"},
                 ],
             ),
-            extra=QueryExtraData(
-                stats={}, sql="...", experiments={}, exception_type=""
-            ),
+            extra=QueryExtraData(stats={}, sql="...", experiments={}),
         ),
         {
             "_snuba_event_id": ["event_id"],
@@ -82,9 +78,7 @@ TEST_CASES = [
                     "_snuba_message": "",
                 },
             ),
-            extra=QueryExtraData(
-                stats={}, sql="...", experiments={}, exception_type=""
-            ),
+            extra=QueryExtraData(stats={}, sql="...", experiments={}),
         ),
         QueryResult(
             result=Result(
@@ -99,9 +93,7 @@ TEST_CASES = [
                 ],
                 totals={"event_id": "", "duration": 223, "message": ""},
             ),
-            extra=QueryExtraData(
-                stats={}, sql="...", experiments={}, exception_type=""
-            ),
+            extra=QueryExtraData(stats={}, sql="...", experiments={}),
         ),
         {
             "_snuba_event_id": ["event_id"],
@@ -131,9 +123,7 @@ TEST_CASES = [
                     },
                 ],
             ),
-            extra=QueryExtraData(
-                stats={}, sql="...", experiments={}, exception_type=""
-            ),
+            extra=QueryExtraData(stats={}, sql="...", experiments={}),
         ),
         QueryResult(
             result=Result(
@@ -155,9 +145,7 @@ TEST_CASES = [
                     },
                 ],
             ),
-            extra=QueryExtraData(
-                stats={}, sql="...", experiments={}, exception_type=""
-            ),
+            extra=QueryExtraData(stats={}, sql="...", experiments={}),
         ),
         {"_snuba_event_id": ["event_id"]},
         id="Incomplete mapping",


### PR DESCRIPTION
### Overview
This PR is responsible for failing queries to Snuba storages which are not ready yet. For example, a new experimental storage (`readiness_state=limited`) should not be queryable in Sentry prod environments. This PR adds `StorageNotAvailable` error messaging in the storage plan builder. Additionally, in order for this new error to not count against our SLO, a new error type called `QueryPlanException` was created to capture errors outside the query execution flow. More details on how to review this PR below.

### More Details 
I would recommend reviewing this PR in the following order:
* `snuba/datasets/plans/storage_plan_builder.py`: After the appropriate storage is selected for the incoming query, a readiness_state check was added here and throws an error if it is unavailable.
* `snuba/web/views.py`: The exception is bubble back to the original endpoint and the appropriate status code and tags are added.
* `snuba/query/exceptions.py`: Added new exception `QueryPlanException` to capture exceptions outside of query execution. 
* `snuba/web/query.py`: Catches the new exception type and forwards to querylog appropriately.
* * `snuba/querylog/__init__.py`:  Updated `_record_timer_metrics()` to accommodate for new error type which does not use query_list to determine status and SLO.
* `snuba/web/__init__.py`: Added `exception_type: str` to `QueryException` to track the name of which exception was thrown.

* `snuba/datasets/storage.py`: Move `readiness_state` attribute to base `Storage` class.
* `tests/datasets/plans/test_storage_plan_builder.py`: unit test
* `settings files`: Added `READINESS_STATE_FAIL_QUERIES` to control failing queries in each sentry env.

### Blast Radius
All incoming queries to storages which are not available in a given environment will now fail. However, right now, all sentry environments are currently configured to support all readiness states. Therefore, there should no immediate effect until we begin rollout. The settings variable `READINESS_STATE_FAIL_QUERIES` to control which sentry envs will use this change.