### PR TITLE
fix: Rate-limit the number of invalid message payloads

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -79,6 +79,8 @@ logger = logging.getLogger("snuba.consumer")
 
 commit_codec = CommitCodec()
 
+_LAST_INVALID_MESSAGE: MutableMapping[str, float] = {}
+
 
 class CommitLogConfig(NamedTuple):
     producer: ConfluentProducer
@@ -511,14 +513,14 @@ def process_message(
                 try:
                     codec.validate(decoded)
                 except Exception as err:
-                    config = state.get_config(
-                        f"log_validate_schema_{snuba_logical_topic.name}", 1.0
+                    min_seconds_ago = (
+                        state.get_config("log_validate_schema_every_n_seconds", 1) or 1
                     )
-                    log_validate_sample_rate = float(
-                        config if config is not None else 1.0
-                    )
-                    sentry_sdk.set_tag("invalid_message_schema", "true")
-                    if random.random() < log_validate_sample_rate:
+                    if (
+                        _LAST_INVALID_MESSAGE.get(snuba_logical_topic.name, 0)
+                        < start - min_seconds_ago
+                    ):
+                        _LAST_INVALID_MESSAGE[snuba_logical_topic.name] = start
                         logger.warning(err, exc_info=True)
 
             # TODO: this is not the most efficient place to emit a metric, but

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -521,6 +521,7 @@ def process_message(
                         < start - min_seconds_ago
                     ):
                         _LAST_INVALID_MESSAGE[snuba_logical_topic.name] = start
+                        sentry_sdk.set_tag("invalid_message_schema", "true")
                         logger.warning(err, exc_info=True)
 
             # TODO: this is not the most efficient place to emit a metric, but


### PR DESCRIPTION
Instead of sampling invalid messages, let's throttle them so we don't
miss spurious, small issues, and globally so we don't forget to do it
for a particular dataset.
