### PR TITLE
(feat): Re-enable fossa

### DIFF
--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Enforce License Compliance'
-        uses: getsentry/action-enforce-license-compliance@693b4f5a92ea8629db875f0226b05e8af43c95ae
+        uses: getsentry/action-enforce-license-compliance@26a9658b31b89b999a8c050f17bcae242d90c826
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Enforce License Compliance'
-        uses: getsentry/action-enforce-license-compliance@26a9658b31b89b999a8c050f17bcae242d90c826
+        uses: getsentry/action-enforce-license-compliance@6599a041195852debba3417e069829060d671e76
         with:
           fossa_api_key: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
This PR re-enables FOSSA license compliance scans. The action has been running for a few days now in all repos except getsentry, snuba, and sentry without issues. Changes have been made to the action to make sure it is more resilient to FOSSA errors (outages, network issues)

Here's the relevant PR in the license scan action: https://github.com/getsentry/action-enforce-license-compliance/pull/16