### PR TITLE
feat(metrics): Pass sentry_received_timestamp for e2e latency

### DIFF
--- a/snuba/datasets/processors/generic_metrics_processor.py
+++ b/snuba/datasets/processors/generic_metrics_processor.py
@@ -141,7 +141,9 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
                 GRANULARITY_ONE_DAY,
             ],
         }
-        return InsertBatch([processed], None)
+        return InsertBatch(
+            [processed], datetime.utcfromtimestamp(message["sentry_received_timestamp"])
+        )
 
 
 class GenericSetsMetricsProcessor(GenericMetricsBucketProcessor):

--- a/snuba/datasets/processors/metrics_bucket_processor.py
+++ b/snuba/datasets/processors/metrics_bucket_processor.py
@@ -113,7 +113,9 @@ class MetricsBucketProcessor(DatasetMessageProcessor, ABC):
             "partition": metadata.partition,
             "offset": metadata.offset,
         }
-        return InsertBatch([processed], None)
+        return InsertBatch(
+            [processed], datetime.utcfromtimestamp(message["sentry_received_timestamp"])
+        )
 
 
 class SetsMetricsProcessor(MetricsBucketProcessor):


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/SNS-2173

We would potentially also like to record the latency of just the indexer (i.e. up until the broker timestamp of the message on the snuba topic)