### PR TITLE
feat(geo): make geo.subdivision queryable

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -366,6 +366,14 @@ storages:
             to_nested_col_name: contexts
             to_nested_mapping_key: geo.city
             nullable: true
+        - mapper: ColumnToMapping
+          args:
+            from_table_name: null
+            from_col_name: geo_subdivision
+            to_nested_col_table_name: null
+            to_nested_col_name: contexts
+            to_nested_mapping_key: geo.subdivision
+            nullable: true
         - mapper: ColumnToNullIf
           args:
             from_table_name: null

--- a/snuba/datasets/configuration/discover/entities/discover_events.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_events.yaml
@@ -269,6 +269,14 @@ storages:
             to_nested_col_name: contexts
             to_nested_mapping_key: geo.city
             nullable: true
+        - mapper: ColumnToMapping
+          args:
+            from_table_name: null
+            from_col_name: geo_subdivision
+            to_nested_col_table_name: null
+            to_nested_col_name: contexts
+            to_nested_mapping_key: geo.subdivision
+            nullable: true
         - mapper: DefaultNoneColumnMapper
           args:
             column_names:

--- a/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
@@ -211,6 +211,14 @@ storages:
             to_nested_col_name: contexts
             to_nested_mapping_key: geo.city
             nullable: true
+        - mapper: ColumnToMapping
+          args:
+            from_table_name: null
+            from_col_name: geo_subdivision
+            to_nested_col_table_name: null
+            to_nested_col_name: contexts
+            to_nested_mapping_key: geo.subdivision
+            nullable: true
         - mapper: ColumnToLiteral
           args:
             from_table_name: null

--- a/snuba/datasets/configuration/events/entities/events.yaml
+++ b/snuba/datasets/configuration/events/entities/events.yaml
@@ -269,6 +269,14 @@ storages:
             to_nested_col_name: contexts
             to_nested_mapping_key: geo.city
             nullable: true
+        - mapper: ColumnToMapping
+          args:
+            from_table_name: null
+            from_col_name: geo_subdivision
+            to_nested_col_table_name: null
+            to_nested_col_name: contexts
+            to_nested_mapping_key: geo.subdivision
+            nullable: true
       subscriptables:
         - mapper: SubscriptableMapper
           args:

--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -136,6 +136,14 @@ storages:
             nullable: True
         - mapper: ColumnToMapping
           args:
+            from_table_name:
+            from_col_name: "geo_subdivision"
+            to_nested_col_table_name:
+            to_nested_col_name: "contexts"
+            to_nested_mapping_key: "geo.subdivision"
+            nullable: True
+        - mapper: ColumnToMapping
+          args:
             from_table_name: null
             from_col_name: "transaction"
             to_nested_col_table_name: null

--- a/snuba/datasets/configuration/transactions/entities/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/entities/transactions.yaml
@@ -264,6 +264,18 @@ storages:
                     nullable: True,
                   },
               },
+              {
+                mapper: ColumnToMapping,
+                args:
+                  {
+                    from_table_name,
+                    from_col_name: "geo_subdivision",
+                    to_nested_col_table_name,
+                    to_nested_col_name: "contexts",
+                    to_nested_mapping_key: "geo.subdivision",
+                    nullable: True,
+                  },
+              },
             ],
           subscriptables:
             [


### PR DESCRIPTION
Now that we store`geo.subdivision` https://github.com/getsentry/relay/pull/2058 we need to expose it for querying

Fixes https://github.com/getsentry/getsentry/issues/10313