### PR TITLE
feat: Kafka topic configuration

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -642,7 +642,7 @@ def build_multistorage_batch_writer(
                     replacement_topic_spec.topic,
                     override_params={
                         "partitioner": "consistent",
-                        "message.max.bytes": 50000000,  # 50MB, default is 1MB
+                        "message.max.bytes": 10000000,  # 10MB, default is 1MB
                     },
                 )
             ),

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -124,7 +124,7 @@ class ConsumerBuilder:
                     bootstrap_servers=kafka_params.replacements_bootstrap_servers,
                     override_params={
                         "partitioner": "consistent",
-                        "message.max.bytes": 50000000,  # 50MB, default is 1MB)
+                        "message.max.bytes": 10000000,  # 10MB, default is 1MB)
                     },
                 )
             )

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -64,7 +64,10 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
         Topic.TRANSACTIONS: {"message.timestamp.type": "LogAppendTime"},
         Topic.METRICS: {"message.timestamp.type": "LogAppendTime"},
         Topic.PROFILES: {"message.timestamp.type": "LogAppendTime"},
-        Topic.REPLAYEVENTS: {"message.timestamp.type": "LogAppendTime"},
+        Topic.REPLAYEVENTS: {
+            "message.timestamp.type": "LogAppendTime",
+            "max.message.bytes": "15000000",
+        },
         Topic.GENERIC_METRICS: {"message.timestamp.type": "LogAppendTime"},
         Topic.GENERIC_EVENTS: {"message.timestamp.type": "LogAppendTime"},
     }


### PR DESCRIPTION
We need to start aligning topic configuration and encoding the correct values so that they match in all environments. 50MB is way too large and does not reflect any actual values set in prod. This is problematic because we don't see these issues in dev that actually exist in prod. Reduce the default to 10MB, with the exception of Replays which is 15MB. We should also fix the rest of the topics later.

