### PR TITLE
ref(consumers): record sentry_received_timestamp metrics

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -125,15 +125,14 @@ class LatencyRecorder:
         if self._max is None or latency_seconds > self._max:
             self._max = latency_seconds
 
-    def has_data(self) -> bool:
-        return self._max is not None
-
     @property
     def avg_ms(self) -> float:
         return (self._sum / self._msg_count) * 1000
 
     @property
     def max_ms(self) -> Optional[float]:
+        if not self._max:
+            return None
         return self._max * 1000
 
 
@@ -186,10 +185,10 @@ class InsertBatchWriter:
                 )
                 sentry_received_latency_recorder.record(sentry_received_latency)
 
-        if snuba_latency_recorder.has_data():
+        if snuba_latency_recorder.max_ms:
             self.__metrics.timing("max_latency_ms", snuba_latency_recorder.max_ms)
             self.__metrics.timing("latency_ms", snuba_latency_recorder.avg_ms)
-        if end_to_end_latency_recorder.has_data():
+        if end_to_end_latency_recorder.max_ms:
             self.__metrics.timing(
                 "max_end_to_end_latency_ms", end_to_end_latency_recorder.max_ms
             )
@@ -198,7 +197,7 @@ class InsertBatchWriter:
                 end_to_end_latency_recorder.avg_ms,
             )
 
-        if sentry_received_latency_recorder.has_data():
+        if sentry_received_latency_recorder.max_ms:
             self.__metrics.timing(
                 "max_sentry_received_latency_ms",
                 sentry_received_latency_recorder.max_ms,

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -15,6 +15,7 @@ from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.consumer import (
     BytesInsertBatch,
     InsertBatchWriter,
+    LatencyRecorder,
     MultistorageConsumerProcessingStrategyFactory,
     ProcessedMessageBatchWriter,
     ReplacementBatchWriter,
@@ -273,3 +274,18 @@ def test_metrics_writing_e2e() -> None:
         ):
             strategy.close()
             strategy.join()
+
+
+def test_latency_recorder() -> None:
+    recorder = LatencyRecorder()
+
+    assert recorder.has_data() == False
+
+    recorder.record(1.0)
+    recorder.record(0.5)
+    recorder.record(1.2)
+
+    assert recorder.has_data() == True
+    assert recorder.max_ms == 1200.0
+    # (2.7 / 3) * 1000 == 900
+    assert recorder.avg_ms == 900.0

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -279,13 +279,12 @@ def test_metrics_writing_e2e() -> None:
 def test_latency_recorder() -> None:
     recorder = LatencyRecorder()
 
-    assert recorder.has_data() == False
+    assert recorder.max_ms is None
 
     recorder.record(1.0)
     recorder.record(0.5)
     recorder.record(1.2)
 
-    assert recorder.has_data() == True
     assert recorder.max_ms == 1200.0
     # (2.7 / 3) * 1000 == 900
     assert recorder.avg_ms == 900.0


### PR DESCRIPTION
**context**
We want to be able to include the latency from sentry indexer for metrics and generic metrics SLOs. We needed to add the `sentry_received_timestamp` in order to do so since the other timestamps we had were either the broker timestamp (so latency of the snuba consumer itself) or the relay timestamp (which we didn't want to include as part of SNS SLOs)

**pre reqs**
- [x] `sentry_received_timestamp` must be added to the payload in the indexer https://github.com/getsentry/sentry/pull/47577
- [x] `sentry_recieved_timestamp` must be passed through the processor in snuba ~https://github.com/getsentry/snuba/pull/4052~  **edit** this pr had to be re-done so we need https://github.com/getsentry/snuba/pull/4198
