### PR TITLE
fix(observability): Not all ClickHouse Errors need to be surfaced to Sentry

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -44,9 +44,9 @@ from snuba.query.data_source.join import JoinClause
 from snuba.query.data_source.simple import Table
 from snuba.query.query_settings import QuerySettings
 from snuba.querylog.query_metadata import (
+    SLO,
     ClickhouseQueryMetadata,
     QueryStatus,
-    RequestStatus,
     Status,
     get_query_status_from_error_codes,
     get_request_status,
@@ -598,7 +598,7 @@ def _raw_query(
         elif isinstance(cause, ExecutionTimeoutError):
             status = QueryStatus.TIMEOUT
 
-        if request_status.status == RequestStatus.ERROR:
+        if request_status.slo == SLO.AGAINST:
             logger.exception("Error running query: %s\n%s", sql, cause)
 
         with configure_scope() as scope:

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -598,12 +598,7 @@ def _raw_query(
         elif isinstance(cause, ExecutionTimeoutError):
             status = QueryStatus.TIMEOUT
 
-        status = status or QueryStatus.ERROR
-        if request_status.status not in (
-            RequestStatus.TABLE_RATE_LIMITED,
-            RequestStatus.RATE_LIMITED,
-        ):
-            # Don't log rate limiting errors to avoid clutter
+        if request_status.status == RequestStatus.ERROR:
             logger.exception("Error running query: %s\n%s", sql, cause)
 
         with configure_scope() as scope:
@@ -611,7 +606,7 @@ def _raw_query(
                 sentry_sdk.set_tag("slo_status", request_status.status.value)
 
         stats = update_with_status(
-            status=status,
+            status=status or QueryStatus.ERROR,
             request_status=request_status,
             error_code=error_code,
             triggered_rate_limiter=str(trigger_rate_limiter),


### PR DESCRIPTION
### Overview
- We're seeing a lot of redundant ClickHouse errors in Sentry
- The only ones we really want to see are internal errors - not rate limits or other user errors