### PR TITLE
fix(migrations): Allow setting file changes to happen in migrations

### DIFF
--- a/scripts/check-migrations.py
+++ b/scripts/check-migrations.py
@@ -13,6 +13,7 @@ not coupled with other changes.
 ALLOWED_MIGRATIONS_GLOBS = [
     "snuba/migrations/groups.py",
     "snuba/migrations/group_loader.py",
+    "snuba/settings/*",
     "tests",
     "test_distributed_migrations",
     "test_initialization",


### PR DESCRIPTION
When a new migration group is added, a key element is registering the storage set key. Storage set keys can be hardcoded or be dynamically configured using the settings file. In order to use the dynamically configured settings file, we should allow modifications to settings file to happen in the same PR as migrations.