### PR TITLE
fix(CI): add partial states to gocd pipeline

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -13,7 +13,6 @@ pipelines:
             # Required for checkruns.
             GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
             GOCD_ACCESS_TOKEN: "{{SECRET:[devinfra][gocd_access_token]}}"
-            MIGRATIONS_READINESS: -r complete -r partial
         group: snuba
         lock_behavior: unlockWhenFinished
         materials:
@@ -205,7 +204,7 @@ pipelines:
                                     --label-selector="service=snuba-admin" \
                                     --container-name="snuba-admin" \
                                     "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                                    -- snuba migrations migrate ${MIGRATIONS_READINESS}
+                                    -- snuba migrations migrate -r complete -r partial
                               - plugin:
                                     options:
                                         script: |

--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -13,7 +13,7 @@ pipelines:
             # Required for checkruns.
             GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
             GOCD_ACCESS_TOKEN: "{{SECRET:[devinfra][gocd_access_token]}}"
-            MIGRATIONS_READINESS: complete
+            MIGRATIONS_READINESS: -r complete -r partial
         group: snuba
         lock_behavior: unlockWhenFinished
         materials:
@@ -205,7 +205,7 @@ pipelines:
                                     --label-selector="service=snuba-admin" \
                                     --container-name="snuba-admin" \
                                     "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                                    -- snuba migrations migrate -r ${MIGRATIONS_READINESS}
+                                    -- snuba migrations migrate ${MIGRATIONS_READINESS}
                               - plugin:
                                     options:
                                         script: |

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -32,7 +32,6 @@ def list() -> None:
     check_clickhouse_connections()
     runner = Runner()
     for group, group_migrations in runner.show_all():
-
         readiness_state = get_group_readiness_state(group)
         click.echo(f"{group.value} (readiness_state: {readiness_state.value})")
         for migration_id, status, blocking in group_migrations:
@@ -100,7 +99,7 @@ def migrate(
             fake=fake,
             group=migration_group,
             readiness_states=(
-                (ReadinessState(state) for state in readiness_state)
+                [ReadinessState(state) for state in readiness_state]
                 if readiness_state
                 else None
             ),

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -58,6 +58,7 @@ def list() -> None:
 @click.option(
     "-r",
     "--readiness-state",
+    multiple=True,
     type=click.Choice([r.value for r in ReadinessState], case_sensitive=False),
     default=None,
 )
@@ -69,7 +70,7 @@ def list() -> None:
 )
 def migrate(
     group: Optional[str],
-    readiness_state: Optional[str],
+    readiness_state: Optional[Sequence[str]],
     through: str,
     force: bool,
     fake: bool,
@@ -98,8 +99,10 @@ def migrate(
             force=force,
             fake=fake,
             group=migration_group,
-            readiness_state=(
-                ReadinessState(readiness_state) if readiness_state else None
+            readiness_states=(
+                (ReadinessState(state) for state in readiness_state)
+                if readiness_state
+                else None
             ),
         )
     except MigrationError as e:

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -161,7 +161,7 @@ class Runner:
         fake: bool = False,
         force: bool = False,
         group: Optional[MigrationGroup] = None,
-        readiness_state: Optional[ReadinessState] = None,
+        readiness_states: Optional[Sequence[ReadinessState]] = None,
     ) -> None:
         """
         If group is specified, runs all pending migrations for that specific group. Makes
@@ -182,11 +182,11 @@ class Runner:
                 MigrationGroup.SYSTEM
             ) + self._get_pending_migrations_for_group(group)
 
-        if readiness_state:
+        if readiness_states:
             pending_migrations = [
                 m
                 for m in pending_migrations
-                if get_group_readiness_state(m.group) == readiness_state
+                if get_group_readiness_state(m.group) in readiness_states
             ]
 
         use_through = False if through == "all" else True

--- a/tests/cli/test_migrations.py
+++ b/tests/cli/test_migrations.py
@@ -1,0 +1,51 @@
+from typing import Optional, Sequence
+
+import pytest
+from click import Command
+from click.testing import CliRunner
+
+from snuba.cli.migrations import list, migrate, reverse, reverse_in_progress, run
+
+
+def _check_run(
+    runner: CliRunner, func: Command, args: Optional[Sequence[str]] = None
+) -> None:
+    result = runner.invoke(func, args)
+    assert result.exit_code == 0
+
+
+@pytest.mark.clickhouse_db
+def test_migrations_cli() -> None:
+    runner = CliRunner()
+    # test different combinations of arguments
+    _check_run(runner, list)
+    _check_run(runner, migrate, ["--readiness-state", "complete", "-r", "partial"])
+    _check_run(runner, migrate)
+    _check_run(runner, migrate, ["-g", "system"])
+    _check_run(runner, migrate, ["--group", "system"])
+    _check_run(
+        runner,
+        run,
+        [
+            "--force",
+            "--dry-run",
+            "--group",
+            "system",
+            "--migration-id",
+            "0001_migrations",
+        ],
+    )
+    _check_run(
+        runner,
+        reverse,
+        [
+            "--force",
+            "--dry-run",
+            "--group",
+            "system",
+            "--migration-id",
+            "0001_migrations",
+        ],
+    )
+    _check_run(runner, reverse_in_progress, ["--group", "system"])
+    _check_run(runner, reverse_in_progress)

--- a/tests/cli/test_optimize.py
+++ b/tests/cli/test_optimize.py
@@ -9,4 +9,4 @@ from snuba.cli.optimize import optimize
 def test_optimize_cli() -> None:
     runner = CliRunner()
     result = runner.invoke(optimize, ["--parallel", "2", "--storage", "errors"])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.stderr

--- a/tests/cli/test_optimize.py
+++ b/tests/cli/test_optimize.py
@@ -8,4 +8,5 @@ from snuba.cli.optimize import optimize
 @pytest.mark.clickhouse_db
 def test_optimize_cli() -> None:
     runner = CliRunner()
-    runner.invoke(optimize, ["--parallel", "2", "--storage", "errors"])
+    result = runner.invoke(optimize, ["--parallel", "2", "--storage", "errors"])
+    assert result.exit_code == 0

--- a/tests/cli/test_optimize.py
+++ b/tests/cli/test_optimize.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from click.testing import CliRunner
 
@@ -8,5 +10,19 @@ from snuba.cli.optimize import optimize
 @pytest.mark.clickhouse_db
 def test_optimize_cli() -> None:
     runner = CliRunner()
-    result = runner.invoke(optimize, ["--parallel", "2", "--storage", "errors"])
-    assert result.exit_code == 0, result.stderr
+    host = os.environ.get("CLICKHOUSE_HOST", "127.0.0.1")
+    port = os.environ.get("CLICKHOUSE_PORT", "9000")
+    result = runner.invoke(
+        optimize,
+        [
+            "--clickhouse-host",
+            host,
+            "--clickhouse-port",
+            port,
+            "--parallel",
+            "2",
+            "--storage",
+            "errors",
+        ],
+    )
+    assert result.exit_code == 0, result.output

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -281,13 +281,13 @@ def test_run_all_using_readiness() -> None:
     )
 
     # using different readiness wont change anything
-    runner.run_all(force=True, group=group, readiness_state=ReadinessState.LIMITED)
+    runner.run_all(force=True, group=group, readiness_states=[ReadinessState.LIMITED])
     assert len(runner._get_pending_migrations_for_group(group=group)) == (
         all_generic_metrics
     )
 
     # using correct readiness state runs the migration
-    runner.run_all(force=True, group=group, readiness_state=ReadinessState.COMPLETE)
+    runner.run_all(force=True, group=group, readiness_states=[ReadinessState.COMPLETE])
     assert len(runner._get_pending_migrations_for_group(group=group)) == 0
 
 


### PR DESCRIPTION
This add the partial readiness state into the gocd pipeline. We adjust the cli migrations command to take in multiple `-r` parameters to provide readiness states.  Eventually, when the DRS project is complete, this may be deprecates as it may become unnecessary to pass in the readiness state via parameters; the pipelines should be able to infer what state to target based on their enviroment.

This PR adds in a few extra sanity tests for the CLI given that we have quite a few parameters being passed in now.