### PR TITLE
ref: Don't pass slice_id to build_base_consumer() unnecessarily

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -192,7 +192,7 @@ def consumer(
         slice_id=slice_id,
     )
 
-    consumer = consumer_builder.build_base_consumer(slice_id)
+    consumer = consumer_builder.build_base_consumer()
 
     def handler(signum: int, frame: Any) -> None:
         consumer.signal_shutdown()

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -78,6 +78,7 @@ class ConsumerBuilder:
         commit_retry_policy: Optional[RetryPolicy] = None,
         profile_path: Optional[str] = None,
     ) -> None:
+        self.slice_id = slice_id
         self.storage = get_writable_storage(storage_key)
         self.__kafka_params = kafka_params
         self.consumer_group = kafka_params.group_id
@@ -312,12 +313,10 @@ class ConsumerBuilder:
         if self.replacements_producer:
             self.replacements_producer.flush()
 
-    def build_base_consumer(
-        self, slice_id: Optional[int] = None
-    ) -> StreamProcessor[KafkaPayload]:
+    def build_base_consumer(self) -> StreamProcessor[KafkaPayload]:
         """
         Builds the consumer.
         """
         return self.__build_consumer(
-            self.build_streaming_strategy_factory(slice_id), slice_id
+            self.build_streaming_strategy_factory(self.slice_id), self.slice_id
         )


### PR DESCRIPTION
It's already passed into the constructor of this class. This change removes the possibility of building an invalid consumer with inconsistent slice_id values.