### PR TITLE
fix(inc): use errors readonly storage by default

### DIFF
--- a/snuba/datasets/entities/storage_selectors/errors.py
+++ b/snuba/datasets/entities/storage_selectors/errors.py
@@ -21,7 +21,7 @@ class ErrorsQueryStorageSelector(QueryStorageSelector):
         storage_connections: Sequence[EntityStorageConnection],
     ) -> EntityStorageConnection:
         use_readonly_storage = (
-            state.get_config("enable_events_readonly_table", False)
+            state.get_config("enable_events_readonly_table", True)
             and not query_settings.get_consistent()
         )
 


### PR DESCRIPTION
errors_ro is used in production by default, thus we should use it by default in all our code unless we need to do otherwise