### PR TITLE
Revert "Revert "feat(spans): Initial spans migrations (#4089)""

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -308,3 +308,14 @@ class SearchIssuesLoader(DirectoryLoader):
             "0006_add_subtitle_culprit_level_resource_id",
             "0007_add_transaction_duration",
         ]
+
+
+class SpansLoader(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.snuba_migrations.spans")
+
+    def get_migrations(self) -> Sequence[str]:
+        return [
+            "0001_spans_v1",
+            "0002_spans_add_tags_hashmap",
+        ]

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -16,6 +16,7 @@ from snuba.migrations.group_loader import (
     ReplaysLoader,
     SearchIssuesLoader,
     SessionsLoader,
+    SpansLoader,
     SystemLoader,
     TestMigrationLoader,
     TransactionsLoader,
@@ -37,6 +38,7 @@ class MigrationGroup(Enum):
     GENERIC_METRICS = "generic_metrics"
     TEST_MIGRATION = "test_migration"
     SEARCH_ISSUES = "search_issues"
+    SPANS = "spans"
 
 
 # Migration groups are mandatory by default. Specific groups can
@@ -51,6 +53,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.GENERIC_METRICS,
     MigrationGroup.TEST_MIGRATION,
     MigrationGroup.SEARCH_ISSUES,
+    MigrationGroup.SPANS,
 }
 
 
@@ -143,6 +146,11 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.SEARCH_ISSUES: _MigrationGroup(
         loader=SearchIssuesLoader(),
         storage_sets_keys={StorageSetKey.SEARCH_ISSUES},
+        readiness_state=ReadinessState.PARTIAL,
+    ),
+    MigrationGroup.SPANS: _MigrationGroup(
+        loader=SpansLoader(),
+        storage_sets_keys={StorageSetKey.SPANS},
         readiness_state=ReadinessState.PARTIAL,
     ),
 }

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -81,6 +81,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "generic_metrics_distributions",
             "search_issues",
             "generic_metrics_counters",
+            "spans",
         },
         "single_node": True,
     },
@@ -247,10 +248,14 @@ SKIPPED_MIGRATION_GROUPS: Set[str] = {
     "functions",
     "test_migration",
     "search_issues",
+    "spans",
 }
 
 if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
     SKIPPED_MIGRATION_GROUPS.remove("search_issues")
+
+if os.environ.get("ENABLE_AUTORUN_MIGRATION_SPANS", False):
+    SKIPPED_MIGRATION_GROUPS.remove("spans")
 
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -26,6 +26,7 @@ CLUSTERS = [
             "generic_metrics_distributions",
             "search_issues",
             "generic_metrics_counters",
+            "spans",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -54,6 +54,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "generic_metrics_distributions",
             "search_issues",
             "generic_metrics_counters",
+            "spans",
         },
         "single_node": False,
         "cluster_name": "storage_cluster",

--- a/snuba/snuba_migrations/spans/0001_spans_v1.py
+++ b/snuba/snuba_migrations/spans/0001_spans_v1.py
@@ -1,0 +1,99 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import UUID, Column, DateTime, Nested, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import Float
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+UNKNOWN_SPAN_STATUS = 2
+
+columns: List[Column[Modifiers]] = [
+    Column("project_id", UInt(64)),
+    Column("transaction_id", UUID(Modifiers(nullable=True))),
+    Column("transaction_op", String(Modifiers(nullable=True))),
+    Column("trace_id", UUID()),
+    Column("span_id", UInt(64)),
+    Column("parent_span_id", UInt(64, Modifiers(nullable=True))),
+    Column("segment_id", UInt(64)),
+    Column("is_segment", UInt(8)),
+    Column("segment_name", String(Modifiers(default="''"))),
+    Column("start_timestamp", DateTime()),
+    Column("end_timestamp", DateTime(Modifiers(codecs=["DoubleDelta"]))),
+    Column("duration", UInt(32)),
+    Column("exclusive_time", Float(64)),
+    Column("op", String(Modifiers(low_cardinality=True))),
+    Column("group", UInt(64)),
+    Column("span_status", UInt(8)),
+    Column("span_kind", String(Modifiers(low_cardinality=True))),
+    Column("description", String()),
+    Column("status", UInt(32, Modifiers(nullable=True))),
+    Column("module", String(Modifiers(low_cardinality=True))),
+    Column("action", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("domain", String(Modifiers(nullable=True))),
+    Column("platform", String(Modifiers(low_cardinality=True, nullable=True))),
+    Column("user", String(Modifiers(nullable=True))),
+    Column("tags", Nested([("key", String()), ("value", String())])),
+    Column(
+        "measurements",
+        Nested(
+            [("key", String(Modifiers(low_cardinality=True))), ("value", Float(64))]
+        ),
+    ),
+    Column("partition", UInt(16)),
+    Column("offset", UInt(64)),
+    Column("retention_days", UInt(16)),
+    Column("deleted", UInt(8)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                columns=columns,
+                engine=table_engines.ReplacingMergeTree(
+                    order_by="(project_id, group, end_timestamp, cityHash64(span_id))",
+                    version_column="deleted",
+                    partition_by="(retention_days, toMonday(end_timestamp))",
+                    sample_by="cityHash64(span_id)",
+                    settings={"index_granularity": "8192"},
+                    storage_set=storage_set_name,
+                    ttl="end_timestamp + toIntervalDay(retention_days)",
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name=local_table_name,
+                    sharding_key="cityHash64(trace_id)",
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropTable(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]

--- a/snuba/snuba_migrations/spans/0002_spans_add_tags_hashmap.py
+++ b/snuba/snuba_migrations/spans/0002_spans_add_tags_hashmap.py
@@ -1,0 +1,64 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Array, Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import TAGS_HASH_MAP_COLUMN
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds the tags hash map column defined as Array(Int64) Materialized with
+    arrayMap((k, v) -> cityHash64(
+        concat(replaceRegexpAll(k, '(\\=|\\\\)', '\\\\\\1'), '=', v)
+    ), tags.key, tags.value
+
+    This allows us to quickly find tag key-value pairs since we can
+    add an index on this column.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "_tags_hash_map",
+                    Array(UInt(64), Modifiers(materialized=TAGS_HASH_MAP_COLUMN)),
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "_tags_hash_map",
+                    Array(UInt(64), Modifiers(materialized=TAGS_HASH_MAP_COLUMN)),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="_tags_hash_map",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="_tags_hash_map",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
The PR had to be reverted temporarily because goCD pipeline cannot deploy both code changes and migrations in the same deployment pipeline. But due to a bad code commit, we had to revert the migration PR as well.

Nothing has changed in this code compared to the original PR.

This reverts commit 058e6e54d1eff5fc8385389639fceae475cb7cc2.
