### PR TITLE
build: Arroyo 2.10.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
-sentry-arroyo[json]==2.10.1
+sentry-arroyo[json]==2.10.2
 sentry-kafka-schemas==0.0.33
 sentry-redis-tools==0.1.3
 sentry-relay==0.8.21


### PR DESCRIPTION
This release contains the DLQ rebalancing fixes so we can turn on the DLQ and run the load test again