### PR TITLE
ref(tech-debt) Column validator also checks mapped columns

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -203,9 +203,12 @@ query_processors:
       project_field: project_id
   - processor: BasicFunctionsProcessor
 
+validate_data_model: warn
 validators:
   - validator: EntityRequiredColumnValidator
     args:
       required_filter_columns: ["project_id"]
+  - validator: TagConditionValidator
+    args: {}
 
 required_time_column: timestamp

--- a/snuba/datasets/entity.py
+++ b/snuba/datasets/entity.py
@@ -55,8 +55,9 @@ class Entity(Describable, ABC):
         self.__subscription_validators = subscription_validators
         self.required_time_column = required_time_column
 
+        mappers = [s.translation_mappers for s in storages]
         columns_exist_validator = EntityContainsColumnsValidator(
-            self.__data_model, validation_mode=validate_data_model
+            self.__data_model, mappers, validation_mode=validate_data_model
         )
         self.__validators = (
             [*validators, columns_exist_validator]

--- a/snuba/datasets/pluggable_entity.py
+++ b/snuba/datasets/pluggable_entity.py
@@ -62,9 +62,10 @@ class PluggableEntity(Entity):
     subscription_validators: Optional[Sequence[EntitySubscriptionValidator]] = None
 
     def _get_builtin_validators(self) -> Sequence[QueryValidator]:
+        mappers = [s.translation_mappers for s in self.storages]
         return [
             EntityContainsColumnsValidator(
-                EntityColumnSet(self.columns), self.validate_data_model
+                EntityColumnSet(self.columns), mappers, self.validate_data_model
             )
         ]
 

--- a/snuba/utils/schemas.py
+++ b/snuba/utils/schemas.py
@@ -239,6 +239,7 @@ class ColumnSet(ABC):
 
         self._lookup: MutableMapping[str, FlattenedColumn] = {}
         self._flattened: List[FlattenedColumn] = []
+        self._nested = {}
         for column in self.__columns:
             if not isinstance(column, WildcardColumn):
                 self._flattened.extend(column.type.flatten(column.name))
@@ -246,6 +247,8 @@ class ColumnSet(ABC):
         for col in self._flattened:
             if col.flattened in self._lookup:
                 raise RuntimeError("Duplicate column: {}".format(col.flattened))
+            if isinstance(column.type, Nested):
+                self._nested[column.name] = column
 
             self._lookup[col.flattened] = col
             # also store it by the escaped name
@@ -282,6 +285,8 @@ class ColumnSet(ABC):
 
     def __contains__(self, key: str) -> bool:
         if key in self._lookup:
+            return True
+        if key in self._nested:
             return True
 
         if self._wildcard_columns:

--- a/tests/datasets/configuration/column_validation_entity.yaml
+++ b/tests/datasets/configuration/column_validation_entity.yaml
@@ -1,0 +1,65 @@
+version: v1
+kind: entity
+name: nested
+
+schema:
+- name: event_id
+  type: String
+- name: fixed_event_id
+  type: FixedString
+  args:
+    length: 420
+- name: project_id
+  type: UInt
+  args:
+    size: 64
+- name: primary_hash
+  type: FixedString
+  args:
+    length: 69
+    schema_modifiers:
+    - nullable
+- name: tags
+  type: Nested
+  args:
+    subcolumns:
+      - name: key,
+        type: String
+      - name: value
+        type: String
+storages:
+- storage: discover
+  translation_mappers:
+    columns:
+      -
+        mapper: ColumnToIPAddress
+        args:
+          from_table_name:
+          from_col_name: ip_address
+      -
+        mapper: ColumnToNullIf
+        args:
+          from_table_name:
+          from_col_name: userColumnToNullIf
+      -
+        mapper: ColumnToMapping
+        args:
+          from_table_name:
+          from_col_name: geo_country_code
+          to_nested_col_table_name:
+          to_nested_col_name: contexts
+          to_nested_mapping_key: geo.country_code
+          nullable: True
+      -
+        mapper: ColumnToColumn
+        args:
+          from_table_name:
+          from_col_name: email
+          to_table_name:
+          to_col_name: user_email
+  is_writable: false
+required_time_column: event_id
+storage_selector:
+  selector: DefaultQueryStorageSelector
+query_processors: []
+validators: []

--- a/tests/datasets/validation/test_entity_contains_columns_validator.py
+++ b/tests/datasets/validation/test_entity_contains_columns_validator.py
@@ -1,6 +1,7 @@
 import pytest
 
 from snuba.datasets.configuration.entity_builder import build_entity_from_config
+from snuba.datasets.entity import Entity
 from snuba.query import SelectedExpression
 from snuba.query.data_source.simple import Entity as QueryEntity
 from snuba.query.exceptions import InvalidQueryException
@@ -11,17 +12,47 @@ from snuba.query.validation.validators import (
     EntityContainsColumnsValidator,
 )
 
-entity_contains_columns_tests = [
-    pytest.param(
-        "tests/datasets/configuration/entity_with_fixed_string.yaml",
-        id="Validate Entity Columns",
+CONFIG_PATH = "tests/datasets/configuration/column_validation_entity.yaml"
+
+
+def get_validator(entity: Entity) -> EntityContainsColumnsValidator:
+    validator = None
+    for v in entity.get_validators():
+        if isinstance(v, EntityContainsColumnsValidator):
+            validator = v
+
+    assert validator is not None
+    validator.validation_mode = ColumnValidationMode.ERROR
+    return validator
+
+
+def test_mapped_columns_validation() -> None:
+    entity = build_entity_from_config(CONFIG_PATH)
+
+    query_entity = QueryEntity(entity.entity_key, entity.get_data_model())
+    columns = [
+        SelectedExpression(
+            "ip_address", Column("_snuba_ip_address", None, "ip_address")
+        ),
+        SelectedExpression("email", Column("_snuba_email", None, "email")),
+    ]
+
+    bad_query = LogicalQuery(
+        query_entity,
+        selected_columns=columns
+        + [SelectedExpression("asdf", Column("_snuba_asdf", None, "asdf"))],
     )
-]
+
+    good_query = LogicalQuery(query_entity, selected_columns=columns)
+    validator = get_validator(entity)
+    with pytest.raises(InvalidQueryException):
+        validator.validate(bad_query)
+
+    validator.validate(good_query)
 
 
-@pytest.mark.parametrize("config_path", entity_contains_columns_tests)
-def test_outcomes_columns_validation(config_path: str) -> None:
-    entity = build_entity_from_config(config_path)
+def test_outcomes_columns_validation() -> None:
+    entity = build_entity_from_config(CONFIG_PATH)
 
     query_entity = QueryEntity(entity.entity_key, entity.get_data_model())
 
@@ -47,20 +78,15 @@ def test_outcomes_columns_validation(config_path: str) -> None:
             for column in entity.get_data_model().columns
         ],
     )
-
-    validator = EntityContainsColumnsValidator(
-        entity.get_data_model(), validation_mode=ColumnValidationMode.ERROR
-    )
-
+    validator = get_validator(entity)
     with pytest.raises(InvalidQueryException):
         validator.validate(bad_query)
 
     validator.validate(good_query)
 
 
-@pytest.mark.parametrize("config_path", entity_contains_columns_tests)
-def test_in_where_clause_and_function(config_path):
-    entity = build_entity_from_config(config_path)
+def test_in_where_clause_and_function() -> None:
+    entity = build_entity_from_config(CONFIG_PATH)
 
     query_entity = QueryEntity(entity.entity_key, entity.get_data_model())
 
@@ -76,9 +102,7 @@ def test_in_where_clause_and_function(config_path):
         ],
         condition=FunctionCall(None, "f1", (Column(None, None, "bad_column"),)),
     )
-    validator = EntityContainsColumnsValidator(
-        entity.get_data_model(), validation_mode=ColumnValidationMode.ERROR
-    )
+    validator = get_validator(entity)
 
     with pytest.raises(InvalidQueryException):
         validator.validate(bad_query)


### PR DESCRIPTION
The EntityContainsColumnValidator wasn't checking the mapped columns when
validating if a column was allowed on the entity. Change this so that any mapped
columns are also marked as valid.

Also enable this on one dataset (search_issues) as a test. If everything works
correctly, the rest of the dataset will also get this validator.

Some of these changes were copied from this old PR: https://github.com/getsentry/snuba/pull/3976/files, but with the added checking of the storage mappers.