### PR TITLE
feat(capman): add support for low priority referrers

### DIFF
--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -188,8 +188,6 @@ def test_passthrough_subscriptions(policy) -> None:
 @pytest.mark.redis_db
 def test_single_thread_referrers(policy) -> None:
     _configure_policy(policy)
-    # currently subscriptions are not throttled due to them being on the critical path
-    # this test makes sure that no matter how much quota they consume, they are not throttled
     tenant_ids = {"referrer": "delete-events-from-file"}
     assert policy.get_quota_allowance(tenant_ids=tenant_ids).max_threads == 1
     policy.update_quota_balance(


### PR DESCRIPTION
Sentry has some batch scripts it needs to run sometimes. instead of worrying about which organization they are running for, just let them run on one thread