### PR TITLE
temp(capman): do not enforce allocation policy by default

### DIFF
--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -102,7 +102,7 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         # TODO: This kind of killswitch should just be included with every allocation policy
         is_active = cast(bool, get_config(f"{self.rate_limit_prefix}.is_active", True))
         is_enforced = cast(
-            bool, get_config(f"{self.rate_limit_prefix}.is_enforced", True)
+            bool, get_config(f"{self.rate_limit_prefix}.is_enforced", False)
         )
         throttled_thread_number = cast(
             int, get_config(f"{self.rate_limit_prefix}.throttled_thread_number", 1)


### PR DESCRIPTION
getsentry has tests which don't run in our CI. This will be fixed
