### PR TITLE
fix: Move topic compression into topic definition not producer config

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -59,14 +59,6 @@ def _kafka_producer() -> Producer:
             build_kafka_producer_configuration(
                 topic=None,
                 override_params={
-                    # at time of writing (2022-05-09) lz4 was chosen because it
-                    # compresses quickly. If more compression is needed at the cost of
-                    # performance, zstd can be used instead. Recording the query
-                    # is part of the API request, therefore speed is important
-                    # perf-testing: https://indico.fnal.gov/event/16264/contributions/36466/attachments/22610/28037/Zstd__LZ4.pdf
-                    # by default a topic is configured to use whatever compression method the producer used
-                    # https://docs.confluent.io/platform/current/installation/configuration/topic-configs.html#topicconfigs_compression.type
-                    "compression.type": "lz4",
                     # the querylog payloads can get really large so we allow larger messages
                     # (double the default)
                     # The performance is not business critical and therefore we accept the tradeoffs

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -59,6 +59,13 @@ class Topic(Enum):
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
+    # at time of writing (2022-05-09) lz4 was chosen because it
+    # compresses quickly. If more compression is needed at the cost of
+    # performance, zstd can be used instead. Recording the query
+    # is part of the API request, therefore speed is important
+    # perf-testing: https://indico.fnal.gov/event/16264/contributions/36466/attachments/22610/28037/Zstd__LZ4.pdf
+    default_config = {"compression.type": "lz4"}
+
     config = {
         Topic.EVENTS: {"message.timestamp.type": "LogAppendTime"},
         Topic.TRANSACTIONS: {"message.timestamp.type": "LogAppendTime"},
@@ -71,4 +78,4 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
         Topic.GENERIC_METRICS: {"message.timestamp.type": "LogAppendTime"},
         Topic.GENERIC_EVENTS: {"message.timestamp.type": "LogAppendTime"},
     }
-    return config.get(topic, {})
+    return {**default_config, **config.get(topic, {})}


### PR DESCRIPTION
This is consistent with Sentry prod where the compression type is always defined on the topic not in the producer config
