### PR TITLE
feat(capman): enforce the allocation policy by default (again)

### DIFF
--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -112,7 +112,7 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         # TODO: This kind of killswitch should just be included with every allocation policy
         is_active = cast(bool, get_config(f"{self.rate_limit_prefix}.is_active", True))
         is_enforced = cast(
-            bool, get_config(f"{self.rate_limit_prefix}.is_enforced", False)
+            bool, get_config(f"{self.rate_limit_prefix}.is_enforced", True)
         )
         throttled_thread_number = cast(
             int, get_config(f"{self.rate_limit_prefix}.throttled_thread_number", 1)


### PR DESCRIPTION
Tests in sentry and getsentry have now been updated. We should be able to turn this on again (and quick revert if it breaks CI).

The hard part of this is that it's not easy to run getsentry tests in CI so we're in this in-between. But it's almost over!