### PR TITLE
ref: Bump sentry-kafka-schemas to 0.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.10.2
-sentry-kafka-schemas==0.0.33
+sentry-kafka-schemas==0.1.0
 sentry-redis-tools==0.1.3
 sentry-relay==0.8.21
 sentry-sdk==1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.10.2
-sentry-kafka-schemas==0.1.3
+sentry-kafka-schemas==0.1.4
 sentry-redis-tools==0.1.3
 sentry-relay==0.8.21
 sentry-sdk==1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo[json]==2.10.2
-sentry-kafka-schemas==0.1.0
+sentry-kafka-schemas==0.1.3
 sentry-redis-tools==0.1.3
 sentry-relay==0.8.21
 sentry-sdk==1.18.0

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -26,7 +26,7 @@ def _get_codec_impl(topic: Topic) -> Optional[Codec[Any]]:
         return None
 
 
-_NOOP_CODEC = JsonCodec(json_schema=None)
+_NOOP_CODEC: Codec[Any] = JsonCodec(json_schema=None)
 _cache: MutableMapping[Topic, Codec[Any]] = {}
 
 

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -4,7 +4,7 @@ from typing import Any, MutableMapping, Optional
 import sentry_kafka_schemas
 import sentry_sdk
 from sentry_kafka_schemas.codecs import Codec
-from sentry_kafka_schemas.codecs.json import JsonCodec, T
+from sentry_kafka_schemas.codecs.json import JsonCodec
 
 from snuba.utils.streams.topics import Topic
 
@@ -26,15 +26,7 @@ def _get_codec_impl(topic: Topic) -> Optional[Codec[Any]]:
         return None
 
 
-class NoopCodec(JsonCodec[T]):
-    def __init__(self):
-        pass
-
-    def validate(self, data: T) -> None:
-        pass
-
-
-_NOOP_CODEC = NoopCodec()
+_NOOP_CODEC = JsonCodec(json_schema=None)
 _cache: MutableMapping[Topic, Codec[Any]] = {}
 
 

--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -1,21 +1,22 @@
 import logging
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, MutableMapping, Optional
 
 import sentry_kafka_schemas
 import sentry_sdk
-from arroyo.codecs.json import JsonCodec
+from sentry_kafka_schemas.codecs import Codec
+from sentry_kafka_schemas.codecs.json import JsonCodec, T
 
 from snuba.utils.streams.topics import Topic
 
 logger = logging.getLogger(__name__)
 
 
-def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
+def _get_codec_impl(topic: Topic) -> Optional[Codec[Any]]:
     """
     This function returns either the schema if it is defined, or None if not.
     """
     try:
-        return sentry_kafka_schemas.get_schema(topic.value)["schema"]
+        return sentry_kafka_schemas.get_codec(topic.value)
     except sentry_kafka_schemas.SchemaNotFound:
         return None
     except Exception as err:
@@ -25,11 +26,20 @@ def get_schema(topic: Topic) -> Optional[Mapping[str, Any]]:
         return None
 
 
-_cache: MutableMapping[Topic, JsonCodec[Any]] = {}
+class NoopCodec(JsonCodec[T]):
+    def __init__(self):
+        pass
+
+    def validate(self, data: T) -> None:
+        pass
 
 
-def get_json_codec(topic: Topic) -> JsonCodec[Any]:
+_NOOP_CODEC = NoopCodec()
+_cache: MutableMapping[Topic, Codec[Any]] = {}
+
+
+def get_json_codec(topic: Topic) -> Codec[Any]:
     if topic not in _cache:
-        _cache[topic] = JsonCodec(schema=get_schema(topic))
+        _cache[topic] = _get_codec_impl(topic) or _NOOP_CODEC
 
     return _cache[topic]


### PR DESCRIPTION
Use codecs from sentry-kafka-schemas instead of Arroyo.

This change would allow us to transparently handle decoding of msgpack
topics, solely based off of configuration in sentry-kafka-schemas. Snuba
doesn't have to know about the underlying encoding format anymore. We
don't want to do that, but I think it's pretty cool.

Unfortunately, when there's no schema, we get no codec back from
sentry-kafka-schemas. So we have to define our own noop subclass.
Eventually we should be able to get definitions for all topics. We might
already have them, actually.
