### PR TITLE
feat(rust-consumer): Ignore invalid message

### DIFF
--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -106,10 +106,17 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                     })
                 }
             }
-        })
-        .unwrap();
+        });
 
-        self.next_step.submit(message.replace(result))
+        match result {
+            Ok(data) => self.next_step.submit(message.replace(data)),
+            Err(_) => {
+                log::error!("Invalid message");
+                Ok(())
+            },
+        }
+
+
     }
 
     fn close(&mut self) {


### PR DESCRIPTION
We are doing DLQ testing and intentionally putting invalid messages on topics. Just ignore those in Rust consumer.
