### PR TITLE
build: Don't need json dependency from Arroyo anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-dateutil==2.8.2
 python-rapidjson==1.8
 pytz==2022.2.1
 redis==4.3.4
-sentry-arroyo[json]==2.10.2
+sentry-arroyo==2.10.2
 sentry-kafka-schemas==0.1.4
 sentry-redis-tools==0.1.3
 sentry-relay==0.8.21


### PR DESCRIPTION
sentry-kafka-schemas provides the codecs now