### PR TITLE
fix(consumer): Commit at least once per second even with prefilter

### DIFF
--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from typing import Callable, Mapping, Optional, Protocol, Union
 
 from arroyo.backends.kafka import KafkaPayload
+from arroyo.commit import ONCE_PER_SECOND
 from arroyo.processing.strategies import (
     FilterStep,
     ProcessingStrategy,
@@ -149,6 +150,8 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             )
 
         if self.__prefilter is not None:
-            strategy = FilterStep(self.__should_accept, strategy)
+            strategy = FilterStep(
+                self.__should_accept, strategy, commit_policy=ONCE_PER_SECOND
+            )
 
         return strategy


### PR DESCRIPTION
We fixed this bug ages ago in the last-seen updater, and ST might be
running into it in generic-metrics.
