### PR TITLE
feat(spans): Change required time column to be timestamp

### DIFF
--- a/snuba/datasets/configuration/spans/entities/spans.yaml
+++ b/snuba/datasets/configuration/spans/entities/spans.yaml
@@ -97,6 +97,14 @@ storage_selector:
   selector: DefaultQueryStorageSelector
 
 query_processors:
+  - processor: TimeSeriesProcessor
+    args:
+      time_group_columns:
+        time: end_timestamp
+      time_parse_columns:
+        - start_timestamp
+        - end_timestamp
+        - timestamp
   - processor: BasicFunctionsProcessor
   - processor: ReferrerRateLimiterProcessor
   - processor: ProjectReferrerRateLimiter
@@ -117,4 +125,4 @@ validators:
     args: {}
   - validator: DatetimeConditionValidator
     args: {}
-required_time_column: end_timestamp
+required_time_column: timestamp


### PR DESCRIPTION
Changes the time required column from `end_timestamp` to `timestamp`. There is already a column mapper defined which maps timestamp to end_timestamp [here](https://github.com/getsentry/snuba/blob/master/snuba/datasets/configuration/spans/entities/spans.yaml#L72-L77). Also adds the timeseries processor to spans entity