### PR TITLE
fix(dataset-config): make SPANS hardcoded to fix single-tenant deploy

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -16,6 +16,7 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "PROFILES": "profiles",
     "FUNCTIONS": "functions",
     "SEARCH_ISSUES": "search_issues",
+    "SPANS": "spans",
 }
 
 


### PR DESCRIPTION
Came across this error trying to run a single-tenant deploy (https://deploy.getsentry.net/go/tab/build/detail/st-s4s-experimental/1/run-migrations/1/snuba-migrations), and we don't want those deploys to be blocked:
```
Traceback (most recent call last):
  File "/usr/local/bin/snuba", line 33, in <module>
    sys.exit(load_entry_point('snuba', 'console_scripts', 'snuba')())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1651, in invoke
    cmd_name, cmd, args = self.resolve_command(ctx, args)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1698, in resolve_command
    cmd = self.get_command(ctx, cmd_name)
  File "/usr/src/snuba/snuba/cli/__init__.py", line 58, in get_command
    initialize.initialize_snuba()
  File "/usr/src/snuba/snuba/core/initialize.py", line 41, in initialize_snuba
    _load_storages()
  File "/usr/src/snuba/snuba/core/initialize.py", line 21, in _load_storages
    from snuba.datasets.storages.factory import initialize_storage_factory
  File "/usr/src/snuba/snuba/datasets/storages/factory.py", line 12, in <module>
    from snuba.datasets.storages.validator import StorageValidator
  File "/usr/src/snuba/snuba/datasets/storages/validator.py", line 6, in <module>
    from snuba.migrations.groups import get_group_readiness_state_from_storage_set
  File "/usr/src/snuba/snuba/migrations/groups.py", line 153, in <module>
    storage_sets_keys={StorageSetKey.SPANS},
  File "/usr/src/snuba/snuba/clusters/storage_sets.py", line 31, in __getattr__
    raise AttributeError(attr)
AttributeError: SPANS
```

I was able to reproduce locally by removing `spans` from settings.CLUSTERS, which shouldn't be defined in most single tenants yet. 

I verified that hardcoding the storage set key fixed the error.