### PR TITLE
fix(replays): use uuid with dashes for event hash

### DIFF
--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -173,7 +173,7 @@ class ReplaysProcessor(DatasetMessageProcessor):
         if event_hash is None:
             event_hash = segment_id_to_event_hash(replay_event["segment_id"])
 
-        processed["event_hash"] = event_hash
+        processed["event_hash"] = str(uuid.UUID(event_hash))
 
     def process_message(
         self, message: Mapping[Any, Any], metadata: KafkaMessageMetadata

--- a/snuba/datasets/processors/replays_processor.py
+++ b/snuba/datasets/processors/replays_processor.py
@@ -273,7 +273,7 @@ def segment_id_to_event_hash(segment_id: int | None) -> str:
         # originate from the SDK and do not relate to a specific segment.
         #
         # For example: archive requests.
-        return str(uuid.uuid4().hex)
+        return str(uuid.uuid4())
     else:
         segment_id_bytes = force_bytes(str(segment_id))
         segment_hash = md5(segment_id_bytes).hexdigest()

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -339,6 +339,12 @@ class TestReplaysProcessor:
         expect = InsertBatch([result], None)
         assert output == expect
 
+        # Assert the event_hash UUID contains dashes.
+        assert isinstance(output, InsertBatch)
+        generated_event_hash = output.rows[0]["event_hash"]
+        assert len(generated_event_hash) == 36
+        assert generated_event_hash == str(uuid.UUID(generated_event_hash))
+
     def test_process_message_mismatched_types(self) -> None:
         meta = KafkaMessageMetadata(
             offset=0, partition=0, timestamp=datetime(1970, 1, 1)
@@ -473,7 +479,7 @@ class TestReplaysProcessor:
         result = ReplaysProcessor().process_message(minimal_payload, meta)
         assert isinstance(result, InsertBatch)
         assert len(result.rows) == 1
-        assert result.rows[0]["event_hash"] == event_hash
+        assert result.rows[0]["event_hash"] == str(uuid.UUID(event_hash))
 
     def test_process_message_nulls(self) -> None:
         meta = KafkaMessageMetadata(


### PR DESCRIPTION
- on clickhouse 20.3, uuids need to have dashes on them. We didn't have this covered in a test case but we now see it occuring in a few different places with new behavior we're trying to add.