### PR TITLE
chore(capman): add user reports to single thread referrers

### DIFF
--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -57,6 +57,7 @@ _SINGLE_THREAD_REFERRERS = set(
         "delete-events-by-tag-value",
         "delete.fetch_last_group",
         "forward-events",
+        "tasks.update_user_reports",
     ]
 )
 


### PR DESCRIPTION
There is a user report task which calls `eventstore.get_events` and it's not very important (because it has been rejected for a straight week and nobody has said anything) but probably shouldn't leave it broken. We throttle it to one thread and call it a day. 