### PR TITLE
feat: Add bump-version workflow from sentry

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,73 @@
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        required: true
+        type: string
+        description: package name such as `sentry-arroyo`
+      version:
+        required: true
+        type: string
+        description: desired version such as `1.2.3`, or `latest` to pull the latest version from PyPI
+      pr_options:
+        type: string
+        default: ""
+        description: additional options for gh pr create, such as for asking for specific reviewers
+
+  # for use in other (cron/scheduled) workflows to bump specific
+  # company-internal dependencies on a more aggressive schedule
+  workflow_call:
+    inputs:
+      package:
+        required: true
+        type: string
+      version:
+        required: true
+        type: string
+      pr_options:
+        type: string
+        default: ""
+
+# disable all permissions -- we use the PAT's permissions instead
+permissions: {}
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3.1.0
+      with:
+        token: ${{ secrets.BUMP_SENTRY_TOKEN }}
+    - run: |
+        set -euxo pipefail
+
+        if [ "$VERSION" = latest ]; then
+          VERSION="$(curl -sL https://pypi.org/pypi/$PACKAGE/json | jq -r .info.version)"
+        fi
+
+        git checkout -b "bot/bump-version/$PACKAGE/$VERSION"
+
+        re="$(sed 's/[_-]/[_-]/g' <<< "$PACKAGE")"
+        sed -i "s/^$re==.*/$PACKAGE==$VERSION/g" -- requirements*.txt
+
+        if git diff --exit-code; then
+          exit 0
+        fi
+
+        git \
+            -c user.name=getsentry-bot \
+            -c user.email='10587625+getsentry-bot@users.noreply.github.com' \
+            commit \
+            --all \
+            --message "ref: bump $PACKAGE to $VERSION" \
+            --message "Co-Authored-By: $SENDER <$SENDER_ID+$SENDER@users.noreply.github.com>"
+
+        git push origin HEAD --quiet
+
+        gh pr create --fill ${{ inputs.pr_options }}
+      env:
+        GH_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
+        PACKAGE: ${{ inputs.package }}
+        VERSION: ${{ inputs.version }}
+        SENDER: ${{ github.event.sender.login }}
+        SENDER_ID: ${{ github.event.sender.id }}


### PR DESCRIPTION
This is an exact copy of the bump-version workflow from sentry.

It allows you to open PRs for dependency bumps by manually triggering
the action from the Actions tab.

This might be more convenient than bumping sentry-arroyo or schemas repo via CLI
