### PR TITLE
fix(optimize): Remove cutoff for parally optimize

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -308,14 +308,6 @@ ENABLE_ISSUE_OCCURRENCE_CONSUMER = os.environ.get(
 # Enable spans ingestion
 ENABLE_SPANS_CONSUMER = os.environ.get("ENABLE_SPANS_CONSUMER", False)
 
-# Start time in hours from UTC 00:00:00 after which we are allowed to run
-# optimize jobs in parallel.
-PARALLEL_OPTIMIZE_JOB_START_TIME = 0
-
-# Cutoff time from UTC 00:00:00 to stop running optimize jobs in
-# parallel to avoid running in parallel when peak traffic starts.
-PARALLEL_OPTIMIZE_JOB_END_TIME = 9
-
 # Cutoff time from UTC 00:00:00 to stop running optimize jobs to
 # avoid spilling over to the next day.
 OPTIMIZE_JOB_CUTOFF_TIME = 23
@@ -329,6 +321,14 @@ OPTIMIZE_MERGE_MIN_ELAPSED_CUTTOFF_TIME = 10 * 60  # 10 mins
 OPTIMIZE_MERGE_SIZE_CUTOFF = 50_000_000_000  # 50GB
 # Maximum jitter to add to the scheduling of threads of an optimize job
 OPTIMIZE_PARALLEL_MAX_JITTER_MINUTES = 30
+
+# Start time in hours from UTC 00:00:00 after which we are allowed to run
+# optimize jobs in parallel.
+PARALLEL_OPTIMIZE_JOB_START_TIME = 0
+
+# Cutoff time from UTC 00:00:00 to stop running optimize jobs in
+# parallel to avoid running in parallel when peak traffic starts.
+PARALLEL_OPTIMIZE_JOB_END_TIME = OPTIMIZE_JOB_CUTOFF_TIME
 
 # Configuration directory settings
 CONFIG_FILES_PATH = f"{Path(__file__).parent.parent.as_posix()}/datasets/configuration"


### PR DESCRIPTION
With bigger clusters, we have capacity to run 2 merges in parallel for longer. Change the parallel cutoff time to be the same as regular optimize cutoff time.