### PR TITLE
fix(dependabot): Ignore sentry-kafka-schemas

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
     open-pull-requests-limit: 50
     ignore:
       - dependency-name: "parsimonious"
+      # sentry-kafka-schemas has its own lints to ensure it is reasonably
+      # up-to-date -- we should rely on them
+      - dependency-name: "sentry-kafka-schemas"


### PR DESCRIPTION
We have our own mechanisms for ensuring the schemas are reasonably up to
date, and we should actively stress-test them. If they don't work, we
have a problem in other repos that do not use dependabot.
