### PR TITLE
feat: Add hypothesis-based fuzzing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ htmlcov/
 snuba.egg-info/
 .DS_Store
 .idea/
+.hypothesis/
 node_modules
 .vscode/*.log
 snuba/admin/dist/bundle.js*

--- a/tests/consumers/test_schemas.py
+++ b/tests/consumers/test_schemas.py
@@ -4,7 +4,7 @@ from typing import Any, Iterator, Optional
 
 import pytest
 import sentry_kafka_schemas
-from hypothesis import given
+from hypothesis import HealthCheck, given, settings
 from hypothesis_jsonschema import from_schema
 from sentry_kafka_schemas.sentry_kafka_schemas import _get_schema
 
@@ -66,6 +66,7 @@ def test_fuzz_schemas(config: TopicConfig):
     schema = _get_schema(config.logical_topic_name)["schema"]
 
     @given(value=from_schema(schema))
+    @settings(suppress_health_check=[HealthCheck.too_slow], deadline=None)
     def inner(value):
         run_test(Case(config=config, example=value))
 

--- a/tests/consumers/test_schemas.py
+++ b/tests/consumers/test_schemas.py
@@ -28,7 +28,7 @@ class TopicConfig:
     replacer_processor: Optional[ReplacerProcessor[Any]]
 
     def __repr__(self) -> str:
-        return repr(self.logical_topic_name)
+        return f"{self.logical_topic_name}: {self.processor}"
 
 
 @dataclass

--- a/tests/consumers/test_schemas.py
+++ b/tests/consumers/test_schemas.py
@@ -4,6 +4,8 @@ from typing import Any, Iterator, Optional
 
 import pytest
 import sentry_kafka_schemas
+from hypothesis import given
+from hypothesis_jsonschema import from_schema
 from sentry_kafka_schemas.sentry_kafka_schemas import _get_schema
 
 from snuba.consumers.types import KafkaMessageMetadata
@@ -59,16 +61,11 @@ def _generate_topic_configs() -> Iterator[TopicConfig]:
         )
 
 
-from hypothesis import given, settings
-from hypothesis_jsonschema import from_schema
-
-
 @pytest.mark.parametrize("config", _generate_topic_configs(), ids=repr)
 def test_fuzz_schemas(config: TopicConfig):
     schema = _get_schema(config.logical_topic_name)["schema"]
 
     @given(value=from_schema(schema))
-    @settings(max_examples=1)
     def inner(value):
         run_test(Case(config=config, example=value))
 


### PR DESCRIPTION
Add a test that produces sample messages from topic schemas, and verifies our
message processors don't crash based on those messages.

Background: The idea of generating sample data from our topic schemas for a
staging environment has been floated around. We'd have to figure out whether
the schemas are strict enough to faciliate that usecase and how well the data
generators perform.

That staging environment does not need realistic data, just some form of valid
data, since it is about finding crashes more so than performance regressions.

There are still many crashes to fix which are real but unlikely to actually happen
on accident. There is also a whole category of clickhouse errors (integer overflow)
that schemas do not prevent (but could)

I don't think it is viable to run this test in CI -- it is completely indeterministic, adds more than 5 minutes of runtime to the testsuite, and probably has many more errors I'm not even aware of.