### PR TITLE
docs(clickhouse): Document supported clickhouse versions

### DIFF
--- a/docs/source/clickhouse/supported_versions.rst
+++ b/docs/source/clickhouse/supported_versions.rst
@@ -1,0 +1,15 @@
+=============================
+ClickHouse supported versions
+=============================
+The following versions of Clickhouse have been tested and are known to work
+with Snuba:
+
+- 20.3
+- 20.7
+- 21.8
+
+Any version of Clikhouse used outside of this list could potentially work,
+but is not guaranteed to work. Some functionality might be broken. Use a
+different version at your own risk. There are plans to support more recent
+versions of Clickhouse in the future. When Snuba has been validated to work
+with the new versions of Clickhouse, this list will be updated.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,3 +19,4 @@ Contents:
    clickhouse/death_queries
    clickhouse/topology
    clickhouse/schema_design
+   clickhouse/supported_versions


### PR DESCRIPTION
Since we know which versions of clickhouse Snuba current works with, lets document it.