### PR TITLE
fix: Fix permissions of bump-version.yml workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -66,7 +66,8 @@ jobs:
 
         gh pr create --fill ${{ inputs.pr_options }}
       env:
-        GH_TOKEN: ${{ secrets.BUMP_SENTRY_TOKEN }}
+        # Using this instead of BUMP_SENTRY_TOKEN as per advice from asottile
+        GH_TOKEN: ${{ secrets.GETSENTRY_BOT_REVERT_TOKEN }}
         PACKAGE: ${{ inputs.package }}
         VERSION: ${{ inputs.version }}
         SENDER: ${{ github.event.sender.login }}


### PR DESCRIPTION
This workflow can be triggered manually to bump a python package to a
newer version. We want to ensure this is available in snuba so that
people can bump sentry-kafka-schemas more easily.
