### PR TITLE
fix(consumers): Add timeout for http batch writes

### DIFF
--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import re
-import socket
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from queue import Queue, SimpleQueue
@@ -243,9 +242,6 @@ class HTTPWriteBatch:
                 "http_batch.timeout",
                 tags={"table": str(self.__statement.get_qualified_table())},
             )
-            # Container names are available as the hostnames within the container. Let's use that
-            # when logging to Sentry.
-            sentry_sdk.set_tag("hostname", socket.gethostname())
             raise
 
         logger.debug("Received response for %r.", self)

--- a/snuba/clickhouse/http.py
+++ b/snuba/clickhouse/http.py
@@ -341,6 +341,7 @@ class HTTPBatchWriter(BatchWriter[bytes]):
             batch.append(value)
 
         batch.close()
+        batch_join_timeout = state.get_config("http_batch_join_timeout", 10)
         # IMPORTANT: Please read the docstring of this method if you ever decide to remove the
         # timeout argument from the join method.
-        batch.join(timeout=10)
+        batch.join(timeout=batch_join_timeout)

--- a/tests/clickhouse/test_http.py
+++ b/tests/clickhouse/test_http.py
@@ -1,7 +1,10 @@
+from unittest.mock import Mock
+
 import pytest
 
-from snuba.clickhouse.http import ValuesRowEncoder
+from snuba.clickhouse.http import HTTPWriteBatch, InsertStatement, ValuesRowEncoder
 from snuba.query.expressions import FunctionCall, Literal
+from snuba.utils.metrics.backends.dummy import DummyMetricsBackend
 
 
 @pytest.fixture
@@ -29,3 +32,29 @@ def test_encode_preserves_column_order(values_encoder: ValuesRowEncoder) -> None
 def test_encode_fails_on_non_expression(values_encoder: ValuesRowEncoder) -> None:
     with (pytest.raises(TypeError)):
         values_encoder.encode({"col1": "string not wrapped by a literal object"})
+
+
+def test_http_write_batch_raises_exception_on_timeout() -> None:
+    # create a mock executor and connection pool
+    executor = Mock()
+    pool = Mock()
+
+    # create an instance of HTTPWriteBatch with a very short timeout
+    batch = HTTPWriteBatch(
+        executor=executor,
+        pool=pool,
+        metrics=DummyMetricsBackend(),
+        user="user",
+        password="password",
+        statement=InsertStatement(table_name="table"),
+        encoding=None,
+        options={},
+        chunk_size=None,
+        buffer_size=0,
+        debug_buffer_size_bytes=None,
+    )
+    batch._result = Mock()
+    batch._result.result = Mock(side_effect=TimeoutError())
+
+    with pytest.raises(TimeoutError):
+        batch.join(timeout=0.1)


### PR DESCRIPTION
When a join is being called on HTTPWriteBatch we should limit the time spent waiting for the operation to be successful. If we do not limit the time spent the consumer can stay hung for any amount of time. It would stay hung till the kafka broker realizes that the consumer is dead (which today is 5 minutes). Instead of waiting so long, we should fail fast and abort earlier.