### PR TITLE
feat(admin): add amount of rows in result set to tracing tool

### DIFF
--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -1,16 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
 from snuba.admin.clickhouse.common import (
     get_ro_query_node_connection,
     validate_ro_query,
 )
-from snuba.clickhouse.native import ClickhouseResult
 from snuba.clusters.cluster import ClickhouseClientSettings
 
 
-def run_query_and_get_trace(storage_name: str, query: str) -> ClickhouseResult:
-    validate_ro_query(query)
+@dataclass
+class TraceOutput:
+    trace_output: str
+    cols: list[tuple[str, str]]
+    num_rows_result: int
 
+
+def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
+    validate_ro_query(query)
     connection = get_ro_query_node_connection(
         storage_name, ClickhouseClientSettings.TRACING
     )
-    query_result = connection.execute(query=query, capture_trace=True)
-    return query_result
+    query_result = connection.execute(
+        query=query, capture_trace=True, with_column_types=True
+    )
+    return TraceOutput(
+        trace_output=query_result.trace_output,
+        cols=query_result.meta,
+        num_rows_result=len(query_result.results),
+    )

--- a/snuba/admin/clickhouse/tracing.py
+++ b/snuba/admin/clickhouse/tracing.py
@@ -26,6 +26,6 @@ def run_query_and_get_trace(storage_name: str, query: str) -> TraceOutput:
     )
     return TraceOutput(
         trace_output=query_result.trace_output,
-        cols=query_result.meta,
+        cols=query_result.meta,  # type: ignore
         num_rows_result=len(query_result.results),
     )

--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -117,7 +117,7 @@ function TracingQueries(props: { api: Client }) {
         const tracing_result = {
           input_query: `${query.sql}`,
           timestamp: result.timestamp,
-          num_rows: result.num_rows_result,
+          num_rows_result: result.num_rows_result,
           cols: result.cols,
           trace_output: result.trace_output,
           error: result.error,
@@ -145,7 +145,7 @@ function TracingQueries(props: { api: Client }) {
     if (queryResult.error) {
       elements = { Error: [queryResult.error, 200] };
     } else {
-      elements = { Trace: [queryResult.trace_output, 400] };
+      elements = { Trace: [queryResult, 400] };
     }
     return tracingOutput(elements);
   }
@@ -169,7 +169,14 @@ function TracingQueries(props: { api: Client }) {
               </div>
             );
           } else if (title === "Trace") {
-            return heirarchicalTraceDisplay(title, value);
+            return (
+                <div>
+                    <br />
+                    <b>Number of rows in result set:</b> {value.num_rows_result}
+                    <br />
+                    {heirarchicalTraceDisplay(title, value.trace_output)}
+                </div>
+            );
           }
         })}
       </>

--- a/snuba/admin/static/tracing/index.tsx
+++ b/snuba/admin/static/tracing/index.tsx
@@ -117,6 +117,8 @@ function TracingQueries(props: { api: Client }) {
         const tracing_result = {
           input_query: `${query.sql}`,
           timestamp: result.timestamp,
+          num_rows: result.num_rows_result,
+          cols: result.cols,
           trace_output: result.trace_output,
           error: result.error,
         };

--- a/snuba/admin/static/tracing/types.tsx
+++ b/snuba/admin/static/tracing/types.tsx
@@ -7,6 +7,8 @@ type TracingResult = {
   input_query?: string;
   timestamp: number;
   trace_output?: string;
+  cols?: Array<Array<string>>;
+  num_rows_result?: number;
   error?: string;
 };
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -350,7 +350,9 @@ def clickhouse_trace_query() -> Response:
     try:
         result = run_query_and_get_trace(storage, raw_sql)
         trace_output = result.trace_output
-        return make_response(jsonify({"trace_output": trace_output}), 200)
+        return make_response(
+            jsonify({"trace_output": trace_output, "cols": len(result.results)}), 200
+        )
     except InvalidCustomQuery as err:
         return make_response(
             jsonify(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -23,7 +23,7 @@ from snuba.admin.clickhouse.predefined_querylog_queries import QuerylogQuery
 from snuba.admin.clickhouse.predefined_system_queries import SystemQuery
 from snuba.admin.clickhouse.querylog import describe_querylog_schema, run_querylog_query
 from snuba.admin.clickhouse.system_queries import run_system_query_on_host_with_sql
-from snuba.admin.clickhouse.tracing import run_query_and_get_trace
+from snuba.admin.clickhouse.tracing import TraceOutput, run_query_and_get_trace
 from snuba.admin.kafka.topics import get_broker_data
 from snuba.admin.migrations_policies import (
     check_migration_perms,
@@ -349,10 +349,7 @@ def clickhouse_trace_query() -> Response:
 
     try:
         result = run_query_and_get_trace(storage, raw_sql)
-        trace_output = result.trace_output
-        return make_response(
-            jsonify({"trace_output": trace_output, "cols": len(result.results)}), 200
-        )
+        return make_response(jsonify(asdict(result)), 200)
     except InvalidCustomQuery as err:
         return make_response(
             jsonify(

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -23,7 +23,7 @@ from snuba.admin.clickhouse.predefined_querylog_queries import QuerylogQuery
 from snuba.admin.clickhouse.predefined_system_queries import SystemQuery
 from snuba.admin.clickhouse.querylog import describe_querylog_schema, run_querylog_query
 from snuba.admin.clickhouse.system_queries import run_system_query_on_host_with_sql
-from snuba.admin.clickhouse.tracing import TraceOutput, run_query_and_get_trace
+from snuba.admin.clickhouse.tracing import run_query_and_get_trace
 from snuba.admin.kafka.topics import get_broker_data
 from snuba.admin.migrations_policies import (
     check_migration_perms,

--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -186,8 +186,7 @@ class ClickhousePool(object):
                     trace_output = ""
                     if capture_trace:
                         with capture_logging() as buffer:
-                            query_execute()  # In order to avoid exposing PII the results are discarded
-                            result_data = [[], []] if with_column_types else []
+                            result_data = query_execute()
                             trace_output = buffer.getvalue()
                     else:
                         result_data = query_execute()

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -75,8 +75,8 @@ def test_capture_trace() -> None:
     data = clickhouse.execute(
         "SELECT count() FROM errors_local", with_column_types=True, capture_trace=True
     )
-    assert data.results == []
-    assert data.meta == []
+    assert data.results == [(0,)]
+    assert data.meta == [("count()", "UInt64")]
     assert data.trace_output != ""
     assert data.profile is not None
     assert data.profile["elapsed"] > 0


### PR DESCRIPTION
To give more guidance to the product on how much data their queries are returning, it's useful to say how many rows it returns. We can probably add more stuff to this summary as time goes on

![image](https://github.com/getsentry/snuba/assets/3169433/39286d5c-6134-42d3-9c32-ef30adcaa696)
