### PR TITLE
fix(CapMan): Validate Tenant IDs

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 
 from snuba import settings
 from snuba.datasets.storages.storage_key import StorageKey
-from snuba.query.exceptions import InvalidQueryException
 from snuba.state import delete_config as delete_runtime_config
 from snuba.state import get_all_configs as get_all_runtime_configs
 from snuba.state import get_config as get_runtime_config
@@ -576,19 +575,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
         return config
 
-    def __validate_tenant_ids(self, tenant_ids: dict[str, str | int]) -> None:
-        missing = [
-            tenant
-            for tenant in self._required_tenant_types
-            if tenant_ids.get(tenant, None) is None
-        ]
-        if missing:
-            raise InvalidQueryException(
-                f"Tenant ids missing or are None: {', '.join(missing)}"
-            )
-
     def get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
-        self.__validate_tenant_ids(tenant_ids)
         try:
             allowance = self._get_quota_allowance(tenant_ids)
         except Exception:

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 
 from snuba import settings
 from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.exceptions import InvalidQueryException
 from snuba.state import delete_config as delete_runtime_config
 from snuba.state import get_all_configs as get_all_runtime_configs
 from snuba.state import get_config as get_runtime_config
@@ -575,7 +576,19 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
         return config
 
+    def __validate_tenant_ids(self, tenant_ids: dict[str, str | int]) -> None:
+        missing = [
+            tenant
+            for tenant in self._required_tenant_types
+            if tenant_ids.get(tenant, None) is None
+        ]
+        if missing:
+            raise InvalidQueryException(
+                f"Tenant ids missing or are None: {', '.join(missing)}"
+            )
+
     def get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+        self.__validate_tenant_ids(tenant_ids)
         try:
             allowance = self._get_quota_allowance(tenant_ids)
         except Exception:

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -122,14 +122,15 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
     def _are_tenant_ids_valid(
         self, tenant_ids: dict[str, str | int]
     ) -> tuple[bool, str]:
-        if "referrer" not in tenant_ids:
+        if tenant_ids.get("referrer") is None:
             return False, "no referrer"
         if (
-            "organization_id" not in tenant_ids
+            tenant_ids.get("organization_id") is None
             and tenant_ids.get("referrer", None) not in _ORG_LESS_REFERRERS
             and tenant_ids.get("referrer", None) not in _SINGLE_THREAD_REFERRERS
         ):
             return False, f"no organization_id for referrer {tenant_ids['referrer']}"
+
         return True, ""
 
     def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -711,7 +711,7 @@ def db_query(
                         --> execute_query_with_readthrough_caching
                             ### READTHROUGH CACHE GOES HERE ###
                                 --> execute_query_with_rate_limits
-                                    --> execue_query
+                                    --> execute_query
 
         The implication is that if a user hits the cache they will not be rate limited because the
         request will simply be cached. That is the behavior at time of writing (28-03-2023) but there


### PR DESCRIPTION
### Overview
- Queries with bad Tenant IDs are showing up as errors in Sentry
- We should start rejecting these queries
- Modified existing validation to check for `None`s
