### PR TITLE
ref(capman): remove extended allocation policies

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -229,7 +229,7 @@ schema:
     - date
   not_deleted_mandatory_condition: deleted
 allocation_policy:
-  name: ErrorsAllocationPolicy
+  name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
       - organzation_id

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -226,7 +226,7 @@ schema:
   dist_table_name: errors_dist_ro
   not_deleted_mandatory_condition: deleted
 allocation_policy:
-  name: ErrorsAllocationPolicy
+  name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
       - organzation_id

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -163,9 +163,8 @@ schema:
   partition_format: [retention_days, date]
 
 allocation_policy:
-  name: TransactionsAllocationPolicy
+  name: BytesScannedWindowAllocationPolicy
   args:
-    storage_set_key: transactions
     required_tenant_types:
       - organzation_id
       - referrer

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -4,7 +4,6 @@ import logging
 import time
 from typing import Any
 
-from snuba import environment
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.allocation_policies import (
     DEFAULT_PASSTHROUGH_POLICY,
@@ -19,7 +18,6 @@ from snuba.state.sliding_windows import (
     RedisSlidingWindowRateLimiter,
     RequestedQuota,
 )
-from snuba.utils.metrics.wrapper import MetricsWrapper
 
 logger = logging.getLogger("snuba.query.bytes_scanned_window_policy")
 
@@ -115,10 +113,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             ),
         ]
 
-    @property
-    def metrics(self) -> MetricsWrapper:
-        return MetricsWrapper(environment.metrics, self.__class__.__name__)
-
     def _are_tenant_ids_valid(
         self, tenant_ids: dict[str, str | int]
     ) -> tuple[bool, str]:
@@ -141,8 +135,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             self.metrics.increment(
                 "db_request_rejected",
                 tags={
-                    "storage_key": self._storage_key.value,
-                    "is_enforced": str(self.is_enforced),
                     "referrer": str(tenant_ids.get("referrer", "no_referrer")),
                 },
             )
@@ -190,8 +182,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
                 self.metrics.increment(
                     "db_request_throttled",
                     tags={
-                        "storage_key": self._storage_key.value,
-                        "is_enforced": str(self.is_enforced),
                         "referrer": str(tenant_ids.get("referrer", "no_referrer")),
                     },
                 )

--- a/snuba/query/allocation_policies/errors_allocation_policy.py
+++ b/snuba/query/allocation_policies/errors_allocation_policy.py
@@ -1,7 +1,0 @@
-from snuba.query.allocation_policies.bytes_scanned_window_policy import (
-    BytesScannedWindowAllocationPolicy,
-)
-
-
-class ErrorsAllocationPolicy(BytesScannedWindowAllocationPolicy):
-    pass

--- a/snuba/query/allocation_policies/transactions_allocation_policy.py
+++ b/snuba/query/allocation_policies/transactions_allocation_policy.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from snuba.query.allocation_policies.bytes_scanned_window_policy import (
-    BytesScannedWindowAllocationPolicy,
-)
-
-
-class TransactionsAllocationPolicy(BytesScannedWindowAllocationPolicy):
-    pass


### PR DESCRIPTION
The extensions of the BytesScannedWIndowAllocaitonPolicy were stopgap measures to put an allocation policy on the transaction storage. We can now remove that tech debt and reuse the `BytesScannedWindowAllocationPolicy` since the config prefix is decided by the storage key.

**Breaking Changes**

The `metrics` of the allocation policy used to be named the same as the allocation policy class name. That has been changed to always have `allocation_policy` as the name and the rest of the information to be default tags. As a result. The allocation policy dashboard will have to be fixed after this PR is merged