### PR TITLE
feat: Add command name to transaction name

### DIFF
--- a/snuba/cli/__init__.py
+++ b/snuba/cli/__init__.py
@@ -47,7 +47,7 @@ class SnubaCLI(click.MultiCommand):
         # since all of our infrastructure depends on this being the
         # case
         with sentry_sdk.start_transaction(
-            op="snuba_init", name="Snuba CLI Initialization", sampled=True
+            op="snuba_init", name=f"[cli init] {name}", sampled=True
         ):
             actual_command_name = name.replace("-", "_")
             ns: dict[str, click.Command] = {}


### PR DESCRIPTION
I think this provide better context in the errors product, where
transaction is noted next to each error title and just reads "CLI
initialization" for many of them.

For measuring performance of the snuba CLI, I _think_ it makes sense to
measure it on a per-command basis but I'm not entirely sure. Perhaps
common initialization time should be split out into its own transaction?
