### PR TITLE
fix(parsing): Update error message for missing datetime column comparison condition

### DIFF
--- a/docs/source/query/overview.rst
+++ b/docs/source/query/overview.rst
@@ -261,7 +261,7 @@ A query validation issue would generally have this format::
     {
         "error": {
             "type": "invalid_query",
-            "message": "missing >= condition on column timestamp for entity events"
+            "message": "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')"
         }
     }
 

--- a/docs/source/query/overview.rst
+++ b/docs/source/query/overview.rst
@@ -261,7 +261,7 @@ A query validation issue would generally have this format::
     {
         "error": {
             "type": "invalid_query",
-            "message": "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')"
+            "message": "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')"
         }
     }
 

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1297,11 +1297,11 @@ def _align_max_days_date_align(
     )
     if not lower:
         raise ParsingException(
-            f"missing >= condition on column {entity.required_time_column} for entity {key.value}"
+            f"missing >= condition with a datetime literal on column {entity.required_time_column} for entity {key.value}"
         )
     elif not upper:
         raise ParsingException(
-            f"missing < condition on column {entity.required_time_column} for entity {key.value}"
+            f"missing < condition with a datetime literal on column {entity.required_time_column} for entity {key.value}"
         )
 
     from_date, from_exp = lower

--- a/snuba/query/snql/parser.py
+++ b/snuba/query/snql/parser.py
@@ -1297,11 +1297,13 @@ def _align_max_days_date_align(
     )
     if not lower:
         raise ParsingException(
-            f"missing >= condition with a datetime literal on column {entity.required_time_column} for entity {key.value}"
+            f"Missing >= condition with a datetime literal on column {entity.required_time_column} for entity {key.value}. "
+            f"Example: {entity.required_time_column} >= toDateTime('2023-05-16 00:00')"
         )
     elif not upper:
         raise ParsingException(
-            f"missing < condition with a datetime literal on column {entity.required_time_column} for entity {key.value}"
+            f"Missing < condition with a datetime literal on column {entity.required_time_column} for entity {key.value}. "
+            f"Example: {entity.required_time_column} < toDateTime('2023-05-16 00:00')"
         )
 
     from_date, from_exp = lower

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -41,22 +41,22 @@ test_cases = [
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c",
-        "missing >= condition on column timestamp for entity events",
+        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="simple query missing required conditions",
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = '1' AND e.timestamp >= toDateTime('2021-01-01') AND e.timestamp <= toDateTime('2021-01-02')",
-        "missing < condition on column timestamp for entity events",
+        "Missing < condition with a datetime literal on column timestamp for entity discover. Example: timestamp < toDateTime('2023-05-16 00:00')",
         id="simple query required conditions have wrong type",
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = 1",
-        "missing >= condition on column timestamp for entity events",
+        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="simple query missing some required conditions",
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c",
-        "missing >= condition on column timestamp for entity events",
+        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="join missing required conditions on both sides",
     ),
     pytest.param(
@@ -66,12 +66,12 @@ test_cases = [
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = 1 AND t.finish_ts > toDateTime('2021-01-01') ",
-        "missing >= condition on column timestamp for entity events",
+        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="join missing some required conditions on both sides",
     ),
     pytest.param(
         "MATCH { MATCH (events) SELECT count() AS count BY title } SELECT max(count) AS max_count",
-        "missing >= condition on column timestamp for entity events",
+        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="subquery missing required conditions",
     ),
     pytest.param(

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -61,7 +61,7 @@ test_cases = [
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = 1 AND e.timestamp >= toDateTime('2021-01-01') AND e.timestamp < toDateTime('2021-01-02')",
-        "missing >= condition on column finish_ts for entity transactions",
+        "Missing >= condition with a datetime literal on column finish_ts for entity transactions. Example: finish_ts >= toDateTime('2023-05-16 00:00')",
         id="join missing required conditions on one side",
     ),
     pytest.param(

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -41,22 +41,22 @@ test_cases = [
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c",
-        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
+        "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="simple query missing required conditions",
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = '1' AND e.timestamp >= toDateTime('2021-01-01') AND e.timestamp <= toDateTime('2021-01-02')",
-        "Missing < condition with a datetime literal on column timestamp for entity discover. Example: timestamp < toDateTime('2023-05-16 00:00')",
+        "Missing < condition with a datetime literal on column timestamp for entity events. Example: timestamp < toDateTime('2023-05-16 00:00')",
         id="simple query required conditions have wrong type",
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = 1",
-        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
+        "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="simple query missing some required conditions",
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c",
-        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
+        "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="join missing required conditions on both sides",
     ),
     pytest.param(
@@ -66,12 +66,12 @@ test_cases = [
     ),
     pytest.param(
         "MATCH (e: events) -[contains]-> (t: transactions) SELECT 4-5, e.c WHERE e.project_id = 1 AND t.finish_ts > toDateTime('2021-01-01') ",
-        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
+        "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="join missing some required conditions on both sides",
     ),
     pytest.param(
         "MATCH { MATCH (events) SELECT count() AS count BY title } SELECT max(count) AS max_count",
-        "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')",
+        "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')",
         id="subquery missing required conditions",
     ),
     pytest.param(

--- a/tests/query/test_query_validation.py
+++ b/tests/query/test_query_validation.py
@@ -14,7 +14,9 @@ test_cases = [
         SELECT event_id
         WHERE timestamp LIKE 'carbonara'
         """,
-        ParsingException("missing >= condition on column timestamp for entity events"),
+        ParsingException(
+            "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')"
+        ),
         id="Invalid LIKE param",
     ),
     pytest.param(

--- a/tests/query/test_query_validation.py
+++ b/tests/query/test_query_validation.py
@@ -15,7 +15,7 @@ test_cases = [
         WHERE timestamp LIKE 'carbonara'
         """,
         ParsingException(
-            "Missing >= condition with a datetime literal on column timestamp for entity discover. Example: timestamp >= toDateTime('2023-05-16 00:00')"
+            "Missing >= condition with a datetime literal on column timestamp for entity events. Example: timestamp >= toDateTime('2023-05-16 00:00')"
         ),
         id="Invalid LIKE param",
     ),


### PR DESCRIPTION
Currently, if a query is sent in which a required datetime column is compared to a string literal instead of a datetime literal, the error message that is returned is misleading. This new error message should make it more clear that the datetime column needs to be compared with a datetime literal.