### PR TITLE
fix(capman): create auditlog notifications for allocation policy updates

### DIFF
--- a/snuba/admin/audit_log/action.py
+++ b/snuba/admin/audit_log/action.py
@@ -13,6 +13,8 @@ class AuditLogAction(Enum):
     REVERSED_MIGRATION_COMPLETED = "reversed.migration.completed"
     RAN_MIGRATION_FAILED = "ran.migration.failed"
     REVERSED_MIGRATION_FAILED = "reversed.migration.failed"
+    ALLOCATION_POLICY_UPDATE = "allocation_policy.update"
+    ALLOCATION_POLICY_DELETE = "allocation_policy.update"
 
 
 RUNTIME_CONFIG_ACTIONS = [
@@ -28,4 +30,9 @@ MIGRATION_ACTIONS = [
     AuditLogAction.REVERSED_MIGRATION_COMPLETED,
     AuditLogAction.RAN_MIGRATION_FAILED,
     AuditLogAction.REVERSED_MIGRATION_FAILED,
+]
+
+ALLOCATION_POLICY_ACTIONS = [
+    AuditLogAction.ALLOCATION_POLICY_DELETE,
+    AuditLogAction.ALLOCATION_POLICY_UPDATE,
 ]

--- a/snuba/admin/audit_log/action.py
+++ b/snuba/admin/audit_log/action.py
@@ -14,7 +14,7 @@ class AuditLogAction(Enum):
     RAN_MIGRATION_FAILED = "ran.migration.failed"
     REVERSED_MIGRATION_FAILED = "reversed.migration.failed"
     ALLOCATION_POLICY_UPDATE = "allocation_policy.update"
-    ALLOCATION_POLICY_DELETE = "allocation_policy.update"
+    ALLOCATION_POLICY_DELETE = "allocation_policy.delete"
 
 
 RUNTIME_CONFIG_ACTIONS = [

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -716,33 +716,19 @@ def snql_to_sql() -> Response:
 @application.route("/allocation_policies")
 @check_tool_perms(tools=[AdminTools.CAPACITY_MANAGEMENT])
 def allocation_policies() -> Response:
-    try:
-        return Response(
-            json.dumps(get_allocation_policies()),
-            200,
-            {"Content-Type": "application/json"},
-        )
-    except Exception as exception:
-        return Response(
-            json.dumps({"error": str(exception)}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
+    return Response(
+        json.dumps(get_allocation_policies()),
+        200,
+        {"Content-Type": "application/json"},
+    )
 
 
 @application.route("/allocation_policy_configs/<path:storage>", methods=["GET"])
 @check_tool_perms(tools=[AdminTools.CAPACITY_MANAGEMENT])
 def get_allocation_policy_configs(storage: str) -> Response:
-    try:
-        policy = get_storage(StorageKey(storage)).get_allocation_policy()
-        configs = policy.get_current_configs()
-        return Response(json.dumps(configs), 200, {"Content-Type": "application/json"})
-    except Exception as exception:
-        return Response(
-            json.dumps({"error": str(exception)}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
+    policy = get_storage(StorageKey(storage)).get_allocation_policy()
+    configs = policy.get_current_configs()
+    return Response(json.dumps(configs), 200, {"Content-Type": "application/json"})
 
 
 @application.route(
@@ -751,18 +737,11 @@ def get_allocation_policy_configs(storage: str) -> Response:
 )
 @check_tool_perms(tools=[AdminTools.CAPACITY_MANAGEMENT])
 def get_allocation_policy_optional_config_definitions(storage: str) -> Response:
-    try:
-        policy = get_storage(StorageKey(storage)).get_allocation_policy()
-        config_definitions = policy.get_optional_config_definitions_json()
-        return Response(
-            json.dumps(config_definitions), 200, {"Content-Type": "application/json"}
-        )
-    except Exception as exception:
-        return Response(
-            json.dumps({"error": str(exception)}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
+    policy = get_storage(StorageKey(storage)).get_allocation_policy()
+    config_definitions = policy.get_optional_config_definitions_json()
+    return Response(
+        json.dumps(config_definitions), 200, {"Content-Type": "application/json"}
+    )
 
 
 @application.route("/allocation_policy_config", methods=["POST", "DELETE"])
@@ -789,29 +768,28 @@ def set_allocation_policy_config() -> Response:
             400,
             {"Content-Type": "application/json"},
         )
-    except Exception as exception:
-        return Response(
-            json.dumps({"error": str(exception)}, indent=4),
-            400,
-            {"Content-Type": "application/json"},
-        )
 
     if request.method == "DELETE":
-        try:
-            policy.delete_config_value(config_key=key, params=params, user=user)
-            return Response("", 200)
-        except Exception as exception:
-            return Response(
-                json.dumps({"error": str(exception)}, indent=4),
-                400,
-                {"Content-Type": "application/json"},
-            )
-    else:
+        policy.delete_config_value(config_key=key, params=params, user=user)
+        audit_log.record(
+            user or "",
+            AuditLogAction.ALLOCATION_POLICY_DELETE,
+            {"storage": storage, "key": key},
+            notify=True,
+        )
+        return Response("", 200)
+    elif request.method == "POST":
         try:
             value = data["value"]
             assert isinstance(value, str), "Invalid value"
             policy.set_config_value(
                 config_key=key, value=value, params=params, user=user
+            )
+            audit_log.record(
+                user or "",
+                AuditLogAction.ALLOCATION_POLICY_UPDATE,
+                {"storage": storage, "key": key, "value": value, "params": str(params)},
+                notify=True,
             )
             return Response("", 200)
         except (KeyError, AssertionError) as exc:
@@ -820,9 +798,9 @@ def set_allocation_policy_config() -> Response:
                 400,
                 {"Content-Type": "application/json"},
             )
-        except Exception as exception:
-            return Response(
-                json.dumps({"error": str(exception)}, indent=4),
-                400,
-                {"Content-Type": "application/json"},
-            )
+    else:
+        return Response(
+            json.dumps({"error": "Method not allowed"}),
+            405,
+            {"Content-Type": "application/json"},
+        )

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -479,10 +479,6 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
 
     try:
         result = parse_and_run_query(dataset, request, timer)
-        import pdb
-
-        pdb.set_trace()
-        print(result)
     except QueryException as exception:
         status = 500
         details: Mapping[str, Any]

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -479,6 +479,10 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
 
     try:
         result = parse_and_run_query(dataset, request, timer)
+        import pdb
+
+        pdb.set_trace()
+        print(result)
     except QueryException as exception:
         status = 500
         details: Mapping[str, Any]

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -368,7 +369,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
     # and deleting the config afterwards
     auditlog_records = []
 
-    def mock_record(user, action, data, notify) -> None:
+    def mock_record(user: Any, action: Any, data: Any, notify: Any) -> None:
         nonlocal auditlog_records
         auditlog_records.append((user, action, data, notify))
 

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -368,7 +368,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
     # and deleting the config afterwards
     auditlog_records = []
 
-    def mock_record(user, action, data, notify):
+    def mock_record(user, action, data, notify) -> None:
         nonlocal auditlog_records
         auditlog_records.append((user, action, data, notify))
 


### PR DESCRIPTION
Changes to the allocation policy were not being published to the auditlog or the slack feed. This should fix that.

Also:

* Removes unnecessary `try/catch (Exception)`s
* Adds an allocation policy API test