### PR TITLE
feat(schema-validation): Validate all messages 😱

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -492,7 +492,7 @@ def process_message(
 ) -> Union[None, BytesInsertBatch, ReplacementBatch]:
 
     validate_sample_rate = float(
-        state.get_config(f"validate_schema_{snuba_logical_topic.name}", 0) or 0.0
+        state.get_config(f"validate_schema_{snuba_logical_topic.name}", 1.0) or 0.0
     )
 
     assert isinstance(message.value, BrokerValue)


### PR DESCRIPTION
Validate every message for which we have a schema by default

Schema validation can still be turned off or the rate turned down via config. But the default is now to validate 100% of messages. We have been running this way on many topics for a few months already.