### PR TITLE
feat(clickhouse-settings): Add ability to override clickhouse query settings via query processor

### DIFF
--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Optional, Sequence
+from typing import Any, MutableMapping, Optional, Sequence
 
 from snuba.query.query_settings import QuerySettings
 from snuba.state.quota import ResourceQuota
@@ -71,3 +71,9 @@ class RateLimiterDelegate(QuerySettings):
 
     def set_resource_quota(self, quota: ResourceQuota) -> None:
         self.__delegate.set_resource_quota(quota)
+
+    def get_clickhouse_settings(self) -> MutableMapping[str, Any]:
+        return self.__delegate.get_clickhouse_settings()
+
+    def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
+        return self.__delegate.set_clickhouse_settings(settings)

--- a/snuba/query/processors/physical/clickhouse_settings_override.py
+++ b/snuba/query/processors/physical/clickhouse_settings_override.py
@@ -1,0 +1,17 @@
+from typing import Any, MutableMapping
+
+from snuba.clickhouse.query import Query
+from snuba.query.processors.physical import ClickhouseQueryProcessor
+from snuba.query.query_settings import QuerySettings
+
+
+class ClickhouseSettingsOverride(ClickhouseQueryProcessor):
+    """
+    Overrides arbitrary clickhouse settings via a dictionary specifying the clickhouse settings to override.
+    """
+
+    def __init__(self, settings: MutableMapping[str, Any]) -> None:
+        self.__settings = settings
+
+    def process_query(self, query: Query, query_settings: QuerySettings) -> None:
+        query_settings.set_clickhouse_settings(self.__settings)

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional, Sequence
+from typing import Any, List, MutableMapping, Optional, Sequence
 
 from snuba.state.quota import ResourceQuota
 from snuba.state.rate_limit import RateLimitParameters
@@ -52,6 +52,14 @@ class QuerySettings(ABC):
     def set_resource_quota(self, quota: ResourceQuota) -> None:
         pass
 
+    @abstractmethod
+    def get_clickhouse_settings(self) -> MutableMapping[str, Any]:
+        pass
+
+    @abstractmethod
+    def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
+        pass
+
 
 # TODO: I don't like that there are two different classes for the same thing
 # this could probably be replaces with a `source` attribute on the class
@@ -80,6 +88,7 @@ class HTTPQuerySettings(QuerySettings):
         self.__legacy = legacy
         self.__rate_limit_params: List[RateLimitParameters] = []
         self.__resource_quota: Optional[ResourceQuota] = None
+        self.__clickhouse_settings: MutableMapping[str, Any] = {}
         self.referrer = referrer
 
     def get_turbo(self) -> bool:
@@ -108,6 +117,12 @@ class HTTPQuerySettings(QuerySettings):
 
     def set_resource_quota(self, quota: ResourceQuota) -> None:
         self.__resource_quota = quota
+
+    def get_clickhouse_settings(self) -> MutableMapping[str, Any]:
+        return self.__clickhouse_settings
+
+    def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
+        self.__clickhouse_settings = settings
 
 
 class SubscriptionQuerySettings(QuerySettings):
@@ -164,4 +179,10 @@ class SubscriptionQuerySettings(QuerySettings):
         return None
 
     def set_resource_quota(self, quota: ResourceQuota) -> None:
+        pass
+
+    def get_clickhouse_settings(self) -> MutableMapping[str, Any]:
+        return {}
+
+    def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         pass

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -144,6 +144,7 @@ class SubscriptionQuerySettings(QuerySettings):
         self.__feature = feature
         self.__app_id = app_id
         self.referrer = referrer
+        self.__clickhouse_settings: MutableMapping[str, Any] = {}
 
     def get_turbo(self) -> bool:
         return False
@@ -182,7 +183,7 @@ class SubscriptionQuerySettings(QuerySettings):
         pass
 
     def get_clickhouse_settings(self) -> MutableMapping[str, Any]:
-        return {}
+        return self.__clickhouse_settings
 
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
-        pass
+        self.__clickhouse_settings = settings

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -179,6 +179,9 @@ def execute_query(
     """
     Execute a query and return a result.
     """
+    # Apply clickhouse query setting overrides
+    clickhouse_query_settings = query_settings.get_clickhouse_settings()
+
     # Force query to use the first shard replica, which
     # should have synchronously received any cluster writes
     # before this query is run.

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -180,7 +180,7 @@ def execute_query(
     Execute a query and return a result.
     """
     # Apply clickhouse query setting overrides
-    clickhouse_query_settings = query_settings.get_clickhouse_settings()
+    clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
 
     # Force query to use the first shard replica, which
     # should have synchronously received any cluster writes

--- a/tests/query/processors/test_clickhouse_settings_override.py
+++ b/tests/query/processors/test_clickhouse_settings_override.py
@@ -1,0 +1,56 @@
+from typing import Any, MutableMapping
+
+import pytest
+
+from snuba.clickhouse.columns import ColumnSet, DateTime
+from snuba.clickhouse.columns import SchemaModifiers as Modifiers
+from snuba.clickhouse.columns import String
+from snuba.clickhouse.query import Query
+from snuba.query import SelectedExpression
+from snuba.query.data_source.simple import Table
+from snuba.query.expressions import Column, FunctionCall
+from snuba.query.processors.physical.clickhouse_settings_override import (
+    ClickhouseSettingsOverride,
+)
+from snuba.query.query_settings import HTTPQuerySettings
+
+tests = [
+    pytest.param({}),
+    pytest.param(
+        {
+            "max_rows_to_group_by": 1000000,
+            "group_by_overflow_mode": "any",
+        }
+    ),
+]
+
+
+@pytest.mark.parametrize("clickhouse_settings", tests)
+@pytest.mark.redis_db
+def test_apply_clickhouse_settings(
+    clickhouse_settings: MutableMapping[str, Any]
+) -> None:
+    query = Query(
+        Table(
+            "discover",
+            ColumnSet(
+                [
+                    ("timestamp", DateTime()),
+                    ("mismatched1", String(Modifiers(nullable=True))),
+                    ("mismatched2", String(Modifiers(nullable=True))),
+                ]
+            ),
+        ),
+        selected_columns=[
+            SelectedExpression(
+                name="_snuba_count_unique_sdk_version",
+                expression=FunctionCall(
+                    None, "uniq", (Column(None, None, "mismatched1"),)
+                ),
+            )
+        ],
+    )
+    settings = HTTPQuerySettings()
+
+    ClickhouseSettingsOverride(clickhouse_settings).process_query(query, settings)
+    assert settings.get_clickhouse_settings() == clickhouse_settings

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -424,3 +424,47 @@ def test_allocation_policy_updates_quota() -> None:
     with pytest.raises(QueryException) as e:
         _run_query()
     assert isinstance(e.value.__cause__, AllocationPolicyViolation)
+
+
+@pytest.mark.redis_db
+def test_clickhouse_settings_applied_to_query() -> None:
+    query, storage, attribution_info = _build_test_query("count(distinct(project_id))")
+
+    query_metadata_list: list[ClickhouseQueryMetadata] = []
+    stats: dict[str, Any] = {}
+
+    settings = HTTPQuerySettings()
+    clickhouse_settings = {
+        "max_rows_to_group_by": 1000000,
+        "group_by_overflow_mode": "any",
+    }
+    settings.set_clickhouse_settings(clickhouse_settings)
+
+    reader = mock.MagicMock()
+    result = mock.MagicMock()
+    reader.execute.return_value = result
+    result.get.return_value.get.return_value = 0
+
+    db_query(
+        clickhouse_query=query,
+        query_settings=settings,
+        attribution_info=attribution_info,
+        dataset_name="events",
+        query_metadata_list=query_metadata_list,
+        formatted_query=format_query(query),
+        reader=reader,
+        timer=Timer("foo"),
+        stats=stats,
+        trace_id="trace_id",
+        robust=False,
+    )
+
+    clickhouse_settings_used = reader.execute.call_args.args[1]
+    assert (
+        "max_rows_to_group_by" in clickhouse_settings_used
+        and clickhouse_settings_used["max_rows_to_group_by"] == 1000000
+    )
+    assert (
+        "group_by_overflow_mode" in clickhouse_settings_used
+        and clickhouse_settings_used["group_by_overflow_mode"] == "any"
+    )


### PR DESCRIPTION
This allows custom clickhouse query settings to be specified in the dataset config through a physical query processor.