### PR TITLE
ref(consumer): pass sentry_received_timestamp again

### DIFF
--- a/snuba/datasets/processors/generic_metrics_processor.py
+++ b/snuba/datasets/processors/generic_metrics_processor.py
@@ -141,7 +141,13 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
                 GRANULARITY_ONE_DAY,
             ],
         }
-        return InsertBatch([processed], None)
+        return InsertBatch(
+            [processed],
+            None,
+            sentry_received_timestamp=datetime.utcfromtimestamp(
+                message["sentry_received_timestamp"]
+            ),
+        )
 
 
 class GenericSetsMetricsProcessor(GenericMetricsBucketProcessor):

--- a/snuba/datasets/processors/generic_metrics_processor.py
+++ b/snuba/datasets/processors/generic_metrics_processor.py
@@ -141,12 +141,14 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
                 GRANULARITY_ONE_DAY,
             ],
         }
+        sentry_received_timestamp = None
+        if message.get("sentry_received_timestamp"):
+            sentry_received_timestamp = datetime.utcfromtimestamp(
+                message["sentry_received_timestamp"]
+            )
+
         return InsertBatch(
-            [processed],
-            None,
-            sentry_received_timestamp=datetime.utcfromtimestamp(
-                message.get("sentry_received_timestamp")
-            ),
+            [processed], None, sentry_received_timestamp=sentry_received_timestamp
         )
 
 

--- a/snuba/datasets/processors/generic_metrics_processor.py
+++ b/snuba/datasets/processors/generic_metrics_processor.py
@@ -145,7 +145,7 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
             [processed],
             None,
             sentry_received_timestamp=datetime.utcfromtimestamp(
-                message["sentry_received_timestamp"]
+                message.get("sentry_received_timestamp")
             ),
         )
 

--- a/snuba/datasets/processors/metrics_aggregate_processor.py
+++ b/snuba/datasets/processors/metrics_aggregate_processor.py
@@ -99,12 +99,14 @@ class MetricsAggregateProcessor(DatasetMessageProcessor, ABC):
             }
             for granularity in self.GRANULARITIES_SECONDS
         ]
+        sentry_received_timestamp = None
+        if message.get("sentry_received_timestamp"):
+            sentry_received_timestamp = datetime.utcfromtimestamp(
+                message["sentry_received_timestamp"]
+            )
+
         return AggregateInsertBatch(
-            processed,
-            None,
-            sentry_received_timestamp=datetime.utcfromtimestamp(
-                message.get("sentry_received_timestamp")
-            ),
+            processed, None, sentry_received_timestamp=sentry_received_timestamp
         )
 
 

--- a/snuba/datasets/processors/metrics_aggregate_processor.py
+++ b/snuba/datasets/processors/metrics_aggregate_processor.py
@@ -99,7 +99,13 @@ class MetricsAggregateProcessor(DatasetMessageProcessor, ABC):
             }
             for granularity in self.GRANULARITIES_SECONDS
         ]
-        return AggregateInsertBatch(processed, None)
+        return AggregateInsertBatch(
+            processed,
+            None,
+            sentry_received_timestamp=datetime.utcfromtimestamp(
+                message["sentry_received_timestamp"]
+            ),
+        )
 
 
 class SetsAggregateProcessor(MetricsAggregateProcessor):

--- a/snuba/datasets/processors/metrics_aggregate_processor.py
+++ b/snuba/datasets/processors/metrics_aggregate_processor.py
@@ -103,7 +103,7 @@ class MetricsAggregateProcessor(DatasetMessageProcessor, ABC):
             processed,
             None,
             sentry_received_timestamp=datetime.utcfromtimestamp(
-                message["sentry_received_timestamp"]
+                message.get("sentry_received_timestamp")
             ),
         )
 

--- a/snuba/datasets/processors/metrics_bucket_processor.py
+++ b/snuba/datasets/processors/metrics_bucket_processor.py
@@ -113,7 +113,13 @@ class MetricsBucketProcessor(DatasetMessageProcessor, ABC):
             "partition": metadata.partition,
             "offset": metadata.offset,
         }
-        return InsertBatch([processed], None)
+        return InsertBatch(
+            [processed],
+            None,
+            sentry_received_timestamp=datetime.utcfromtimestamp(
+                message["sentry_received_timestamp"]
+            ),
+        )
 
 
 class SetsMetricsProcessor(MetricsBucketProcessor):

--- a/snuba/datasets/processors/metrics_bucket_processor.py
+++ b/snuba/datasets/processors/metrics_bucket_processor.py
@@ -117,7 +117,7 @@ class MetricsBucketProcessor(DatasetMessageProcessor, ABC):
             [processed],
             None,
             sentry_received_timestamp=datetime.utcfromtimestamp(
-                message["sentry_received_timestamp"]
+                message.get("sentry_received_timestamp")
             ),
         )
 

--- a/snuba/datasets/processors/metrics_bucket_processor.py
+++ b/snuba/datasets/processors/metrics_bucket_processor.py
@@ -113,12 +113,14 @@ class MetricsBucketProcessor(DatasetMessageProcessor, ABC):
             "partition": metadata.partition,
             "offset": metadata.offset,
         }
+        sentry_received_timestamp = None
+        if message.get("sentry_received_timestamp"):
+            sentry_received_timestamp = datetime.utcfromtimestamp(
+                message["sentry_received_timestamp"]
+            )
+
         return InsertBatch(
-            [processed],
-            None,
-            sentry_received_timestamp=datetime.utcfromtimestamp(
-                message.get("sentry_received_timestamp")
-            ),
+            [processed], None, sentry_received_timestamp=sentry_received_timestamp
         )
 
 

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -35,6 +35,7 @@ NIL_UUID = "00000000-0000-0000-0000-000000000000"
 class InsertBatch(NamedTuple):
     rows: Sequence[WriterTableRow]
     origin_timestamp: Optional[datetime]
+    sentry_received_timestamp: Optional[datetime] = None
 
 
 # Indicates that we need an encoder that will interpolate

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -236,6 +236,7 @@ def test_metrics_writing_e2e() -> None:
             "tags": {"6": 91, "9": 134, "4": 117, "5": 7},
             "metric_id": 8,
             "retention_days": 90,
+            "sentry_received_timestamp": datetime.now().timestamp(),
         }
     )
 

--- a/tests/test_generic_metrics_api.py
+++ b/tests/test_generic_metrics_api.py
@@ -99,6 +99,7 @@ class TestGenericMetricsApiSets(BaseApiTest):
         self.project_id = 2
         self.metric_id = 3
         self.base_time = utc_yesterday_12_15()
+        self.sentry_received_timestamp = utc_yesterday_12_15()
         self.default_tags = SHARED_TAGS
         self.mapping_meta = SHARED_MAPPING_META
         self.unique_values = 5
@@ -135,6 +136,8 @@ class TestGenericMetricsApiSets(BaseApiTest):
                     "retention_days": RETENTION_DAYS,
                     "mapping_meta": mapping_meta,
                     "use_case_id": self.use_case_id,
+                    "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                    + n,
                 },
                 KafkaMessageMetadata(0, 0, self.base_time),
             )
@@ -260,6 +263,7 @@ class TestGenericMetricsApiDistributions(BaseApiTest):
         self.project_id = 2
         self.metric_id = 3
         self.base_time = utc_yesterday_12_15()
+        self.sentry_received_timestamp = utc_yesterday_12_15()
         self.default_tags = SHARED_TAGS
         self.mapping_meta = SHARED_MAPPING_META
 
@@ -300,6 +304,8 @@ class TestGenericMetricsApiDistributions(BaseApiTest):
                     "retention_days": RETENTION_DAYS,
                     "mapping_meta": self.mapping_meta,
                     "use_case_id": self.use_case_id,
+                    "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                    + n,
                 },
                 KafkaMessageMetadata(0, 0, self.base_time),
             )
@@ -413,6 +419,7 @@ class TestGenericMetricsApiCounters(BaseApiTest):
         self.project_id = 2
         self.metric_id = 3
         self.base_time = utc_yesterday_12_15()
+        self.sentry_received_timestamp = utc_yesterday_12_15()
         self.default_tags = SHARED_TAGS
         self.mapping_meta = SHARED_MAPPING_META
 
@@ -444,6 +451,8 @@ class TestGenericMetricsApiCounters(BaseApiTest):
                     "retention_days": RETENTION_DAYS,
                     "mapping_meta": self.mapping_meta,
                     "use_case_id": self.use_case_id,
+                    "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                    + n,
                 },
                 KafkaMessageMetadata(0, 0, self.base_time),
             )
@@ -510,6 +519,7 @@ class TestOrgGenericMetricsApiCounters(BaseApiTest):
 
         self.count = 3600
         self.base_time = utc_yesterday_12_15()
+        self.sentry_received_timestamp = utc_yesterday_12_15()
 
         self.start_time = self.base_time
         self.end_time = (
@@ -552,6 +562,8 @@ class TestOrgGenericMetricsApiCounters(BaseApiTest):
                                 "retention_days": RETENTION_DAYS,
                                 "mapping_meta": self.mapping_meta,
                                 "use_case_id": self.use_case_id,
+                                "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                                + n,
                             }
                         ),
                         KafkaMessageMetadata(0, 0, self.base_time),

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -77,6 +77,7 @@ class TestMetricsApiCounters(BaseApiTest):
         self.skew = timedelta(seconds=self.seconds)
 
         self.base_time = utc_yesterday_12_15()
+        self.sentry_received_time = utc_yesterday_12_15() - timedelta(minutes=1)
         self.storage = cast(
             WritableTableStorage,
             get_entity(EntityKey.METRICS_COUNTERS).get_writable_storage(),
@@ -107,6 +108,8 @@ class TestMetricsApiCounters(BaseApiTest):
                                 "tags": self.default_tags,
                                 "metric_id": self.metric_id,
                                 "retention_days": RETENTION_DAYS,
+                                "sentry_received_timestamp": self.sentry_received_time.timestamp()
+                                + n,
                             }
                         ),
                         KafkaMessageMetadata(0, 0, self.base_time),
@@ -226,6 +229,9 @@ class TestOrgMetricsApiCounters(BaseApiTest):
         self.base_time = datetime.utcnow().replace(
             minute=0, second=0, microsecond=0, tzinfo=pytz.utc
         )
+        self.sentry_received_timestamp = datetime.utcnow().replace(
+            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+        )
         self.storage = cast(
             WritableTableStorage,
             get_entity(EntityKey.METRICS_COUNTERS).get_writable_storage(),
@@ -256,6 +262,8 @@ class TestOrgMetricsApiCounters(BaseApiTest):
                                     "timestamp": self.base_time.timestamp() + n,
                                     "metric_id": self.metric_id,
                                     "retention_days": RETENTION_DAYS,
+                                    "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                                    + n,
                                 }
                             ),
                             KafkaMessageMetadata(0, 0, self.base_time),
@@ -368,6 +376,9 @@ class TestMetricsApiSets(BaseApiTest):
         self.skew = timedelta(seconds=self.seconds)
 
         self.base_time = utc_yesterday_12_15() - timedelta(minutes=self.seconds)
+        self.sentry_received_timestamp = utc_yesterday_12_15() - timedelta(
+            minutes=self.seconds
+        )
         self.storage = cast(
             WritableTableStorage,
             get_entity(EntityKey.METRICS_SETS).get_writable_storage(),
@@ -393,6 +404,8 @@ class TestMetricsApiSets(BaseApiTest):
                     "tags": self.default_tags,
                     "metric_id": self.metric_id,
                     "retention_days": RETENTION_DAYS,
+                    "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                    + n,
                 }
 
                 processed = processor.process_message(
@@ -467,6 +480,9 @@ class TestMetricsApiDistributions(BaseApiTest):
         self.skew = timedelta(seconds=self.seconds)
 
         self.base_time = utc_yesterday_12_15() - timedelta(seconds=self.seconds)
+        self.sentry_received_timestamp = utc_yesterday_12_15() - timedelta(
+            seconds=self.seconds
+        )
         self.storage = cast(
             WritableTableStorage,
             get_entity(EntityKey.METRICS_DISTRIBUTIONS).get_writable_storage(),
@@ -492,6 +508,8 @@ class TestMetricsApiDistributions(BaseApiTest):
                     "tags": self.default_tags,
                     "metric_id": self.metric_id,
                     "retention_days": RETENTION_DAYS,
+                    "sentry_received_timestamp": self.sentry_received_timestamp.timestamp()
+                    + n,
                 }
 
                 processed = processor.process_message(


### PR DESCRIPTION
Same as https://github.com/getsentry/snuba/pull/4052 (which got reverted in https://github.com/getsentry/snuba/commit/0d1b0cfa4540e99ff6689e529961eb6d2fb8a3b4 because sentry didn't for some reason have the previous changes that fixed the tests) Fixed tests were re-added in https://github.com/getsentry/sentry/pull/49348