### PR TITLE
feat(capman): Allow overriding policy defaults in configuration

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -234,6 +234,10 @@ allocation_policy:
     required_tenant_types:
       - organzation_id
       - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -231,6 +231,10 @@ allocation_policy:
     required_tenant_types:
       - organzation_id
       - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 10000000
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -168,6 +168,10 @@ allocation_policy:
     required_tenant_types:
       - organzation_id
       - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 100000
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -315,7 +315,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         self,
         storage_key: StorageKey,
         required_tenant_types: list[str],
-        default_config_overrides: dict[str, Any] = {},
+        default_config_overrides: dict[str, Any],
         **kwargs: str,
     ) -> None:
         self._required_tenant_types = set(required_tenant_types)
@@ -701,6 +701,7 @@ class PassthroughPolicy(AllocationPolicy):
 DEFAULT_PASSTHROUGH_POLICY = PassthroughPolicy(
     StorageKey("default.no_storage_key"),
     required_tenant_types=[],
+    default_config_overrides={},
 )
 
 import_submodules_in_directory(

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -407,7 +407,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
     def __get_overridden_additional_config_defaults(
         self, default_config_overrides: dict[str, Any]
     ) -> list[AllocationPolicyConfig]:
-        """overrides the defaults specified for the config in code with the default specifed
+        """overrides the defaults specified for the config in code with the default specified
         to the instance of the policy
         """
         definitions = self._additional_config_definitions()

--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -233,7 +233,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         >>> def _get_quota_allowance(...) -> QuotaAllowance:
         >>>     if self.__get_current_qps() < self.get_config_value("qps_limit"):
         >>>         return QuotaAllowance(can_run=True, ...)
-        >>>     return QuotaAllowance(Changes to the allocation policy were not being published to the auditlog or the slack feed. This should fix that.
+        >>>     return QuotaAllowance(can_run=False, ...)
         >>>
         >>> def _update_quota_balance(...) -> None:
         >>>     self.__add_query_hit()

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -4,7 +4,6 @@ import logging
 import time
 from typing import Any
 
-from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.allocation_policies import (
     DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicy,
@@ -81,14 +80,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
 
     WINDOW_SECONDS = 10 * 60
     WINDOW_GRANULARITY_SECONDS = 60
-
-    def __init__(
-        self,
-        storage_key: StorageKey,
-        required_tenant_types: list[str],
-        **kwargs: str,
-    ) -> None:
-        super().__init__(storage_key, required_tenant_types)
 
     def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
         return [

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -296,5 +296,31 @@ def test_get_current_configs(policy: AllocationPolicy) -> None:
     } in policy_configs
 
 
-def test_default_config_override():
-    policy = SomeParametrizedConfigPolicy(StorageKey("some_storage"), [], {"my_param_config": 420})
+@pytest.mark.redis_db
+def test_default_config_override() -> None:
+    policy = SomeParametrizedConfigPolicy(
+        StorageKey("some_storage"), [], {"my_param_config": 420, "is_enforced": 0}
+    )
+    assert (
+        policy.get_config_value(
+            "my_param_config", params={"org": 1, "ref": "a"}, validate=True
+        )
+        == 420
+    )
+    assert policy.get_config_value("is_enforced") == 0
+
+
+@pytest.mark.redis_db
+def test_bad_defaults() -> None:
+    with pytest.raises(ValueError):
+        SomeParametrizedConfigPolicy(
+            StorageKey("some_storage"), [], {"is_enforced": "0"}
+        )
+    with pytest.raises(ValueError):
+        SomeParametrizedConfigPolicy(
+            StorageKey("some_storage"), [], {"is_active": False}
+        )
+    with pytest.raises(ValueError):
+        SomeParametrizedConfigPolicy(
+            StorageKey("some_storage"), [], {"my_param_config": False}
+        )

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -294,3 +294,7 @@ def test_get_current_configs(policy: AllocationPolicy) -> None:
         "value": 100,
         "params": {"org": 10, "ref": "test"},
     } in policy_configs
+
+
+def test_default_config_override():
+    policy = SomeParametrizedConfigPolicy(StorageKey("some_storage"), [], {"my_param_config": 420})

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -25,6 +25,7 @@ def policy() -> AllocationPolicy:
     policy = BytesScannedWindowAllocationPolicy(
         storage_key=StorageKey("errors"),
         required_tenant_types=["referrer", "organization_id"],
+        default_config_overrides={},
     )
     return policy
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1254,7 +1254,7 @@ class TestSnQLApi(BaseApiTest):
         with patch(
             "snuba.web.db_query._get_allocation_policy",
             return_value=RejectAllocationPolicy123(
-                StorageKey("doesntmatter"), ["a", "b", "c"]
+                StorageKey("doesntmatter"), ["a", "b", "c"], {}
             ),
         ):
             response = self.post(

--- a/tests/web/test__get_allocation_policy.py
+++ b/tests/web/test__get_allocation_policy.py
@@ -29,7 +29,7 @@ events_table_name = events_storage.get_table_writer().get_schema().get_table_nam
 events_table = Table(
     events_table_name,
     events_storage.get_schema().get_columns(),
-    allocation_policy=PassthroughPolicy(StorageKey("flimflam"), []),
+    allocation_policy=PassthroughPolicy(StorageKey("flimflam"), [], {}),
     final=False,
     sampling_rate=None,
     mandatory_conditions=events_storage.get_schema()
@@ -84,7 +84,7 @@ join_query = CompositeQuery(
     [
         pytest.param(
             composite_query,
-            PassthroughPolicy(StorageKey("flimflam"), []),
+            PassthroughPolicy(StorageKey("flimflam"), [], {}),
             id="composite query uses leaf query's allocation policy",
         ),
         pytest.param(
@@ -99,7 +99,7 @@ join_query = CompositeQuery(
                     ),
                 ],
             ),
-            PassthroughPolicy(StorageKey("flimflam"), []),
+            PassthroughPolicy(StorageKey("flimflam"), [], {}),
             id="double nested composite query uses leaf query's allocation policy",
         ),
         pytest.param(
@@ -120,7 +120,7 @@ join_query = CompositeQuery(
                     Literal(None, datetime(2020, 1, 1, 12, 0)),
                 ),
             ),
-            PassthroughPolicy(StorageKey("flimflam"), []),
+            PassthroughPolicy(StorageKey("flimflam"), [], {}),
             id="simple query uses table's allocation policy",
         ),
     ],

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -285,7 +285,7 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
     with mock.patch(
         "snuba.web.db_query._get_allocation_policy",
         return_value=RejectAllocationPolicy(
-            StorageKey("doesntmatter"), ["a", "b", "c"]
+            StorageKey("doesntmatter"), ["a", "b", "c"], {}
         ),
     ):
         query_metadata_list: list[ClickhouseQueryMetadata] = []
@@ -341,7 +341,7 @@ def test_allocation_policy_threads_applied_to_query() -> None:
 
     query, storage, attribution_info = _build_test_query(
         "count(distinct(project_id))",
-        ThreadLimitPolicy(StorageKey("doesntmatter"), ["a", "b", "c"]),
+        ThreadLimitPolicy(StorageKey("doesntmatter"), ["a", "b", "c"], {}),
     )
 
     query_metadata_list: list[ClickhouseQueryMetadata] = []
@@ -398,7 +398,7 @@ def test_allocation_policy_updates_quota() -> None:
 
     query, storage, attribution_info = _build_test_query(
         "count(distinct(project_id))",
-        CountQueryPolicy(StorageKey("doesntmatter"), ["a", "b", "c"]),
+        CountQueryPolicy(StorageKey("doesntmatter"), ["a", "b", "c"], {}),
     )
 
     def _run_query() -> None:


### PR DESCRIPTION
### Context

Currently, a policy has configured defaults and whenever it is reused, those defaults are used as well. That runs into a problem when the policy is used across two storages with different needs (for example, the `org_bytes_scanned_limit` default is different for errors vs transactions.

### This PR:

* Allows for the policy defaults to be overridden at instantiation
* inputs the existing defaults we have in production into configuration
* adds validation to catch mistyped defaults on AllocationPolicyConfig(s)