### PR TITLE
feat(spans): Add profile_id column to spans table

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -318,4 +318,5 @@ class SpansLoader(DirectoryLoader):
         return [
             "0001_spans_v1",
             "0002_spans_add_tags_hashmap",
+            "0003_spans_add_profile_id",
         ]

--- a/snuba/snuba_migrations/spans/0003_spans_add_profile_id.py
+++ b/snuba/snuba_migrations/spans/0003_spans_add_profile_id.py
@@ -1,0 +1,58 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+from snuba.utils.schemas import UUID
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Add the profile_id column to the spans table
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "profile_id",
+                    UUID(Modifiers(nullable=True)),
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "profile_id",
+                    UUID(Modifiers(nullable=True)),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="profile_id",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="profile_id",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
Added the profile id column to the spans table. Since the profile id column needs to be grouped upon and be used in finding profiles on the profiles cluster, defining it as a separate column to have the query be faster
