### PR TITLE
Fix slack notifications for when allocation policy changes

### DIFF
--- a/snuba/admin/audit_log/base.py
+++ b/snuba/admin/audit_log/base.py
@@ -31,7 +31,7 @@ class AuditLog:
             timestamp=timestamp,
             **data,
         )
+        blocks = build_blocks(data, action, timestamp, user)
+        payload: MutableMapping[str, Any] = {"blocks": blocks}
         if notify and self.client.is_configured:
-            blocks = build_blocks(data, action, timestamp, user)
-            payload: MutableMapping[str, Any] = {"blocks": blocks}
             self.client.post_message(message=payload)

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List, Optional, Union
 
 from snuba import settings
 from snuba.admin.audit_log.action import (
+    ALLOCATION_POLICY_ACTIONS,
     MIGRATION_ACTIONS,
     RUNTIME_CONFIG_ACTIONS,
-    ALLOCATION_POLICY_ACTIONS,
     AuditLogAction,
 )
 
@@ -17,7 +17,7 @@ def build_blocks(
     elif action in MIGRATION_ACTIONS:
         text = build_migration_run_text(data, action)
     elif action in ALLOCATION_POLICY_ACTIONS:
-        text = build_migration_run_text(data, action)
+        text = build_allocation_policy_changed_text(data, action)
     else:
         text = f"{action.value}: {data}"
 
@@ -27,6 +27,23 @@ def build_blocks(
     }
 
     return [section, build_context(user, timestamp, action)]
+
+
+def build_allocation_policy_changed_text(
+    data: Any, action: AuditLogAction
+) -> Optional[str]:
+    base = f"*Storage {data['storage']} Allocation Policy Changed:*"
+
+    if action == AuditLogAction.ALLOCATION_POLICY_DELETE:
+        removed = f"~```'{data['key']}({data.get('params', {})})'```~"
+        return f"{base} :put_litter_in_its_place:\n\n{removed}"
+    elif action == AuditLogAction.ALLOCATION_POLICY_UPDATE:
+        updated = f"```'{data['key']}({data.get('params', {})})' = '{data['value']}'```"
+        return f"{base} :up: :date:\n\n{updated}"
+    else:
+        # todo: raise error, cause slack won't accept this
+        # if it is none
+        return f"{action.value}: {data}"
 
 
 def build_runtime_config_text(data: Any, action: AuditLogAction) -> Optional[str]:

--- a/snuba/admin/notifications/slack/utils.py
+++ b/snuba/admin/notifications/slack/utils.py
@@ -4,6 +4,7 @@ from snuba import settings
 from snuba.admin.audit_log.action import (
     MIGRATION_ACTIONS,
     RUNTIME_CONFIG_ACTIONS,
+    ALLOCATION_POLICY_ACTIONS,
     AuditLogAction,
 )
 
@@ -15,8 +16,10 @@ def build_blocks(
         text = build_runtime_config_text(data, action)
     elif action in MIGRATION_ACTIONS:
         text = build_migration_run_text(data, action)
+    elif action in ALLOCATION_POLICY_ACTIONS:
+        text = build_migration_run_text(data, action)
     else:
-        text = action.value
+        text = f"{action.value}: {data}"
 
     section = {
         "type": "section",

--- a/tests/admin/notifications/test_build_blocks.py
+++ b/tests/admin/notifications/test_build_blocks.py
@@ -45,5 +45,4 @@ def test_build_blocks(
         datetime.now().isoformat(),
         "ninja",
     )
-    print(res[0]["text"]["text"])
     assert res[0]["text"]["text"] == expected

--- a/tests/admin/notifications/test_build_blocks.py
+++ b/tests/admin/notifications/test_build_blocks.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+from snuba.admin.audit_log.action import AuditLogAction
+from snuba.admin.notifications.slack.utils import build_blocks
+
+
+@pytest.mark.parametrize(
+    "data,action,expected",
+    [
+        pytest.param(
+            {
+                "storage": "errors",
+                "key": "org_limit_bytes_scanned_override",
+                "value": "420",
+                "params": "{'org_id': 1}",
+            },
+            AuditLogAction.ALLOCATION_POLICY_UPDATE,
+            """*Storage errors Allocation Policy Changed:* :up: :date:\n\n```'org_limit_bytes_scanned_override({'org_id': 1})' = '420'```""",
+            id="Allocation policy update",
+        ),
+        pytest.param(
+            {
+                "storage": "errors",
+                "key": "org_limit_bytes_scanned_override",
+                "params": "{'org_id': 1}",
+            },
+            AuditLogAction.ALLOCATION_POLICY_DELETE,
+            """*Storage errors Allocation Policy Changed:* :put_litter_in_its_place:\n\n~```'org_limit_bytes_scanned_override({'org_id': 1})'```~""",
+            id="Allocation policy delete",
+        ),
+    ],
+)
+def test_build_blocks(
+    data: dict[str, Any], action: AuditLogAction, expected: str
+) -> None:
+
+    res = build_blocks(
+        data,
+        action,
+        datetime.now().isoformat(),
+        "ninja",
+    )
+    print(res[0]["text"]["text"])
+    assert res[0]["text"]["text"] == expected

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -388,6 +388,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
 
         assert response.status_code == 200, response.json
         # make sure an auditlog entry was recorded
+        print(auditlog_records)
         assert auditlog_records.pop()
         response = admin_api.get("/allocation_policy_configs/errors")
         assert response.status_code == 200
@@ -427,5 +428,6 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
             "type": "int",
             "value": 420,
         } not in response.json  # type: ignore
+        print(auditlog_records)
         # make sure an auditlog entry was recorded
         assert auditlog_records.pop()

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -388,7 +388,6 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
 
         assert response.status_code == 200, response.json
         # make sure an auditlog entry was recorded
-        print(auditlog_records)
         assert auditlog_records.pop()
         response = admin_api.get("/allocation_policy_configs/errors")
         assert response.status_code == 200
@@ -428,6 +427,5 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
             "type": "int",
             "value": 420,
         } not in response.json  # type: ignore
-        print(auditlog_records)
         # make sure an auditlog entry was recorded
         assert auditlog_records.pop()


### PR DESCRIPTION
Current message does not tell us what change fix it and also fix the default behavior to be less useless. Add tests for slack message generation

![image](https://github.com/getsentry/snuba/assets/3169433/4d705b63-e567-498f-8d31-b9f725a6c92d)
