### PR TITLE
fix: Fix attribution producer

### DIFF
--- a/snuba/attribution/log.py
+++ b/snuba/attribution/log.py
@@ -11,9 +11,7 @@ from confluent_kafka import Producer
 from snuba import settings
 from snuba.attribution import logger, metrics
 from snuba.state import safe_dumps
-from snuba.utils.streams.configuration_builder import (
-    build_default_kafka_producer_configuration,
-)
+from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
 from snuba.utils.streams.topics import Topic
 
 from .appid import AppID
@@ -72,7 +70,7 @@ def _attribution_producer() -> Producer:
     global kfk
 
     if kfk is None:
-        kfk = Producer(build_default_kafka_producer_configuration())
+        kfk = Producer(build_kafka_producer_configuration(Topic.ATTRIBUTION, None))
 
     return kfk
 

--- a/snuba/utils/streams/configuration_builder.py
+++ b/snuba/utils/streams/configuration_builder.py
@@ -76,7 +76,3 @@ def build_kafka_producer_configuration(
         override_params=override_params,
     )
     return broker_config
-
-
-def build_default_kafka_producer_configuration() -> KafkaBrokerConfig:
-    return build_kafka_producer_configuration(None, None)


### PR DESCRIPTION
The attribution producer should use the config specified for that topic, not assume the default configuration applies.
