### PR TITLE
fix: Querylog producer

### DIFF
--- a/snuba/state/__init__.py
+++ b/snuba/state/__init__.py
@@ -57,7 +57,7 @@ def _kafka_producer() -> Producer:
     if kfk is None:
         kfk = Producer(
             build_kafka_producer_configuration(
-                topic=None,
+                topic=Topic.QUERYLOG,
                 override_params={
                     # at time of writing (2022-05-09) lz4 was chosen because it
                     # compresses quickly. If more compression is needed at the cost of


### PR DESCRIPTION
Similar to https://github.com/getsentry/snuba/pull/4218

Uses the configuration defined on the querylog topic, rather than assuming default
