### PR TITLE
feat: Default join timeout for all consumers of 5 seconds

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -116,7 +116,7 @@ logger = logging.getLogger(__name__)
     "--output-block-size",
     type=int,
 )
-@click.option("--join-timeout", type=int, help="Join timeout in seconds.")
+@click.option("--join-timeout", type=int, help="Join timeout in seconds.", default=5)
 @click.option(
     "--profile-path", type=click.Path(dir_okay=True, file_okay=False, exists=True)
 )
@@ -144,8 +144,8 @@ def consumer(
     processes: Optional[int],
     input_block_size: Optional[int],
     output_block_size: Optional[int],
+    join_timeout: int = 5,
     log_level: Optional[str] = None,
-    join_timeout: Optional[int] = None,
     profile_path: Optional[str] = None,
     max_poll_interval_ms: Optional[int] = None,
 ) -> None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -69,9 +69,9 @@ class ConsumerBuilder:
         max_batch_time_ms: int,
         metrics: MetricsBackend,
         slice_id: Optional[int],
+        join_timeout: int,
         stats_callback: Optional[Callable[[str], None]] = None,
         commit_retry_policy: Optional[RetryPolicy] = None,
-        join_timeout: Optional[int] = None,
         profile_path: Optional[str] = None,
         max_poll_interval_ms: Optional[int] = None,
     ) -> None:

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -61,6 +61,7 @@ consumer_builder = ConsumerBuilder(
         tags={"group": consumer_group_name, "storage": test_storage_key.value},
     ),
     slice_id=None,
+    join_timeout=5,
 )
 
 optional_consumer_config = resolve_consumer_config(
@@ -104,6 +105,7 @@ consumer_builder_with_opt = ConsumerBuilder(
         tags={"group": consumer_group_name, "storage": test_storage_key.value},
     ),
     slice_id=None,
+    join_timeout=5,
 )
 
 


### PR DESCRIPTION
Previously the default was to wait forever, however this causes problems with rebalancing. 5 seconds is probably a better default. Any partially processed messages that aren't done in this time will be picked up again when the partition is reassigned.

Note this currently doesn't get applied to the HTTP write step since that has it's own timeout set here: https://github.com/getsentry/snuba/blob/e3565b26f9d34a4142bb081c445732f16b7be67b/snuba/clickhouse/http.py#L344