### PR TITLE
feat(spans): Extract information from span data

### DIFF
--- a/snuba/datasets/processors/spans_processor.py
+++ b/snuba/datasets/processors/spans_processor.py
@@ -6,7 +6,6 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, Mapping, MutableMapping, MutableSequence, Optional, Tuple
 
-import sqlparse
 from sentry_relay.consts import SPAN_STATUS_NAME_TO_CODE
 
 from snuba import environment, state
@@ -51,33 +50,13 @@ def is_project_in_allowlist(project_id: int) -> bool:
     return False
 
 
-def parse_query(query: Any, is_savepoint: bool) -> str:
+def clean_span_tags(tags: Mapping[str, Any]) -> MutableMapping[str, Any]:
     """
-    TODO: This is a temporary solution to extract some useful data from spans until we have a proper
-          mechanism of upstream sending us the data we need.
+    A lot of metadata regarding spans is sent in spans.data. We do not want to store everything
+    as tags in clickhouse. This method allows only a few pre defined keys to be stored as tags.
     """
-    result = ""
-    for token in query:
-        if isinstance(token, sqlparse.sql.Where):
-            result += parse_query(token, is_savepoint)
-        elif isinstance(token, sqlparse.sql.Parenthesis):
-            if token.value == "(%s)":
-                result += "(...)"
-                continue
-            result += parse_query(token, is_savepoint)
-        elif isinstance(token, sqlparse.sql.Comparison):
-            result += parse_query(token, is_savepoint)
-        elif isinstance(token, sqlparse.sql.IdentifierList) and "%s" in token.value:
-            result += "..."
-        elif (
-            isinstance(token, sqlparse.sql.Identifier)
-            and is_savepoint
-            and token.value.upper() != "RELEASE"
-        ):
-            result += "{savepoint identifier}"
-        else:
-            result += token.value
-    return result
+    allowed_keys = {"environment", "release", "user"}
+    return {k: v for k, v in tags.items() if k in allowed_keys}
 
 
 class SpansMessageProcessor(DatasetMessageProcessor):
@@ -87,12 +66,6 @@ class SpansMessageProcessor(DatasetMessageProcessor):
     The initial version of this processor is able to read existing data
     from the transactions topic and de-normalize it into the spans table.
     """
-
-    # Tags which need to be pushed down to each individual span
-    PUSH_DOWN_TAGS = {
-        "environment",
-        "release",
-    }
 
     def __extract_timestamp(self, field: int) -> Tuple[datetime, int]:
         # We are purposely using a naive datetime here to work with the rest of the codebase.
@@ -166,7 +139,7 @@ class SpansMessageProcessor(DatasetMessageProcessor):
 
         span_hash = transaction_ctx.get("hash", None)
         processed["group"] = 0 if not span_hash else int(span_hash, 16)
-        processed["segment_name"] = common_span_fields["segment_name"] = _unicodify(
+        processed["segment_name"] = _unicodify(
             event_dict["data"].get("transaction") or ""
         )
 
@@ -204,13 +177,12 @@ class SpansMessageProcessor(DatasetMessageProcessor):
         tags: Mapping[str, Any] = _as_dict_safe(event_dict["data"].get("tags", None))
         processed["tags.key"], processed["tags.value"] = extract_extra_tags(tags)
 
-        span_environment = _unicodify(tags.get("environment", ""))
         release = _unicodify(tags.get("sentry:release", event_dict.get("release", "")))
         user = _unicodify(tags.get("sentry:user", ""))
         processed["user"] = user
 
-        common_span_fields["tags.key"] = ["environment", "release", "user"]
-        common_span_fields["tags.value"] = [span_environment, release, user]
+        common_span_fields["tags.key"] = ["release", "user"]
+        common_span_fields["tags.value"] = [release, user]
 
     @staticmethod
     def _process_measurements(
@@ -263,125 +235,37 @@ class SpansMessageProcessor(DatasetMessageProcessor):
         processed_span: MutableMapping[str, Any],
         span_dict: SpanDict,
     ) -> None:
-        """
-        TODO: This is a bit of a hack, but we need to extract some details from spans temporarily
-              until we get proper data from upstream. This code should be removed once we have
-              the proper data flowing through the pipeline.
-        """
+        span_data = span_dict.get("data", None)
         op = span_dict.get("op", "")
         description = span_dict.get("description", "")
-
-        do_application_logic = state.get_config(
-            "spans_process_application_logic", False
-        )
-        if do_application_logic:
-            # Op specific processing
-            if op != "db.redis" and op.startswith("db"):
-                parse_state = None
-                table = ""
-
-                # This is wrong for so many reasons lol, but just something simple to pull some values out
-                raw_parsed = sqlparse.parse(description)[0]
-                processed_span["description"] = parse_query(
-                    raw_parsed, "SAVEPOINT" in description.upper()
-                )
-                parsed = sqlparse.parse(processed_span["description"])[0]
-                operation = None
-                processed_span["op"] = parsed.tokens[0].value
-                for token in parsed.tokens:
-                    if operation is None and token.is_keyword:
-                        operation = token.value
-                        if token.value == "FROM":
-                            operation = "SELECT"
-
-                    if isinstance(token, sqlparse.sql.Comment) or token.is_whitespace:
-                        continue
-                    elif token.is_keyword:
-                        if token.value.lower() == "select":
-                            parse_state = "select"
-                        elif token.value.lower() == "into":
-                            parse_state = "insert"
-                        elif token.value.lower() == "delete from":
-                            parse_state = "delete"
-                        elif token.value.lower() == "update":
-                            parse_state = "update"
-                        elif token.value.lower() == "from":
-                            parse_state = "from"
-                        elif token.value.lower() == "order by":
-                            parse_state = "order"
-                        elif token.value.lower() == "limit":
-                            parse_state = "limit"
-                        else:
-                            parse_state = None
-                    elif isinstance(token, sqlparse.sql.Where):
-                        condition = ""
-                        for t in token.tokens:
-                            if isinstance(t, sqlparse.sql.Comment) or t.is_keyword:
-                                continue
-
-                            condition += t.value
-
-                        processed_span["tags.key"].append("where")
-                        processed_span["tags.value"].append(condition)
-                    else:
-                        if parse_state in {"from", "update", "delete"}:
-                            table = token.value
-                        elif parse_state == "insert":
-                            table = token.value
-                            parse_state = None
-                        elif parse_state == "select":
-                            processed_span["tags.key"].append("columns")
-                            processed_span["tags.value"].append(token.value)
-                        elif parse_state == "limit":
-                            processed_span["tags.key"].append("limit")
-                            processed_span["tags.value"].append(token.value)
-                        elif parse_state == "order":
-                            processed_span["tags.key"].append("order")
-                            processed_span["tags.value"].append(token.value)
-                if isinstance(table, str):
-                    if "select" in table.lower():
-                        table = "join"
-                    domain = table.replace('"', "").strip()
-                    processed_span["domain"] = domain
-                processed_span["op"] = operation.upper() if operation else operation
-                processed_span["module"] = "db"
-                processed_span["platform"] = "postgres"  # Lying for now
-                processed_span["status"] = 0
-            elif op == "db.redis":
-                processed_span["module"] = "cache"
-                parsed = sqlparse.parse(description)[0]
-                operation = None
-                key = None
-                for token in parsed.tokens:
-                    if isinstance(token, sqlparse.sql.Comment) or token.is_whitespace:
-                        continue
-                    elif key is None and ":" in token.value:
-                        key = token.value.replace("'", "")
-                processed_span["op"] = "unknown"
-                processed_span["domain"] = key.split(":")[0] if key else ""
-                processed_span["platform"] = "redis"
-                processed_span["status"] = 0
-            elif op == "http.client":
-                processed_span["module"] = "http"
-                span_dict_data = span_dict.get("data", {})
-                processed_span["op"] = span_dict_data.get("method", "")
-                processed_span["status"] = int(span_dict_data.get("status_code", 0))
-                url = str(span_dict_data.get("url", ""))
-                processed_span["description"] = url
-                if url:
-                    split_url = url.split("/")
-                    processed_span["domain"] = (
-                        split_url[2] if len(split_url) > 2 else ""
-                    )
-            else:
-                processed_span["module"] = "unknown"
-        else:
+        if span_data is None:
+            # In case we have a span without data, we can't do anything about few of the fields.
             processed_span["op"] = op
             processed_span["description"] = description
             processed_span["module"] = "unknown"
-            processed_span["status"] = 0
-            processed_span["platform"] = ""
+            processed_span["span_status"] = 0
             processed_span["domain"] = ""
+            processed_span["platform"] = ""
+            processed_span["action"] = ""
+            processed_span["status"] = 0
+            return
+
+        processed_span["op"] = _unicodify(span_data.get("span.op", op))
+        processed_span["description"] = _unicodify(
+            span_data.get("span.description", description)
+        )
+        processed_span["module"] = _unicodify(span_data.get("span.module", "unknown"))
+        span_status = span_data.get("span.status", None)
+        if span_status:
+            processed_span["span_status"] = SPAN_STATUS_NAME_TO_CODE.get(
+                span_status, UNKNOWN_SPAN_STATUS
+            )
+        else:
+            processed_span["span_status"] = UNKNOWN_SPAN_STATUS
+        processed_span["domain"] = _unicodify(span_data.get("span.domain", ""))
+        processed_span["platform"] = _unicodify(span_data.get("span.platform", ""))
+        processed_span["action"] = _unicodify(span_data.get("span.action", ""))
+        processed_span["status"] = span_data.get("span.status_code", 0)
 
     def _process_span(
         self, span_dict: SpanDict, common_span_fields: CommonSpanDict
@@ -419,10 +303,16 @@ class SpansMessageProcessor(DatasetMessageProcessor):
         ).total_seconds()
         processed_span["duration"] = max(int(duration_secs * 1000), 0)
         processed_span["exclusive_time"] = span_dict.get("exclusive_time", 0)
-        tags: Mapping[str, Any] = _as_dict_safe(span_dict.get("data", None))
-        span_tag_keys, span_tag_values = extract_extra_tags(tags)
-        processed_span["tags.key"].extend(span_tag_keys)
-        processed_span["tags.value"].extend(span_tag_values)
+
+        span_data: Mapping[str, Any] = _as_dict_safe(span_dict.get("data", None))
+        if span_data:
+            processed_span["segment_name"] = _unicodify(
+                span_data.get("transaction", "")
+            )
+            cleaned_tags = clean_span_tags(span_data)
+            span_tag_keys, span_tag_values = extract_extra_tags(cleaned_tags)
+            processed_span["tags.key"].extend(span_tag_keys)
+            processed_span["tags.value"].extend(span_tag_values)
 
         self._process_child_span_module_details(processed_span, span_dict)
 
@@ -430,12 +320,10 @@ class SpansMessageProcessor(DatasetMessageProcessor):
         # setup. Just to be safe, lets setup all required clickhouse columns (which are not
         # nullable) with their default values if they have not been setup yet.
         processed_span["span_kind"] = processed_span.get("span_kind", "")
-        processed_span["span_status"] = processed_span.get("span_status", 0)
         processed_span["measurements.key"] = processed_span.get("measurements.key", [])
         processed_span["measurements.value"] = processed_span.get(
             "measurements.value", []
         )
-        processed_span["module"] = processed_span.get("module", "")
 
         return processed_span
 


### PR DESCRIPTION
Upstream now sends relevant data in `spans.data` field of the payload. Use the information provided in the payload to populate fields in the clickhouse table. With this, we do not need the logic of performing application logic processing anymore in snuba spans consumer so we can get rid of it.

In order to validate that the spans processor is performing valid transformations the PR also adds a test to perform strict validation of the results.
