### PR TITLE
feat(DRS):  Enable migration group readiness states for those not skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,6 @@ jobs:
             -e REDIS_HOST=sentry_redis \
             -e REDIS_PORT=6379 \
             -e REDIS_DB=1 \
-            -e ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES=1 \
             --name sentry_snuba \
             --network sentry \
             snuba-test

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -41,15 +41,12 @@ DIST_TABLE_NAME = "migrations_dist"
 def get_active_migration_groups() -> Sequence[MigrationGroup]:
     groups = []
     for group in MigrationGroup:
-        if group.value in settings.READINESS_STATE_MIGRATION_GROUPS_ENABLED:
+        if not (
+            group in OPTIONAL_GROUPS
+            and group.value in settings.SKIPPED_MIGRATION_GROUPS
+        ):
             readiness_state = get_group_readiness_state(group)
             if readiness_state.value in settings.SUPPORTED_STATES:
-                groups.append(group)
-        else:
-            if not (
-                group in OPTIONAL_GROUPS
-                and group.value in settings.SKIPPED_MIGRATION_GROUPS
-            ):
                 groups.append(group)
     return groups
 

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -41,13 +41,13 @@ DIST_TABLE_NAME = "migrations_dist"
 def get_active_migration_groups() -> Sequence[MigrationGroup]:
     groups = []
     for group in MigrationGroup:
-        if not (
+        if (
             group in OPTIONAL_GROUPS
             and group.value in settings.SKIPPED_MIGRATION_GROUPS
+            or get_group_readiness_state(group).value not in settings.SUPPORTED_STATES
         ):
-            readiness_state = get_group_readiness_state(group)
-            if readiness_state.value in settings.SUPPORTED_STATES:
-                groups.append(group)
+            continue
+        groups.append(group)
     return groups
 
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -244,14 +244,8 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 # The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
 # Migrations for skipped groups will not be run.
 SKIPPED_MIGRATION_GROUPS: Set[str] = {
-    "querylog",
-    "test_migration",
-    "search_issues",
     "spans",
 }
-
-if os.environ.get("ENABLE_AUTORUN_MIGRATION_SEARCH_ISSUES", False):
-    SKIPPED_MIGRATION_GROUPS.remove("search_issues")
 
 if os.environ.get("ENABLE_AUTORUN_MIGRATION_SPANS", False):
     SKIPPED_MIGRATION_GROUPS.remove("spans")

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -374,11 +374,12 @@ def test_get_active_migration_groups(temp_settings: Any) -> None:
         MigrationGroup.SEARCH_ISSUES not in active_groups
     )  # should be skipped by SKIPPED_MIGRATION_GROUPS
 
-    temp_settings.READINESS_STATE_MIGRATION_GROUPS_ENABLED = {"search_issues"}
+    temp_settings.SKIPPED_MIGRATION_GROUPS = {}
+    temp_settings.SUPPORTED_STATES = {}
     active_groups = get_active_migration_groups()
     assert (
-        MigrationGroup.SEARCH_ISSUES in active_groups
-    )  # should be active by readiness_state
+        MigrationGroup.SEARCH_ISSUES not in active_groups
+    )  # should be skipped by readiness_state
 
 
 @pytest.mark.clickhouse_db

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -451,13 +451,14 @@ def test_no_schema_differences() -> None:
 def test_settings_skipped_group() -> None:
     from snuba.migrations import runner
 
-    with patch("snuba.settings.SKIPPED_MIGRATION_GROUPS", {"querylog"}):
-        runner.Runner().run_all(force=True)
+    with patch("snuba.settings.SKIPPED_MIGRATION_GROUPS", {"test_migration"}):
+        with patch("snuba.settings.READINESS_STATE_MIGRATION_GROUPS_ENABLED", {}):
+            runner.Runner().run_all(force=True)
 
     connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
         ClickhouseClientSettings.MIGRATE
     )
-    assert connection.execute("SHOW TABLES LIKE 'querylog_local'").results == []
+    assert connection.execute("SHOW TABLES LIKE 'test_migration_local'").results == []
 
 
 @pytest.mark.clickhouse_db


### PR DESCRIPTION
### Overview
This PR is responsible for enabling readiness_states for all migration groups that are not part of `SKIPPED_MIGRATION_GROUPS` in their respective environments. This [section of this document](https://www.notion.so/sentry/Dataset-Readiness-State-Rollout-Plan-d38deffe77534856a4e4f4a3b0cfb110?pvs=4#479d1451ca8a457e9542fedce8cdf87c) is used to track the roll out.

### What will happen after this is deployed?
* Existing migration groups will now use its `readiness_state` flag to determine whether or not the migration group is skipped in particular sentry environments.

### Blast Radius
The following migration groups will use readiness states for each environment:
* In SaaS: All groups except for `sessions`.
* In S4S: All groups except for `functions`,`profiles`, `querylog`,`search_issues`, `spans`, `test_migration`.
* In self-hosted: All groups except for `sessions`.
* In ST: All groups except for `functions`,`profiles`, `querylog`,`search_issues`, `spans`, `test_migration`.
