### PR TITLE
fix(DRS): Set test_migration group to partial

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -141,7 +141,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.TEST_MIGRATION: _MigrationGroup(
         loader=TestMigrationLoader(),
         storage_sets_keys=set(),
-        readiness_state=ReadinessState.LIMITED,
+        readiness_state=ReadinessState.PARTIAL,
     ),
     MigrationGroup.SEARCH_ISSUES: _MigrationGroup(
         loader=SearchIssuesLoader(),


### PR DESCRIPTION
The `test_migration` group needs to be set to partial because snuba admin (in SaaS) contains an [auth-role](https://github.com/getsentry/snuba/blob/f1774371103e4f368357d31f372f654fd7cee9e4/snuba/admin/auth_roles.py#L161) which accesses this migration group 