### PR TITLE
perf: Make the batch write step faster

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -326,12 +326,6 @@ class ProcessedMessageBatchWriter:
 
             self.__replacement_batch_writer.join(timeout)
 
-        # XXX: This adds a blocking call when each batch is joined. Ideally we would only
-        # call proudcer.flush() when the consumer / strategy is actually being shut down but
-        # the CollectStep that this is called from does not allow us to hook into that easily.
-        if self.__commit_log_config:
-            self.__commit_log_config.producer.flush()
-
 
 json_row_encoder = JSONRowEncoder()
 

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -286,6 +286,9 @@ class ConsumerBuilder:
         if self.replacements_producer:
             self.replacements_producer.flush()
 
+        if self.commit_log_producer:
+            self.commit_log_producer.flush()
+
     def build_base_consumer(self) -> StreamProcessor[KafkaPayload]:
         """
         Builds the consumer.


### PR DESCRIPTION
We don't need to wait for the commit log producer to flush between every batch / message produced. This adds an unnecessary and slow blocking operation to each batch. This change removes the flush between each batch and only calls flush once when the consumer is shutting down.