### PR TITLE
feat(dlq): Add `ExitAfterNMessages` strategy

### DIFF
--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -158,7 +158,6 @@ class ConsumerBuilder:
     def __build_consumer(
         self,
         strategy_factory: ProcessingStrategyFactory[KafkaPayload],
-        slice_id: Optional[int] = None,
     ) -> StreamProcessor[KafkaPayload]:
 
         configuration = build_kafka_consumer_configuration(
@@ -232,7 +231,6 @@ class ConsumerBuilder:
 
     def build_streaming_strategy_factory(
         self,
-        slice_id: Optional[int] = None,
     ) -> ProcessingStrategyFactory[KafkaPayload]:
         table_writer = self.storage.get_table_writer()
         stream_loader = table_writer.get_stream_loader()
@@ -263,7 +261,7 @@ class ConsumerBuilder:
                 metrics=self.metrics,
                 replacements_producer=self.replacements_producer,
                 replacements_topic=self.replacements_topic,
-                slice_id=slice_id,
+                slice_id=self.slice_id,
                 commit_log_config=commit_log_config,
             ),
             max_batch_size=self.max_batch_size,
@@ -293,6 +291,4 @@ class ConsumerBuilder:
         """
         Builds the consumer.
         """
-        return self.__build_consumer(
-            self.build_streaming_strategy_factory(self.slice_id), self.slice_id
-        )
+        return self.__build_consumer(self.build_streaming_strategy_factory())

--- a/snuba/consumers/dlq.py
+++ b/snuba/consumers/dlq.py
@@ -104,8 +104,13 @@ class ExitAfterNMessages(ProcessingStrategy[TPayload]):
         self.__commit = commit
         self.__last_message_time = time.time()
         self.__max_message_timeout = max_message_timeout
+        self.__exiting = False
 
     def __exit(self) -> None:
+        if self.__exiting:
+            return
+
+        self.__exiting = True
         self.__commit({}, force=True)
         logger.info("Processed %d messages", self.__processed_messages)
         signal.raise_signal(signal.SIGINT)

--- a/snuba/consumers/dlq.py
+++ b/snuba/consumers/dlq.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+import logging
+import signal
+import time
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Optional, TypeVar
 
 import rapidjson
+from arroyo.processing.strategies.abstract import ProcessingStrategy
+from arroyo.types import Commit, Message
 
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.redis import RedisClientKey, get_redis_client
 
 redis_client = get_redis_client(RedisClientKey.DLQ)
 DLQ_REDIS_KEY = "dlq_instruction"
+
+
+logger = logging.getLogger(__name__)
 
 
 class DlqPolicy(Enum):
@@ -70,3 +78,56 @@ def clear_instruction() -> None:
 
 def store_instruction(instruction: DlqInstruction) -> None:
     redis_client.set(DLQ_REDIS_KEY, instruction.to_bytes())
+
+
+TPayload = TypeVar("TPayload")
+
+
+class ExitAfterNMessages(ProcessingStrategy[TPayload]):
+    """
+    Commits offsets until N messages is reached, then forces the
+    consumer to terminate. This is used by the DLQ consumer
+    which is expected to process a fixed number of messages requested
+    by the user.
+
+    If max_timeout is hit, the consumer also exits.
+    """
+
+    def __init__(
+        self,
+        commit: Commit,
+        num_messages_to_process: int,
+        max_message_timeout: float,
+    ) -> None:
+        self.__num_messages_to_process = num_messages_to_process
+        self.__processed_messages = 0
+        self.__commit = commit
+        self.__last_message_time = time.time()
+        self.__max_message_timeout = max_message_timeout
+
+    def __exit(self) -> None:
+        self.__commit({}, force=True)
+        logger.info("Processed %d messages", self.__processed_messages)
+        signal.raise_signal(signal.SIGINT)
+
+    def poll(self) -> None:
+        if self.__last_message_time + self.__max_message_timeout < time.time():
+            self.__exit()
+
+        if self.__processed_messages >= self.__num_messages_to_process:
+            self.__exit()
+
+    def submit(self, message: Message[TPayload]) -> None:
+        if self.__processed_messages < self.__num_messages_to_process:
+            self.__last_message_time = time.time()
+            self.__commit(message.committable)
+            self.__processed_messages += 1
+
+    def close(self) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+    def join(self, timeout: Optional[float] = None) -> None:
+        self.__commit({}, force=True)


### PR DESCRIPTION
This is strategy to be used by the DLQ consumer. It processes messages until either a specified number of messages if reached, or if a max timeout is reached between messages. After that point it raises sigint and the consumer will exit.

