### PR TITLE
fix(logs) : use structlog in migrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ sentry-redis-tools==0.1.6
 sentry-relay==0.8.21
 sentry-sdk==1.18.0
 simplejson==3.17.6
-structlog==23.1.0
+structlog==22.3.0
 structlog-sentry==2.0.2
 sql-metadata==2.6.0
 typing-extensions==4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ sentry-relay==0.8.21
 sentry-sdk==1.18.0
 simplejson==3.17.6
 structlog==22.3.0
-structlog-sentry==2.0.2
+structlog-sentry==2.0.0
 sql-metadata==2.6.0
 typing-extensions==4.5.0
 urllib3==1.26.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,8 +30,8 @@ sentry-redis-tools==0.1.6
 sentry-relay==0.8.21
 sentry-sdk==1.18.0
 simplejson==3.17.6
-structlog==22.1.0
-structlog-sentry==2.0.0
+structlog==23.1.0
+structlog-sentry==2.0.2
 sql-metadata==2.6.0
 typing-extensions==4.5.0
 urllib3==1.26.12

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -29,6 +29,7 @@ def list() -> None:
     """
     Lists migrations and their statuses
     """
+    setup_logging()
     check_clickhouse_connections()
     runner = Runner()
     for group, group_migrations in runner.show_all():

--- a/snuba/environment.py
+++ b/snuba/environment.py
@@ -62,6 +62,9 @@ def setup_logging(level: Optional[str] = None) -> None:
         processors=[
             add_severity_attribute,
             structlog.contextvars.merge_contextvars,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
             structlog.processors.TimeStamper(fmt="iso", utc=True),
             SentryProcessor(),
             drop_level,

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -1,8 +1,8 @@
-import logging
 import re
 import time
 from typing import Sequence
 
+import structlog
 from packaging import version
 
 from snuba.clickhouse.native import ClickhousePool
@@ -19,7 +19,7 @@ from snuba.migrations.clickhouse import CLICKHOUSE_SERVER_MIN_VERSION
 from snuba.migrations.errors import InactiveClickhouseReplica, InvalidClickhouseVersion
 from snuba.settings import ENABLE_DEV_FEATURES
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger().bind(module=__name__)
 
 
 def check_clickhouse_connections() -> None:

--- a/snuba/migrations/runner.py
+++ b/snuba/migrations/runner.py
@@ -1,8 +1,8 @@
-import logging
 from datetime import datetime
 from functools import partial
 from typing import List, Mapping, MutableMapping, NamedTuple, Optional, Sequence, Tuple
 
+import structlog
 from clickhouse_driver import errors
 
 from snuba import settings
@@ -32,7 +32,7 @@ from snuba.migrations.migration import ClickhouseNodeMigration, CodeMigration, M
 from snuba.migrations.operations import OperationTarget, SqlOperation
 from snuba.migrations.status import Status
 
-logger = logging.getLogger("snuba.migrations")
+logger = structlog.get_logger().bind(module=__name__)
 
 LOCAL_TABLE_NAME = "migrations_local"
 DIST_TABLE_NAME = "migrations_dist"


### PR DESCRIPTION
## Context

We're trying to improve how we do some of the logging and transition towards using structlog since it works better with GCP. This PR transitions the migrations module to use structlog, eventually we will update the other modules too. There's a bug where string interpolation and tracebacks don't work properly in structlog v22.0 so we bumped it up to v22.3.