### PR TITLE
feat(profiling): Promote profiles and functions to complete

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -117,12 +117,12 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.PROFILES: _MigrationGroup(
         loader=ProfilesLoader(),
         storage_sets_keys={StorageSetKey.PROFILES},
-        readiness_state=ReadinessState.PARTIAL,
+        readiness_state=ReadinessState.COMPLETE,
     ),
     MigrationGroup.FUNCTIONS: _MigrationGroup(
         loader=FunctionsLoader(),
         storage_sets_keys={StorageSetKey.FUNCTIONS},
-        readiness_state=ReadinessState.PARTIAL,
+        readiness_state=ReadinessState.COMPLETE,
     ),
     MigrationGroup.REPLAYS: _MigrationGroup(
         loader=ReplaysLoader(),


### PR DESCRIPTION
### Overview
The PR will enable migrations for the profiles and functions datasets in self-hosted. Since we have migrated to readiness_states this [PR](https://github.com/getsentry/snuba/pull/4195) is now stale. This change required for https://github.com/getsentry/self-hosted/pull/2154.

Note: Setting profiles and functions to `readiness_state: complete` will not allow migrations on single-tenant as these groups still [exist in SKIPPED_MIGRATION_GROUPS](https://github.com/getsentry/ops/blob/f28e6508f0457c7c1788e9e1adf9aaffe71b9e45/single-tenant/k8s/snuba/templates/snuba.conf.py.j2#L83).