### PR TITLE
feat(DRS): Enable readiness state for storages

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -254,8 +254,6 @@ if os.environ.get("ENABLE_AUTORUN_MIGRATION_SPANS", False):
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 # [04-18-2023] These two readiness state settings are temporary and used to facilitate the rollout of readiness states.
 # We expect to remove them after all storages and migration groups have been migrated.
-READINESS_STATE_MIGRATION_GROUPS_ENABLED: set[str] = set()
-READINESS_STATE_STORAGES_ENABLED: set[str] = set()
 READINESS_STATE_FAIL_QUERIES: bool = True
 
 MAX_RESOLUTION_FOR_JITTER = 60

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -131,8 +131,7 @@ def filter_checked_storages(ignore_experimental: bool) -> List[Storage]:
 
     storages: List[Storage] = []
     for entity in entities:
-        entity_storages = entity.get_all_storages()
-        for storage in entity_storages:
+        for storage in entity.get_all_storages():
             if storage.get_readiness_state().value in settings.SUPPORTED_STATES:
                 storages.append(storage)
     return storages

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -57,7 +57,7 @@ from snuba.datasets.factory import (
     get_enabled_dataset_names,
 )
 from snuba.datasets.schemas.tables import TableSchema
-from snuba.datasets.storage import ReadableTableStorage, Storage, StorageNotAvailable
+from snuba.datasets.storage import Storage, StorageNotAvailable
 from snuba.query.allocation_policies import AllocationPolicyViolation
 from snuba.query.exceptions import InvalidQueryException, QueryPlanException
 from snuba.query.query_settings import HTTPQuerySettings
@@ -133,12 +133,7 @@ def filter_checked_storages(ignore_experimental: bool) -> List[Storage]:
     for entity in entities:
         entity_storages = entity.get_all_storages()
         for storage in entity_storages:
-            assert isinstance(storage, ReadableTableStorage)
-            storage_name = storage.get_storage_key().value
-            if storage_name in settings.READINESS_STATE_STORAGES_ENABLED:
-                if storage.get_readiness_state().value in settings.SUPPORTED_STATES:
-                    storages.append(storage)
-            else:
+            if storage.get_readiness_state().value in settings.SUPPORTED_STATES:
                 storages.append(storage)
     return storages
 

--- a/tests/migrations/test_runner.py
+++ b/tests/migrations/test_runner.py
@@ -453,8 +453,7 @@ def test_settings_skipped_group() -> None:
     from snuba.migrations import runner
 
     with patch("snuba.settings.SKIPPED_MIGRATION_GROUPS", {"test_migration"}):
-        with patch("snuba.settings.READINESS_STATE_MIGRATION_GROUPS_ENABLED", {}):
-            runner.Runner().run_all(force=True)
+        runner.Runner().run_all(force=True)
 
     connection = get_cluster(StorageSetKey.MIGRATIONS).get_query_connection(
         ClickhouseClientSettings.MIGRATE

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -14,6 +14,9 @@ from snuba.web.views import check_clickhouse, filter_checked_storages
 
 
 class BadStorage(mock.MagicMock):
+    def get_readiness_state(self) -> ReadinessState:
+        return ReadinessState.DEPRECATE
+
     def get_cluster(self) -> None:
         raise Exception("No cluster")
 

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -151,7 +151,6 @@ def test_filter_checked_storages(
         "partial",
         "complete",
     }  # remove deprecate from supported states
-    temp_settings.READINESS_STATE_STORAGES_ENABLED = {"mock_storage"}
     storages = filter_checked_storages(ignore_experimental=True)
 
     # check experimental dataset's storage is not in list


### PR DESCRIPTION
### Overview
This PR is responsible for enabling readiness_states for all storages. This [section of this document](https://www.notion.so/sentry/Dataset-Readiness-State-Rollout-Plan-d38deffe77534856a4e4f4a3b0cfb110?pvs=4#479d1451ca8a457e9542fedce8cdf87c) is used to track the roll out.

### What will happen after this is deployed?
* Existing storages will use their `readiness_state` flag to determine whether or not to execute clickhouse healthchecks in a particular environment.
* Note the `DISABLED_DATASETS` and `is_experimental` still takes precedence over readiness_states.

### Blast Radius
The following storages will use readiness states for each environment:
* In SaaS: All storages except for `groupassignees`, `groupedmessages`, `search_issues`, `querylog`, `sessions`, `spans`.
* In S4S: All storages except for `functions`, `groupassignees`, `groupedmessages`, `search_issues`, `profiles`, `querylog`, `spans`.
* In Self-hosted: All storages except for `search_issues`, `spans`.
* In ST: All storages except for `functions`, `groupassignees`, `groupedmessages`, `search_issues`, `profiles`, `querylog`, `spans`.

These storages are excluded because they still depend on the `DISABLED_DATASETS` and `is_experimental` flags. Eventually, when we obtain parity across environments, we can migrate the rest off these flags and into readiness states.
