### PR TITLE
config(replays): change group_by_overflow to break

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -162,7 +162,7 @@ query_processors:
     args:
       settings:
         max_rows_to_group_by: 1000000
-        group_by_overflow_mode: any
+        group_by_overflow_mode: break
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 stream_loader:


### PR DESCRIPTION
Still observing memory usage at high volume queries. changing the overflow mode to `break` should fix this. It's possible small numbers of replays could be broken as it will stop all scanning once the key limit is reached, but i think this is a very unlikely edge case, all though will have to verify in production.

Relevant docs: https://clickhouse.com/docs/en/operations/settings/query-complexity