### PR TITLE
feat(CapMan): Most throttled Orgs visibility

### DIFF
--- a/snuba/admin/clickhouse/predefined_querylog_queries.py
+++ b/snuba/admin/clickhouse/predefined_querylog_queries.py
@@ -296,10 +296,10 @@ class MostThrottledOrgs(QuerylogQuery):
     not 10 max threads (ie throttled to 1 thread) for some reason. How many threads ClickHouse would've run the query with given max 10 threads is still unknown."""
 
     sql = """
-    SELECT organization, c_throttled, c_total, divide(c_throttled, c_total) as ratio
+    SELECT organization, throttled_queries, total_queries, divide(throttled_queries, total_queries) as ratio
     FROM
     (
-        SELECT organization, count(*) as c_throttled
+        SELECT organization, count(*) as throttled_queries
         FROM querylog_local
         WHERE
             timestamp > (now() - {{duration}})
@@ -311,7 +311,7 @@ class MostThrottledOrgs(QuerylogQuery):
     AS throttled_orgs
     INNER JOIN
     (
-        SELECT organization, count(*) as c_total
+        SELECT organization, count(*) as total_queries
         FROM querylog_local
         WHERE
             timestamp > (now() - {{duration}})
@@ -331,7 +331,7 @@ class OrgQueryDurationQuantiles(QuerylogQuery):
     sql = """
     SELECT
         organization,
-        sum(c) as c_total,
+        sum(c) as total_queries,
         quantile(0.50)(duration_ms) as p50,
         quantile(0.75)(duration_ms) as p75,
         quantile(0.9)(duration_ms) as p90,


### PR DESCRIPTION
### Overview
- Adding some queries to bring visibility to how Orgs are affected by allocation policies
- Ideally these queries can be used together to gain some insights, modifications may be required depending on what kind of analysis you're doing but they are a decent base

Sample result for past 30 mins of most throttled orgs query:
![image](https://github.com/getsentry/snuba/assets/23463457/9589d47f-e237-498e-8512-dfd4883f760d)

Sample result for past 30 mins of quantiles query:
![image](https://github.com/getsentry/snuba/assets/23463457/5f2a34c5-0c9d-4a57-b04b-02a12f2d7a25)

