### PR TITLE
fix(logs): use structlog for optimize module

### DIFF
--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
@@ -17,6 +16,8 @@ from typing import (
     TypeVar,
 )
 
+import structlog
+
 from snuba import settings
 from snuba.clickhouse.escaping import escape_string
 from snuba.clickhouse.http import HTTPBatchWriter, InsertStatement, JSONRow
@@ -31,7 +32,7 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.serializable_exception import SerializableException
 from snuba.writer import BatchWriter
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger().bind(module=__name__)
 
 
 class ClickhouseClientSettingsType(NamedTuple):


### PR DESCRIPTION
## Context
Were in the process of migrating over the logs to use stuctured logging where possible. This makes them easier to parse in tools like GCP. The plan is to implement this module by module. This PR enables structured logging for the optimize module.