### PR TITLE
ref: Decouple processing batches and clickhouse batches

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -72,13 +72,31 @@ logger = logging.getLogger(__name__)
     "--max-batch-size",
     default=settings.DEFAULT_MAX_BATCH_SIZE,
     type=int,
-    help="Max number of messages to batch in memory before writing to Kafka.",
+    help=(
+        "Max number of messages to batch in memory.\n\n"
+        "Batching parameters apply to three steps: Batching of messages for "
+        "processing them (=transforming them into ClickHouse rows), batching for"
+        "the INSERT statement, and batching of offset commits.\n\n"
+        "Commits are additionally debounced to happen at most once per second."
+    ),
 )
 @click.option(
     "--max-batch-time-ms",
     default=settings.DEFAULT_MAX_BATCH_TIME_MS,
     type=int,
-    help="Max length of time to buffer messages in memory before writing to Kafka.",
+    help="Max duration to buffer messages in memory for.",
+)
+@click.option(
+    "--max-insert-batch-size",
+    default=None,
+    type=int,
+    help="Max number of messages to batch in memory for inserts into ClickHouse. Defaults to --max-batch-size",
+)
+@click.option(
+    "--max-insert-batch-time-ms",
+    default=None,
+    type=int,
+    help="Max duration to batch in memory for inserts into ClickHouse. Defaults to --max-batch-time-ms",
 )
 @click.option(
     "--auto-offset-reset",
@@ -137,6 +155,8 @@ def consumer(
     slice_id: Optional[int],
     max_batch_size: int,
     max_batch_time_ms: int,
+    max_insert_batch_size: Optional[int],
+    max_insert_batch_time_ms: Optional[int],
     auto_offset_reset: str,
     no_strict_offset_reset: bool,
     queued_max_messages_kbytes: int,
@@ -202,6 +222,8 @@ def consumer(
         ),
         max_batch_size=max_batch_size,
         max_batch_time_ms=max_batch_time_ms,
+        max_insert_batch_size=max_insert_batch_size,
+        max_insert_batch_time_ms=max_insert_batch_time_ms,
         metrics=metrics,
         profile_path=profile_path,
         stats_callback=stats_callback,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -10,7 +10,7 @@ from arroyo.backends.kafka import (
     build_kafka_configuration,
     build_kafka_consumer_configuration,
 )
-from arroyo.commit import IMMEDIATE
+from arroyo.commit import ONCE_PER_SECOND
 from arroyo.dlq import DlqLimit, DlqPolicy, KafkaDlqProducer
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategyFactory
@@ -68,6 +68,8 @@ class ConsumerBuilder:
         processing_params: ProcessingParameters,
         max_batch_size: int,
         max_batch_time_ms: int,
+        max_insert_batch_size: Optional[int],
+        max_insert_batch_time_ms: Optional[int],
         metrics: MetricsBackend,
         slice_id: Optional[int],
         join_timeout: int,
@@ -130,6 +132,8 @@ class ConsumerBuilder:
         self.metrics = metrics
         self.max_batch_size = max_batch_size
         self.max_batch_time_ms = max_batch_time_ms
+        self.max_insert_batch_size = max_insert_batch_size
+        self.max_insert_batch_time_ms = max_insert_batch_time_ms
         self.group_id = kafka_params.group_id
         self.auto_offset_reset = kafka_params.auto_offset_reset
         self.strict_offset_reset = kafka_params.strict_offset_reset
@@ -225,7 +229,7 @@ class ConsumerBuilder:
             consumer,
             self.raw_topic,
             strategy_factory,
-            IMMEDIATE,
+            ONCE_PER_SECOND,
             dlq_policy=dlq_policy,
             join_timeout=self.join_timeout,
         )
@@ -267,6 +271,9 @@ class ConsumerBuilder:
             ),
             max_batch_size=self.max_batch_size,
             max_batch_time=self.max_batch_time_ms / 1000.0,
+            max_insert_batch_size=self.max_insert_batch_size,
+            max_insert_batch_time=self.max_insert_batch_time_ms
+            and self.max_insert_batch_time_ms / 1000.0,
             processes=self.processes,
             input_block_size=self.input_block_size,
             output_block_size=self.output_block_size,
@@ -319,6 +326,9 @@ class ConsumerBuilder:
             ),
             max_batch_size=self.max_batch_size,
             max_batch_time=self.max_batch_time_ms / 1000.0,
+            max_insert_batch_size=self.max_insert_batch_size,
+            max_insert_batch_time=self.max_insert_batch_time_ms
+            and self.max_insert_batch_time_ms / 1000.0,
             processes=self.processes,
             input_block_size=self.input_block_size,
             output_block_size=self.output_block_size,

--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -63,6 +63,8 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
         processes: Optional[int],
         input_block_size: Optional[int],
         output_block_size: Optional[int],
+        max_insert_batch_size: Optional[int],
+        max_insert_batch_time: Optional[float],
         # Passed in the case of DLQ consumer which exits after a certain number of messages
         # is processed
         max_messages_to_process: Optional[int] = None,
@@ -75,6 +77,8 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
 
         self.__max_batch_size = max_batch_size
         self.__max_batch_time = max_batch_time
+        self.__max_insert_batch_size = max_insert_batch_size or max_batch_size
+        self.__max_insert_batch_time = max_insert_batch_time or max_batch_time
 
         if processes is not None:
             assert input_block_size is not None, "input block size required"
@@ -121,8 +125,8 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             commit_strategy = CommitOffsets(commit)
 
         collect: Reduce[ProcessedMessage, ProcessedMessageBatchWriter] = Reduce(
-            self.__max_batch_size,
-            self.__max_batch_time,
+            self.__max_insert_batch_size,
+            self.__max_insert_batch_time,
             accumulator,
             self.__collector,
             RunTaskInThreads(

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -681,6 +681,8 @@ if application.debug or application.testing:
                     processes=None,
                     input_block_size=None,
                     output_block_size=None,
+                    max_insert_batch_size=None,
+                    max_insert_batch_time=None,
                 ).create_with_partitions(commit, {})
                 strategy.submit(message)
                 strategy.close()

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -55,6 +55,8 @@ consumer_builder = ConsumerBuilder(
     ),
     max_batch_size=3,
     max_batch_time_ms=4,
+    max_insert_batch_size=None,
+    max_insert_batch_time_ms=None,
     metrics=MetricsWrapper(
         environment.metrics,
         "test_consumer",
@@ -99,6 +101,8 @@ consumer_builder_with_opt = ConsumerBuilder(
     ),
     max_batch_size=3,
     max_batch_time_ms=4,
+    max_insert_batch_size=None,
+    max_insert_batch_time_ms=None,
     metrics=MetricsWrapper(
         environment.metrics,
         "test_consumer",

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -77,6 +77,8 @@ def test_streaming_consumer_strategy() -> None:
         write_step,
         max_batch_size=10,
         max_batch_time=60,
+        max_insert_batch_size=None,
+        max_insert_batch_time=None,
         processes=None,
         input_block_size=None,
         output_block_size=None,


### PR DESCRIPTION
Add two new parameters to be able to control the size of INSERT
statements separately from the size of multiprocessing batches.

Also change commit policy so that committing never happens more than
once per second. Committing is still inherently tied to how the
preceding processing steps batch.
