### PR TITLE
fix: Fix flaky optimize test

### DIFF
--- a/tests/clickhouse/optimize/test_optimize_tracker.py
+++ b/tests/clickhouse/optimize/test_optimize_tracker.py
@@ -83,10 +83,9 @@ def test_optimized_partition_tracker(tracker: OptimizedPartitionTracker) -> None
     assert_partitions(completed={"Partition 1"}, pending={"Partition 2"})
 
     tracker.update_completed_partitions("Partition 2")
-    assert tracker.get_completed_partitions() == {"Partition 1", "Partition 2"}
     # Check that we don't return None but a set whose length is 0 indicating
     # that all optimizations have been run.
-    assert_partitions(pending=set())
+    assert_partitions(completed={"Partition 1", "Partition 2"}, pending=set())
 
     tracker.delete_all_states()
     assert_partitions(all=set(), completed=set())


### PR DESCRIPTION
Apparently we already retry all assertions in this test 10 times, except
this one. ~It's not entirely clear to me why, there's no code comment
indicating why.~ seems like it was simply an oversight: #4217 #4143 