### PR TITLE
fix(subscriptions) Final bypass for subscriptions

### DIFF
--- a/snuba/query/processors/physical/replaced_groups.py
+++ b/snuba/query/processors/physical/replaced_groups.py
@@ -11,7 +11,7 @@ from snuba.clickhouse.query_dsl.accessors import (
 from snuba.query.conditions import not_in_condition
 from snuba.query.expressions import Column, FunctionCall, Literal
 from snuba.query.processors.physical import ClickhouseQueryProcessor
-from snuba.query.query_settings import QuerySettings
+from snuba.query.query_settings import QuerySettings, SubscriptionQuerySettings
 from snuba.replacers.projects_query_flags import ProjectsQueryFlags
 from snuba.replacers.replacer_processor import ReplacerState
 from snuba.state import get_config
@@ -50,6 +50,18 @@ class PostReplacementConsistencyEnforcer(ClickhouseQueryProcessor):
         if project_ids is None:
             self._set_query_final(query, False)
             return
+
+        for no_final_subscriptions_project in (
+            get_config("skip_final_subscriptions_projects") or "[]"
+        )[1:-1].split(","):
+            if (
+                no_final_subscriptions_project
+                and int(no_final_subscriptions_project) in project_ids
+                and isinstance(query_settings, SubscriptionQuerySettings)
+            ):
+                metrics.increment(name="subscriptions_skipped_final")
+                self._set_query_final(query, False)
+                return
 
         for denied_project_id_string in (
             get_config("post_replacement_consistency_projects_denylist") or "[]"


### PR DESCRIPTION
We encountered some subscription queries that, when run in final mode, cause the query to fail with OOM from clickhouse.
This can break the whole subscriptions pipeline. 

As a quick fix, this pr adds a bypass option to turn the final flag off on subscriptions on specific projects.
This can be activated when needed.