### PR TITLE
fix: Ensure subscriptions executor shuts down in 5 seconds

### DIFF
--- a/snuba/subscriptions/executor_consumer.py
+++ b/snuba/subscriptions/executor_consumer.py
@@ -170,6 +170,7 @@ def build_executor_consumer(
             result_topic_spec.topic_name,
         ),
         commit_policy=ONCE_PER_SECOND,
+        join_timeout=5.0,
     )
 
 


### PR DESCRIPTION
This is the same as the default value we applied to consumers here (https://github.com/getsentry/snuba/pull/4222)

