### PR TITLE
feat(oncall): reject search issues queries with bad columns

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -205,7 +205,7 @@ query_processors:
       project_field: project_id
   - processor: BasicFunctionsProcessor
 
-validate_data_model: warn
+validate_data_model: error
 validators:
   - validator: EntityRequiredColumnValidator
     args:


### PR DESCRIPTION
We keep getting alerted for queries with bad columns on search issues. Let's turn on the validator and not make it our problem anymore