### PR TITLE
feat(CapMan): Spans Allocation Policy

### DIFF
--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -77,7 +77,7 @@ allocation_policy:
   name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
-      - organzation_id
+      - organization_id
       - referrer
     default_config_overrides:
       is_enforced: 1

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -73,7 +73,16 @@ schema:
   local_table_name: spans_local
   dist_table_name: spans_dist
   partition_format: [retention_days, date]
-
+allocation_policy:
+  name: BytesScannedWindowAllocationPolicy
+  args:
+    required_tenant_types:
+      - organzation_id
+      - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: UniqInSelectAndHavingProcessor
   - processor: UUIDColumnProcessor

--- a/tests/test_spans_api.py
+++ b/tests/test_spans_api.py
@@ -225,6 +225,7 @@ class TestSpansApi(BaseApiTest):
                     "turbo": False,
                     "consistent": True,
                     "debug": True,
+                    "tenant_ids": {"referrer": "tests", "organization_id": 1},
                 }
             ),
             headers={"referer": "test"},


### PR DESCRIPTION
### Overview
- As part of our effort to add an Allocation Policy to every storage, adding a `BytesScannedWindowPolicy` to the `spans` storage

Sentry testing:
https://github.com/getsentry/sentry/pull/50010