### PR TITLE
feat(CapMan): Outcomes Allocation Policies

### DIFF
--- a/snuba/datasets/configuration/outcomes/storages/hourly.yaml
+++ b/snuba/datasets/configuration/outcomes/storages/hourly.yaml
@@ -20,6 +20,16 @@ schema:
     ]
   local_table_name: outcomes_hourly_local
   dist_table_name: outcomes_hourly_dist
+allocation_policy:
+  name: BytesScannedWindowAllocationPolicy
+  args:
+    required_tenant_types:
+      - organzation_id
+      - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: PrewhereProcessor
     args:

--- a/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
@@ -24,6 +24,16 @@ schema:
     ]
   local_table_name: outcomes_raw_local
   dist_table_name: outcomes_raw_dist
+allocation_policy:
+  name: BytesScannedWindowAllocationPolicy
+  args:
+    required_tenant_types:
+      - organzation_id
+      - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: TableRateLimit
 mandatory_condition_checkers:


### PR DESCRIPTION
### Overview
- As part of our effort to add an Allocation Policy to every storage, adding a `BytesScannedWindowPolicy` to the `outcomes` storages