### PR TITLE
feat(CapMan): GroupedMessages Allocation Policy

### DIFF
--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -45,6 +45,16 @@ default_control_topic: cdc_control
 postgres_table: sentry_groupedmessage
 row_processor:
   processor: GroupedMessageRowProcessor
+allocation_policy:
+  name: BytesScannedWindowAllocationPolicy
+  args:
+    required_tenant_types:
+      - organzation_id
+      - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 10000000
 query_processors:
   - processor: PrewhereProcessor
     args:

--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -49,7 +49,7 @@ allocation_policy:
   name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
-      - organzation_id
+      - organization_id
       - referrer
     default_config_overrides:
       is_enforced: 1

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -615,6 +615,7 @@ V1_CDC_STORAGE_SCHEMA = {
         "query_processors": STORAGE_QUERY_PROCESSORS_SCHEMA,
         "query_splitters": STORAGE_QUERY_SPLITTERS_SCHEMA,
         "mandatory_condition_checkers": STORAGE_MANDATORY_CONDITION_CHECKERS_SCHEMA,
+        "allocation_policy": STORAGE_ALLOCATION_POLICY_SCHEMA,
         "replacer_processor": STORAGE_REPLACER_PROCESSOR_SCHEMA,
         "writer_options": {
             "type": "object",


### PR DESCRIPTION
### Overview
- As part of our effort to add an Allocation Policy to every storage, adding a `BytesScannedWindowPolicy` to the `grouped_messages` storage