### PR TITLE
fix(CapMan): `organzation_id` -> `organization_id`

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -232,7 +232,7 @@ allocation_policy:
   name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
-      - organzation_id
+      - organization_id
       - referrer
     default_config_overrides:
       is_enforced: 1

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -229,7 +229,7 @@ allocation_policy:
   name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
-      - organzation_id
+      - organization_id
       - referrer
     default_config_overrides:
       is_enforced: 1

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -166,7 +166,7 @@ allocation_policy:
   name: BytesScannedWindowAllocationPolicy
   args:
     required_tenant_types:
-      - organzation_id
+      - organization_id
       - referrer
     default_config_overrides:
       is_enforced: 1


### PR DESCRIPTION
### Overview
- Thankfully this doesn't do any validation just yet, but this spelling should still be fixed..