### PR TITLE
Volo/capman/replays policy

### DIFF
--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -172,3 +172,13 @@ stream_loader:
   dlq_policy:
     type: produce
     args: [snuba-dead-letter-replays]
+allocation_policy:
+  name: BytesScannedWindowAllocationPolicy
+  args:
+    required_tenant_types:
+      - organization_id
+      - referrer
+    default_config_overrides:
+      is_enforced: 1
+      throttled_thread_number: 1
+      org_limit_bytes_scanned: 100000

--- a/tests/test_replays_api.py
+++ b/tests/test_replays_api.py
@@ -51,6 +51,7 @@ class TestReplaysApi(BaseApiTest):
                     LIMIT 10 OFFSET 0
                     """,
                     "debug": True,
+                    "tenant_ids": {"referrer": "replays", "organization_id": 1},
                 }
             ),
         )
@@ -95,6 +96,7 @@ class TestReplaysApi(BaseApiTest):
                     LIMIT 10 OFFSET 0
                     """,
                     "debug": True,
+                    "tenant_ids": {"referrer": "replays", "organization_id": 1},
                 }
             ),
         )


### PR DESCRIPTION
Turn the replays allocation policy back on. 

Replays getsentry tests fixed [here](https://github.com/getsentry/getsentry/pull/10720) and setry tests fixed [here](https://github.com/getsentry/sentry/pull/50180)

both tests were run against the image generated by this PR. Should be no surprises