### PR TITLE
feat(functions): Add timeseries processor for functions entity

### DIFF
--- a/snuba/datasets/configuration/functions/entities/functions.yaml
+++ b/snuba/datasets/configuration/functions/entities/functions.yaml
@@ -90,6 +90,12 @@ query_processors:
   - processor: ResourceQuotaProcessor
     args:
       project_field: project_id
+  - processor: TimeSeriesProcessor
+    args:
+      time_group_columns:
+        time: timestamp
+      time_parse_columns:
+      - timestamp
 
 validators:
   - validator: EntityRequiredColumnValidator


### PR DESCRIPTION
To support timeseries on functions data, this adds the timeseries processor on the functions entity.