### PR TITLE
fix(search-issues): remove dashes from profile_id and replay_id when querying

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -86,7 +86,7 @@ query_processors:
       column_name: tags
   - processor: UUIDColumnProcessor
     args:
-      columns: [occurrence_id, event_id, trace_id]
+      columns: [occurrence_id, event_id, trace_id, profile_id, replay_id]
   - processor: MappingColumnPromoter
     args:
       mapping_specs:

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -292,5 +292,9 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
         assert response.status_code == 200, data
         assert data["stats"]["consistent"]
         assert data["data"] == [
-            {"project_id": 1, "profile_id": profile_id, "replay_id": replay_id}
+            {
+                "project_id": 1,
+                "profile_id": profile_id.replace("-", ""),
+                "replay_id": replay_id.replace("-", ""),
+            }
         ]


### PR DESCRIPTION
Forgot to include `profile_id` and `replay_id` in the `UUIDColumnProcessor`