### PR TITLE
ref(admin): Revert dashboard developer setting

### DIFF
--- a/snuba/admin/tool_policies.py
+++ b/snuba/admin/tool_policies.py
@@ -6,7 +6,6 @@ from typing import Any, Callable
 
 from flask import Response, g, jsonify, make_response
 
-from snuba import settings
 from snuba.admin.auth_roles import InteractToolAction
 from snuba.admin.user import AdminUser
 
@@ -64,15 +63,6 @@ def check_tool_perms(
     def decorator(f: Callable[..., Response]) -> Callable[..., Response]:
         @wraps(f)
         def check_perms(*args: Any, **kwargs: Any) -> Response:
-            if settings.ADMIN_DEVELOPER_MODE:
-                for tool in tools:
-                    if tool in DEVELOPER_TOOLS:
-                        return f(*args, **kwargs)
-
-                return make_response(jsonify({"error": error_message}), 403)
-
-            # TODO: This functionality can be deprecated in favour of the developer setting after
-            # that is properly configured and deployed
             allowed_tools = get_user_allowed_tools(g.user)
             if AdminTools.ALL in allowed_tools:
                 return f(*args, **kwargs)

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -35,7 +35,6 @@ from snuba.admin.runtime_config import (
     get_config_type_from_value,
 )
 from snuba.admin.tool_policies import (
-    DEVELOPER_TOOLS,
     AdminTools,
     check_tool_perms,
     get_user_allowed_tools,
@@ -100,12 +99,6 @@ def health() -> Response:
 
 @application.route("/tools")
 def tools() -> Response:
-    if settings.ADMIN_DEVELOPER_MODE:
-        return make_response(
-            jsonify({"tools": [t.value for t in DEVELOPER_TOOLS]}), 200
-        )
-
-    # TODO: This can return all the tools once developer mode is deployed
     return make_response(
         jsonify({"tools": [t.value for t in get_user_allowed_tools(g.user)]}), 200
     )

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -48,8 +48,6 @@ ADMIN_IAM_POLICY_FILE = os.environ.get(
     f"{Path(__file__).parent.parent.as_posix()}/admin/iam_policy/iam_policy.json",
 )
 
-ADMIN_DEVELOPER_MODE = int(os.environ.get("ADMIN_DEVELOPER_MODE", "0")) == 1
-
 ######################
 # End Admin Settings #
 ######################

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 import simplejson as json
 from flask.testing import FlaskClient
-
-from snuba import settings
-from snuba.admin.tool_policies import DEVELOPER_TOOLS
 
 
 @pytest.fixture
@@ -24,22 +19,3 @@ def test_tools(admin_api: FlaskClient) -> None:
     assert len(data["tools"]) > 0
     assert "snql-to-sql" in data["tools"]
     assert "all" in data["tools"]
-
-
-@patch("snuba.settings.ADMIN_DEVELOPER_MODE", True)
-def test_tools_developer_mode(admin_api: FlaskClient) -> None:
-    response = admin_api.get("/tools")
-    assert response.status_code == 200
-    data = json.loads(response.data)
-    assert len(data["tools"]) == len(DEVELOPER_TOOLS)
-    assert set(data["tools"]) == set(t.value for t in DEVELOPER_TOOLS)
-    assert "all" not in data["tools"]
-
-
-@patch("snuba.settings.ADMIN_DEVELOPER_MODE", True)
-def test_invalid_request_developer_mode(admin_api: FlaskClient) -> None:
-    settings.ADMIN_DEVELOPER_MODE = True
-    response = admin_api.get("/clickhouse_queries")
-    assert response.status_code == 403
-    data = json.loads(response.data)
-    assert "No permissions" in data["error"]


### PR DESCRIPTION
This setting was added to enable running two parallel deployments of the admin
tool. However since our permissions now need to be more fine-grained, the
separate deployment is no longer useful.

This should have no impact, this setting was never actually applied in prod.