### PR TITLE
feat(profiles): Promote profiles and functions storages to complete

### DIFF
--- a/snuba/datasets/configuration/functions/storages/functions.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions.yaml
@@ -4,7 +4,7 @@ name: functions
 storage:
   key: functions
   set_key: functions
-readiness_state: partial
+readiness_state: complete
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/functions/storages/functions_raw.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions_raw.yaml
@@ -4,7 +4,7 @@ name: functions_raw
 storage:
   key: functions_raw
   set_key: functions
-readiness_state: partial
+readiness_state: complete
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/profiles/storages/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/storages/profiles.yaml
@@ -4,7 +4,7 @@ name: profiles
 storage:
   key: profiles
   set_key: profiles
-readiness_state: partial
+readiness_state: complete
 schema:
   columns:
     [


### PR DESCRIPTION
### Overview
This PR will enable clickhouse health checks for the profiles and functions datasets in self-hosted.

Note: Setting profiles and functions to `readiness_state: complete` will not turn on health checks on single-tenant yet since the DISABLED dataset override still exists [here](https://github.com/getsentry/ops/blob/1edfe7a6cb13a74bafce96b20e9338cb080b49df/single-tenant/k8s/snuba/templates/snuba.conf.py.j2#L96).