### PR TITLE
ref(consumer-builder): Don't pass storage key separately to consumer builder

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -186,7 +186,6 @@ def consumer(
         metrics.gauge("librdkafka.total_queue_size", stats.get("replyq", 0))
 
     consumer_builder = ConsumerBuilder(
-        storage_key=storage_key,
         consumer_config=consumer_config,
         kafka_params=KafkaParameters(
             group_id=consumer_group,

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -58,11 +58,13 @@ class ConsumerBuilder:
     Simplifies the initialization of a consumer by merging parameters that
     generally come from the command line with defaults that come from the
     dataset class and defaults that come from the settings file.
+
+    Multiple storage consumer is not currently supported via consumer builder,
+    supports building a single storage consumer only.
     """
 
     def __init__(
         self,
-        storage_key: StorageKey,
         consumer_config: ConsumerConfig,
         kafka_params: KafkaParameters,
         processing_params: ProcessingParameters,
@@ -76,6 +78,9 @@ class ConsumerBuilder:
         profile_path: Optional[str] = None,
         max_poll_interval_ms: Optional[int] = None,
     ) -> None:
+        assert len(consumer_config.storages) == 1, "Only one storage supported"
+        storage_key = StorageKey(consumer_config.storages[0].name)
+
         self.join_timeout = join_timeout
         self.slice_id = slice_id
         self.storage = get_writable_storage(storage_key)

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -39,7 +39,6 @@ consumer_config = resolve_consumer_config(
 
 # Below, a ConsumerBuilder with only required args
 consumer_builder = ConsumerBuilder(
-    storage_key=test_storage_key,
     consumer_config=consumer_config,
     kafka_params=KafkaParameters(
         group_id=consumer_group_name,
@@ -89,7 +88,6 @@ optional_kafka_params = KafkaParameters(
 # and optional args, but only those with
 # no default values
 consumer_builder_with_opt = ConsumerBuilder(
-    storage_key=test_storage_key,
     consumer_config=optional_consumer_config,
     kafka_params=optional_kafka_params,
     processing_params=ProcessingParameters(


### PR DESCRIPTION
Since we are using the consumer config object now, we don't need to pass the storage key separately
