### PR TITLE
ref(validation): Turn on column validation by default

### DIFF
--- a/snuba/datasets/entity.py
+++ b/snuba/datasets/entity.py
@@ -38,7 +38,7 @@ class Entity(Describable, ABC):
         join_relationships: Mapping[str, JoinRelationship],
         validators: Optional[Sequence[QueryValidator]],
         required_time_column: Optional[str],
-        validate_data_model: ColumnValidationMode = ColumnValidationMode.DO_NOTHING,
+        validate_data_model: ColumnValidationMode = ColumnValidationMode.ERROR,
         subscription_processors: Optional[Sequence[EntitySubscriptionProcessor]],
         subscription_validators: Optional[Sequence[EntitySubscriptionValidator]],
     ) -> None:


### PR DESCRIPTION
This enables the column validation by default on all entities.

The code itself has been tested on multiple datasets, so it should
be safe to turn on across the board. This PR will be validated
against all Sentry tests.

- [X] Snuba CI passes
- [X] Sentry tests pass (https://github.com/getsentry/sentry/pull/50446)
- [X] Getsentry tests pass (https://github.com/getsentry/getsentry/pull/10769)