### PR TITLE
fix: Off by one error in snuba commit log

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -313,7 +313,7 @@ class ProcessedMessageBatchWriter:
 
         assert isinstance(message.value, BrokerValue)
         self.__offsets_to_produce[message.value.partition] = (
-            message.value.offset + 1,
+            message.value.next_offset,
             message.value.timestamp,
         )
 

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -313,7 +313,7 @@ class ProcessedMessageBatchWriter:
 
         assert isinstance(message.value, BrokerValue)
         self.__offsets_to_produce[message.value.partition] = (
-            message.value.offset,
+            message.value.offset + 1,
             message.value.timestamp,
         )
 


### PR DESCRIPTION
This is a fix for https://github.com/getsentry/self-hosted/issues/1982

The offset that should be published to the commit log is the same as the one committed to Kafka (current offset + 1).

This is a fix for a regression introduced in https://github.com/getsentry/snuba/pull/3531.
