### PR TITLE
ref: Don't pass unnecessary argument to process_message

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -521,14 +521,12 @@ MultistorageProcessedMessage = Sequence[
 
 def process_message(
     processor: MessageProcessor,
-    consumer_group: str,
     snuba_logical_topic: SnubaTopic,
     message: Message[KafkaPayload],
 ) -> Union[None, BytesInsertBatch, ReplacementBatch]:
     local_metrics = MetricsWrapper(
         metrics,
         tags={
-            "consumer_group": consumer_group,
             "snuba_logical_topic": snuba_logical_topic.name,
         },
     )

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -86,7 +86,6 @@ class ConsumerBuilder:
         self.storage = get_writable_storage(storage_key)
         self.__consumer_config = consumer_config
         self.__kafka_params = kafka_params
-        self.consumer_group = kafka_params.group_id
 
         broker_config = build_kafka_consumer_configuration(
             self.__consumer_config.raw_topic.broker_config,
@@ -259,7 +258,6 @@ class ConsumerBuilder:
             process_message=functools.partial(
                 process_message,
                 processor,
-                self.consumer_group,
                 logical_topic,
             ),
             collector=build_batch_writer(
@@ -311,7 +309,6 @@ class ConsumerBuilder:
             process_message=functools.partial(
                 process_message,
                 processor,
-                self.consumer_group,
                 logical_topic,
             ),
             collector=build_batch_writer(

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -672,7 +672,6 @@ if application.debug or application.testing:
                     functools.partial(
                         process_message,
                         stream_loader.get_processor(),
-                        "consumer_grouup",
                         stream_loader.get_default_topic_spec().topic,
                     ),
                     build_batch_writer(table_writer, metrics=metrics),

--- a/tests/consumers/test_consumer_builder.py
+++ b/tests/consumers/test_consumer_builder.py
@@ -117,7 +117,7 @@ def test_consumer_builder_non_optional_attributes(con_build) -> None:  # type: i
 
     assert con_build.storage == get_writable_storage(test_storage_key)
 
-    assert con_build.consumer_group == consumer_group_name
+    assert con_build.group_id == consumer_group_name
 
     assert isinstance(con_build.raw_topic, Topic)
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -71,9 +71,7 @@ def test_streaming_consumer_strategy() -> None:
 
     factory = KafkaConsumerStrategyFactory(
         None,
-        functools.partial(
-            process_message, processor, "consumer_group", SnubaTopic.EVENTS
-        ),
+        functools.partial(process_message, processor, SnubaTopic.EVENTS),
         write_step,
         max_batch_size=10,
         max_batch_time=60,


### PR DESCRIPTION
This was originally passed in due to the old DLQ implementation which wrote the consumer group into the invalid message that was produced. It's no longer needed.
