### PR TITLE
ref: Remove unnecessary try/except in outcomes processor

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -587,6 +587,13 @@ def process_message(
             ),
         )
     except Exception as err:
+        local_metrics.increment(
+            "invalid_message",
+            tags={
+                "topic": snuba_logical_topic.name,
+                "processor": type(processor).__name__,
+            },
+        )
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("invalid_message", "true")
             logger.warning(err, exc_info=True)

--- a/snuba/datasets/processors/outcomes_processor.py
+++ b/snuba/datasets/processors/outcomes_processor.py
@@ -72,20 +72,16 @@ class OutcomesProcessor(DatasetMessageProcessor):
             metrics.increment("bad_outcome_timestamp")
             timestamp = _ensure_valid_date(datetime.utcnow())
 
-        try:
-            message = {
-                "org_id": outcome.get("org_id", 0),
-                "project_id": outcome.get("project_id", 0),
-                "key_id": outcome.get("key_id"),
-                "timestamp": timestamp,
-                "outcome": outcome["outcome"],
-                "category": outcome.get("category", DataCategory.ERROR),
-                "quantity": outcome.get("quantity", 1),
-                "reason": _unicodify(reason),
-                "event_id": str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
-            }
-        except Exception:
-            metrics.increment("bad_outcome")
-            return None
+        message = {
+            "org_id": outcome.get("org_id", 0),
+            "project_id": outcome.get("project_id", 0),
+            "key_id": outcome.get("key_id"),
+            "timestamp": timestamp,
+            "outcome": outcome["outcome"],
+            "category": outcome.get("category", DataCategory.ERROR),
+            "quantity": outcome.get("quantity", 1),
+            "reason": _unicodify(reason),
+            "event_id": str(uuid.UUID(v_uuid)) if v_uuid is not None else None,
+        }
 
         return InsertBatch([message], None)


### PR DESCRIPTION
The metric is now logged for all processors, no needed for users to do this individually in each message processor
