### PR TITLE
ref: Clean up the way DLQ is specified in storage config files

### DIFF
--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -107,5 +107,4 @@ stream_loader:
   default_topic: generic-events
   commit_log_topic: snuba-generic-events-commit-log
   dlq_policy:
-    type: produce
-    args: [ snuba-dead-letter-generic-events ]
+    topic: snuba-dead-letter-generic-events

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -75,14 +75,9 @@ STREAM_LOADER_SCHEMA = {
         "dlq_policy": {
             "type": "object",
             "properties": {
-                "type": {
+                "topic": {
                     "type": "string",
-                    "description": "DLQ policy type",
-                },
-                "args": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Key/value mappings required to instantiate DLQ class (e.g. topic name).",
+                    "description": "DLQ topic name",
                 },
             },
             "additionalProperties": False,

--- a/snuba/datasets/configuration/metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/metrics/storages/counters.yaml
@@ -53,6 +53,4 @@ stream_loader:
     name: CounterAggregateProcessor
   default_topic: snuba-metrics
   dlq_policy:
-    type: produce
-    args:
-      - snuba-dead-letter-metrics
+    topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/metrics/storages/distributions.yaml
@@ -82,6 +82,4 @@ stream_loader:
     name: DistributionsAggregateProcessor
   default_topic: snuba-metrics
   dlq_policy:
-    type: produce
-    args:
-      - snuba-dead-letter-metrics
+    topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/metrics/storages/raw.yaml
+++ b/snuba/datasets/configuration/metrics/storages/raw.yaml
@@ -52,6 +52,4 @@ stream_loader:
   subscription_scheduled_topic: scheduled-subscriptions-metrics
   subscription_result_topic: metrics-subscription-results
   dlq_policy:
-    type: produce
-    args:
-      - snuba-dead-letter-metrics
+    topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/metrics/storages/sets.yaml
@@ -57,6 +57,4 @@ stream_loader:
     name: SetsAggregateProcessor
   default_topic: snuba-metrics
   dlq_policy:
-    type: produce
-    args:
-      - snuba-dead-letter-metrics
+    topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/querylog/storages/querylog.yaml
+++ b/snuba/datasets/configuration/querylog/storages/querylog.yaml
@@ -168,5 +168,4 @@ stream_loader:
     name: QuerylogProcessor
   default_topic: snuba-queries
   dlq_policy:
-    type: produce
-    args: [snuba-dead-letter-querylog]
+    topic: snuba-dead-letter-querylog

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -170,8 +170,7 @@ stream_loader:
     name: ReplaysProcessor
   default_topic: ingest-replay-events
   dlq_policy:
-    type: produce
-    args: [snuba-dead-letter-replays]
+    topic: snuba-dead-letter-replays
 allocation_policy:
   name: BytesScannedWindowAllocationPolicy
   args:

--- a/snuba/datasets/configuration/utils.py
+++ b/snuba/datasets/configuration/utils.py
@@ -52,12 +52,7 @@ def generate_dlq_config(dlq_policy_config: dict[str, Any]) -> Optional[DlqConfig
     """
     Returns DLQ config if DLQ policy is configured, otherwise returns None
     """
-    if dlq_policy_config["type"] == "produce":
-        dlq_topic = dlq_policy_config["args"][0]
-        return DlqConfig(topic=Topic(dlq_topic))
-
-    # TODO: Add rest of DLQ policy types
-    return None
+    return DlqConfig(topic=Topic(dlq_policy_config["topic"]))
 
 
 def get_query_processors(


### PR DESCRIPTION
The only thing the user should specify is the topic to be used
