### PR TITLE
feat: Add logical topic to shared consumer config

### DIFF
--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -18,6 +18,7 @@ pub struct ConsumerConfig {
 #[derive(Deserialize)]
 pub struct TopicConfig {
     pub physical_topic_name: String,
+    pub logical_topic_name: String,
     pub broker_config: BrokerConfig,
 }
 

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -36,6 +36,7 @@ class StorageConfig:
 @dataclass(frozen=True)
 class TopicConfig:
     broker_config: Mapping[str, Any]
+    logical_topic_name: str
     physical_topic_name: str
 
 
@@ -70,13 +71,22 @@ def _resolve_topic_config(
         if cli_param is not None:
             raise ValueError(f"{param} not supported for this storage")
         return None
-    elif cli_param is not None:
+
+    assert topic_spec is not None
+
+    if cli_param is not None:
         physical_topic_name = cli_param
     else:
         physical_topic_name = topic_spec.get_physical_topic_name(slice_id)
 
     broker = _get_default_topic_configuration(topic_spec.topic, slice_id)
-    return TopicConfig(broker_config=broker, physical_topic_name=physical_topic_name)
+
+    logical_topic_name = topic_spec.topic.value
+    return TopicConfig(
+        broker_config=broker,
+        logical_topic_name=logical_topic_name,
+        physical_topic_name=physical_topic_name,
+    )
 
 
 def _resolve_env_config() -> Optional[EnvConfig]:

--- a/tests/consumers/test_consumer_config.py
+++ b/tests/consumers/test_consumer_config.py
@@ -6,7 +6,7 @@ from snuba.consumers.consumer_config import resolve_consumer_config
 def test_consumer_config() -> None:
     resolved = resolve_consumer_config(
         storage_names=["errors"],
-        raw_topic=None,
+        raw_topic="new-events",
         commit_log_topic=None,
         replacements_topic=None,
         slice_id=None,
@@ -19,7 +19,8 @@ def test_consumer_config() -> None:
 
     assert len(resolved.storages) == 1
     assert resolved.storages[0].clickhouse_table_name in ("errors_local", "errors_dist")
-    assert resolved.raw_topic.physical_topic_name == "events"
+    assert resolved.raw_topic.physical_topic_name == "new-events"
+    assert resolved.raw_topic.logical_topic_name == "events"
     assert resolved.commit_log_topic is not None
     assert resolved.commit_log_topic.physical_topic_name == "snuba-commit-log"
     assert resolved.replacements_topic is not None


### PR DESCRIPTION
So it can be easily resolved for all of our consumers without duplicating code in each.