### PR TITLE
ref(admin) Allow access to tracing/snql-to-sql by default

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -168,17 +168,13 @@ ROLES = {
         name="all-tools",
         actions={InteractToolAction([TOOL_RESOURCES["all"]])},
     ),
-    "SnQLToSQL": Role(
-        name="snql-to-snql",
+    "ProductTools": Role(
+        name="product-tools",
         actions={
-            InteractToolAction([TOOL_RESOURCES["snql-to-sql"]])
-        },  # Matches the `id` in snuba/admin/static/data.tsx/NAV_ITEMS
-    ),
-    "Tracing": Role(
-        name="tracing",
-        actions={
-            InteractToolAction([TOOL_RESOURCES["tracing"]])
-        },  # Matches the `id` in snuba/admin/static/data.tsx/NAV_ITEMS
+            InteractToolAction(
+                [TOOL_RESOURCES["snql-to-sql"], TOOL_RESOURCES["tracing"]]
+            )
+        },
     ),
 }
 
@@ -186,7 +182,7 @@ DEFAULT_ROLES = [
     ROLES["MigrationsReader"],
     ROLES["TestMigrationsExecutor"],
     ROLES["SearchIssuesExecutor"],
-    ROLES["SnQLToSQL"],
+    ROLES["ProductTools"],
 ]
 
 if settings.TESTING or settings.DEBUG:

--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -39,25 +39,16 @@
           "user:oliver.newland@sentry.io",
           "user:rahul.saini@sentry.io",
           "user:riya.chakraborty@sentry.io",
-          "user:volo.kluev@sentry.io"
+          "user:volo.kluev@sentry.io",
+          "user:david.tsukernik@sentry.io"
         ],
         "role": "roles/AllTools"
       },
       {
         "members": [
-            "user:colton.allen@sentry.io",
-            "user:josh.ferge@sentry.io",
-            "user:kevan.fisher@sentry.io"
+            "group:access-snuba-admin@sentry.io"
         ],
-        "role": "roles/SnQLToSQL"
-      },
-      {
-        "members": [
-            "user:colton.allen@sentry.io",
-            "user:josh.ferge@sentry.io",
-            "user:kevan.fisher@sentry.io"
-        ],
-        "role": "roles/Tracing"
+        "role": "roles/ProductTools"
       }
     ]
   }

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 import simplejson as json
 from flask.testing import FlaskClient
+
+from snuba.admin.auth_roles import ROLES
 
 
 @pytest.fixture
@@ -19,3 +23,16 @@ def test_tools(admin_api: FlaskClient) -> None:
     assert len(data["tools"]) > 0
     assert "snql-to-sql" in data["tools"]
     assert "all" in data["tools"]
+
+
+@patch("snuba.admin.auth.DEFAULT_ROLES", [ROLES["ProductTools"]])
+def test_product_tools_role(
+    admin_api: FlaskClient,
+) -> None:
+    response = admin_api.get("/tools")
+    assert response.status_code == 200
+    data = json.loads(response.data)
+    assert len(data["tools"]) > 0
+    assert "snql-to-sql" in data["tools"]
+    assert "tracing" in data["tools"]
+    assert "all" not in data["tools"]


### PR DESCRIPTION
Create a new role for product developers that gives access to the tracing and
snql-to-sql tool. Make this role a default role, so everyone with access to the
admin tool will have access to both tools.

Small additional changes: add David to list of users with access to all tools,
and have the product tool role reflect the actual google group we will use to
grant access going forward.