### PR TITLE
Use Google Groups API for authorization

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -97,3 +97,6 @@ ignore_missing_imports = True
 
 [mypy-googleapiclient.discovery]
 ignore_missing_imports = True
+
+[mypy-googleapiclient.http]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -91,3 +91,9 @@ ignore_missing_imports = True
 
 [mypy-sqlparse]
 ignore_missing_imports = True
+
+[mypy-googleapiclient]
+ignore_missing_imports = True
+
+[mypy-googleapiclient.discovery]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ pyuwsgi==2.0.20
 Werkzeug==2.2.2
 PyYAML==6.0
 sqlparse==0.4.2
+google-api-python-client==2.88.0

--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -3,13 +3,12 @@ from __future__ import annotations
 import json
 from typing import Sequence
 
-import googleapiclient.discovery
 import structlog
 from flask import request
 
 from snuba import settings
 from snuba.admin.auth_roles import DEFAULT_ROLES, ROLES
-from snuba.admin.google import check_transitive_membership, get_group_id
+from snuba.admin.google import CloudIdentityAPI
 from snuba.admin.jwt import validate_assertion
 from snuba.admin.user import AdminUser
 
@@ -38,10 +37,8 @@ def authorize_request() -> AdminUser:
 
 
 def _is_member_of_group(user: AdminUser, group: str) -> bool:
-    service = googleapiclient.discovery.build("cloudidentity", "v1")
-    group = get_group_id(service, group)
-
-    return check_transitive_membership(service, group, user.email)
+    google_api = CloudIdentityAPI()
+    return google_api.check_group_membership(group_email=group, member=user.email)
 
 
 def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 
 import structlog
 from googleapiclient.discovery import Resource, build
+from sentry_sdk import capture_exception
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -21,6 +22,7 @@ class CloudIdentityAPI:
             self.initialized = True
         except Exception as e:
             logger.exception(e)
+            capture_exception(e)
 
     def _get_group_id(self, group_email: str) -> Optional[str]:
         if not self.initialized:

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -1,4 +1,3 @@
-from abc import ABC
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -8,15 +7,9 @@ from googleapiclient.discovery import Resource, build
 logger = structlog.get_logger().bind(module=__name__)
 
 
-class GoogleAPIWrapper(ABC):
-    """
-    An abstract class defining an interface for google cloud APIs.
-    """
-
-
 class CloudIdentityAPI:
     """
-    An interface for the Google Cloud Identity API.
+    A class for interfacing with the Google Cloud Identity API.
     """
 
     def __init__(self, service: Resource = None) -> None:

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -19,9 +19,11 @@ class CloudIdentityAPI:
     An interface for the Google Cloud Identity API.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, service: Resource = None) -> None:
         try:
-            self.service: Resource = build("cloudidentity", "v1")
+            self.service: Resource = (
+                service if service else build("cloudidentity", "v1")
+            )
         except Exception as e:
             logger.exception(e)
 
@@ -44,12 +46,10 @@ class CloudIdentityAPI:
 
         return None
 
-    def check_group_membership(self, group_email: str, member: str) -> bool:
+    def _check_transitive_membership(
+        self, group_resource_name: str, member: str
+    ) -> bool:
         try:
-            group_resource_name = self._get_group_id(group_email)
-            if not group_resource_name:
-                return False
-
             query_params = urlencode({"query": "member_key_id == '{}'".format(member)})
             request = (
                 self.service.groups()
@@ -63,9 +63,17 @@ class CloudIdentityAPI:
                     f"An HTTP error occured when checking if user {member} is a member of group {group_resource_name}",
                     google_api_error=response["error"],
                 )
-
             return bool(response.get("hasMembership", False))
         except Exception as e:
             logger.exception(e)
+
+        return False
+
+    def check_group_membership(self, group_email: str, member: str) -> bool:
+        group_resource_name = self._get_group_id(group_email)
+        if group_resource_name:
+            return self._check_transitive_membership(
+                group_resource_name=group_resource_name, member=member
+            )
 
         return False

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -1,49 +1,71 @@
+from abc import ABC
+from typing import Optional
 from urllib.parse import urlencode
 
 import structlog
-from googleapiclient.discovery import Resource
+from googleapiclient.discovery import Resource, build
 
 logger = structlog.get_logger().bind(module=__name__)
 
 
-def get_group_id(service: Resource, group_email: str) -> str:
-    try:
-        query_params = f"groupKey.id={group_email}"
-        request = service.groups().lookup()
-        request.uri += "&" + query_params
-        response = request.execute()
-        if "error" in response:
-            logger.exception(
-                f"An HTTP error occured when fetching group id for email {group_email}.",
-                google_api_error=response["error"],
+class GoogleAPIWrapper(ABC):
+    """
+    An abstract class defining an interface for google cloud APIs.
+    """
+
+
+class CloudIdentityAPI:
+    """
+    An interface for the Google Cloud Identity API.
+    """
+
+    def __init__(self) -> None:
+        try:
+            self.service: Resource = build("cloudidentity", "v1")
+        except Exception as e:
+            logger.exception(e)
+
+    def _get_group_id(self, group_email: str) -> Optional[str]:
+        try:
+            query_params = f"groupKey.id={group_email}"
+            request = self.service.groups().lookup()
+            request.uri += "&" + query_params
+            response = request.execute()
+            if "error" in response:
+                logger.exception(
+                    f"An HTTP error occured when fetching group id for email {group_email}.",
+                    google_api_error=response["error"],
+                )
+                return None
+
+            return str(response["name"])
+        except Exception as e:
+            logger.exception(e)
+
+        return None
+
+    def check_group_membership(self, group_email: str, member: str) -> bool:
+        try:
+            group_resource_name = self._get_group_id(group_email)
+            if not group_resource_name:
+                return False
+
+            query_params = urlencode({"query": "member_key_id == '{}'".format(member)})
+            request = (
+                self.service.groups()
+                .memberships()
+                .checkTransitiveMembership(parent=group_resource_name)
             )
+            request.uri += "&" + query_params
+            response = request.execute()
+            if "error" in response:
+                logger.exception(
+                    f"An HTTP error occured when checking if user {member} is a member of group {group_resource_name}",
+                    google_api_error=response["error"],
+                )
 
-        return str(response.get("name", ""))
-    except Exception as e:
-        logger.exception(e)
+            return bool(response.get("hasMembership", False))
+        except Exception as e:
+            logger.exception(e)
 
-    return ""
-
-
-def check_transitive_membership(
-    service: Resource, group_resource_name: str, member: str
-) -> bool:
-    try:
-        query_params = urlencode({"query": "member_key_id == '{}'".format(member)})
-        request = (
-            service.groups()
-            .memberships()
-            .checkTransitiveMembership(parent=group_resource_name)
-        )
-        request.uri += "&" + query_params
-        response = request.execute()
-        if "error" in response:
-            logger.exception(
-                f"An HTTP error occured when checking if user {member} is a member of group {group_resource_name}",
-                google_api_error=response["error"],
-            )
-        return bool(response.get("hasMembership", False))
-    except Exception as e:
-        logger.exception(e)
-
-    return False
+        return False

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -13,14 +13,19 @@ class CloudIdentityAPI:
     """
 
     def __init__(self, service: Resource = None) -> None:
+        self.initialized = False
         try:
             self.service: Resource = (
                 service if service else build("cloudidentity", "v1")
             )
+            self.initialized = True
         except Exception as e:
             logger.exception(e)
 
     def _get_group_id(self, group_email: str) -> Optional[str]:
+        if not self.initialized:
+            return None
+
         try:
             query_params = f"groupKey.id={group_email}"
             request = self.service.groups().lookup()
@@ -42,6 +47,9 @@ class CloudIdentityAPI:
     def _check_transitive_membership(
         self, group_resource_name: str, member: str
     ) -> bool:
+        if not self.initialized:
+            return False
+
         try:
             query_params = urlencode({"query": "member_key_id == '{}'".format(member)})
             request = (
@@ -63,6 +71,9 @@ class CloudIdentityAPI:
         return False
 
     def check_group_membership(self, group_email: str, member: str) -> bool:
+        if not self.initialized:
+            return False
+
         group_resource_name = self._get_group_id(group_email)
         if group_resource_name:
             return self._check_transitive_membership(

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -1,0 +1,31 @@
+from urllib.parse import urlencode
+
+from googleapiclient.discovery import Resource
+
+
+def check_transitive_membership(service: Resource, parent: str, member: str) -> bool:
+    try:
+        query_params = urlencode({"query": "member_key_id == '{}'".format(member)})
+        request = (
+            service.groups().memberships().checkTransitiveMembership(parent=parent)
+        )
+        request.uri += "&" + query_params
+        response = request.execute()
+        return bool(response["hasMembership"])
+    except Exception as e:
+        print(e)
+
+    return False
+
+
+def get_group_id(service: Resource, group_email: str) -> str:
+    try:
+        query_params = f"groupKey.id={group_email}"
+        request = service.groups().lookup()
+        request.uri += "&" + query_params
+        response = request.execute()
+        return str(response["name"])
+    except Exception as e:
+        print(e)
+
+    return ""

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -3,7 +3,6 @@ from urllib.parse import urlencode
 
 import structlog
 from googleapiclient.discovery import Resource, build
-from sentry_sdk import capture_exception
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -22,7 +21,6 @@ class CloudIdentityAPI:
             self.initialized = True
         except Exception as e:
             logger.exception(e)
-            capture_exception(e)
 
     def _get_group_id(self, group_email: str) -> Optional[str]:
         if not self.initialized:

--- a/tests/admin/data/mock_responses/check_transitive_membership_200.json
+++ b/tests/admin/data/mock_responses/check_transitive_membership_200.json
@@ -1,0 +1,3 @@
+{
+    "hasMembership": true
+}

--- a/tests/admin/data/mock_responses/group_lookup_200.json
+++ b/tests/admin/data/mock_responses/group_lookup_200.json
@@ -1,0 +1,3 @@
+{
+    "name": "groups/group_id"
+}

--- a/tests/admin/data/mock_responses/group_lookup_403.json
+++ b/tests/admin/data/mock_responses/group_lookup_403.json
@@ -1,0 +1,7 @@
+{
+    "error": {
+        "code": 403,
+        "message": "Error(2028): Permission denied for resource team-sns2@sentry.io (or it may not exist).",
+        "status": "PERMISSION_DENIED"
+    }
+}

--- a/tests/admin/test_google.py
+++ b/tests/admin/test_google.py
@@ -5,17 +5,19 @@ from snuba.admin.google import check_transitive_membership, get_group_id
 
 
 def test_get_group_id() -> None:
-    http = HttpMock("data/group_lookup_200")
+    http = HttpMock("tests/admin/data/mock_responses/group_lookup_200.json")
     service = build("cloudidentity", "v1", http=http, developerKey="api_key")
     assert get_group_id(service, "group_email") == "groups/group_id"
 
-    http = HttpMock("data/group_lookup_403")
+    http = HttpMock("tests/admin/data/mock_responses/group_lookup_403.json")
     service = build("cloudidentity", "v1", http=http, developerKey="api_key")
     assert get_group_id(service=service, group_email="group_email") == ""
 
 
 def test_check_transitive_membership() -> None:
-    http = HttpMock("data/check_transitive_member_200")
+    http = HttpMock(
+        "tests/admin/data/mock_responses/check_transitive_membership_200.json"
+    )
     service = build("cloudidentity", "v1", http=http, developerKey="api_key")
     assert check_transitive_membership(
         service=service, group_resource_name="groups/group_id", member="member"

--- a/tests/admin/test_google.py
+++ b/tests/admin/test_google.py
@@ -1,0 +1,22 @@
+from googleapiclient.discovery import build
+from googleapiclient.http import HttpMock
+
+from snuba.admin.google import check_transitive_membership, get_group_id
+
+
+def test_get_group_id() -> None:
+    http = HttpMock("data/group_lookup_200")
+    service = build("cloudidentity", "v1", http=http, developerKey="api_key")
+    assert get_group_id(service, "group_email") == "groups/group_id"
+
+    http = HttpMock("data/group_lookup_403")
+    service = build("cloudidentity", "v1", http=http, developerKey="api_key")
+    assert get_group_id(service=service, group_email="group_email") == ""
+
+
+def test_check_transitive_membership() -> None:
+    http = HttpMock("data/check_transitive_member_200")
+    service = build("cloudidentity", "v1", http=http, developerKey="api_key")
+    assert check_transitive_membership(
+        service=service, group_resource_name="groups/group_id", member="member"
+    )

--- a/tests/admin/test_google.py
+++ b/tests/admin/test_google.py
@@ -1,17 +1,19 @@
 from googleapiclient.discovery import build
 from googleapiclient.http import HttpMock
 
-from snuba.admin.google import check_transitive_membership, get_group_id
+from snuba.admin.google import CloudIdentityAPI
 
 
 def test_get_group_id() -> None:
     http = HttpMock("tests/admin/data/mock_responses/group_lookup_200.json")
     service = build("cloudidentity", "v1", http=http, developerKey="api_key")
-    assert get_group_id(service, "group_email") == "groups/group_id"
+    api_client = CloudIdentityAPI(service=service)
+    assert api_client._get_group_id("group_email") == "groups/group_id"
 
     http = HttpMock("tests/admin/data/mock_responses/group_lookup_403.json")
     service = build("cloudidentity", "v1", http=http, developerKey="api_key")
-    assert get_group_id(service=service, group_email="group_email") == ""
+    api_client = CloudIdentityAPI(service=service)
+    assert not api_client._get_group_id(group_email="group_email")
 
 
 def test_check_transitive_membership() -> None:
@@ -19,6 +21,16 @@ def test_check_transitive_membership() -> None:
         "tests/admin/data/mock_responses/check_transitive_membership_200.json"
     )
     service = build("cloudidentity", "v1", http=http, developerKey="api_key")
-    assert check_transitive_membership(
-        service=service, group_resource_name="groups/group_id", member="member"
+    api_client = CloudIdentityAPI(service=service)
+    assert api_client._check_transitive_membership(
+        group_resource_name="groups/group_id", member="member"
+    )
+
+
+def test_check_group_membership() -> None:
+    http = HttpMock("tests/admin/data/mock_responses/group_lookup_403.json")
+    service = build("cloudidentity", "v1", http=http, developerKey="api_key")
+    api_client = CloudIdentityAPI(service=service)
+    assert not api_client.check_group_membership(
+        group_email="group_email", member="member"
     )


### PR DESCRIPTION
This change calls the Groups API to check that a user has membership in a given group. This will allow the iam_policy file to use group-based role assignment.