### PR TITLE
feat(spans): Add migration to create start_ms and end_ms columns

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -319,4 +319,5 @@ class SpansLoader(DirectoryLoader):
         return [
             "0001_spans_v1",
             "0002_spans_add_tags_hashmap",
+            "0003_spans_add_ms_columns",
         ]

--- a/snuba/snuba_migrations/spans/0003_spans_add_ms_columns.py
+++ b/snuba/snuba_migrations/spans/0003_spans_add_ms_columns.py
@@ -1,0 +1,91 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds columns start_ms and end_ms to the spans table. These columns would contain the
+    millisecond precision of start_timestamp and end_timestamp respectively.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "start_ms",
+                    UInt(16),
+                ),
+                target=OperationTarget.LOCAL,
+                after="start_timestamp",
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "end_ms",
+                    UInt(16),
+                ),
+                target=OperationTarget.LOCAL,
+                after="end_timestamp",
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "start_ms",
+                    UInt(16),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+                after="start_timestamp",
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "end_ms",
+                    UInt(16),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+                after="end_timestamp",
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="end_ms",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="start_ms",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="end_ms",
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="start_ms",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
In order to store millisecond precision data we create 2 new columns to store it. We already have start_timestamp and end_timestamp columns which store second level precision data. We cannot use DateTime64 column since they were introduced in Clickhouse version 21.3