### PR TITLE
fix(capman): Change max_threads to use allocation policy config

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -24,6 +24,7 @@ CAPMAN_HASH = "capman"
 
 IS_ACTIVE = "is_active"
 IS_ENFORCED = "is_enforced"
+MAX_THREADS = "max_threads"
 
 
 @dataclass(frozen=True)
@@ -333,6 +334,12 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
                 value_type=int,
                 default=default_config_overrides.get(IS_ENFORCED, 1),
             ),
+            AllocationPolicyConfig(
+                name=MAX_THREADS,
+                description="The max threads Clickhouse can use for the query.",
+                value_type=int,
+                default=default_config_overrides.get(MAX_THREADS, 10),
+            ),
         ]
         self._overridden_additional_config_definitions = (
             self.__get_overridden_additional_config_defaults(default_config_overrides)
@@ -365,7 +372,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
     @property
     def max_threads(self) -> int:
         """Maximum number of threads run a single query on ClickHouse with."""
-        return cast(int, get_runtime_config("query_settings/max_threads", 8))
+        return int(self.get_config_value(MAX_THREADS))
 
     @classmethod
     def config_key(cls) -> str:

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -12,7 +12,6 @@ from sentry_redis_tools.sliding_windows_rate_limiter import (
 )
 
 from snuba.query.allocation_policies import (
-    DEFAULT_PASSTHROUGH_POLICY,
     AllocationPolicy,
     AllocationPolicyConfig,
     QueryResultOrError,
@@ -126,9 +125,9 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         return True, ""
 
     def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
-
         if not self.is_active:
-            return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids)
+            return QuotaAllowance(True, self.max_threads, {})
+
         ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
         if not ids_are_valid:
             self.metrics.increment(
@@ -144,7 +143,7 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         referrer = tenant_ids.get("referrer", "no_referrer")
         org_id = tenant_ids.get("organization_id", None)
         if referrer in _PASS_THROUGH_REFERRERS:
-            return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids)
+            return QuotaAllowance(True, self.max_threads, {})
         if referrer in _SINGLE_THREAD_REFERRERS:
             return QuotaAllowance(
                 can_run=True,

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -177,7 +177,9 @@ def test_db_query_success() -> None:
         trace_id="trace_id",
         robust=False,
     )
-    assert stats["quota_allowance"] == dict(can_run=True, max_threads=8, explanation={})
+    assert stats["quota_allowance"] == dict(
+        can_run=True, max_threads=10, explanation={}
+    )
     assert len(query_metadata_list) == 1
     assert result.extra["stats"] == stats
     assert result.extra["sql"] is not None
@@ -218,7 +220,7 @@ def test_db_query_bypass_cache() -> None:
                 robust=False,
             )
             assert stats["quota_allowance"] == dict(
-                can_run=True, max_threads=8, explanation={}
+                can_run=True, max_threads=10, explanation={}
             )
             assert len(query_metadata_list) == 1
             assert result.extra["stats"] == stats


### PR DESCRIPTION
Change the `max_threads` attribute of an AllocationPolicy to use the config of
the policy instead of the state config. This means it can be overridden in the
dataset configuration files as well.

This means that the max threads in the allocation policy will no longer use the
state setting. The state setting still is used in db_query.py however. The
default value for the allocation policy max threads has been set to match what
is in prod currently.