### PR TITLE
fix(dlq): ExitAfterNMessages strategy should be first step not last

### DIFF
--- a/snuba/cli/dlq_consumer.py
+++ b/snuba/cli/dlq_consumer.py
@@ -162,7 +162,7 @@ def dlq_consumer(
             max_batch_time_ms=max_batch_time_ms,
             metrics=metrics,
             slice_id=instruction.slice_id,
-            join_timeout=5,
+            join_timeout=None,
         )
 
         consumer = consumer_builder.build_dlq_consumer(instruction)

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -72,7 +72,7 @@ class ConsumerBuilder:
         max_batch_time_ms: int,
         metrics: MetricsBackend,
         slice_id: Optional[int],
-        join_timeout: int,
+        join_timeout: Optional[int],
         stats_callback: Optional[Callable[[str], None]] = None,
         commit_retry_policy: Optional[RetryPolicy] = None,
         profile_path: Optional[str] = None,

--- a/tests/consumers/test_dlq.py
+++ b/tests/consumers/test_dlq.py
@@ -32,11 +32,11 @@ def test_store_instruction() -> None:
 
 
 def test_exit_after_n_messages() -> None:
-    commit = Mock()
+    next_step = Mock()
     num_messages_to_process = 10
     max_message_timeout = 1.0
     strategy: ProcessingStrategy[int] = ExitAfterNMessages(
-        commit, num_messages_to_process, max_message_timeout
+        next_step, num_messages_to_process, max_message_timeout
     )
 
     topic = Topic("topic")


### PR DESCRIPTION
Previous approach was not correct. Since the strategy was placed at the end of the pipeline it was counting batches of messages not actual messages on the raw topic. Now it's the first step in the sequence so the message count should be correct.