### PR TITLE
fix(envrc): Try to grab the right Python version

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,21 +1,22 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 
-for f in $HOME/.pyenv/versions/3.8.16/bin/python python3.8 python3; do
-    echo "Attempting to find Python at $f"
-
-    if which $f > /dev/null; then
-        python_bin=python3.8
-        break
-    fi
-done
-
-if [ -z "$python_bin" ]; then
-    echo "!!! ERROR -- did not find a suitable Python version, giving up."
-    echo "Install Python 3 manually, or install sentry first."
-fi
 
 if [ ! -d .venv ]; then
+    for f in $HOME/.pyenv/versions/3.8.16/bin/python python3.8 python3; do
+        echo "Attempting to find Python at $f"
+
+        if which $f > /dev/null; then
+            python_bin=python3.8
+            break
+        fi
+    done
+
+    if [ -z "$python_bin" ]; then
+        echo "!!! ERROR -- did not find a suitable Python version, giving up."
+        echo "Install Python 3 manually, or install sentry first."
+    fi
+
     $python_bin -m venv .venv
     source .venv/bin/activate
     pip install $(grep ^-- requirements.txt) --upgrade pip==22.2.2 wheel==0.37.1

--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,22 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 
+for f in $HOME/.pyenv/versions/3.8.16/bin/python python3.8 python3; do
+    echo "Attempting to find Python at $f"
+
+    if which $f > /dev/null; then
+        python_bin=python3.8
+        break
+    fi
+done
+
+if [ -z "$python_bin" ]; then
+    echo "!!! ERROR -- did not find a suitable Python version, giving up."
+    echo "Install Python 3 manually, or install sentry first."
+fi
+
 if [ ! -d .venv ]; then
-    python3 -m venv .venv
+    $python_bin -m venv .venv
     source .venv/bin/activate
     pip install $(grep ^-- requirements.txt) --upgrade pip==22.2.2 wheel==0.37.1
     make develop

--- a/.envrc
+++ b/.envrc
@@ -15,6 +15,7 @@ if [ ! -d .venv ]; then
     if [ -z "$python_bin" ]; then
         echo "!!! ERROR -- did not find a suitable Python version, giving up."
         echo "Install Python 3 manually, or install sentry first."
+        exit 1
     fi
 
     $python_bin -m venv .venv

--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,6 @@
 #!/bin/bash
 # shellcheck disable=SC1091
 
-
 if [ ! -d .venv ]; then
     for f in $HOME/.pyenv/versions/3.8.16/bin/python python3.8 python3; do
         echo "Attempting to find Python at $f"


### PR DESCRIPTION
Just migrated to new laptop, and clickhouse-driver does not install with
the random Python 3.11 I happen to have installed, so this envrc does
not work out of the box.

A lot of people who try to contribute to Snuba likely already have
sentry installed, so I think we can just piggyback off of their Python
3 install. We practically already do for devservices.
