### PR TITLE
ref(DRS): Deprecate dataset experimental flag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -61,5 +61,8 @@
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": true,
-  "python.testing.pytestArgs": ["tests"]
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "esbonio.sphinx.confDir": ""
 }

--- a/docs/source/configuration/dataset.md
+++ b/docs/source/configuration/dataset.md
@@ -5,6 +5,5 @@
 - **version**: Version of schema.
 - **kind**: Component kind.
 - **name** *(string)*: Name of the dataset.
-- **is_experimental** *(boolean)*: Marks the dataset as experimental. Healthchecks failing on this dataset will not block deploys and affect Snuba server's SLOs.
 - **entities** *(object)*:
   - **all** *(array)*: Names of entities associated with this dataset.

--- a/snuba/datasets/configuration/dataset_builder.py
+++ b/snuba/datasets/configuration/dataset_builder.py
@@ -11,5 +11,4 @@ def build_dataset_from_config(config_file_path: str) -> PluggableDataset:
     return PluggableDataset(
         name=config["name"],
         all_entities=[EntityKey(key) for key in config["entities"]],
-        is_experimental=bool(config["is_experimental"]),
     )

--- a/snuba/datasets/configuration/discover/dataset.yaml
+++ b/snuba/datasets/configuration/discover/dataset.yaml
@@ -2,8 +2,6 @@ version: v1
 kind: dataset
 name: discover
 
-is_experimental: false
-
 entities:
   - discover
   - discover_events

--- a/snuba/datasets/configuration/events/dataset.yaml
+++ b/snuba/datasets/configuration/events/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: events
 
-is_experimental: false
-
 entities:
   - events

--- a/snuba/datasets/configuration/functions/dataset.yaml
+++ b/snuba/datasets/configuration/functions/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: functions
 
-is_experimental: false
-
 entities:
   - functions

--- a/snuba/datasets/configuration/generic_metrics/dataset.yaml
+++ b/snuba/datasets/configuration/generic_metrics/dataset.yaml
@@ -2,8 +2,6 @@ version: v1
 kind: dataset
 name: generic_metrics
 
-is_experimental: false
-
 entities:
   - generic_metrics_sets
   - generic_metrics_distributions

--- a/snuba/datasets/configuration/groupassignee/dataset.yaml
+++ b/snuba/datasets/configuration/groupassignee/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: groupassignee
 
-is_experimental: false
-
 entities:
   - groupassignee

--- a/snuba/datasets/configuration/groupedmessage/dataset.yaml
+++ b/snuba/datasets/configuration/groupedmessage/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: groupedmessage
 
-is_experimental: false
-
 entities:
   - groupedmessage

--- a/snuba/datasets/configuration/issues/dataset.yaml
+++ b/snuba/datasets/configuration/issues/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: search_issues
 
-is_experimental: true
-
 entities:
   - search_issues

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -713,10 +713,6 @@ V1_DATASET_SCHEMA = {
         "version": {"const": "v1", "description": "Version of schema"},
         "kind": {"const": "dataset", "description": "Component kind"},
         "name": {"type": "string", "description": "Name of the dataset"},
-        "is_experimental": {
-            "type": "boolean",
-            "description": "Marks the dataset as experimental. Healthchecks failing on this dataset will not block deploys and affect Snuba server's SLOs",
-        },
         "entities": {
             "type": "array",
             "items": TYPE_STRING,
@@ -728,7 +724,6 @@ V1_DATASET_SCHEMA = {
         "kind",
         "name",
         "entities",
-        "is_experimental",
     ],
     "additionalProperties": False,
 }

--- a/snuba/datasets/configuration/metrics/dataset.yaml
+++ b/snuba/datasets/configuration/metrics/dataset.yaml
@@ -2,8 +2,6 @@ version: v1
 kind: dataset
 name: metrics
 
-is_experimental: false
-
 entities:
   - metrics_counters
   - metrics_distributions

--- a/snuba/datasets/configuration/outcomes/dataset.yaml
+++ b/snuba/datasets/configuration/outcomes/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: outcomes
 
-is_experimental: false
-
 entities:
   - outcomes

--- a/snuba/datasets/configuration/outcomes_raw/dataset.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: outcomes_raw
 
-is_experimental: false
-
 entities:
   - outcomes_raw

--- a/snuba/datasets/configuration/profiles/dataset.yaml
+++ b/snuba/datasets/configuration/profiles/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: profiles
 
-is_experimental: false
-
 entities:
   - profiles

--- a/snuba/datasets/configuration/replays/dataset.yaml
+++ b/snuba/datasets/configuration/replays/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: replays
 
-is_experimental: false
-
 entities:
   - replays

--- a/snuba/datasets/configuration/sessions/dataset.yaml
+++ b/snuba/datasets/configuration/sessions/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: sessions
 
-is_experimental: false
-
 entities:
   - sessions

--- a/snuba/datasets/configuration/spans/dataset.yaml
+++ b/snuba/datasets/configuration/spans/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: spans
 
-is_experimental: true
-
 entities:
   - spans

--- a/snuba/datasets/configuration/transactions/dataset.yaml
+++ b/snuba/datasets/configuration/transactions/dataset.yaml
@@ -2,7 +2,5 @@ version: v1
 kind: dataset
 name: transactions
 
-is_experimental: false
-
 entities:
   - transactions

--- a/snuba/datasets/dataset.py
+++ b/snuba/datasets/dataset.py
@@ -43,15 +43,6 @@ class Dataset:
     def __init__(self, *, all_entities: Sequence[EntityKey]) -> None:
         self.__all_entities = all_entities
 
-    def is_experimental(self) -> bool:
-        """Marks the dataset as experimental. Healthchecks failing on this
-        dataset:
-            * do not block deploys
-            * affect the snuba server's SLO
-            * still have metrics reported
-        """
-        return False
-
     def get_all_entities(self) -> Sequence[Entity]:
         return [get_entity(entity_key) for entity_key in self.__all_entities]
 

--- a/snuba/datasets/pluggable_dataset.py
+++ b/snuba/datasets/pluggable_dataset.py
@@ -19,14 +19,9 @@ class PluggableDataset(Dataset):
         *,
         name: str,
         all_entities: list[EntityKey],
-        is_experimental: bool | None,
     ) -> None:
         super().__init__(all_entities=all_entities)
         self.name = name
-        self.__is_experimental = is_experimental or False
-
-    def is_experimental(self) -> bool:
-        return self.__is_experimental
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, PluggableDataset) and self.name == other.name

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -136,6 +136,8 @@ def check_clickhouse(metric_tags: dict[str, Any] | None = None) -> bool:
     """
     try:
         storages = filter_checked_storages()
+        for storage in storages:
+            print(storage.get_storage_set_key())
         connection_grouped_table_names: MutableMapping[
             ConnectionId, Set[str]
         ] = defaultdict(set)

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -89,13 +89,12 @@ def temp_settings() -> Any:
 
 @mock.patch(
     "snuba.web.views.get_enabled_dataset_names",
-    return_value=["events", "experimental"],
+    return_value=["events"],
 )
 @mock.patch("snuba.web.views.get_dataset", side_effect=fake_get_dataset)
 @pytest.mark.clickhouse_db
 def test_check_clickhouse(mock1: mock.MagicMock, mock2: mock.MagicMock) -> None:
     assert check_clickhouse()
-    assert not check_clickhouse()
 
 
 @mock.patch(

--- a/tests/web/test_check_clickhouse.py
+++ b/tests/web/test_check_clickhouse.py
@@ -30,10 +30,6 @@ class ExperimentalDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(all_entities=[])
 
-    @classmethod
-    def is_experimental(cls) -> bool:
-        return True
-
     def get_all_entities(self) -> Sequence[BadEntity]:
         return [BadEntity()]
 
@@ -62,10 +58,6 @@ class MockDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(all_entities=[])
 
-    @classmethod
-    def is_experimental(cls) -> bool:
-        return False
-
     def get_all_entities(self) -> Sequence[MockEntity]:
         return [MockEntity()]
 
@@ -73,10 +65,6 @@ class MockDataset(Dataset):
 class BadDataset(Dataset):
     def __init__(self) -> None:
         super().__init__(all_entities=[])
-
-    @classmethod
-    def is_experimental(cls) -> bool:
-        return False
 
     def get_all_entities(self) -> Sequence[BadEntity]:
         return [BadEntity()]
@@ -106,8 +94,8 @@ def temp_settings() -> Any:
 @mock.patch("snuba.web.views.get_dataset", side_effect=fake_get_dataset)
 @pytest.mark.clickhouse_db
 def test_check_clickhouse(mock1: mock.MagicMock, mock2: mock.MagicMock) -> None:
-    assert check_clickhouse(ignore_experimental=True)
-    assert not check_clickhouse(ignore_experimental=False)
+    assert check_clickhouse()
+    assert not check_clickhouse()
 
 
 @mock.patch(
@@ -120,7 +108,7 @@ def test_bad_dataset_fails_healthcheck(
 ) -> None:
     # the bad dataset is enabled and not experimental, therefore the healthcheck
     # should fail
-    assert not check_clickhouse(ignore_experimental=True)
+    assert not check_clickhouse()
 
 
 @mock.patch(
@@ -132,7 +120,7 @@ def test_dataset_undefined_storage_set(
     mock1: mock.MagicMock, mock2: mock.MagicMock
 ) -> None:
     metrics_tags: dict[str, str] = {}
-    assert not check_clickhouse(ignore_experimental=True, metric_tags=metrics_tags)
+    assert not check_clickhouse(metric_tags=metrics_tags)
     for v in metrics_tags.values():
         assert isinstance(v, str)
 
@@ -151,7 +139,7 @@ def test_filter_checked_storages(
         "partial",
         "complete",
     }  # remove deprecate from supported states
-    storages = filter_checked_storages(ignore_experimental=True)
+    storages = filter_checked_storages()
 
     # check experimental dataset's storage is not in list
     assert BadStorage() not in storages


### PR DESCRIPTION
### Overview
This PR is responsible for deprecating the `is_experimental` flag in favour of readiness_states. Right now, the `is_experimental` flag is responsible for skipping health-checks of all storages of a particular dataset in all sentry environments. Now that we have readiness_states managing health-checks, we no longer need this flag.

### What is changing?
There are two datasets that are still marked `is_experimental: true`: `search_issues` and `spans`. When this flag is removed, both these datasets will use their storage readiness_states to manage health-checks.