### PR TITLE
feat(spans): Allow spans migrations to run locally

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -256,6 +256,10 @@ COLUMN_SPLIT_MIN_COLS = 6
 COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 
+# The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
+# Migrations for skipped groups will not be run.
+SKIPPED_MIGRATION_GROUPS: Set[str] = set()
+
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 # [04-18-2023] These two readiness state settings are temporary and used to facilitate the rollout of readiness states.

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -256,15 +256,6 @@ COLUMN_SPLIT_MIN_COLS = 6
 COLUMN_SPLIT_MAX_LIMIT = 1000
 COLUMN_SPLIT_MAX_RESULTS = 5000
 
-# The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
-# Migrations for skipped groups will not be run.
-SKIPPED_MIGRATION_GROUPS: Set[str] = {
-    "spans",
-}
-
-if os.environ.get("ENABLE_AUTORUN_MIGRATION_SPANS", False):
-    SKIPPED_MIGRATION_GROUPS.remove("spans")
-
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}
 # [04-18-2023] These two readiness state settings are temporary and used to facilitate the rollout of readiness states.


### PR DESCRIPTION
This PR allows spans migrations to run locally in snuba since this already runs in SaaS.