### PR TITLE
fix(gen-metrics): Add tags hash column to the generic metrics dist ta…

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -293,6 +293,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0010_counters_aggregate_table",
             "0011_counters_raw_table",
             "0012_counters_mv",
+            "0013_distributions_dist_tags_hash",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0013_distributions_dist_tags_hash.py
+++ b/snuba/snuba_migrations/generic_metrics/0013_distributions_dist_tags_hash.py
@@ -10,7 +10,7 @@ from snuba.migrations.columns import MigrationModifiers as Modifiers
 from snuba.migrations.operations import OperationTarget, SqlOperation
 
 storage_set_name = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
-dist_table_name = "generic_metric_distributions_aggregated_local"
+dist_table_name = "generic_metric_distributions_aggregated_dist"
 
 
 class Migration(migration.ClickhouseNodeMigration):

--- a/snuba/snuba_migrations/generic_metrics/0013_distributions_dist_tags_hash.py
+++ b/snuba/snuba_migrations/generic_metrics/0013_distributions_dist_tags_hash.py
@@ -1,0 +1,52 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Array, Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import (
+    hash_map_int_key_str_value_column_definition,
+)
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+dist_table_name = "generic_metric_distributions_aggregated_local"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds the tags hash map column to the distributed table. The column already exists on the
+    local tables.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "_raw_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_key_str_value_column_definition(
+                                "tags.key", "tags.raw_value"
+                            )
+                        ),
+                    ),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="_raw_tags_hash",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]


### PR DESCRIPTION
We have the tags hash on the raw tags table on generic metrics defined on the local tables but do not have it on the dist tables. This PR adds it to the dist tables for distributions. A separate PR will create it for counters and sets dist tables.