### PR TITLE
fix(dlq): Pass force to configure_metrics

### DIFF
--- a/snuba/cli/dlq_consumer.py
+++ b/snuba/cli/dlq_consumer.py
@@ -126,7 +126,7 @@ def dlq_consumer(
 
         metrics = MetricsWrapper(environment.metrics, "dlq_consumer", tags=metrics_tags)
 
-        configure_metrics(StreamMetricsAdapter(metrics))
+        configure_metrics(StreamMetricsAdapter(metrics), force=True)
 
         orig_consumer_config = resolve_consumer_config(
             storage_names=[instruction.storage_key.value],


### PR DESCRIPTION
The dlq consumer reconfigures metrics for each instruction it receives so force is needed
