### PR TITLE
feat(errors): process trace_sampled and num_processing_errors from event

### DIFF
--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -146,8 +146,6 @@ class ErrorsProcessor(DatasetMessageProcessor):
         processing_errors = data.get("errors", None)
         if processing_errors is not None and isinstance(processing_errors, list):
             processed["num_processing_errors"] = len(processing_errors)
-        # else:
-        #     processed["num_processing_errors"] = None
 
         processed["offset"] = metadata.offset
         processed["partition"] = metadata.partition

--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -143,6 +143,12 @@ class ErrorsProcessor(DatasetMessageProcessor):
 
         self.extract_stacktraces(processed, stacks, threads)
 
+        processing_errors = data.get("errors", None)
+        if processing_errors is not None and isinstance(processing_errors, list):
+            processed["num_processing_errors"] = len(processing_errors)
+        # else:
+        #     processed["num_processing_errors"] = None
+
         processed["offset"] = metadata.offset
         processed["partition"] = metadata.partition
         processed["message_timestamp"] = metadata.timestamp
@@ -262,6 +268,7 @@ class ErrorsProcessor(DatasetMessageProcessor):
         transaction_ctx = contexts.get("trace") or {}
         trace_id = transaction_ctx.get("trace_id", None)
         span_id = transaction_ctx.get("span_id", None)
+        trace_sampled = transaction_ctx.get("sampled", None)
 
         replay_ctx = contexts.get("replay") or {}
         replay_id = replay_ctx.get("replay_id", None)
@@ -277,6 +284,8 @@ class ErrorsProcessor(DatasetMessageProcessor):
             output["trace_id"] = str(uuid.UUID(trace_id))
         if span_id:
             output["span_id"] = int(span_id, 16)
+        if trace_sampled:
+            output["trace_sampled"] = bool(trace_sampled)
 
     def extract_common(
         self,

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 from uuid import UUID
 
 import pytest
@@ -33,9 +33,11 @@ class ErrorEvent:
     geo: Mapping[str, str]
     threads: Mapping[str, Any] | None
     trace_id: str
+    trace_sampled: bool | None
     environment: str
     replay_id: uuid.UUID | None
     received_timestamp: datetime
+    errors: Sequence[Mapping[str, Any]] | None
 
     def serialize(self) -> tuple[int, str, Mapping[str, Any]]:
         serialized_event: dict[str, Any] = {
@@ -252,6 +254,12 @@ class ErrorEvent:
             }
         if self.threads:
             serialized_event["data"]["threads"] = self.threads
+        if self.trace_sampled:
+            serialized_event["data"]["contexts"]["trace"][
+                "sampled"
+            ] = self.trace_sampled
+        if self.errors:
+            serialized_event["data"]["errors"] = self.errors
 
         return (
             2,
@@ -379,6 +387,10 @@ class ErrorEvent:
             expected_result["tags.key"].insert(4, "replayId")
             expected_result["tags.value"].insert(4, self.replay_id.hex)
 
+        if self.trace_sampled:
+            expected_result["contexts.key"].insert(5, "trace.sampled")
+            expected_result["contexts.value"].insert(5, str(self.trace_sampled))
+
         return expected_result
 
 
@@ -410,6 +422,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             received_timestamp=recieved,
             threads=None,
@@ -427,6 +440,7 @@ class TestErrorsProcessor:
                 "city": "fake_city",
                 "subdivision": "fake_subdivision",
             },
+            errors=None,
         )
 
     def test_errors_basic(self) -> None:
@@ -458,6 +472,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             received_timestamp=recieved,
             threads=None,
@@ -475,6 +490,7 @@ class TestErrorsProcessor:
                 "subdivision": "fake_subdivision",
             },
             replay_id=uuid.uuid4(),
+            errors=None,
         )
 
         payload = message.serialize()
@@ -494,6 +510,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             threads=None,
             received_timestamp=recieved,
@@ -511,6 +528,7 @@ class TestErrorsProcessor:
                 "subdivision": "fake_subdivision",
             },
             replay_id=None,
+            errors=None,
         )
         replay_id = uuid.uuid4()
         payload = message.serialize()
@@ -537,6 +555,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             received_timestamp=recieved,
             release="1.0.0",
@@ -554,6 +573,7 @@ class TestErrorsProcessor:
                 "subdivision": "fake_subdivision",
             },
             replay_id=replay_id,
+            errors=None,
         )
 
         payload = message.serialize()
@@ -577,6 +597,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             received_timestamp=recieved,
             threads=None,
@@ -594,6 +615,7 @@ class TestErrorsProcessor:
                 "subdivision": "fake_subdivision",
             },
             replay_id=None,
+            errors=None,
         )
         invalid_replay_id = "imnotavaliduuid"
         payload = message.serialize()
@@ -619,6 +641,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             received_timestamp=recieved,
             release="1.0.0",
@@ -650,6 +673,7 @@ class TestErrorsProcessor:
                     },
                 ]
             },
+            errors=None,
         )
         payload = message.serialize()
         meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
@@ -671,6 +695,7 @@ class TestErrorsProcessor:
             platform="python",
             message="",
             trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
             timestamp=timestamp,
             received_timestamp=recieved,
             release="1.0.0",
@@ -702,12 +727,116 @@ class TestErrorsProcessor:
                     },
                 ]
             },
+            errors=None,
         )
         payload = message.serialize()
         meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
 
         result = message.build_result(meta)
         result["exception_main_thread"] = False
+
+        assert self.processor.process_message(payload, meta) == InsertBatch(
+            [result], None
+        )
+
+    def test_trace_sampled(self) -> None:
+        timestamp, recieved = self.__get_timestamps()
+        message = ErrorEvent(
+            event_id=str(uuid.UUID("dcb9d002cac548c795d1c9adbfc68040")),
+            organization_id=1,
+            project_id=2,
+            group_id=100,
+            platform="python",
+            message="",
+            trace_id=str(uuid.uuid4()),
+            trace_sampled=True,
+            timestamp=timestamp,
+            received_timestamp=recieved,
+            release="1.0.0",
+            dist="dist",
+            environment="prod",
+            email="foo@bar.com",
+            ip_address="127.0.0.1",
+            user_id="myself",
+            username="me",
+            geo={
+                "country_code": "XY",
+                "region": "fake_region",
+                "city": "fake_city",
+                "subdivision": "fake_subdivision",
+            },
+            replay_id=None,
+            threads=None,
+            errors=None,
+        )
+        payload = message.serialize()
+        meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
+
+        result = message.build_result(meta)
+        result["trace_sampled"] = True
+
+        assert self.processor.process_message(payload, meta) == InsertBatch(
+            [result], None
+        )
+
+        # verify processing trace.sampled=None works as it did before
+        message.trace_sampled = None
+        payload = message.serialize()
+        meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
+
+        result2 = message.build_result(meta)
+
+        assert self.processor.process_message(payload, meta) == InsertBatch(
+            [result2], None
+        )
+
+    def test_errors_processed(self) -> None:
+        timestamp, recieved = self.__get_timestamps()
+        message = ErrorEvent(
+            event_id=str(uuid.UUID("dcb9d002cac548c795d1c9adbfc68040")),
+            organization_id=1,
+            project_id=2,
+            group_id=100,
+            platform="python",
+            message="",
+            trace_id=str(uuid.uuid4()),
+            trace_sampled=False,
+            timestamp=timestamp,
+            received_timestamp=recieved,
+            release="1.0.0",
+            dist="dist",
+            environment="prod",
+            email="foo@bar.com",
+            ip_address="127.0.0.1",
+            user_id="myself",
+            username="me",
+            geo={
+                "country_code": "XY",
+                "region": "fake_region",
+                "city": "fake_city",
+                "subdivision": "fake_subdivision",
+            },
+            replay_id=None,
+            threads=None,
+            errors=[{"type": "one"}, {"type": "two"}, {"type": "three"}],
+            # errors=None,
+        )
+        payload = message.serialize()
+        meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
+
+        result = message.build_result(meta)
+        result["num_processing_errors"] = 3
+
+        assert self.processor.process_message(payload, meta) == InsertBatch(
+            [result], None
+        )
+
+        # ensure old behavior where data.errors=None won't set 'num_processing_errors'
+        message.errors = None
+        payload = message.serialize()
+        meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
+
+        result = message.build_result(meta)
 
         assert self.processor.process_message(payload, meta) == InsertBatch(
             [result], None

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -819,7 +819,6 @@ class TestErrorsProcessor:
             replay_id=None,
             threads=None,
             errors=[{"type": "one"}, {"type": "two"}, {"type": "three"}],
-            # errors=None,
         )
         payload = message.serialize()
         meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)


### PR DESCRIPTION
Related to this https://github.com/getsentry/snuba/pull/4276

Extracts `trace_sampled` from the error event `data.context.trace` map.
Extracts `num_processing_errors` from the error event `data.errors` list of processing errors.

A follow-up PR will be created to expose these two new columns in the entity and discover.