### PR TITLE
feat(dlq): DLQ topics API for admin

### DIFF
--- a/snuba/admin/dead_letter_queue/__init__.py
+++ b/snuba/admin/dead_letter_queue/__init__.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import MutableSequence, NamedTuple, Optional, Sequence, TypedDict
+
+from snuba import settings
+from snuba.datasets.slicing import is_storage_set_sliced
+from snuba.datasets.storage import WritableTableStorage
+from snuba.datasets.storages.factory import get_all_storage_keys, get_writable_storage
+from snuba.datasets.table_storage import KafkaTopicSpec
+
+Topic = TypedDict(
+    "Topic",
+    {"logicalName": str, "physicalName": str, "slice": Optional[int], "storage": str},
+)
+
+
+class DlqTopic(NamedTuple):
+    logical_name: str
+    physical_name: str
+    slice_id: Optional[int]
+    storage: str
+
+    def to_json(self) -> Topic:
+        return {
+            "logicalName": self.logical_name,
+            "physicalName": self.physical_name,
+            "slice": self.slice_id,
+            "storage": self.storage,
+        }
+
+
+def get_dlq_topics() -> Sequence[Topic]:
+    dlq_topics = []
+
+    storages = get_writable_storages()
+    for storage in storages:
+
+        stream_loader = storage.get_table_writer().get_stream_loader()
+        dlq_config = stream_loader.get_dlq_config()
+        if dlq_config is not None:
+            for slice_id in get_slices(storage):
+                logical_name = dlq_config.topic.value
+                physical_name = KafkaTopicSpec(
+                    dlq_config.topic
+                ).get_physical_topic_name(slice_id)
+                dlq_topics.append(
+                    DlqTopic(
+                        logical_name,
+                        physical_name,
+                        slice_id,
+                        storage.get_storage_key().value,
+                    )
+                )
+
+    return [t.to_json() for t in dlq_topics]
+
+
+def get_slices(storage: WritableTableStorage) -> Sequence[Optional[int]]:
+    storage_set_key = storage.get_storage_set_key()
+
+    if is_storage_set_sliced(storage_set_key):
+        return list(range(settings.SLICED_STORAGE_SETS[storage_set_key.value]))
+    else:
+        return [None]
+
+
+def get_writable_storages() -> Sequence[WritableTableStorage]:
+    writable_storages: MutableSequence[WritableTableStorage] = []
+    storage_keys = get_all_storage_keys()
+    for storage_key in storage_keys:
+        try:
+            writable_storages.append(get_writable_storage(storage_key))
+        except AssertionError:
+            pass
+
+    return writable_storages

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -32,6 +32,8 @@ import {
   AllocationPolicyOptionalConfigDefinition,
 } from "./capacity_management/types";
 
+import { Topic } from "./dead_letter_queue/types";
+
 interface Client {
   getSettings: () => Promise<Settings>;
   getConfigs: () => Promise<Config[]>;
@@ -79,6 +81,7 @@ interface Client {
     key: string,
     params: object
   ) => Promise<void>;
+  getDlqTopics: () => Promise<Topic[]>;
 }
 
 function Client() {
@@ -363,6 +366,12 @@ function Client() {
           });
         }
       });
+    },
+    getDlqTopics: () => {
+      const url = baseUrl + "dead_letter_queue";
+      return fetch(url, {
+        headers: { "Content-Type": "application/json" },
+      }).then((resp) => resp.json());
     },
   };
 }

--- a/snuba/admin/static/dead_letter_queue/index.tsx
+++ b/snuba/admin/static/dead_letter_queue/index.tsx
@@ -16,13 +16,6 @@ function DeadLetterQueue(props: { api: Client }) {
 
   return (
     <div>
-      <div>
-        <p>
-          <mark>
-            This is a mockup of the dead letter queue UI. It does not work yet!
-          </mark>
-        </p>
-      </div>
       <form>
         <fieldset>
           <select
@@ -59,16 +52,10 @@ function DeadLetterQueue(props: { api: Client }) {
               Physical topic: <code>{topic.physicalName}</code>
             </div>
             <div>
-              Slice: <code>null</code>
+              Slice: <code>{topic.slice}</code>
             </div>
             <div>
               Storage: <code>{topic.storage}</code>
-            </div>
-            <div>
-              Current offsets: <code>{`\{0: 3\, 1: 1, 2: 3}`}</code>
-            </div>
-            <div>
-              Latest offsets: <code>{`\{0: 20\, 1: 1, 2: 3}`}</code>
             </div>
           </fieldset>
         )}

--- a/snuba/admin/static/dead_letter_queue/index.tsx
+++ b/snuba/admin/static/dead_letter_queue/index.tsx
@@ -1,73 +1,18 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import Client from "../api_client";
 import { COLORS } from "../theme";
+import { Topic } from "./types";
 
-type Topic = {
-  logicalTopic: string;
-  physicalTopic: string;
-  slice: number | null;
-  storage: string;
-};
-
-const dlq_topics: Topic[] = [
-  {
-    logicalTopic: "snuba-dead-letter-metrics-sets",
-    physicalTopic: "snuba-dead-letter-metrics-sets",
-    slice: null,
-    storage: "generic_metrics_sets_raw",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-metrics-counters",
-    physicalTopic: "snuba-dead-letter-metrics-counters",
-    slice: null,
-    storage: "generic_metrics_counters_raw",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-metrics-distributions",
-    physicalTopic: "snuba-dead-letter-metrics-distributions",
-    slice: null,
-    storage: "generic_metrics_distributions_raw",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-generic-metrics-sets",
-    physicalTopic: "snuba-dead-letter-generic-metrics-sets",
-    slice: null,
-    storage: "generic_metrics_sets_raw",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-generic-metrics-counters",
-    physicalTopic: "snuba-dead-letter-generic-metrics-counters",
-    slice: null,
-    storage: "generic_metrics_counters_raw",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-generic-metrics-distributions",
-    physicalTopic: "snuba-dead-letter-generic-metrics-distributions",
-    slice: null,
-    storage: "generic_metrics_distributions_raw",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-replays",
-    physicalTopic: "snuba-dead-letter-replays",
-    slice: null,
-    storage: "replays",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-generic-events",
-    physicalTopic: "snuba-dead-letter-generic-events",
-    slice: null,
-    storage: "search_issues",
-  },
-  {
-    logicalTopic: "snuba-dead-letter-querylog",
-    physicalTopic: "snuba-dead-letter-querylog",
-    slice: null,
-    storage: "querylog",
-  },
-];
-
-function DeadLetterQueue() {
+function DeadLetterQueue(props: { api: Client }) {
+  const [dlqTopics, setDlqTopics] = useState<Topic[]>([]);
   const [topic, setTopic] = useState<Topic | null>(null);
   const [messagesToProcess, setMessagesToProcess] = useState(0);
+
+  useEffect(() => {
+    props.api.getDlqTopics().then((res) => {
+      setDlqTopics(res);
+    });
+  }, []);
 
   return (
     <div>
@@ -81,11 +26,11 @@ function DeadLetterQueue() {
       <form>
         <fieldset>
           <select
-            value={topic ? topic.logicalTopic : ""}
+            value={topic ? topic.logicalName : ""}
             style={selectStyle}
             onChange={(evt) => {
-              for (let topic of dlq_topics) {
-                if (topic.logicalTopic === evt.target.value) {
+              for (let topic of dlqTopics) {
+                if (topic.logicalName === evt.target.value) {
                   setTopic(topic);
                   return;
                 }
@@ -97,21 +42,21 @@ function DeadLetterQueue() {
             <option disabled value="">
               Select DLQ topic
             </option>
-            {dlq_topics.map((topic) => (
+            {dlqTopics.map((topic) => (
               <option
-                key={topic.logicalTopic}
-                value={topic.logicalTopic}
-              >{`${topic.logicalTopic} (slice: ${topic.slice})`}</option>
+                key={topic.logicalName}
+                value={topic.logicalName}
+              >{`${topic.logicalName} (slice: ${topic.slice})`}</option>
             ))}
           </select>
         </fieldset>
         {topic && (
           <fieldset>
             <div>
-              Logical topic: <code>{topic.logicalTopic}</code>
+              Logical topic: <code>{topic.logicalName}</code>
             </div>
             <div>
-              Physical topic: <code>{topic.physicalTopic}</code>
+              Physical topic: <code>{topic.physicalName}</code>
             </div>
             <div>
               Slice: <code>null</code>

--- a/snuba/admin/static/dead_letter_queue/types.tsx
+++ b/snuba/admin/static/dead_letter_queue/types.tsx
@@ -1,0 +1,8 @@
+type Topic = {
+  logicalName: string;
+  physicalName: string;
+  slice: number | null;
+  storage: string;
+};
+
+export { Topic };

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -24,6 +24,7 @@ from snuba.admin.clickhouse.predefined_system_queries import SystemQuery
 from snuba.admin.clickhouse.querylog import describe_querylog_schema, run_querylog_query
 from snuba.admin.clickhouse.system_queries import run_system_query_on_host_with_sql
 from snuba.admin.clickhouse.tracing import run_query_and_get_trace
+from snuba.admin.dead_letter_queue import get_dlq_topics
 from snuba.admin.kafka.topics import get_broker_data
 from snuba.admin.migrations_policies import (
     check_migration_perms,
@@ -823,3 +824,9 @@ def set_allocation_policy_config() -> Response:
             405,
             {"Content-Type": "application/json"},
         )
+
+
+@application.route("/dead_letter_queue", methods=["GET"])
+@check_tool_perms(tools=[AdminTools.KAFKA])
+def dlq_topics() -> Response:
+    return make_response(jsonify(get_dlq_topics()), 200)

--- a/snuba/datasets/storage.py
+++ b/snuba/datasets/storage.py
@@ -172,6 +172,7 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
         write_format: WriteFormat = WriteFormat.JSON,
         ignore_write_errors: bool = False,
     ) -> None:
+        self.__storage_key = storage_key
         super().__init__(
             storage_key,
             storage_set_key,
@@ -192,6 +193,9 @@ class WritableTableStorage(ReadableTableStorage, WritableStorage):
             write_format=write_format,
         )
         self.__ignore_write_errors = ignore_write_errors
+
+    def get_storage_key(self) -> StorageKey:
+        return self.__storage_key
 
     def get_table_writer(self) -> TableWriter:
         return self.__table_writer

--- a/tests/admin/dead_letter_queue/test_dlq.py
+++ b/tests/admin/dead_letter_queue/test_dlq.py
@@ -1,0 +1,5 @@
+from snuba.admin.dead_letter_queue import get_dlq_topics
+
+
+def test_dlq() -> None:
+    assert len(get_dlq_topics()) == 7


### PR DESCRIPTION
Moves the hardcoded DLQ topics out of the admin UI and generate them from storage config definitions
