### PR TITLE
ref(admin): Give team-sns google group full access to snuba admin

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -40,7 +40,7 @@
           "user:rahul.saini@sentry.io",
           "user:riya.chakraborty@sentry.io",
           "user:volo.kluev@sentry.io",
-          "user:david.tsukernik@sentry.io"
+          "group:team-sns@sentry.io"
         ],
         "role": "roles/AllTools"
       },


### PR DESCRIPTION
Replacing myself with team-sns in the iam_policy file, so I can check that I still have access to all the tools in prod.