### PR TITLE
fix: Temporarily revert dlq topic changes

### DIFF
--- a/snuba/datasets/configuration/metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/metrics/storages/counters.yaml
@@ -52,4 +52,4 @@ stream_loader:
   processor:
     name: CounterAggregateProcessor
   default_topic: snuba-metrics
-  dlq_topic: snuba-dead-letter-metrics-counters
+  dlq_topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/metrics/storages/distributions.yaml
@@ -81,4 +81,4 @@ stream_loader:
   processor:
     name: DistributionsAggregateProcessor
   default_topic: snuba-metrics
-  dlq_topic: snuba-dead-letter-metrics-distributions
+  dlq_topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/metrics/storages/sets.yaml
@@ -56,4 +56,4 @@ stream_loader:
   processor:
     name: SetsAggregateProcessor
   default_topic: snuba-metrics
-  dlq_topic: snuba-dead-letter-metrics-sets
+  dlq_topic: snuba-dead-letter-metrics


### PR DESCRIPTION
They should actually exist in prod first


