### PR TITLE
fix(iam-policy): Don't use iam_policy.json in debug and test environments

### DIFF
--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -50,7 +50,6 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
                 role: str = binding["role"].split("roles/")[-1]
                 for member in binding["members"]:
                     if f"user:{user.email}" == member:
-                        print(member)
                         iam_roles.append(role)
                         break
                     if member.startswith("group:"):

--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -74,7 +74,6 @@ def _set_roles(user: AdminUser) -> AdminUser:
         iam_roles = get_iam_roles_from_file(user)
 
     user.roles = [*[ROLES[role] for role in iam_roles if role in ROLES], *DEFAULT_ROLES]
-    print(user.roles)
     return user
 
 

--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -50,6 +50,7 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
                 role: str = binding["role"].split("roles/")[-1]
                 for member in binding["members"]:
                     if f"user:{user.email}" == member:
+                        print(member)
                         iam_roles.append(role)
                         break
                     if member.startswith("group:"):
@@ -68,8 +69,12 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
 def _set_roles(user: AdminUser) -> AdminUser:
     # todo: depending on provider convert user email
     # to subset of DEFAULT_ROLES based on IAM roles
-    iam_roles = get_iam_roles_from_file(user)
+    iam_roles: Sequence[str] = []
+    if not settings.DEBUG and not settings.TESTING:
+        iam_roles = get_iam_roles_from_file(user)
+
     user.roles = [*[ROLES[role] for role in iam_roles if role in ROLES], *DEFAULT_ROLES]
+    print(user.roles)
     return user
 
 


### PR DESCRIPTION
If we are in a debug or test environment, we should not use the iam_policy.json file to decide roles.