### PR TITLE
ref(capman): Move is_active check to base allocation policy

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -677,7 +677,10 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
     def get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
         try:
-            allowance = self._get_quota_allowance(tenant_ids)
+            if not self.is_active:
+                allowance = QuotaAllowance(True, self.max_threads, {})
+            else:
+                allowance = self._get_quota_allowance(tenant_ids)
         except Exception:
             logger.exception(
                 "Allocation policy failed to get quota allowance, this is a bug, fix it"
@@ -699,6 +702,8 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         result_or_error: QueryResultOrError,
     ) -> None:
         try:
+            if not self.is_active:
+                return
             return self._update_quota_balance(tenant_ids, result_or_error)
         except Exception:
             logger.exception(

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -125,9 +125,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         return True, ""
 
     def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
-        if not self.is_active:
-            return QuotaAllowance(True, self.max_threads, {})
-
         ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
         if not ids_are_valid:
             self.metrics.increment(
@@ -201,8 +198,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         tenant_ids: dict[str, str | int],
         result_or_error: QueryResultOrError,
     ) -> None:
-        if not self.is_active:
-            return
         if result_or_error.error:
             return
         ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -65,18 +65,17 @@ def test_raises_on_false_can_run() -> None:
         ).get_quota_allowance({})
 
 
+class BadlyWrittenAllocationPolicy(PassthroughPolicy):
+    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+        raise AttributeError("You messed up!")
+
+    def _update_quota_balance(
+        self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
+    ) -> None:
+        raise ValueError("you messed up AGAIN")
+
+
 def test_passes_through_on_error() -> None:
-    class BadlyWrittenAllocationPolicy(PassthroughPolicy):
-        def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
-        ) -> QuotaAllowance:
-            raise AttributeError("You messed up!")
-
-        def _update_quota_balance(
-            self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
-        ) -> None:
-            raise ValueError("you messed up AGAIN")
-
     with pytest.raises(AttributeError):
         BadlyWrittenAllocationPolicy(
             StorageKey("something"), [], {}
@@ -389,32 +388,34 @@ def test_bad_defaults() -> None:
 
 
 @pytest.mark.redis_db
-@mock.patch("snuba.query.allocation_policies.AllocationPolicy")
-def test_is_not_active(
-    mock: mock.MagicMock,
-) -> None:
-    policy = SomeParametrizedConfigPolicy(
+def test_is_not_active() -> None:
+    # active policy
+    policy = BadlyWrittenAllocationPolicy(
         StorageKey("some_storage"),
         [],
-        {"my_param_config": 420, "is_active": 0, "is_enforced": 0},
+        {"my_param_config": 420, "is_active": 1, "is_enforced": 0},
     )
-    mock_return_value = mock.return_value
+
     tenant_ids: dict[str, int | str] = {
         "organization_id": 123,
         "referrer": "some_referrer",
     }
-    policy.update_quota_balance(
-        tenant_ids,
-        QueryResultOrError(
-            query_result=QueryResult(
-                result={"profile": {"bytes": 420}},
-                extra={"stats": {}, "sql": "", "experiments": {}},
-            ),
-            error=None,
+    result_or_error = QueryResultOrError(
+        query_result=QueryResult(
+            result={"profile": {"bytes": 420}},
+            extra={"stats": {}, "sql": "", "experiments": {}},
         ),
+        error=None,
     )
-    policy.get_quota_allowance(tenant_ids)
 
-    # assert that child methods were not called because policy is inactive
-    mock_return_value._update_quota_balance.assert_not_called()
-    mock_return_value._get_quota_allowance.assert_not_called()
+    # Should error since private methods _get_quota_allowance and _update_quota_balance are called
+    with pytest.raises(AttributeError):
+        policy.get_quota_allowance(tenant_ids)
+    with pytest.raises(ValueError):
+        policy.update_quota_balance(tenant_ids, result_or_error)
+
+    policy.set_config_value(config_key="is_active", value=0)  # make policy inactive
+
+    # Should not error anymore since private methods are not called due to inactivity
+    policy.get_quota_allowance(tenant_ids)
+    policy.update_quota_balance(tenant_ids, result_or_error)

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -95,19 +95,14 @@ def test_org_isolation(policy: AllocationPolicy) -> None:
     assert allowance.max_threads == MAX_THREAD_NUMBER
 
 
-from unittest import mock
-
-
-@mock.patch("snuba.query.allocation_policies.AllocationPolicy")
 @pytest.mark.redis_db
-def test_killswitch(mock: mock.MagicMock, policy: AllocationPolicy) -> None:
+def test_killswitch(policy: AllocationPolicy) -> None:
     _configure_policy(policy)
     policy.set_config_value("is_active", 0)
     tenant_ids: dict[str, int | str] = {
         "organization_id": 123,
         "referrer": "some_referrer",
     }
-    mock_get_quota_allowance = mock.return_value
     policy.update_quota_balance(
         tenant_ids,
         QueryResultOrError(
@@ -119,9 +114,6 @@ def test_killswitch(mock: mock.MagicMock, policy: AllocationPolicy) -> None:
         ),
     )
     allowance = policy.get_quota_allowance(tenant_ids)
-    # assert that child methods were not called
-    mock_get_quota_allowance._update_quota_balance.assert_not_called()
-    mock_get_quota_allowance._get_quota_allowance.assert_not_called()
     # policy is not active so no change
     assert allowance.max_threads == MAX_THREAD_NUMBER
 

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -95,14 +95,19 @@ def test_org_isolation(policy: AllocationPolicy) -> None:
     assert allowance.max_threads == MAX_THREAD_NUMBER
 
 
+from unittest import mock
+
+
+@mock.patch("snuba.query.allocation_policies.AllocationPolicy")
 @pytest.mark.redis_db
-def test_killswitch(policy: AllocationPolicy) -> None:
+def test_killswitch(mock: mock.MagicMock, policy: AllocationPolicy) -> None:
     _configure_policy(policy)
     policy.set_config_value("is_active", 0)
     tenant_ids: dict[str, int | str] = {
         "organization_id": 123,
         "referrer": "some_referrer",
     }
+    mock_get_quota_allowance = mock.return_value
     policy.update_quota_balance(
         tenant_ids,
         QueryResultOrError(
@@ -114,6 +119,9 @@ def test_killswitch(policy: AllocationPolicy) -> None:
         ),
     )
     allowance = policy.get_quota_allowance(tenant_ids)
+    # assert that child methods were not called
+    mock_get_quota_allowance._update_quota_balance.assert_not_called()
+    mock_get_quota_allowance._get_quota_allowance.assert_not_called()
     # policy is not active so no change
     assert allowance.max_threads == MAX_THREAD_NUMBER
 


### PR DESCRIPTION
### Overview
Minor refactor to move `is_active` logic to be contained within the Allocation Policy base class. This makes it such that any new policies being added would not need to reimplement is_active logic.