### PR TITLE
fix(iam-policy): Don't build google cloud API client in debug and test environments

### DIFF
--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -50,7 +50,6 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
                 role: str = binding["role"].split("roles/")[-1]
                 for member in binding["members"]:
                     if f"user:{user.email}" == member:
-                        print(member)
                         iam_roles.append(role)
                         break
                     if member.startswith("group:"):

--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -74,7 +74,6 @@ def _set_roles(user: AdminUser) -> AdminUser:
         iam_roles = get_iam_roles_from_file(user)
 
     user.roles = [*[ROLES[role] for role in iam_roles if role in ROLES], *DEFAULT_ROLES]
-    print(user.roles)
     return user
 
 

--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -50,6 +50,7 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
                 role: str = binding["role"].split("roles/")[-1]
                 for member in binding["members"]:
                     if f"user:{user.email}" == member:
+                        print(member)
                         iam_roles.append(role)
                         break
                     if member.startswith("group:"):
@@ -68,8 +69,12 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
 def _set_roles(user: AdminUser) -> AdminUser:
     # todo: depending on provider convert user email
     # to subset of DEFAULT_ROLES based on IAM roles
-    iam_roles = get_iam_roles_from_file(user)
+    iam_roles: Sequence[str] = []
+    if not settings.DEBUG and not settings.TESTING:
+        iam_roles = get_iam_roles_from_file(user)
+
     user.roles = [*[ROLES[role] for role in iam_roles if role in ROLES], *DEFAULT_ROLES]
+    print(user.roles)
     return user
 
 

--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -68,10 +68,7 @@ def get_iam_roles_from_file(user: AdminUser) -> Sequence[str]:
 def _set_roles(user: AdminUser) -> AdminUser:
     # todo: depending on provider convert user email
     # to subset of DEFAULT_ROLES based on IAM roles
-    iam_roles: Sequence[str] = []
-    if not settings.DEBUG and not settings.TESTING:
-        iam_roles = get_iam_roles_from_file(user)
-
+    iam_roles = get_iam_roles_from_file(user)
     user.roles = [*[ROLES[role] for role in iam_roles if role in ROLES], *DEFAULT_ROLES]
     return user
 

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -16,13 +16,12 @@ class CloudIdentityAPI:
 
     def __init__(self, service: Resource = None) -> None:
         self.initialized = False
+        self.service = service
         if settings.DEBUG or settings.TESTING:
             return
 
         try:
-            self.service: Resource = (
-                service if service else build("cloudidentity", "v1")
-            )
+            self.service = build("cloudidentity", "v1")
             self.initialized = True
         except Exception as e:
             logger.exception(e)

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -17,13 +17,11 @@ class CloudIdentityAPI:
     def __init__(self, service: Resource = None) -> None:
         self.service = service
         self.initialized = service is not None
-        if settings.DEBUG or settings.TESTING:
+        if settings.DEBUG or settings.TESTING or self.initialized:
             return
 
         try:
-            self.service: Resource = (
-                service if service else build("cloudidentity", "v1")
-            )
+            self.service = build("cloudidentity", "v1")
             self.initialized = True
         except Exception as e:
             logger.exception(e)

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -4,6 +4,8 @@ from urllib.parse import urlencode
 import structlog
 from googleapiclient.discovery import Resource, build
 
+from snuba import settings
+
 logger = structlog.get_logger().bind(module=__name__)
 
 
@@ -20,7 +22,8 @@ class CloudIdentityAPI:
             )
             self.initialized = True
         except Exception as e:
-            logger.exception(e)
+            if not settings.DEBUG and not settings.TESTING:
+                logger.exception(e)
 
     def _get_group_id(self, group_email: str) -> Optional[str]:
         if not self.initialized:

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -21,7 +21,9 @@ class CloudIdentityAPI:
             return
 
         try:
-            self.service = build("cloudidentity", "v1")
+            self.service: Resource = (
+                service if service else build("cloudidentity", "v1")
+            )
             self.initialized = True
         except Exception as e:
             logger.exception(e)

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -16,14 +16,16 @@ class CloudIdentityAPI:
 
     def __init__(self, service: Resource = None) -> None:
         self.initialized = False
+        if settings.DEBUG or settings.TESTING:
+            return
+
         try:
             self.service: Resource = (
                 service if service else build("cloudidentity", "v1")
             )
             self.initialized = True
         except Exception as e:
-            if not settings.DEBUG and not settings.TESTING:
-                logger.exception(e)
+            logger.exception(e)
 
     def _get_group_id(self, group_email: str) -> Optional[str]:
         if not self.initialized:

--- a/snuba/admin/google.py
+++ b/snuba/admin/google.py
@@ -15,8 +15,8 @@ class CloudIdentityAPI:
     """
 
     def __init__(self, service: Resource = None) -> None:
-        self.initialized = False
         self.service = service
+        self.initialized = service is not None
         if settings.DEBUG or settings.TESTING:
             return
 


### PR DESCRIPTION
Since we don't use the google cloud API on local and testing environments, we should not be building the api client at all.