### PR TITLE
ref(iam-policy): Replace user emails with group emails in iam_policy file

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -1,54 +1,34 @@
 {
-    "bindings": [
-      {
-        "members": [
-          "user:fpacifici@sentry.io",
-          "user:meredith@sentry.io",
-          "user:nikhar.saxena@sentry.io",
-          "user:dalitso.banda@sentry.io"
-        ],
-        "role": "roles/NonBlockingMigrationsExecutor"
-      },
-      {
-        "members": [
-          "user:fpacifici@sentry.io",
-          "user:meredith@sentry.io",
-          "user:nikhar.saxena@sentry.io",
-          "user:dalitso.banda@sentry.io"
-        ],
-        "role": "roles/SearchIssuesExecutor"
-      },
-      {
-        "members": [
-          "group:team-sns@sentry.io"
-        ],
-        "role": "roles/MigrationsReader"
-      },
-      {
-        "members": [
-          "user:dalitso.banda@sentry.io",
-          "user:enoch.tang@sentry.io",
-          "user:evan.hicks@sentry.io",
-          "user:fpacifici@sentry.io",
-          "user:john.yang@sentry.io",
-          "user:lyn@sentry.io",
-          "user:markus@sentry.io",
-          "user:matthew.cannizzaro@sentry.io",
-          "user:meredith@sentry.io",
-          "user:nikhar.saxena@sentry.io",
-          "user:oliver.newland@sentry.io",
-          "user:rahul.saini@sentry.io",
-          "user:riya.chakraborty@sentry.io",
-          "user:volo.kluev@sentry.io",
-          "group:team-sns@sentry.io"
-        ],
-        "role": "roles/AllTools"
-      },
-      {
-        "members": [
-            "group:access-snuba-admin@sentry.io"
-        ],
-        "role": "roles/ProductTools"
-      }
-    ]
-  }
+  "bindings": [
+    {
+      "members": [
+        "group:role-deploy-snuba-migrations-operator@sentry.io"
+      ],
+      "role": "roles/NonBlockingMigrationsExecutor"
+    },
+    {
+      "members": [
+        "group:role-deploy-snuba-migrations-operator@sentry.io"
+      ],
+      "role": "roles/SearchIssuesExecutor"
+    },
+    {
+      "members": [
+        "group:team-sns@sentry.io"
+      ],
+      "role": "roles/MigrationsReader"
+    },
+    {
+      "members": [
+        "group:team-sns@sentry.io"
+      ],
+      "role": "roles/AllTools"
+    },
+    {
+      "members": [
+          "group:access-snuba-admin@sentry.io"
+      ],
+      "role": "roles/ProductTools"
+    }
+  ]
+}


### PR DESCRIPTION
After replacing my own email with team-sns and validating that I can see all tools on snuba admin, we can now transition all user emails to groups.