### PR TITLE
feat(dlq): Redesign admin UI, add API endpoints for replaying

### DIFF
--- a/snuba/admin/static/dead_letter_queue/index.tsx
+++ b/snuba/admin/static/dead_letter_queue/index.tsx
@@ -1,107 +1,196 @@
 import React, { useEffect, useState } from "react";
 import Client from "../api_client";
 import { COLORS } from "../theme";
-import { Topic } from "./types";
+import { Policy, ReplayInstruction, Topic } from "./types";
 
 function DeadLetterQueue(props: { api: Client }) {
+  // Undefined means not loaded yet, null means no instruction was set
+  const [instruction, setInstruction] = useState<
+    ReplayInstruction | null | undefined
+  >(undefined);
+  const [isEditing, setIsEditing] = useState(false);
   const [dlqTopics, setDlqTopics] = useState<Topic[]>([]);
   const [topic, setTopic] = useState<Topic | null>(null);
-  const [messagesToProcess, setMessagesToProcess] = useState(0);
+  const [messagesToProcess, setMessagesToProcess] = useState(1);
+  const [policy, setPolicy] = useState<Policy | null>(null);
 
   useEffect(() => {
+    props.api.getDlqInstruction().then((res) => {
+      setInstruction(res);
+    });
     props.api.getDlqTopics().then((res) => {
       setDlqTopics(res);
     });
   }, []);
 
+  function clearInstruction() {
+    props.api.clearDlqInstruction().then((res) => {
+      setInstruction(res);
+    });
+  }
+
+  function replayDlq() {
+    if (policy === null || topic === null) {
+      return;
+    }
+
+    let instruction: ReplayInstruction = {
+      messagesToProcess,
+      policy,
+    };
+
+    props.api.setDlqInstruction(topic, instruction).then((res) => {
+      setInstruction(res);
+      setIsEditing(false);
+      setTopic(null);
+      setMessagesToProcess(0);
+      setPolicy(null);
+    });
+  }
+
+  if (typeof instruction === undefined) {
+    return null;
+  }
+
   return (
     <div>
-      <form>
-        <fieldset>
-          <select
-            value={topic ? topic.logicalName : ""}
-            style={selectStyle}
-            onChange={(evt) => {
-              for (let topic of dlqTopics) {
-                if (topic.logicalName === evt.target.value) {
-                  setTopic(topic);
-                  return;
-                }
-              }
-
-              setTopic(null);
+      <div style={currentValue}>
+        <p style={paragraphStyle}>This is the currently set DLQ instruction:</p>
+        <p>
+          <code>{JSON.stringify(instruction) || "None set"}</code>
+        </p>
+      </div>
+      {!isEditing && (
+        <div>
+          <a
+            style={linkStyle}
+            onClick={() => {
+              setIsEditing(true);
             }}
           >
-            <option disabled value="">
-              Select DLQ topic
-            </option>
-            {dlqTopics.map((topic) => (
-              <option
-                key={topic.logicalName}
-                value={topic.logicalName}
-              >{`${topic.logicalName} (slice: ${topic.slice})`}</option>
-            ))}
-          </select>
-        </fieldset>
-        {topic && (
-          <fieldset>
-            <div>
-              Logical topic: <code>{topic.logicalName}</code>
-            </div>
-            <div>
-              Physical topic: <code>{topic.physicalName}</code>
-            </div>
-            <div>
-              Slice: <code>{topic.slice}</code>
-            </div>
-            <div>
-              Storage: <code>{topic.storage}</code>
-            </div>
-          </fieldset>
-        )}
-      </form>
-      {topic && (
-        <form style={reprocessForm}>
-          <h3 style={{ margin: "0 0 10px 0" }}>Reprocess messages:</h3>
-          <fieldset>
-            <label htmlFor="policy" style={label}>
-              DLQ policy:
-            </label>
-            <select id="policy" name="policy" style={selectStyle}>
-              <option>Select invalid message policy</option>
-              <option>Re-produce to DLQ</option>
-              <option>Crash on error</option>
-              <option>Drop invalid messages</option>
-            </select>
-          </fieldset>
-          <fieldset>
-            <label htmlFor="messagesToProcess" style={label}>
-              Max messages to process:
-            </label>
-            <input
-              type="number"
-              name="messagesToProcess"
-              value={messagesToProcess}
-              placeholder="Max messages to process"
-              onChange={(evt) => {
-                setMessagesToProcess(parseInt(evt.target.value, 10));
-              }}
-            />
-          </fieldset>
-          <fieldset>
-            <button
-              type="button"
-              style={buttonStyle}
-              onClick={(evt) => console.log("Do reprocess")}
+            edit
+          </a>
+        </div>
+      )}
+      {isEditing && (
+        <div style={{ margin: "30px 0 0 0" }}>
+          <h3 style={{ margin: "0 0 10px 0" }}>Editing</h3>
+          {instruction && (
+            <a
+              style={{ ...linkStyle, color: "red" }}
+              onClick={clearInstruction}
             >
-              Reprocess messages
-            </button>
-          </fieldset>
-        </form>
+              clear instruction
+            </a>
+          )}
+          {!instruction && (
+            <form style={formStyle}>
+              <fieldset>
+                <label htmlFor="topic" style={label}>
+                  Storage/topic:
+                </label>
+                <select
+                  id="topic"
+                  name="topic"
+                  value={topic ? topic.logicalName : ""}
+                  style={selectStyle}
+                  onChange={(evt) => {
+                    for (let topic of dlqTopics) {
+                      if (topic.logicalName === evt.target.value) {
+                        setTopic(topic);
+                        return;
+                      }
+                    }
+
+                    setTopic(null);
+                  }}
+                >
+                  <option disabled value="">
+                    Select DLQ topic
+                  </option>
+                  {dlqTopics.map((topic) => (
+                    <option
+                      key={`${topic.storage}-${topic.logicalName}-${topic.slice}`}
+                      value={topic.logicalName}
+                    >{`${topic.storage} - ${topic.logicalName} (slice: ${topic.slice})`}</option>
+                  ))}
+                </select>
+              </fieldset>
+              <fieldset>
+                <label htmlFor="policy" style={label}>
+                  DLQ policy:
+                </label>
+                <select
+                  id="policy"
+                  name="policy"
+                  style={selectStyle}
+                  onChange={(evt) => {
+                    let value = (evt.target.value as Policy) || null;
+                    setPolicy(value);
+                  }}
+                >
+                  <option value="">Select invalid message policy</option>
+                  <option value="reinsert-dlq">
+                    Re-insert to DLQ some long description
+                  </option>
+                  <option value="stop-on-error">Crash on error</option>
+                  <option value="drop-invalid-messages">
+                    Drop invalid messages
+                  </option>
+                </select>
+              </fieldset>
+              <fieldset>
+                <label htmlFor="messagesToProcess" style={label}>
+                  Max messages to process:
+                </label>
+                <input
+                  type="number"
+                  id="messagesToProcess"
+                  name="messagesToProcess"
+                  value={messagesToProcess}
+                  placeholder="Max messages to process"
+                  onChange={(evt) => {
+                    let value = parseInt(evt.target.value, 10);
+                    if (!isNaN(value) && value >= 0) {
+                      setMessagesToProcess(value);
+                    }
+                  }}
+                />
+              </fieldset>
+              <fieldset>
+                <button
+                  type="button"
+                  style={buttonStyle}
+                  onClick={replayDlq}
+                  disabled={policy === null || topic === null}
+                >
+                  Reprocess messages
+                </button>
+              </fieldset>
+            </form>
+          )}
+          <div>
+            <a
+              style={linkStyle}
+              onClick={() => {
+                setIsEditing(false);
+              }}
+            >
+              cancel
+            </a>
+          </div>
+        </div>
       )}
     </div>
   );
 }
+
+const currentValue = {
+  display: "block",
+  width: "100%",
+  border: `1px solid ${COLORS.TABLE_BORDER}`,
+  padding: 10,
+};
 
 const selectStyle = {
   marginBottom: 8,
@@ -118,10 +207,20 @@ const label = {
   display: "block",
 };
 
-const reprocessForm = {
-  width: 1000,
-  padding: 20,
-  backgroundColor: COLORS.BG_LIGHT,
+const paragraphStyle = {
+  fontSize: 15,
+  color: COLORS.TEXT_LIGHTER,
+};
+
+const linkStyle = {
+  cursor: "pointer",
+  fontSize: 13,
+  color: COLORS.TEXT_LIGHTER,
+  textDecoration: "underline",
+};
+
+const formStyle = {
+  padding: "20px 0",
 };
 
 export default DeadLetterQueue;

--- a/snuba/admin/static/dead_letter_queue/types.tsx
+++ b/snuba/admin/static/dead_letter_queue/types.tsx
@@ -5,4 +5,11 @@ type Topic = {
   storage: string;
 };
 
-export { Topic };
+type Policy = "reinsert-dlq" | "stop-on-error" | "drop-invalid-messages";
+
+type ReplayInstruction = {
+  messagesToProcess: number;
+  policy: Policy;
+};
+
+export { Policy, Topic, ReplayInstruction };

--- a/snuba/consumers/dlq.py
+++ b/snuba/consumers/dlq.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class DlqPolicy(Enum):
-    CRASH = "stop-on-error"
+    STOP_ON_ERROR = "stop-on-error"
     REINSERT_DLQ = "reinsert-dlq"
     DROP_INVALID_MESSAGES = "drop-invalid-messages"
 

--- a/snuba/consumers/dlq.py
+++ b/snuba/consumers/dlq.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class DlqPolicy(Enum):
-    STOP_ON_ERROR = "stop-on-error"
+    CRASH = "stop-on-error"
     REINSERT_DLQ = "reinsert-dlq"
     DROP_INVALID_MESSAGES = "drop-invalid-messages"
 


### PR DESCRIPTION
Tried to make it look a bit cleaner/minimalistic. Added ability to get/post/delete the replay instruction.

<img width="1547" alt="Screenshot 2023-06-14 at 5 02 54 pm" src="https://github.com/getsentry/snuba/assets/1779792/1108287f-eb48-4bc8-a4c5-ab98efe3ddff">
