### PR TITLE
feat(search_issues): Promote search_issues migration group to complete

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -146,7 +146,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.SEARCH_ISSUES: _MigrationGroup(
         loader=SearchIssuesLoader(),
         storage_sets_keys={StorageSetKey.SEARCH_ISSUES},
-        readiness_state=ReadinessState.PARTIAL,
+        readiness_state=ReadinessState.COMPLETE,
     ),
     MigrationGroup.SPANS: _MigrationGroup(
         loader=SpansLoader(),

--- a/snuba/settings/settings_self_hosted.py
+++ b/snuba/settings/settings_self_hosted.py
@@ -17,6 +17,10 @@ USE_REDIS_CLUSTER = False
 DOGSTATSD_HOST = env("DOGSTATSD_HOST")
 DOGSTATSD_PORT = env("DOGSTATSD_PORT")
 
+# Migrations in skipped groups will not be run
+SKIPPED_MIGRATION_GROUPS: Set[str] = {
+    "search_issues",
+}
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "complete"}
 READINESS_STATE_FAIL_QUERIES: bool = False


### PR DESCRIPTION
### Overview
The following PR is responsible for promoting the `search_issues` migration group from the `partial` readiness state to `complete` state. This enables makes the migration group visible and executable in more Sentry internal environments (ST). However, this skips the migration group in self-hosted as the dataset is not ready for it yet.  