### PR TITLE
feat(admin-auth): Add TTL cache for admin roles

### DIFF
--- a/snuba/admin/auth.py
+++ b/snuba/admin/auth.py
@@ -74,7 +74,7 @@ def _set_roles(user: AdminUser) -> AdminUser:
     iam_roles = redis_client.smembers(user.email)
     if not iam_roles:
         iam_roles = get_iam_roles_from_file(user)
-        redis_client.sadd(user.email, iam_roles)
+        redis_client.sadd(user.email, *iam_roles)
         redis_client.expire(user.email, settings.ADMIN_ROLES_REDIS_TTL)
 
     user.roles = [*[ROLES[role] for role in iam_roles if role in ROLES], *DEFAULT_ROLES]

--- a/snuba/redis.py
+++ b/snuba/redis.py
@@ -113,6 +113,7 @@ class RedisClientKey(Enum):
     CONFIG = "config"
     DLQ = "dlq"
     OPTIMIZE = "optimize"
+    ADMIN_AUTH = "admin_auth"
 
 
 _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
@@ -136,6 +137,9 @@ _redis_clients: Mapping[RedisClientKey, RedisClientType] = {
     ),
     RedisClientKey.OPTIMIZE: _initialize_specialized_redis_cluster(
         settings.REDIS_CLUSTERS["optimize"]
+    ),
+    RedisClientKey.ADMIN_AUTH: _initialize_specialized_redis_cluster(
+        settings.REDIS_CLUSTERS["admin_auth"]
     ),
 }
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -55,6 +55,8 @@ ADMIN_REPLAYS_SAMPLE_RATE_ON_ERROR = float(
     os.environ.get("ADMIN_REPLAYS_SAMPLE_RATE_ON_ERROR", 1.0)
 )
 
+ADMIN_ROLES_REDIS_TTL = 600
+
 ######################
 # End Admin Settings #
 ######################
@@ -154,6 +156,7 @@ class RedisClusters(TypedDict):
     config: RedisClusterConfig | None
     dlq: RedisClusterConfig | None
     optimize: RedisClusterConfig | None
+    admin_auth: RedisClusterConfig | None
 
 
 REDIS_CLUSTERS: RedisClusters = {
@@ -164,6 +167,7 @@ REDIS_CLUSTERS: RedisClusters = {
     "config": None,
     "dlq": None,
     "optimize": None,
+    "admin_auth": None,
 }
 
 # Query Recording Options

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -55,5 +55,6 @@ REDIS_CLUSTERS = {
         (6, "config"),
         (7, "dlq"),
         (8, "optimize"),
+        (9, "admin_auth"),
     ]
 }

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -32,6 +32,7 @@ def admin_api() -> FlaskClient:
     return application.test_client()
 
 
+@pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_migration_groups(admin_api: FlaskClient) -> None:
     runner = Runner()
@@ -77,6 +78,7 @@ def test_migration_groups(admin_api: FlaskClient) -> None:
         ]
 
 
+@pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_list_migration_status(admin_api: FlaskClient) -> None:
     with patch(
@@ -138,6 +140,7 @@ def test_list_migration_status(admin_api: FlaskClient) -> None:
     assert sorted_response == sorted_expected_json
 
 
+@pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 @pytest.mark.parametrize("action", ["run", "reverse"])
 def test_run_reverse_migrations(admin_api: FlaskClient, action: str) -> None:

--- a/tests/admin/clickhouse_migrations/test_api.py
+++ b/tests/admin/clickhouse_migrations/test_api.py
@@ -347,8 +347,6 @@ def test_get_iam_roles(caplog: Any) -> None:
                 tool_role,
             ]
 
-            _set_roles(user1)
-
             user2 = AdminUser(email="test_user2@sentry.io", id="unknown")
             _set_roles(user2)
 
@@ -366,6 +364,8 @@ def test_get_iam_roles(caplog: Any) -> None:
                 tool_role,
             ]
 
+        iam_file.close()
+        iam_file = tempfile.NamedTemporaryFile()
         iam_file.write(json.dumps({"bindings": []}).encode("utf-8"))
         iam_file.flush()
 
@@ -381,7 +381,7 @@ def test_get_iam_roles(caplog: Any) -> None:
             ]
 
             redis_client = get_redis_client(RedisClientKey.ADMIN_AUTH)
-            redis_client.delete(user1.email)
+            redis_client.delete(f"roles-{user1.email}")
             _set_roles(user1)
 
             assert user1.roles == [

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -166,6 +166,7 @@ def test_config_descriptions(admin_api: FlaskClient) -> None:
     }
 
 
+@pytest.mark.redis_db
 def get_node_for_table(
     admin_api: FlaskClient, storage_name: str
 ) -> tuple[str, str, int]:
@@ -204,6 +205,7 @@ def test_system_query(admin_api: FlaskClient) -> None:
     assert data["rows"] == []
 
 
+@pytest.mark.redis_db
 def test_predefined_system_queries(admin_api: FlaskClient) -> None:
     response = admin_api.get(
         "/clickhouse_queries",
@@ -249,6 +251,7 @@ def test_query_trace_bad_query(admin_api: FlaskClient) -> None:
     assert "clickhouse" == data["error"]["type"]
 
 
+@pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_query_trace_invalid_query(admin_api: FlaskClient) -> None:
     table, _, _ = get_node_for_table(admin_api, "errors_ro")
@@ -279,6 +282,7 @@ def test_querylog_query(admin_api: FlaskClient) -> None:
     assert "column_names" in data and data["column_names"] == ["count()"]
 
 
+@pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_querylog_invalid_query(admin_api: FlaskClient) -> None:
     table, _, _ = get_node_for_table(admin_api, "errors_ro")
@@ -301,6 +305,7 @@ def test_querylog_describe(admin_api: FlaskClient) -> None:
     assert "column_names" in data and "rows" in data
 
 
+@pytest.mark.redis_db
 def test_predefined_querylog_queries(admin_api: FlaskClient) -> None:
     response = admin_api.get(
         "/querylog_queries",
@@ -313,6 +318,7 @@ def test_predefined_querylog_queries(admin_api: FlaskClient) -> None:
     assert data[0]["name"] == "QueryByID"
 
 
+@pytest.mark.redis_db
 def test_get_snuba_datasets(admin_api: FlaskClient) -> None:
     response = admin_api.get("/snuba_datasets")
     assert response.status_code == 200
@@ -320,6 +326,7 @@ def test_get_snuba_datasets(admin_api: FlaskClient) -> None:
     assert set(data) == set(get_enabled_dataset_names())
 
 
+@pytest.mark.redis_db
 def test_convert_SnQL_to_SQL_invalid_dataset(admin_api: FlaskClient) -> None:
     response = admin_api.post(
         "/snql_to_sql", data=json.dumps({"dataset": "", "query": ""})
@@ -329,6 +336,7 @@ def test_convert_SnQL_to_SQL_invalid_dataset(admin_api: FlaskClient) -> None:
     assert data["error"]["message"] == "dataset '' does not exist"
 
 
+@pytest.mark.redis_db
 @pytest.mark.redis_db
 def test_convert_SnQL_to_SQL_invalid_query(admin_api: FlaskClient) -> None:
     response = admin_api.post(

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -16,6 +16,7 @@ def admin_api() -> FlaskClient:
     return application.test_client()
 
 
+@pytest.mark.redis_db
 def test_tools(admin_api: FlaskClient) -> None:
     response = admin_api.get("/tools")
     assert response.status_code == 200
@@ -25,6 +26,7 @@ def test_tools(admin_api: FlaskClient) -> None:
     assert "all" in data["tools"]
 
 
+@pytest.mark.redis_db
 @patch("snuba.admin.auth.DEFAULT_ROLES", [ROLES["ProductTools"]])
 def test_product_tools_role(
     admin_api: FlaskClient,


### PR DESCRIPTION
Currently, we set up a user's roles every time we make a request which is inefficient as it requires reading from a file and making multiple API requests to google. In order to improve performance, I've added a TTL cache with a 10 min TTL. Since it's unlikely for roles and groups to change, we should consider increasing this TTL in the future.