### PR TITLE
ref(sessions): Demote sessions migration group to deprecate

### DIFF
--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -107,7 +107,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.SESSIONS: _MigrationGroup(
         loader=SessionsLoader(),
         storage_sets_keys={StorageSetKey.SESSIONS},
-        readiness_state=ReadinessState.COMPLETE,
+        readiness_state=ReadinessState.DEPRECATE,
     ),
     MigrationGroup.QUERYLOG: _MigrationGroup(
         loader=QuerylogLoader(),


### PR DESCRIPTION
The sessions storages are already set to `deprecate` and this migration group should follow. Note that session this to `deprecate` means that the migrations will only be executable locally and in self-hosted. These migrations will not be executable in any other sentry environments anymore (include ST). 