### PR TITLE
feat(errors): expose trace_sampled and num_processing_errors columns for events and discover 

### DIFF
--- a/snuba/datasets/configuration/discover/entities/discover.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover.yaml
@@ -259,6 +259,16 @@ schema:
       type: UUID,
       args: { schema_modifiers: [nullable] },
     },
+    {
+      name: trace_sampled,
+      type: UInt,
+      args: { schema_modifiers: [ nullable ], size: 8 },
+    },
+    {
+      name: num_processing_errors,
+      type: UInt,
+      args: { schema_modifiers: [ nullable ], size: 64 },
+    },
   ]
 required_time_column: timestamp
 storages:

--- a/snuba/datasets/configuration/discover/entities/discover_events.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_events.yaml
@@ -192,6 +192,16 @@ schema:
             [{ name: name, type: String }, { name: version, type: String }],
         },
     },
+    {
+      name: trace_sampled,
+      type: UInt,
+      args: { schema_modifiers: [ nullable ], size: 8 },
+    },
+    {
+      name: num_processing_errors,
+      type: UInt,
+      args: { schema_modifiers: [ nullable ], size: 64 },
+    },
   ]
 required_time_column: timestamp
 storages:

--- a/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
+++ b/snuba/datasets/configuration/discover/entities/discover_transactions.yaml
@@ -267,6 +267,8 @@ storages:
               - exception_main_thread
               - modules.name
               - modules.version
+              - trace_sampled
+              - num_processing_errors
       subscriptables:
         - mapper: SubscriptableMapper
           args:

--- a/snuba/datasets/configuration/events/entities/events.yaml
+++ b/snuba/datasets/configuration/events/entities/events.yaml
@@ -192,6 +192,16 @@ schema:
             [{ name: name, type: String }, { name: version, type: String }],
         },
     },
+    {
+      name: trace_sampled,
+      type: UInt,
+      args: { schema_modifiers: [ nullable ], size: 8 },
+    },
+    {
+      name: num_processing_errors,
+      type: UInt,
+      args: { schema_modifiers: [ nullable ], size: 64 },
+    },
   ]
 required_time_column: timestamp
 storages:

--- a/snuba/query/snql/discover_entity_selection.py
+++ b/snuba/query/snql/discover_entity_selection.py
@@ -89,6 +89,8 @@ EVENTS_COLUMNS = ColumnSet(
         ),
         ("modules", Nested([("name", String()), ("version", String())])),
         ("exception_main_thread", UInt(8, Modifiers(nullable=True))),
+        ("trace_sampled", UInt(8, Modifiers(nullable=True))),
+        ("num_processing_errors", UInt(64, Modifiers(nullable=True))),
     ]
 )
 

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1736,6 +1736,29 @@ class TestDiscoverApi(BaseApiTest):
         data = json.loads(response.data)["data"]
         assert len(data) == 11
 
+    def test_trace_sample_num_processing_errors(self) -> None:
+        response = self.post(
+            json.dumps(
+                {
+                    "selected_columns": ["trace_sampled", "num_processing_errors"],
+                    "limit": 1000,
+                    "project": [self.project_id],
+                    "dataset": "discover",
+                    "tenant_ids": {"referrer": "r", "organization_id": 1234},
+                    "from_date": (self.base_time - self.skew).isoformat(),
+                    "to_date": (self.base_time + self.skew).isoformat(),
+                    "conditions": [["project_id", "IN", [self.project_id]]],
+                    "consistent": False,
+                }
+            ),
+            entity="discover",
+        )
+
+        assert response.status_code == 200
+        data = json.loads(response.data)["data"]
+        assert len(data) == 1
+        assert data == [{"trace_sampled": None, "num_processing_errors": 0}]
+
 
 class TestDiscoverAPIEntitySelection(TestDiscoverApi):
     """


### PR DESCRIPTION
Makes `trace_sampled` and `num_processing_errors` columns available to be queried from events and discover. 