### PR TITLE
feat(dlq): Add in progress status

### DIFF
--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -46,6 +46,7 @@ from snuba.admin.tool_policies import (
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.consumers.dlq import (
     DlqInstruction,
+    DlqInstructionStatus,
     DlqPolicy,
     clear_instruction,
     load_instruction,
@@ -928,7 +929,11 @@ def dlq_replay() -> Response:
             return make_response("Instruction exists", 400)
 
         instruction = DlqInstruction(
-            policy, storage_key, slice_id, max_messages_to_process
+            policy,
+            DlqInstructionStatus.NOT_STARTED,
+            storage_key,
+            slice_id,
+            max_messages_to_process,
         )
         store_instruction(instruction)
 

--- a/tests/consumers/test_dlq.py
+++ b/tests/consumers/test_dlq.py
@@ -7,26 +7,45 @@ from arroyo.types import BrokerValue, Message, Partition, Topic
 
 from snuba.consumers.dlq import (
     DlqInstruction,
+    DlqInstructionStatus,
     DlqPolicy,
     ExitAfterNMessages,
     clear_instruction,
     load_instruction,
+    mark_instruction_in_progress,
     store_instruction,
 )
 from snuba.datasets.storages.storage_key import StorageKey
 
 
+@pytest.mark.redis_db
 def test_dlq_instruction() -> None:
-    instruction = DlqInstruction(DlqPolicy.STOP_ON_ERROR, StorageKey.QUERYLOG, None, 1)
+    instruction = DlqInstruction(
+        DlqPolicy.STOP_ON_ERROR,
+        DlqInstructionStatus.NOT_STARTED,
+        StorageKey.QUERYLOG,
+        None,
+        1,
+    )
     encoded = instruction.to_bytes()
     assert DlqInstruction.from_bytes(encoded) == instruction
 
 
 @pytest.mark.redis_db
 def test_store_instruction() -> None:
-    instruction = DlqInstruction(DlqPolicy.STOP_ON_ERROR, StorageKey.QUERYLOG, None, 1)
+    instruction = DlqInstruction(
+        DlqPolicy.STOP_ON_ERROR,
+        DlqInstructionStatus.NOT_STARTED,
+        StorageKey.QUERYLOG,
+        None,
+        1,
+    )
     store_instruction(instruction)
     assert load_instruction() == instruction
+    mark_instruction_in_progress()
+    loaded_instruction = load_instruction()
+    assert loaded_instruction is not None
+    assert loaded_instruction.status == DlqInstructionStatus.IN_PROGRESS
     clear_instruction()
     assert load_instruction() is None
 


### PR DESCRIPTION
Instruction is marked in progress when it is picked up by consumer and only cleared when the consumer exits.

