### PR TITLE
Update settings loader

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -424,8 +424,12 @@ def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
             )
 
         for attr in dir(settings_module):
+            new_attr = getattr(settings_module, attr)
             if attr.isupper():
-                obj[attr] = getattr(settings_module, attr)
+                if isinstance(obj[attr], dict) and isinstance(new_attr, dict):
+                    obj[attr].update(new_attr)
+                else:
+                    obj[attr] = new_attr
 
 
 _load_settings()


### PR DESCRIPTION
Currently, dictionaries defined in the default settings file are fully overwritten by prod/test settings files if the variable is redefined. This change allows specific keys in the dictionary to be overwritten, so if a key is added to the default settings file, it doesn't necessarily have to be added to other settings files.