### PR TITLE
fix(starfish): stringify results before sending them to the client

### DIFF
--- a/tests/admin/cardinality_analyzer/test_metrics_query.py
+++ b/tests/admin/cardinality_analyzer/test_metrics_query.py
@@ -39,6 +39,8 @@ from snuba.clickhouse.native import ClickhouseResult
         ),
     ],
 )
-def test_stringify_result(result: ClickhouseResult, expected_result: ClickhouseResult):
+def test_stringify_result(
+    result: ClickhouseResult, expected_result: ClickhouseResult
+) -> None:
     stringified_result = _stringify_result(result)
     assert stringified_result == expected_result

--- a/tests/admin/cardinality_analyzer/test_metrics_query.py
+++ b/tests/admin/cardinality_analyzer/test_metrics_query.py
@@ -1,0 +1,44 @@
+import pytest
+
+from snuba.admin.cardinality_analyzer.cardinality_analyzer import _stringify_result
+from snuba.clickhouse.native import ClickhouseResult
+
+
+@pytest.mark.parametrize(
+    "result,expected_result",
+    [
+        pytest.param(
+            ClickhouseResult(
+                [
+                    [9223372036854776050, 909817],
+                    [9223372036854776020, 909817],
+                ]
+            ),
+            ClickhouseResult(
+                [
+                    ["9223372036854776050", "909817"],
+                    ["9223372036854776020", "909817"],
+                ]
+            ),
+            id="simple",
+        ),
+        pytest.param(
+            ClickhouseResult(
+                [
+                    [[123, 456]],
+                    [[567, 8910]],
+                ]
+            ),
+            ClickhouseResult(
+                [
+                    ["[123, 456]"],
+                    ["[567, 8910]"],
+                ]
+            ),
+            id="simple",
+        ),
+    ],
+)
+def test_stringify_result(result: ClickhouseResult, expected_result: ClickhouseResult):
+    stringified_result = _stringify_result(result)
+    assert stringified_result == expected_result


### PR DESCRIPTION
We're having issues where the metric ids are too large to fit in a double and thus are being rounded and showing incorrect data.

By converting them to strings before sending them back we can avoid this issue