### PR TITLE
feat(search-issues): Add message column to search issues

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -311,6 +311,7 @@ class SearchIssuesLoader(DirectoryLoader):
             "0006_add_subtitle_culprit_level_resource_id",
             "0007_add_transaction_duration",
             "0008_add_profile_id_replay_id",
+            "0009_add_message",
         ]
 
 

--- a/snuba/snuba_migrations/search_issues/0009_add_message.py
+++ b/snuba/snuba_migrations/search_issues/0009_add_message.py
@@ -1,0 +1,45 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, String
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        ops = [
+            [
+                operations.AddColumn(
+                    storage_set=StorageSetKey.SEARCH_ISSUES,
+                    table_name=table_name,
+                    column=Column("message", String()),
+                    after="replay_id",
+                    target=target,
+                ),
+            ]
+            for table_name, target in [
+                ("search_issues_local_v2", OperationTarget.LOCAL),
+                ("search_issues_dist_v2", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+        return ops[0] + ops[1]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        ops = [
+            [
+                operations.DropColumn(
+                    storage_set=StorageSetKey.SEARCH_ISSUES,
+                    table_name=table_name,
+                    column_name="message",
+                    target=target,
+                ),
+            ]
+            for table_name, target in [
+                ("search_issues_dist_v2", OperationTarget.DISTRIBUTED),
+                ("search_issues_local_v2", OperationTarget.LOCAL),
+            ]
+        ]
+        return ops[0] + ops[1]


### PR DESCRIPTION
This adds the `message` column to search issues, since we missed including it a column initially.

Related to https://github.com/getsentry/sentry/issues/50345
