### PR TITLE
feat(search-issues): Start writing message column in search issues

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -9,6 +9,7 @@ schema:
     { name: group_id, type: UInt, args: { size: 64 } },
     { name: search_title, type: String },
     { name: resource_id, type: String },
+    { name: message, type: String },
     { name: subtitle, type: String },
     { name: culprit, type: String },
     { name: level, type: String, args: { schema_modifiers: [ low_cardinality ] } },

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -23,7 +23,7 @@ schema:
 
 
       { name: resource_id, type: String, args: { schema_modifiers: [ nullable ] } },
-      { name: message, type: String, args: { schema_modifiers: [ nullable ] } },
+      { name: message, type: String },
       { name: subtitle, type: String, args: { schema_modifiers: [ nullable ] } },
       { name: culprit, type: String, args: { schema_modifiers: [ nullable ] } },
       { name: level, type: String, args: { schema_modifiers: [ nullable ] } },

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -23,6 +23,7 @@ schema:
 
 
       { name: resource_id, type: String, args: { schema_modifiers: [ nullable ] } },
+      { name: message, type: String, args: { schema_modifiers: [ nullable ] } },
       { name: subtitle, type: String, args: { schema_modifiers: [ nullable ] } },
       { name: culprit, type: String, args: { schema_modifiers: [ nullable ] } },
       { name: level, type: String, args: { schema_modifiers: [ nullable ] } },

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -92,6 +92,7 @@ class SearchIssueEvent(TypedDict, total=False):
     group_id: int
     platform: str
     primary_hash: str
+    message: str
     datetime: str
 
     data: IssueEventData

--- a/snuba/datasets/processors/search_issues_processor.py
+++ b/snuba/datasets/processors/search_issues_processor.py
@@ -276,6 +276,7 @@ class SearchIssuesMessageProcessor(DatasetMessageProcessor):
             "receive_timestamp": receive_timestamp,
             "client_timestamp": client_timestamp,
             "platform": event["platform"],
+            "message": _unicodify(event["message"]),
         }
 
         # optional fields

--- a/tests/datasets/test_search_issues_processor.py
+++ b/tests/datasets/test_search_issues_processor.py
@@ -36,6 +36,7 @@ def message_base() -> SearchIssueEvent:
         "primary_hash": str(uuid.uuid4()),
         "datetime": datetime.utcnow().isoformat() + "Z",
         "platform": "other",
+        "message": "something",
         "data": {
             "received": datetime.now().timestamp(),
         },
@@ -70,6 +71,7 @@ class TestSearchIssuesMessageProcessor:
         "platform",
         "tags.key",
         "tags.value",
+        "message",
     }
 
     def process_message(
@@ -438,6 +440,14 @@ class TestSearchIssuesMessageProcessor:
             message_base["data"]["contexts"]["replay"]["replay_id"] = invalid_replay_id
             with pytest.raises(ValueError):
                 self.process_message(message_base)
+
+    def test_extract_message(self, message_base):
+        message = "a message"
+        message_base["message"] = message
+        processed = self.process_message(message_base)
+        self.assert_required_columns(processed)
+        insert_row = processed.rows[0]
+        assert insert_row["message"] == message
 
     def test_ensure_uuid(self):
         with pytest.raises(ValueError):

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -29,6 +29,7 @@ def base_insert_event(
             "primary_hash": str(uuid.uuid4()),
             "datetime": datetime.utcnow().isoformat() + "Z",
             "platform": "other",
+            "message": "message",
             "data": {
                 "received": now.timestamp(),
             },
@@ -94,6 +95,7 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
             primary_hash=str(uuid.uuid4().hex),
             datetime=datetime.utcnow().isoformat() + "Z",
             platform="other",
+            message="message",
             data={"received": now.timestamp()},
             occurrence_data=dict(
                 id=str(uuid.uuid4().hex),


### PR DESCRIPTION
This starts writing to the new `message` column. `message` is already being sent from sentry, so we just need to start writing it here.

I will let this write for a week or two before switching over to use it. We don't need the full 90 days of data for this to be effective.

Relies on https://github.com/getsentry/snuba/pull/4385
Related to https://github.com/getsentry/sentry/issues/50345