### PR TITLE
feat(search-issues): Make `message` column available for querying

### DIFF
--- a/snuba/datasets/configuration/issues/entities/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/entities/search_issues.yaml
@@ -84,12 +84,6 @@ storages:
         - mapper: ColumnToColumn
           args:
             from_table_name:
-            from_col_name: "message"
-            to_table_name:
-            to_col_name: "search_title"
-        - mapper: ColumnToColumn
-          args:
-            from_table_name:
             from_col_name: "title"
             to_table_name:
             to_col_name: "search_title"

--- a/tests/test_search_issues_api.py
+++ b/tests/test_search_issues_api.py
@@ -301,3 +301,31 @@ class TestSearchIssuesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
                 "replay_id": replay_id.replace("-", ""),
             }
         ]
+
+    def test_eventstream_query_message(self) -> None:
+        now = datetime.utcnow()
+        insert_row = base_insert_event(now)
+        message = "my message"
+        insert_row[2]["message"] = message
+
+        response = self.app.post(
+            "/tests/search_issues/eventstream", data=json.dumps(insert_row)
+        )
+        assert response.status_code == 200
+
+        from_date = (now - timedelta(days=1)).isoformat()
+        to_date = (now + timedelta(days=1)).isoformat()
+        response = self.post_query(
+            f"""MATCH (search_issues)
+                        SELECT project_id, message
+                        WHERE project_id = 1
+                        AND timestamp >= toDateTime('{from_date}')
+                        AND timestamp < toDateTime('{to_date}')
+                    """
+        )
+
+        data = json.loads(response.data)
+
+        assert response.status_code == 200, data
+        assert data["stats"]["consistent"]
+        assert data["data"] == [{"project_id": 1, "message": message}]


### PR DESCRIPTION
This allows the message column on search issues to be queried, and stops using `issue_title`. We won't merge this until we've dual written data for a week or two.

Relies on https://github.com/getsentry/snuba/pull/4385, https://github.com/getsentry/snuba/pull/4387 Related to https://github.com/getsentry/sentry/issues/50345




<!-- Describe your PR here. -->