### PR TITLE
rust: unlock mutex to avoid deadlock

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -211,6 +211,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
                             strategy.terminate();
                         }
                     }
+                    drop(trait_callbacks); // unlock mutex so we can close consumer
                     self.consumer.close();
                     return Err(e);
                 }


### PR DESCRIPTION
Fix a small annoying issue where we would deadlock if there was a poll error thrown 