### PR TITLE
ref(generic-metrics): Remove 10 seconds granularity

### DIFF
--- a/snuba/datasets/processors/metrics_aggregate_processor.py
+++ b/snuba/datasets/processors/metrics_aggregate_processor.py
@@ -40,11 +40,10 @@ def timestamp_to_bucket(timestamp: datetime, interval_seconds: int) -> datetime:
 
 
 class MetricsAggregateProcessor(DatasetMessageProcessor, ABC):
-    TEN_SECONDS = 10
     ONE_MINUTE = 60
     ONE_HOUR = 3600
     ONE_DAY = 3600 * 24
-    GRANULARITIES_SECONDS = [TEN_SECONDS, ONE_MINUTE, ONE_HOUR, ONE_DAY]
+    GRANULARITIES_SECONDS = [ONE_MINUTE, ONE_HOUR, ONE_DAY]
 
     @abstractmethod
     def _should_process(self, message: Mapping[str, Any]) -> bool:

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -294,6 +294,9 @@ class GenericMetricsLoader(DirectoryLoader):
             "0011_counters_raw_table",
             "0012_counters_mv",
             "0013_distributions_dist_tags_hash",
+            "0014_sets_mv_2",
+            "0015_distributions_mv_2",
+            "0016_counters_mv_2",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0014_sets_mv_2.py
+++ b/snuba/snuba_migrations/generic_metrics/0014_sets_mv_2.py
@@ -16,7 +16,7 @@ from snuba.migrations.operations import OperationTarget
 
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
-    view_name = "generic_metric_sets_aggregation_mv"
+    view_name = "generic_metric_sets_aggregation_mv_2"
     dest_table_columns: Sequence[Column[Modifiers]] = [
         Column("org_id", UInt(64)),
         Column("project_id", UInt(64)),
@@ -81,4 +81,10 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0014_sets_mv_2.py
+++ b/snuba/snuba_migrations/generic_metrics/0014_sets_mv_2.py
@@ -1,0 +1,84 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_sets_aggregation_mv"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name="generic_metric_sets_local",
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(timestamp),
+                             multiIf(granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                    retention_days,
+                    uniqCombined64State(arrayJoin(set_values)) as value
+                FROM generic_metric_sets_raw_local
+                WHERE materialization_version = 2
+                  AND metric_type = 'set'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/snuba_migrations/generic_metrics/0015_distributions_mv_2.py
+++ b/snuba/snuba_migrations/generic_metrics/0015_distributions_mv_2.py
@@ -16,7 +16,7 @@ from snuba.migrations.operations import OperationTarget
 
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
-    view_name = "generic_metric_distributions_aggregation_mv"
+    view_name = "generic_metric_distributions_aggregation_mv_2"
     dest_table_columns: Sequence[Column[Modifiers]] = [
         Column("org_id", UInt(64)),
         Column("project_id", UInt(64)),
@@ -87,4 +87,10 @@ class Migration(migration.ClickhouseNodeMigration):
         ]
 
     def backwards_ops(self) -> Sequence[operations.SqlOperation]:
-        return []
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0015_distributions_mv_2.py
+++ b/snuba/snuba_migrations/generic_metrics/0015_distributions_mv_2.py
@@ -1,0 +1,90 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_distributions_aggregation_mv"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("uniqCombined64", [UInt(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name="generic_metric_distributions_aggregated_local",
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(timestamp),
+                             multiIf(granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                    retention_days,
+                    quantilesState(0.5, 0.75, 0.9, 0.95, 0.99)((arrayJoin(distribution_values) AS values_rows)) as percentiles,
+                    minState(values_rows) as min,
+                    maxState(values_rows) as max,
+                    avgState(values_rows) as avg,
+                    sumState(values_rows) as sum,
+                    countState(values_rows) as count,
+                    histogramState(250)(values_rows) as histogram_buckets
+                FROM generic_metric_distributions_raw_local
+                WHERE materialization_version = 2
+                  AND metric_type = 'distribution'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return []

--- a/snuba/snuba_migrations/generic_metrics/0016_counters_mv_2.py
+++ b/snuba/snuba_migrations/generic_metrics/0016_counters_mv_2.py
@@ -1,0 +1,92 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import (
+    AggregateFunction,
+    Column,
+    DateTime,
+    Nested,
+    String,
+    UInt,
+)
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget
+from snuba.utils.schemas import Float
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    view_name = "generic_metric_counters_aggregation_mv"
+    dest_table_name = "generic_metric_counters_aggregated_local"
+    dest_table_columns: Sequence[Column[Modifiers]] = [
+        Column("org_id", UInt(64)),
+        Column("project_id", UInt(64)),
+        Column("metric_id", UInt(64)),
+        Column("granularity", UInt(8)),
+        Column("timestamp", DateTime(modifiers=Modifiers(codecs=["DoubleDelta"]))),
+        Column("retention_days", UInt(16)),
+        Column(
+            "tags",
+            Nested(
+                [
+                    ("key", UInt(64)),
+                    ("indexed_value", UInt(64)),
+                    ("raw_value", String()),
+                ]
+            ),
+        ),
+        Column("value", AggregateFunction("sum", [Float(64)])),
+        Column("use_case_id", String(Modifiers(low_cardinality=True))),
+    ]
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.CreateMaterializedView(
+                storage_set=self.storage_set_key,
+                view_name=self.view_name,
+                columns=self.dest_table_columns,
+                destination_table_name=self.dest_table_name,
+                target=OperationTarget.LOCAL,
+                query="""
+                SELECT
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    arrayJoin(granularities) as granularity,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    toDateTime(multiIf(granularity=1,60,granularity=2,3600,granularity=3,86400,-1) *
+                      intDiv(toUnixTimestamp(timestamp),
+                             multiIf(granularity=1,60,granularity=2,3600,granularity=3,86400,-1))) as timestamp,
+                    retention_days,
+                    sumState(count_value) as value
+                FROM generic_metric_counters_raw_local
+                WHERE materialization_version = 2
+                  AND metric_type = 'counter'
+                GROUP BY
+                    use_case_id,
+                    org_id,
+                    project_id,
+                    metric_id,
+                    tags.key,
+                    tags.indexed_value,
+                    tags.raw_value,
+                    timestamp,
+                    granularity,
+                    retention_days
+                """,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=self.storage_set_key,
+                table_name=self.view_name,
+                target=OperationTarget.LOCAL,
+            )
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0016_counters_mv_2.py
+++ b/snuba/snuba_migrations/generic_metrics/0016_counters_mv_2.py
@@ -17,7 +17,7 @@ from snuba.utils.schemas import Float
 
 class Migration(migration.ClickhouseNodeMigration):
     blocking = False
-    view_name = "generic_metric_counters_aggregation_mv"
+    view_name = "generic_metric_counters_aggregation_mv_2"
     dest_table_name = "generic_metric_counters_aggregated_local"
     dest_table_columns: Sequence[Column[Modifiers]] = [
         Column("org_id", UInt(64)),


### PR DESCRIPTION
### Overview
Create migrations for materialized view of sets, counters, and distributions to remove granularity of 10 seconds.

### Testing
Ran snuba locally with migrations applied and sent 9 messages in total, a single (set, counter, distribution) kafka payload for 3 use case IDs.

```
SELECT
    use_case_id,
    org_id,
    project_id,
    metric_id,
    granularity
FROM generic_metric_sets_local
WHERE arrayExists(v -> match(v, 'gen_metric_e2e_.*FJ1D6416'), tags.raw_value)
UNION ALL
SELECT
    use_case_id,
    org_id,
    project_id,
    metric_id,
    granularity
FROM generic_metric_distributions_aggregated_local
WHERE arrayExists(v -> match(v, 'gen_metric_e2e_.*FJ1D6416'), tags.raw_value)
UNION ALL
SELECT
    use_case_id,
    org_id,
    project_id,
    metric_id,
    granularity
FROM generic_metric_counters_aggregated_local
WHERE arrayExists(v -> match(v, 'gen_metric_e2e_.*FJ1D6416'), tags.raw_value)

Query id: 3554e50f-e92d-4333-949e-4c8e00e36cef

┌─use_case_id──┬─org_id─┬─project_id─┬─metric_id─┬─granularity─┐
│ transactions │      1 │          3 │     65551 │           1 │
│ transactions │      1 │          3 │     65551 │           2 │
│ transactions │      1 │          3 │     65551 │           3 │
│ spans        │      1 │          3 │     65559 │           1 │
│ spans        │      1 │          3 │     65559 │           2 │
│ spans        │      1 │          3 │     65559 │           3 │
│ hello        │      1 │          3 │     65641 │           1 │
│ hello        │      1 │          3 │     65641 │           2 │
│ hello        │      1 │          3 │     65641 │           3 │
└──────────────┴────────┴────────────┴───────────┴─────────────┘
┌─use_case_id──┬─org_id─┬─project_id─┬─metric_id─┬─granularity─┐
│ transactions │      1 │          3 │     65553 │           1 │
│ transactions │      1 │          3 │     65553 │           2 │
│ transactions │      1 │          3 │     65553 │           3 │
│ spans        │      1 │          3 │     65556 │           1 │
│ spans        │      1 │          3 │     65556 │           2 │
│ spans        │      1 │          3 │     65556 │           3 │
│ hello        │      1 │          3 │     65643 │           1 │
│ hello        │      1 │          3 │     65643 │           2 │
│ hello        │      1 │          3 │     65643 │           3 │
└──────────────┴────────┴────────────┴───────────┴─────────────┘
┌─use_case_id──┬─org_id─┬─project_id─┬─metric_id─┬─granularity─┐
│ transactions │      1 │          3 │     65546 │           1 │
│ transactions │      1 │          3 │     65546 │           2 │
│ transactions │      1 │          3 │     65546 │           3 │
│ spans        │      1 │          3 │     65562 │           1 │
│ spans        │      1 │          3 │     65562 │           2 │
│ spans        │      1 │          3 │     65562 │           3 │
│ hello        │      1 │          3 │     65649 │           1 │
│ hello        │      1 │          3 │     65649 │           2 │
│ hello        │      1 │          3 │     65649 │           3 │
└──────────────┴────────┴────────────┴───────────┴─────────────┘

```