### PR TITLE
fix(CapMan): Allocation Policies causing potentially timeout errors on ST

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -395,7 +395,10 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
     @property
     def is_enforced(self) -> bool:
-        return bool(self.get_config_value(IS_ENFORCED))
+        return (
+            bool(self.get_config_value(IS_ENFORCED))
+            and settings.ENFORCE_BYTES_SCANNED_WINDOW_POLICY
+        )
 
     @property
     def max_threads(self) -> int:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -188,6 +188,7 @@ SNAPSHOT_LOAD_PRODUCT = "snuba"
 BULK_CLICKHOUSE_BUFFER = 10000
 BULK_BINARY_LOAD_CHUNK = 2**22  # 4 MB
 
+
 # Processor/Writer Options
 
 
@@ -244,6 +245,10 @@ TURBO_SAMPLE_RATE = 0.1
 
 PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 PRETTY_FORMAT_EXPRESSIONS = True
+
+# Capacity Management
+
+ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
 
 # By default, allocation policies won't block requests from going through in a production
 # environment to not cause incidents unnecessarily. If something goes wrong with allocation

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -247,7 +247,9 @@ PROJECT_STACKTRACE_BLACKLIST: Set[int] = set()
 PRETTY_FORMAT_EXPRESSIONS = True
 
 # Capacity Management
-
+# HACK: This is necessary because single tenant does not have snuba-admin deployed / accessible
+# so we can't change policy configs ourselves. This should be removed once we have snuba-admin
+# available for single tenant since we can enable/disable policies at runtime there.
 ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
 
 # By default, allocation policies won't block requests from going through in a production

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -26,6 +26,8 @@ PRETTY_FORMAT_EXPRESSIONS = True
 # should fail on bad code
 RAISE_ON_ALLOCATION_POLICY_FAILURES = True
 
+ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
+
 # override replacer threshold to write to redis every time a replacement message is consumed
 REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms
 


### PR DESCRIPTION
### Overview
- Currently there is some strong correlation between the latest query errors and timeouts on Disney ST and Allocation Policy throttles on the instance
- Disney ST max threads are 30 by default, the throttling sets the queries to 1 thread - a massive difference
- I don't believe we have a huge load problem on ST so we can probably disable the policy enforcement altogether
- Ideally this is done through Snuba Admin but since that does not yet exist for ST this is a good enough solution