### PR TITLE
feat(outcomes): Add new backpressure client report reason

### DIFF
--- a/snuba/datasets/processors/outcomes_processor.py
+++ b/snuba/datasets/processors/outcomes_processor.py
@@ -33,6 +33,7 @@ CLIENT_DISCARD_REASONS = frozenset(
         "sample_rate",
         "send_error",
         "internal_sdk_error",
+        "backpressure",
     ]
 )
 


### PR DESCRIPTION
As part of adding some backpressure handling to SDKs, we need a new Client Report reason.

see
* https://github.com/getsentry/sentry-python/pull/2189
* https://github.com/getsentry/sentry-python/issues/2095 
* https://github.com/getsentry/team-webplatform-meta/issues/50