### PR TITLE
feat(profiling): Add insufficient data as client discard reason

### DIFF
--- a/snuba/datasets/processors/outcomes_processor.py
+++ b/snuba/datasets/processors/outcomes_processor.py
@@ -33,6 +33,7 @@ CLIENT_DISCARD_REASONS = frozenset(
         "sample_rate",
         "send_error",
         "internal_sdk_error",
+        "insufficient_data",
     ]
 )
 


### PR DESCRIPTION
We'd like to add a new client discard reason called `insufficient_data` for the use case where the SDK did not collect enough data for a valid profile and discards it as a result.