### PR TITLE
Add GoCD role to migrations stage

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -191,6 +191,9 @@ pipelines:
             - migrate:
                   approval:
                       type: manual
+                      allow_only_on_success: true
+                      roles:
+                        - role-deploy-snuba-operator
                   fetch_materials: true
                   jobs:
                       migrate:


### PR DESCRIPTION
Adding a role permission to the migration stage. This will limit the migration stage access to only people in the `role-deploy-snuba-operator` google group. Ideally, this group should have been called `role-deploy-snuba-migrations-operator` but it's hard to change names on the dev-infra GoCD side.
