### PR TITLE
Introduce pipedream

### DIFF
--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -18,3 +18,16 @@ jobs:
             - uses: getsentry/action-setup-gocd-cli@2f7943ce1a380dea121fd6338a60dc9aabf8e7f1  # v1.0.1
             - name: Lint Pipelines with gocd-cli
               run: ./.github/workflows/lint-pipelines.sh
+
+    render:
+        name: Render GoCD Pipelines with Jsonnet
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
+            - uses: getsentry/action-gocd-jsonnet@v0
+              with:
+                  jb-install: true
+                  check-for-changes: true
+                  convert-to-yaml: true
+                  jsonnet-dir: gocd/templates
+                  generated-dir: gocd/generated-pipelines

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 .vscode/*.log
 snuba/admin/dist/bundle.js*
 tmp/
+gocd/templates/vendor/

--- a/Makefile
+++ b/Makefile
@@ -84,3 +84,13 @@ lint-rust:
 	cd rust_snuba && cargo clippy -- -D warnings
 
 .PHONY: lint-rust
+
+gocd:
+	rm -rf ./gocd/generated-pipelines
+	mkdir -p ./gocd/generated-pipelines
+	cd ./gocd/templates && jb install
+	find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
+	find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
+	cd ./gocd/templates && jsonnet -J vendor -m ../generated-pipelines ./snuba.jsonnet
+	cd ./gocd/generated-pipelines && find . -type f \( -name '*.yaml' \) -print0 | xargs -n 1 -0 yq -p json -o yaml -i
+.PHONY: gocd

--- a/gocd/README.md
+++ b/gocd/README.md
@@ -1,0 +1,59 @@
+# Snuba Pipelines
+
+Relay is in the process of moving to a set of rendered jsonnet pipelines.
+
+## Jsonnet
+
+You can render the jsonnet pipelines by running:
+
+```
+make gocd
+```
+
+This will clean, fmt, lint and generate the GoCD pipelines to
+`./gocd/generated-pipelines`.
+
+
+The snuba pipelines are using the https://github.com/getsentry/gocd-jsonnet
+libraries to generate the pipeline for each region.
+
+## Files
+
+Below is a description of the directories in the `gocd/` directory.
+
+### `gocd/templates/`
+
+These are a set of jsonnet and libsonnet files which are used
+to generate the GoCD pipelines. This avoids duplication across
+our pipelines as we deploy to multiple regions.
+
+The `gocd/templates/snuba.jsonnet` file is the entry point for the
+generated pipelines.
+
+`gocd/templates/pipelines/snuba.libsonnet` define the pipeline behaviors.
+This library defines the GoCD pipeline, following the same naming
+as the [GoCD yaml pipelines](https://github.com/tomzo/gocd-yaml-config-plugin#readme).
+
+`gocd/templates/bash/*.sh` are shell scripts that are inlined in the
+resulting pipelines. This seperation means syntax highlighting and
+extra tooling works for bash scripts.
+
+`gocd/templates/jsonnetfile.json` and `gocd/templates/jsonnetfile.lock.json`
+are used by [jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler#readme), a package manager for jsonnet.
+
+You can update jsonnet dependencies by runnning `jb update`.
+
+### `gocd/generated-pipelines/`
+
+The current setup of GoCD at sentry is only able to look for
+yaml pipelines in a repo, so the genered pipelines have the be
+commited.
+
+The dev-infra team is working on a GoCD plugin that will accept
+the jsonnet directly, removing the need for commiting the
+generated-pipelines.
+
+### `gocd/pipelines/`
+
+These are the original pipelines and will be used until we move
+to the jsonnet pipelines.

--- a/gocd/generated-pipelines/snuba-next-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-next-monitor.yaml
@@ -17,6 +17,20 @@ pipelines:
         git: git@github.com:getsentry/snuba.git
         shallow_clone: false
     stages:
+      - ready:
+          jobs:
+            ready:
+              tasks:
+                - exec:
+                    command: true
+      - wait:
+          approval:
+            type: manual
+          jobs:
+            wait:
+              tasks:
+                - exec:
+                    command: true
       - checks:
           jobs:
             checks:

--- a/gocd/generated-pipelines/snuba-next-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-next-monitor.yaml
@@ -1,0 +1,251 @@
+format_version: 10
+pipelines:
+  deploy-snuba-next-monitor:
+    environment_variables:
+      GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
+      GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
+      SENTRY_REGION: monitor
+    group: snuba-next-regions
+    lock_behavior: unlockWhenFinished
+    materials:
+      deploy-snuba-next-us-pipeline-complete:
+        pipeline: deploy-snuba-next-us
+        stage: pipeline-complete
+      snuba_repo:
+        branch: master
+        destination: snuba
+        git: git@github.com:getsentry/snuba.git
+        shallow_clone: false
+    stages:
+      - checks:
+          jobs:
+            checks:
+              elastic_profile_id: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                      getsentry/snuba \
+                      ${GO_REVISION_SNUBA_REPO} \
+                      "Tests and code coverage (test)" \
+                      "Tests and code coverage (test_distributed)" \
+                      "Tests and code coverage (test_distributed_migrations)" \
+                      "Dataset Config Validation" \
+                      "sentry (0)" \
+                      "sentry (1)" \
+                      "self-hosted-end-to-end"
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+                      ${GO_REVISION_SNUBA_REPO} \
+                      sentryio \
+                      "us.gcr.io/sentryio/snuba"
+                - script: |
+                    ##!/bin/bash
+
+                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
+                    snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
+              timeout: 1800
+      - deploy-canary:
+          fetch_materials: true
+          jobs:
+            create-sentry-release:
+              elastic_profile_id: snuba
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
+                    sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
+                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary
+              timeout: 300
+            deploy-canary:
+              elastic_profile_id: snuba
+              environment_variables:
+                LABEL_SELECTOR: service=snuba,is_canary=true
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --container-name="api" \
+                      --container-name="consumer" \
+                      --container-name="errors-consumer" \
+                      --container-name="errors-replacer" \
+                      --container-name="events-subscriptions-executor" \
+                      --container-name="events-subscriptions-scheduler" \
+                      --container-name="generic-metrics-counters-consumer" \
+                      --container-name="generic-metrics-counters-subscriptions-executor" \
+                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                      --container-name="generic-metrics-distributions-consumer" \
+                      --container-name="generic-metrics-distributions-subscriptions-executor" \
+                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                      --container-name="generic-metrics-sets-consumer" \
+                      --container-name="generic-metrics-sets-subscriptions-executor" \
+                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                      --container-name="loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-errors-consumer" \
+                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-outcomes-consumer" \
+                      --container-name="loadtest-transactions-consumer" \
+                      --container-name="metrics-consumer" \
+                      --container-name="metrics-counters-subscriptions-scheduler" \
+                      --container-name="metrics-sets-subscriptions-scheduler" \
+                      --container-name="metrics-subscriptions-executor" \
+                      --container-name="outcomes-billing-consumer" \
+                      --container-name="outcomes-consumer" \
+                      --container-name="profiles-consumer" \
+                      --container-name="profiling-functions-consumer" \
+                      --container-name="querylog-consumer" \
+                      --container-name="replacer" \
+                      --container-name="replays-consumer" \
+                      --container-name="search-issues-consumer" \
+                      --container-name="snuba-admin" \
+                      --container-name="transactions-consumer-new" \
+                      --container-name="transactions-subscriptions-executor" \
+                      --container-name="transactions-subscriptions-scheduler" \
+                      --container-name="rust-querylog-consumer" \
+                      --container-name="spans-consumer" \
+                      --container-name="dlq-consumer" \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --type="cronjob" \
+                      --container-name="cleanup" \
+                      --container-name="optimize"
+              timeout: 1200
+      - deploy-primary:
+          fetch_materials: true
+          jobs:
+            create-sentry-release:
+              elastic_profile_id: snuba
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
+                    sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
+              timeout: 300
+            deploy-canary:
+              elastic_profile_id: snuba
+              environment_variables:
+                LABEL_SELECTOR: service=snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --container-name="api" \
+                      --container-name="consumer" \
+                      --container-name="errors-consumer" \
+                      --container-name="errors-replacer" \
+                      --container-name="events-subscriptions-executor" \
+                      --container-name="events-subscriptions-scheduler" \
+                      --container-name="generic-metrics-counters-consumer" \
+                      --container-name="generic-metrics-counters-subscriptions-executor" \
+                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                      --container-name="generic-metrics-distributions-consumer" \
+                      --container-name="generic-metrics-distributions-subscriptions-executor" \
+                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                      --container-name="generic-metrics-sets-consumer" \
+                      --container-name="generic-metrics-sets-subscriptions-executor" \
+                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                      --container-name="loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-errors-consumer" \
+                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-outcomes-consumer" \
+                      --container-name="loadtest-transactions-consumer" \
+                      --container-name="metrics-consumer" \
+                      --container-name="metrics-counters-subscriptions-scheduler" \
+                      --container-name="metrics-sets-subscriptions-scheduler" \
+                      --container-name="metrics-subscriptions-executor" \
+                      --container-name="outcomes-billing-consumer" \
+                      --container-name="outcomes-consumer" \
+                      --container-name="profiles-consumer" \
+                      --container-name="profiling-functions-consumer" \
+                      --container-name="querylog-consumer" \
+                      --container-name="replacer" \
+                      --container-name="replays-consumer" \
+                      --container-name="search-issues-consumer" \
+                      --container-name="snuba-admin" \
+                      --container-name="transactions-consumer-new" \
+                      --container-name="transactions-subscriptions-executor" \
+                      --container-name="transactions-subscriptions-scheduler" \
+                      --container-name="rust-querylog-consumer" \
+                      --container-name="spans-consumer" \
+                      --container-name="dlq-consumer" \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --type="cronjob" \
+                      --container-name="cleanup" \
+                      --container-name="optimize"
+              timeout: 1200
+      - migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="service=snuba-admin" \
+                      --container-name="snuba-admin" \
+                      "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- snuba migrations migrate -r complete -r partial
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                        /devinfra/scripts/k8s/k8stunnel \
+                        && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                          --label-selector="service=snuba-admin" \
+                          --container-name="snuba-admin" \
+                          "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- snuba migrations reverse-in-progress
+                    run_if: failed
+              timeout: 1200
+      - pipeline-complete:
+          approval:
+            allow_only_on_success: true
+            type: success
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/generated-pipelines/snuba-next-us.yaml
+++ b/gocd/generated-pipelines/snuba-next-us.yaml
@@ -17,6 +17,20 @@ pipelines:
         git: git@github.com:getsentry/snuba.git
         shallow_clone: false
     stages:
+      - ready:
+          jobs:
+            ready:
+              tasks:
+                - exec:
+                    command: true
+      - wait:
+          approval:
+            type: manual
+          jobs:
+            wait:
+              tasks:
+                - exec:
+                    command: true
       - checks:
           jobs:
             checks:

--- a/gocd/generated-pipelines/snuba-next-us.yaml
+++ b/gocd/generated-pipelines/snuba-next-us.yaml
@@ -1,0 +1,251 @@
+format_version: 10
+pipelines:
+  deploy-snuba-next-us:
+    environment_variables:
+      GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
+      GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
+      SENTRY_REGION: us
+    group: snuba-next-regions
+    lock_behavior: unlockWhenFinished
+    materials:
+      deploy-snuba-next-pipeline-complete:
+        pipeline: deploy-snuba-next
+        stage: pipeline-complete
+      snuba_repo:
+        branch: master
+        destination: snuba
+        git: git@github.com:getsentry/snuba.git
+        shallow_clone: false
+    stages:
+      - checks:
+          jobs:
+            checks:
+              elastic_profile_id: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                      getsentry/snuba \
+                      ${GO_REVISION_SNUBA_REPO} \
+                      "Tests and code coverage (test)" \
+                      "Tests and code coverage (test_distributed)" \
+                      "Tests and code coverage (test_distributed_migrations)" \
+                      "Dataset Config Validation" \
+                      "sentry (0)" \
+                      "sentry (1)" \
+                      "self-hosted-end-to-end"
+                - script: |
+                    ##!/bin/bash
+
+                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+                      ${GO_REVISION_SNUBA_REPO} \
+                      sentryio \
+                      "us.gcr.io/sentryio/snuba"
+                - script: |
+                    ##!/bin/bash
+
+                    deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
+                    snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
+              timeout: 1800
+      - deploy-canary:
+          fetch_materials: true
+          jobs:
+            create-sentry-release:
+              elastic_profile_id: snuba
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
+                    sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
+                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary
+              timeout: 300
+            deploy-canary:
+              elastic_profile_id: snuba
+              environment_variables:
+                LABEL_SELECTOR: service=snuba,is_canary=true
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --container-name="api" \
+                      --container-name="consumer" \
+                      --container-name="errors-consumer" \
+                      --container-name="errors-replacer" \
+                      --container-name="events-subscriptions-executor" \
+                      --container-name="events-subscriptions-scheduler" \
+                      --container-name="generic-metrics-counters-consumer" \
+                      --container-name="generic-metrics-counters-subscriptions-executor" \
+                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                      --container-name="generic-metrics-distributions-consumer" \
+                      --container-name="generic-metrics-distributions-subscriptions-executor" \
+                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                      --container-name="generic-metrics-sets-consumer" \
+                      --container-name="generic-metrics-sets-subscriptions-executor" \
+                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                      --container-name="loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-errors-consumer" \
+                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-outcomes-consumer" \
+                      --container-name="loadtest-transactions-consumer" \
+                      --container-name="metrics-consumer" \
+                      --container-name="metrics-counters-subscriptions-scheduler" \
+                      --container-name="metrics-sets-subscriptions-scheduler" \
+                      --container-name="metrics-subscriptions-executor" \
+                      --container-name="outcomes-billing-consumer" \
+                      --container-name="outcomes-consumer" \
+                      --container-name="profiles-consumer" \
+                      --container-name="profiling-functions-consumer" \
+                      --container-name="querylog-consumer" \
+                      --container-name="replacer" \
+                      --container-name="replays-consumer" \
+                      --container-name="search-issues-consumer" \
+                      --container-name="snuba-admin" \
+                      --container-name="transactions-consumer-new" \
+                      --container-name="transactions-subscriptions-executor" \
+                      --container-name="transactions-subscriptions-scheduler" \
+                      --container-name="rust-querylog-consumer" \
+                      --container-name="spans-consumer" \
+                      --container-name="dlq-consumer" \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --type="cronjob" \
+                      --container-name="cleanup" \
+                      --container-name="optimize"
+              timeout: 1200
+      - deploy-primary:
+          fetch_materials: true
+          jobs:
+            create-sentry-release:
+              elastic_profile_id: snuba
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
+                    sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
+              timeout: 300
+            deploy-canary:
+              elastic_profile_id: snuba
+              environment_variables:
+                LABEL_SELECTOR: service=snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --container-name="api" \
+                      --container-name="consumer" \
+                      --container-name="errors-consumer" \
+                      --container-name="errors-replacer" \
+                      --container-name="events-subscriptions-executor" \
+                      --container-name="events-subscriptions-scheduler" \
+                      --container-name="generic-metrics-counters-consumer" \
+                      --container-name="generic-metrics-counters-subscriptions-executor" \
+                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                      --container-name="generic-metrics-distributions-consumer" \
+                      --container-name="generic-metrics-distributions-subscriptions-executor" \
+                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                      --container-name="generic-metrics-sets-consumer" \
+                      --container-name="generic-metrics-sets-subscriptions-executor" \
+                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                      --container-name="loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-errors-consumer" \
+                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-outcomes-consumer" \
+                      --container-name="loadtest-transactions-consumer" \
+                      --container-name="metrics-consumer" \
+                      --container-name="metrics-counters-subscriptions-scheduler" \
+                      --container-name="metrics-sets-subscriptions-scheduler" \
+                      --container-name="metrics-subscriptions-executor" \
+                      --container-name="outcomes-billing-consumer" \
+                      --container-name="outcomes-consumer" \
+                      --container-name="profiles-consumer" \
+                      --container-name="profiling-functions-consumer" \
+                      --container-name="querylog-consumer" \
+                      --container-name="replacer" \
+                      --container-name="replays-consumer" \
+                      --container-name="search-issues-consumer" \
+                      --container-name="snuba-admin" \
+                      --container-name="transactions-consumer-new" \
+                      --container-name="transactions-subscriptions-executor" \
+                      --container-name="transactions-subscriptions-scheduler" \
+                      --container-name="rust-querylog-consumer" \
+                      --container-name="spans-consumer" \
+                      --container-name="dlq-consumer" \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --type="cronjob" \
+                      --container-name="cleanup" \
+                      --container-name="optimize"
+              timeout: 1200
+      - migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="service=snuba-admin" \
+                      --container-name="snuba-admin" \
+                      "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- snuba migrations migrate -r complete -r partial
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                        /devinfra/scripts/k8s/k8stunnel \
+                        && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                          --label-selector="service=snuba-admin" \
+                          --container-name="snuba-admin" \
+                          "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- snuba migrations reverse-in-progress
+                    run_if: failed
+              timeout: 1200
+      - pipeline-complete:
+          approval:
+            allow_only_on_success: true
+            type: success
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/generated-pipelines/snuba-next.yaml
+++ b/gocd/generated-pipelines/snuba-next.yaml
@@ -1,0 +1,20 @@
+format_version: 10
+pipelines:
+  deploy-snuba-next:
+    group: snuba-next
+    lock_behavior: unlockWhenFinished
+    materials:
+      snuba_repo:
+        branch: master
+        destination: snuba
+        git: git@github.com:getsentry/snuba.git
+        shallow_clone: true
+    stages:
+      - pipeline-complete:
+          approval:
+            type: manual
+          jobs:
+            pipeline-complete:
+              tasks:
+                - exec:
+                    command: true

--- a/gocd/templates/bash/check-cloud-build.sh
+++ b/gocd/templates/bash/check-cloud-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+  ${GO_REVISION_SNUBA_REPO} \
+  sentryio \
+  "us.gcr.io/sentryio/snuba"

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/githubactions/checkruns.py \
+  getsentry/snuba \
+  ${GO_REVISION_SNUBA_REPO} \
+  "Tests and code coverage (test)" \
+  "Tests and code coverage (test_distributed)" \
+  "Tests and code coverage (test_distributed_migrations)" \
+  "Dataset Config Validation" \
+  "sentry (0)" \
+  "sentry (1)" \
+  "self-hosted-end-to-end"

--- a/gocd/templates/bash/check-migrations.sh
+++ b/gocd/templates/bash/check-migrations.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
+snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel \
+&& /devinfra/scripts/k8s/k8s-deploy.py \
+  --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+  --label-selector="${LABEL_SELECTOR}" \
+  --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  --container-name="api" \
+  --container-name="consumer" \
+  --container-name="errors-consumer" \
+  --container-name="errors-replacer" \
+  --container-name="events-subscriptions-executor" \
+  --container-name="events-subscriptions-scheduler" \
+  --container-name="generic-metrics-counters-consumer" \
+  --container-name="generic-metrics-counters-subscriptions-executor" \
+  --container-name="generic-metrics-counters-subscriptions-scheduler" \
+  --container-name="generic-metrics-distributions-consumer" \
+  --container-name="generic-metrics-distributions-subscriptions-executor" \
+  --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+  --container-name="generic-metrics-sets-consumer" \
+  --container-name="generic-metrics-sets-subscriptions-executor" \
+  --container-name="generic-metrics-sets-subscriptions-scheduler" \
+  --container-name="loadbalancer-outcomes-consumer" \
+  --container-name="loadtest-errors-consumer" \
+  --container-name="loadtest-loadbalancer-outcomes-consumer" \
+  --container-name="loadtest-outcomes-consumer" \
+  --container-name="loadtest-transactions-consumer" \
+  --container-name="metrics-consumer" \
+  --container-name="metrics-counters-subscriptions-scheduler" \
+  --container-name="metrics-sets-subscriptions-scheduler" \
+  --container-name="metrics-subscriptions-executor" \
+  --container-name="outcomes-billing-consumer" \
+  --container-name="outcomes-consumer" \
+  --container-name="profiles-consumer" \
+  --container-name="profiling-functions-consumer" \
+  --container-name="querylog-consumer" \
+  --container-name="replacer" \
+  --container-name="replays-consumer" \
+  --container-name="search-issues-consumer" \
+  --container-name="snuba-admin" \
+  --container-name="transactions-consumer-new" \
+  --container-name="transactions-subscriptions-executor" \
+  --container-name="transactions-subscriptions-scheduler" \
+  --container-name="rust-querylog-consumer" \
+  --container-name="spans-consumer" \
+  --container-name="dlq-consumer" \
+&& /devinfra/scripts/k8s/k8s-deploy.py \
+  --label-selector="${LABEL_SELECTOR}" \
+  --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  --type="cronjob" \
+  --container-name="cleanup" \
+  --container-name="optimize"

--- a/gocd/templates/bash/migrate-reverse.sh
+++ b/gocd/templates/bash/migrate-reverse.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel \
+&& /devinfra/scripts/k8s/k8s-spawn-job.py \
+  --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+  --label-selector="service=snuba-admin" \
+  --container-name="snuba-admin" \
+  "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- snuba migrations reverse-in-progress

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel \
+&& /devinfra/scripts/k8s/k8s-spawn-job.py \
+  --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+  --label-selector="service=snuba-admin" \
+  --container-name="snuba-admin" \
+  "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- snuba migrations migrate -r complete -r partial

--- a/gocd/templates/bash/sentry-release-canary.sh
+++ b/gocd/templates/bash/sentry-release-canary.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
+sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
+sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary

--- a/gocd/templates/bash/sentry-release-primary.sh
+++ b/gocd/templates/bash/sentry-release-primary.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
+sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "v1.0.0"
+        }
+      },
+      "version": "64a622b25deec33176e989230bc5f83fc0c77a84",
+      "sum": "KuyVvvF8E8xkLBz5LKh4YQgI9Sy2w10waj1MpQSiM6E="
+    }
+  ],
+  "legacyImports": false
+}

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -1,0 +1,124 @@
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.libsonnet';
+
+// The return value of this function is the body of a GoCD pipeline.
+// More information on gocd-flavor YAML this is producing can be found here:
+// - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
+// - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
+
+function(region) {
+  environment_variables: {
+    SENTRY_REGION: region,
+    // Required for checkruns.
+    GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+    GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}',
+  },
+  group: 'snuba-next',
+  lock_behavior: 'unlockWhenFinished',
+  materials: {
+    snuba_repo: {
+      git: 'git@github.com:getsentry/snuba.git',
+      shallow_clone: false,
+      branch: 'master',
+      destination: 'snuba',
+    },
+  },
+  stages: [
+    {
+      checks: {
+        jobs: {
+          checks: {
+            timeout: 1800,
+            elastic_profile_id: 'snuba',
+            tasks: [
+              gocdtasks.script(importstr '../bash/check-github.sh'),
+              gocdtasks.script(importstr '../bash/check-cloud-build.sh'),
+              gocdtasks.script(importstr '../bash/check-migrations.sh'),
+            ],
+          },
+        },
+      },
+    },
+    {
+      'deploy-canary': {
+        fetch_materials: true,
+        jobs: {
+          'create-sentry-release': {
+            environment_variables: {
+              SENTRY_ORG: 'sentry',
+              SENTRY_PROJECT: 'snuba',
+              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+            },
+            timeout: 300,
+            elastic_profile_id: 'snuba',
+            tasks: [
+              gocdtasks.script(importstr '../bash/sentry-release-canary.sh'),
+            ],
+          },
+          'deploy-canary': {
+            timeout: 1200,
+            elastic_profile_id: 'snuba',
+            environment_variables: {
+              LABEL_SELECTOR: 'service=snuba,is_canary=true',
+            },
+            tasks: [
+              gocdtasks.script(importstr '../bash/deploy.sh'),
+            ],
+          },
+        },
+      },
+    },
+    {
+      'deploy-primary': {
+        fetch_materials: true,
+        jobs: {
+          'create-sentry-release': {
+            environment_variables: {
+              SENTRY_ORG: 'sentry',
+              SENTRY_PROJECT: 'snuba',
+              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+            },
+            timeout: 300,
+            elastic_profile_id: 'snuba',
+            tasks: [
+              gocdtasks.script(importstr '../bash/sentry-release-primary.sh'),
+            ],
+          },
+          'deploy-canary': {
+            timeout: 1200,
+            elastic_profile_id: 'snuba',
+            environment_variables: {
+              LABEL_SELECTOR: 'service=snuba',
+            },
+            tasks: [
+              gocdtasks.script(importstr '../bash/deploy.sh'),
+            ],
+          },
+        },
+      },
+    },
+    {
+      migrate: {
+        fetch_materials: true,
+        jobs: {
+          migrate: {
+            timeout: 1200,
+            elastic_profile_id: 'snuba',
+            tasks: [
+              gocdtasks.script(importstr '../bash/migrate.sh'),
+              {
+                plugin: {
+                  options: gocdtasks.script(importstr '../bash/migrate-reverse.sh'),
+                  run_if: 'failed',
+                  configuration: {
+                    id: 'script-executor',
+                    version: 1,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  ],
+}

--- a/gocd/templates/snuba.jsonnet
+++ b/gocd/templates/snuba.jsonnet
@@ -1,0 +1,17 @@
+local snuba = import './pipelines/snuba.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'snuba-next',
+  auto_deploy: false,
+  materials: {
+    snuba_repo: {
+      git: 'git@github.com:getsentry/snuba.git',
+      shallow_clone: true,
+      branch: 'master',
+      destination: 'snuba',
+    },
+  },
+};
+
+pipedream.render(pipedream_config, snuba)

--- a/gocd/templates/snuba.jsonnet
+++ b/gocd/templates/snuba.jsonnet
@@ -3,7 +3,6 @@ local pipedream = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/pipedream.lib
 
 local pipedream_config = {
   name: 'snuba-next',
-  auto_deploy: false,
   materials: {
     snuba_repo: {
       git: 'git@github.com:getsentry/snuba.git',
@@ -12,6 +11,11 @@ local pipedream_config = {
       destination: 'snuba',
     },
   },
+
+  // Set to true to auto-deploy changes (defaults to true)
+  auto_deploy: false,
+  // Set to true if you want each pipeline to require manual approval
+  auto_pipeline_progression: false,
 };
 
 pipedream.render(pipedream_config, snuba)


### PR DESCRIPTION
This introduces a new set of GoCD pipelines generated from jsonnet.

1. deploy snuba (a noop pipeline that starts the pipedream flow)
1. deploy snuba US (What is currently snuba-deploy)
1. deploy snuba monitor (Deploys to a single tenant style region)

**The main differences from the current snuba.yaml pipeline**:

1. The migrate step is now run with approval
1. There were some differences in the canary and prod deploy tasks. Canary had the container `dlq-consumer` and prod didn't. Production has the container `rust-querylog-consumer` and canary didn't. I've merged the two steps into one shell script and the label selector for canary vs prod is now managed by an environment variable.

Please let me know if either of the both should be changed some other way.