### PR TITLE
fix(dlq): Fixes call to process_message

### DIFF
--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -268,6 +268,7 @@ class ConsumerBuilder:
                 processor,
                 self.consumer_group,
                 logical_topic,
+                self.__enforce_schema,
             ),
             collector=build_batch_writer(
                 table_writer,


### PR DESCRIPTION
We now pass enforce_schema to the process_message function. Forgot to pass it in one place.

Fix SNUBA-3CN
