### PR TITLE
Add script for customer deployments

### DIFF
--- a/gocd/generated-pipelines/snuba-next-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-next-monitor.yaml
@@ -223,19 +223,36 @@ pipelines:
           jobs:
             migrate:
               elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba
               tasks:
                 - script: |
                     ##!/bin/bash
 
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    ## At the time of writing (2023-06-28) the single tenant deployments
+                    ## have been using a different migration process compared to the
+                    ## US deployment of snuba.
+                    ## This script should be merged with migrate.sh if we can figure
+                    ## out a common migration script for all regions.
 
-                    /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-spawn-job.py \
-                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="service=snuba-admin" \
-                      --container-name="snuba-admin" \
-                      "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      -- snuba migrations migrate -r complete -r partial
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-bootstrap" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba bootstrap --force --no-migrate
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate --force
                 - plugin:
                     configuration:
                       id: script-executor
@@ -245,14 +262,15 @@ pipelines:
                         ##!/bin/bash
 
                         eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
 
-                        /devinfra/scripts/k8s/k8stunnel \
-                        && /devinfra/scripts/k8s/k8s-spawn-job.py \
-                          --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                          --label-selector="service=snuba-admin" \
-                          --container-name="snuba-admin" \
-                          "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                          -- snuba migrations reverse-in-progress
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
                     run_if: failed
               timeout: 1200
       - pipeline-complete:

--- a/gocd/generated-pipelines/snuba-next-us.yaml
+++ b/gocd/generated-pipelines/snuba-next-us.yaml
@@ -223,19 +223,23 @@ pipelines:
           jobs:
             migrate:
               elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba-admin
               tasks:
                 - script: |
                     ##!/bin/bash
 
                     eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
 
-                    /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-spawn-job.py \
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
                       --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="service=snuba-admin" \
-                      --container-name="snuba-admin" \
-                      "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      -- snuba migrations migrate -r complete -r partial
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate -r complete -r partial
                 - plugin:
                     configuration:
                       id: script-executor
@@ -245,14 +249,15 @@ pipelines:
                         ##!/bin/bash
 
                         eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
 
-                        /devinfra/scripts/k8s/k8stunnel \
-                        && /devinfra/scripts/k8s/k8s-spawn-job.py \
-                          --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                          --label-selector="service=snuba-admin" \
-                          --container-name="snuba-admin" \
-                          "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                          -- snuba migrations reverse-in-progress
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
                     run_if: failed
               timeout: 1200
       - pipeline-complete:

--- a/gocd/templates/bash/migrate-reverse.sh
+++ b/gocd/templates/bash/migrate-reverse.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+/devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8stunnel \
-&& /devinfra/scripts/k8s/k8s-spawn-job.py \
-  --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-  --label-selector="service=snuba-admin" \
-  --container-name="snuba-admin" \
-  "snuba-migrate-reverse" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-  -- snuba migrations reverse-in-progress
+/devinfra/scripts/k8s/k8s-spawn-job.py \
+  --label-selector="service=${SNUBA_SERVICE_NAME}" \
+  --container-name="${SNUBA_SERVICE_NAME}" \
+  "snuba-migrate-reverse" \
+  "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- \
+  snuba migrations reverse-in-progress

--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# At the time of writing (2023-06-28) the single tenant deployments
+# have been using a different migration process compared to the
+# US deployment of snuba.
+# This script should be merged with migrate.sh if we can figure
+# out a common migration script for all regions.
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-spawn-job.py \
+  --label-selector="service=${SNUBA_SERVICE_NAME}" \
+  --container-name="${SNUBA_SERVICE_NAME}" \
+  "snuba-bootstrap" \
+  "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- \
+  snuba bootstrap --force --no-migrate
+
+/devinfra/scripts/k8s/k8s-spawn-job.py \
+  --label-selector="service=${SNUBA_SERVICE_NAME}" \
+  --container-name="${SNUBA_SERVICE_NAME}" \
+  "snuba-migrate" \
+  "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- \
+  snuba migrations migrate --force

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
 eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+/devinfra/scripts/k8s/k8stunnel
 
-/devinfra/scripts/k8s/k8stunnel \
-&& /devinfra/scripts/k8s/k8s-spawn-job.py \
+/devinfra/scripts/k8s/k8s-spawn-job.py \
   --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-  --label-selector="service=snuba-admin" \
-  --container-name="snuba-admin" \
-  "snuba-migrate" "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-  -- snuba migrations migrate -r complete -r partial
+  --label-selector="service=${SNUBA_SERVICE_NAME}" \
+  --container-name="${SNUBA_SERVICE_NAME}" \
+  "snuba-migrate" \
+  "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  -- \
+  snuba migrations migrate -r complete -r partial

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -103,8 +103,14 @@ function(region) {
           migrate: {
             timeout: 1200,
             elastic_profile_id: 'snuba',
+            environment_variables: {
+              SNUBA_SERVICE_NAME: if region == 'monitor' || std.startsWith(region, 'customer-') then 'snuba' else 'snuba-admin',
+            },
             tasks: [
-              gocdtasks.script(importstr '../bash/migrate.sh'),
+              if region == 'monitor' || std.startsWith(region, 'customer-') then
+                gocdtasks.script(importstr '../bash/migrate-st.sh')
+              else
+                gocdtasks.script(importstr '../bash/migrate.sh'),
               {
                 plugin: {
                   options: gocdtasks.script(importstr '../bash/migrate-reverse.sh'),


### PR DESCRIPTION
I noticed that s4s has slightly differently migration steps for s4s and ST deployments.

This PR moves the container name / service name to an environment variable so we can re-use the migrate-reverse script on all regions and then there is a second script for the ST deployments migration.

Hopefully in the future we can merge the migration scripts, but this is the safest approach to avoid breaking things for now.