### PR TITLE
feat(consumer): Add transactions consumer SLO

### DIFF
--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -476,6 +476,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
 
         try:
             raw_received = _collapse_uint32(int(event_dict["data"]["received"]))
+            assert raw_received is not None
             received = datetime.utcfromtimestamp(raw_received)
             return InsertBatch([processed], received)
         except Exception:

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -24,6 +24,7 @@ from snuba.processor import (
     InsertBatch,
     ProcessedMessage,
     _as_dict_safe,
+    _collapse_uint32,
     _ensure_valid_date,
     _ensure_valid_ip,
     _unicodify,
@@ -473,4 +474,11 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         # the following operation modifies the event_dict and is therefore *not* order-independent
         self._process_contexts_and_user(processed, event_dict)
 
-        return InsertBatch([processed], event_dict["data"]["received"])
+        raw_received = _collapse_uint32(int(event_dict["data"]["received"]))
+        received = (
+            datetime.utcfromtimestamp(raw_received)
+            if raw_received is not None
+            else None
+        )
+
+        return InsertBatch([processed], received)

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -474,11 +474,11 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         # the following operation modifies the event_dict and is therefore *not* order-independent
         self._process_contexts_and_user(processed, event_dict)
 
-        raw_received = _collapse_uint32(int(event_dict["data"]["received"]))
-        received = (
-            datetime.utcfromtimestamp(raw_received)
-            if raw_received is not None
-            else None
-        )
+        if event_dict["data"]["received"] is not None:
+            raw_received = _collapse_uint32(int(event_dict["data"]["received"]))
+            assert raw_received is not None
+            received = datetime.utcfromtimestamp(raw_received)
+        else:
+            received = None
 
         return InsertBatch([processed], received)

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -472,4 +472,4 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         # the following operation modifies the event_dict and is therefore *not* order-independent
         self._process_contexts_and_user(processed, event_dict)
 
-        return InsertBatch([processed], None)
+        return InsertBatch([processed], processed["received"])

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -479,6 +479,6 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
             assert raw_received is not None
             received = datetime.utcfromtimestamp(raw_received)
             return InsertBatch([processed], received)
-        except KeyError as err:
-            logger.exception("Missing required field received in payload", err)
+        except (KeyError, AssertionError) as err:
+            logger.exception(err)
             return InsertBatch([processed], None)

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -479,5 +479,6 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
             assert raw_received is not None
             received = datetime.utcfromtimestamp(raw_received)
             return InsertBatch([processed], received)
-        except KeyError:
-            raise KeyError("Missing received timestamp field in transaction")
+        except KeyError as err:
+            logger.exception("Missing required field received in payload", err)
+            return InsertBatch([processed], None)

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -141,6 +141,7 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
             metrics.increment("group_ids_exceeded_limit")
 
         processed["group_ids"] = group_ids[:GROUP_IDS_LIMIT]
+
         return processed
 
     def _process_tags(
@@ -472,4 +473,4 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         # the following operation modifies the event_dict and is therefore *not* order-independent
         self._process_contexts_and_user(processed, event_dict)
 
-        return InsertBatch([processed], processed["received"])
+        return InsertBatch([processed], event_dict["data"]["received"])

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -479,5 +479,5 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
             assert raw_received is not None
             received = datetime.utcfromtimestamp(raw_received)
             return InsertBatch([processed], received)
-        except Exception:
+        except KeyError:
             raise KeyError("Missing received timestamp field in transaction")

--- a/snuba/datasets/processors/transactions_processor.py
+++ b/snuba/datasets/processors/transactions_processor.py
@@ -474,11 +474,9 @@ class TransactionsMessageProcessor(DatasetMessageProcessor):
         # the following operation modifies the event_dict and is therefore *not* order-independent
         self._process_contexts_and_user(processed, event_dict)
 
-        if event_dict["data"]["received"] is not None:
+        try:
             raw_received = _collapse_uint32(int(event_dict["data"]["received"]))
-            assert raw_received is not None
             received = datetime.utcfromtimestamp(raw_received)
-        else:
-            received = None
-
-        return InsertBatch([processed], received)
+            return InsertBatch([processed], received)
+        except Exception:
+            raise KeyError("Missing received timestamp field in transaction")

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Optional, Sequence, Tuple
+from unittest.mock import ANY
 
 import pytest
 
@@ -364,7 +365,7 @@ class TestTransactionsProcessor:
         )
         assert TransactionsMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)], None)
+        ) == InsertBatch([message.build_result(meta)], ANY)
         settings.TRANSACT_SKIP_CONTEXT_STORE = old_skip_context
 
     def test_too_many_spans(self) -> None:
@@ -389,7 +390,7 @@ class TestTransactionsProcessor:
 
         assert TransactionsMessageProcessor().process_message(
             payload, meta
-        ) == InsertBatch([result], None)
+        ) == InsertBatch([result], ANY)
         settings.TRANSACT_SKIP_CONTEXT_STORE = old_skip_context
 
     def test_missing_transaction_source(self) -> None:
@@ -433,7 +434,7 @@ class TestTransactionsProcessor:
         )
         assert TransactionsMessageProcessor().process_message(
             message.serialize(), meta
-        ) == InsertBatch([message.build_result(meta)], None)
+        ) == InsertBatch([message.build_result(meta)], ANY)
         settings.TRANSACT_SKIP_CONTEXT_STORE = old_skip_context
 
     def test_replay_id_as_tag(self) -> None:
@@ -463,7 +464,7 @@ class TestTransactionsProcessor:
 
         assert TransactionsMessageProcessor().process_message(
             payload, meta
-        ) == InsertBatch([result], None)
+        ) == InsertBatch([result], ANY)
 
     def test_replay_id_as_tag_and_context(self) -> None:
         """
@@ -493,7 +494,7 @@ class TestTransactionsProcessor:
 
         assert TransactionsMessageProcessor().process_message(
             payload, meta
-        ) == InsertBatch([result], None)
+        ) == InsertBatch([result], ANY)
 
     def test_replay_id_as_invalid_tag(self) -> None:
         """
@@ -520,4 +521,4 @@ class TestTransactionsProcessor:
 
         assert TransactionsMessageProcessor().process_message(
             payload, meta
-        ) == InsertBatch([result], None)
+        ) == InsertBatch([result], ANY)

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -308,6 +308,9 @@ class TestTransactionsProcessor:
             op="navigation",
             timestamp=finish,
             start_timestamp=start,
+            received=(
+                datetime.now(tz=timezone.utc) - timedelta(seconds=15)
+            ).timestamp(),
             platform="python",
             dist="",
             user_name="me",

--- a/tests/datasets/test_transaction_processor.py
+++ b/tests/datasets/test_transaction_processor.py
@@ -46,6 +46,7 @@ class TransactionEvent:
     has_app_ctx: bool = True
     profile_id: Optional[str] = None
     replay_id: Optional[str] = None
+    received: Optional[float] = None
 
     def get_app_context(self) -> Optional[Mapping[str, str]]:
         if self.has_app_ctx:
@@ -134,6 +135,7 @@ class TransactionEvent:
                     "datetime": "2019-08-08T22:29:53.917000Z",
                     "timestamp": self.timestamp,
                     "start_timestamp": self.start_timestamp,
+                    "received": self.received,
                     "measurements": {
                         "lcp": {"value": 32.129},
                         "lcp.elementSize": {"value": 4242},


### PR DESCRIPTION
The `received` field is (most likely) always present in transaction payloads, but we currently don't do anything with it in the relevant MessageProcessor. This PR allows us to grab the timestamp at which Relay received the transaction and pass it into the SLO calculation, to help us get the ingest transactions SLO. 

I think, if we are confident that we are always containing the `received` field, then we should change the Kafka schema to make `received` a required field. Need to verify this is the case though.