### PR TITLE
feat(admin): Stop blocking text/images on Snuba Admin replays

### DIFF
--- a/snuba/admin/static/index.tsx
+++ b/snuba/admin/static/index.tsx
@@ -24,7 +24,10 @@ client.getSettings().then((settings) => {
   if (settings.dsn != "") {
     Sentry.init({
       dsn: settings.dsn,
-      integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+      integrations: [
+        new Sentry.BrowserTracing(),
+        new Sentry.Replay({ maskAllText: false, blockAllMedia: false }),
+      ],
       // Performance Monitoring
       tracesSampleRate: settings.tracesSampleRate,
       // Session Replay


### PR DESCRIPTION
### Overview
- Watching a Snuba Admin replay shouldn't block any text, there's no PII
- It would be nice to see exactly the query strings etc that are being input