### PR TITLE
feat(oncall): Make readthrough cache fail open on redis errors

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -267,7 +267,7 @@ RAISE_ON_ALLOCATION_POLICY_FAILURES = False
 # By default, the readthrough cache won't block requests from going through in a production
 # environment to not cause incidents unnecessarily. If something goes wrong with redis or the readthrough cache
 # the request will still be able to go through as if the cache did not exist
-RAISE_ON_READTHROUGH_CACHE_FAILURES = False
+RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES = False
 
 
 # (logical topic name, # of partitions)

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -264,6 +264,12 @@ ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
 # situation eventually)
 RAISE_ON_ALLOCATION_POLICY_FAILURES = False
 
+# By default, the readthrough cache won't block requests from going through in a production
+# environment to not cause incidents unnecessarily. If something goes wrong with redis or the readthrough cache
+# the request will still be able to go through as if the cache did not exist
+RAISE_ON_READTHROUGH_CACHE_FAILURES = False
+
+
 # (logical topic name, # of partitions)
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}
 

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -25,6 +25,7 @@ PRETTY_FORMAT_EXPRESSIONS = True
 # environment to not cause incidents unnecessarily. But if you're testing the policy, it
 # should fail on bad code
 RAISE_ON_ALLOCATION_POLICY_FAILURES = True
+RAISE_ON_READTHROUGH_CACHE_FAILURES = False
 
 ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
 

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -25,9 +25,9 @@ PRETTY_FORMAT_EXPRESSIONS = True
 # environment to not cause incidents unnecessarily. But if you're testing the policy, it
 # should fail on bad code
 RAISE_ON_ALLOCATION_POLICY_FAILURES = True
-RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES = False
+RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES = True
 
-ENFORCE_BYTES_SCANNED_WINDOW_POLICY = False
+ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
 
 # override replacer threshold to write to redis every time a replacement message is consumed
 REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms

--- a/snuba/settings/settings_test.py
+++ b/snuba/settings/settings_test.py
@@ -25,9 +25,9 @@ PRETTY_FORMAT_EXPRESSIONS = True
 # environment to not cause incidents unnecessarily. But if you're testing the policy, it
 # should fail on bad code
 RAISE_ON_ALLOCATION_POLICY_FAILURES = True
-RAISE_ON_READTHROUGH_CACHE_FAILURES = False
+RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES = False
 
-ENFORCE_BYTES_SCANNED_WINDOW_POLICY = True
+ENFORCE_BYTES_SCANNED_WINDOW_POLICY = False
 
 # override replacer threshold to write to redis every time a replacement message is consumed
 REPLACER_PROCESSING_TIMEOUT_THRESHOLD = 0  # ms

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -303,4 +303,5 @@ class RedisCache(Cache[TValue]):
         except (ConnectionError, ReadOnlyError, RedisTimeoutError):
             if settings.RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES:
                 raise
+            metrics.increment("snuba.read_through_cache.fail_open")
             return function()

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -81,7 +81,7 @@ class RedisCache(Cache[TValue]):
         record_cache_hit_type: Callable[[int], None],
         timeout: int,
         timer: Optional[Timer] = None,
-    ):
+    ) -> TValue:
         # This method is designed with the following goals in mind:
         # 1. The value generation function is only executed when no value
         # already exists for the key.


### PR DESCRIPTION
Sometimes redis has a fit. That's not good but not catastrophic. If the readthrough cache fails due to a redis issue, just run the function normally, don't slow everything to a halt