### PR TITLE
perm(cardinality-analyzer): Add ingest team

### DIFF
--- a/snuba/admin/iam_policy/iam_policy.json
+++ b/snuba/admin/iam_policy/iam_policy.json
@@ -33,7 +33,7 @@
     {
       "members": [
           "group:team-starfish@sentry.io",
-          "user:iker.barriocanal@sentry.io"
+          "group:team-ingestion-pipeline@sentry.io"
       ],
       "role": "roles/CardinalityAnalyzer"
     }


### PR DESCRIPTION
Give the entire ingest team permission to use the cardinality analyzer.