### PR TITLE
fix(spans): Add `group_raw` to HexIntColumnProcessor

### DIFF
--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -92,7 +92,7 @@ query_processors:
       columns: [transaction_id, trace_id]
   - processor: HexIntColumnProcessor
     args:
-      columns: [span_id, parent_span_id, segment_id, group]
+      columns: [span_id, parent_span_id, segment_id, group, group_raw]
   - processor: MappingOptimizer
     args:
       column_name: tags


### PR DESCRIPTION
Add `group_raw` to the HexIntColumnProcessor because
right now we return the raw int and we'd like to return
the hash instead as we do with `group`