### PR TITLE
Add production queries tool to product tools

### DIFF
--- a/snuba/admin/auth_roles.py
+++ b/snuba/admin/auth_roles.py
@@ -80,6 +80,7 @@ TOOL_RESOURCES = {
     "snql-to-sql": ToolResource("snql-to-sql"),
     "tracing": ToolResource("tracing"),
     "cardinality-analyzer": ToolResource("cardinality-analyzer"),
+    "production-queries": ToolResource("production-queries"),
     "all": ToolResource("all"),
 }
 
@@ -150,7 +151,11 @@ ROLES = {
         name="product-tools",
         actions={
             InteractToolAction(
-                [TOOL_RESOURCES["snql-to-sql"], TOOL_RESOURCES["tracing"]]
+                [
+                    TOOL_RESOURCES["snql-to-sql"],
+                    TOOL_RESOURCES["tracing"],
+                    TOOL_RESOURCES["production-queries"],
+                ]
             )
         },
     ),

--- a/tests/admin/test_authorization.py
+++ b/tests/admin/test_authorization.py
@@ -37,4 +37,5 @@ def test_product_tools_role(
     assert len(data["tools"]) > 0
     assert "snql-to-sql" in data["tools"]
     assert "tracing" in data["tools"]
+    assert "production-queries" in data["tools"]
     assert "all" not in data["tools"]


### PR DESCRIPTION
This PR adds the production queries tool to the list of product tools in order to expose it to all sentry engineers.