### PR TITLE
feat(generic-metrics): Add aggregation options for generic metrics raw tables

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -295,6 +295,8 @@ class GenericMetricsLoader(DirectoryLoader):
             "0012_counters_mv",
             "0013_distributions_dist_tags_hash",
             "0014_distribution_add_options",
+            "0015_sets_add_options",
+            "0016_counters_add_options",
         ]
 
 

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -294,6 +294,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0011_counters_raw_table",
             "0012_counters_mv",
             "0013_distributions_dist_tags_hash",
+            "0014_distribution_add_options",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
@@ -46,7 +46,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 "day_retention_days",
                 UInt(8, MigrationModifiers(default=str("retention_days"))),
             ),
-            "min_retention_days",
+            "hr_retention_days",
         ),
     ]
 

--- a/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
@@ -1,0 +1,82 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    local_table_name = "generic_metric_distributions_raw_local"
+    dist_table_name = "generic_metric_distributions_raw_dist"
+
+    columns = [
+        (
+            Column("enable_histogram", UInt(8, MigrationModifiers(default=str("0")))),
+            "granularities",
+        ),
+        (
+            Column(
+                "decasecond_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "enable_histogram",
+        ),
+        (
+            Column(
+                "min_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "decasecond_retention_days",
+        ),
+        (
+            Column(
+                "hr_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "min_retention_days",
+        ),
+        (
+            Column(
+                "day_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "min_retention_days",
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
@@ -23,14 +23,14 @@ class Migration(migration.ClickhouseNodeMigration):
         (
             Column(
                 "decasecond_retention_days",
-                UInt(8, MigrationModifiers(default=str("retention_days"))),
+                UInt(8, MigrationModifiers(default=str("7"))),
             ),
             "enable_histogram",
         ),
         (
             Column(
                 "min_retention_days",
-                UInt(8, MigrationModifiers(default=str("retention_days"))),
+                UInt(8, MigrationModifiers(default=str("30"))),
             ),
             "decasecond_retention_days",
         ),

--- a/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0014_distribution_add_options.py
@@ -61,8 +61,8 @@ class Migration(migration.ClickhouseNodeMigration):
             )
             for column, after in self.columns
             for table_name, target in [
-                (self.dist_table_name, OperationTarget.DISTRIBUTED),
                 (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
             ]
         ]
 

--- a/snuba/snuba_migrations/generic_metrics/0015_sets_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0015_sets_add_options.py
@@ -42,7 +42,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 "day_retention_days",
                 UInt(8, MigrationModifiers(default=str("retention_days"))),
             ),
-            "min_retention_days",
+            "hr_retention_days",
         ),
     ]
 

--- a/snuba/snuba_migrations/generic_metrics/0015_sets_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0015_sets_add_options.py
@@ -1,0 +1,78 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set_key = StorageSetKey.GENERIC_METRICS_SETS
+
+    local_table_name = "generic_metric_sets_raw_local"
+    dist_table_name = "generic_metric_sets_raw_dist"
+
+    columns = [
+        (
+            Column(
+                "decasecond_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "granularities",
+        ),
+        (
+            Column(
+                "min_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "decasecond_retention_days",
+        ),
+        (
+            Column(
+                "hr_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "min_retention_days",
+        ),
+        (
+            Column(
+                "day_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "min_retention_days",
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/generic_metrics/0016_counters_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0016_counters_add_options.py
@@ -42,7 +42,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 "day_retention_days",
                 UInt(8, MigrationModifiers(default=str("retention_days"))),
             ),
-            "min_retention_days",
+            "hr_retention_days",
         ),
     ]
 

--- a/snuba/snuba_migrations/generic_metrics/0016_counters_add_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0016_counters_add_options.py
@@ -1,0 +1,78 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set_key = StorageSetKey.GENERIC_METRICS_COUNTERS
+
+    local_table_name = "generic_metric_counters_raw_local"
+    dist_table_name = "generic_metric_counters_raw_dist"
+
+    columns = [
+        (
+            Column(
+                "decasecond_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "granularities",
+        ),
+        (
+            Column(
+                "min_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "decasecond_retention_days",
+        ),
+        (
+            Column(
+                "hr_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "min_retention_days",
+        ),
+        (
+            Column(
+                "day_retention_days",
+                UInt(8, MigrationModifiers(default=str("retention_days"))),
+            ),
+            "min_retention_days",
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                after=after,
+                target=target,
+            )
+            for column, after in self.columns
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column_name=column.name,
+                target=target,
+            )
+            for column, _ in self.columns
+            for table_name, target in [
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+                (self.local_table_name, OperationTarget.LOCAL),
+            ]
+        ]


### PR DESCRIPTION
| PR                                                   | Changes                                                  | Status        | Branch From                                          |
| ---------------------------------------------------- | -------------------------------------------------------- | ------------- | ---------------------------------------------------- |
| [#1](https://github.com/getsentry/snuba/pull/4467) | ➤ Add aggregation options for generic metrics raw tables | Ready for review          | master                                               |
| [#2](https://github.com/getsentry/snuba/pull/4477) | Add new MatViews for generic metrics | Ready for review | [#1](https://github.com/getsentry/snuba/pull/4467) |
| [#3](https://github.com/getsentry/snuba/pull/4478) | Bump `materialization_version` for generic metrics | Ready for review | [#2](https://github.com/getsentry/snuba/pull/4477) |


### Overview

### Add new options in raw tables of distribution, sets, and counters

- `decasecond_retention_days`: the number of days 10 seconds granularity aggregation will be stored for
- `min_retention_days`: the number of days 60 seconds granularity aggregation will be stored for
- `hr_retention_days`: the number of days 3600 seconds granularity aggregation will be stored for
- `enable_histogram`: Whether to enable histogram or not (distributions only)
