### PR TITLE
feat(prod-queries): Improve UI components and add execution duration

### DIFF
--- a/snuba/admin/static/production_queries/types.tsx
+++ b/snuba/admin/static/production_queries/types.tsx
@@ -7,6 +7,7 @@ type QueryResult = {
   input_query?: string;
   columns: [string];
   rows: [[string]];
+  duration_ms: number;
 };
 
 type QueryResultColumnMeta = {


### PR DESCRIPTION
Made some general UI improvements:
- Execution Duration
- Spinner while executing query
- Better looking textbox, dataset selection, and button using Mantine

![image](https://github.com/getsentry/snuba/assets/132949946/24253bca-2eac-41d8-a7e0-2f1c84c8c71a)
