### PR TITLE
Fix typo in snuba pipelines

### DIFF
--- a/gocd/generated-pipelines/snuba-next-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-next-monitor.yaml
@@ -157,7 +157,7 @@ pipelines:
                     sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
                     sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
               timeout: 300
-            deploy-canary:
+            deploy-primary:
               elastic_profile_id: snuba
               environment_variables:
                 LABEL_SELECTOR: service=snuba

--- a/gocd/generated-pipelines/snuba-next-us.yaml
+++ b/gocd/generated-pipelines/snuba-next-us.yaml
@@ -157,7 +157,7 @@ pipelines:
                     sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e production
                     sentry-cli releases finalize "${GO_REVISION_SNUBA_REPO}"
               timeout: 300
-            deploy-canary:
+            deploy-primary:
               elastic_profile_id: snuba
               environment_variables:
                 LABEL_SELECTOR: service=snuba

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -83,7 +83,7 @@ function(region) {
               gocdtasks.script(importstr '../bash/sentry-release-primary.sh'),
             ],
           },
-          'deploy-canary': {
+          'deploy-primary': {
             timeout: 1200,
             elastic_profile_id: 'snuba',
             environment_variables: {


### PR DESCRIPTION
Noticed a naming mistake in the pipedream deploy-primary name.