### PR TITLE
feat(snubsplain): Add basic frontend for snubsplain

### DIFF
--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -52,8 +52,8 @@ interface Client {
   getAuditlog: () => Promise<ConfigChange[]>;
   getClickhouseNodes: () => Promise<[ClickhouseNodeData]>;
   getSnubaDatasetNames: () => Promise<SnubaDatasetName[]>;
-  convertSnQLQuery: (query: SnQLRequest) => Promise<SnQLResult>;
   executeSnQLQuery: (query: SnQLRequest) => Promise<any>;
+  debugSnQLQuery: (query: SnQLRequest) => Promise<SnQLResult>;
   getPredefinedQueryOptions: () => Promise<[PredefinedQuery]>;
   executeSystemQuery: (req: QueryRequest) => Promise<QueryResult>;
   executeTracingQuery: (req: TracingRequest) => Promise<TracingResult>;
@@ -188,7 +188,7 @@ function Client() {
       return fetch(url).then((resp) => resp.json());
     },
 
-    convertSnQLQuery: (query: SnQLRequest) => {
+    debugSnQLQuery: (query: SnQLRequest) => {
       const url = baseUrl + "snuba_debug";
       return fetch(url, {
         headers: { "Content-Type": "application/json" },

--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -10,6 +10,7 @@ import CapacityManagement from "./capacity_management";
 import DeadLetterQueue from "./dead_letter_queue";
 import CardinalityAnalyzer from "./cardinality_analyzer";
 import ProductionQueries from "./production_queries";
+import SnubaExplain from "./snuba_explain";
 
 function Placeholder(props: any) {
   return null;
@@ -27,6 +28,11 @@ const NAV_ITEMS = [
     id: "snql-to-sql",
     display: "🌐 SnQL to SQL",
     component: SnQLToSQL,
+  },
+  {
+    id: "snuba-explain",
+    display: "🩺 Snubsplain",
+    component: SnubaExplain,
   },
   {
     id: "clickhouse",

--- a/snuba/admin/static/snql_to_sql/index.tsx
+++ b/snuba/admin/static/snql_to_sql/index.tsx
@@ -49,7 +49,7 @@ function SnQLToSQL(props: { api: Client }) {
     }
     setIsExecuting(true);
     props.api
-      .convertSnQLQuery(snql_query as SnQLRequest)
+      .debugSnQLQuery(snql_query as SnQLRequest)
       .then((result) => {
         const query_result = {
           input_query: snql_query.query,

--- a/snuba/admin/static/snql_to_sql/types.tsx
+++ b/snuba/admin/static/snql_to_sql/types.tsx
@@ -9,6 +9,7 @@ type SnQLRequest = {
 type SnQLResult = {
   input_query?: string;
   sql: string;
+  explain?: object;
 };
 
 export { SnubaDatasetName, SnQLRequest, SnQLResult, SnQLQueryState };

--- a/snuba/admin/static/snuba_explain/index.tsx
+++ b/snuba/admin/static/snuba_explain/index.tsx
@@ -1,0 +1,168 @@
+import React, { useEffect, useState } from "react";
+import Client from "../api_client";
+import QueryEditor from "../query_editor";
+import { Collapse } from "../collapse";
+
+import { SnQLRequest, SnQLResult, ExplainResult, ExplainStep } from "./types";
+import { Step } from "./step_render";
+
+import {
+  executeActionsStyle,
+  selectStyle,
+  executeButtonStyle,
+  collapsibleStyle,
+} from "./styles";
+import { SnubaDatasetName, SnQLQueryState } from "../snql_to_sql/types";
+
+function SnubaExplain(props: { api: Client }) {
+  const [datasets, setDatasets] = useState<SnubaDatasetName[]>([]);
+  const [snql_query, setQuery] = useState<SnQLQueryState>({});
+  const [queryResultHistory, setQueryResultHistory] = useState<SnQLResult[]>(
+    []
+  );
+  const [isExecuting, setIsExecuting] = useState<boolean>(false);
+
+  useEffect(() => {
+    props.api.getSnubaDatasetNames().then((res) => {
+      setDatasets(res);
+    });
+  }, []);
+
+  function selectDataset(dataset: string) {
+    setQuery((prevQuery) => {
+      return {
+        ...prevQuery,
+        dataset,
+      };
+    });
+  }
+
+  function updateQuerySql(query: string) {
+    setQuery((prevQuery) => {
+      return {
+        ...prevQuery,
+        query,
+      };
+    });
+  }
+
+  function explainQuery() {
+    if (isExecuting) {
+      window.alert("A query is already running");
+    }
+    setIsExecuting(true);
+    props.api
+      .debugSnQLQuery(snql_query as SnQLRequest)
+      .then((result) => {
+        const query_result = {
+          input_query: snql_query.query,
+          sql: result.sql,
+          explain: result.explain as ExplainResult,
+        };
+        setQueryResultHistory((prevHistory) => [query_result, ...prevHistory]);
+      })
+      .catch((err) => {
+        console.log("ERROR", err);
+        window.alert("An error occurred: " + err.message);
+      })
+      .finally(() => {
+        setIsExecuting(false);
+      });
+  }
+
+  let currentExplain, currentRow, groupedSteps;
+  if (queryResultHistory.length > 0) {
+    currentRow = queryResultHistory[0];
+    currentExplain = currentRow.explain;
+    if (currentExplain != null) {
+      // Group the steps by their category
+      groupedSteps = currentExplain.steps.reduce(
+        (acc: ExplainStep[][], step: ExplainStep) => {
+          if (acc.length == 0) {
+            acc.push([step]);
+          } else if (acc.slice(-1)[0].slice(-1)[0].category != step.category) {
+            acc.push([step]);
+          } else {
+            acc[acc.length - 1].push(step);
+          }
+          return acc;
+        },
+        []
+      );
+    }
+  }
+
+  return (
+    <div>
+      <h2>Construct a SnQL Query</h2>
+      <QueryEditor
+        onQueryUpdate={(sql) => {
+          updateQuerySql(sql);
+        }}
+      />
+      <div style={executeActionsStyle}>
+        <div>
+          <select
+            value={snql_query.dataset || ""}
+            onChange={(evt) => selectDataset(evt.target.value)}
+            style={selectStyle}
+          >
+            <option disabled value="">
+              Select a dataset
+            </option>
+            {datasets.map((dataset) => (
+              <option key={dataset} value={dataset}>
+                {dataset}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div style={executeActionsStyle}>
+          <div>
+            <button
+              onClick={(evt) => {
+                evt.preventDefault();
+                explainQuery();
+              }}
+              style={executeButtonStyle}
+              disabled={
+                isExecuting ||
+                snql_query.dataset == undefined ||
+                snql_query.query == undefined
+              }
+            >
+              Explain Query
+            </button>
+          </div>
+        </div>
+      </div>
+      {currentExplain != null && currentRow != null && groupedSteps != null && (
+        <div>
+          <h2>SNUBSPLAIN</h2>
+          <Collapse key="orig_ast" text="Original AST">
+            <span>{currentExplain.original_ast}</span>
+          </Collapse>
+          <h3>Steps</h3>
+          <ol style={collapsibleStyle}>
+            {groupedSteps.map((steps, i) => (
+              <div>
+                <Collapse key={i} text={steps[0].category}>
+                  {steps.map((step, i) => (
+                    <li>
+                      <Step key={i} step={step} />
+                    </li>
+                  ))}
+                </Collapse>
+              </div>
+            ))}
+          </ol>
+          <Collapse key="final_sql" text="Final SQL">
+            <span>{currentRow.sql}</span>
+          </Collapse>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SnubaExplain;

--- a/snuba/admin/static/snuba_explain/index.tsx
+++ b/snuba/admin/static/snuba_explain/index.tsx
@@ -37,7 +37,7 @@ function SnubaExplain(props: { api: Client }) {
     });
   }
 
-  function updateQuerySql(query: string) {
+  function updateQuerySnQL(query: string) {
     setQuery((prevQuery) => {
       return {
         ...prevQuery,
@@ -97,7 +97,7 @@ function SnubaExplain(props: { api: Client }) {
       <h2>Construct a SnQL Query</h2>
       <QueryEditor
         onQueryUpdate={(sql) => {
-          updateQuerySql(sql);
+          updateQuerySnQL(sql);
         }}
       />
       <div style={executeActionsStyle}>

--- a/snuba/admin/static/snuba_explain/step_render.tsx
+++ b/snuba/admin/static/snuba_explain/step_render.tsx
@@ -1,0 +1,34 @@
+import React, { ReactNode } from "react";
+
+import { COLORS } from "../theme";
+import { ExplainStep, QueryTransformData } from "./types";
+
+import { Collapse } from "../collapse";
+
+type StepProps = {
+  step: ExplainStep;
+};
+
+function QueryTransformStep(props: StepProps) {
+  const { step } = props;
+  const data = step.data as QueryTransformData;
+  return (
+    <div>
+      <Collapse key={step.name} text={step.name}>
+        <span>{data.original_query}</span>
+        <span>{data.new_query}</span>
+      </Collapse>
+    </div>
+  );
+}
+
+function Step(props: StepProps) {
+  const { step } = props;
+  if (step.type === "query_transform") {
+    return <QueryTransformStep step={step} />;
+  } else {
+    return <div />;
+  }
+}
+
+export { Step };

--- a/snuba/admin/static/snuba_explain/styles.tsx
+++ b/snuba/admin/static/snuba_explain/styles.tsx
@@ -1,0 +1,25 @@
+const executeActionsStyle = {
+  display: "flex",
+  justifyContent: "space-between",
+  marginTop: 8,
+};
+
+const executeButtonStyle = {
+  height: 30,
+  border: 0,
+  padding: "4px 20px",
+};
+
+const selectStyle = {
+  marginRight: 8,
+  height: 30,
+};
+
+let collapsibleStyle = { listStyleType: "none", fontFamily: "Monaco" };
+
+export {
+  executeActionsStyle,
+  executeButtonStyle,
+  selectStyle,
+  collapsibleStyle,
+};

--- a/snuba/admin/static/snuba_explain/types.tsx
+++ b/snuba/admin/static/snuba_explain/types.tsx
@@ -1,0 +1,40 @@
+type SnubaDatasetName = string;
+type SnQLQueryState = Partial<SnQLRequest>;
+
+type SnQLRequest = {
+  dataset: string;
+  query: string;
+};
+
+type QueryTransformData = {
+  original_query: string;
+  new_query: string;
+};
+
+type ExplainStep = {
+  category: string;
+  type: string;
+  name: string;
+  data: object;
+};
+
+type ExplainResult = {
+  original_ast: string;
+  steps: ExplainStep[];
+};
+
+type SnQLResult = {
+  input_query?: string;
+  sql: string;
+  explain?: ExplainResult;
+};
+
+export {
+  SnubaDatasetName,
+  SnQLRequest,
+  SnQLResult,
+  SnQLQueryState,
+  ExplainResult,
+  ExplainStep,
+  QueryTransformData,
+};

--- a/snuba/admin/static/snuba_explain/utils.tsx
+++ b/snuba/admin/static/snuba_explain/utils.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+function TextArea(props: {
+  value: string;
+  onChange: (nextValue: string) => void;
+}) {
+  const { value, onChange } = props;
+  return (
+    <textarea
+      spellCheck={false}
+      value={value}
+      onChange={(evt) => onChange(evt.target.value)}
+      style={{ width: "100%", height: 100 }}
+      placeholder={"Write your query here"}
+    />
+  );
+}
+
+function copyText(text: string) {
+  window.navigator.clipboard.writeText(text);
+}
+
+export { TextArea, copyText };

--- a/snuba/admin/tool_policies.py
+++ b/snuba/admin/tool_policies.py
@@ -29,7 +29,7 @@ class AdminTools(Enum):
     CAPACITY_MANAGEMENT = "capacity-management"
     PRODUCTION_QUERIES = "production-queries"
     CARDINALITY_ANALYZER = "cardinality-analyzer"
-    SNUBA_EXPLAIN = "snuba_explain"
+    SNUBA_EXPLAIN = "snuba-explain"
 
 
 DEVELOPER_TOOLS: set[AdminTools] = {AdminTools.SNQL_TO_SQL, AdminTools.QUERY_TRACING}

--- a/snuba/datasets/plans/storage_plan_builder.py
+++ b/snuba/datasets/plans/storage_plan_builder.py
@@ -39,6 +39,7 @@ from snuba.query.processors.physical.mandatory_condition_applier import (
     MandatoryConditionApplier,
 )
 from snuba.query.query_settings import QuerySettings
+from snuba.state import explain_meta
 from snuba.utils.metrics.util import with_span
 
 # TODO: Importing snuba.web here is just wrong. What's need to be done to avoid this
@@ -73,6 +74,10 @@ class SimpleQueryPlanExecutionStrategy(QueryPlanExecutionStrategy[Query]):
                 with sentry_sdk.start_span(
                     description=type(processor).__name__, op="processor"
                 ):
+                    if query_settings.get_dry_run():
+                        explain_meta.add_step(
+                            "storage_processor", type(processor).__name__
+                        )
                     processor.process_query(query, query_settings)
             return runner(
                 clickhouse_query=query,

--- a/snuba/pipeline/composite.py
+++ b/snuba/pipeline/composite.py
@@ -31,6 +31,7 @@ from snuba.query.processors.physical import (
     CompositeQueryProcessor,
 )
 from snuba.query.query_settings import QuerySettings
+from snuba.state import explain_meta
 from snuba.web import QueryResult
 
 
@@ -438,6 +439,8 @@ class CompositeExecutionStrategy(QueryPlanExecutionStrategy[CompositeQuery[Table
         ).visit(query)
 
         for p in self.__composite_processors:
+            if query_settings.get_dry_run():
+                explain_meta.add_step("composite_storage_processor", type(p).__name__)
             p.process_query(query, query_settings)
 
         return runner(

--- a/snuba/state/explain_meta.py
+++ b/snuba/state/explain_meta.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from flask import g
+
+ExplainType = Literal["query_transform"]
 
 
 @dataclass
 class ExplainStep:
-    category: str  # The type of step e.g. "processor"
+    category: str  # The class of step e.g. "processor"
+    type: ExplainType  # A value that tells the frontend what data the step has
     name: str  # The specific name for the step e.g. "TimeSeriesProcessor"
     data: dict[str, Any] = field(
         default_factory=dict
@@ -17,6 +20,7 @@ class ExplainStep:
 
 @dataclass
 class ExplainMeta:
+    original_ast: str = "TBD"
     steps: list[ExplainStep] = field(default_factory=list)
 
     def add_step(self, step: ExplainStep) -> None:
@@ -27,7 +31,7 @@ def add_step(category: str, name: str, data: dict[str, Any] | None = None) -> No
     try:
         if data is None:
             data = {}
-        step = ExplainStep(category, name, data)
+        step = ExplainStep(category, "query_transform", name, data)
 
         if not hasattr(g, "explain_meta"):
             g.explain_meta = ExplainMeta()

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -370,6 +370,7 @@ def test_snuba_debug_valid_query(admin_api: FlaskClient) -> None:
     assert {
         "category": "entity_processor",
         "name": "BasicFunctionsProcessor",
+        "type": "query_transform",
         "data": {},
     } in data["explain"]["steps"]
 


### PR DESCRIPTION
Add a basic frontend for the explain data that is being sent by the endpoint.
This adds a new tool called Snubsplain to the admin tool, which when provided a
SnQL query will show the list of query processors that ran.

Frontend Changes:
- Create a new Snuba Explain tool that uses the meta data returned from calling
  the debugSnQLQuery endpoint
- Build a basic framework for rendering different steps of the query pipeline
- Show the names of the query processors that ran and in what order
- Show the final Clickhouse SQL that ran

Backend Changes:
- Capture the storage query processor names
- Set up some standard dataclasses for capturing explain meta data

![snubsplain-v1](https://github.com/getsentry/snuba/assets/2727124/dc5cb5e6-ec9a-4b1d-bbbd-4af556168b34)