### PR TITLE
Fix deployments for snuba on ST regions

### DIFF
--- a/gocd/generated-pipelines/snuba-next-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-next-monitor.yaml
@@ -63,84 +63,6 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
-      - deploy-canary:
-          fetch_materials: true
-          jobs:
-            create-sentry-release:
-              elastic_profile_id: snuba
-              environment_variables:
-                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}'
-                SENTRY_ORG: sentry
-                SENTRY_PROJECT: snuba
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
-                    sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
-                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary
-              timeout: 300
-            deploy-canary:
-              elastic_profile_id: snuba
-              environment_variables:
-                LABEL_SELECTOR: service=snuba,is_canary=true
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-
-                    /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
-                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      --container-name="api" \
-                      --container-name="consumer" \
-                      --container-name="errors-consumer" \
-                      --container-name="errors-replacer" \
-                      --container-name="events-subscriptions-executor" \
-                      --container-name="events-subscriptions-scheduler" \
-                      --container-name="generic-metrics-counters-consumer" \
-                      --container-name="generic-metrics-counters-subscriptions-executor" \
-                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
-                      --container-name="generic-metrics-distributions-consumer" \
-                      --container-name="generic-metrics-distributions-subscriptions-executor" \
-                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
-                      --container-name="generic-metrics-sets-consumer" \
-                      --container-name="generic-metrics-sets-subscriptions-executor" \
-                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
-                      --container-name="loadbalancer-outcomes-consumer" \
-                      --container-name="loadtest-errors-consumer" \
-                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
-                      --container-name="loadtest-outcomes-consumer" \
-                      --container-name="loadtest-transactions-consumer" \
-                      --container-name="metrics-consumer" \
-                      --container-name="metrics-counters-subscriptions-scheduler" \
-                      --container-name="metrics-sets-subscriptions-scheduler" \
-                      --container-name="metrics-subscriptions-executor" \
-                      --container-name="outcomes-billing-consumer" \
-                      --container-name="outcomes-consumer" \
-                      --container-name="profiles-consumer" \
-                      --container-name="profiling-functions-consumer" \
-                      --container-name="querylog-consumer" \
-                      --container-name="replacer" \
-                      --container-name="replays-consumer" \
-                      --container-name="search-issues-consumer" \
-                      --container-name="snuba-admin" \
-                      --container-name="transactions-consumer-new" \
-                      --container-name="transactions-subscriptions-executor" \
-                      --container-name="transactions-subscriptions-scheduler" \
-                      --container-name="rust-querylog-consumer" \
-                      --container-name="spans-consumer" \
-                      --container-name="dlq-consumer" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
-                      --label-selector="${LABEL_SELECTOR}" \
-                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      --type="cronjob" \
-                      --container-name="cleanup" \
-                      --container-name="optimize"
-              timeout: 1200
       - deploy-primary:
           fetch_materials: true
           jobs:
@@ -167,56 +89,19 @@ pipelines:
 
                     eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
                       --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="${LABEL_SELECTOR}" \
+                      --label-selector="service=snuba" \
                       --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      --container-name="api" \
-                      --container-name="consumer" \
-                      --container-name="errors-consumer" \
-                      --container-name="errors-replacer" \
-                      --container-name="events-subscriptions-executor" \
-                      --container-name="events-subscriptions-scheduler" \
-                      --container-name="generic-metrics-counters-consumer" \
-                      --container-name="generic-metrics-counters-subscriptions-executor" \
-                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
-                      --container-name="generic-metrics-distributions-consumer" \
-                      --container-name="generic-metrics-distributions-subscriptions-executor" \
-                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
-                      --container-name="generic-metrics-sets-consumer" \
-                      --container-name="generic-metrics-sets-subscriptions-executor" \
-                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
-                      --container-name="loadbalancer-outcomes-consumer" \
-                      --container-name="loadtest-errors-consumer" \
-                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
-                      --container-name="loadtest-outcomes-consumer" \
-                      --container-name="loadtest-transactions-consumer" \
-                      --container-name="metrics-consumer" \
-                      --container-name="metrics-counters-subscriptions-scheduler" \
-                      --container-name="metrics-sets-subscriptions-scheduler" \
-                      --container-name="metrics-subscriptions-executor" \
-                      --container-name="outcomes-billing-consumer" \
-                      --container-name="outcomes-consumer" \
-                      --container-name="profiles-consumer" \
-                      --container-name="profiling-functions-consumer" \
-                      --container-name="querylog-consumer" \
-                      --container-name="replacer" \
-                      --container-name="replays-consumer" \
-                      --container-name="search-issues-consumer" \
-                      --container-name="snuba-admin" \
-                      --container-name="transactions-consumer-new" \
-                      --container-name="transactions-subscriptions-executor" \
-                      --container-name="transactions-subscriptions-scheduler" \
-                      --container-name="rust-querylog-consumer" \
-                      --container-name="spans-consumer" \
-                      --container-name="dlq-consumer" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
-                      --label-selector="${LABEL_SELECTOR}" \
+                      --container-name="snuba"
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="service=snuba" \
                       --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
-                      --container-name="cleanup" \
-                      --container-name="optimize"
+                      --container-name="cleanup"
               timeout: 1200
       - migrate:
           fetch_materials: true

--- a/gocd/templates/bash/deploy-st.sh
+++ b/gocd/templates/bash/deploy-st.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+/devinfra/scripts/k8s/k8stunnel
+
+/devinfra/scripts/k8s/k8s-deploy.py \
+  --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+  --label-selector="service=snuba" \
+  --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  --container-name="snuba"
+
+/devinfra/scripts/k8s/k8s-deploy.py \
+  --label-selector="service=snuba" \
+  --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+  --type="cronjob" \
+  --container-name="cleanup"

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -5,6 +5,44 @@ local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/v1.0.0/gocd-tasks.li
 // - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
 // - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
 
+local is_st(region) = (region == 'monitor' || std.startsWith(region, 'customer-'));
+
+local deploy_canary_stages(region) =
+  if region != 'us' then
+    []
+  else
+    [
+      {
+        'deploy-canary': {
+          fetch_materials: true,
+          jobs: {
+            'create-sentry-release': {
+              environment_variables: {
+                SENTRY_ORG: 'sentry',
+                SENTRY_PROJECT: 'snuba',
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+              },
+              timeout: 300,
+              elastic_profile_id: 'snuba',
+              tasks: [
+                gocdtasks.script(importstr '../bash/sentry-release-canary.sh'),
+              ],
+            },
+            'deploy-canary': {
+              timeout: 1200,
+              elastic_profile_id: 'snuba',
+              environment_variables: {
+                LABEL_SELECTOR: 'service=snuba,is_canary=true',
+              },
+              tasks: [
+                gocdtasks.script(importstr '../bash/deploy.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ];
+
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
@@ -38,35 +76,9 @@ function(region) {
         },
       },
     },
-    {
-      'deploy-canary': {
-        fetch_materials: true,
-        jobs: {
-          'create-sentry-release': {
-            environment_variables: {
-              SENTRY_ORG: 'sentry',
-              SENTRY_PROJECT: 'snuba',
-              SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
-            },
-            timeout: 300,
-            elastic_profile_id: 'snuba',
-            tasks: [
-              gocdtasks.script(importstr '../bash/sentry-release-canary.sh'),
-            ],
-          },
-          'deploy-canary': {
-            timeout: 1200,
-            elastic_profile_id: 'snuba',
-            environment_variables: {
-              LABEL_SELECTOR: 'service=snuba,is_canary=true',
-            },
-            tasks: [
-              gocdtasks.script(importstr '../bash/deploy.sh'),
-            ],
-          },
-        },
-      },
-    },
+
+  ] + deploy_canary_stages(region) + [
+
     {
       'deploy-primary': {
         fetch_materials: true,
@@ -90,7 +102,10 @@ function(region) {
               LABEL_SELECTOR: 'service=snuba',
             },
             tasks: [
-              gocdtasks.script(importstr '../bash/deploy.sh'),
+              if is_st(region) then
+                gocdtasks.script(importstr '../bash/deploy-st.sh')
+              else
+                gocdtasks.script(importstr '../bash/deploy.sh'),
             ],
           },
         },
@@ -104,10 +119,12 @@ function(region) {
             timeout: 1200,
             elastic_profile_id: 'snuba',
             environment_variables: {
-              SNUBA_SERVICE_NAME: if region == 'monitor' || std.startsWith(region, 'customer-') then 'snuba' else 'snuba-admin',
+              // ST deployments use 'snuba' for container and label selectors
+              // in migrations, whereas the US region deployment uses snuba-admin.
+              SNUBA_SERVICE_NAME: if is_st(region) then 'snuba' else 'snuba-admin',
             },
             tasks: [
-              if region == 'monitor' || std.startsWith(region, 'customer-') then
+              if is_st(region) then
                 gocdtasks.script(importstr '../bash/migrate-st.sh')
               else
                 gocdtasks.script(importstr '../bash/migrate.sh'),


### PR DESCRIPTION
After running the snuba pipedream on s4s I noticed a few differences and issues I missed.

1. Canary deployments are only needed for saas deployments (a.k.a 'US' region)
2. ST deployments deploy with `--container-name="snuba"` which isn't in the list of containers for saas, so I've opted to create a deploy script for ST deployments that match what we use at the moment.
