### PR TITLE
feat(capman): add project_id as implicit tenant

### DIFF
--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -98,8 +98,10 @@ def build_request(
             )
 
             project_ids = get_object_ids_in_query_ast(query, "project_id")
+            query_project_id = None
             if project_ids is not None and len(project_ids) == 1:
-                sentry_sdk.set_tag("snuba_project_id", project_ids.pop())
+                query_project_id = project_ids.pop()
+                sentry_sdk.set_tag("snuba_project_id", query_project_id)
 
             org_ids = get_object_ids_in_query_ast(query, "org_id")
             if org_ids is not None and len(org_ids) == 1:
@@ -113,6 +115,11 @@ def build_request(
             attribution_info["tenant_ids"] = request_parts.attribution_info[
                 "tenant_ids"
             ]
+            if (
+                "project_id" not in attribution_info["tenant_ids"]
+                and query_project_id is not None
+            ):
+                attribution_info["tenant_ids"]["project_id"] = query_project_id
 
             request_id = uuid.uuid4().hex
             request = Request(

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -139,7 +139,7 @@ TENANT_ID_TESTS = [
 
 
 @pytest.mark.parametrize("request_payload, expected_tenant_ids", TENANT_ID_TESTS)
-def test_tenant_ids(request_payload, expected_tenant_ids):
+def test_tenant_ids(request_payload, expected_tenant_ids) -> None:
     dataset = get_dataset("events")
     schema = RequestSchema.build(HTTPQuerySettings)
 

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any, Dict
 
@@ -139,7 +141,9 @@ TENANT_ID_TESTS = [
 
 
 @pytest.mark.parametrize("request_payload, expected_tenant_ids", TENANT_ID_TESTS)
-def test_tenant_ids(request_payload, expected_tenant_ids) -> None:
+def test_tenant_ids(
+    request_payload: dict[str, Any], expected_tenant_ids: dict[str, Any]
+) -> None:
     dataset = get_dataset("events")
     schema = RequestSchema.build(HTTPQuerySettings)
 


### PR DESCRIPTION
In order to port the project based rate limiters to the capman framework, we have to have project ids as tenants, we currently do not. Add logic in the `build_request` function to add `project_id` to `AttributionInfo.tenant_ids`

This logic makes an explicit decision that when there are multiple projects being searched in one request, there is no project tenant, instead the organization_id becomes the tenant. 