### PR TITLE
Fix MultistorageCollector as #4297

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -458,7 +458,7 @@ class MultistorageCollector:
             self.__messages[storage_key].append(other_message)
             assert isinstance(message.value, BrokerValue)
             self.__offsets_to_produce[message.value.partition] = (
-                message.value.offset,
+                message.value.next_offset,
                 message.value.timestamp,
             )
 


### PR DESCRIPTION
I was digging the off-by-one error in snuba commit log issue. I prepared two-line fix for 23.3.1 but soon I found the one-line fix (#4297) was merged in last month. I think the rest should be fixed too.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
