### PR TITLE
feat(admin): Make System Queries and Tracing Tool use query editor component

### DIFF
--- a/snuba/admin/static/clickhouse_queries/index.tsx
+++ b/snuba/admin/static/clickhouse_queries/index.tsx
@@ -5,8 +5,6 @@ import QueryDisplay from "./query_display";
 import { QueryResult, PredefinedQuery } from "./types";
 
 function ClickhouseQueries(props: { api: Client }) {
-  const [predefinedQuery, setPredefinedQuery] =
-    useState<PredefinedQuery | null>(null);
   const [predefinedQueryOptions, setPredefinedQueryOptions] = useState<
     PredefinedQuery[]
   >([]);
@@ -31,19 +29,6 @@ function ClickhouseQueries(props: { api: Client }) {
     );
   }
 
-  function updatePredefinedQuery(queryName: string) {
-    const selectedQuery = predefinedQueryOptions.find(
-      (query) => query.name === queryName
-    );
-    if (selectedQuery) {
-      setPredefinedQuery(() => {
-        return {
-          ...selectedQuery,
-        };
-      });
-    }
-  }
-
   function formatSQL(sql: string) {
     const formatted = sql
       .split("\n")
@@ -54,28 +39,10 @@ function ClickhouseQueries(props: { api: Client }) {
 
   return (
     <div>
-      <div>
-        <form>
-          <select
-            value={predefinedQuery?.name || ""}
-            onChange={(evt) => updatePredefinedQuery(evt.target.value)}
-            style={selectStyle}
-          >
-            <option disabled value="">
-              Select a predefined query
-            </option>
-            {predefinedQueryOptions.map((option: PredefinedQuery) => (
-              <option key={option.name} value={option.name}>
-                {option.name}
-              </option>
-            ))}
-          </select>
-        </form>
-      </div>
       {QueryDisplay({
         api: props.api,
         resultDataPopulator: tablePopulator,
-        predefinedQuery: predefinedQuery,
+        predefinedQueryOptions: predefinedQueryOptions,
       })}
     </div>
   );

--- a/snuba/admin/static/clickhouse_queries/query_display.tsx
+++ b/snuba/admin/static/clickhouse_queries/query_display.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Client from "../api_client";
 import { Collapse } from "../collapse";
+import QueryEditor from "../query_editor";
 
 import { Prism } from "@mantine/prism";
 import { RichTextEditor } from "@mantine/tiptap";
@@ -21,7 +22,7 @@ type QueryState = Partial<QueryRequest>;
 function QueryDisplay(props: {
   api: Client;
   resultDataPopulator: (queryResult: QueryResult) => JSX.Element;
-  predefinedQuery: PredefinedQuery | null;
+  predefinedQueryOptions: Array<PredefinedQuery>;
 }) {
   const [nodeData, setNodeData] = useState<ClickhouseNodeData[]>([]);
   const [query, setQuery] = useState<QueryState>({});
@@ -34,12 +35,6 @@ function QueryDisplay(props: {
       setNodeData(res);
     });
   }, []);
-
-  useEffect(() => {
-    if (props.predefinedQuery) {
-      setQuery({ sql: props.predefinedQuery.sql });
-    }
-  }, [props.predefinedQuery]);
 
   function selectStorage(storage: string) {
     setQuery((prevQuery) => {
@@ -135,10 +130,12 @@ function QueryDisplay(props: {
     <div>
       <form>
         <h2>Construct a ClickHouse System Query</h2>
-        <div style={queryDescription}>{props.predefinedQuery?.description}</div>
-        <div>
-          <TextArea value={query.sql || ""} onChange={updateQuerySql} />
-        </div>
+        <QueryEditor
+          onQueryUpdate={(sql) => {
+            updateQuerySql(sql);
+          }}
+          predefinedQueryOptions={props.predefinedQueryOptions}
+        />
         <div style={executeActionsStyle}>
           <div>
             <select

--- a/snuba/admin/static/tests/tracing/index.spec.tsx
+++ b/snuba/admin/static/tests/tracing/index.spec.tsx
@@ -16,6 +16,7 @@ import { ClickhouseNodeData } from "../../clickhouse_queries/types";
 import default_response from "./fixture";
 
 it("select executor rows should appear", async () => {
+  global.ResizeObserver = require("resize-observer-polyfill");
   let mockClient = {
     ...Client(),
     executeTracingQuery: jest
@@ -38,10 +39,6 @@ it("select executor rows should appear", async () => {
     <TracingQueries api={mockClient} />
   );
   await waitFor(() => expect(mockClient.getClickhouseNodes).toBeCalledTimes(1));
-
-  act(() => {
-    selectEvent.select(getByRole("combobox"), "test");
-  });
 
   expect(queryByText("Copy to clipboard", { exact: false })).toBeNull();
 

--- a/snuba/admin/static/tracing/query_display.tsx
+++ b/snuba/admin/static/tracing/query_display.tsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useState } from "react";
+import Client from "../api_client";
+import QueryEditor from "../query_editor";
+import { Table } from "../table";
+
+import {
+  LogLine,
+  TracingRequest,
+  TracingResult,
+  PredefinedQuery,
+} from "./types";
+
+type QueryState = Partial<TracingRequest>;
+
+function QueryDisplay(props: {
+  api: Client;
+  resultDataPopulator: (queryResult: TracingResult) => JSX.Element;
+  predefinedQueryOptions: Array<PredefinedQuery>;
+}) {
+  const [storages, setStorages] = useState<string[]>([]);
+  const [query, setQuery] = useState<QueryState>({});
+  const [queryResultHistory, setQueryResultHistory] = useState<TracingResult[]>(
+    []
+  );
+  const [isExecuting, setIsExecuting] = useState<boolean>(false);
+
+  useEffect(() => {
+    props.api.getClickhouseNodes().then((res) => {
+      setStorages(res.map((n) => n.storage_name));
+    });
+  }, []);
+
+  function updateQuerySql(sql: string) {
+    setQuery((prevQuery) => {
+      return {
+        ...prevQuery,
+        sql,
+      };
+    });
+  }
+
+  function executeQuery() {
+    if (isExecuting) {
+      window.alert("A query is already running");
+    }
+    setIsExecuting(true);
+    props.api
+      .executeTracingQuery(query as TracingRequest)
+      .then((result) => {
+        const tracing_result = {
+          input_query: `${query.sql}`,
+          timestamp: result.timestamp,
+          num_rows_result: result.num_rows_result,
+          cols: result.cols,
+          trace_output: result.trace_output,
+          error: result.error,
+        };
+        setQueryResultHistory((prevHistory) => [
+          tracing_result,
+          ...prevHistory,
+        ]);
+      })
+      .catch((err) => {
+        console.log("ERROR", err);
+        window.alert("An error occurred: " + err.error.message);
+      })
+      .finally(() => {
+        setIsExecuting(false);
+      });
+  }
+
+  function selectStorage(storage: string) {
+    setQuery((prevQuery) => {
+      return {
+        ...prevQuery,
+        storage: storage,
+      };
+    });
+    console.log(query);
+  }
+
+  function copyText(text: string) {
+    window.navigator.clipboard.writeText(text);
+  }
+
+  return (
+    <div>
+      <h2>Construct a ClickHouse Query</h2>
+      <a href="https://getsentry.github.io/snuba/clickhouse/death_queries.html">
+        🛑 WARNING! BEFORE RUNNING QUERIES, READ THIS 🛑
+      </a>
+      <QueryEditor
+        onQueryUpdate={(sql) => {
+          updateQuerySql(sql);
+        }}
+        predefinedQueryOptions={props.predefinedQueryOptions}
+      />
+      <div style={executeActionsStyle}>
+        <div>
+          <select
+            value={query.storage || ""}
+            onChange={(evt) => selectStorage(evt.target.value)}
+            style={selectStyle}
+          >
+            <option disabled value="">
+              Select a storage
+            </option>
+            {storages.map((storage) => (
+              <option key={storage} value={storage}>
+                {storage}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <button
+            onClick={(_) => executeQuery()}
+            style={executeButtonStyle}
+            disabled={isExecuting || !query.storage || !query.sql}
+          >
+            Execute query
+          </button>
+        </div>
+      </div>
+      <div>
+        <h2>Query results</h2>
+        <Table
+          headerData={["Query", "Response"]}
+          rowData={queryResultHistory.map((queryResult) => [
+            <span>{queryResult.input_query}</span>,
+            <div>
+              <button
+                style={executeButtonStyle}
+                onClick={() => copyText(JSON.stringify(queryResult))}
+              >
+                Copy to clipboard
+              </button>
+              {props.resultDataPopulator(queryResult)}
+            </div>,
+          ])}
+          columnWidths={[1, 5]}
+        />
+      </div>
+    </div>
+  );
+}
+
+const executeActionsStyle = {
+  display: "flex",
+  justifyContent: "space-between",
+  marginTop: 8,
+};
+
+const executeButtonStyle = {
+  height: 30,
+  border: 0,
+  padding: "4px 20px",
+  marginRight: 10,
+};
+
+const selectStyle = {
+  marginRight: 8,
+  height: 30,
+};
+
+function TextArea(props: {
+  value: string;
+  onChange: (nextValue: string) => void;
+}) {
+  const { value, onChange } = props;
+  return (
+    <textarea
+      spellCheck={false}
+      value={value}
+      onChange={(evt) => onChange(evt.target.value)}
+      style={{ width: "100%", height: 140 }}
+      placeholder={"Write your query here"}
+    />
+  );
+}
+
+const queryDescription = {
+  minHeight: 10,
+  width: "auto",
+  fontSize: 16,
+  padding: "10px 5px",
+};
+export default QueryDisplay;

--- a/snuba/admin/static/tracing/types.tsx
+++ b/snuba/admin/static/tracing/types.tsx
@@ -21,4 +21,10 @@ type LogLine = {
   message: string;
 };
 
-export { TracingRequest, TracingResult, LogLine };
+type PredefinedQuery = {
+  name: string;
+  sql: string;
+  description: string;
+};
+
+export { TracingRequest, TracingResult, LogLine, PredefinedQuery };


### PR DESCRIPTION
### Overview
The following PR is responsible for migrating the System Queries and Tracing Tool to use the [query_editor](https://github.com/getsentry/snuba/blob/master/snuba/admin/static/query_editor.tsx) component. Doing so provides consistency among all query tools in admin and fixes some text input bugs.

System Queries:
![image](https://github.com/getsentry/snuba/assets/23560545/59acdfb4-1dc9-4566-97ec-81e28d7564b6)


Tracing Tool:
![image](https://github.com/getsentry/snuba/assets/23560545/ae7c19fb-005b-4449-be6c-1858a85370d1)
