### PR TITLE
feat(capman): pass query_id into allocation policy

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass, field, replace
 from typing import Any, cast
@@ -25,6 +26,33 @@ CAPMAN_HASH = "capman"
 IS_ACTIVE = "is_active"
 IS_ENFORCED = "is_enforced"
 MAX_THREADS = "max_threads"
+
+
+def get_quota_allowance(
+    allocation_policies: list["AllocationPolicy"], tenant_ids: dict[str, int | str]
+) -> QuotaAllowance:
+    quota_allowances: dict[str, QuotaAllowance] = {}
+    query_id = str(uuid.uuid4())
+    min_allowance = QuotaAllowance(True, 100, {})
+    for allocation_policy in allocation_policies:
+        allowance = allocation_policy.get_quota_allowance(tenant_ids, query_id)
+        min_allowance = min_allowance.merge(allowance)
+        quota_allowances[
+            allocation_policy.config_key()
+        ] = allocation_policy.get_quota_allowance(tenant_ids, query_id)
+    return min_allowance
+
+
+def update_quota_balance(
+    allocation_policies: list["AllocationPolicy"],
+    tenant_ids: dict[str, int | str],
+    query_id: str,
+    query_result_or_error: QueryResultOrError,
+) -> None:
+    for allocation_policy in allocation_policies:
+        allocation_policy.update_quota_balance(
+            tenant_ids, query_id, query_result_or_error
+        )
 
 
 @dataclass(frozen=True)
@@ -97,11 +125,31 @@ class QuotaAllowance:
     # because I don't know what exactly should go in it yet
     explanation: dict[str, Any]
 
-    def __lt__(self, other: QuotaAllowance) -> bool:
-        return self.max_threads < other.max_threads
-
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+    def __lt__(self, other: QuotaAllowance) -> bool:
+        if self.can_run and not other.can_run:
+            return False
+        return self.max_threads < other.max_threads
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, QuotaAllowance):
+            return False
+        return (
+            self.can_run == other.can_run
+            and self.max_threads == other.max_threads
+            and self.explanation == other.explanation
+        )
+
+    def merge(self, other: QuotaAllowance):
+        return QuotaAllowance(
+            can_run=self.can_run and other.can_run,
+            max_threads=min(self.max_threads, other.max_threads),
+            # FIXME: this is not the right wayt to merge it
+            # one will clobber the other but we should be able to see both
+            explanation={**self.explanation, **other.explanation},
+        )
 
 
 class AllocationPolicyViolation(SerializableException):
@@ -177,7 +225,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         >>>     # Use your configs in the following methods
 
         >>>     def _get_quota_allowance(
-        >>>         self, tenant_ids: dict[str, str | int]
+        >>>         self, tenant_ids: dict[str, str | int], query_id: str
         >>>     ) -> QuotaAllowance:
         >>>         # before a query is run on clickhouse, make a decision whether it can be run and with
         >>>         # how many threads
@@ -186,6 +234,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         >>>     def _update_quota_balance(
         >>>         self,
         >>>         tenant_ids: dict[str, str | int],
+        >>>         query_id: str
         >>>         result_or_error: QueryResultOrError,
         >>>     ) -> None:
         >>>         # after the query has been run, update whatever this allocation policy
@@ -197,10 +246,11 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         >>> policy = MyAllocationPolicy(
         >>>     StorageKey("mystorage"), required_tenant_types=["organization_id", "referrer"]
         >>> )
-        >>> allowance = policy.get_quota_allowance({"organization_id": 1234, "referrer": "myreferrer"})
+        >>> allowance = policy.get_quota_allowance({"organization_id": 1234, "referrer": "myreferrer"}, query_id="deadbeef")
         >>> result = run_db_query(allowance)
         >>> policy.update_quota_balance(
         >>>     tenant_ids={"organization_id": 1234, "referrer": "myreferrer"},
+        >>>     query_id="deadbeef",
         >>>     QueryResultOrError(result=result)
         >>> )
 
@@ -678,37 +728,43 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
         return config
 
-    def get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         try:
             if not self.is_active:
                 allowance = QuotaAllowance(True, self.max_threads, {})
             else:
-                allowance = self._get_quota_allowance(tenant_ids)
+                allowance = self._get_quota_allowance(tenant_ids, query_id)
         except Exception:
             logger.exception(
                 "Allocation policy failed to get quota allowance, this is a bug, fix it"
             )
             if settings.RAISE_ON_ALLOCATION_POLICY_FAILURES:
                 raise
-            return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids)
+            return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids, query_id)
         if not allowance.can_run:
             raise AllocationPolicyViolation.from_args(tenant_ids, allowance)
         return allowance
 
     @abstractmethod
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         pass
 
     def update_quota_balance(
         self,
         tenant_ids: dict[str, str | int],
+        query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         try:
             if not self.is_active:
                 return
-            return self._update_quota_balance(tenant_ids, result_or_error)
+            return self._update_quota_balance(tenant_ids, query_id, result_or_error)
         except Exception:
+            # FIXME: Remove this
             logger.exception(
                 "Allocation policy failed to update quota balance, this is a bug, fix it"
             )
@@ -719,6 +775,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
     def _update_quota_balance(
         self,
         tenant_ids: dict[str, str | int],
+        query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         pass
@@ -728,7 +785,9 @@ class PassthroughPolicy(AllocationPolicy):
     def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
         return []
 
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         return QuotaAllowance(
             can_run=True, max_threads=self.max_threads, explanation={}
         )
@@ -736,6 +795,7 @@ class PassthroughPolicy(AllocationPolicy):
     def _update_quota_balance(
         self,
         tenant_ids: dict[str, str | int],
+        query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         pass

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -124,7 +124,9 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
 
         return True, ""
 
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
         if not ids_are_valid:
             self.metrics.increment(
@@ -196,6 +198,7 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
     def _update_quota_balance(
         self,
         tenant_ids: dict[str, str | int],
+        query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         if result_or_error.error:

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -389,12 +389,15 @@ def test_get_allocation_policy_configs(admin_api: FlaskClient) -> None:
             ]
 
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             return QuotaAllowance(True, 1, {})
 
         def _update_quota_balance(
-            self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
+            self,
+            tenant_ids: dict[str, str | int],
+            query_id: str,
+            result_or_error: QueryResultOrError,
         ) -> None:
             pass
 

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -48,29 +48,37 @@ def test_eq() -> None:
 @pytest.mark.redis_db
 def test_passthrough_allows_queries() -> None:
     DEFAULT_PASSTHROUGH_POLICY.set_config_value("max_threads", 420)
-    assert DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance({}).can_run
-    assert DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance({}).max_threads == 420
+    assert DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance({}, "deadbeef").can_run
+    assert (
+        DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance({}, "deadbeef").max_threads
+        == 420
+    )
 
 
 def test_raises_on_false_can_run() -> None:
     class RejectingEverythingAllocationPolicy(PassthroughPolicy):
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             return QuotaAllowance(can_run=False, max_threads=1, explanation={})
 
     with pytest.raises(AllocationPolicyViolation):
         RejectingEverythingAllocationPolicy(
             StorageKey("something"), [], default_config_overrides={}
-        ).get_quota_allowance({})
+        ).get_quota_allowance({}, query_id="deadbeef")
 
 
 class BadlyWrittenAllocationPolicy(PassthroughPolicy):
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         raise AttributeError("You messed up!")
 
     def _update_quota_balance(
-        self, tenant_ids: dict[str, str | int], result_or_error: QueryResultOrError
+        self,
+        tenant_ids: dict[str, str | int],
+        query_id: str,
+        result_or_error: QueryResultOrError,
     ) -> None:
         raise ValueError("you messed up AGAIN")
 
@@ -79,23 +87,23 @@ def test_passes_through_on_error() -> None:
     with pytest.raises(AttributeError):
         BadlyWrittenAllocationPolicy(
             StorageKey("something"), [], {}
-        ).get_quota_allowance({})
+        ).get_quota_allowance({}, query_id="deadbeef")
 
     with pytest.raises(ValueError):
-        BadlyWrittenAllocationPolicy(StorageKey("something"), [], {}).update_quota_balance(None, None)  # type: ignore
+        BadlyWrittenAllocationPolicy(StorageKey("something"), [], {}).update_quota_balance(None, None, None)  # type: ignore
 
     # should not raise even though the implementation is buggy (this is the production setting)
     with mock.patch("snuba.settings.RAISE_ON_ALLOCATION_POLICY_FAILURES", False):
         assert (
             BadlyWrittenAllocationPolicy(StorageKey("something"), [], {})
-            .get_quota_allowance({})
+            .get_quota_allowance({}, query_id="deadbeef")
             .can_run
         )
 
         BadlyWrittenAllocationPolicy(
             StorageKey("something"), [], {}
         ).update_quota_balance(
-            None, None  # type: ignore
+            None, None, None  # type: ignore
         )
 
 
@@ -147,7 +155,9 @@ class SomeParametrizedConfigPolicy(AllocationPolicy):
             ),
         ]
 
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         raise
 
     def _update_quota_balance(
@@ -410,12 +420,25 @@ def test_is_not_active() -> None:
 
     # Should error since private methods _get_quota_allowance and _update_quota_balance are called
     with pytest.raises(AttributeError):
-        policy.get_quota_allowance(tenant_ids)
+        policy.get_quota_allowance(tenant_ids, "deadbeef")
     with pytest.raises(ValueError):
-        policy.update_quota_balance(tenant_ids, result_or_error)
+        policy.update_quota_balance(tenant_ids, "deadbeef", result_or_error)
 
     policy.set_config_value(config_key="is_active", value=0)  # make policy inactive
 
     # Should not error anymore since private methods are not called due to inactivity
-    policy.get_quota_allowance(tenant_ids)
-    policy.update_quota_balance(tenant_ids, result_or_error)
+    policy.get_quota_allowance(tenant_ids, "deadbeef")
+    policy.update_quota_balance(tenant_ids, "deadbeef", result_or_error)
+
+
+def test_quota_allowance_merge():
+    # Test the snuba.query.allocation_policies.QuotaAllowance merge function by making 2 allowances, merging them and checking the result
+    allowance1 = QuotaAllowance(
+        max_threads=10, can_run=False, explanation={"reason": "something bad"}
+    )
+    allowance2 = QuotaAllowance(
+        max_threads=10, can_run=True, explanation={"reason": "something else bad"}
+    )
+    # FIXME: make this test work and fix the conditions
+    # the explanations should be merged in a sane way
+    assert allowance1.merge(allowance2) == allowance1

--- a/tests/query/allocation_policies/test_allocation_policy_base.py
+++ b/tests/query/allocation_policies/test_allocation_policy_base.py
@@ -429,16 +429,3 @@ def test_is_not_active() -> None:
     # Should not error anymore since private methods are not called due to inactivity
     policy.get_quota_allowance(tenant_ids, "deadbeef")
     policy.update_quota_balance(tenant_ids, "deadbeef", result_or_error)
-
-
-def test_quota_allowance_merge():
-    # Test the snuba.query.allocation_policies.QuotaAllowance merge function by making 2 allowances, merging them and checking the result
-    allowance1 = QuotaAllowance(
-        max_threads=10, can_run=False, explanation={"reason": "something bad"}
-    )
-    allowance2 = QuotaAllowance(
-        max_threads=10, can_run=True, explanation={"reason": "something else bad"}
-    )
-    # FIXME: make this test work and fix the conditions
-    # the explanations should be merged in a sane way
-    assert allowance1.merge(allowance2) == allowance1

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -31,7 +31,9 @@ class RejectAllocationPolicy123(AllocationPolicy):
     def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
         return []
 
-    def _get_quota_allowance(self, tenant_ids: dict[str, str | int]) -> QuotaAllowance:
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
         return QuotaAllowance(
             can_run=False,
             max_threads=0,
@@ -41,6 +43,7 @@ class RejectAllocationPolicy123(AllocationPolicy):
     def _update_quota_balance(
         self,
         tenant_ids: dict[str, str | int],
+        query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         return

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -278,7 +278,7 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
             return []
 
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             return QuotaAllowance(
                 can_run=False,
@@ -289,6 +289,7 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
         def _update_quota_balance(
             self,
             tenant_ids: dict[str, str | int],
+            query_id: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             return
@@ -344,7 +345,7 @@ def test_allocation_policy_threads_applied_to_query() -> None:
             return []
 
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             return QuotaAllowance(
                 can_run=True,
@@ -355,13 +356,14 @@ def test_allocation_policy_threads_applied_to_query() -> None:
         def _update_quota_balance(
             self,
             tenant_ids: dict[str, str | int],
+            query_id: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             return
 
     class ThreadLimitPolicyDuplicate(ThreadLimitPolicy):
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             return QuotaAllowance(
                 can_run=True,
@@ -412,7 +414,7 @@ def test_allocation_policy_updates_quota() -> None:
             return []
 
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             can_run = True
             if queries_run + 1 > MAX_QUERIES_TO_RUN:
@@ -426,6 +428,7 @@ def test_allocation_policy_updates_quota() -> None:
         def _update_quota_balance(
             self,
             tenant_ids: dict[str, str | int],
+            query_id: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             nonlocal queries_run
@@ -438,7 +441,7 @@ def test_allocation_policy_updates_quota() -> None:
             return []
 
         def _get_quota_allowance(
-            self, tenant_ids: dict[str, str | int]
+            self, tenant_ids: dict[str, str | int], query_id: str
         ) -> QuotaAllowance:
             can_run = True
             if queries_run_duplicate + 1 > MAX_QUERIES_TO_RUN:
@@ -454,6 +457,7 @@ def test_allocation_policy_updates_quota() -> None:
         def _update_quota_balance(
             self,
             tenant_ids: dict[str, str | int],
+            query_id: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             nonlocal queries_run_duplicate


### PR DESCRIPTION
Rate limiting mechanisms need a query id to keep track of. Allocation policy does not have such a concept so I'm introducing it here. 