### PR TITLE
migration(group_attributes): create new GroupAttributes table that mirrors a subset of columns from sentry

### DIFF
--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -17,7 +17,6 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "FUNCTIONS": "functions",
     "SEARCH_ISSUES": "search_issues",
     "SPANS": "spans",
-    "GROUP_ATTRIBUTES": "group_attributes",
 }
 
 

--- a/snuba/clusters/storage_sets.py
+++ b/snuba/clusters/storage_sets.py
@@ -17,6 +17,7 @@ _HARDCODED_STORAGE_SET_KEYS = {
     "FUNCTIONS": "functions",
     "SEARCH_ISSUES": "search_issues",
     "SPANS": "spans",
+    "GROUP_ATTRIBUTES": "group_attributes",
 }
 
 

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -328,7 +328,7 @@ class SpansLoader(DirectoryLoader):
         ]
 
 
-class GroupAttributes(DirectoryLoader):
+class GroupAttributesLoader(DirectoryLoader):
     def __init__(self) -> None:
         super().__init__("snuba.snuba_migrations.group_attributes")
 

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -330,7 +330,7 @@ class SpansLoader(DirectoryLoader):
 
 class GroupAttributes(DirectoryLoader):
     def __init__(self) -> None:
-        super().__init__("snuba.snuba_migrations.search_issues")
+        super().__init__("snuba.snuba_migrations.group_attributes")
 
     def get_migrations(self) -> Sequence[str]:
         return [

--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -326,3 +326,13 @@ class SpansLoader(DirectoryLoader):
             "0003_spans_add_ms_columns",
             "0004_spans_group_raw_col",
         ]
+
+
+class GroupAttributes(DirectoryLoader):
+    def __init__(self) -> None:
+        super().__init__("snuba.snuba_migrations.search_issues")
+
+    def get_migrations(self) -> Sequence[str]:
+        return [
+            "0001_group_attributes",
+        ]

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -158,7 +158,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     ),
     MigrationGroup.GROUP_ATTRIBUTES: _MigrationGroup(
         loader=GroupAttributesLoader(),
-        storage_sets_keys={StorageSetKey.Group_ATTRIBUTES},
+        storage_sets_keys={StorageSetKey.GROUP_ATTRIBUTES},
         readiness_state=ReadinessState.PARTIAL,
     ),
 }

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -8,6 +8,7 @@ from snuba.migrations.group_loader import (
     EventsLoader,
     FunctionsLoader,
     GenericMetricsLoader,
+    GroupAttributesLoader,
     GroupLoader,
     MetricsLoader,
     OutcomesLoader,
@@ -153,6 +154,11 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.SPANS: _MigrationGroup(
         loader=SpansLoader(),
         storage_sets_keys={StorageSetKey.SPANS},
+        readiness_state=ReadinessState.PARTIAL,
+    ),
+    MigrationGroup.GROUP_ATTRIBUTES: _MigrationGroup(
+        loader=GroupAttributesLoader(),
+        storage_sets_keys={StorageSetKey.Group_ATTRIBUTES},
         readiness_state=ReadinessState.PARTIAL,
     ),
 }

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -39,6 +39,7 @@ class MigrationGroup(Enum):
     TEST_MIGRATION = "test_migration"
     SEARCH_ISSUES = "search_issues"
     SPANS = "spans"
+    GROUP_ATTRIBUTES = "group_attributes"
 
 
 # Migration groups are mandatory by default. Specific groups can
@@ -54,6 +55,7 @@ OPTIONAL_GROUPS = {
     MigrationGroup.TEST_MIGRATION,
     MigrationGroup.SEARCH_ISSUES,
     MigrationGroup.SPANS,
+    MigrationGroup.GROUP_ATTRIBUTES,
 }
 
 

--- a/snuba/migrations/groups.py
+++ b/snuba/migrations/groups.py
@@ -159,7 +159,7 @@ _REGISTERED_MIGRATION_GROUPS: Dict[MigrationGroup, _MigrationGroup] = {
     MigrationGroup.GROUP_ATTRIBUTES: _MigrationGroup(
         loader=GroupAttributesLoader(),
         storage_sets_keys={StorageSetKey.GROUP_ATTRIBUTES},
-        readiness_state=ReadinessState.PARTIAL,
+        readiness_state=ReadinessState.LIMITED,
     ),
 }
 

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -274,7 +274,7 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 
 # The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
 # Migrations for skipped groups will not be run.
-SKIPPED_MIGRATION_GROUPS: Set[str] = {"group_attributes"}
+SKIPPED_MIGRATION_GROUPS: Set[str] = set()
 
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -101,6 +101,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "search_issues",
             "generic_metrics_counters",
             "spans",
+            "group_attributes",
         },
         "single_node": True,
     },

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -274,7 +274,7 @@ COLUMN_SPLIT_MAX_RESULTS = 5000
 
 # The migration groups that can be skipped are listed in OPTIONAL_GROUPS.
 # Migrations for skipped groups will not be run.
-SKIPPED_MIGRATION_GROUPS: Set[str] = set()
+SKIPPED_MIGRATION_GROUPS: Set[str] = {"group_attributes"}
 
 # Dataset readiness states supported in this environment
 SUPPORTED_STATES: Set[str] = {"deprecate", "limited", "partial", "complete"}

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -27,7 +27,6 @@ CLUSTERS = [
             "search_issues",
             "generic_metrics_counters",
             "spans",
-            "group_attributes",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -27,6 +27,7 @@ CLUSTERS = [
             "search_issues",
             "generic_metrics_counters",
             "spans",
+            "group_attributes",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -55,6 +55,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "search_issues",
             "generic_metrics_counters",
             "spans",
+            "group_attributes",
         },
         "single_node": False,
         "cluster_name": "storage_cluster",

--- a/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
@@ -23,6 +23,8 @@ columns: List[Column[Modifiers]] = [
     Column("owner_ownership_rule_team_id", UInt(64, Modifiers(nullable=True))),
     Column("owner_codeowners_user_id", UInt(64, Modifiers(nullable=True))),
     Column("owner_codeowners_team_id", UInt(64, Modifiers(nullable=True))),
+    # meta
+    Column("deleted", UInt(8)),
     Column("message_timestamp", DateTime()),
     Column("partition", UInt(16)),
     Column("offset", UInt(64)),
@@ -40,6 +42,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
                     order_by="(project_id, group_id)",
+                    version_column="deleted",
                     settings={"index_granularity": "8192"},
                     storage_set=StorageSetKey.GROUP_ATTRIBUTES,
                 ),

--- a/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
@@ -39,7 +39,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="group_attributes_local",
                 columns=columns,
                 engine=table_engines.ReplacingMergeTree(
-                    order_by="(project_id, group_id",
+                    order_by="(project_id, group_id)",
                     settings={"index_granularity": "8192"},
                     storage_set=StorageSetKey.GROUP_ATTRIBUTES,
                 ),

--- a/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
@@ -1,0 +1,71 @@
+from typing import List, Sequence
+
+from snuba.clickhouse.columns import Column, DateTime, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations, table_engines
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+columns: List[Column[Modifiers]] = [
+    Column("project_id", UInt(64)),
+    Column("group_id", UInt(64)),
+    # Group
+    Column("group_status", UInt(8)),
+    Column("group_substatus", UInt(8, Modifiers(nullable=True))),
+    Column("group_first_seen", DateTime()),
+    Column("group_num_comments", UInt(64)),
+    # GroupAssignee
+    Column("assignee_user_id", UInt(64, Modifiers(nullable=True))),
+    Column("assignee_team_id", UInt(64, Modifiers(nullable=True))),
+    # GroupOwner
+    Column("owner_suspect_commit_user_id", UInt(64, Modifiers(nullable=True))),
+    Column("owner_ownership_rule_user_id", UInt(64, Modifiers(nullable=True))),
+    Column("owner_ownership_rule_team_id", UInt(64, Modifiers(nullable=True))),
+    Column("owner_codeowners_user_id", UInt(64, Modifiers(nullable=True))),
+    Column("owner_codeowners_team_id", UInt(64, Modifiers(nullable=True))),
+    Column("message_timestamp", DateTime()),
+    Column("partition", UInt(16)),
+    Column("offset", UInt(64)),
+]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.CreateTable(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_local",
+                columns=columns,
+                engine=table_engines.ReplacingMergeTree(
+                    order_by="(project_id, group_id",
+                    settings={"index_granularity": "8192"},
+                    storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.CreateTable(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name="group_attributes_dist",
+                columns=columns,
+                engine=table_engines.Distributed(
+                    local_table_name="group_attributes_dist",
+                    sharding_key="cityHash64(group_id)",
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropTable(
+                storage_set=StorageSetKey.GROUP_ATTRIBUTES,
+                table_name=params[0],
+                target=params[1],
+            )
+            for params in [
+                ("group_attributes_dist", OperationTarget.DISTRIBUTED),
+                ("group_attributes_local", OperationTarget.LOCAL),
+            ]
+        ]

--- a/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
+++ b/snuba/snuba_migrations/group_attributes/0001_group_attributes.py
@@ -53,7 +53,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 table_name="group_attributes_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="group_attributes_dist",
+                    local_table_name="group_attributes_local",
                     sharding_key="cityHash64(group_id)",
                 ),
                 target=OperationTarget.DISTRIBUTED,


### PR DESCRIPTION
This new dataset replicates a subset of crucial values from the Groups, GroupAssignee and GroupOwners postgres tables. 

The plan is to stream the latest 'snapshot' values described in the schema every time any of the postgres column values are updated/created/deleted. 

The latest snapshot will always replace the oldest snapshot and eventually get replaced by clickhouse. 

Note: for the time being, this table should only be available in SaaS and in 'prototype' mode. We want to verify joins between the events/search_issues and this table works as expected and that most straight-forward way was to build the dataset, insert some data, and execute some parallel issue search queries to verify. 