### PR TITLE
check connections on consumer startup

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -16,6 +16,7 @@ from snuba.consumers.consumer_config import resolve_consumer_config
 from snuba.datasets.storages.factory import get_writable_storage_keys
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.environment import setup_logging, setup_sentry
+from snuba.migrations.connect import check_clickhouse_connections
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
 
@@ -179,6 +180,10 @@ def consumer(
 
     setup_logging(log_level)
     setup_sentry()
+
+    logger.info("Checking Clickhouse connections")
+    check_clickhouse_connections()
+
     logger.info("Consumer Starting")
 
     storage_key = StorageKey(storage_name)

--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -13,7 +13,7 @@ from snuba.consumers.consumer_builder import (
     ProcessingParameters,
 )
 from snuba.consumers.consumer_config import resolve_consumer_config
-from snuba.datasets.storages.factory import get_writable_storage_keys
+from snuba.datasets.storages.factory import get_storage, get_writable_storage_keys
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.environment import setup_logging, setup_sentry
 from snuba.migrations.connect import check_clickhouse_connections
@@ -181,13 +181,15 @@ def consumer(
     setup_logging(log_level)
     setup_sentry()
 
-    logger.info("Checking Clickhouse connections")
-    check_clickhouse_connections()
-
     logger.info("Consumer Starting")
 
     storage_key = StorageKey(storage_name)
     sentry_sdk.set_tag("storage", storage_name)
+
+    logger.info("Checking Clickhouse connections")
+    storage = get_storage(storage_key)
+    cluster = storage.get_cluster()
+    check_clickhouse_connections([cluster])
 
     metrics_tags = {
         "consumer_group": consumer_group,

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -21,7 +21,7 @@ from snuba.migrations.clickhouse import (
     CLICKHOUSE_SERVER_MIN_VERSION,
 )
 from snuba.migrations.errors import InactiveClickhouseReplica, InvalidClickhouseVersion
-from snuba.settings import CLICKHOUSE_STARTUP_CHECK_RETRIES, ENABLE_DEV_FEATURES
+from snuba.settings import ENABLE_DEV_FEATURES
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -57,7 +57,7 @@ def check_clickhouse_connections(
                     exc_info=e,
                 )
                 attempts += 1
-                if attempts == CLICKHOUSE_STARTUP_CHECK_RETRIES:
+                if attempts == 60:
                     raise
                 time.sleep(1)
 

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -20,7 +20,7 @@ from snuba.migrations.clickhouse import (
     CLICKHOUSE_SERVER_MIN_VERSION,
 )
 from snuba.migrations.errors import InactiveClickhouseReplica, InvalidClickhouseVersion
-from snuba.settings import ENABLE_DEV_FEATURES
+from snuba.settings import CLICKHOUSE_STARTUP_CHECK_RETRIES, ENABLE_DEV_FEATURES
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -54,7 +54,7 @@ def check_clickhouse_connections() -> None:
                     exc_info=e,
                 )
                 attempts += 1
-                if attempts == 60:
+                if attempts == CLICKHOUSE_STARTUP_CHECK_RETRIES:
                     raise
                 time.sleep(1)
 

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -9,6 +9,7 @@ from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.cluster import (
     CLUSTERS,
     ClickhouseClientSettings,
+    ClickhouseCluster,
     ClickhouseNode,
     UndefinedClickhouseCluster,
 )
@@ -25,13 +26,15 @@ from snuba.settings import CLICKHOUSE_STARTUP_CHECK_RETRIES, ENABLE_DEV_FEATURES
 logger = structlog.get_logger().bind(module=__name__)
 
 
-def check_clickhouse_connections() -> None:
+def check_clickhouse_connections(
+    clusters: Sequence[ClickhouseCluster] = CLUSTERS,
+) -> None:
     """
     Ensure that we can establish a connection with every cluster.
     """
     attempts = 0
 
-    for cluster in CLUSTERS:
+    for cluster in clusters:
         clickhouse = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
 
         while True:

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -73,7 +73,6 @@ DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
-CLICKHOUSE_STARTUP_CHECK_RETRIES = 60
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -73,6 +73,7 @@ DISABLED_DATASETS: Set[str] = set()
 
 # Clickhouse Options
 CLICKHOUSE_MAX_POOL_SIZE = 25
+CLICKHOUSE_STARTUP_CHECK_RETRIES = 60
 
 CLUSTERS: Sequence[Mapping[str, Any]] = [
     {


### PR DESCRIPTION
Sometimes it takes envoy sidecar a while to load. Instead of crashlooping immediately, this lets snuba consumers spin for 60 clickhouse connection attempts at startup to check connectivity before running.
