### PR TITLE
feat(generic-metrics): Bump `materialization_version` to 2 for generic distribution metrics

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -83,7 +83,8 @@ def aggregation_options_for_distribution_message(
     _: Mapping[str, Any]
 ) -> Mapping[str, Any]:
     return {
-        "materialization_version": 1,
+        "materialization_version": 2,
+        "enable_histogram": 1,
         "granularities": [
             GRANULARITY_ONE_MINUTE,
             GRANULARITY_ONE_HOUR,


### PR DESCRIPTION
| PR                                                   | Changes                                                  | Status        | Branch From                                          |
| ---------------------------------------------------- | -------------------------------------------------------- | ------------- | ---------------------------------------------------- |
| [#1](https://github.com/getsentry/snuba/pull/4467) | Add aggregation options for generic metrics raw tables | Merged         | master                                               |
| [#2](https://github.com/getsentry/snuba/pull/4504) | Add new MatView for generic distribution metrics | Merged | master |
| [#3](https://github.com/getsentry/snuba/pull/4509) | Add facilities to insert aggregation options in processor | Merged | [#2](https://github.com/getsentry/snuba/pull/4504) |
| [#4](https://github.com/getsentry/snuba/pull/4505) | ➤ Bump `materialization_version` to 2 for generic distribution metrics | Approved | [#3](https://github.com/getsentry/snuba/pull/4509) |



### Overview

### Bump `materialization_version` to 2 for generic distribution metrics

This kicks in the new MatView for generic distribution metrics.

**Note**: We're setting `enable_histogram` to `1` because it is set to `0` as default in clickhouse. There's a single pesky endpoint still using histogram. Once we have the rest of the system built, we will tag that specific metric ID with an aggregation option enum to enable histogram for that specific metric only. However, for now, we will have to make do with enabling histogram for all.