### PR TITLE
feat(group-attributes): expose storage and entity, process messages

### DIFF
--- a/snuba/cli/devserver.py
+++ b/snuba/cli/devserver.py
@@ -440,6 +440,22 @@ def devserver(*, bootstrap: bool, workers: bool) -> None:
             ),
         ]
 
+    if settings.ENABLE_GROUP_ATTRIBUTES_CONSUMER:
+        daemons += [
+            (
+                "group-attributes-consumer",
+                [
+                    "snuba",
+                    "consumer",
+                    "--auto-offset-reset=latest",
+                    "--no-strict-offset-reset",
+                    "--log-level=debug",
+                    "--storage=group_attributes",
+                    "--consumer-group=group_attributes_group",
+                ],
+            ),
+        ]
+
     manager = Manager()
     for name, cmd in daemons:
         manager.add_process(

--- a/snuba/datasets/configuration/group_attributes/dataset.yaml
+++ b/snuba/datasets/configuration/group_attributes/dataset.yaml
@@ -1,0 +1,6 @@
+version: v1
+kind: dataset
+name: group_attributes
+
+entities:
+  - group_attributes

--- a/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
@@ -48,9 +48,9 @@ query_processors:
   - processor: BasicFunctionsProcessor
 
 validate_data_model: error
-validators: []
-#  - validator: EntityRequiredColumnValidator
-#    args:
-#      required_filter_columns: ["project_id"]
+validators:
+  - validator: EntityRequiredColumnValidator
+    args:
+      required_filter_columns: ["project_id"]
 
 required_time_column: null

--- a/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/entities/group_attributes.yaml
@@ -1,0 +1,56 @@
+version: v1
+kind: entity
+name: group_attributes
+
+schema:
+  [
+    { name: project_id, type: UInt, args: { size: 64 } },
+    { name: group_id, type: UInt, args: { size: 64 } },
+
+    { name: group_status, type: UInt, args: { size: 8 } },
+    { name: group_substatus, type: UInt, args: { size: 8, schema_modifiers: [ nullable ] } },
+    { name: group_first_seen, type: DateTime },
+    { name: group_num_comments, type: UInt, args: { size: 64 } },
+
+    { name: assignee_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+    { name: assignee_team_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+
+    { name: owner_suspect_commit_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+    { name: owner_ownership_rule_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+    { name: owner_ownership_rule_team_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+    { name: owner_codeowners_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+    { name: owner_codeowners_team_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+
+    { name: deleted, type: UInt, args: { size: 8 } },
+    { name: message_timestamp, type: DateTime },
+    { name: partition, type: UInt, args: { size: 16 } },
+    { name: offset, type: UInt, args: { size: 64 } },
+  ]
+
+storages:
+  - storage: group_attributes
+    is_writable: true
+
+storage_selector:
+  selector: DefaultQueryStorageSelector
+
+query_processors:
+  - processor: ReferrerRateLimiterProcessor
+#  - processor: ProjectReferrerRateLimiter
+#    args:
+#      project_column: project_id
+#  - processor: ProjectRateLimiterProcessor
+#    args:
+#      project_column: project_id
+#  - processor: ResourceQuotaProcessor
+#    args:
+#      project_field: project_id
+  - processor: BasicFunctionsProcessor
+
+validate_data_model: error
+validators: []
+#  - validator: EntityRequiredColumnValidator
+#    args:
+#      required_filter_columns: ["project_id"]
+
+required_time_column: null

--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -38,6 +38,9 @@ schema:
 
 allocation_policies:
   - name: PassthroughPolicy
+    args:
+      required_tenant_types:
+        - blank
 
 query_processors:
   - processor: TableRateLimit

--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -1,0 +1,52 @@
+version: v1
+kind: writable_storage
+name: group_attributes
+
+storage:
+  key: group_attributes
+  set_key: group_attributes
+
+readiness_state: limited
+
+schema:
+  columns:
+    [
+      { name: project_id, type: UInt, args: { size: 64 } },
+      { name: group_id, type: UInt, args: { size: 64 } },
+
+      { name: group_status, type: UInt, args: { size: 8 } },
+      { name: group_substatus, type: UInt, args: { size: 8, schema_modifiers: [ nullable ] } },
+      { name: group_first_seen, type: DateTime },
+      { name: group_num_comments, type: UInt, args: { size: 64 } },
+
+      { name: assignee_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+      { name: assignee_team_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+
+      { name: owner_suspect_commit_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+      { name: owner_ownership_rule_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+      { name: owner_ownership_rule_team_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+      { name: owner_codeowners_user_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+      { name: owner_codeowners_team_id, type: UInt, args: { size: 64, schema_modifiers: [ nullable ] } },
+
+      { name: deleted, type: UInt, args: { size: 8 } },
+      { name: message_timestamp, type: DateTime },
+      { name: partition, type: UInt, args: { size: 16 } },
+      { name: offset, type: UInt, args: { size: 64 } },
+    ]
+  local_table_name: group_attributes_local
+  dist_table_name: group_attributes_dist
+
+allocation_policies:
+  - name: PassthroughPolicy
+
+query_processors:
+  - processor: TableRateLimit
+
+mandatory_condition_checkers:
+  - condition: ProjectIdEnforcer
+
+stream_loader:
+  processor:
+    name: GroupAttributesMessageProcessor
+  default_topic: group-attributes
+  dlq_topic: snuba-dead-letter-group-attributes

--- a/snuba/datasets/processors/group_attributes_processor.py
+++ b/snuba/datasets/processors/group_attributes_processor.py
@@ -39,7 +39,7 @@ class GroupAttributesMessageProcessor(DatasetMessageProcessor):
                     ],
                     "owner_codeowners_user_id": message["owner_codeowners_user_id"],
                     "owner_codeowners_team_id": message["owner_codeowners_team_id"],
-                    "deleted": message["group_deleted"],
+                    "deleted": 1 if message["group_deleted"] else 0,
                     "message_timestamp": metadata.timestamp,
                     "partition": metadata.partition,
                     "offset": metadata.offset,

--- a/snuba/datasets/processors/group_attributes_processor.py
+++ b/snuba/datasets/processors/group_attributes_processor.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+from sentry_kafka_schemas.schema_types.group_attributes_v1 import (
+    GroupAttributesSnapshot,
+)
+
+from snuba import environment
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.processors import DatasetMessageProcessor
+from snuba.processor import InsertBatch, ProcessedMessage
+from snuba.utils.metrics.wrapper import MetricsWrapper
+
+metrics = MetricsWrapper(environment.metrics, "group_attributes.processor")
+
+
+class GroupAttributesMessageProcessor(DatasetMessageProcessor):
+    def process_message(
+        self, message: GroupAttributesSnapshot, metadata: KafkaMessageMetadata
+    ) -> Optional[ProcessedMessage]:
+        return InsertBatch(
+            [
+                {
+                    "project_id": message["project_id"],
+                    "group_id": message["group_id"],
+                    "group_status": message["status"],
+                    "group_substatus": message["substatus"],
+                    "group_first_seen": message["first_seen"],
+                    "group_num_comments": message["num_comments"],
+                    "assignee_user_id": message["assignee_user_id"],
+                    "assignee_team_id": message["assignee_team_id"],
+                    "owner_suspect_commit_user_id": message[
+                        "owner_suspect_commit_user_id"
+                    ],
+                    "owner_ownership_rule_user_id": message[
+                        "owner_ownership_rule_user_id"
+                    ],
+                    "owner_ownership_rule_team_id": message[
+                        "owner_ownership_rule_team_id"
+                    ],
+                    "owner_codeowners_user_id": message["owner_codeowners_user_id"],
+                    "owner_codeowners_team_id": message["owner_codeowners_team_id"],
+                    "deleted": message["group_deleted"],
+                    "message_timestamp": metadata.timestamp,
+                    "partition": metadata.partition,
+                    "offset": metadata.offset,
+                }
+            ],
+            None,
+        )

--- a/snuba/datasets/processors/group_attributes_processor.py
+++ b/snuba/datasets/processors/group_attributes_processor.py
@@ -1,10 +1,11 @@
+from datetime import datetime
 from typing import Optional
 
 from sentry_kafka_schemas.schema_types.group_attributes_v1 import (
     GroupAttributesSnapshot,
 )
 
-from snuba import environment
+from snuba import environment, settings
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.processor import InsertBatch, ProcessedMessage
@@ -24,7 +25,9 @@ class GroupAttributesMessageProcessor(DatasetMessageProcessor):
                     "group_id": message["group_id"],
                     "group_status": message["status"],
                     "group_substatus": message["substatus"],
-                    "group_first_seen": message["first_seen"],
+                    "group_first_seen": datetime.strptime(
+                        message["first_seen"], settings.PAYLOAD_DATETIME_FORMAT
+                    ),
                     "group_num_comments": message["num_comments"],
                     "assignee_user_id": message["assignee_user_id"],
                     "assignee_team_id": message["assignee_team_id"],

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -332,6 +332,11 @@ ENABLE_ISSUE_OCCURRENCE_CONSUMER = os.environ.get(
 # Enable spans ingestion
 ENABLE_SPANS_CONSUMER = os.environ.get("ENABLE_SPANS_CONSUMER", False)
 
+# Enable group attributes consumer
+ENABLE_GROUP_ATTRIBUTES_CONSUMER = os.environ.get(
+    "ENABLE_GROUP_ATTRIBUTES_CONSUMER", False
+)
+
 # Cutoff time from UTC 00:00:00 to stop running optimize jobs to
 # avoid spilling over to the next day.
 OPTIMIZE_JOB_CUTOFF_TIME = 23

--- a/snuba/settings/validation.py
+++ b/snuba/settings/validation.py
@@ -58,6 +58,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "profiles-call-tree",
         "ingest-replay-events",
         "generic-events",
+        "group-attributes",
         "snuba-generic-events-commit-log",
         "snuba-dead-letter-replays",
         "snuba-generic-metrics",
@@ -72,6 +73,7 @@ def validate_settings(locals: Mapping[str, Any]) -> None:
         "snuba-dead-letter-metrics-counters",
         "snuba-dead-letter-generic-events",
         "snuba-dead-letter-querylog",
+        "snuba-dead-letter-group-attributes",
         "snuba-generic-events-commit-log",
     }
 

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -48,6 +48,7 @@ class Topic(Enum):
     GENERIC_METRICS_COUNTERS_COMMIT_LOG = "snuba-generic-metrics-counters-commit-log"
     GENERIC_EVENTS = "generic-events"
     GENERIC_EVENTS_COMMIT_LOG = "snuba-generic-events-commit-log"
+    GROUP_ATTRIBUTES = "group_attributes"
 
     ATTRIBUTION = "snuba-attribution"
     DEAD_LETTER_METRICS = "snuba-dead-letter-metrics"
@@ -59,6 +60,7 @@ class Topic(Enum):
     DEAD_LETTER_REPLAYS = "snuba-dead-letter-replays"
     DEAD_LETTER_GENERIC_EVENTS = "snuba-dead-letter-generic-events"
     DEAD_LETTER_QUERYLOG = "snuba-dead-letter-querylog"
+    DEAD_LETTER_GROUP_ATTRIBUTES = "snuba-dead-letter-group-attributes"
 
 
 def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
@@ -74,5 +76,6 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
         Topic.GENERIC_METRICS: {"message.timestamp.type": "LogAppendTime"},
         Topic.GENERIC_EVENTS: {"message.timestamp.type": "LogAppendTime"},
         Topic.QUERYLOG: {"max.message.bytes": "2000000"},
+        Topic.GROUP_ATTRIBUTES: {"message.timestamp.type": "LogAppendTime"},
     }
     return config.get(topic, {})

--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -48,7 +48,7 @@ class Topic(Enum):
     GENERIC_METRICS_COUNTERS_COMMIT_LOG = "snuba-generic-metrics-counters-commit-log"
     GENERIC_EVENTS = "generic-events"
     GENERIC_EVENTS_COMMIT_LOG = "snuba-generic-events-commit-log"
-    GROUP_ATTRIBUTES = "group_attributes"
+    GROUP_ATTRIBUTES = "group-attributes"
 
     ATTRIBUTION = "snuba-attribution"
     DEAD_LETTER_METRICS = "snuba-dead-letter-metrics"

--- a/tests/admin/dead_letter_queue/test_dlq.py
+++ b/tests/admin/dead_letter_queue/test_dlq.py
@@ -2,4 +2,4 @@ from snuba.admin.dead_letter_queue import get_dlq_topics
 
 
 def test_dlq() -> None:
-    assert len(get_dlq_topics()) == 7
+    assert len(get_dlq_topics()) == 8

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -77,5 +77,6 @@ def test_all_names() -> None:
             "replays",
             "search_issues",
             "spans",
+            "group_attributes",
         ]
     )

--- a/tests/datasets/test_dataset_factory.py
+++ b/tests/datasets/test_dataset_factory.py
@@ -60,23 +60,21 @@ def test_get_dataset_factory_and_mapping_coupling() -> None:
 
 def test_all_names() -> None:
     factory._DS_FACTORY = None
-    assert set(get_enabled_dataset_names()) == set(
-        [
-            "discover",
-            "events",
-            "groupassignee",
-            "groupedmessage",
-            "metrics",
-            "outcomes",
-            "outcomes_raw",
-            "sessions",
-            "transactions",
-            "profiles",
-            "functions",
-            "generic_metrics",
-            "replays",
-            "search_issues",
-            "spans",
-            "group_attributes",
-        ]
-    )
+    assert set(get_enabled_dataset_names()) == {
+        "discover",
+        "events",
+        "groupassignee",
+        "groupedmessage",
+        "metrics",
+        "outcomes",
+        "outcomes_raw",
+        "sessions",
+        "transactions",
+        "profiles",
+        "functions",
+        "generic_metrics",
+        "replays",
+        "search_issues",
+        "spans",
+        "group_attributes",
+    }

--- a/tests/datasets/test_entity_factory.py
+++ b/tests/datasets/test_entity_factory.py
@@ -36,6 +36,7 @@ ENTITY_KEYS = [
     EntityKey.GENERIC_METRICS_COUNTERS,
     EntityKey.GENERIC_ORG_METRICS_COUNTERS,
     EntityKey.SPANS,
+    EntityKey.GROUP_ATTRIBUTES,
 ]
 
 

--- a/tests/datasets/test_group_attributes_processor.py
+++ b/tests/datasets/test_group_attributes_processor.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+from typing import Optional
+
+import pytest
+from sentry_kafka_schemas.schema_types.group_attributes_v1 import (
+    GroupAttributesSnapshot,
+)
+
+from snuba import settings
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.processors.group_attributes_processor import (
+    GroupAttributesMessageProcessor,
+)
+from snuba.processor import ProcessedMessage
+from snuba.writer import WriterTableRow
+
+
+@pytest.fixture
+def group_created() -> GroupAttributesSnapshot:
+    return {
+        "group_deleted": False,
+        "project_id": 1,
+        "group_id": 1,
+        "status": 0,
+        "substatus": 7,
+        "first_seen": "2023-02-27T15:40:12.223000Z",
+        "num_comments": 0,
+        "assignee_user_id": None,
+        "assignee_team_id": None,
+        "owner_suspect_commit_user_id": None,
+        "owner_ownership_rule_user_id": None,
+        "owner_ownership_rule_team_id": None,
+        "owner_codeowners_user_id": None,
+        "owner_codeowners_team_id": None,
+        "timestamp": "2023-02-27T15:40:12.223000Z",
+    }
+
+
+class TestGroupAttributesMessageProcessor:
+    KAFKA_META = KafkaMessageMetadata(
+        offset=0, partition=0, timestamp=datetime(1970, 1, 1)
+    )
+
+    processor = GroupAttributesMessageProcessor()
+
+    def process_message(
+        self, message, kafka_meta: KafkaMessageMetadata = KAFKA_META
+    ) -> Optional[ProcessedMessage]:
+        return self.processor.process_message(message, kafka_meta)
+
+    def processed_single_row(self, message) -> WriterTableRow:
+        return self.process_message(message).rows[0]
+
+    def test_group_created(self, group_created):
+        assert (
+            self.processed_single_row(group_created).items()
+            >= {
+                "project_id": 1,
+                "group_id": 1,
+                "group_status": 0,
+                "group_substatus": 7,
+                "group_first_seen": datetime.strptime(
+                    group_created["first_seen"], settings.PAYLOAD_DATETIME_FORMAT
+                ),
+                "group_num_comments": 0,
+                "assignee_user_id": None,
+                "assignee_team_id": None,
+                "owner_suspect_commit_user_id": None,
+                "owner_ownership_rule_user_id": None,
+                "owner_ownership_rule_team_id": None,
+                "owner_codeowners_user_id": None,
+                "owner_codeowners_team_id": None,
+                "deleted": 0,
+            }.items()
+        )

--- a/tests/test_group_attributes_api.py
+++ b/tests/test_group_attributes_api.py
@@ -1,0 +1,115 @@
+from datetime import datetime
+from typing import Any, Callable, Tuple, Union
+
+import pytest
+import simplejson as json
+from sentry_kafka_schemas.schema_types.group_attributes_v1 import (
+    GroupAttributesSnapshot,
+)
+
+from snuba.consumers.types import KafkaMessageMetadata
+from snuba.core.initialize import initialize_snuba
+from snuba.datasets.entities.entity_key import EntityKey
+from snuba.datasets.entities.factory import get_entity
+from tests.base import BaseApiTest
+from tests.datasets.configuration.utils import ConfigurationTest
+from tests.helpers import write_processed_messages
+from tests.test_api import SimpleAPITest
+
+
+def attribute_message() -> GroupAttributesSnapshot:
+    return {
+        "group_deleted": False,
+        "project_id": 1,
+        "group_id": 1,
+        "status": 0,
+        "substatus": 7,
+        "first_seen": "2023-02-27T15:40:12.223000Z",
+        "num_comments": 0,
+        "assignee_user_id": None,
+        "assignee_team_id": None,
+        "owner_suspect_commit_user_id": None,
+        "owner_ownership_rule_user_id": None,
+        "owner_ownership_rule_team_id": None,
+        "owner_codeowners_user_id": None,
+        "owner_codeowners_team_id": None,
+        "timestamp": "2023-02-27T15:40:12.223000Z",
+    }
+
+
+def kafka_metadata() -> KafkaMessageMetadata:
+    return KafkaMessageMetadata(offset=0, partition=0, timestamp=datetime(1970, 1, 1))
+
+
+class TestGroupAttributesSnQLApi(SimpleAPITest, BaseApiTest, ConfigurationTest):
+    @pytest.fixture
+    def test_entity(self) -> Union[str, Tuple[str, str]]:
+        return "group_attributes"
+
+    @pytest.fixture
+    def test_app(self) -> Any:
+        return self.app
+
+    @pytest.fixture(autouse=True)
+    def setup_post(self, _build_snql_post_methods: Callable[..., Any]) -> None:
+        self.post = _build_snql_post_methods
+
+    def setup_method(self, test_method: Callable[..., Any]) -> None:
+        super().setup_method(test_method)
+        initialize_snuba()
+        self.writable_storage = get_entity(
+            EntityKey.GROUP_ATTRIBUTES
+        ).get_writable_storage()
+        assert self.writable_storage is not None
+
+    def insert_row(self, message: GroupAttributesSnapshot) -> None:
+        rows = [
+            self.writable_storage.get_table_writer()
+            .get_stream_loader()
+            .get_processor()
+            .process_message(message, kafka_metadata())
+        ]
+        write_processed_messages(self.writable_storage, rows)
+
+    def post_query(
+        self,
+        query: str,
+        turbo: bool = False,
+        consistent: bool = True,
+        debug: bool = True,
+    ) -> Any:
+        return self.app.post(
+            "/group_attributes/snql",
+            data=json.dumps(
+                {
+                    "query": query,
+                    "turbo": False,
+                    "consistent": True,
+                    "debug": True,
+                    "tenant_ids": {"referrer": "test", "organization_id": 1},
+                }
+            ),
+            headers={"referer": "test"},
+        )
+
+    def test_endpoint(self) -> None:
+        self.insert_row(attribute_message())
+
+        response = self.post_query(
+            """MATCH (group_attributes)
+                SELECT project_id, group_id
+                WHERE project_id = 1
+                LIMIT 1000
+            """
+        )
+
+        data = json.loads(response.data)
+
+        assert response.status_code == 200, data
+        assert data["stats"]["consistent"]
+        assert data["data"] == [
+            {
+                "project_id": 1,
+                "group_id": 1,
+            }
+        ]


### PR DESCRIPTION
Part 2 of getting group_attributes dataset stood up. This should only be made available in CI and dev. 

* defines the topic for consuming write messages and the dead letter topic 
* defines the storage for the dataset
* defines the entity
* implements a basic processor to start writing to the table

I'll create a follow-up PR to define the join relationships between the entities along with appropriate tests. Just wanna start processing the messages and begin writing to the table in this PR.

I verified this locally by doing the following:
* Running snuba locally with this consumer enabled: `ENABLE_GROUP_ATTRIBUTES_CONSUMER="1" snuba devserver` 
* Produce a message to the topic using an example json message from [sentry-kafka-schemas](https://github.com/getsentry/sentry-kafka-schemas/blob/main/examples/group-attributes/1/group_created.json): `kcat -b localhost:9092 -X broker.address.family=v4 -t group-attributes -T -P examples/group-attributes/1/group_created.json` 
* Verifying the row gets created in clickhouse: `select * from group_attrbiutes_local`