### PR TITLE
feat(consumer): add health check step to consumers

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -149,6 +149,12 @@ logger = logging.getLogger(__name__)
     "--max-poll-interval-ms",
     type=int,
 )
+@click.option(
+    "--health-check-file",
+    default=None,
+    type=str,
+    help="Arroyo will touch this file at intervals to indicate health. If not provided, no health check is performed.",
+)
 def consumer(
     *,
     storage_name: str,
@@ -176,6 +182,7 @@ def consumer(
     log_level: Optional[str] = None,
     profile_path: Optional[str] = None,
     max_poll_interval_ms: Optional[int] = None,
+    health_check_file: Optional[str] = None,
 ) -> None:
 
     setup_logging(log_level)
@@ -238,6 +245,7 @@ def consumer(
         slice_id=slice_id,
         join_timeout=join_timeout,
         max_poll_interval_ms=max_poll_interval_ms,
+        health_check_file=health_check_file,
         enforce_schema=enforce_schema,
     )
 

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -78,6 +78,12 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     type=int,
     help="Skip execution if timestamp is beyond this threshold compared to the system time",
 )
+@click.option(
+    "--health-check-file",
+    default=None,
+    type=str,
+    help="Arroyo will touch this file at intervals to indicate health. If not provided, no health check is performed.",
+)
 def subscriptions_executor(
     *,
     dataset_name: str,
@@ -91,6 +97,7 @@ def subscriptions_executor(
     no_strict_offset_reset: bool,
     log_level: Optional[str],
     stale_threshold_seconds: Optional[int],
+    health_check_file: Optional[str],
 ) -> None:
     """
     The subscription's executor consumes scheduled subscriptions from the scheduled
@@ -149,6 +156,7 @@ def subscriptions_executor(
         not no_strict_offset_reset,
         metrics,
         stale_threshold_seconds,
+        health_check_file,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -74,6 +74,12 @@ logger = logging.getLogger(__name__)
     type=int,
     help="Skip scheduling if timestamp is beyond this threshold compared to the system time",
 )
+@click.option(
+    "--health-check-file",
+    default=None,
+    type=str,
+    help="Arroyo will touch this file at intervals to indicate health. If not provided, no health check is performed.",
+)
 def subscriptions_scheduler(
     *,
     entity_name: str,
@@ -88,6 +94,7 @@ def subscriptions_scheduler(
     log_level: Optional[str],
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
+    health_check_file: Optional[str],
 ) -> None:
     """
     The subscriptions scheduler's job is to schedule subscriptions for a single entity.
@@ -182,6 +189,7 @@ def subscriptions_scheduler(
         stale_threshold_seconds,
         metrics,
         slice_id,
+        health_check_file,
     )
 
     logger.info("Checking Clickhouse connections")

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -72,6 +72,12 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     type=int,
     help="Skip scheduling if timestamp is beyond this threshold compared to the system time",
 )
+@click.option(
+    "--health-check-file",
+    default=None,
+    type=str,
+    help="Arroyo will touch this file at intervals to indicate health. If not provided, no health check is performed.",
+)
 @click.option("--log-level", help="Logging level to use.")
 def subscriptions_scheduler_executor(
     *,
@@ -85,6 +91,7 @@ def subscriptions_scheduler_executor(
     schedule_ttl: int,
     delay_seconds: Optional[int],
     stale_threshold_seconds: Optional[int],
+    health_check_file: Optional[str],
     log_level: Optional[str],
 ) -> None:
     """
@@ -137,6 +144,7 @@ def subscriptions_scheduler_executor(
         stale_threshold_seconds,
         total_concurrent_queries,
         metrics,
+        health_check_file,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -76,6 +76,7 @@ class ConsumerBuilder:
         enforce_schema: bool,
         profile_path: Optional[str] = None,
         max_poll_interval_ms: Optional[int] = None,
+        health_check_file: Optional[str] = None,
     ) -> None:
         assert len(consumer_config.storages) == 1, "Only one storage supported"
         storage_key = StorageKey(consumer_config.storages[0].name)
@@ -146,6 +147,7 @@ class ConsumerBuilder:
         self.output_block_size = processing_params.output_block_size
         self.__profile_path = profile_path
         self.max_poll_interval_ms = max_poll_interval_ms
+        self.health_check_file = health_check_file
 
         self.dlq_producer: Optional[KafkaProducer] = None
 
@@ -239,6 +241,7 @@ class ConsumerBuilder:
             input_block_size=self.input_block_size,
             output_block_size=self.output_block_size,
             initialize_parallel_transform=setup_sentry,
+            health_check_file=self.health_check_file,
         )
 
         if self.__profile_path is not None:

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -50,6 +50,7 @@ def build_scheduler_executor_consumer(
     stale_threshold_seconds: Optional[int],
     total_concurrent_queries: int,
     metrics: MetricsBackend,
+    health_check_file: Optional[str] = None,
 ) -> StreamProcessor[Tick]:
     dataset = get_dataset(dataset_name)
 
@@ -104,6 +105,7 @@ def build_scheduler_executor_consumer(
         stale_threshold_seconds,
         result_topic.topic_name,
         schedule_ttl,
+        health_check_file,
     )
 
     return StreamProcessor(
@@ -136,6 +138,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
         stale_threshold_seconds: Optional[int],
         result_topic: str,
         schedule_ttl: int,
+        health_check_file: Optional[str] = None,
     ) -> None:
         self.__partitions = partitions
         self.__entity_names = entity_names
@@ -180,6 +183,7 @@ class CombinedSchedulerExecutorFactory(ProcessingStrategyFactory[Tick]):
             metrics,
             stale_threshold_seconds,
             result_topic,
+            health_check_file,
         )
 
         modes = {

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -364,7 +364,7 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
             self.__slice_id,
         )
 
-        strategy = TickBuffer(
+        strategy: ProcessingStrategy[Tick] = TickBuffer(
             self.__mode,
             self.__partitions,
             self.__buffer_size,
@@ -373,6 +373,6 @@ class SubscriptionSchedulerProcessingFactory(ProcessingStrategyFactory[Tick]):
         )
 
         if self.__health_check_file:
-            strategy = Healthcheck(self.__health_check_file, self.__metrics)
+            strategy = Healthcheck(self.__health_check_file, strategy)
 
         return strategy

--- a/tests/cli/test_consumer.py
+++ b/tests/cli/test_consumer.py
@@ -1,0 +1,31 @@
+from typing import Sequence
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+import snuba.cli.consumer
+import snuba.consumers.consumer_builder
+from snuba.cli.consumer import consumer
+
+
+# mock builder
+@patch.object(snuba.cli.consumer, "ConsumerBuilder")
+@patch.object(snuba.cli.consumer, "check_clickhouse_connections")
+# mock signal handlers so other tests don't get affected
+@patch.object(snuba.cli.consumer, "signal")
+# don't set the metrics global state
+@patch.object(snuba.cli.consumer, "configure_metrics")
+def test_consumer_cli(*_mocks: Sequence[Mock]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        consumer,
+        [
+            "--storage",
+            "querylog",
+            "--auto-offset-reset",
+            "latest",
+            "--health-check-file",
+            "/tmp/test",
+        ],
+    )
+    assert result.exit_code == 0, result.output

--- a/tests/cli/test_subscriptions.py
+++ b/tests/cli/test_subscriptions.py
@@ -1,0 +1,81 @@
+from typing import Sequence
+from unittest.mock import Mock, patch
+
+from click import Command
+from click.testing import CliRunner
+
+import snuba.subscriptions.executor_consumer
+from snuba.cli.subscriptions_executor import subscriptions_executor
+from snuba.cli.subscriptions_scheduler import subscriptions_scheduler
+from snuba.cli.subscriptions_scheduler_executor import subscriptions_scheduler_executor
+
+
+# don't access clickhouse
+@patch.object(snuba.cli.subscriptions_executor, "check_clickhouse_connections")
+@patch.object(
+    snuba.cli.subscriptions_scheduler_executor, "check_clickhouse_connections"
+)
+@patch.object(snuba.cli.subscriptions_scheduler, "check_clickhouse_connections")
+# don't set the metrics global state
+@patch.object(snuba.cli.subscriptions_executor, "configure_metrics")
+@patch.object(snuba.cli.subscriptions_scheduler_executor, "configure_metrics")
+@patch.object(snuba.cli.subscriptions_scheduler, "configure_metrics")
+# mock the builders, they are tested elsewhere
+@patch.object(snuba.cli.subscriptions_executor, "build_executor_consumer")
+@patch.object(
+    snuba.cli.subscriptions_scheduler_executor, "build_scheduler_executor_consumer"
+)
+@patch.object(snuba.cli.subscriptions_scheduler, "SchedulerBuilder")
+# mock signal handlers so other tests don't get affected
+@patch.object(snuba.cli.subscriptions_executor, "signal")
+@patch.object(snuba.cli.subscriptions_scheduler_executor, "signal")
+@patch.object(snuba.cli.subscriptions_scheduler, "signal")
+def test_subscriptions_cli(*_mocks: Sequence[Mock]) -> None:
+    runner = CliRunner()
+    _test_cli(
+        runner,
+        subscriptions_executor,
+        [
+            "--dataset",
+            "events",
+            "--entity",
+            "events",
+            "--health-check-file",
+            "/tmp/test",
+        ],
+    )
+
+    _test_cli(
+        runner,
+        subscriptions_scheduler_executor,
+        [
+            "--dataset",
+            "events",
+            "--entity",
+            "events",
+            "--consumer-group",
+            "test",
+            "--followed-consumer-group",
+            "test",
+            "--health-check-file",
+            "/tmp/test",
+        ],
+    )
+
+    _test_cli(
+        runner,
+        subscriptions_scheduler,
+        [
+            "--entity",
+            "events",
+            "--followed-consumer-group",
+            "test",
+            "--health-check-file",
+            "/tmp/test",
+        ],
+    )
+
+
+def _test_cli(runner: CliRunner, command: Command, args: Sequence[str]) -> None:
+    result = runner.invoke(command, args)
+    assert result.exit_code == 0, result.output

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -1,7 +1,9 @@
 import functools
 import itertools
 import json
+import os
 import pickle
+import tempfile
 from datetime import datetime
 from pickle import PickleBuffer
 from typing import MutableSequence, Optional
@@ -72,6 +74,7 @@ def test_streaming_consumer_strategy() -> None:
             ),
         )
 
+    health_check_file = tempfile.mktemp()
     factory = KafkaConsumerStrategyFactory(
         None,
         functools.partial(
@@ -85,6 +88,7 @@ def test_streaming_consumer_strategy() -> None:
         processes=None,
         input_block_size=None,
         output_block_size=None,
+        health_check_file=health_check_file,
     )
 
     commit_function = Mock()
@@ -123,6 +127,8 @@ def test_streaming_consumer_strategy() -> None:
     ):
         strategy.close()
         strategy.join()
+
+    os.remove(health_check_file)
 
 
 def test_json_row_batch_pickle_simple() -> None:


### PR DESCRIPTION
Add a health check step to consumers. The health check touches a file `tmp/health.txt`  at regular intervals. In k8s, we can check for this file to see if our consumer is up and running and healthy. This can be use avoid k8s rolling over to consumer pods that are unhealthy or haven't yet completed their setup.

needs: https://github.com/getsentry/arroyo/pull/274