### PR TITLE
feat(generic-metrics): Add facilities to insert aggregation options in processor

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -20,6 +20,11 @@ ILLEGAL_VALUE_IN_DIST = "Illegal value in distribution."
 ILLEGAL_VALUE_IN_COUNTER = "Illegal value in counter."
 INT_FLOAT_EXPECTED = "Int or Float expected"
 
+# These are the hardcoded values from the materialized view
+GRANULARITY_ONE_MINUTE = 1
+GRANULARITY_ONE_HOUR = 2
+GRANULARITY_ONE_DAY = 3
+
 
 def is_set_message(message: Mapping[str, Any]) -> bool:
     return message["type"] is not None and message["type"] == InputType.SET.value
@@ -61,3 +66,38 @@ def value_for_counter_message(message: Mapping[str, Any]) -> Mapping[str, Any]:
     ), f"{ILLEGAL_VALUE_IN_COUNTER} {INT_FLOAT_EXPECTED}: {value}"
 
     return {"metric_type": OutputType.COUNTER.value, "count_value": value}
+
+
+def aggregation_options_for_set_message(_: Mapping[str, Any]) -> Mapping[str, Any]:
+    return {
+        "materialization_version": 1,
+        "granularities": [
+            GRANULARITY_ONE_MINUTE,
+            GRANULARITY_ONE_HOUR,
+            GRANULARITY_ONE_DAY,
+        ],
+    }
+
+
+def aggregation_options_for_distribution_message(
+    _: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    return {
+        "materialization_version": 1,
+        "granularities": [
+            GRANULARITY_ONE_MINUTE,
+            GRANULARITY_ONE_HOUR,
+            GRANULARITY_ONE_DAY,
+        ],
+    }
+
+
+def aggregation_options_for_counter_message(_: Mapping[str, Any]) -> Mapping[str, Any]:
+    return {
+        "materialization_version": 1,
+        "granularities": [
+            GRANULARITY_ONE_MINUTE,
+            GRANULARITY_ONE_HOUR,
+            GRANULARITY_ONE_DAY,
+        ],
+    }

--- a/snuba/datasets/processors/generic_metrics_processor.py
+++ b/snuba/datasets/processors/generic_metrics_processor.py
@@ -17,6 +17,9 @@ from sentry_kafka_schemas.schema_types.snuba_generic_metrics_v1 import GenericMe
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.events_format import EventTooOld, enforce_retention
 from snuba.datasets.metrics_messages import (
+    aggregation_options_for_counter_message,
+    aggregation_options_for_distribution_message,
+    aggregation_options_for_set_message,
     is_counter_message,
     is_distribution_message,
     is_set_message,
@@ -27,11 +30,6 @@ from snuba.datasets.metrics_messages import (
 from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.processor import InsertBatch, ProcessedMessage, _ensure_valid_date
 
-# These are the hardcoded values from the materialized view
-GRANULARITY_ONE_MINUTE = 1
-GRANULARITY_ONE_HOUR = 2
-GRANULARITY_ONE_DAY = 3
-
 
 class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
     @abstractmethod
@@ -40,6 +38,10 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
 
     @abstractmethod
     def _process_values(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _aggregation_options(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
         raise NotImplementedError
 
     #
@@ -57,7 +59,7 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
         buffer = bytearray()
         for field in [org_id, project_id, metric_id]:
             buffer.extend(field.to_bytes(length=8, byteorder="little"))
-        for (key, value) in sorted_tag_items:
+        for key, value in sorted_tag_items:
             buffer.extend(bytes(key, "utf-8"))
             if isinstance(value, int):
                 buffer.extend(value.to_bytes(length=8, byteorder="little"))
@@ -132,14 +134,9 @@ class GenericMetricsBucketProcessor(DatasetMessageProcessor, ABC):
             "tags.raw_value": raw_values,
             "tags.indexed_value": indexed_values,
             **self._process_values(message),
-            "materialization_version": 1,
+            **self._aggregation_options(message),
             "retention_days": retention_days,
             "timeseries_id": self._hash_timeseries_id(message, sorted_tag_items),
-            "granularities": [
-                GRANULARITY_ONE_MINUTE,
-                GRANULARITY_ONE_HOUR,
-                GRANULARITY_ONE_DAY,
-            ],
         }
         sentry_received_timestamp = None
         if message.get("sentry_received_timestamp"):
@@ -159,6 +156,9 @@ class GenericSetsMetricsProcessor(GenericMetricsBucketProcessor):
     def _process_values(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
         return values_for_set_message(message)
 
+    def _aggregation_options(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
+        return aggregation_options_for_set_message(message)
+
 
 class GenericDistributionsMetricsProcessor(GenericMetricsBucketProcessor):
     def _should_process(self, message: Mapping[str, Any]) -> bool:
@@ -167,6 +167,9 @@ class GenericDistributionsMetricsProcessor(GenericMetricsBucketProcessor):
     def _process_values(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
         return values_for_distribution_message(message)
 
+    def _aggregation_options(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
+        return aggregation_options_for_distribution_message(message)
+
 
 class GenericCountersMetricsProcessor(GenericMetricsBucketProcessor):
     def _should_process(self, message: Mapping[str, Any]) -> bool:
@@ -174,3 +177,6 @@ class GenericCountersMetricsProcessor(GenericMetricsBucketProcessor):
 
     def _process_values(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
         return value_for_counter_message(message)
+
+    def _aggregation_options(self, message: Mapping[str, Any]) -> Mapping[str, Any]:
+        return aggregation_options_for_counter_message(message)


### PR DESCRIPTION
| PR                                                   | Changes                                                  | Status        | Branch From                                          |
| ---------------------------------------------------- | -------------------------------------------------------- | ------------- | ---------------------------------------------------- |
| [#1](https://github.com/getsentry/snuba/pull/4467) | Add aggregation options for generic metrics raw tables | Merged         | master                                               |
| [#2](https://github.com/getsentry/snuba/pull/4504) | Add new MatView for generic distribution metrics | Merged | master |
| [#3](https://github.com/getsentry/snuba/pull/4509) | ➤ Add facilities to insert aggregation options in processor | Ready for review | [#2](https://github.com/getsentry/snuba/pull/4504) |
| [#4](https://github.com/getsentry/snuba/pull/4505) | Bump `materialization_version` to 2 for generic distribution metrics | Ready for review | [#3](https://github.com/getsentry/snuba/pull/4509) |

### Overview

Refactor `GenericMetricsBucketProcessor` to allow specialized aggregation options for each messages / metric type.

This allows sentry to embed information within each metric message that snuba can then use to set the aggregation column values (which granularity is enabled, retention days for each granularities, etc. See [4467](https://github.com/getsentry/snuba/pull/4467))