### PR TITLE
feat(subscriptions): add clickhouse connection check

### DIFF
--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -121,11 +121,6 @@ def subscriptions_executor(
 
     storage = get_entity(entity_key).get_writable_storage()
     assert storage is not None
-
-    logger.info("Checking Clickhouse connections")
-    cluster = storage.get_cluster()
-    check_clickhouse_connections([cluster])
-
     stream_loader = storage.get_table_writer().get_stream_loader()
     result_topic_spec = stream_loader.get_subscription_result_topic_spec()
     assert result_topic_spec is not None
@@ -137,6 +132,10 @@ def subscriptions_executor(
             override_params={"partitioner": "consistent"},
         )
     )
+
+    logger.info("Checking Clickhouse connections")
+    cluster = storage.get_cluster()
+    check_clickhouse_connections([cluster])
 
     processor = build_executor_consumer(
         dataset_name,

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Optional, Sequence
 
 import click
+import structlog
 from arroyo import configure_metrics
 from arroyo.backends.kafka import KafkaProducer
 
@@ -12,6 +13,7 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_enabled_dataset_names
 from snuba.environment import setup_logging, setup_sentry
+from snuba.migrations.connect import check_clickhouse_connections
 from snuba.subscriptions.executor_consumer import build_executor_consumer
 from snuba.utils.metrics.wrapper import MetricsWrapper
 from snuba.utils.streams.configuration_builder import build_kafka_producer_configuration
@@ -98,6 +100,8 @@ def subscriptions_executor(
     setup_logging(log_level)
     setup_sentry()
 
+    logger = structlog.get_logger().bind(module=__name__)
+
     metrics_tags = {
         "dataset": dataset_name,
     }
@@ -117,6 +121,11 @@ def subscriptions_executor(
 
     storage = get_entity(entity_key).get_writable_storage()
     assert storage is not None
+
+    logger.info("Checking Clickhouse connections")
+    cluster = storage.get_cluster()
+    check_clickhouse_connections([cluster])
+
     stream_loader = storage.get_table_writer().get_stream_loader()
     result_topic_spec = stream_loader.get_subscription_result_topic_spec()
     assert result_topic_spec is not None

--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -150,10 +150,6 @@ def subscriptions_scheduler(
         storage is not None
     ), f"Entity {entity_name} does not have a writable storage by default."
 
-    logger.info("Checking Clickhouse connections")
-    cluster = storage.get_cluster()
-    check_clickhouse_connections([cluster])
-
     if stale_threshold_seconds is not None and delay_seconds is not None:
         assert (
             stale_threshold_seconds > delay_seconds
@@ -187,6 +183,10 @@ def subscriptions_scheduler(
         metrics,
         slice_id,
     )
+
+    logger.info("Checking Clickhouse connections")
+    cluster = storage.get_cluster()
+    check_clickhouse_connections([cluster])
 
     processor = builder.build_consumer()
 

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -109,11 +109,6 @@ def subscriptions_scheduler_executor(
 
     storage = get_entity(entity_key).get_writable_storage()
     assert storage is not None
-
-    logger.info("Checking Clickhouse connections")
-    cluster = storage.get_cluster()
-    check_clickhouse_connections([cluster])
-
     stream_loader = storage.get_table_writer().get_stream_loader()
     result_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
     assert result_topic_spec is not None
@@ -124,6 +119,10 @@ def subscriptions_scheduler_executor(
             override_params={"partitioner": "consistent"},
         )
     )
+
+    logger.info("Checking Clickhouse connections")
+    cluster = storage.get_cluster()
+    check_clickhouse_connections([cluster])
 
     processor = build_scheduler_executor_consumer(
         dataset_name,

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import Any, Iterator, Optional, Sequence
 
 import click
+import structlog
 from arroyo import configure_metrics
 from arroyo.backends.kafka import KafkaProducer
 
@@ -12,6 +13,7 @@ from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_enabled_dataset_names
 from snuba.environment import setup_logging, setup_sentry
+from snuba.migrations.connect import check_clickhouse_connections
 from snuba.subscriptions.combined_scheduler_executor import (
     build_scheduler_executor_consumer,
 )
@@ -91,6 +93,8 @@ def subscriptions_scheduler_executor(
     setup_logging(log_level)
     setup_sentry()
 
+    logger = structlog.get_logger().bind(module=__name__)
+
     metrics = MetricsWrapper(
         environment.metrics,
         "subscriptions.scheduler_executor",
@@ -105,6 +109,11 @@ def subscriptions_scheduler_executor(
 
     storage = get_entity(entity_key).get_writable_storage()
     assert storage is not None
+
+    logger.info("Checking Clickhouse connections")
+    cluster = storage.get_cluster()
+    check_clickhouse_connections([cluster])
+
     stream_loader = storage.get_table_writer().get_stream_loader()
     result_topic_spec = stream_loader.get_subscription_scheduled_topic_spec()
     assert result_topic_spec is not None


### PR DESCRIPTION
Our subscriptions containers are starting up before the connections to clickhouse are ready. This add a check to attempt to connect to clickhouse for 60s before starting up the consumers.