### PR TITLE
fix(ci): improve caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Get branch name
         id: branch
         # strip `refs/heads/` from $GITHUB_REF and replace `/` with `-` so that
@@ -141,18 +144,27 @@ jobs:
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
 
       - name: Build snuba docker image for CI
+        uses: docker/build-push-action@v4
         if: github.repository_owner == 'getsentry'
-        run: |
-          docker build . \
-            --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --build-arg SHOULD_BUILD_RUST=false \
-            -t ghcr.io/getsentry/snuba-ci:latest \
-            -t ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
-            -t ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
-            --cache-from ghcr.io/getsentry/snuba-ci:latest \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
-            --target testing
+        with:
+          context: .
+          # push: true
+          load: true
+          build-args: |
+            SHOULD_BUILD_RUST=false
+          target: testing
+          tags: |
+            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            ghcr.io/getsentry/snuba-ci:latest
+          cache-from: |
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
+          cache-to: |
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }},mode=max
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }},mode=max
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest,mode=max
 
       - name: Publish images for cache
         if: steps.branch.outputs.branch == 'master' || github.event.pull_request.head.repo.full_name == github.repository
@@ -181,6 +193,9 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout code
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Pull snuba CI images
         run: |
           docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
@@ -188,14 +203,19 @@ jobs:
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
 
       - name: Build snuba docker image for CI
-        run: |
-          docker build . \
-            -t snuba-test \
-            --build-arg SHOULD_BUILD_RUST=false \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
-            --cache-from ghcr.io/getsentry/snuba-ci:latest \
-            --target testing
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          tags: snuba-test
+          load: true
+          build-args: |
+            SHOULD_BUILD_RUST=false
+          target: testing
+          cache-from: |
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
 
       - name: Docker set up
         run: |
@@ -222,7 +242,7 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
   admin-tests:
-    needs: [linting]
+    needs: [linting, tests]
     name: Front end tests for snuba admin
     runs-on: ubuntu-latest
     steps:
@@ -341,9 +361,9 @@ jobs:
           docker build . \
             -t snuba-test \
             --build-arg SHOULD_BUILD_RUST=false \
-            --cache-from ghcr.io/getsentry/snuba-ci:latest \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
-            --cache-from ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
+            --cache-from type=registry,ghcr.io/getsentry/snuba-ci:latest \
+            --cache-from type=registry,ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
+            --cache-from type=registry,ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
             --target testing
 
       # Checkout Sentry and run integration tests against latest snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,7 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
   admin-tests:
-    needs: [linting, tests]
+    needs: [linting]
     name: Front end tests for snuba admin
     runs-on: ubuntu-latest
     steps:
@@ -356,6 +356,9 @@ jobs:
       - name: Checkout snuba
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Pull snuba CI images
         run: |
           set +e # skip missing images
@@ -365,14 +368,26 @@ jobs:
           set -e
 
       - name: Build snuba docker image for CI
-        run: |
-          docker build . \
-            -t snuba-test \
-            --build-arg SHOULD_BUILD_RUST=false \
-            --cache-from type=registry,ghcr.io/getsentry/snuba-ci:latest \
-            --cache-from type=registry,ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} \
-            --cache-from type=registry,ghcr.io/getsentry/snuba-ci:${{ github.sha }} \
-            --target testing
+        uses: docker/build-push-action@v4
+        if: github.repository_owner == 'getsentry'
+        with:
+          context: .
+          load: true
+          build-args: |
+            SHOULD_BUILD_RUST=false
+          target: testing
+          tags: |
+            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            ghcr.io/getsentry/snuba-ci:latest
+          cache-from: |
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
+          cache-to: |
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }},mode=max
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }},mode=max
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest,mode=max
 
       # Checkout Sentry and run integration tests against latest snuba
       # Make sure this is after `docker build`, otherwise we'll break docker cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,11 @@ jobs:
       - name: Pull snuba CI images
         if: github.repository_owner == 'getsentry'
         run: |
-          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
-            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} || \
+          set +e # skip missing images
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} ; \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }} ; \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
+          set -e
 
       - name: Build snuba docker image for CI
         uses: docker/build-push-action@v4
@@ -198,9 +200,11 @@ jobs:
 
       - name: Pull snuba CI images
         run: |
-          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
-            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} || \
+          set +e # skip missing images
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} ; \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} ; \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
+          set -e
 
       - name: Build snuba docker image for CI
         uses: docker/build-push-action@v4
@@ -267,9 +271,11 @@ jobs:
 
       - name: Pull snuba CI images
         run: |
-          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
-            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} || \
+          set +e # skip missing images
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} ; \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} ; \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
+          set -e
 
       - name: Build snuba docker image for CI
         run: |
@@ -352,9 +358,11 @@ jobs:
 
       - name: Pull snuba CI images
         run: |
-          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} || \
-            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} || \
+          set +e # skip missing images
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} ; \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} ; \
             docker pull ghcr.io/getsentry/snuba-ci:latest || true
+          set -e
 
       - name: Build snuba docker image for CI
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,25 +369,18 @@ jobs:
 
       - name: Build snuba docker image for CI
         uses: docker/build-push-action@v4
-        if: github.repository_owner == 'getsentry'
         with:
           context: .
+          push: false
+          tags: snuba-test
           load: true
           build-args: |
             SHOULD_BUILD_RUST=false
           target: testing
-          tags: |
-            ghcr.io/getsentry/snuba-ci:${{ github.sha }}
-            ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
-            ghcr.io/getsentry/snuba-ci:latest
           cache-from: |
             type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }}
             type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
-          cache-to: |
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }},mode=max
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ steps.branch.outputs.branch }},mode=max
-            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest,mode=max
 
       # Checkout Sentry and run integration tests against latest snuba
       # Make sure this is after `docker build`, otherwise we'll break docker cache


### PR DESCRIPTION
Use the docker build step to use more aggressive caching. Also fixes a bug where we were not always pulling images into the cache. I found this shaved off a 2-3 minutes in CI since we were not always building the image at each step.


