### PR TITLE
fix(generic-metrics): Update default retention days for generic set metrics

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -299,6 +299,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0015_sets_add_options",
             "0016_counters_add_options",
             "0017_distributions_mv2",
+            "0018_sets_update_options",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0018_sets_update_options.py
+++ b/snuba/snuba_migrations/generic_metrics/0018_sets_update_options.py
@@ -1,0 +1,63 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    set_storage_key = StorageSetKey.GENERIC_METRICS_SETS
+
+    local_table_name = "generic_metric_sets_raw_local"
+    dist_table_name = "generic_metric_sets_raw_dist"
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=self.set_storage_key,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in (
+                Column(
+                    "decasecond_retention_days",
+                    UInt(8, MigrationModifiers(default=str("7"))),
+                ),
+                Column(
+                    "min_retention_days",
+                    UInt(8, MigrationModifiers(default=str("30"))),
+                ),
+            )
+            for table_name, target in (
+                (self.local_table_name, operations.OperationTarget.LOCAL),
+                (self.dist_table_name, operations.OperationTarget.DISTRIBUTED),
+            )
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=self.set_storage_key,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in (
+                Column(
+                    "decasecond_retention_days",
+                    UInt(8, MigrationModifiers(default=str("retention_days"))),
+                ),
+                Column(
+                    "min_retention_days",
+                    UInt(8, MigrationModifiers(default=str("retention_days"))),
+                ),
+            )
+            for table_name, target in (
+                (self.dist_table_name, operations.OperationTarget.DISTRIBUTED),
+                (self.local_table_name, operations.OperationTarget.LOCAL),
+            )
+        ]


### PR DESCRIPTION
### Overview

Update defaults for the decasecond granularity retention days and minute granularity retention days from `retention_days` (max retention days specified by customer) to 7 days and 30 days.