### PR TITLE
Switch to pipedream pipelines

### DIFF
--- a/gocd/generated-pipelines/rollback-snuba.yaml
+++ b/gocd/generated-pipelines/rollback-snuba.yaml
@@ -1,18 +1,18 @@
 format_version: 10
 pipelines:
-  rollback-snuba-next:
+  rollback-snuba:
     display_order: 1
     environment_variables:
-      ALL_PIPELINE_FLAGS: --pipeline="deploy-snuba-next-monitor" --pipeline="deploy-snuba-next-us" --pipeline="deploy-snuba-next"
+      ALL_PIPELINE_FLAGS: --pipeline="deploy-snuba-monitor" --pipeline="deploy-snuba-us" --pipeline="deploy-snuba"
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      REGION_PIPELINE_FLAGS: --pipeline="deploy-snuba-next-monitor" --pipeline="deploy-snuba-next-us"
+      REGION_PIPELINE_FLAGS: --pipeline="deploy-snuba-monitor" --pipeline="deploy-snuba-us"
       ROLLBACK_MATERIAL_NAME: snuba_repo
       ROLLBACK_STAGE: deploy-primary
-    group: snuba-next
+    group: snuba
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-snuba-next-us-pipeline-complete:
-        pipeline: deploy-snuba-next-us
+      deploy-snuba-us-pipeline-complete:
+        pipeline: deploy-snuba-us
         stage: pipeline-complete
     stages:
       - pause_pipelines:

--- a/gocd/generated-pipelines/snuba-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-monitor.yaml
@@ -1,16 +1,16 @@
 format_version: 10
 pipelines:
-  deploy-snuba-next-monitor:
+  deploy-snuba-monitor:
     display_order: 2
     environment_variables:
       GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
       SENTRY_REGION: monitor
-    group: snuba-next
+    group: snuba
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-snuba-next-pipeline-complete:
-        pipeline: deploy-snuba-next
+      deploy-snuba-pipeline-complete:
+        pipeline: deploy-snuba
         stage: pipeline-complete
       snuba_repo:
         branch: master
@@ -18,20 +18,6 @@ pipelines:
         git: git@github.com:getsentry/snuba.git
         shallow_clone: false
     stages:
-      - ready:
-          jobs:
-            ready:
-              tasks:
-                - exec:
-                    command: true
-      - wait:
-          approval:
-            type: manual
-          jobs:
-            wait:
-              tasks:
-                - exec:
-                    command: true
       - checks:
           jobs:
             checks:

--- a/gocd/generated-pipelines/snuba-us.yaml
+++ b/gocd/generated-pipelines/snuba-us.yaml
@@ -1,16 +1,16 @@
 format_version: 10
 pipelines:
-  deploy-snuba-next-us:
+  deploy-snuba-us:
     display_order: 3
     environment_variables:
       GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
       SENTRY_REGION: us
-    group: snuba-next
+    group: snuba
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-snuba-next-monitor-pipeline-complete:
-        pipeline: deploy-snuba-next-monitor
+      deploy-snuba-monitor-pipeline-complete:
+        pipeline: deploy-snuba-monitor
         stage: pipeline-complete
       snuba_repo:
         branch: master
@@ -18,20 +18,6 @@ pipelines:
         git: git@github.com:getsentry/snuba.git
         shallow_clone: false
     stages:
-      - ready:
-          jobs:
-            ready:
-              tasks:
-                - exec:
-                    command: true
-      - wait:
-          approval:
-            type: manual
-          jobs:
-            wait:
-              tasks:
-                - exec:
-                    command: true
       - checks:
           jobs:
             checks:

--- a/gocd/generated-pipelines/snuba.yaml
+++ b/gocd/generated-pipelines/snuba.yaml
@@ -1,8 +1,8 @@
 format_version: 10
 pipelines:
-  deploy-snuba-next:
+  deploy-snuba:
     display_order: 0
-    group: snuba-next
+    group: snuba
     lock_behavior: unlockWhenFinished
     materials:
       snuba_repo:

--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -3,7 +3,7 @@
 # - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
 format_version: 10
 pipelines:
-    deploy-snuba:
+    deploy-snuba-old:
         environment_variables:
             GCP_PROJECT: internal-sentry
             GKE_CLUSTER: zdpwkxst
@@ -13,7 +13,7 @@ pipelines:
             # Required for checkruns.
             GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
             GOCD_ACCESS_TOKEN: "{{SECRET:[devinfra][gocd_access_token]}}"
-        group: snuba
+        group: snuba-old
         lock_behavior: unlockWhenFinished
         materials:
             snuba_repo:

--- a/gocd/templates/snuba.jsonnet
+++ b/gocd/templates/snuba.jsonnet
@@ -2,7 +2,7 @@ local snuba = import './pipelines/snuba.libsonnet';
 local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
 
 local pipedream_config = {
-  name: 'snuba-next',
+  name: 'snuba',
   materials: {
     snuba_repo: {
       git: 'git@github.com:getsentry/snuba.git',
@@ -18,8 +18,6 @@ local pipedream_config = {
 
   // Set to true to auto-deploy changes (defaults to true)
   auto_deploy: false,
-  // Set to true if you want each pipeline to require manual approval
-  auto_pipeline_progression: false,
 };
 
 pipedream.render(pipedream_config, snuba)


### PR DESCRIPTION
This switches the snuba pipelines over to pipedream which will deploy to monitor (s4s) and then saas.

The only difference this will have for the current pipeline is that pipedream will run migrations as part of the deployment, it will no longer be an optional & manual step at the end of the pipeline. This was discussed with @dbanda 

NOTE: The old pipelines will still be available but will be moved to a new group "snuba-old" in case they are needed during the transition.