### PR TITLE
Fix canaries and migrations in s4s snuba

### DIFF
--- a/gocd/generated-pipelines/snuba-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-monitor.yaml
@@ -49,7 +49,7 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
-      - migrate:
+      - st_migrate:
           fetch_materials: true
           jobs:
             migrate:
@@ -221,6 +221,61 @@ pipelines:
                       --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
                       --container-name="cleanup"
+              timeout: 1200
+      - migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ## At the time of writing (2023-06-28) the single tenant deployments
+                    ## have been using a different migration process compared to the
+                    ## US deployment of snuba.
+                    ## This script should be merged with migrate.sh if we can figure
+                    ## out a common migration script for all regions.
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-bootstrap" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba bootstrap --force --no-migrate
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate --force
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
+
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
+                    run_if: failed
               timeout: 1200
       - pipeline-complete:
           approval:

--- a/gocd/generated-pipelines/snuba-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-monitor.yaml
@@ -49,6 +49,61 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
+      - migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ## At the time of writing (2023-06-28) the single tenant deployments
+                    ## have been using a different migration process compared to the
+                    ## US deployment of snuba.
+                    ## This script should be merged with migrate.sh if we can figure
+                    ## out a common migration script for all regions.
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-bootstrap" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba bootstrap --force --no-migrate
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate --force
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
+
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
+                    run_if: failed
+              timeout: 1200
       - deploy-canary:
           fetch_materials: true
           jobs:
@@ -166,61 +221,6 @@ pipelines:
                       --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
                       --container-name="cleanup"
-              timeout: 1200
-      - migrate:
-          fetch_materials: true
-          jobs:
-            migrate:
-              elastic_profile_id: snuba
-              environment_variables:
-                SNUBA_SERVICE_NAME: snuba
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    ## At the time of writing (2023-06-28) the single tenant deployments
-                    ## have been using a different migration process compared to the
-                    ## US deployment of snuba.
-                    ## This script should be merged with migrate.sh if we can figure
-                    ## out a common migration script for all regions.
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-
-                    /devinfra/scripts/k8s/k8s-spawn-job.py \
-                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                      --container-name="${SNUBA_SERVICE_NAME}" \
-                      "snuba-bootstrap" \
-                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      -- \
-                      snuba bootstrap --force --no-migrate
-
-                    /devinfra/scripts/k8s/k8s-spawn-job.py \
-                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                      --container-name="${SNUBA_SERVICE_NAME}" \
-                      "snuba-migrate" \
-                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      -- \
-                      snuba migrations migrate --force
-                - plugin:
-                    configuration:
-                      id: script-executor
-                      version: 1
-                    options:
-                      script: |
-                        ##!/bin/bash
-
-                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                        /devinfra/scripts/k8s/k8stunnel
-
-                        /devinfra/scripts/k8s/k8s-spawn-job.py \
-                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                          --container-name="${SNUBA_SERVICE_NAME}" \
-                          "snuba-migrate-reverse" \
-                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                          -- \
-                          snuba migrations reverse-in-progress
-                    run_if: failed
               timeout: 1200
       - pipeline-complete:
           approval:

--- a/gocd/generated-pipelines/snuba-monitor.yaml
+++ b/gocd/generated-pipelines/snuba-monitor.yaml
@@ -49,6 +49,84 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
+      - deploy-canary:
+          fetch_materials: true
+          jobs:
+            create-sentry-release:
+              elastic_profile_id: snuba
+              environment_variables:
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}'
+                SENTRY_ORG: sentry
+                SENTRY_PROJECT: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    sentry-cli releases new "${GO_REVISION_SNUBA_REPO}"
+                    sentry-cli releases set-commits "${GO_REVISION_SNUBA_REPO}" --commit "getsentry/snuba@${GO_REVISION_SNUBA_REPO}"
+                    sentry-cli releases deploys "${GO_REVISION_SNUBA_REPO}" new -e canary
+              timeout: 300
+            deploy-canary:
+              elastic_profile_id: snuba
+              environment_variables:
+                LABEL_SELECTOR: service=snuba,is_canary=true
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+
+                    /devinfra/scripts/k8s/k8stunnel \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --container-name="api" \
+                      --container-name="consumer" \
+                      --container-name="errors-consumer" \
+                      --container-name="errors-replacer" \
+                      --container-name="events-subscriptions-executor" \
+                      --container-name="events-subscriptions-scheduler" \
+                      --container-name="generic-metrics-counters-consumer" \
+                      --container-name="generic-metrics-counters-subscriptions-executor" \
+                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
+                      --container-name="generic-metrics-distributions-consumer" \
+                      --container-name="generic-metrics-distributions-subscriptions-executor" \
+                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
+                      --container-name="generic-metrics-sets-consumer" \
+                      --container-name="generic-metrics-sets-subscriptions-executor" \
+                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
+                      --container-name="loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-errors-consumer" \
+                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
+                      --container-name="loadtest-outcomes-consumer" \
+                      --container-name="loadtest-transactions-consumer" \
+                      --container-name="metrics-consumer" \
+                      --container-name="metrics-counters-subscriptions-scheduler" \
+                      --container-name="metrics-sets-subscriptions-scheduler" \
+                      --container-name="metrics-subscriptions-executor" \
+                      --container-name="outcomes-billing-consumer" \
+                      --container-name="outcomes-consumer" \
+                      --container-name="profiles-consumer" \
+                      --container-name="profiling-functions-consumer" \
+                      --container-name="querylog-consumer" \
+                      --container-name="replacer" \
+                      --container-name="replays-consumer" \
+                      --container-name="search-issues-consumer" \
+                      --container-name="snuba-admin" \
+                      --container-name="transactions-consumer-new" \
+                      --container-name="transactions-subscriptions-executor" \
+                      --container-name="transactions-subscriptions-scheduler" \
+                      --container-name="rust-querylog-consumer" \
+                      --container-name="spans-consumer" \
+                      --container-name="dlq-consumer" \
+                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="${LABEL_SELECTOR}" \
+                      --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      --type="cronjob" \
+                      --container-name="cleanup" \
+                      --container-name="optimize"
+              timeout: 1200
       - deploy-primary:
           fetch_materials: true
           jobs:

--- a/gocd/generated-pipelines/snuba-us.yaml
+++ b/gocd/generated-pipelines/snuba-us.yaml
@@ -49,6 +49,48 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
+      - migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba-admin
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate -r complete -r partial
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
+
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
+                    run_if: failed
+              timeout: 1200
       - deploy-canary:
           fetch_materials: true
           jobs:
@@ -203,48 +245,6 @@ pipelines:
                       --type="cronjob" \
                       --container-name="cleanup" \
                       --container-name="optimize"
-              timeout: 1200
-      - migrate:
-          fetch_materials: true
-          jobs:
-            migrate:
-              elastic_profile_id: snuba
-              environment_variables:
-                SNUBA_SERVICE_NAME: snuba-admin
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-
-                    /devinfra/scripts/k8s/k8s-spawn-job.py \
-                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                      --container-name="${SNUBA_SERVICE_NAME}" \
-                      "snuba-migrate" \
-                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      -- \
-                      snuba migrations migrate -r complete -r partial
-                - plugin:
-                    configuration:
-                      id: script-executor
-                      version: 1
-                    options:
-                      script: |
-                        ##!/bin/bash
-
-                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                        /devinfra/scripts/k8s/k8stunnel
-
-                        /devinfra/scripts/k8s/k8s-spawn-job.py \
-                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                          --container-name="${SNUBA_SERVICE_NAME}" \
-                          "snuba-migrate-reverse" \
-                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                          -- \
-                          snuba migrations reverse-in-progress
-                    run_if: failed
               timeout: 1200
       - pipeline-complete:
           approval:

--- a/gocd/generated-pipelines/snuba-us.yaml
+++ b/gocd/generated-pipelines/snuba-us.yaml
@@ -49,48 +49,6 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
-      - migrate:
-          fetch_materials: true
-          jobs:
-            migrate:
-              elastic_profile_id: snuba
-              environment_variables:
-                SNUBA_SERVICE_NAME: snuba-admin
-              tasks:
-                - script: |
-                    ##!/bin/bash
-
-                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                    /devinfra/scripts/k8s/k8stunnel
-
-                    /devinfra/scripts/k8s/k8s-spawn-job.py \
-                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                      --container-name="${SNUBA_SERVICE_NAME}" \
-                      "snuba-migrate" \
-                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      -- \
-                      snuba migrations migrate -r complete -r partial
-                - plugin:
-                    configuration:
-                      id: script-executor
-                      version: 1
-                    options:
-                      script: |
-                        ##!/bin/bash
-
-                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
-                        /devinfra/scripts/k8s/k8stunnel
-
-                        /devinfra/scripts/k8s/k8s-spawn-job.py \
-                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
-                          --container-name="${SNUBA_SERVICE_NAME}" \
-                          "snuba-migrate-reverse" \
-                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                          -- \
-                          snuba migrations reverse-in-progress
-                    run_if: failed
-              timeout: 1200
       - deploy-canary:
           fetch_materials: true
           jobs:
@@ -245,6 +203,48 @@ pipelines:
                       --type="cronjob" \
                       --container-name="cleanup" \
                       --container-name="optimize"
+              timeout: 1200
+      - migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba-admin
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate -r complete -r partial
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
+
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
+                    run_if: failed
               timeout: 1200
       - pipeline-complete:
           approval:

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -7,6 +7,52 @@ local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libs
 
 local is_st(region) = (region == 'monitor' || std.startsWith(region, 'customer-'));
 
+local migrate_stage(stage_name, region) = [
+  {
+    [stage_name]: {
+      fetch_materials: true,
+      jobs: {
+        migrate: {
+          timeout: 1200,
+          elastic_profile_id: 'snuba',
+          environment_variables: {
+            // ST deployments use 'snuba' for container and label selectors
+            // in migrations, whereas the US region deployment uses snuba-admin.
+            SNUBA_SERVICE_NAME: if is_st(region) then 'snuba' else 'snuba-admin',
+          },
+          tasks: [
+            if is_st(region) then
+              gocdtasks.script(importstr '../bash/migrate-st.sh')
+            else
+              gocdtasks.script(importstr '../bash/migrate.sh'),
+            {
+              plugin: {
+                options: gocdtasks.script(importstr '../bash/migrate-reverse.sh'),
+                run_if: 'failed',
+                configuration: {
+                  id: 'script-executor',
+                  version: 1,
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  },
+];
+
+// Snuba relies on checks to prevent folks from writing migrations and code
+// at the same time, this means there is a requirement that folks MUST deploy
+// the migration before merge code changes relying on that migration.
+// This doesn't hold true for ST deployments today, so temporarily run an
+// early migration stage for ST deployments.
+local early_migrate(region) =
+  if is_st(region) then
+    migrate_stage('st_migrate', region)
+  else
+    [];
+
 function(region) {
   environment_variables: {
     SENTRY_REGION: region,
@@ -41,38 +87,7 @@ function(region) {
       },
     },
 
-    {
-      migrate: {
-        fetch_materials: true,
-        jobs: {
-          migrate: {
-            timeout: 1200,
-            elastic_profile_id: 'snuba',
-            environment_variables: {
-              // ST deployments use 'snuba' for container and label selectors
-              // in migrations, whereas the US region deployment uses snuba-admin.
-              SNUBA_SERVICE_NAME: if is_st(region) then 'snuba' else 'snuba-admin',
-            },
-            tasks: [
-              if is_st(region) then
-                gocdtasks.script(importstr '../bash/migrate-st.sh')
-              else
-                gocdtasks.script(importstr '../bash/migrate.sh'),
-              {
-                plugin: {
-                  options: gocdtasks.script(importstr '../bash/migrate-reverse.sh'),
-                  run_if: 'failed',
-                  configuration: {
-                    id: 'script-executor',
-                    version: 1,
-                  },
-                },
-              },
-            ],
-          },
-        },
-      },
-    },
+  ] + early_migrate(region) + [
 
     {
       'deploy-canary': {
@@ -136,5 +151,6 @@ function(region) {
         },
       },
     },
-  ],
+
+  ] + migrate_stage('migrate', region),
 }


### PR DESCRIPTION
Snuba s4s doesnt have any canary pods, but the create sentry release script for canary step makes the release which is needed for the prod deployment