### PR TITLE
ref(capman): split the rate limit function into a start and finish phase

### DIFF
--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -185,7 +185,7 @@ def rate_limit_start_request(
     #
     # it is fine to only perform this cleanup for the shard of the current
     # query, because on average there will be many other queries that hit other
-    # shards and perform cleanup therea
+    # shards and perform cleanup there
     pipe.zremrangebyscore(query_bucket, "-inf", "({:f}".format(now - rate_history_sec))
 
     # Now for the tricky bit:

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -255,7 +255,8 @@ def rate_limit_start_request(
             pipe.zcount(bucket, "({:f}".format(now), "+inf")
 
     try:
-        pipe_results = iter(pipe.execute())
+        results = pipe.execute()
+        pipe_results = iter(results)
 
         # skip zremrangebyscore, zadd and expire
         next(pipe_results)
@@ -272,9 +273,10 @@ def rate_limit_start_request(
         else:
             concurrent = 0
     except Exception as ex:
+        # if something goes wrong, we don't want to block the request,
+        # set the values such that they pass under any limit
         logger.exception(ex)
         return RateLimitStats(rate=-1, concurrent=-1)
-        return
 
     per_second = historical / float(state.rate_lookback_s)
 

--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -334,6 +334,7 @@ def rate_limit_finish_request(
     rate_limit_shard_factor: int,
     was_rate_limited: bool,
 ) -> None:
+    """Second half of rate limiting, called after the request is finished. See rate_limit_start_request for details"""
     bucket_shard = hash(query_id) % rate_limit_shard_factor
     query_bucket = _get_bucket_key(
         state.ratelimit_prefix, rate_limit_params.bucket, bucket_shard

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -71,6 +71,14 @@ class TestRateLimit:
                 pass
 
     @pytest.mark.redis_db
+    def test_fails_open(self, rate_limit_shards: Any) -> None:
+        with patch("snuba.state.rate_limit.rds.pipeline") as pipeline:
+            pipeline.execute.side_effect = Exception("Boom!")
+            rate_limit_params = RateLimitParameters("foo", "bar", 4, 20)
+            with rate_limit(rate_limit_params):
+                pass
+
+    @pytest.mark.redis_db
     def test_per_second_limit(self, rate_limit_shards: Any) -> None:
         bucket = uuid.uuid4()
         rate_limit_params = RateLimitParameters("foo", str(bucket), 1, None)


### PR DESCRIPTION
The allocation policy infrastructure assumes theres a start and a finish of a query, the rate limit code is a context manager which assumes everything happens in a specific block.

This PR:

* Splits apart the rate limit function into two reusable components
* Adds a test for the fail open case for the rate limiter (which wasn't tested before)
* maintains the context manager abstraction so everything still works as before