### PR TITLE
feat(rust-consumer): Add RunTaskInThreads strategy

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 pub mod commit_offsets;
 pub mod produce;
 pub mod reduce;
+pub mod run_task_in_threads;
 pub mod transform;
 
 #[derive(Debug, Clone)]

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -1,0 +1,174 @@
+use crate::processing::strategies::{
+    CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
+};
+use crate::types::Message;
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+
+pub type RunTaskFunc<TPayload, TTransformed> = Pin<
+    Box<
+        dyn Fn(
+            Message<TPayload>,
+        ) -> Pin<
+            Box<dyn Future<Output = Result<Message<TTransformed>, InvalidMessage>> + Send>,
+        >,
+    >,
+>;
+
+pub trait TaskRunner<TPayload: Clone, TTransformed: Clone + Send + Sync>: Send + Sync {
+    fn get_task(&self) -> RunTaskFunc<TPayload, TTransformed>;
+}
+
+pub struct RunTaskInThreads<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> {
+    next_step: Box<dyn ProcessingStrategy<TTransformed>>,
+    task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
+    concurrency: usize,
+    runtime: tokio::runtime::Runtime,
+    handles: VecDeque<JoinHandle<Result<Message<TTransformed>, InvalidMessage>>>,
+    message_carried_over: Option<Message<TTransformed>>,
+}
+
+impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
+    RunTaskInThreads<TPayload, TTransformed>
+{
+    pub fn new<N>(
+        next_step: N,
+        task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
+        concurrency: usize,
+    ) -> Self
+    where
+        N: ProcessingStrategy<TTransformed> + 'static,
+    {
+        RunTaskInThreads {
+            next_step: Box::new(next_step),
+            task_runner,
+            concurrency,
+            runtime: tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+            handles: VecDeque::new(),
+            message_carried_over: None,
+        }
+    }
+}
+
+impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
+    ProcessingStrategy<TPayload> for RunTaskInThreads<TPayload, TTransformed>
+{
+    fn poll(&mut self) -> Option<CommitRequest> {
+        if let Some(message) = self.message_carried_over.take() {
+            if let Err(MessageRejected {
+                message: transformed_message,
+            }) = self.next_step.submit(message)
+            {
+                self.message_carried_over = Some(transformed_message);
+                return None;
+            }
+        }
+
+        while !self.handles.is_empty() {
+            if let Some(front) = self.handles.front() {
+                if front.is_finished() {
+                    let handle = self.handles.pop_front().unwrap();
+                    match self.runtime.block_on(handle) {
+                        Ok(Ok(message)) => {
+                            if let Err(MessageRejected {
+                                message: transformed_message,
+                            }) = self.next_step.submit(message)
+                            {
+                                self.message_carried_over = Some(transformed_message);
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            log::error!("function errored {:?}", e);
+                        }
+                        Err(e) => {
+                            log::error!("the thread crashed {}", e);
+                        }
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+
+        self.next_step.poll()
+    }
+
+    fn submit(&mut self, message: Message<TPayload>) -> Result<(), MessageRejected<TPayload>> {
+        if self.message_carried_over.is_some() {
+            log::warn!("carried over message, rejecting subsequent messages");
+            return Err(MessageRejected { message });
+        }
+
+        if self.handles.len() > self.concurrency {
+            log::warn!("Reached max concurrency, rejecting message");
+            return Err(MessageRejected { message });
+        }
+
+        let handle = self.runtime.spawn((self.task_runner.get_task())(message));
+        self.handles.push_back(handle);
+
+        Ok(())
+    }
+
+    fn close(&mut self) {
+        self.next_step.close();
+    }
+
+    fn terminate(&mut self) {
+        // TODO: Implement terminate
+        self.next_step.terminate();
+    }
+
+    fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
+        // TODO: Implement join
+        self.next_step.join(timeout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RunTaskFunc, RunTaskInThreads, TaskRunner};
+    use crate::processing::strategies::{CommitRequest, MessageRejected, ProcessingStrategy};
+    use crate::types::Message;
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
+    #[test]
+    fn test() {
+        struct Noop {}
+        impl ProcessingStrategy<String> for Noop {
+            fn poll(&mut self) -> Option<CommitRequest> {
+                None
+            }
+            fn submit(&mut self, _message: Message<String>) -> Result<(), MessageRejected<String>> {
+                Ok(())
+            }
+            fn close(&mut self) {}
+            fn terminate(&mut self) {}
+            fn join(&mut self, _timeout: Option<Duration>) -> Option<CommitRequest> {
+                None
+            }
+        }
+
+        struct IdentityTaskRunner {}
+
+        impl<T: Clone + Send + Sync + 'static> TaskRunner<T, T> for IdentityTaskRunner {
+            fn get_task(&self) -> RunTaskFunc<T, T> {
+                Box::pin(|msg: Message<T>| Box::pin(async move { Ok(msg) }))
+            }
+        }
+
+        let mut strategy = RunTaskInThreads::new(Noop {}, Box::new(IdentityTaskRunner {}), 1);
+
+        let message = Message::new_any_message("hello_world".to_string(), BTreeMap::new());
+
+        strategy.submit(message).unwrap();
+        strategy.poll();
+    }
+}

--- a/rust_snuba/rust_arroyo/src/processing/strategies/transform.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/transform.rs
@@ -10,9 +10,7 @@ pub struct Transform<TPayload: Clone + Send + Sync, TTransformed: Clone + Send +
     pub message_carried_over: Option<Message<TTransformed>>,
 }
 
-impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
-    Transform<TPayload, TTransformed>
-{
+impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> Transform<TPayload, TTransformed> {
     pub fn new<N>(
         function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
         next_step: N,
@@ -33,10 +31,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> Processin
 {
     fn poll(&mut self) -> Option<CommitRequest> {
         if let Some(message) = self.message_carried_over.take() {
-            if let Err(MessageRejected {
-                message: transformed_message,
-            }) = self.next_step.submit(message)
-            {
+            if let Err(MessageRejected{message: transformed_message}) = self.next_step.submit(message) {
                 self.message_carried_over = Some(transformed_message);
             }
         }
@@ -46,16 +41,15 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> Processin
 
     fn submit(&mut self, message: Message<TPayload>) -> Result<(), MessageRejected<TPayload>> {
         if self.message_carried_over.is_some() {
-            return Err(MessageRejected { message });
+            return Err(MessageRejected {
+                message,
+            });
         }
 
         // TODO: Handle InvalidMessage
         let transformed = (self.function)(message.payload()).unwrap();
 
-        if let Err(MessageRejected {
-            message: transformed_message,
-        }) = self.next_step.submit(message.replace(transformed))
-        {
+        if let Err(MessageRejected{message: transformed_message}) = self.next_step.submit(message.replace(transformed)) {
             self.message_carried_over = Some(transformed_message);
         }
         Ok(())

--- a/rust_snuba/rust_arroyo/src/types/mod.rs
+++ b/rust_snuba/rust_arroyo/src/types/mod.rs
@@ -113,6 +113,31 @@ pub struct Message<T: Clone> {
 }
 
 impl<T: Clone> Message<T> {
+    pub fn new_broker_message(
+        payload: T,
+        partition: Partition,
+        offset: u64,
+        timestamp: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            inner_message: InnerMessage::BrokerMessage(BrokerMessage {
+                payload,
+                partition,
+                offset,
+                timestamp,
+            }),
+        }
+    }
+
+    pub fn new_any_message(payload: T, committable: BTreeMap<Partition, u64>) -> Self {
+        Self {
+            inner_message: InnerMessage::AnyMessage(AnyMessage {
+                payload,
+                committable,
+            }),
+        }
+    }
+
     pub fn payload(&self) -> T {
         match &self.inner_message {
             InnerMessage::BrokerMessage(BrokerMessage { payload, .. }) => payload.clone(),

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -21,7 +21,7 @@ impl ClickhouseWriter {
 }
 
 impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
-    fn get_task<'a>(&self) -> RunTaskFunc<BytesInsertBatch, BytesInsertBatch> {
+    fn get_task(&self) -> RunTaskFunc<BytesInsertBatch, BytesInsertBatch> {
         let skip_write = self.skip_write;
         let client: ClickhouseClient = self.client.clone();
         Box::pin(move |msg: Message<BytesInsertBatch>| {
@@ -37,6 +37,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
 
                 if skip_write {
                     log::info!("skipping write of {} rows", len);
+                    return Ok(msg);
                 }
 
                 log::debug!("performing write");

--- a/rust_snuba/src/strategies/mod.rs
+++ b/rust_snuba/src/strategies/mod.rs
@@ -1,2 +1,2 @@
-pub mod python;
 pub mod clickhouse;
+pub mod python;

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -128,8 +128,8 @@ impl ProcessingStrategy<KafkaPayload> for PythonTransformStep {
                     self.message_carried_over = Some(transformed_message);
                 }
             },
-            Err(_) => {
-                log::error!("Invalid message");
+            Err(e) => {
+                log::error!("Invalid message {:?}", e);
             },
         }
 


### PR DESCRIPTION
Break the task scheduling code out of the Clickhouse writer strategy so it can be used for parallel execution of any functions, such as custom message processors.

The ClickHouse strategy now uses RunTaskInThreads under the hood.