### PR TITLE
fix(cardinality-analyzer): Fix CSV escaping

### DIFF
--- a/snuba/admin/static/cardinality_analyzer/CSV.ts
+++ b/snuba/admin/static/cardinality_analyzer/CSV.ts
@@ -13,7 +13,7 @@ export class CSV {
     let sanitizedValue: string = "";
 
     if (typeof value === "string") {
-      sanitizedValue = value.replace(/"/g, '\\"');
+      sanitizedValue = value.replace(/"/g, '""');
 
       if (value.includes(",")) {
         return `"${sanitizedValue}"`;

--- a/snuba/admin/static/cardinality_analyzer/CSV.ts
+++ b/snuba/admin/static/cardinality_analyzer/CSV.ts
@@ -1,0 +1,21 @@
+export class CSV {
+  static sheet(rows: Array<Array<unknown>>) {
+    return rows.map(CSV.row).join("\n");
+  }
+
+  static row(values: unknown[]): string {
+    return values.map(CSV.cell).join(",");
+  }
+
+  static cell(value: unknown): string {
+    if (!value) return "";
+
+    if (typeof value === "string") {
+      if (value.includes(",")) {
+        return `"${value}"`;
+      }
+    }
+
+    return value.toString();
+  }
+}

--- a/snuba/admin/static/cardinality_analyzer/CSV.ts
+++ b/snuba/admin/static/cardinality_analyzer/CSV.ts
@@ -10,14 +10,15 @@ export class CSV {
   static cell(value: unknown): string {
     if (!value) return "";
 
-    let sanitizedValue: string = "";
-
     if (typeof value === "string") {
+      let sanitizedValue: string = "";
       sanitizedValue = value.replace(/"/g, '""');
 
       if (value.includes(",")) {
         return `"${sanitizedValue}"`;
       }
+
+      return sanitizedValue;
     }
 
     return value.toString();

--- a/snuba/admin/static/cardinality_analyzer/CSV.ts
+++ b/snuba/admin/static/cardinality_analyzer/CSV.ts
@@ -10,9 +10,13 @@ export class CSV {
   static cell(value: unknown): string {
     if (!value) return "";
 
+    let sanitizedValue: string = "";
+
     if (typeof value === "string") {
+      sanitizedValue = value.replace(/"/g, '\\"');
+
       if (value.includes(",")) {
-        return `"${value}"`;
+        return `"${sanitizedValue}"`;
       }
     }
 

--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -5,6 +5,10 @@ import QueryEditor from "../query_editor";
 
 import { CardinalityQueryRequest, CardinalityQueryResult, PredefinedQuery } from "./types";
 
+enum ClipboardFormats {
+  CSV = "csv",
+  JSON = "json",
+}
 type QueryState = Partial<CardinalityQueryRequest>;
 
 function QueryDisplay(props: {
@@ -46,8 +50,17 @@ function QueryDisplay(props: {
     return output;
   }
 
-  function copyText(queryResult: CardinalityQueryResult, format: string) {
-    const formatter = format == "csv" ? convertResultsToCSV : JSON.stringify;
+  function copyText(queryResult: CardinalityQueryResult, format: ClipboardFormats) {
+    let formatter: (input: CardinalityQueryResult) => string = (s) => s.toString();
+
+    if (format === ClipboardFormats.JSON) {
+      formatter = JSON.stringify;
+    }
+
+    if (format === ClipboardFormats.CSV) {
+      formatter = convertResultsToCSV;
+    }
+
     window.navigator.clipboard.writeText(formatter(queryResult));
   }
 
@@ -82,12 +95,12 @@ function QueryDisplay(props: {
               <div key={idx}>
                 <p>{queryResult.input_query}</p>
                 <p>
-                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, "json")}>
+                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.JSON)}>
                     Copy to clipboard (JSON)
                   </button>
                 </p>
                 <p>
-                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, "csv")}>
+                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.CSV)}>
                     Copy to clipboard (CSV)
                   </button>
                 </p>
@@ -98,10 +111,10 @@ function QueryDisplay(props: {
 
           return (
             <Collapse key={idx} text={queryResult.input_query}>
-              <button style={executeButtonStyle} onClick={() => copyText(queryResult, "json")}>
+              <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.JSON)}>
                 Copy to clipboard (JSON)
               </button>
-              <button style={executeButtonStyle} onClick={() => copyText(queryResult, "csv")}>
+              <button style={executeButtonStyle} onClick={() => copyText(queryResult, ClipboardFormats.CSV)}>
                 Copy to clipboard (CSV)
               </button>
               {props.resultDataPopulator(queryResult)}

--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -126,28 +126,4 @@ const executeButtonStyle = {
   marginRight: 10,
 };
 
-const selectStyle = {
-  marginRight: 8,
-  height: 30,
-};
-
-function TextArea(props: { value: string; onChange: (nextValue: string) => void }) {
-  const { value, onChange } = props;
-  return (
-    <textarea
-      spellCheck={false}
-      value={value}
-      onChange={(evt) => onChange(evt.target.value)}
-      style={{ width: "100%", height: 140 }}
-      placeholder={"Write your query here"}
-    />
-  );
-}
-
-const queryDescription = {
-  minHeight: 10,
-  width: "auto",
-  fontSize: 16,
-  padding: "10px 5px",
-};
 export default QueryDisplay;

--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Client from "../api_client";
 import { Collapse } from "../collapse";
+import { CSV } from "./CSV";
 import QueryEditor from "../query_editor";
 
 import { CardinalityQueryRequest, CardinalityQueryResult, PredefinedQuery } from "./types";
@@ -42,12 +43,7 @@ function QueryDisplay(props: {
   }
 
   function convertResultsToCSV(queryResult: CardinalityQueryResult) {
-    let output = queryResult.column_names.join(",");
-    for (const row of queryResult.rows) {
-      const escaped = row.map((v) => (typeof v == "string" && v.includes(",") ? '"' + v + '"' : v));
-      output = output + "\n" + escaped.join(",");
-    }
-    return output;
+    return CSV.sheet([queryResult.column_names, ...queryResult.rows]);
   }
 
   function copyText(queryResult: CardinalityQueryResult, format: ClipboardFormats) {

--- a/snuba/admin/static/cardinality_analyzer/query_display.tsx
+++ b/snuba/admin/static/cardinality_analyzer/query_display.tsx
@@ -13,9 +13,7 @@ function QueryDisplay(props: {
   predefinedQueryOptions: Array<PredefinedQuery>;
 }) {
   const [query, setQuery] = useState<QueryState>({});
-  const [queryResultHistory, setCardinalityQueryResultHistory] = useState<
-    CardinalityQueryResult[]
-  >([]);
+  const [queryResultHistory, setCardinalityQueryResultHistory] = useState<CardinalityQueryResult[]>([]);
 
   function updateQuerySql(sql: string) {
     setQuery((prevQuery) => {
@@ -42,9 +40,7 @@ function QueryDisplay(props: {
   function convertResultsToCSV(queryResult: CardinalityQueryResult) {
     let output = queryResult.column_names.join(",");
     for (const row of queryResult.rows) {
-      const escaped = row.map((v) =>
-        typeof v == "string" && v.includes(",") ? '"' + v + '"' : v
-      );
+      const escaped = row.map((v) => (typeof v == "string" && v.includes(",") ? '"' + v + '"' : v));
       output = output + "\n" + escaped.join(",");
     }
     return output;
@@ -86,18 +82,12 @@ function QueryDisplay(props: {
               <div key={idx}>
                 <p>{queryResult.input_query}</p>
                 <p>
-                  <button
-                    style={executeButtonStyle}
-                    onClick={() => copyText(queryResult, "json")}
-                  >
+                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, "json")}>
                     Copy to clipboard (JSON)
                   </button>
                 </p>
                 <p>
-                  <button
-                    style={executeButtonStyle}
-                    onClick={() => copyText(queryResult, "csv")}
-                  >
+                  <button style={executeButtonStyle} onClick={() => copyText(queryResult, "csv")}>
                     Copy to clipboard (CSV)
                   </button>
                 </p>
@@ -108,16 +98,10 @@ function QueryDisplay(props: {
 
           return (
             <Collapse key={idx} text={queryResult.input_query}>
-              <button
-                style={executeButtonStyle}
-                onClick={() => copyText(queryResult, "json")}
-              >
+              <button style={executeButtonStyle} onClick={() => copyText(queryResult, "json")}>
                 Copy to clipboard (JSON)
               </button>
-              <button
-                style={executeButtonStyle}
-                onClick={() => copyText(queryResult, "csv")}
-              >
+              <button style={executeButtonStyle} onClick={() => copyText(queryResult, "csv")}>
                 Copy to clipboard (CSV)
               </button>
               {props.resultDataPopulator(queryResult)}
@@ -147,10 +131,7 @@ const selectStyle = {
   height: 30,
 };
 
-function TextArea(props: {
-  value: string;
-  onChange: (nextValue: string) => void;
-}) {
+function TextArea(props: { value: string; onChange: (nextValue: string) => void }) {
   const { value, onChange } = props;
   return (
     <textarea

--- a/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
+++ b/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
@@ -1,0 +1,21 @@
+import { CSV } from "../../cardinality_analyzer/CSV";
+
+describe("CSV.sheet", () => {
+  it("Should return a CSV value of a grid of values", () => {
+    expect(
+      CSV.sheet([
+        ["name", "age"],
+        ["George", 33],
+      ])
+    ).toEqual(`name,age\nGeorge,33`);
+  });
+
+  it("Should escape commas by wrapping in double quotes", () => {
+    expect(
+      CSV.sheet([
+        ["name", "motto"],
+        ["George", "do a good job, don't do a bad job"],
+      ])
+    ).toEqual(`name,motto\nGeorge,"do a good job, don't do a bad job"`);
+  });
+});

--- a/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
+++ b/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
@@ -19,12 +19,21 @@ describe("CSV.sheet", () => {
     ).toEqual(`name,motto\nGeorge,"do a good job, don't do a bad job"`);
   });
 
-  it("Should escape quotes by escaping with a backslash", () => {
+  it("Should escape quotes in comma-containing values", () => {
     expect(
       CSV.sheet([
         ["name", "motto"],
         ["George", 'hello, "world"'],
       ])
     ).toEqual(`name,motto\nGeorge,"hello, ""world"""`);
+  });
+
+  it("Should escape quotes by escaping with a backslash", () => {
+    expect(
+      CSV.sheet([
+        ["name", "motto"],
+        ["George", 'hello "world"'],
+      ])
+    ).toEqual(`name,motto\nGeorge,hello ""world""`);
   });
 });

--- a/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
+++ b/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
@@ -25,6 +25,6 @@ describe("CSV.sheet", () => {
         ["name", "motto"],
         ["George", 'hello, "world"'],
       ])
-    ).toEqual(`name,motto\nGeorge,"hello, \\"world\\""`);
+    ).toEqual(`name,motto\nGeorge,"hello, ""world"""`);
   });
 });

--- a/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
+++ b/snuba/admin/static/tests/cardinality_analyzer/CSV.spec.ts
@@ -18,4 +18,13 @@ describe("CSV.sheet", () => {
       ])
     ).toEqual(`name,motto\nGeorge,"do a good job, don't do a bad job"`);
   });
+
+  it("Should escape quotes by escaping with a backslash", () => {
+    expect(
+      CSV.sheet([
+        ["name", "motto"],
+        ["George", 'hello, "world"'],
+      ])
+    ).toEqual(`name,motto\nGeorge,"hello, \\"world\\""`);
+  });
 });


### PR DESCRIPTION
The "Copy to clipboard (CSV)" button is great, but it doesn't escape double quotes in the CSV, so the content is sometimes mangled. This is a fix.

![Screenshot 2023-07-20 at 12 04 37 PM](https://github.com/getsentry/snuba/assets/989898/991f4b6e-fbbb-4a41-8290-bf9968f7f4cb)

## Changes

- Prettier
- Remove unused variables
- Add some more typing
- Extract CSV class
- Add spec
