### PR TITLE
Revert back to snuba group for role access

### DIFF
--- a/gocd/pipelines/snuba.yaml
+++ b/gocd/pipelines/snuba.yaml
@@ -13,7 +13,8 @@ pipelines:
             # Required for checkruns.
             GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
             GOCD_ACCESS_TOKEN: "{{SECRET:[devinfra][gocd_access_token]}}"
-        group: snuba-old
+        group: snuba
+        display_order: 100 # Ensure it's last pipeline in UI
         lock_behavior: unlockWhenFinished
         materials:
             snuba_repo:


### PR DESCRIPTION
I didn't acknowledge that using a different group would impact the roles managing view, operate and admin access.

This PR moves the old pipeline back to the snuba group with appropriate access roles.