### PR TITLE
Rename monitor to s4s and add first customer

### DIFF
--- a/gocd/generated-pipelines/rollback-snuba.yaml
+++ b/gocd/generated-pipelines/rollback-snuba.yaml
@@ -3,16 +3,16 @@ pipelines:
   rollback-snuba:
     display_order: 1
     environment_variables:
-      ALL_PIPELINE_FLAGS: --pipeline=deploy-snuba-monitor --pipeline=deploy-snuba-us --pipeline=deploy-snuba
+      ALL_PIPELINE_FLAGS: --pipeline=deploy-snuba-s4s --pipeline=deploy-snuba-us --pipeline=deploy-snuba-customer-1 --pipeline=deploy-snuba
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      REGION_PIPELINE_FLAGS: --pipeline=deploy-snuba-monitor --pipeline=deploy-snuba-us
+      REGION_PIPELINE_FLAGS: --pipeline=deploy-snuba-s4s --pipeline=deploy-snuba-us --pipeline=deploy-snuba-customer-1
       ROLLBACK_MATERIAL_NAME: snuba_repo
       ROLLBACK_STAGE: deploy-primary
     group: snuba
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-snuba-us-pipeline-complete:
-        pipeline: deploy-snuba-us
+      deploy-snuba-customer-1-pipeline-complete:
+        pipeline: deploy-snuba-customer-1
         stage: pipeline-complete
     stages:
       - pause_pipelines:

--- a/gocd/generated-pipelines/snuba-customer-1.yaml
+++ b/gocd/generated-pipelines/snuba-customer-1.yaml
@@ -1,16 +1,16 @@
 format_version: 10
 pipelines:
-  deploy-snuba-monitor:
-    display_order: 2
+  deploy-snuba-customer-1:
+    display_order: 4
     environment_variables:
       GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      SENTRY_REGION: monitor
+      SENTRY_REGION: customer-1
     group: snuba
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-snuba-pipeline-complete:
-        pipeline: deploy-snuba
+      deploy-snuba-us-pipeline-complete:
+        pipeline: deploy-snuba-us
         stage: pipeline-complete
       snuba_repo:
         branch: master

--- a/gocd/generated-pipelines/snuba-s4s.yaml
+++ b/gocd/generated-pipelines/snuba-s4s.yaml
@@ -1,16 +1,16 @@
 format_version: 10
 pipelines:
-  deploy-snuba-us:
-    display_order: 3
+  deploy-snuba-s4s:
+    display_order: 2
     environment_variables:
       GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}'
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      SENTRY_REGION: us
+      SENTRY_REGION: s4s
     group: snuba
     lock_behavior: unlockWhenFinished
     materials:
-      deploy-snuba-s4s-pipeline-complete:
-        pipeline: deploy-snuba-s4s
+      deploy-snuba-pipeline-complete:
+        pipeline: deploy-snuba
         stage: pipeline-complete
       snuba_repo:
         branch: master

--- a/gocd/generated-pipelines/snuba-s4s.yaml
+++ b/gocd/generated-pipelines/snuba-s4s.yaml
@@ -49,6 +49,61 @@ pipelines:
                     deploy_sha=`snuba/scripts/fetch_service_refs.py --pipeline "deploy-snuba"`
                     snuba/scripts/check-migrations.py --to $deploy_sha --workdir snuba
               timeout: 1800
+      - st_migrate:
+          fetch_materials: true
+          jobs:
+            migrate:
+              elastic_profile_id: snuba
+              environment_variables:
+                SNUBA_SERVICE_NAME: snuba
+              tasks:
+                - script: |
+                    ##!/bin/bash
+
+                    ## At the time of writing (2023-06-28) the single tenant deployments
+                    ## have been using a different migration process compared to the
+                    ## US deployment of snuba.
+                    ## This script should be merged with migrate.sh if we can figure
+                    ## out a common migration script for all regions.
+
+                    eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-bootstrap" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba bootstrap --force --no-migrate
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-migrate" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba migrations migrate --force
+                - plugin:
+                    configuration:
+                      id: script-executor
+                      version: 1
+                    options:
+                      script: |
+                        ##!/bin/bash
+
+                        eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
+                        /devinfra/scripts/k8s/k8stunnel
+
+                        /devinfra/scripts/k8s/k8s-spawn-job.py \
+                          --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                          --container-name="${SNUBA_SERVICE_NAME}" \
+                          "snuba-migrate-reverse" \
+                          "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                          -- \
+                          snuba migrations reverse-in-progress
+                    run_if: failed
+              timeout: 1200
       - deploy-canary:
           fetch_materials: true
           jobs:
@@ -153,56 +208,19 @@ pipelines:
 
                     eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
 
-                    /devinfra/scripts/k8s/k8stunnel \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                    /devinfra/scripts/k8s/k8stunnel
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
                       --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
-                      --label-selector="${LABEL_SELECTOR}" \
+                      --label-selector="service=snuba" \
                       --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
-                      --container-name="api" \
-                      --container-name="consumer" \
-                      --container-name="errors-consumer" \
-                      --container-name="errors-replacer" \
-                      --container-name="events-subscriptions-executor" \
-                      --container-name="events-subscriptions-scheduler" \
-                      --container-name="generic-metrics-counters-consumer" \
-                      --container-name="generic-metrics-counters-subscriptions-executor" \
-                      --container-name="generic-metrics-counters-subscriptions-scheduler" \
-                      --container-name="generic-metrics-distributions-consumer" \
-                      --container-name="generic-metrics-distributions-subscriptions-executor" \
-                      --container-name="generic-metrics-distributions-subscriptions-scheduler" \
-                      --container-name="generic-metrics-sets-consumer" \
-                      --container-name="generic-metrics-sets-subscriptions-executor" \
-                      --container-name="generic-metrics-sets-subscriptions-scheduler" \
-                      --container-name="loadbalancer-outcomes-consumer" \
-                      --container-name="loadtest-errors-consumer" \
-                      --container-name="loadtest-loadbalancer-outcomes-consumer" \
-                      --container-name="loadtest-outcomes-consumer" \
-                      --container-name="loadtest-transactions-consumer" \
-                      --container-name="metrics-consumer" \
-                      --container-name="metrics-counters-subscriptions-scheduler" \
-                      --container-name="metrics-sets-subscriptions-scheduler" \
-                      --container-name="metrics-subscriptions-executor" \
-                      --container-name="outcomes-billing-consumer" \
-                      --container-name="outcomes-consumer" \
-                      --container-name="profiles-consumer" \
-                      --container-name="profiling-functions-consumer" \
-                      --container-name="querylog-consumer" \
-                      --container-name="replacer" \
-                      --container-name="replays-consumer" \
-                      --container-name="search-issues-consumer" \
-                      --container-name="snuba-admin" \
-                      --container-name="transactions-consumer-new" \
-                      --container-name="transactions-subscriptions-executor" \
-                      --container-name="transactions-subscriptions-scheduler" \
-                      --container-name="rust-querylog-consumer" \
-                      --container-name="spans-consumer" \
-                      --container-name="dlq-consumer" \
-                    && /devinfra/scripts/k8s/k8s-deploy.py \
-                      --label-selector="${LABEL_SELECTOR}" \
+                      --container-name="snuba"
+
+                    /devinfra/scripts/k8s/k8s-deploy.py \
+                      --label-selector="service=snuba" \
                       --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                       --type="cronjob" \
-                      --container-name="cleanup" \
-                      --container-name="optimize"
+                      --container-name="cleanup"
               timeout: 1200
       - migrate:
           fetch_materials: true
@@ -210,22 +228,35 @@ pipelines:
             migrate:
               elastic_profile_id: snuba
               environment_variables:
-                SNUBA_SERVICE_NAME: snuba-admin
+                SNUBA_SERVICE_NAME: snuba
               tasks:
                 - script: |
                     ##!/bin/bash
+
+                    ## At the time of writing (2023-06-28) the single tenant deployments
+                    ## have been using a different migration process compared to the
+                    ## US deployment of snuba.
+                    ## This script should be merged with migrate.sh if we can figure
+                    ## out a common migration script for all regions.
 
                     eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")
                     /devinfra/scripts/k8s/k8stunnel
 
                     /devinfra/scripts/k8s/k8s-spawn-job.py \
-                      --context="gke_${GCP_PROJECT}_${GKE_REGION}-${GKE_CLUSTER_ZONE}_${GKE_CLUSTER}" \
+                      --label-selector="service=${SNUBA_SERVICE_NAME}" \
+                      --container-name="${SNUBA_SERVICE_NAME}" \
+                      "snuba-bootstrap" \
+                      "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
+                      -- \
+                      snuba bootstrap --force --no-migrate
+
+                    /devinfra/scripts/k8s/k8s-spawn-job.py \
                       --label-selector="service=${SNUBA_SERVICE_NAME}" \
                       --container-name="${SNUBA_SERVICE_NAME}" \
                       "snuba-migrate" \
                       "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                       -- \
-                      snuba migrations migrate -r complete -r partial
+                      snuba migrations migrate --force
                 - plugin:
                     configuration:
                       id: script-executor

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.1.9"
+      "version": "v1.2.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "398935d57d495803fc5e677b6b8c4d012da33d41",
-      "sum": "Daqk+eHsSP/IttLc+PlG37AUysHMYZ3VKw1vX+16uO4="
+      "version": "09f7eb7034b4060ac24da3ac0a7424974a715ae2",
+      "sum": "MHRy0TLoc9hgIJMwdp6PoTN9+qmv5PkbTLbNcvLDH4Q="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This switches the name of monitor to s4s (just easier to understand for sentaurs).

The `customer-1` pipeline is the first customer pipeline being added, this should follow the same process as s4s.

NOTE: This uses a new helper to determine a ST deploy or not, this means naming changes like the monitor -> s4s change will be less error prone.

#skip-changelog
