### PR TITLE
feat: Group the validation warnings for each topic separately

### DIFF
--- a/snuba/consumers/schemas.py
+++ b/snuba/consumers/schemas.py
@@ -19,10 +19,10 @@ def _get_codec_impl(topic: Topic) -> Optional[Codec[Any]]:
         return sentry_kafka_schemas.get_codec(topic.value)
     except sentry_kafka_schemas.SchemaNotFound:
         return None
-    except Exception as err:
+    except Exception:
         with sentry_sdk.push_scope() as scope:
             scope.set_tag("snuba_logical_topic", topic.name)
-            logger.warning(err, exc_info=True)
+            logger.warning(f"Validation error - {topic.name}", exc_info=True)
         return None
 
 


### PR DESCRIPTION
One of the topics is known to have quite a bit of invalid data and is drowning out the rest. This makes it easier to assign fixing these errors for each topic separately as they are typically unrelated.
