### PR TITLE
feat(oncall): break down query execution metrics by table and referrer

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -330,7 +330,11 @@ def _format_storage_query_and_run(
         sentry_sdk.set_tag("query_size_group", get_query_size_group(query_size_bytes))
         metrics.increment(
             "execute",
-            tags={"table": table_names, "referrer": attribution_info.referrer},
+            tags={
+                "table": table_names,
+                "referrer": attribution_info.referrer,
+                "data": query_metadata.dataset,
+            },
         )
 
     timer.mark("prepare_query")

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -325,9 +325,13 @@ def _format_storage_query_and_run(
         span.set_data(
             "query", textwrap.wrap(formatted_sql, 100, break_long_words=False)
         )  # To avoid the query being truncated
+        span.set_data("table", table_names)
         span.set_data("query_size_bytes", query_size_bytes)
         sentry_sdk.set_tag("query_size_group", get_query_size_group(query_size_bytes))
-        metrics.increment("execute")
+        metrics.increment(
+            "execute",
+            tags={"table": table_names, "referrer": attribution_info.referrer},
+        )
 
     timer.mark("prepare_query")
 


### PR DESCRIPTION
This metric is not very useful atm because we don't really care how many queries we're executing in aggregate. We need to know which tables we're hitting and which referrer is doing it. Split up this metric by those dimensions