### PR TITLE
feat(prod-queries): Add button to view all allowed projects

### DIFF
--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -52,6 +52,7 @@ interface Client {
   getAuditlog: () => Promise<ConfigChange[]>;
   getClickhouseNodes: () => Promise<[ClickhouseNodeData]>;
   getSnubaDatasetNames: () => Promise<SnubaDatasetName[]>;
+  getAllowedProjects: () => Promise<string[]>;
   executeSnQLQuery: (query: SnQLRequest) => Promise<any>;
   debugSnQLQuery: (query: SnQLRequest) => Promise<SnQLResult>;
   getPredefinedQueryOptions: () => Promise<[PredefinedQuery]>;
@@ -185,6 +186,11 @@ function Client() {
 
     getSnubaDatasetNames: () => {
       const url = baseUrl + "snuba_datasets";
+      return fetch(url).then((resp) => resp.json());
+    },
+
+    getAllowedProjects: () => {
+      const url = baseUrl + "allowed_projects";
       return fetch(url).then((resp) => resp.json());
     },
 

--- a/snuba/admin/static/production_queries/index.tsx
+++ b/snuba/admin/static/production_queries/index.tsx
@@ -3,10 +3,21 @@ import Client from "../api_client";
 import { Table } from "../table";
 import { QueryResult, QueryResultColumnMeta, SnQLRequest } from "./types";
 import { executeActionsStyle, executeButtonStyle, selectStyle } from "./styles";
-import { Button, Loader, Select, Textarea } from "@mantine/core";
+import {
+  Box,
+  Button,
+  Collapse,
+  Group,
+  Loader,
+  Select,
+  Text,
+  Textarea,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 
 function ProductionQueries(props: { api: Client }) {
   const [datasets, setDatasets] = useState<string[]>([]);
+  const [allowedProjects, setAllowedProjects] = useState<string[]>([]);
   const [snql_query, setQuery] = useState<Partial<SnQLRequest>>({});
   const [queryResultHistory, setQueryResultHistory] = useState<QueryResult[]>(
     []
@@ -16,6 +27,12 @@ function ProductionQueries(props: { api: Client }) {
   useEffect(() => {
     props.api.getSnubaDatasetNames().then((res) => {
       setDatasets(res);
+    });
+  }, []);
+
+  useEffect(() => {
+    props.api.getAllowedProjects().then((res) => {
+      setAllowedProjects(res);
     });
   }, []);
 
@@ -73,7 +90,7 @@ function ProductionQueries(props: { api: Client }) {
     <div>
       <form>
         <h2>Run a SnQL Query</h2>
-        <p>Currently, we only support queries with project_id = 1</p>
+        <ProjectsList projects={allowedProjects} />
         <div>
           <Textarea
             value={snql_query.query || ""}
@@ -129,6 +146,22 @@ function ProductionQueries(props: { api: Client }) {
         )}
       </div>
     </div>
+  );
+}
+
+function ProjectsList(props: { projects: string[] }) {
+  const [opened, { toggle }] = useDisclosure(false);
+
+  return (
+    <Box mb="xs" mx="auto">
+      <Group position="left" mb={5}>
+        <Button onClick={toggle}>View Allowed Projects</Button>
+      </Group>
+
+      <Collapse in={opened}>
+        <Text>{props.projects.join(", ")}</Text>
+      </Collapse>
+    </Box>
   );
 }
 

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -993,3 +993,9 @@ def production_snql_query() -> Response:
             400,
             {"Content-Type": "application/json"},
         )
+
+
+@application.route("/allowed_projects", methods=["GET"])
+@check_tool_perms(tools=[AdminTools.PRODUCTION_QUERIES])
+def get_allowed_projects() -> Response:
+    return make_response(jsonify(settings.ADMIN_ALLOWED_PROD_PROJECTS), 200)


### PR DESCRIPTION
This adds the ability to view all allowed project ids.
![image](https://github.com/getsentry/snuba/assets/132949946/0afee6ae-c1d4-41be-87be-32cc8e255d83)
