### PR TITLE
Fix GoCD pipedream validation

### DIFF
--- a/.github/workflows/validate-pipelines.yml
+++ b/.github/workflows/validate-pipelines.yml
@@ -15,13 +15,14 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
-          - uses: getsentry/action-gocd-jsonnet@v0
+          - uses: getsentry/action-gocd-jsonnet@v1
             with:
               jb-install: true
               check-for-changes: true
               convert-to-yaml: true
               jsonnet-dir: gocd/templates
               generated-dir: gocd/generated-pipelines
+              render-as-single-file: false
 
     files-changed:
         name: files-changed
@@ -60,6 +61,13 @@ jobs:
                 token_format: 'id_token'
                 id_token_audience: '610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com'
                 id_token_include_email: true
+            - uses: getsentry/action-gocd-jsonnet@v1
+              with:
+                jb-install: true
+                convert-to-yaml: true
+                jsonnet-dir: gocd/templates
+                generated-dir: gocd/generated-pipelines
+                render-as-single-file: true
             - uses: getsentry/action-validate-gocd-pipelines@v1
               with:
                 configrepo: snuba__master

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,6 @@ gocd:
 	cd ./gocd/templates && jb install && jb update
 	find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnetfmt -i
 	find . -type f \( -name '*.libsonnet' -o -name '*.jsonnet' \) -print0 | xargs -n 1 -0 jsonnet-lint -J ./gocd/templates/vendor
-	cd ./gocd/templates && jsonnet -J vendor -m ../generated-pipelines ./snuba.jsonnet
+	cd ./gocd/templates && jsonnet --ext-code output-files=true -J vendor -m ../generated-pipelines ./snuba.jsonnet
 	cd ./gocd/generated-pipelines && find . -type f \( -name '*.yaml' \) -print0 | xargs -n 1 -0 yq -p json -o yaml -i
 .PHONY: gocd

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.2.3"
+      "version": "v1.3.1"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "7da062271f318ce8346eebe9d6c6390ea83db54b",
-      "sum": "DipfCjM31SzDxkoPHnwn9knAPdCB/J0Dqe3eD6nZ+Zg="
+      "version": "a4c5d3321eca6881815ca9ca2683f17a7601063e",
+      "sum": "UXZ2ItgRHoL09NLvg2mFBAtmTTdmRLMrTry2Nhlpx1g="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This change does the following:
- Update the gocd-jsonnet libs such that it supports output multiple files OR a single file. The single file will be used by the GoCD jsonnet plugin (the pipelines will be exactly the same in GoCD)
- Update the validation workflow to use the single file fixing the gocd validation action.

#skip-changelog