### PR TITLE
feat(async-queries): Add ability to override query settings for async queries

### DIFF
--- a/snuba/pipeline/settings_delegator.py
+++ b/snuba/pipeline/settings_delegator.py
@@ -77,3 +77,6 @@ class RateLimiterDelegate(QuerySettings):
 
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         return self.__delegate.set_clickhouse_settings(settings)
+
+    def get_asynchronous(self) -> bool:
+        return self.__delegate.get_asynchronous()

--- a/snuba/query/query_settings.py
+++ b/snuba/query/query_settings.py
@@ -60,6 +60,10 @@ class QuerySettings(ABC):
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         pass
 
+    @abstractmethod
+    def get_asynchronous(self) -> bool:
+        pass
+
 
 # TODO: I don't like that there are two different classes for the same thing
 # this could probably be replaces with a `source` attribute on the class
@@ -79,6 +83,7 @@ class HTTPQuerySettings(QuerySettings):
         # TODO: is this flag still relevant?
         legacy: bool = False,
         referrer: str = "unknown",
+        asynchronous: bool = False,
     ) -> None:
         super().__init__()
         self.__turbo = turbo
@@ -90,6 +95,7 @@ class HTTPQuerySettings(QuerySettings):
         self.__resource_quota: Optional[ResourceQuota] = None
         self.__clickhouse_settings: MutableMapping[str, Any] = {}
         self.referrer = referrer
+        self.__asynchronous = asynchronous
 
     def get_turbo(self) -> bool:
         return self.__turbo
@@ -123,6 +129,9 @@ class HTTPQuerySettings(QuerySettings):
 
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         self.__clickhouse_settings = settings
+
+    def get_asynchronous(self) -> bool:
+        return self.__asynchronous
 
 
 class SubscriptionQuerySettings(QuerySettings):
@@ -187,3 +196,6 @@ class SubscriptionQuerySettings(QuerySettings):
 
     def set_clickhouse_settings(self, settings: MutableMapping[str, Any]) -> None:
         self.__clickhouse_settings = settings
+
+    def get_asynchronous(self) -> bool:
+        return False

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -540,15 +540,15 @@ def _get_query_settings_from_config(
         if k.startswith("query_settings/")
     }
 
-    if override_prefix:
-        for k, v in all_confs.items():
-            if k.startswith(f"{override_prefix}/query_settings/"):
-                clickhouse_query_settings[k.split("/", 2)[2]] = v
-
     if async_override:
         for k, v in all_confs.items():
             if k.startswith("async_query_settings/"):
                 clickhouse_query_settings[k.split("/", 1)[1]] = v
+
+    if override_prefix:
+        for k, v in all_confs.items():
+            if k.startswith(f"{override_prefix}/query_settings/"):
+                clickhouse_query_settings[k.split("/", 2)[2]] = v
 
     return clickhouse_query_settings
 

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -521,6 +521,7 @@ def _get_cache_wait_timeout(
 
 def _get_query_settings_from_config(
     override_prefix: Optional[str],
+    async_override: bool,
 ) -> MutableMapping[str, Any]:
     """
     Helper function to get the query settings from the config.
@@ -543,6 +544,11 @@ def _get_query_settings_from_config(
         for k, v in all_confs.items():
             if k.startswith(f"{override_prefix}/query_settings/"):
                 clickhouse_query_settings[k.split("/", 2)[2]] = v
+
+    if async_override:
+        for k, v in all_confs.items():
+            if k.startswith("async_query_settings/"):
+                clickhouse_query_settings[k.split("/", 1)[1]] = v
 
     return clickhouse_query_settings
 
@@ -567,7 +573,7 @@ def _raw_query(
     QueryException that  the rest of the stack depends on. See the `db_query` docstring for more details
     """
     clickhouse_query_settings = _get_query_settings_from_config(
-        reader.get_query_settings_prefix()
+        reader.get_query_settings_prefix(), query_settings.get_asynchronous()
     )
 
     timer.mark("get_configs")

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -130,7 +130,7 @@ test_data = [
 ]
 
 
-@pytest.mark.parametrize("query_config,expected,query_prefix", test_data)
+@pytest.mark.parametrize("query_config,expected,query_prefix,async_override", test_data)
 @pytest.mark.redis_db
 def test_query_settings_from_config(
     query_config: Mapping[str, Any],

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -48,6 +48,7 @@ test_data = [
             "merge_tree_max_rows_to_use_cache": 50000,
         },
         None,
+        False,
         id="no override when query settings prefix empty",
     ),
     pytest.param(
@@ -62,6 +63,7 @@ test_data = [
             "merge_tree_max_rows_to_use_cache": 50000,
         },
         "other-query-prefix",
+        False,
         id="no override for different query prefix",
     ),
     pytest.param(
@@ -76,7 +78,54 @@ test_data = [
             "merge_tree_max_rows_to_use_cache": 100000,
         },
         "some-query-prefix",
+        False,
         id="override for same query prefix",
+    ),
+    pytest.param(
+        {
+            "query_settings/max_threads": 10,
+            "query_settings/merge_tree_max_rows_to_use_cache": 50000,
+            "some-query-prefix/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/merge_tree_max_rows_to_use_cache": 100000,
+        },
+        {
+            "max_threads": 10,
+            "merge_tree_max_rows_to_use_cache": 50000,
+        },
+        None,
+        True,
+        id="no override when no async settings",
+    ),
+    pytest.param(
+        {
+            "query_settings/max_threads": 10,
+            "query_settings/merge_tree_max_rows_to_use_cache": 50000,
+            "some-query-prefix/query_settings/merge_tree_max_rows_to_use_cache": 100000,
+            "async_query_settings/max_threads": 20,
+        },
+        {
+            "max_threads": 20,
+            "merge_tree_max_rows_to_use_cache": 50000,
+        },
+        "other-query-prefix",
+        True,
+        id="override for async settings with no prefix override",
+    ),
+    pytest.param(
+        {
+            "query_settings/max_threads": 10,
+            "query_settings/merge_tree_max_rows_to_use_cache": 50000,
+            "some-query-prefix/query_settings/max_threads": 5,
+            "some-query-prefix/query_settings/merge_tree_max_rows_to_use_cache": 100000,
+            "async_query_settings/max_threads": 20,
+        },
+        {
+            "max_threads": 5,
+            "merge_tree_max_rows_to_use_cache": 100000,
+        },
+        "some-query-prefix",
+        True,
+        id="no override for async settings with prefix override",
     ),
 ]
 
@@ -87,10 +136,11 @@ def test_query_settings_from_config(
     query_config: Mapping[str, Any],
     expected: MutableMapping[str, Any],
     query_prefix: Optional[str],
+    async_override: bool,
 ) -> None:
     for k, v in query_config.items():
         state.set_config(k, v)
-    assert _get_query_settings_from_config(query_prefix) == expected
+    assert _get_query_settings_from_config(query_prefix, async_override) == expected
 
 
 test_thread_quota_data = [


### PR DESCRIPTION
Adding the ability to override query settings using the `async_query_settings/` prefix in runtime config. These async query settings take priority over regular query settings, but cluster specific query settings take priority over async query settings.