### PR TITLE
fix(capman): Bake in `is_enforced` behavior into every allocation policy

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -721,6 +721,8 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
                     "max_threads": str(allowance.max_threads),
                 },
             )
+        if not self.is_enforced:
+            return DEFAULT_PASSTHROUGH_POLICY.get_quota_allowance(tenant_ids, query_id)
         return allowance
 
     @abstractmethod

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -130,12 +130,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
     ) -> QuotaAllowance:
         ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
         if not ids_are_valid:
-            self.metrics.increment(
-                "db_request_rejected",
-                tags={
-                    "referrer": str(tenant_ids.get("referrer", "no_referrer")),
-                },
-            )
             if self.is_enforced:
                 return QuotaAllowance(
                     can_run=False, max_threads=0, explanation={"reason": why}
@@ -177,12 +171,6 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             explanation: dict[str, Any] = {}
             granted_quota = granted_quotas[0]
             if granted_quota.granted <= 0:
-                self.metrics.increment(
-                    "db_request_throttled",
-                    tags={
-                        "referrer": str(tenant_ids.get("referrer", "no_referrer")),
-                    },
-                )
                 explanation[
                     "reason"
                 ] = f"organization {org_id} is over the bytes scanned limit of {org_limit_bytes_scanned}"


### PR DESCRIPTION
It turns out that allocation policies don't have `is_enforced` built in to them like I thought. This is especially bad because the UI makes it look like it is. Fix the bug and also make the metrics which the `BytesScannedWindowAllocationPolicy` outputs be outputted by default