### PR TITLE
feat(capman): pass through subscriptions for new concurrent rate limiter

### DIFF
--- a/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
+++ b/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
@@ -148,7 +148,11 @@ def test_tenant_selection(policy):
 
 def test_pass_through(policy: ConcurrentRateLimitAllocationPolicy) -> None:
     ## should not be blocked because the subscriptions_executor referrer is not rate limited
-    for i in range(MAX_CONCURRENT_QUERIES * 2):
-        policy.get_quota_allowance(
-            tenant_ids={"referrer": "subscriptions_executor"}, query_id=f"abc{i}"
-        )
+    try:
+        for i in range(MAX_CONCURRENT_QUERIES * 2):
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "subscriptions_executor", "project_id": 1234},
+                query_id=f"abc{i}",
+            )
+    except AllocationPolicyViolation:
+        pytest.fail("should not have been blocked")

--- a/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
+++ b/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
@@ -144,3 +144,11 @@ def test_tenant_selection(policy):
     )
     with pytest.raises(AllocationPolicyViolation):
         policy._get_tenant_key_and_value({})
+
+
+def test_pass_through(policy: ConcurrentRateLimitAllocationPolicy) -> None:
+    ## should not be blocked because the subscriptions_executor referrer is not rate limited
+    for i in range(MAX_CONCURRENT_QUERIES * 2):
+        policy.get_quota_allowance(
+            tenant_ids={"referrer": "subscriptions_executor"}, query_id=f"abc{i}"
+        )


### PR DESCRIPTION
Our current policy is to not rate limit subscriptions, this puts that policy in code