### PR TITLE
feat(group_attributes): bump readiness for the storage so it can be queried 

### DIFF
--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -6,7 +6,7 @@ storage:
   key: group_attributes
   set_key: group_attributes
 
-readiness_state: limited
+readiness_state: partial
 
 schema:
   columns:


### PR DESCRIPTION
Did some verification in SaaS and as far as I can tell everything seems to be looking good. All the infra appears to be working as expected so we should bump this readiness up appropriately
<img width="404" alt="Screenshot 2023-08-03 at 3 56 53 PM" src="https://github.com/getsentry/snuba/assets/101606877/d9639012-925e-47cf-ad66-c9ff0336f4ef">

