### PR TITLE
Remove the test regions from rollbacks

### DIFF
--- a/gocd/generated-pipelines/rollback-snuba.yaml
+++ b/gocd/generated-pipelines/rollback-snuba.yaml
@@ -3,9 +3,9 @@ pipelines:
   rollback-snuba:
     display_order: 1
     environment_variables:
-      ALL_PIPELINE_FLAGS: --pipeline=deploy-snuba-s4s --pipeline=deploy-snuba-us --pipeline=deploy-snuba-customer-1 --pipeline=deploy-snuba-customer-2 --pipeline=deploy-snuba-customer-3 --pipeline=deploy-snuba-customer-4 --pipeline=deploy-snuba-customer-5 --pipeline=deploy-snuba-customer-6 --pipeline=deploy-snuba
+      ALL_PIPELINE_FLAGS: --pipeline=deploy-snuba-s4s --pipeline=deploy-snuba-us --pipeline=deploy-snuba-customer-1 --pipeline=deploy-snuba-customer-2 --pipeline=deploy-snuba-customer-3 --pipeline=deploy-snuba-customer-4 --pipeline=deploy-snuba
       GOCD_ACCESS_TOKEN: '{{SECRET:[devinfra][gocd_access_token]}}'
-      REGION_PIPELINE_FLAGS: --pipeline=deploy-snuba-s4s --pipeline=deploy-snuba-us --pipeline=deploy-snuba-customer-1 --pipeline=deploy-snuba-customer-2 --pipeline=deploy-snuba-customer-3 --pipeline=deploy-snuba-customer-4 --pipeline=deploy-snuba-customer-5 --pipeline=deploy-snuba-customer-6
+      REGION_PIPELINE_FLAGS: --pipeline=deploy-snuba-s4s --pipeline=deploy-snuba-us --pipeline=deploy-snuba-customer-1 --pipeline=deploy-snuba-customer-2 --pipeline=deploy-snuba-customer-3 --pipeline=deploy-snuba-customer-4
       ROLLBACK_MATERIAL_NAME: snuba_repo
       ROLLBACK_STAGE: deploy-primary
     group: snuba

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.4.1"
+      "version": "v1.4.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "f3a6151e1b83f3fad9bfa25f06c95af77104630f",
-      "sum": "6A5JFwhCTvywB8JvE2uFWV2VG0K9LrO3DPkjH4fAgP0="
+      "version": "a4d0a7bedf0dc3cce9a28a85e95b736b139a7d4e",
+      "sum": "iSfWUcTtYZpJ4WEgQAqjD7I/Vi2UFpF0CXvtSIhqMXY="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This is needed since pipedream rollbacks expect all pipelines to be on the same SHA, which may not be true for test regions