### PR TITLE
feat(replays): Add encodings to numeric columns

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -172,6 +172,7 @@ class ReplaysLoader(DirectoryLoader):
             "0009_add_dom_index_columns",
             "0010_add_nullable_columns",
             "0011_add_is_dead_rage",
+            "0014_add_numeric_encodings",
         ]
 
 

--- a/snuba/snuba_migrations/replays/0014_add_numeric_encodings.py
+++ b/snuba/snuba_migrations/replays/0014_add_numeric_encodings.py
@@ -1,6 +1,6 @@
 from typing import Iterator, List, Sequence
 
-from snuba.clickhouse.columns import Column, DateTime, Float, UInt
+from snuba.clickhouse.columns import Column, Float, UInt
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, operations
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -59,5 +59,4 @@ columns: List[Column[Modifiers]] = [
     Column("project_id", UInt(64, Modifiers(codecs=["DoubleDelta", "LZ4"]))),
     Column("segment_id", UInt(64, Modifiers(codecs=["T64", "LZ4"]))),
     Column("session_sample_rate", Float(64, Modifiers(codecs=["Gorilla", "LZ4"]))),
-    Column("timestamp", DateTime(Modifiers(codecs=["DoubleDelta", "LZ4"]))),
 ]

--- a/snuba/snuba_migrations/replays/0014_add_numeric_encodings.py
+++ b/snuba/snuba_migrations/replays/0014_add_numeric_encodings.py
@@ -1,0 +1,63 @@
+from typing import Iterator, List, Sequence
+
+from snuba.clickhouse.columns import Column, DateTime, Float, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(forward_columns_iter())
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return list(backward_columns_iter())
+
+
+def forward_columns_iter() -> Iterator[operations.ModifyColumn]:
+    for column in columns:
+        yield operations.ModifyColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_local",
+            column=column,
+            target=operations.OperationTarget.LOCAL,
+        )
+
+        yield operations.ModifyColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_dist",
+            column=column,
+            target=operations.OperationTarget.DISTRIBUTED,
+        )
+
+
+def backward_columns_iter() -> Iterator[operations.SqlOperation]:
+    for column in columns:
+        yield operations.ModifyColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_dist",
+            column=column,
+            target=operations.OperationTarget.DISTRIBUTED,
+        )
+
+        yield operations.ModifyColumn(
+            storage_set=StorageSetKey.REPLAYS,
+            table_name="replays_local",
+            column=column,
+            target=operations.OperationTarget.LOCAL,
+        )
+
+
+columns: List[Column[Modifiers]] = [
+    Column("click_is_dead", UInt(8, Modifiers(codecs=["Delta", "LZ4"]))),
+    Column("click_is_rage", UInt(8, Modifiers(codecs=["Delta", "LZ4"]))),
+    Column("error_sample_rate", Float(64, Modifiers(codecs=["Gorilla", "LZ4"]))),
+    Column("is_archived", UInt(8, Modifiers(codecs=["Delta", "LZ4"]))),
+    Column("offset", UInt(8, Modifiers(codecs=["DoubleDelta", "LZ4"]))),
+    Column("project_id", UInt(64, Modifiers(codecs=["DoubleDelta", "LZ4"]))),
+    Column("segment_id", UInt(64, Modifiers(codecs=["Delta", "LZ4"]))),
+    Column("session_sample_rate", Float(64, Modifiers(codecs=["Gorilla", "LZ4"]))),
+    Column("timestamp", DateTime(Modifiers(codecs=["DoubleDelta", "LZ4"]))),
+]

--- a/snuba/snuba_migrations/replays/0014_add_numeric_encodings.py
+++ b/snuba/snuba_migrations/replays/0014_add_numeric_encodings.py
@@ -57,7 +57,7 @@ columns: List[Column[Modifiers]] = [
     Column("is_archived", UInt(8, Modifiers(codecs=["Delta", "LZ4"]))),
     Column("offset", UInt(8, Modifiers(codecs=["DoubleDelta", "LZ4"]))),
     Column("project_id", UInt(64, Modifiers(codecs=["DoubleDelta", "LZ4"]))),
-    Column("segment_id", UInt(64, Modifiers(codecs=["Delta", "LZ4"]))),
+    Column("segment_id", UInt(64, Modifiers(codecs=["T64", "LZ4"]))),
     Column("session_sample_rate", Float(64, Modifiers(codecs=["Gorilla", "LZ4"]))),
     Column("timestamp", DateTime(Modifiers(codecs=["DoubleDelta", "LZ4"]))),
 ]


### PR DESCRIPTION
Edit: tests fail because storages/replays.yaml.  If I update it the `ddl-changes / Post new DDL changes from migrations (pull_request)` check will fail.

All values are LZ4 compressed rather than ZSTD.  ZSTD has better compression but I know its slightly slower.  I wasn't sure how to measure the impact of (de-)compression so I opted for LZ4 which compressed plenty for our needs.  Feel free to challenge this assumption.

Integer Delta Encoding:

Values in this category are almost always the same value (e.g. 0).  From testing delta encoding offers the best performance.

- `click_is_dead`
- `click_is_rage`
- `is_archived`

Integer Double Delta Encoding:

Values in this category increment but not predictably.  Double Delta encoding provided the best compression.

- `project_id` almost always the same value as the previous value.
- `offset` almost always the same value as the previous value.
- `timestamp` almost always the same value as the previous value.

Integer T64 Encoding:

Though segment_id is monotonically increasing for a replay_id, on disk the value is essentially random within the bounds of 0 to 720 with most not exceeding ~20.  Compression here is just okay.  Roughly 3x.

- `segment_id`

Float Gorilla Encoding:

These values rarely change (if at all). Gorilla offers very good compression for static floats.

- `error_sample_rate`
- `session_sample_rate`
