### PR TITLE
fix(capman): rate limit overrides should not collide

### DIFF
--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Callable, cast
 
 from snuba.query.allocation_policies import (
     AllocationPolicy,
@@ -180,7 +181,7 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
         concurrent_limit = self.get_config_value("concurrent_limit")
         if overrides:
             concurrent_limit = min(overrides.values())
-            tenant_value = min(overrides, key=overrides.get)  # type: ignore
+            tenant_value = min(overrides, key=cast(Callable[[str], int], overrides.get))
 
         return (
             RateLimitParameters(

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -173,7 +173,7 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
         )
 
     def _get_rate_limit_params(
-        self, tenant_ids
+        self, tenant_ids: dict[str, str | int]
     ) -> tuple[RateLimitParameters, dict[str, int]]:
         tenant_key, tenant_value = self._get_tenant_key_and_value(tenant_ids)
         overrides = self._get_overrides(tenant_ids)


### PR DESCRIPTION
### Context

With the existing override implementation, the rate limit key was never differentiated which would make overrides:

1. Not work for increasing limits
2. Eat away from the default

Example:
Let's say we have a `referrer_project_override` for `project_id=1` and `referrer=statistical_detectors`, any query hitting the `statistical_detectors` referrer would eat away at the concurrent limit from all other referrers and vice versa. While this is not explicitly "bad", it's confusing behavior.

### What this PR Does

Makes it so any overriden tenants consume from their own bucket, avoiding collisions.


### Blast radius

This policy is not enforced anywhere yet so now is a good time to approve this
