### PR TITLE
feat(spans): Add migration to fill nodestore version column

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -330,6 +330,7 @@ class SpansLoader(DirectoryLoader):
             "0002_spans_add_tags_hashmap",
             "0003_spans_add_ms_columns",
             "0004_spans_group_raw_col",
+            "0005_spans_nodestore_version",
         ]
 
 

--- a/snuba/snuba_migrations/spans/0005_spans_nodestore_version.py
+++ b/snuba/snuba_migrations/spans/0005_spans_nodestore_version.py
@@ -1,0 +1,57 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds group_raw column to store the hash of the raw description.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "nodestore_version",
+                    UInt(8, modifiers=MigrationModifiers(codecs=["Delta"])),
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "nodestore_version",
+                    UInt(8, modifiers=MigrationModifiers(codecs=["Delta"])),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="nodestore_version",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="nodestore_version",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
We are trying a new scheme for storing span contexts in nodestore. As such we do not know whether it would cause problems or not. So we need to have schema version used when storing contexts in nodestore to link things correctly. Added a migration to add nodestore_column in the spans schema. Added a Delta encoding since most times we would only have 1 value in the column.