### PR TITLE
fix(oncall): Query execution dataset metric tag

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -333,7 +333,7 @@ def _format_storage_query_and_run(
             tags={
                 "table": table_names,
                 "referrer": attribution_info.referrer,
-                "data": query_metadata.dataset,
+                "dataset": query_metadata.dataset,
             },
         )
 


### PR DESCRIPTION
This tag isn't [visible](https://app.datadoghq.com/metric/explorer?start=1691596522370&end=1691600122370&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyBoieABGGAB0GPIQjXDEcJkEcMAAVDzNGk6Z+CIIABQAlCA8ALpUru54mKHhS6orGDGl8bMLIBpyaDmg8hgnCAg5STgwI6saEJmJaKJwTnKK5ThvUK-vJz0JjKERuDxoWb8CD2TBYT4KG5vERKeY8PiHeRvBAAYSkwhgKFqaDQPCAA), try hitting `sum by`, I only see referrer and table. Maybe `data` is a ddog key word, we use `dataset` in other metric tags usually.