### PR TITLE
ref(attribution): Stop writing to attribution consumer

### DIFF
--- a/snuba/cli/api.py
+++ b/snuba/cli/api.py
@@ -3,7 +3,6 @@ from typing import Optional, Union
 
 import click
 
-from snuba.attribution.log import flush_attribution_producer
 from snuba.environment import setup_logging
 from snuba.utils import uwsgi
 
@@ -50,10 +49,9 @@ def api(
         if log_level:
             os.environ["LOG_LEVEL"] = log_level
 
-        with flush_attribution_producer():
-            uwsgi.run(
-                "snuba.web.wsgi:application",
-                f"{host}:{port}",
-                processes=processes,
-                threads=threads,
-            )
+        uwsgi.run(
+            "snuba.web.wsgi:application",
+            f"{host}:{port}",
+            processes=processes,
+            threads=threads,
+        )

--- a/snuba/cli/subscriptions_executor.py
+++ b/snuba/cli/subscriptions_executor.py
@@ -8,7 +8,6 @@ from arroyo import configure_metrics
 from arroyo.backends.kafka import KafkaProducer
 
 from snuba import environment, state
-from snuba.attribution.log import flush_attribution_producer
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_enabled_dataset_names
@@ -165,7 +164,7 @@ def subscriptions_executor(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with closing(producer), flush_querylog(), flush_attribution_producer():
+    with closing(producer), flush_querylog():
         processor.run()
 
 

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -8,7 +8,6 @@ from arroyo import configure_metrics
 from arroyo.backends.kafka import KafkaProducer
 
 from snuba import environment, state
-from snuba.attribution.log import flush_attribution_producer
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_enabled_dataset_names
@@ -153,7 +152,7 @@ def subscriptions_scheduler_executor(
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with closing(producer), flush_querylog(), flush_attribution_producer():
+    with closing(producer), flush_querylog():
         processor.run()
 
 


### PR DESCRIPTION
This consumer is not being used by anyone, and is mostly obsolete due to
COGS/CapMan. There's no point keeping it running since it's just one more thing
to support.

Plan to remove:

[ ] Stop writing to the log (this PR)
[ ] Remove deployments of consumers (separate PRs)
[ ] Remove attribution code