### PR TITLE
fix(Cache): Cache fail open on ValueError

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -300,7 +300,7 @@ class RedisCache(Cache[TValue]):
             return self.__get_readthrough(
                 key, function, record_cache_hit_type, timeout, timer
             )
-        except (ConnectionError, ReadOnlyError, RedisTimeoutError):
+        except (ConnectionError, ReadOnlyError, RedisTimeoutError, ValueError):
             if settings.RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES:
                 raise
             metrics.increment("snuba.read_through_cache.fail_open")


### PR DESCRIPTION
Redis Cache fail open was already done here:
#4449 

Updated it to include `ValueError` which is thrown by the ResultCacheCodec upon decoding a value it cannot read. This was the main [error](https://sentry.sentry.io/issues/4360761362/?end=2023-08-02T06%3A59%3A59&project=300688&query=ValueError&referrer=issue-stream&start=2023-08-01T07%3A00%3A00&stream_index=0) rejecting queries in INC-474.