### PR TITLE
feat(cache): Avoid Caching certain Referrers

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -270,6 +270,9 @@ RAISE_ON_ALLOCATION_POLICY_FAILURES = False
 # the request will still be able to go through as if the cache did not exist
 RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES = False
 
+# List of referrers not to look in or cache results for. Queries with these referrers generally
+# require live and up to date data, so caching should be avoided entirely.
+AVOID_CACHE_REFERRERS = ["subscriptions_executor"]
 
 # (logical topic name, # of partitions)
 TOPIC_PARTITION_COUNTS: Mapping[str, int] = {}

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -23,7 +23,7 @@ from clickhouse_driver.errors import ErrorCodes
 from sentry_sdk import Hub
 from sentry_sdk.api import configure_scope
 
-from snuba import environment, state
+from snuba import environment, settings, state
 from snuba.attribution.attribution_info import AttributionInfo
 from snuba.clickhouse.errors import ClickhouseError
 from snuba.clickhouse.formatter.nodes import FormattedQuery
@@ -398,7 +398,9 @@ def execute_query_with_readthrough_caching(
         if span:
             span.set_data("cache_status", span_tag)
 
-    if referrer in (state.get_config("avoid_cache_referrers") or "[]")[1:-1].split(","):
+    if referrer in settings.AVOID_CACHE_REFERRERS and state.get_config(
+        "enable_avoid_cache_referrers"
+    ):
         clickhouse_query_settings["query_id"] = f"randomized-{uuid.uuid4().hex}"
         return execute_query_with_rate_limits(
             clickhouse_query,


### PR DESCRIPTION
### Overview
- Currently ~1% of all `subscriptions_executor` queries are handled by the cache
    - In general, `subscriptions_executor` queries shouldn't be served by the cache as they should get live and up to date data from ClickHouse to make accurate alerting decisions
- `subscriptions_executor` queries make up the highest percentage of all queries handled by Snuba
    - This also means ~99% of these are cached but the cached data will never be useful, taking up Redis space/network for no reason

We need a way to avoid the cache by referrer for this case and potentially more cases in future that require live uncached data.

### Changes
- Introduced a `AVOID_CACHE_REFERRERS` setting, which is currently a list containing one referrer `subscriptions_executor`
- Introduced a runtime config `enable_avoid_cache_referrers` which can be used to enable/disable the logic
