### PR TITLE
feat(cache): More generalized cache fail-open

### DIFF
--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional
 
 from pkg_resources import resource_string
 
-from redis.exceptions import RedisError, ResponseError
+from redis.exceptions import ResponseError
 from snuba import environment, settings
 from snuba.redis import RedisClientType
 from snuba.state import get_config
@@ -315,7 +315,7 @@ class RedisCache(Cache[TValue]):
             # Not a Redis Cache Error -> bubble up
             assert e.__cause__ is not None
             raise e.__cause__
-        except (RedisError, ValueError):
+        except Exception:
             # A Redis Cache Error -> run value generation directly
             if settings.RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES:
                 raise

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -320,4 +320,5 @@ class RedisCache(Cache[TValue]):
             if settings.RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES:
                 raise
             metrics.increment("snuba.read_through_cache.fail_open")
+            logger.warning("Redis readthrough cache failed open", exc_info=True)
             return value_generation_function()

--- a/snuba/state/cache/redis/backend.py
+++ b/snuba/state/cache/redis/backend.py
@@ -6,8 +6,7 @@ from typing import Callable, Optional
 
 from pkg_resources import resource_string
 
-from redis.exceptions import ConnectionError, ReadOnlyError, ResponseError
-from redis.exceptions import TimeoutError as RedisTimeoutError
+from redis.exceptions import RedisError, ResponseError
 from snuba import environment, settings
 from snuba.redis import RedisClientType
 from snuba.state import get_config
@@ -29,6 +28,16 @@ metrics = MetricsWrapper(environment.metrics, "read_through_cache")
 RESULT_VALUE = 0
 RESULT_EXECUTE = 1
 RESULT_WAIT = 2
+
+
+class ValueGenerationError(Exception):
+    """
+    Any exception raised by the attempt to execute the value generation function
+    should be wrapped by this exception. This makes it easy to distinguish between
+    Redis and value generation function errors.
+    """
+
+    pass
 
 
 class RedisCache(Cache[TValue]):
@@ -77,7 +86,7 @@ class RedisCache(Cache[TValue]):
     def __get_readthrough(
         self,
         key: str,
-        function: Callable[[], TValue],
+        value_generation_function: Callable[[], TValue],
         record_cache_hit_type: Callable[[int], None],
         timeout: int,
         timer: Optional[Timer] = None,
@@ -169,7 +178,9 @@ class RedisCache(Cache[TValue]):
             try:
                 # The task is run in a thread pool so that we can return
                 # control to the caller once the timeout is reached.
-                value = self.__executor.submit(function).result(task_timeout)
+                value = self.__executor.submit(value_generation_function).result(
+                    task_timeout
+                )
                 argv.extend(
                     [self.__codec.encode(value), get_config("cache_expiry_sec", 1)]
                 )
@@ -191,7 +202,7 @@ class RedisCache(Cache[TValue]):
                 # we want the result key to only store real query results in it as the TTL
                 # of a cached query can be fairly long (minutes).
                 redis_key_to_write_to = error_key
-                raise e
+                raise ValueGenerationError() from e
             finally:
                 # Regardless of whether the function succeeded or failed, we
                 # need to mark the task as completed. If there is no result
@@ -286,7 +297,7 @@ class RedisCache(Cache[TValue]):
     def get_readthrough(
         self,
         key: str,
-        function: Callable[[], TValue],
+        value_generation_function: Callable[[], TValue],
         record_cache_hit_type: Callable[[int], None],
         timeout: int,
         timer: Optional[Timer] = None,
@@ -294,14 +305,19 @@ class RedisCache(Cache[TValue]):
         # in case something is wrong with redis, we want to be able to
         # disable the read_through_cache but still serve traffic.
         if get_config("read_through_cache.short_circuit", 0):
-            return function()
+            return value_generation_function()
 
         try:
             return self.__get_readthrough(
-                key, function, record_cache_hit_type, timeout, timer
+                key, value_generation_function, record_cache_hit_type, timeout, timer
             )
-        except (ConnectionError, ReadOnlyError, RedisTimeoutError, ValueError):
+        except ValueGenerationError as e:
+            # Not a Redis Cache Error -> bubble up
+            assert e.__cause__ is not None
+            raise e.__cause__
+        except (RedisError, ValueError):
+            # A Redis Cache Error -> run value generation directly
             if settings.RAISE_ON_READTHROUGH_CACHE_REDIS_FAILURES:
                 raise
             metrics.increment("snuba.read_through_cache.fail_open")
-            return function()
+            return value_generation_function()


### PR DESCRIPTION
### Overview
- Currently, the Redis Cache fails open on a select few Exceptions
- Differentiating between a redis failure vs clickhouse failure isn't really established in the fail-open logic
- This PR adds a way to identify errors raised by the value generation function execution step within the readthrough cache, since those are the only errors should actually fail the query
    - Any exception raised during value gen function is wrapped with `ValueGenerationError` which is then later caught and the original exception is raised
- All other errors fail open, ie executes the value generation function which routes the query to ClickHouse instead
    - Previously only a metric `snuba.read_through_cache.fail_open` was incremented upon cache fail-opens
    - Now a warning is also logged with the exception stack attached to diagnose why the cache failed
