### PR TITLE
migration(spans): add sentry tags cols

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -332,6 +332,7 @@ class SpansLoader(DirectoryLoader):
             "0002_spans_add_tags_hashmap",
             "0003_spans_add_ms_columns",
             "0004_spans_group_raw_col",
+            "0005_spans_add_sentry_tags",
         ]
 
 

--- a/snuba/snuba_migrations/spans/0005_spans_add_sentry_tags.py
+++ b/snuba/snuba_migrations/spans/0005_spans_add_sentry_tags.py
@@ -1,0 +1,113 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Array, Column, Nested, String, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+storage_set_name = StorageSetKey.SPANS
+local_table_name = "spans_local"
+dist_table_name = "spans_dist"
+
+
+SENTRY_TAGS_HASH_MAP_COLUMN = (
+    "arrayMap((k, v) -> cityHash64(concat("
+    "replaceRegexpAll(k, '(\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'), '=', v)), "
+    "sentry_tags.key, sentry_tags.value)"
+)
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    """
+    Adds the sentry tags and a sentry tags hash map column defined as Array(Int64)
+    Materialized with SENTRY_TAGS_HASH_MAP_COLUMN expression.
+    This allows us to quickly find tag key-value pairs since we can
+    add an index on this column.
+    """
+
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            # sentry_tags columns
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "sentry_tags", Nested([("key", String()), ("value", String())])
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "sentry_tags", Nested([("key", String()), ("value", String())])
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            # sentry_tags_hash_map columns
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column=Column(
+                    "_sentry_tags_hash_map",
+                    Array(
+                        UInt(64), Modifiers(materialized=SENTRY_TAGS_HASH_MAP_COLUMN)
+                    ),
+                ),
+                target=OperationTarget.LOCAL,
+            ),
+            operations.AddColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column=Column(
+                    "_sentry_tags_hash_map",
+                    Array(
+                        UInt(64), Modifiers(materialized=SENTRY_TAGS_HASH_MAP_COLUMN)
+                    ),
+                ),
+                target=OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="_sentry_tags_hash_map",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="sentry_tags.key",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=dist_table_name,
+                column_name="sentry_tags.value",
+                target=OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="_sentry_tags_hash_map",
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="sentry_tags.key",
+                target=OperationTarget.LOCAL,
+            ),
+            operations.DropColumn(
+                storage_set=storage_set_name,
+                table_name=local_table_name,
+                column_name="sentry_tags.value",
+                target=OperationTarget.LOCAL,
+            ),
+        ]


### PR DESCRIPTION
Adds a migration to add the `sentry_tags` , and `_sentry_tags_hash_map`  hash map,  columns to the spans tables. These columns are identical to `tags` but are used for storing sentry extracted tags. We do this to keep the user tags separate from the sentry tags.