### PR TITLE
feat(ci): Test Clickhouse 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,3 +375,51 @@ jobs:
           docker_repo: getsentry/snuba
           image_url: us.gcr.io/sentryio/snuba:${{ github.event.pull_request.head.sha || github.sha }}
           docker_password: ${{ secrets.DOCKER_HUB_RW_TOKEN }}
+
+  clickhouse-21:
+    needs: [linting, snuba-image]
+    name: Tests on Clickhouse 21
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout code
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Pull snuba CI images
+        run: |
+          set +e # skip missing images
+          docker pull ghcr.io/getsentry/snuba-ci:${{ github.sha }} ; \
+            docker pull ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }} ; \
+            docker pull ghcr.io/getsentry/snuba-ci:latest || true
+          set -e
+
+      - name: Build snuba docker image for CI
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          tags: snuba-test
+          load: true
+          build-args: |
+            SHOULD_BUILD_RUST=false
+          target: testing
+          cache-from: |
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ github.sha }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:${{ needs.snuba-image.outputs.branch }}
+            type=registry,ref=ghcr.io/getsentry/snuba-ci:latest
+
+      - name: Docker set up
+        run: |
+          docker network create --attachable cloudbuild
+
+      - name: Docker Snuba Test Clickhouse 21
+        run: |
+          export CLICKHOUSE_IMAGE=altinity/clickhouse-server:21.8.13.1.altinitystable
+          SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test docker-compose -f docker-compose.gcb.yml run --rm snuba-test
+
+      - name: Upload to codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -66,7 +66,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
       KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
   clickhouse:
-    image: "yandex/clickhouse-server:20.3.9.70"
+    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
     volumes:
       - ./config/clickhouse/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
@@ -80,7 +80,7 @@ services:
   clickhouse-query:
     depends_on:
       - zookeeper
-    image: "yandex/clickhouse-server:20.3.9.70"
+    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
@@ -92,7 +92,7 @@ services:
   clickhouse-01:
     depends_on:
       - zookeeper
-    image: "yandex/clickhouse-server:20.3.9.70"
+    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-01.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -105,7 +105,7 @@ services:
   clickhouse-02:
     depends_on:
       - zookeeper
-    image: "yandex/clickhouse-server:20.3.9.70"
+    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-02.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -118,7 +118,7 @@ services:
   clickhouse-03:
     depends_on:
       - zookeeper
-    image: "yandex/clickhouse-server:20.3.9.70"
+    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-03.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -131,7 +131,7 @@ services:
   clickhouse-04:
     depends_on:
       - zookeeper
-    image: "yandex/clickhouse-server:20.3.9.70"
+    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-04.xml:/etc/clickhouse-server/config.d/macros.xml

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -68,7 +68,9 @@ class TestCleanup:
             return datetime(rounded.year, rounded.month, rounded.day)
 
         # In prod the dates have hours/seconds etc.
-        base = datetime(1999, 12, 26, 1, 14, 35)  # a sunday
+        # use future dates to avoid hitting TTLs
+        base = datetime(2100, 1, 3, 1, 14, 35)  # a sunday
+
         current_time.return_value = base
 
         storage = get_writable_storage(storage_key)

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1251,7 +1251,7 @@ class TestSnQLApi(BaseApiTest):
         )
 
         assert (
-            response.status_code == 500
+            response.status_code == 500 or response.status_code == 400
         )  # TODO: This should be a 400, and will change once we can properly categorise these errors
 
     def test_allocation_policy_violation(self) -> None:


### PR DESCRIPTION
We had an issue today where a migration ran on Clickhouse 20 but failed on Clickhouse 21. This adds a test for Clickhouse 21. This is kept outside the matrix to allow it to be optional. This PR relies on using cached migrations in ci #4622  so that we can finish the tests in a reasonable amount of time.

### test updates
* For some discover API tests, Clickhouse 21 returns no rows whereas Clickhouse 20 would return a count of 0. To fix this, we try the asserts for both cases. 
* Because migrations seem to run faster on 21, we also make the setup function in the discover api test a fixture that runs after the clickhouse_db fixture to guarantee the ordering and avoid a race.
* In the cleanup test, we use a future Sunday date  as the base to avoid hitting the TTLs. Clickhouse 21 tends to work quicker and cleans out the TTL expired rows before the tests could finish.
* Invalid dates throw a 500 in Clickhouse 20 but error 400 in Clickhouse 21, so we are assert for both.