### PR TITLE
feat: Don't retry subscriptions queries which get timeout or OOM from clickhouse

### DIFF
--- a/snuba/web/constants.py
+++ b/snuba/web/constants.py
@@ -18,6 +18,11 @@ ACCEPTABLE_CLICKHOUSE_ERROR_CODES = {
     ErrorCodes.MEMORY_LIMIT_EXCEEDED,
 }
 
+NON_RETRYABLE_CLICKHOUSE_ERROR_CODES = {
+    ErrorCodes.MEMORY_LIMIT_EXCEEDED,
+    ErrorCodes.TOO_SLOW,
+}
+
 
 def get_http_status_for_clickhouse_error(cause: ClickhouseError) -> int:
     """


### PR DESCRIPTION
This is a follow up from INC-395. We should not constantly retry when we get these errors, as it blocks execution of all other subscriptions queries.
