### PR TITLE
fix(gocd): Use deploy-snuba-us as reference for last deployed

### DIFF
--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -27,7 +27,7 @@ def pipeline_passed(pipeline: Dict[str, Any]) -> bool:
 
 
 # print the most recent passing sha for a repo
-def main(pipeline_name: str = "deploy-snuba", repo: str = "snuba") -> int:
+def main(pipeline_name: str = "deploy-snuba-us", repo: str = "snuba") -> int:
     GOCD_ACCESS_TOKEN = os.environ.get("GOCD_ACCESS_TOKEN")
     if not GOCD_ACCESS_TOKEN:
         raise SystemExit(


### PR DESCRIPTION
When checking for migrations changes between HEAD and the last known good deploy, use the `deploy-snuba-us` pipeline, which is the saas. In the new pipedream pipeline `deploy-snuba` is empty.
