### PR TITLE
fix(ci): cache migrations in ci

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,7 +216,6 @@ def clickhouse_db(
                         "CREATE MATERIALIZED VIEW",
                         "CREATE MATERIALIZED VIEW IF NOT EXISTS",
                     )
-                    print(f"Creating table {table_name} on {node}")
                     connection.execute(create_table_query)
                 applied_nodes.add((node, table_name))
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,13 +197,9 @@ def clickhouse_db(
 
     try:
         reset_dataset_factory()
-        if not MIGRATIONS_CACHE or request.module.__name__.startswith(
-            "tests.migrations"
-        ):
+        if not MIGRATIONS_CACHE:
             Runner().run_all(force=True)
-            # build cache once
-            if not MIGRATIONS_CACHE:
-                _build_migrations_cache()
+            _build_migrations_cache()
         else:
             # apply migrations from cache
             applied_nodes = set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -197,15 +197,15 @@ def clickhouse_db(
 
     try:
         reset_dataset_factory()
-        if not MIGRATIONS_CACHE or request.module.__name__ == "tests.migrations":
-
+        if not MIGRATIONS_CACHE or request.module.__name__.startswith(
+            "tests.migrations"
+        ):
             Runner().run_all(force=True)
-            _build_migrations_cache()
+            # build cache once
+            if not MIGRATIONS_CACHE:
+                _build_migrations_cache()
         else:
             # apply migrations from cache
-            assert (
-                "migrations" not in request.module.__name__
-            ), "dont use cache for migrations module"
             applied_nodes = set()
             for (cluster, node), tables in MIGRATIONS_CACHE.items():
                 connection = cluster.get_node_connection(


### PR DESCRIPTION
Instead of running migrations from start to finish each time before a clickhouse, we can cache the end result of applying all migrations and use that instead. We are not adding new migrations within test so that should be fine. This will speed up CI.