### PR TITLE
fix(test): Add missing assertion for metrics processor test

### DIFF
--- a/tests/datasets/test_generic_metrics_processor.py
+++ b/tests/datasets/test_generic_metrics_processor.py
@@ -134,4 +134,4 @@ def test_aggregation_option_is_converted_to_column(
 
     insert_batch = dis_processor.process_message(message, None)
 
-    insert_batch.rows[0]["enable_histogram"] = 1
+    assert insert_batch.rows[0]["enable_histogram"] == 1


### PR DESCRIPTION
### Overview

Adds the missing assertion to the `test_aggregation_option_is_converted_to_column `