### PR TITLE
feat(migrations): add dangerous checks

### DIFF
--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -23,4 +23,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   "snuba-migrate" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
-  snuba migrations migrate --force
+  snuba migrations migrate --check-dangerous --force

--- a/gocd/templates/bash/migrate.sh
+++ b/gocd/templates/bash/migrate.sh
@@ -10,4 +10,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   "snuba-migrate" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
-  snuba migrations migrate -r complete -r partial
+  snuba migrations migrate --check-dangerous -r complete -r partial

--- a/snuba/cli/migrations.py
+++ b/snuba/cli/migrations.py
@@ -65,6 +65,7 @@ def list() -> None:
 @click.argument("through", default="all")
 @click.option("--force", is_flag=True)
 @click.option("--fake", is_flag=True)
+@click.option("--check-dangerous", is_flag=True)
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
@@ -74,6 +75,7 @@ def migrate(
     through: str,
     force: bool,
     fake: bool,
+    check_dangerous: bool,
     log_level: Optional[str] = None,
 ) -> None:
     """
@@ -104,6 +106,7 @@ def migrate(
                 if readiness_state
                 else None
             ),
+            check_dangerous=check_dangerous,
         )
     except MigrationError as e:
         raise click.ClickException(str(e))
@@ -118,6 +121,7 @@ def migrate(
 @click.option("--fake", is_flag=True)
 @click.option("--dry-run", is_flag=True)
 @click.option("--yes", is_flag=True)
+@click.option("--check-dangerous", is_flag=True)
 @click.option(
     "--log-level", help="Logging level to use.", type=click.Choice(LOG_LEVELS)
 )
@@ -128,6 +132,7 @@ def run(
     fake: bool,
     dry_run: bool,
     yes: bool,
+    check_dangerous: bool,
     log_level: Optional[str] = None,
 ) -> None:
     """
@@ -147,7 +152,9 @@ def run(
     migration_key = MigrationKey(migration_group, migration_id)
 
     if dry_run:
-        runner.run_migration(migration_key, dry_run=True)
+        runner.run_migration(
+            migration_key, dry_run=True, check_dangerous=check_dangerous
+        )
         return
 
     try:
@@ -156,7 +163,9 @@ def run(
                 "This will mark the migration as completed without actually running it. Your database may be in an invalid state. Are you sure?",
                 abort=True,
             )
-        runner.run_migration(migration_key, force=force, fake=fake)
+        runner.run_migration(
+            migration_key, force=force, fake=fake, check_dangerous=check_dangerous
+        )
     except MigrationError as e:
         raise click.ClickException(str(e))
 

--- a/snuba/migrations/check_dangerous.py
+++ b/snuba/migrations/check_dangerous.py
@@ -1,0 +1,103 @@
+import re
+from typing import Type
+
+from snuba.migrations.columns import LowCardinality, MigrationModifiers
+from snuba.migrations.operations import ModifyColumn, SqlOperation
+from snuba.utils.schemas import ColumnType, Nullable, String, TypeModifier
+from snuba.utils.types import ColumnStatesMapType
+
+
+class DangerousOperationError(Exception):
+    """
+    Raised when a migration operation is deemed dangerous
+    based on some heuristics.
+    """
+
+    pass
+
+
+def check_dangerous_operation(
+    op: SqlOperation, columns_state: ColumnStatesMapType
+) -> None:
+    """
+    Returns True if the operation is deemed dangerous or will cause a full columns rewrite
+    based on some heuristics.
+    """
+    try:
+        if isinstance(op, ModifyColumn):
+            col = op.get_column()
+            table = op.get_table_name()
+            nodes = op.get_nodes()
+            for node in nodes:
+                old_type = columns_state.get(
+                    (node.host_name, node.port, table, col.name), None
+                )
+                if old_type:
+                    _check_dangerous(old_type, col.type)
+    except DangerousOperationError as err:
+        raise DangerousOperationError(
+            f"Operation {op.format_sql()} is dangerous: \n{err}"
+        ) from err
+
+
+def _check_dangerous(
+    old_type_str: str, new_col_type: ColumnType[MigrationModifiers]
+) -> None:
+    old_type_str = old_type_str.lower()
+
+    # check nullable is not changed
+    _check_modifiers("nullable", Nullable, old_type_str, new_col_type)
+
+    if isinstance(new_col_type, String):
+        if "string" not in old_type_str:
+            raise DangerousOperationError(
+                f"Changing column type from {old_type_str} to {new_col_type} is dangerous"
+                "because one doesn't have String type in it. "
+                "To attempt to run this migration set blocking=True"
+            )
+        # check cardinality is not changed
+        _check_modifiers("lowcardinality", LowCardinality, old_type_str, new_col_type)
+
+    # check codecs make sense
+    _check_codecs(old_type_str, new_col_type)
+
+
+def _check_codecs(old_type: str, new_col_type: ColumnType[MigrationModifiers]) -> None:
+    modifiers = new_col_type.get_modifiers()
+    if isinstance(modifiers, MigrationModifiers):
+
+        def _has_codec(codec_str: str, modifiers: MigrationModifiers) -> bool:
+            for codec in modifiers.codecs or []:
+                if re.match(f"^{codec_str.lower()}[\w\D\(\)]*", codec.lower()):
+                    return True
+            return False
+
+        if _has_codec("Delta", modifiers):
+            if not (_has_codec("ZSTD", modifiers) or _has_codec("LZ4", modifiers)):
+                raise DangerousOperationError(
+                    f"Changing column type from {old_type} to {new_col_type} is dangerous.\n"
+                    "Clickhouse 21 doesn't support Delta codec without ZSTD or LZ4. "
+                    "To attempt to run this migration set blocking=True"
+                )
+
+
+def _check_modifiers(
+    modifier_str: str,
+    modifier: Type[TypeModifier],
+    old_type_str: str,
+    new_col_type: ColumnType[MigrationModifiers],
+) -> None:
+    modifier_str = modifier_str.lower()
+    new_modifiers = new_col_type.get_modifiers()
+    if isinstance(new_modifiers, MigrationModifiers):
+        if (
+            modifier_str in old_type_str
+            and not new_modifiers.has_modifier(modifier)
+            or modifier_str not in old_type_str
+            and new_modifiers.has_modifier(modifier)
+        ):
+            raise DangerousOperationError(
+                f"Changing column type from {old_type_str} to {new_col_type} is dangerous "
+                f"because only one has {modifier_str} type in it.\nChanging it will block or isn't supported. "
+                "To attempt to run this migration set blocking=True"
+            )

--- a/snuba/migrations/connect.py
+++ b/snuba/migrations/connect.py
@@ -1,6 +1,6 @@
 import re
 import time
-from typing import Sequence
+from typing import Sequence, Tuple
 
 import structlog
 from packaging import version
@@ -22,6 +22,7 @@ from snuba.migrations.clickhouse import (
 )
 from snuba.migrations.errors import InactiveClickhouseReplica, InvalidClickhouseVersion
 from snuba.settings import ENABLE_DEV_FEATURES
+from snuba.utils.types import ColumnStatesMapType
 
 logger = structlog.get_logger().bind(module=__name__)
 
@@ -81,12 +82,11 @@ def check_clickhouse(clickhouse: ClickhousePool) -> None:
         )
 
 
-def check_for_inactive_replicas() -> None:
+def _get_all_storage_keys() -> Sequence[StorageKey]:
     """
-    Checks for inactive replicas and raise InactiveClickhouseReplica if any are found.
+    Returns all storage keys that are not part of a dev storage set.
     """
-
-    storage_keys = [
+    return [
         storage_key
         for storage_key in sorted(
             get_all_storage_keys(), key=lambda storage_key: storage_key.value
@@ -95,22 +95,44 @@ def check_for_inactive_replicas() -> None:
         or ENABLE_DEV_FEATURES
     ]
 
+
+def _get_all_nodes_for_storage(
+    storage_key: StorageKey,
+) -> Tuple[Sequence[ClickhouseNode], Sequence[ClickhouseNode], ClickhouseNode]:
+    """
+    Returns all nodes for a given storage key.
+    """
+    storage = get_storage(storage_key)
+    cluster = storage.get_cluster()
+    query_node = cluster.get_query_node()
+    if storage_key == StorageKey.DISCOVER:
+        local_nodes: Sequence[ClickhouseNode] = []
+        distributed_nodes: Sequence[ClickhouseNode] = []
+    else:
+        local_nodes = cluster.get_local_nodes()
+        distributed_nodes = cluster.get_distributed_nodes()
+
+    return (local_nodes, distributed_nodes, query_node)
+
+
+def check_for_inactive_replicas() -> None:
+    """
+    Checks for inactive replicas and raise InactiveClickhouseReplica if any are found.
+    """
+
+    storage_keys = _get_all_storage_keys()
+
     checked_nodes = set()
     inactive_replica_info = []
     for storage_key in storage_keys:
-        storage = get_storage(storage_key)
         try:
+            local_nodes, distributed_nodes, query_node = _get_all_nodes_for_storage(
+                storage_key
+            )
+            storage = get_storage(storage_key)
             cluster = storage.get_cluster()
         except UndefinedClickhouseCluster:
             continue
-
-        query_node = cluster.get_query_node()
-        if storage_key == StorageKey.DISCOVER:
-            local_nodes: Sequence[ClickhouseNode] = []
-            distributed_nodes: Sequence[ClickhouseNode] = []
-        else:
-            local_nodes = cluster.get_local_nodes()
-            distributed_nodes = cluster.get_distributed_nodes()
 
         for node in (*local_nodes, *distributed_nodes, query_node):
             if (node.host_name, node.port) in checked_nodes:
@@ -131,3 +153,39 @@ def check_for_inactive_replicas() -> None:
 
     if inactive_replica_info:
         raise InactiveClickhouseReplica("\n".join(sorted(set(inactive_replica_info))))
+
+
+def get_column_states() -> ColumnStatesMapType:
+    """
+    For every node in the cluster, get the current type of the columns.
+    Passing on this information to the migrations will allow them to
+    check for dangerous migrations
+    """
+    storage_keys = _get_all_storage_keys()
+    column_states: ColumnStatesMapType = {}
+    checked_nodes = set()
+    for storage_key in storage_keys:
+        try:
+            local_nodes, distributed_nodes, query_node = _get_all_nodes_for_storage(
+                storage_key
+            )
+            storage = get_storage(storage_key)
+            cluster = storage.get_cluster()
+        except UndefinedClickhouseCluster:
+            continue
+        for node in (*local_nodes, *distributed_nodes, query_node):
+            if (node.host_name, node.port) in checked_nodes:
+                continue
+            checked_nodes.add((node.host_name, node.port))
+
+            conn = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, node)
+            column_types = conn.execute(
+                "SELECT table, name, type FROM system.columns "
+                f"WHERE database='{conn.database}'",
+            ).results
+
+            for row in column_types:
+                table, col_name, type = row
+                column_states[(node.host_name, node.port, table, col_name)] = type
+
+    return column_states

--- a/snuba/utils/types.py
+++ b/snuba/utils/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Generic, Protocol, TypeVar
+from typing import Any, Generic, MutableMapping, Protocol, Tuple, TypeVar
 
 TComparable = TypeVar("TComparable", contravariant=True)
 
@@ -62,3 +62,6 @@ class Interval(Generic[T]):
     def __post_init__(self) -> None:
         if not self.upper >= self.lower:
             raise InvalidRangeError(self.lower, self.upper)
+
+
+ColumnStatesMapType = MutableMapping[Tuple[str, int, str, str], str]

--- a/tests/cli/test_migrations.py
+++ b/tests/cli/test_migrations.py
@@ -49,3 +49,4 @@ def test_migrations_cli() -> None:
     )
     _check_run(runner, reverse_in_progress, ["--group", "system"])
     _check_run(runner, reverse_in_progress)
+    _check_run(runner, migrate, ["--group", "system", "--check-dangerous"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,7 @@ def clickhouse_db(
                     ClickhouseClientSettings.MIGRATE, node
                 )
                 for table_name, create_table_query in tables.items():
-                    if (node, table_name) in applied_nodes:
+                    if (node.host_name, node.port, table_name) in applied_nodes:
                         continue
                     create_table_query = create_table_query.replace(
                         "CREATE TABLE", "CREATE TABLE IF NOT EXISTS"
@@ -217,7 +217,7 @@ def clickhouse_db(
                         "CREATE MATERIALIZED VIEW IF NOT EXISTS",
                     )
                     connection.execute(create_table_query)
-                applied_nodes.add((node, table_name))
+                applied_nodes.add((node.host_name, node.port, table_name))
         yield
     finally:
         _clear_db()

--- a/tests/migrations/test_check_dangerous.py
+++ b/tests/migrations/test_check_dangerous.py
@@ -1,0 +1,98 @@
+import logging
+from typing import Any, Sequence, Tuple
+from unittest.mock import Mock, patch
+
+import pytest
+
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations.check_dangerous import DangerousOperationError
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+from snuba.migrations.connect import get_column_states
+from snuba.migrations.migration import ClickhouseNodeMigration
+from snuba.migrations.operations import ModifyColumn, OperationTarget, SqlOperation
+from snuba.utils.schemas import Column, String, UInt
+
+logger = logging.getLogger(__name__)
+
+
+def make_migration(op: SqlOperation) -> ClickhouseNodeMigration:
+    class Migration(ClickhouseNodeMigration):
+        blocking = False
+
+        def forwards_ops(self) -> Sequence[SqlOperation]:
+            return [op]
+
+        def backwards_ops(self) -> Sequence[SqlOperation]:
+            return [op]
+
+    return Migration()
+
+
+@patch.object(SqlOperation, "execute")  # dont actually run the migrations
+@pytest.mark.clickhouse_db
+class TestDangerousMigration:
+    table_name = "test_dangerous_migration"
+    connection = None
+
+    @pytest.fixture(scope="class")
+    def create_table(self, create_databases: None) -> None:
+        cluster = get_cluster(StorageSetKey.EVENTS)
+        database = cluster.get_database()
+        cls = self.__class__
+        cls.connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+
+        cls.connection.execute(f"DROP TABLE IF EXISTS {database}.{cls.table_name}")
+        cls.connection.execute(
+            f"CREATE TABLE {database}.{cls.table_name} (name LowCardinality(String), age Nullable(UInt8) ) "
+            " ENGINE = MergeTree ORDER BY name"
+        )
+
+    def _make_modify_op(
+        self, column: Column[MigrationModifiers]
+    ) -> Tuple[SqlOperation, Any]:
+        op = ModifyColumn(
+            StorageSetKey.EVENTS, self.table_name, column, target=OperationTarget.LOCAL
+        )
+        context: Any = ("migration-4", logger, lambda x: x)
+        return op, context
+
+    def _run_modify_migration(self, column: Column[MigrationModifiers]) -> None:
+        op, context = self._make_modify_op(column)
+        make_migration(op).forwards(context, columns_state_to_check=get_column_states())
+
+    def test_nullable_and_cardinality(
+        self, _mock_execute: Mock, create_table: None
+    ) -> None:
+        col = Column("name", String(Modifiers(low_cardinality=True)))
+        self._run_modify_migration(col)
+
+        # changed cardinality
+        with pytest.raises(DangerousOperationError):
+            col = Column("name", String(Modifiers(low_cardinality=False)))
+            self._run_modify_migration(col)
+
+        col = Column("age", UInt(8, Modifiers(nullable=True)))
+        self._run_modify_migration(col)
+
+        # changed nullable
+        with pytest.raises(DangerousOperationError):
+            col = Column("age", UInt(8, Modifiers(nullable=False)))
+            self._run_modify_migration(col)
+
+    def test_codec(self, _mock_execute: Mock, create_table: None) -> None:
+        col = Column("age", UInt(8, Modifiers(nullable=True, codecs=["Delta", "ZSTD"])))
+        self._run_modify_migration(col)
+
+        # Delta alone throws an error
+        with pytest.raises(DangerousOperationError):
+            col = Column("age", UInt(8, Modifiers(nullable=True, codecs=["Delta"])))
+            self._run_modify_migration(col)
+
+    def test_get_column_states(self, _mock_execute: Mock, create_table: None) -> None:
+        states = get_column_states()
+        assert self.connection is not None
+        host, port = self.connection.host, self.connection.port
+        assert states[(host, port, self.table_name, "name")] == "LowCardinality(String)"
+        assert states[(host, port, self.table_name, "age")] == "Nullable(UInt8)"


### PR DESCRIPTION
### Context
Include some heuristics to check if a migration does something dangerous like changing Nullable or Cardinality.

Calling migrate with `--check-dangerous` will check for these before running. Right, now all the heuristics are manually crafted and work by checking the string regex. It's far from exhaustive but catches a few obvious ones:

* changing nullable
* changing string cardinality
* changing from a string to a non-string type
* setting a delta encoding without ZSTD or LZ4

### testing

Have a test that creates a dummy table with some rows with the modifiers and run a dummy test migration against it. The checker detects the violations.


