### PR TITLE
feat(rust-consumer): Port KafkaMessageMetadata to Rust

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1353,6 +1353,7 @@ name = "rust_snuba"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "ctrlc",
  "env_logger 0.10.0",
  "futures",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.69"
+chrono = "0.4.11"
 futures = "0.3.21"
 rust_arroyo = { path = "./rust_arroyo" }
 serde_yaml = "0.9.19"

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -1,13 +1,14 @@
 #![allow(dead_code)]
 
 mod querylog;
-use crate::types::BytesInsertBatch;
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::processing::strategies::InvalidMessage;
 
-pub fn get_processing_function(
-    name: &str,
-) -> Option<fn(KafkaPayload) -> Result<BytesInsertBatch, InvalidMessage>> {
+type ProcessingFunction =
+    fn(KafkaPayload, KafkaMessageMetadata) -> Result<BytesInsertBatch, InvalidMessage>;
+
+pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {
         "QuerylogProcessor" => Some(querylog::process_message),
         _ => None,

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -291,7 +291,9 @@ impl TryFrom<FromQuerylogMessage> for QuerylogMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::DateTime;
     use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::time::SystemTime;
 
     #[test]
     fn test_querylog() {
@@ -395,6 +397,11 @@ mod tests {
             headers: None,
             payload: Some(data.as_bytes().to_vec()),
         };
-        process_message(payload).expect("The message should be processed");
+        let meta = KafkaMessageMetadata {
+            partition: 0,
+            offset: 1,
+            timestamp: DateTime::from(SystemTime::now()),
+        };
+        process_message(payload, meta).expect("The message should be processed");
     }
 }

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -1,4 +1,4 @@
-use crate::types::BytesInsertBatch;
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::processing::strategies::InvalidMessage;
 use serde::{ser::Error, Deserialize, Serialize, Serializer};
@@ -7,7 +7,10 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use uuid::Uuid;
 
-pub fn process_message(payload: KafkaPayload) -> Result<BytesInsertBatch, InvalidMessage> {
+pub fn process_message(
+    payload: KafkaPayload,
+    _metadata: KafkaMessageMetadata,
+) -> Result<BytesInsertBatch, InvalidMessage> {
     if let Some(payload_bytes) = payload.payload {
         let msg: FromQuerylogMessage =
             serde_json::from_slice(&payload_bytes).map_err(|_| InvalidMessage)?;

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -1,6 +1,14 @@
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct BytesInsertBatch {
     pub rows: Vec<Vec<u8>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct KafkaMessageMetadata {
+    pub partition: u16,
+    pub offset: u64,
+    pub timestamp: DateTime<Utc>,
 }


### PR DESCRIPTION
Rust message processors should get passed the Kafka metadata like the Python one. This is needed since a number of processors actually write the partition and offset information to ClickHouse
