### PR TITLE
fix(spans): fix sentry tags migration

### DIFF
--- a/snuba/snuba_migrations/spans/0005_spans_add_sentry_tags.py
+++ b/snuba/snuba_migrations/spans/0005_spans_add_sentry_tags.py
@@ -10,9 +10,10 @@ storage_set_name = StorageSetKey.SPANS
 local_table_name = "spans_local"
 dist_table_name = "spans_dist"
 
-# There an issue in Clickhouse where the arrayMap function does not passes
-# in Nothing values for empty arrays. This causes the regex function to fail
-# without the toString function. This is fixed in Clickhouse 22.
+# There an issue in Clickhouse where the arrayMap function passes
+# in Nothing type values for empty arrays. This causes the regex function to fail
+# without the toString function, unless a merge for the part is completed.
+# This is fixed in Clickhouse 22.
 SENTRY_TAGS_HASH_MAP_COLUMN = (
     "arrayMap((k, v) -> cityHash64(concat("
     "replaceRegexpAll(toString(k), '(\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'), '=', toString(v))), "

--- a/snuba/snuba_migrations/spans/0005_spans_add_sentry_tags.py
+++ b/snuba/snuba_migrations/spans/0005_spans_add_sentry_tags.py
@@ -10,10 +10,12 @@ storage_set_name = StorageSetKey.SPANS
 local_table_name = "spans_local"
 dist_table_name = "spans_dist"
 
-
+# There an issue in Clickhouse where the arrayMap function does not passes
+# in Nothing values for empty arrays. This causes the regex function to fail
+# without the toString function. This is fixed in Clickhouse 22.
 SENTRY_TAGS_HASH_MAP_COLUMN = (
     "arrayMap((k, v) -> cityHash64(concat("
-    "replaceRegexpAll(k, '(\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'), '=', v)), "
+    "replaceRegexpAll(toString(k), '(\\\\=|\\\\\\\\)', '\\\\\\\\\\\\1'), '=', toString(v))), "
     "sentry_tags.key, sentry_tags.value)"
 )
 


### PR DESCRIPTION
There an issue in Clickhouse where the arrayMap function passes in Nothing type values for empty arrays. This causes the regex function to fail on the newly added columns without the toString function, unless a merge for the part is completed first. So our replication task queue was building up with all task that were failing and Clickhouse keeps retrying until it get lucky and a merge happens before.

This is fixed in Clickhouse 22.