### PR TITLE
snuba/settings: adjust usage of importlib.abc

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -425,6 +425,7 @@ def _load_settings(obj: MutableMapping[str, Any] = locals()) -> None:
     provide a full absolute path such as `/foo/bar/my_settings.py`."""
 
     import importlib
+    import importlib.abc
     import importlib.util
     import os
 


### PR DESCRIPTION
Starting from Python 3.10 the one should import `importlib.abc` explicitly.

### Legal Boilerplate

I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.