### PR TITLE
build: Cargo workspace

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -5,6 +5,11 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[workspace]
+members = [
+    "rust_arroyo",
+]
+
 [lib]
 # The name of the native library. This is the name which will be used in Python to import the
 # library (i.e. `import string_sum`). If you change this, you must also change the name of the


### PR DESCRIPTION
So that rust_snuba and rust_arroyo use the same (pinned) library versions of packages
