### PR TITLE
ref: Message processors don't take args

### DIFF
--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -56,7 +56,6 @@ pub struct ClickhouseConfig {
 pub struct MessageProcessorConfig {
     pub python_class_name: String,
     pub python_module: String,
-    // TODO: args support
 }
 
 #[derive(Deserialize)]

--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -14,15 +14,16 @@
 import importlib
 import os
 from datetime import datetime
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Type
 
 import rapidjson
 
 from snuba.consumers.consumer import json_row_encoder
 from snuba.consumers.types import KafkaMessageMetadata
+from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.processor import InsertBatch
 
-processor = None
+processor: Optional[DatasetMessageProcessor] = None
 
 
 def initialize_processor(
@@ -36,7 +37,7 @@ def initialize_processor(
         return
 
     module_object = importlib.import_module(module)
-    Processor = getattr(module_object, classname)
+    Processor: Type[DatasetMessageProcessor] = getattr(module_object, classname)
 
     global processor
     processor = Processor.from_kwargs()

--- a/snuba/consumers/rust_processor.py
+++ b/snuba/consumers/rust_processor.py
@@ -40,7 +40,7 @@ def initialize_processor(
     Processor: Type[DatasetMessageProcessor] = getattr(module_object, classname)
 
     global processor
-    processor = Processor.from_kwargs()
+    processor = Processor()
 
 
 initialize_processor()

--- a/snuba/datasets/cdc/cdcprocessors.py
+++ b/snuba/datasets/cdc/cdcprocessors.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, List, Mapping, Optional, Sequence, Type, cast
+from typing import Any, List, Mapping, Optional, Sequence, Type
 
 from snuba.consumers.types import KafkaMessageMetadata
-from snuba.processor import InsertBatch, MessageProcessor, ProcessedMessage
+from snuba.datasets.processors import DatasetMessageProcessor
+from snuba.processor import InsertBatch, ProcessedMessage
 from snuba.utils.registered_class import RegisteredClass
 from snuba.writer import WriterTableRow
 
@@ -71,22 +72,10 @@ class CdcMessageRow(ABC):
         raise NotImplementedError
 
 
-class CdcProcessor(MessageProcessor, metaclass=RegisteredClass):
+class CdcProcessor(DatasetMessageProcessor, metaclass=RegisteredClass):
     def __init__(self, pg_table: str, message_row_class: Type[CdcMessageRow]):
         self.pg_table = pg_table
         self._message_row_class = message_row_class
-
-    @classmethod
-    def get_from_name(cls, name: str) -> Type["CdcProcessor"]:
-        return cast(Type["CdcProcessor"], cls.class_from_name(name))
-
-    @classmethod
-    def from_kwargs(cls, **kwargs: str) -> CdcProcessor:
-        return cls(**kwargs)  # type: ignore
-
-    @classmethod
-    def config_key(cls) -> str:
-        return cls.__name__
 
     def _process_begin(self, offset: int) -> Sequence[WriterTableRow]:
         return []

--- a/snuba/datasets/cdc/groupassignee_processor.py
+++ b/snuba/datasets/cdc/groupassignee_processor.py
@@ -83,7 +83,7 @@ class GroupAssigneeRow(CdcMessageRow):
 
 
 class GroupAssigneeProcessor(CdcProcessor):
-    def __init__(self, postgres_table: str) -> None:
+    def __init__(self) -> None:
         postgres_table = "sentry_groupasignee"
         super().__init__(
             pg_table=postgres_table,

--- a/snuba/datasets/cdc/groupassignee_processor.py
+++ b/snuba/datasets/cdc/groupassignee_processor.py
@@ -84,6 +84,7 @@ class GroupAssigneeRow(CdcMessageRow):
 
 class GroupAssigneeProcessor(CdcProcessor):
     def __init__(self, postgres_table: str) -> None:
+        postgres_table = "sentry_groupasignee"
         super().__init__(
             pg_table=postgres_table,
             message_row_class=GroupAssigneeRow,

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -113,7 +113,8 @@ class GroupedMessageRow(CdcMessageRow):
 
 
 class GroupedMessageProcessor(CdcProcessor):
-    def __init__(self, postgres_table: str):
+    def __init__(self):
+        postgres_table = "sentry_groupedmessage"
         super(GroupedMessageProcessor, self).__init__(
             pg_table=postgres_table,
             message_row_class=GroupedMessageRow,

--- a/snuba/datasets/cdc/groupedmessage_processor.py
+++ b/snuba/datasets/cdc/groupedmessage_processor.py
@@ -113,7 +113,7 @@ class GroupedMessageRow(CdcMessageRow):
 
 
 class GroupedMessageProcessor(CdcProcessor):
-    def __init__(self):
+    def __init__(self) -> None:
         postgres_table = "sentry_groupedmessage"
         super(GroupedMessageProcessor, self).__init__(
             pg_table=postgres_table,

--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -229,7 +229,7 @@ schema:
       {
         name: num_processing_errors,
         type: UInt,
-        args: { schema_modifiers: [ nullable ], size: 64 },
+        args: { schema_modifiers: [nullable], size: 64 },
       },
       { name: replay_id, type: UUID, args: { schema_modifiers: [nullable] } },
     ]
@@ -357,14 +357,6 @@ replacer_processor:
 stream_loader:
   processor:
     name: ErrorsProcessor
-    args:
-      promoted_tag_columns:
-        environment: environment
-        sentry:release: release
-        sentry:dist: dist
-        sentry:user: user
-        transaction: transaction_name
-        level: level
   default_topic: events
   replacement_topic: event-replacements
   commit_log_topic: snuba-commit-log

--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -355,8 +355,7 @@ replacer_processor:
     state_name: errors
     storage_key_str: errors
 stream_loader:
-  processor:
-    name: ErrorsProcessor
+  processor: ErrorsProcessor
   default_topic: events
   replacement_topic: event-replacements
   commit_log_topic: snuba-commit-log

--- a/snuba/datasets/configuration/functions/storages/functions_raw.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions_raw.yaml
@@ -39,6 +39,5 @@ schema:
   local_table_name: functions_raw_local
   dist_table_name: functions_raw_dist
 stream_loader:
-  processor:
-    name: FunctionsMessageProcessor
+  processor: FunctionsMessageProcessor
   default_topic: profiles-call-tree

--- a/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
@@ -48,8 +48,7 @@ schema:
   local_table_name: generic_metric_counters_raw_local
   dist_table_name: generic_metric_counters_raw_dist
 stream_loader:
-  processor:
-    name: GenericCountersMetricsProcessor
+  processor: GenericCountersMetricsProcessor
   default_topic: snuba-generic-metrics
   pre_filter:
     type: KafkaHeaderSelectFilter

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -48,8 +48,7 @@ schema:
   local_table_name: generic_metric_distributions_raw_local
   dist_table_name: generic_metric_distributions_raw_dist
 stream_loader:
-  processor:
-    name: GenericDistributionsMetricsProcessor
+  processor: GenericDistributionsMetricsProcessor
   default_topic: snuba-generic-metrics
   pre_filter:
     type: KafkaHeaderSelectFilter

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -48,8 +48,7 @@ schema:
   local_table_name: generic_metric_sets_raw_local
   dist_table_name: generic_metric_sets_raw_dist
 stream_loader:
-  processor:
-    name: GenericSetsMetricsProcessor
+  processor: GenericSetsMetricsProcessor
   default_topic: snuba-generic-metrics
   pre_filter:
     type: KafkaHeaderSelectFilter

--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -51,7 +51,6 @@ mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 
 stream_loader:
-  processor:
-    name: GroupAttributesMessageProcessor
+  processor: GroupAttributesMessageProcessor
   default_topic: group-attributes
   dlq_topic: snuba-dead-letter-group-attributes

--- a/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
+++ b/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
@@ -51,8 +51,7 @@ query_processors:
         - project_id
   - processor: ConsistencyEnforcerProcessor
 stream_loader:
-  processor:
-    name: GroupAssigneeProcessor
+  processor: GroupAssigneeProcessor
   default_topic: cdc
   pre_filter:
     type: CdcTableNameMessageFilter

--- a/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
+++ b/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
@@ -53,8 +53,6 @@ query_processors:
 stream_loader:
   processor:
     name: GroupAssigneeProcessor
-    args:
-      postgres_table: sentry_groupasignee
   default_topic: cdc
   pre_filter:
     type: CdcTableNameMessageFilter

--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -65,8 +65,6 @@ query_processors:
 stream_loader:
   processor:
     name: GroupedMessageProcessor
-    args:
-      postgres_table: sentry_groupedmessage
   default_topic: cdc
   pre_filter:
     type: CdcTableNameMessageFilter

--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -63,8 +63,7 @@ query_processors:
         - id
   - processor: ConsistencyEnforcerProcessor
 stream_loader:
-  processor:
-    name: GroupedMessageProcessor
+  processor: GroupedMessageProcessor
   default_topic: cdc
   pre_filter:
     type: CdcTableNameMessageFilter

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -103,8 +103,7 @@ mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 
 stream_loader:
-  processor:
-    name: SearchIssuesMessageProcessor
+  processor: SearchIssuesMessageProcessor
   default_topic: generic-events
   commit_log_topic: snuba-generic-events-commit-log
   dlq_topic: snuba-dead-letter-generic-events

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -21,17 +21,8 @@ STREAM_LOADER_SCHEMA = {
     "type": "object",
     "properties": {
         "processor": {
-            "type": "object",
+            "type": "string",
             "description": "Name of Processor class config key and it's arguments. Responsible for converting an incoming message body from the event stream into a row or statement to be inserted or executed against clickhouse",
-            "properties": {
-                "name": TYPE_STRING,
-                "args": {
-                    "type": "object",
-                    "description": "Key/value mappings required to instantiate the processor class.",
-                },
-            },
-            "additionalProperties": False,
-            "required": ["name"],
         },
         "default_topic": {
             "type": "string",

--- a/snuba/datasets/configuration/metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/metrics/storages/counters.yaml
@@ -49,7 +49,6 @@ query_processors:
       column_name: tags
   - processor: TableRateLimit
 stream_loader:
-  processor:
-    name: CounterAggregateProcessor
+  processor: CounterAggregateProcessor
   default_topic: snuba-metrics
   dlq_topic: snuba-dead-letter-metrics-counters

--- a/snuba/datasets/configuration/metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/metrics/storages/distributions.yaml
@@ -78,7 +78,6 @@ query_processors:
       column_name: tags
   - processor: TableRateLimit
 stream_loader:
-  processor:
-    name: DistributionsAggregateProcessor
+  processor: DistributionsAggregateProcessor
   default_topic: snuba-metrics
   dlq_topic: snuba-dead-letter-metrics-distributions

--- a/snuba/datasets/configuration/metrics/storages/raw.yaml
+++ b/snuba/datasets/configuration/metrics/storages/raw.yaml
@@ -44,8 +44,7 @@ schema:
   local_table_name: metrics_raw_v2_local
   dist_table_name: metrics_raw_v2_dist
 stream_loader:
-  processor:
-    name: PolymorphicMetricsProcessor
+  processor: PolymorphicMetricsProcessor
   default_topic: snuba-metrics
   commit_log_topic: snuba-metrics-commit-log
   subscription_scheduler_mode: global

--- a/snuba/datasets/configuration/metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/metrics/storages/sets.yaml
@@ -53,7 +53,6 @@ query_processors:
       column_name: tags
   - processor: TableRateLimit
 stream_loader:
-  processor:
-    name: SetsAggregateProcessor
+  processor: SetsAggregateProcessor
   default_topic: snuba-metrics
   dlq_topic: snuba-dead-letter-metrics-sets

--- a/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
@@ -39,6 +39,5 @@ query_processors:
 mandatory_condition_checkers:
   - condition: OrgIdEnforcer
 stream_loader:
-  processor:
-    name: OutcomesProcessor
+  processor: OutcomesProcessor
   default_topic: outcomes

--- a/snuba/datasets/configuration/profiles/storages/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/storages/profiles.yaml
@@ -71,6 +71,5 @@ mandatory_condition_checkers:
       field_name: organization_id
   - condition: ProjectIdEnforcer
 stream_loader:
-  processor:
-    name: ProfilesMessageProcessor
+  processor: ProfilesMessageProcessor
   default_topic: processed-profiles

--- a/snuba/datasets/configuration/querylog/storages/querylog.yaml
+++ b/snuba/datasets/configuration/querylog/storages/querylog.yaml
@@ -164,7 +164,6 @@ schema:
 writer_options:
   input_format_skip_unknown_fields: 1
 stream_loader:
-  processor:
-    name: QuerylogProcessor
+  processor: QuerylogProcessor
   default_topic: snuba-queries
   dlq_topic: snuba-dead-letter-querylog

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -168,8 +168,7 @@ query_processors:
 mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 stream_loader:
-  processor:
-    name: ReplaysProcessor
+  processor: ReplaysProcessor
   default_topic: ingest-replay-events
   dlq_topic: snuba-dead-letter-replays
 allocation_policies:

--- a/snuba/datasets/configuration/sessions/storages/raw.yaml
+++ b/snuba/datasets/configuration/sessions/storages/raw.yaml
@@ -34,8 +34,7 @@ mandatory_condition_checkers:
   - condition: OrgIdEnforcer
   - condition: ProjectIdEnforcer
 stream_loader:
-  processor:
-    name: SessionsProcessor
+  processor: SessionsProcessor
   default_topic: ingest-sessions
   commit_log_topic: snuba-sessions-commit-log
   subscription_result_topic: sessions-subscription-results

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -124,6 +124,5 @@ mandatory_condition_checkers:
   - condition: ProjectIdEnforcer
 
 stream_loader:
-  processor:
-    name: SpansMessageProcessor
+  processor: SpansMessageProcessor
   default_topic: snuba-spans

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -158,8 +158,8 @@ def __build_storage_schema(config: dict[str, Any]) -> TableSchema:
 
 
 def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
-    processor_config = loader_config["processor"]
-    processor = DatasetMessageProcessor.from_name(processor_config["name"])
+    processor_name = loader_config["processor"]
+    processor = DatasetMessageProcessor.from_name(processor_name)
     assert processor is not None
     default_topic = Topic(loader_config["default_topic"])
     # optionals

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from snuba.clickhouse.columns import ColumnSet
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.datasets.cdc.cdcprocessors import CdcProcessor
 from snuba.datasets.cdc.cdcstorage import CdcStorage
 from snuba.datasets.cdc.row_processors import CdcRowProcessor
 from snuba.datasets.configuration.json_schema import STORAGE_VALIDATORS
@@ -25,14 +24,12 @@ from snuba.datasets.table_storage import (
     KafkaStreamLoader,
     build_kafka_stream_loader_from_settings,
 )
-from snuba.processor import MessageProcessor
 from snuba.query.allocation_policies import AllocationPolicy
 from snuba.query.conditions import ConditionFunctions, binary_condition
 from snuba.query.expressions import Column, Literal
 from snuba.replacers.replacer_processor import ReplacerProcessor
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.util import PartSegment
-from snuba.utils.registered_class import InvalidConfigKeyError
 from snuba.utils.streams.topics import Topic
 
 KIND = "kind"
@@ -162,15 +159,7 @@ def __build_storage_schema(config: dict[str, Any]) -> TableSchema:
 
 def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
     processor_config = loader_config["processor"]
-    processor: MessageProcessor | None = None
-    try:
-        processor = DatasetMessageProcessor.get_from_name(
-            processor_config["name"]
-        ).from_kwargs(**processor_config.get("args", {}))
-    except InvalidConfigKeyError:
-        processor = CdcProcessor.get_from_name(processor_config["name"]).from_kwargs(
-            **processor_config.get("args", {})
-        )
+    processor = DatasetMessageProcessor.from_name(processor_config["name"])
     assert processor is not None
     default_topic = Topic(loader_config["default_topic"])
     # optionals

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -255,8 +255,7 @@ writer_options:
   input_format_skip_unknown_fields: 1
 
 stream_loader:
-  processor:
-    name: TransactionsMessageProcessor
+  processor: TransactionsMessageProcessor
   default_topic: transactions
   commit_log_topic: snuba-transactions-commit-log
   subscription_scheduler_mode: global

--- a/snuba/datasets/processors/__init__.py
+++ b/snuba/datasets/processors/__init__.py
@@ -30,10 +30,6 @@ class DatasetMessageProcessor(MessageProcessor, metaclass=RegisteredClass):
         return cast(Type["DatasetMessageProcessor"], cls.class_from_name(name))()
 
     @classmethod
-    def from_kwargs(cls, **kwargs: str) -> DatasetMessageProcessor:
-        return cls(**kwargs)
-
-    @classmethod
     def config_key(cls) -> str:
         return cls.__name__
 

--- a/snuba/datasets/processors/__init__.py
+++ b/snuba/datasets/processors/__init__.py
@@ -26,8 +26,9 @@ class DatasetMessageProcessor(MessageProcessor, metaclass=RegisteredClass):
         pass
 
     @classmethod
-    def get_from_name(cls, name: str) -> Type["DatasetMessageProcessor"]:
-        return cast(Type["DatasetMessageProcessor"], cls.class_from_name(name))
+    def from_name(cls, name: str) -> DatasetMessageProcessor:
+        msg_processor = cast(Type["DatasetMessageProcessor"], cls.class_from_name(name))
+        return msg_processor()
 
     @classmethod
     def from_kwargs(cls, **kwargs: str) -> DatasetMessageProcessor:

--- a/snuba/datasets/processors/__init__.py
+++ b/snuba/datasets/processors/__init__.py
@@ -27,8 +27,7 @@ class DatasetMessageProcessor(MessageProcessor, metaclass=RegisteredClass):
 
     @classmethod
     def from_name(cls, name: str) -> DatasetMessageProcessor:
-        msg_processor = cast(Type["DatasetMessageProcessor"], cls.class_from_name(name))
-        return msg_processor()
+        return cast(Type["DatasetMessageProcessor"], cls.class_from_name(name))()
 
     @classmethod
     def from_kwargs(cls, **kwargs: str) -> DatasetMessageProcessor:

--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -48,6 +48,7 @@ logger = logging.getLogger(__name__)
 class ErrorsProcessor(DatasetMessageProcessor):
     def __init__(self) -> None:
         self._promoted_tag_columns = {
+            "environment": "environment",
             "sentry:release": "release",
             "sentry:dist": "dist",
             "sentry:user": "user",

--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -50,7 +50,7 @@ class ErrorsProcessor(DatasetMessageProcessor):
         self._promoted_tag_columns = {
             "sentry:release": "release",
             "sentry:dist": "dist",
-            "sentrY:user": "user",
+            "sentry:user": "user",
             "transaction": "transaction_name",
             "level": "level",
         }

--- a/snuba/datasets/processors/errors_processor.py
+++ b/snuba/datasets/processors/errors_processor.py
@@ -46,8 +46,14 @@ logger = logging.getLogger(__name__)
 
 
 class ErrorsProcessor(DatasetMessageProcessor):
-    def __init__(self, promoted_tag_columns: Mapping[str, str]):
-        self._promoted_tag_columns = promoted_tag_columns
+    def __init__(self) -> None:
+        self._promoted_tag_columns = {
+            "sentry:release": "release",
+            "sentry:dist": "dist",
+            "sentrY:user": "user",
+            "transaction": "transaction_name",
+            "level": "level",
+        }
 
     def process_message(
         self,

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -161,7 +161,7 @@ class TestGroupassignee:
     }
 
     def test_messages(self) -> None:
-        processor = GroupAssigneeProcessor("sentry_groupasignee")
+        processor = GroupAssigneeProcessor()
 
         metadata = KafkaMessageMetadata(
             offset=42, partition=0, timestamp=datetime(1970, 1, 1)

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -226,7 +226,7 @@ class TestGroupedMessage:
     }
 
     def test_messages(self) -> None:
-        processor = GroupedMessageProcessor("sentry_groupedmessage")
+        processor = GroupedMessageProcessor()
 
         metadata = KafkaMessageMetadata(
             offset=42, partition=0, timestamp=datetime(1970, 1, 1)

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -16,9 +16,7 @@ from snuba.utils.streams.topics import Topic
 def test_build_stream_loader() -> None:
     loader = build_stream_loader(
         {
-            "processor": {
-                "name": "GenericSetsMetricsProcessor",
-            },
+            "processor": "GenericSetsMetricsProcessor",
             "default_topic": "snuba-generic-metrics",
             "pre_filter": {
                 "type": "KafkaHeaderSelectFilter",

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 from fastjsonschema.exceptions import JsonSchemaValueException
 
-from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.configuration.json_schema import STORAGE_VALIDATORS
 from snuba.datasets.configuration.storage_builder import build_stream_loader
 from snuba.datasets.message_filters import KafkaHeaderSelectFilter
-from snuba.datasets.processors import DatasetMessageProcessor
 from snuba.datasets.processors.generic_metrics_processor import (
     GenericSetsMetricsProcessor,
 )
-from snuba.processor import ProcessedMessage
 from snuba.subscriptions.utils import SchedulingWatermarkMode
 from snuba.utils.streams.topics import Topic
 
@@ -61,41 +56,6 @@ def test_build_stream_loader() -> None:
         dlq_topic_spec is not None
         and dlq_topic_spec.topic == Topic.DEAD_LETTER_GENERIC_METRICS
     )
-
-
-def test_stream_loader_processor_init_arg() -> None:
-    class TestProcessor(DatasetMessageProcessor):
-        def __init__(self, value: int) -> None:
-            self.value = value
-
-        def process_message(
-            self, message: Any, metadata: KafkaMessageMetadata
-        ) -> ProcessedMessage | None:
-            raise NotImplementedError
-
-    loader = build_stream_loader(
-        {
-            "processor": {
-                "name": "TestProcessor",
-                "args": {"value": 6},
-            },
-            "default_topic": "snuba-generic-metrics",
-            "pre_filter": {
-                "type": "KafkaHeaderSelectFilter",
-                "args": {"header_key": "metric_type", "header_value": "s"},
-            },
-            "commit_log_topic": "snuba-generic-metrics-sets-commit-log",
-            "subscription_scheduler_mode": "global",
-            "subscription_scheduled_topic": "scheduled-subscriptions-generic-metrics-sets",
-            "subscription_result_topic": "generic-metrics-subscription-results",
-            "dlq_policy": {
-                "topic": "snuba-dead-letter-generic-metrics",
-            },
-        }
-    )
-
-    assert isinstance(loader.get_processor(), TestProcessor)
-    assert getattr(loader.get_processor(), "value") == 6
 
 
 def test_invalid_storage() -> None:

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -441,16 +441,7 @@ class TestErrorsProcessor:
         message = self.__get_error_event(timestamp, recieved)
         payload = message.serialize()
         meta = KafkaMessageMetadata(offset=2, partition=2, timestamp=timestamp)
-        processor = ErrorsProcessor(
-            {
-                "environment": "environment",
-                "sentry:release": "release",
-                "sentry:dist": "dist",
-                "sentry:user": "user",
-                "transaction": "transaction_name",
-                "level": "level",
-            }
-        )
+        processor = ErrorsProcessor()
         assert processor.process_message(payload, meta) == InsertBatch(
             [message.build_result(meta)], ANY
         )

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -399,16 +399,7 @@ class ErrorEvent:
 @pytest.mark.redis_db
 class TestErrorsProcessor:
 
-    processor = ErrorsProcessor(
-        {
-            "environment": "environment",
-            "sentry:release": "release",
-            "sentry:dist": "dist",
-            "sentry:user": "user",
-            "transaction": "transaction_name",
-            "level": "level",
-        }
-    )
+    processor = ErrorsProcessor()
 
     def __get_timestamps(self) -> tuple[datetime, datetime]:
         timestamp = datetime.now() - timedelta(seconds=5)

--- a/tests/datasets/test_processors_idempotency.py
+++ b/tests/datasets/test_processors_idempotency.py
@@ -11,20 +11,10 @@ from snuba.datasets.processors.transactions_processor import (
 from snuba.processor import InsertEvent, MessageProcessor
 from tests.fixtures import get_raw_error_message, get_raw_transaction_message
 
-promoted_tag_columns = {
-    "environment": "environment",
-    "sentry:release": "release",
-    "sentry:dist": "dist",
-    "sentry:user": "user",
-    "transaction": "transaction_name",
-    "level": "level",
-}
-
-
 test_data = [
     pytest.param(
         get_raw_error_message(),
-        ErrorsProcessor(promoted_tag_columns),
+        ErrorsProcessor(),
         id="errors processor",
     ),
     pytest.param(


### PR DESCRIPTION
Message processors shouldn't need to take args. Let's simplify to avoid having to port this logic to Rust.
