### PR TITLE
fix(rust_consumer): Fix wrong default for --skip-write

### DIFF
--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -87,7 +87,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     "--skip-write/--no-skip-write",
     "skip_write",
     help="Skip the write to clickhouse",
-    default=False,
+    default=True,
 )
 @click.option(
     "--processes",


### PR DESCRIPTION
A recent PR changed the default, and until this is fixed we may be
writing additional rows into querylog.
