### PR TITLE
feat(capman): Add concurrent rate limit policy to all storages

### DIFF
--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -139,6 +139,14 @@ query_processors:
         - errors
   - processor: TableRateLimit
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -147,14 +147,6 @@ allocation_policies:
         - project_id
       default_config_overrides:
         is_enforced: 0
-  - name: ConcurrentRateLimitAllocationPolicy
-    args:
-      required_tenant_types:
-        - organization_id
-        - referrer
-        - project_id
-      default_config_overrides:
-        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/discover/storages/discover.yaml
+++ b/snuba/datasets/configuration/discover/storages/discover.yaml
@@ -147,6 +147,14 @@ allocation_policies:
         - project_id
       default_config_overrides:
         is_enforced: 0
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -240,6 +240,14 @@ schema:
     - date
   not_deleted_mandatory_condition: deleted
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/events/storages/errors_ro.yaml
+++ b/snuba/datasets/configuration/events/storages/errors_ro.yaml
@@ -237,6 +237,14 @@ schema:
   dist_table_name: errors_dist_ro
   not_deleted_mandatory_condition: deleted
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/functions/storages/functions.yaml
+++ b/snuba/datasets/configuration/functions/storages/functions.yaml
@@ -82,6 +82,14 @@ schema:
 query_processors:
   - processor: TableRateLimit
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
@@ -60,6 +60,14 @@ schema:
   dist_table_name: generic_metric_counters_aggregated_dist
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -94,6 +94,14 @@ schema:
   dist_table_name: generic_metric_distributions_aggregated_dist
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/generic_metrics/storages/org_counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/org_counters.yaml
@@ -31,6 +31,14 @@ schema:
   dist_table_name: generic_metric_counters_aggregated_dist
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets.yaml
@@ -60,6 +60,14 @@ schema:
   dist_table_name: generic_metric_sets_aggregated_dist
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
+++ b/snuba/datasets/configuration/group_attributes/storages/group_attributes.yaml
@@ -38,6 +38,14 @@ schema:
   not_deleted_mandatory_condition: deleted
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: PassthroughPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
+++ b/snuba/datasets/configuration/groupassignee/storages/group_assignees.yaml
@@ -35,6 +35,14 @@ postgres_table: sentry_groupasignee
 row_processor:
   processor: GroupAssigneeRowProcessor
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
+++ b/snuba/datasets/configuration/groupedmessage/storages/grouped_messages.yaml
@@ -46,6 +46,14 @@ postgres_table: sentry_groupedmessage
 row_processor:
   processor: GroupedMessageRowProcessor
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/issues/storages/search_issues.yaml
+++ b/snuba/datasets/configuration/issues/storages/search_issues.yaml
@@ -64,6 +64,14 @@ schema:
   dist_table_name: search_issues_dist_v2
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/outcomes/storages/hourly.yaml
+++ b/snuba/datasets/configuration/outcomes/storages/hourly.yaml
@@ -21,6 +21,14 @@ schema:
   local_table_name: outcomes_hourly_local
   dist_table_name: outcomes_hourly_dist
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
+++ b/snuba/datasets/configuration/outcomes_raw/storages/raw.yaml
@@ -25,6 +25,14 @@ schema:
   local_table_name: outcomes_raw_local
   dist_table_name: outcomes_raw_dist
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/profiles/storages/profiles.yaml
+++ b/snuba/datasets/configuration/profiles/storages/profiles.yaml
@@ -56,6 +56,14 @@ query_processors:
         profile_id: null
   - processor: TableRateLimit
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/replays/storages/replays.yaml
+++ b/snuba/datasets/configuration/replays/storages/replays.yaml
@@ -173,6 +173,14 @@ stream_loader:
   default_topic: ingest-replay-events
   dlq_topic: snuba-dead-letter-replays
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/spans/storages/spans.yaml
+++ b/snuba/datasets/configuration/spans/storages/spans.yaml
@@ -76,6 +76,14 @@ schema:
   dist_table_name: spans_dist
   partition_format: [retention_days, date]
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -163,6 +163,14 @@ schema:
   partition_format: [retention_days, date]
 
 allocation_policies:
+  - name: ConcurrentRateLimitAllocationPolicy
+    args:
+      required_tenant_types:
+        - organization_id
+        - referrer
+        - project_id
+      default_config_overrides:
+        is_enforced: 0
   - name: BytesScannedWindowAllocationPolicy
     args:
       required_tenant_types:

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -180,14 +180,6 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
-  - name: ConcurrentRateLimitAllocationPolicy
-    args:
-      required_tenant_types:
-        - organization_id
-        - referrer
-        - project_id
-      default_config_overrides:
-        is_enforced: 0
 
 query_processors:
   - processor: UniqInSelectAndHavingProcessor

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -508,10 +508,18 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
         response = admin_api.get("/allocation_policy_configs/errors")
         assert response.status_code == 200
 
-        # one policy
-        assert response.json is not None and len(response.json) == 1
-        [policy_configs] = response.json
-        assert policy_configs["policy_name"] == "BytesScannedWindowAllocationPolicy"
+        # two policies
+        assert response.json is not None and len(response.json) == 2
+        policy_configs = response.json
+        bytes_scanned_policy = [
+            policy
+            for policy in policy_configs
+            if policy["policy_name"] == "BytesScannedWindowAllocationPolicy"
+        ][0]
+
+        assert (
+            bytes_scanned_policy["policy_name"] == "BytesScannedWindowAllocationPolicy"
+        )
         assert {
             "default": -1,
             "description": "Number of bytes a specific org can scan in a 10 minute "
@@ -520,7 +528,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
             "params": {"org_id": 1},
             "type": "int",
             "value": 420,
-        } in policy_configs["configs"]
+        } in bytes_scanned_policy["configs"]
 
         # no need to record auditlog when nothing was updated
         assert not auditlog_records
@@ -541,7 +549,7 @@ def test_set_allocation_policy_config(admin_api: FlaskClient) -> None:
 
         response = admin_api.get("/allocation_policy_configs/errors")
         assert response.status_code == 200
-        assert response.json is not None and len(response.json) == 1
+        assert response.json is not None and len(response.json) == 2
         assert {
             "default": -1,
             "description": "Number of bytes a specific org can scan in a 10 minute "

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -196,7 +196,12 @@ def test_db_query_success() -> None:
             "can_run": True,
             "explanation": {},
             "max_threads": 10,
-        }
+        },
+        "ConcurrentRateLimitAllocationPolicy": {
+            "can_run": True,
+            "explanation": {},
+            "max_threads": 10,
+        },
     }
     assert len(query_metadata_list) == 1
     assert result.extra["stats"] == stats
@@ -255,7 +260,12 @@ def test_bypass_cache_refferer() -> None:
                     "can_run": True,
                     "explanation": {},
                     "max_threads": 10,
-                }
+                },
+                "ConcurrentRateLimitAllocationPolicy": {
+                    "can_run": True,
+                    "explanation": {},
+                    "max_threads": 10,
+                },
             }
             assert len(query_metadata_list) == 1
             assert result.extra["stats"] == stats


### PR DESCRIPTION
This policy is already running on transactions, this PR:

* Adds a concurrent limit policy to every other storage we care about
* Does not enforce it (we will turn on enforcement on a one-by-one basis)
* Paves the way to remove all the existing rate limit processors we have in production
