### PR TITLE
feat(replays): migration for event link columns

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -174,6 +174,7 @@ class ReplaysLoader(DirectoryLoader):
             "0011_add_is_dead_rage",
             "0012_materialize_counts",
             "0013_add_low_cardinality_codecs",
+            "0014_add_id_event_columns",
         ]
 
 

--- a/snuba/snuba_migrations/replays/0014_add_id_event_columns.py
+++ b/snuba/snuba_migrations/replays/0014_add_id_event_columns.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import UUID, Column
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.operations import OperationTarget
+
+LOG_LEVELS = ["fatal", "error", "warning", "info", "debug"]
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=StorageSetKey.REPLAYS,
+                table_name=table_name,
+                column=Column(log_level + "_id", UUID()),
+                after="replay_id",
+                target=target,
+            )
+            for log_level in LOG_LEVELS
+            for table_name, target in [
+                ("replays_local", OperationTarget.LOCAL),
+                ("replays_dist", OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                storage_set=StorageSetKey.REPLAYS,
+                table_name=table_name,
+                column_name=log_level + "_id",
+                target=target,
+            )
+            for log_level in LOG_LEVELS
+            for table_name, target in [
+                ("replays_dist", OperationTarget.DISTRIBUTED),
+                ("replays_local", OperationTarget.LOCAL),
+            ]
+        ]


### PR DESCRIPTION
As part of https://github.com/getsentry/team-replay/issues/145, we're adding new columns that can represent replay / event links to verfied-to-exist Sentry events. This PR should create 5 new columns.

Will be used in an upcoming processor PR. 