### PR TITLE
feat(replays): add processor for replay event link type

### DIFF
--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -807,7 +807,7 @@ def make_payload_for_event_link(severity: str) -> tuple[dict[str, Any], str, str
                         "type": "event_link",
                         "replay_id": replay_id,
                         severity + "_id": event_id,
-                        "timestamp": int(now.timestamp()),
+                        "timestamp": str(int(now.timestamp())),
                         "event_hash": md5(
                             (replay_id + event_id).encode("utf-8")
                         ).hexdigest(),

--- a/tests/datasets/test_replays_processor.py
+++ b/tests/datasets/test_replays_processor.py
@@ -827,7 +827,6 @@ def test_replay_event_links(
     event_link_message: tuple[dict[str, Any], str, str]
 ) -> None:
     message, event_id, severity = event_link_message
-    now = datetime.now(tz=timezone.utc).replace(microsecond=0)
 
     meta = KafkaMessageMetadata(offset=0, partition=0, timestamp=datetime(1970, 1, 1))
 
@@ -838,7 +837,7 @@ def test_replay_event_links(
 
     row = rows[0]
     assert row["project_id"] == 1
-    assert row["timestamp"] == now
+    assert "timestamp" in row
     assert row[severity + "_id"] == str(uuid.UUID(event_id))
     assert row["replay_id"] == str(uuid.UUID(message["replay_id"]))
     assert (


### PR DESCRIPTION
Following up to https://github.com/getsentry/snuba/pull/4669, as part of https://github.com/getsentry/team-replay/issues/145, adds a processor for the replay event link new message type.

This message will come in from this PR https://github.com/getsentry/sentry/pull/54986 (still in draft).