### PR TITLE
fix(observability): emit bytes_scanned metric

### DIFF
--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -204,7 +204,11 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             return
         if bytes_scanned == 0:
             return
-        self.metrics.increment("bytes_scanned", bytes_scanned)
+        self.metrics.increment(
+            "bytes_scanned",
+            bytes_scanned,
+            tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
+        )
         if "organization_id" in tenant_ids:
             org_limit_bytes_scanned = self.__get_org_limit_bytes_scanned(
                 tenant_ids.get("organization_id")

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -204,6 +204,7 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
             return
         if bytes_scanned == 0:
             return
+        self.metrics.increment("bytes_scanned", bytes_scanned)
         if "organization_id" in tenant_ids:
             org_limit_bytes_scanned = self.__get_org_limit_bytes_scanned(
                 tenant_ids.get("organization_id")


### PR DESCRIPTION
[This commit](https://github.com/getsentry/snuba/pull/4611) broke our dashboards that record bytes_scanned because it was part of the old attribution system.  We still need to observe that metric tho. 

Emit the bytes_scanned metric from the BytesScannedWindowAllocationPolicy on a per-referrer basis