### PR TITLE
feat(rust-consumer): Configure metrics for Rust consumer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN set -ex; \
 # dependencies from building the Rust source code, see Relay Dockerfile.
 
 FROM build_base AS build_rust_snuba
-ARG RUST_TOOLCHAIN=1.68
+ARG RUST_TOOLCHAIN=1.72
 ARG SHOULD_BUILD_RUST=true
 
 COPY ./rust_snuba/ ./rust_snuba/

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,7 +144,7 @@ FROM application_base AS testing
 USER 0
 RUN pip install -r requirements-test.txt
 
-ARG RUST_TOOLCHAIN=1.68
+ARG RUST_TOOLCHAIN=1.72
 COPY ./rust_snuba/ ./rust_snuba/
 RUN bash -c "set -o pipefail && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain $RUST_TOOLCHAIN  --profile minimal -y"
 ENV PATH="${PATH}:/root/.cargo/bin/"

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -123,12 +123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "by_address"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0"
-
-[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,9 +130,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cadence"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb681a7408f21c9d9dcb6638e340913ea260cc587518b5976510d2341f085a19"
+checksum = "f39286bc075b023101dccdb79456a1334221c768b8faede0c2aff7ed29a9482d"
 dependencies = [
  "crossbeam-channel",
 ]
@@ -190,15 +184,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -899,15 +884,6 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
@@ -1157,36 +1133,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.3",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.9",
- "parking_lot_core 0.9.7",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f386bb233083c799e6e642a9d73db98c24a5deeb95ffc85bf281255dffc98"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1197,7 +1149,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1277,7 +1229,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -1439,12 +1391,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
@@ -1510,16 +1456,11 @@ dependencies = [
 name = "rust_arroyo"
 version = "0.1.0"
 dependencies = [
- "by_address",
- "cadence",
  "chrono",
  "clap",
  "env_logger 0.9.3",
  "futures",
- "lazy_static",
  "log",
- "parking_lot 0.10.2",
- "rand 0.8.5",
  "rdkafka",
  "serde",
  "serde_json",
@@ -1533,6 +1474,7 @@ name = "rust_snuba"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cadence",
  "chrono",
  "ctrlc",
  "env_logger 0.10.0",
@@ -1858,7 +1800,7 @@ checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "rustix",
  "windows-sys 0.42.0",
 ]
@@ -1966,7 +1908,7 @@ dependencies = [
  "memchr",
  "mio 0.8.6",
  "num_cpus",
- "parking_lot 0.12.1",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -21,6 +21,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.69"
+cadence = "0.29.1"
 chrono = { version = "0.4.26", features = ["serde"] }
 futures = "0.3.21"
 rust_arroyo = { path = "./rust_arroyo" }

--- a/rust_snuba/rust_arroyo/Cargo.toml
+++ b/rust_snuba/rust_arroyo/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 chrono = "0.4.26"
 uuid = "0.8"
-by_address = "1.0.4"
 rdkafka = { version = "0.28", features = ["cmake-build"] }
 thiserror = "1.0"
 clap = "2.18.0"
@@ -16,9 +15,5 @@ tokio = { version = "1.19.2", features = ["full"] }
 futures = "0.3.21"
 env_logger = "0.9.0"
 log = "0.4.17"
-cadence = "0.29.0"
-lazy_static = "1.4.0"
-parking_lot = "0.10.0"
-rand="0.8.5"
 serde_json = "1.0.81"
 serde = {version = "1.0.137", features = ["derive"] }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -2,10 +2,11 @@ pub mod strategies;
 
 use crate::backends::{AssignmentCallbacks, Consumer};
 use crate::types::{InnerMessage, Message, Partition, Topic};
+use crate::utils::metrics::{get_metrics, Metrics};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 
 #[derive(Debug, Clone)]
@@ -56,6 +57,9 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
         stg.strategy = Some(stg.processing_factory.create());
     }
     fn on_revoke(&mut self, _: Vec<Partition>) {
+        let metrics = get_metrics();
+        let start = Instant::now();
+
         let mut stg = self.strategies.lock().unwrap();
         match stg.strategy.as_mut() {
             None => {}
@@ -65,6 +69,12 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
             }
         }
         stg.strategy = None;
+
+        metrics.timing(
+            "arroyo.consumer.join.time",
+            start.elapsed().as_millis() as u64,
+            None,
+        );
     }
 }
 

--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -1,234 +1,50 @@
-use cadence::{
-    BufferedUdpMetricSink, Counted, Gauged, MetricBuilder, QueuingMetricSink, StatsdClient, Timed,
-};
-use lazy_static::lazy_static;
-use parking_lot::RwLock;
-use rand::Rng;
+use core::fmt::Debug;
 use std::collections::HashMap;
-use std::net::{ToSocketAddrs, UdpSocket};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
-pub trait Metrics {
-    fn counter(
-        &self,
-        key: &str,
-        value: Option<i64>,
-        tags: Option<HashMap<&str, &str>>,
-        sample_rate: Option<f64>,
-    );
+pub static METRICS: OnceLock<Arc<Mutex<Box<dyn Metrics>>>> = OnceLock::new();
 
-    fn gauge(
-        &self,
-        key: &str,
-        value: u64,
-        tags: Option<HashMap<&str, &str>>,
-        sample_rate: Option<f64>,
-    );
+pub trait Metrics: Debug + Send + Sync {
+    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>);
 
-    fn time(
-        &self,
-        key: &str,
-        value: u64,
-        tags: Option<HashMap<&str, &str>>,
-        sample_rate: Option<f64>,
-    );
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 }
 
-pub struct MetricsClient {
-    statsd_client: StatsdClient,
-    prefix: String,
-}
-
-impl Metrics for MetricsClient {
-    fn counter(
-        &self,
-        key: &str,
-        value: Option<i64>,
-        tags: Option<HashMap<&str, &str>>,
-        sample_rate: Option<f64>,
-    ) {
-        if !self.should_sample(sample_rate) {
-            return;
-        }
-
-        let count_value = value.unwrap_or(1);
-
-        if let Some(tags) = tags {
-            let metric_builder = self.statsd_client.count_with_tags(key, count_value);
-            self.send_with_tags(metric_builder, tags);
-        } else {
-            let result = self.statsd_client.count(key, count_value);
-            match result {
-                Ok(_) => {}
-                Err(_err) => {
-                    println!("Failed to send metric {}: {}", key, _err)
-                }
-            }
-        }
+impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
+    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+        self.as_ref().lock().unwrap().increment(key, value, tags)
     }
-
-    fn gauge(
-        &self,
-        key: &str,
-        value: u64,
-        tags: Option<HashMap<&str, &str>>,
-        sample_rate: Option<f64>,
-    ) {
-        if !self.should_sample(sample_rate) {
-            return;
-        }
-
-        if let Some(tags) = tags {
-            let metric_builder = self.statsd_client.gauge_with_tags(key, value);
-            self.send_with_tags(metric_builder, tags);
-        } else {
-            let result = self.statsd_client.gauge(key, value);
-            match result {
-                Ok(_) => {}
-                Err(_err) => {
-                    println!("Failed to send metric {}: {}", key, _err)
-                }
-            }
-        }
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        self.as_ref().lock().unwrap().gauge(key, value, tags)
     }
-
-    fn time(
-        &self,
-        key: &str,
-        value: u64,
-        tags: Option<HashMap<&str, &str>>,
-        sample_rate: Option<f64>,
-    ) {
-        if !self.should_sample(sample_rate) {
-            return;
-        }
-
-        if let Some(tags) = tags {
-            let metric_builder = self.statsd_client.time_with_tags(key, value);
-            self.send_with_tags(metric_builder, tags);
-        } else {
-            let result = self.statsd_client.time(key, value);
-            match result {
-                Ok(_) => {}
-                Err(_err) => {
-                    println!("Failed to send metric {}: {}", key, _err)
-                }
-            }
-        }
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        self.as_ref().lock().unwrap().timing(key, value, tags)
     }
 }
 
-impl MetricsClient {
-    fn should_sample(&self, sample_rate: Option<f64>) -> bool {
-        rand::thread_rng().gen_range(0.0..=1.0) < sample_rate.unwrap_or(1.0)
-    }
+#[derive(Debug)]
+struct Noop {}
 
-    fn send_with_tags<'t, T: cadence::Metric + From<String>>(
-        &self,
-        mut metric_builder: MetricBuilder<'t, '_, T>,
-        tags: HashMap<&'t str, &'t str>,
-    ) {
-        for (key, value) in tags {
-            metric_builder = metric_builder.with_tag(key, value);
-        }
-        let result = metric_builder.try_send();
-        match result {
-            Ok(_) => {}
-            Err(_err) => {
-                println!("Failed to send metric with tags: {}", _err)
-            }
-        }
-    }
+impl Metrics for Noop {
+    fn increment(&self, _key: &str, _value: Option<i64>, _tags: Option<HashMap<&str, &str>>) {}
+
+    fn gauge(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+
+    fn timing(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 }
 
-lazy_static! {
-    static ref METRICS_CLIENT: RwLock<Option<Arc<MetricsClient>>> = RwLock::new(None);
+pub fn configure_metrics(metrics: Box<dyn Metrics>) {
+    // Metrics can only be configured once
+    METRICS
+        .set(Arc::new(Mutex::new(metrics)))
+        .expect("Metrics already configured");
 }
 
-const METRICS_MAX_QUEUE_SIZE: usize = 1024;
-
-pub fn init<A: ToSocketAddrs>(prefix: &str, host: A) {
-    let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
-    socket.set_nonblocking(true).unwrap();
-
-    let buffered_udp_sink = BufferedUdpMetricSink::from(host, socket).unwrap();
-    let queuing_sink = QueuingMetricSink::with_capacity(buffered_udp_sink, METRICS_MAX_QUEUE_SIZE);
-    // If metrics need to be sent out immediately without waiting then use the udp_sink below.
-    //let udp_sink = UdpMetricSink::from(host, socket).unwrap();
-    let statsd_client = StatsdClient::from_sink(prefix, queuing_sink);
-
-    let metrics_client = MetricsClient {
-        statsd_client,
-        prefix: String::from(prefix),
-    };
-    println!("Emitting metrics with prefix {}", metrics_client.prefix);
-    *METRICS_CLIENT.write() = Some(Arc::new(metrics_client));
-}
-
-// TODO: Remove cloning METRICS_CLIENT each time this is called using thread local storage.
-pub fn increment(
-    key: &str,
-    value: Option<i64>,
-    tags: Option<HashMap<&str, &str>>,
-    sample_rate: Option<f64>,
-) {
-    METRICS_CLIENT
-        .read()
-        .clone()
-        .unwrap()
-        .counter(key, value, tags, sample_rate);
-}
-
-// TODO: Remove cloning METRICS_CLIENT each time this is called using thread local storage.
-pub fn gauge(key: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
-    METRICS_CLIENT
-        .read()
-        .clone()
-        .unwrap()
-        .gauge(key, value, tags, sample_rate);
-}
-
-// TODO: Remove cloning METRICS_CLIENT each time this is called using thread local storage.
-pub fn time(key: &str, value: u64, tags: Option<HashMap<&str, &str>>, sample_rate: Option<f64>) {
-    METRICS_CLIENT
-        .read()
-        .clone()
-        .unwrap()
-        .time(key, value, tags, sample_rate);
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::utils::metrics::{gauge, increment, init, time, METRICS_CLIENT};
-    use std::collections::HashMap;
-
-    #[test]
-    fn test_metrics() {
-        init("my_host", "0.0.0.0:8125");
-
-        assert!(!METRICS_CLIENT
-            .read()
-            .clone()
-            .unwrap()
-            .should_sample(Some(0.0)),);
-        assert!(METRICS_CLIENT
-            .read()
-            .clone()
-            .unwrap()
-            .should_sample(Some(1.0)),);
-
-        increment(
-            "a",
-            Some(1),
-            Some(HashMap::from([("tag1", "value1")])),
-            Some(1.0),
-        );
-        gauge(
-            "b",
-            20,
-            Some(HashMap::from([("tag2", "value2"), ("tag4", "value4")])),
-            None,
-        );
-        time("c", 30, Some(HashMap::from([("tag3", "value3")])), None);
+pub fn get_metrics() -> Arc<Mutex<Box<dyn Metrics>>> {
+    match METRICS.get() {
+        Some(metrics) => metrics.clone(),
+        None => Arc::new(Mutex::new(Box::new(Noop {}))),
     }
 }

--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -12,7 +12,7 @@ pub struct ConsumerConfig {
     pub dlq_topic: Option<TopicConfig>,
     pub max_batch_size: usize,
     pub max_batch_time_ms: u64,
-    pub env: Option<EnvConfig>,
+    pub env: EnvConfig,
 }
 
 #[derive(Deserialize)]
@@ -62,4 +62,6 @@ pub struct MessageProcessorConfig {
 #[serde(deny_unknown_fields)]
 pub struct EnvConfig {
     pub sentry_dsn: Option<String>,
+    pub dogstatsd_host: Option<String>,
+    pub dogstatsd_port: Option<u16>,
 }

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -12,9 +12,11 @@ use rust_arroyo::processing::strategies::reduce::Reduce;
 use rust_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::Topic;
+use rust_arroyo::utils::metrics::configure_metrics;
 
 use pyo3::prelude::*;
 
+use crate::metrics::statsd::StatsDBackend;
 use crate::processors;
 use crate::strategies::clickhouse::ClickhouseWriterStep;
 use crate::strategies::python::PythonTransformStep;
@@ -100,11 +102,32 @@ pub fn consumer_impl(
     assert!(consumer_config.commit_log_topic.is_none());
 
     // setup sentry
-    if let Some(env) = consumer_config.env {
-        if let Some(dsn) = env.sentry_dsn {
-            log::debug!("Using sentry dsn {:?}", dsn);
-            setup_sentry(dsn);
-        }
+    if let Some(dsn) = consumer_config.env.sentry_dsn {
+        log::debug!("Using sentry dsn {:?}", dsn);
+        setup_sentry(dsn);
+    }
+
+    // setup arroyo metrics
+    if let (Some(host), Some(port)) = (
+        consumer_config.env.dogstatsd_host,
+        consumer_config.env.dogstatsd_port,
+    ) {
+        let mut tags = HashMap::new();
+        let storage_name = consumer_config
+            .storages
+            .iter()
+            .map(|s| s.name.clone())
+            .collect::<Vec<_>>()
+            .join(",");
+        tags.insert("storage", storage_name.as_str());
+        tags.insert("consumer_group", consumer_group);
+
+        configure_metrics(Box::new(StatsDBackend::new(
+            &host,
+            port,
+            "snuba.rust_consumer",
+            tags,
+        )));
     }
 
     procspawn::init();

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod consumer;
+mod metrics;
 mod processors;
 mod runtime_config;
 mod strategies;

--- a/rust_snuba/src/metrics/mod.rs
+++ b/rust_snuba/src/metrics/mod.rs
@@ -1,0 +1,2 @@
+pub mod statsd;
+pub mod testing;

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -49,19 +49,19 @@ impl ArroyoMetrics for StatsDBackend {
         if let Err(e) =
             self.send_with_tags(self.client.count_with_tags(key, value.unwrap_or(1)), tags)
         {
-            log::error!("Error sending metric: {}", e);
+            log::debug!("Error sending metric: {}", e);
         }
     }
 
     fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) = self.send_with_tags(self.client.gauge_with_tags(key, value), tags) {
-            log::error!("Error sending metric: {}", e);
+            log::debug!("Error sending metric: {}", e);
         }
     }
 
     fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) = self.send_with_tags(self.client.time_with_tags(key, value), tags) {
-            log::error!("Error sending metric: {}", e);
+            log::debug!("Error sending metric: {}", e);
         }
     }
 }

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -1,0 +1,82 @@
+#![allow(dead_code)]
+
+use cadence::prelude::*;
+use cadence::{BufferedUdpMetricSink, MetricBuilder, MetricError, QueuingMetricSink, StatsdClient};
+use rust_arroyo::utils::metrics::Metrics as ArroyoMetrics;
+use std::collections::HashMap;
+use std::net::UdpSocket;
+
+#[derive(Debug)]
+pub struct StatsDBackend {
+    client: StatsdClient,
+}
+
+impl StatsDBackend {
+    pub fn new(host: &str, port: u16, prefix: &str, global_tags: HashMap<&str, &str>) -> Self {
+        let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        socket.set_nonblocking(true).unwrap();
+        let sink_addr = (host, port);
+        let buffered = BufferedUdpMetricSink::from(sink_addr, socket).unwrap();
+        let queuing_sink = QueuingMetricSink::from(buffered);
+
+        let mut client_builder = StatsdClient::builder(prefix, queuing_sink);
+        for (k, v) in global_tags {
+            client_builder = client_builder.with_tag(k, v);
+        }
+
+        Self {
+            client: client_builder.build(),
+        }
+    }
+
+    fn send_with_tags<'t, T: cadence::Metric + From<String>>(
+        &self,
+        mut builder: MetricBuilder<'t, '_, T>,
+        tags: Option<HashMap<&'t str, &'t str>>,
+    ) -> Result<T, MetricError> {
+        if let Some(t) = tags {
+            for (key, value) in t {
+                builder = builder.with_tag(key, value);
+            }
+        }
+
+        builder.try_send()
+    }
+}
+
+impl ArroyoMetrics for StatsDBackend {
+    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+        if let Err(e) =
+            self.send_with_tags(self.client.count_with_tags(key, value.unwrap_or(1)), tags)
+        {
+            log::error!("Error sending metric: {}", e);
+        }
+    }
+
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        if let Err(e) = self.send_with_tags(self.client.gauge_with_tags(key, value), tags) {
+            log::error!("Error sending metric: {}", e);
+        }
+    }
+
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        if let Err(e) = self.send_with_tags(self.client.time_with_tags(key, value), tags) {
+            log::error!("Error sending metric: {}", e);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn statsd_metric_backend() {
+        let backend = StatsDBackend::new("0.0.0.0", 8125, "test", HashMap::from([("env", "prod")]));
+
+        backend.increment("a", Some(1), Some(HashMap::from([("tag1", "value1")])));
+        backend.gauge("b", 20, Some(HashMap::from([("tag2", "value2")])));
+        backend.timing("c", 30, Some(HashMap::from([("tag3", "value3")])));
+    }
+}

--- a/rust_snuba/src/metrics/testing.rs
+++ b/rust_snuba/src/metrics/testing.rs
@@ -1,0 +1,105 @@
+#![allow(dead_code)]
+
+use cadence::prelude::*;
+use cadence::{Metric, NopMetricSink, StatsdClient};
+use cadence::{MetricBuilder, MetricError};
+
+use rust_arroyo::utils::metrics::Metrics as ArroyoMetrics;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug)]
+pub struct TestingMetricsBackend {
+    client: StatsdClient,
+    metric_calls: Arc<Mutex<Vec<String>>>,
+}
+
+impl TestingMetricsBackend {
+    fn new(prefix: &str) -> Self {
+        let client = StatsdClient::from_sink(prefix, NopMetricSink);
+
+        Self {
+            client,
+            metric_calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn clear(&self) {
+        self.metric_calls.lock().unwrap().clear();
+    }
+
+    fn send_with_tags<'t, T: cadence::Metric + From<String>>(
+        &self,
+        mut builder: MetricBuilder<'t, '_, T>,
+        tags: Option<HashMap<&'t str, &'t str>>,
+    ) -> Result<T, MetricError> {
+        if let Some(t) = tags {
+            for (key, value) in t {
+                builder = builder.with_tag(key, value);
+            }
+        }
+
+        builder.try_send()
+    }
+}
+
+impl ArroyoMetrics for TestingMetricsBackend {
+    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+        let builder = self.client.count_with_tags(key, value.unwrap_or(1));
+
+        let res = self
+            .send_with_tags(builder, tags)
+            .unwrap()
+            .as_metric_str()
+            .to_owned();
+
+        self.metric_calls.lock().unwrap().push(res);
+    }
+
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        let builder = self.client.gauge_with_tags(key, value);
+
+        let res = self
+            .send_with_tags(builder, tags)
+            .unwrap()
+            .as_metric_str()
+            .to_owned();
+
+        self.metric_calls.lock().unwrap().push(res);
+    }
+
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+        let builder = self.client.time_with_tags(key, value);
+
+        let res = self
+            .send_with_tags(builder, tags)
+            .unwrap()
+            .as_metric_str()
+            .to_owned();
+
+        self.metric_calls.lock().unwrap().push(res);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn testing_metrics_backend() {
+        let backend = TestingMetricsBackend::new("snuba.rust-consumer");
+
+        backend.increment("a", Some(1), Some(HashMap::from([("tag1", "value1")])));
+        backend.gauge("b", 20, Some(HashMap::from([("tag2", "value2")])));
+        backend.timing("c", 30, Some(HashMap::from([("tag3", "value3")])));
+
+        let expected = vec![
+            "snuba.rust-consumer.a:1|c|#tag1:value1",
+            "snuba.rust-consumer.b:20|g|#tag2:value2",
+            "snuba.rust-consumer.c:30|ms|#tag3:value3",
+        ];
+
+        assert_eq!(*backend.metric_calls.lock().unwrap(), expected);
+    }
+}

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 mod querylog;
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;

--- a/snuba/consumers/consumer_config.py
+++ b/snuba/consumers/consumer_config.py
@@ -44,6 +44,8 @@ class TopicConfig:
 @dataclass(frozen=True)
 class EnvConfig:
     sentry_dsn: Optional[str]
+    dogstatsd_host: Optional[str]
+    dogstatsd_port: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -90,9 +92,15 @@ def _resolve_topic_config(
     )
 
 
-def _resolve_env_config() -> Optional[EnvConfig]:
+def _resolve_env_config() -> EnvConfig:
     sentry_dsn = settings.SENTRY_DSN
-    return EnvConfig(sentry_dsn=sentry_dsn)
+    dogstatsd_host = settings.DOGSTATSD_HOST
+    dogstatsd_port = settings.DOGSTATSD_PORT
+    return EnvConfig(
+        sentry_dsn=sentry_dsn,
+        dogstatsd_host=dogstatsd_host,
+        dogstatsd_port=dogstatsd_port,
+    )
 
 
 def resolve_consumer_config(


### PR DESCRIPTION
Add statsd and testing metric backends to rust_snuba. Remove the metric implementation and dependency on cadence from Arroyo - users of Arroyo should provide the trait implementation.

Pass the dogstatsd host and port from Python to Rust via config.

Also start logging one metric ("arroyo.consumer.join.time") to verify it works.
