### PR TITLE
fix(profiling): Handle null timestamps for functions

### DIFF
--- a/snuba/datasets/processors/functions_processor.py
+++ b/snuba/datasets/processors/functions_processor.py
@@ -24,7 +24,8 @@ class FunctionsMessageProcessor(DatasetMessageProcessor):
 
         profile_id = str(uuid.UUID(message["profile_id"]))
         now = datetime.utcnow().timestamp()
-        timestamp = datetime.utcfromtimestamp(message.get("timestamp", now) or now)
+        raw_timestamp = max(message.get("timestamp", 0), 0)
+        timestamp = datetime.utcfromtimestamp(raw_timestamp or now)
 
         if "call_trees" in message:
             functions = {}

--- a/snuba/datasets/processors/functions_processor.py
+++ b/snuba/datasets/processors/functions_processor.py
@@ -23,7 +23,8 @@ class FunctionsMessageProcessor(DatasetMessageProcessor):
         max_depth_reached = False
 
         profile_id = str(uuid.UUID(message["profile_id"]))
-        timestamp = datetime.utcfromtimestamp(message["timestamp"])
+        now = datetime.utcnow().timestamp()
+        timestamp = datetime.utcfromtimestamp(message.get("timestamp", now) or now)
 
         if "call_trees" in message:
             functions = {}


### PR DESCRIPTION
Since we started accepted timestamps for Android profiles as an optional field, this started to crash. We have a bunch of profiles without timestamps on the topic so this is a workaround to still ingest them.

We're also fixing the pipeline upstream to fall back on the older value if the timestamp is not sent.

https://github.com/getsentry/vroom/pull/307