### PR TITLE
fix(rust): CommitRequest must be used

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -65,7 +65,9 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
             None => {}
             Some(s) => {
                 s.close();
-                s.join(None);
+                // TODO: We need to actually call consumer.commit() with the commit request.
+                // Right now we are never committing during consumer shutdown.
+                let _ = s.join(None);
             }
         }
         stg.strategy = None;

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -40,6 +40,7 @@ pub trait ProcessingStrategy<TPayload: Clone>: Send + Sync {
     ///
     /// This method may raise exceptions that were thrown by asynchronous
     /// tasks since the previous call to ``poll``.
+    #[must_use]
     fn poll(&mut self) -> Option<CommitRequest>;
 
     /// Submit a message for processing.
@@ -78,6 +79,7 @@ pub trait ProcessingStrategy<TPayload: Clone>: Send + Sync {
     /// until this function exits, allowing any work in progress to be
     /// completed and committed before the continuing the rebalancing
     /// process.
+    #[must_use]
     fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest>;
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -1,7 +1,9 @@
 use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
-use crate::processing::strategies::{CommitRequest, MessageRejected, ProcessingStrategy};
+use crate::processing::strategies::{
+    merge_commit_request, CommitRequest, MessageRejected, ProcessingStrategy,
+};
 use crate::types::{Message, TopicOrPartition};
 use futures::Future;
 use log::warn;
@@ -54,6 +56,8 @@ impl Produce<KafkaPayload> {
 
 impl ProcessingStrategy<KafkaPayload> for Produce<KafkaPayload> {
     fn poll(&mut self) -> Option<CommitRequest> {
+        let mut commit_request = None;
+
         while !self.queue.is_empty() {
             let (message, handle) = self.queue.pop_front().unwrap();
 
@@ -62,14 +66,15 @@ impl ProcessingStrategy<KafkaPayload> for Produce<KafkaPayload> {
                 // block_on(async{
                 //     handle.await.unwrap();
                 // });
-                self.next_step.poll();
+                let next_commit = self.next_step.poll();
+                commit_request = merge_commit_request(commit_request, next_commit);
+
                 self.next_step.submit(new_message).unwrap()
             } else {
                 break;
             }
         }
-        // TODO: This needs to handle commit request
-        None
+        commit_request
     }
 
     fn submit(
@@ -108,6 +113,7 @@ impl ProcessingStrategy<KafkaPayload> for Produce<KafkaPayload> {
     fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
         let start = Instant::now();
         let mut remaining: Option<Duration> = timeout;
+        let mut commit_request = None;
 
         while !self.queue.is_empty() {
             if let Some(t) = remaining {
@@ -120,7 +126,9 @@ impl ProcessingStrategy<KafkaPayload> for Produce<KafkaPayload> {
             let (message, handle) = self.queue.pop_front().unwrap();
             if handle.is_finished() {
                 let new_message = message.clone();
-                self.next_step.poll();
+                let next_commit = self.next_step.poll();
+                commit_request = merge_commit_request(commit_request, next_commit);
+
                 // TODO: Handle message rejected
                 self.next_step.submit(new_message).unwrap()
             } else {
@@ -129,7 +137,8 @@ impl ProcessingStrategy<KafkaPayload> for Produce<KafkaPayload> {
         }
 
         self.next_step.close();
-        self.next_step.join(remaining)
+        let next_commit = self.next_step.join(remaining);
+        merge_commit_request(commit_request, next_commit)
     }
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
@@ -208,11 +208,11 @@ mod tests {
                 )),
             };
             strategy.submit(msg).unwrap();
-            strategy.poll();
+            let _ = strategy.poll();
         }
 
         strategy.close();
-        strategy.join(None);
+        let _ = strategy.join(None);
 
         // 2 batches were created
         assert_eq!(

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -189,7 +189,7 @@ mod tests {
         let message = Message::new_any_message("hello_world".to_string(), BTreeMap::new());
 
         strategy.submit(message).unwrap();
-        strategy.poll();
-        strategy.join(None);
+        let _ = strategy.poll();
+        let _ = strategy.join(None);
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -1,5 +1,5 @@
 use crate::processing::strategies::{
-    CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
+    merge_commit_request, CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
 };
 use crate::types::Message;
 use std::collections::VecDeque;
@@ -124,6 +124,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
     fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
         let start = Instant::now();
         let mut remaining: Option<Duration> = timeout;
+        let mut commit_request: Option<CommitRequest> = None;
 
         // Poll until there are no more messages or timeout is hit
         while self.message_carried_over.is_some() || !self.handles.is_empty() {
@@ -135,7 +136,8 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
                 }
             }
 
-            self.poll();
+            let next_commit = self.poll();
+            commit_request = merge_commit_request(commit_request, next_commit);
         }
 
         // Cancel remaining tasks if any
@@ -144,7 +146,8 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
         }
         self.handles.clear();
 
-        self.next_step.join(remaining)
+        let next_commit = self.next_step.join(timeout);
+        merge_commit_request(commit_request, next_commit)
     }
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -124,7 +124,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
     fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
         let start = Instant::now();
         let mut remaining: Option<Duration> = timeout;
-        let mut commit_request: Option<CommitRequest> = None;
+        let mut commit_request = None;
 
         // Poll until there are no more messages or timeout is hit
         while self.message_carried_over.is_some() || !self.handles.is_empty() {


### PR DESCRIPTION
We are skipping committing offsets in a fewplaces since we are not doing anything with the CommitRequest in some strategies. `ProcessingStrategy.poll()` and `ProcessingStrategy.join()` are annotated must_use to avoid this happening in future.

Added a TODO for committing offsets in the revocation callback, we are not doing anything with them currently.