### PR TITLE
fix(monitoring): Add dataset tag to bytes scanned metric

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -197,7 +197,8 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         >>>     def _update_quota_balance(
         >>>         self,
         >>>         tenant_ids: dict[str, str | int],
-        >>>         query_id: str
+        >>>         query_id: str,
+        >>>         dataset_name: str,
         >>>         result_or_error: QueryResultOrError,
         >>>     ) -> None:
         >>>         # after the query has been run, update whatever this allocation policy
@@ -737,12 +738,15 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         self,
         tenant_ids: dict[str, str | int],
         query_id: str,
+        dataset_name: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         try:
             if not self.is_active:
                 return
-            return self._update_quota_balance(tenant_ids, query_id, result_or_error)
+            return self._update_quota_balance(
+                tenant_ids, query_id, dataset_name, result_or_error
+            )
         except Exception:
             # FIXME: Remove this
             logger.exception(
@@ -756,6 +760,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
         self,
         tenant_ids: dict[str, str | int],
         query_id: str,
+        dataset_name: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         pass
@@ -776,6 +781,7 @@ class PassthroughPolicy(AllocationPolicy):
         self,
         tenant_ids: dict[str, str | int],
         query_id: str,
+        dataset_name: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         pass

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -189,6 +189,7 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         self,
         tenant_ids: dict[str, str | int],
         query_id: str,
+        dataset_name: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         if result_or_error.error:
@@ -208,7 +209,10 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         self.metrics.increment(
             "bytes_scanned",
             bytes_scanned,
-            tags={"referrer": str(tenant_ids.get("referrer", "no_referrer"))},
+            tags={
+                "referrer": str(tenant_ids.get("referrer", "no_referrer")),
+                "dataset": dataset_name,
+            },
         )
         if "organization_id" in tenant_ids:
             org_limit_bytes_scanned = self.__get_org_limit_bytes_scanned(

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -212,6 +212,7 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
         self,
         tenant_ids: dict[str, str | int],
         query_id: str,
+        dataset_name: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         rate_limit_params, _ = self._get_rate_limit_params(tenant_ids)

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -760,6 +760,7 @@ def db_query(
             allocation_policy.update_quota_balance(
                 tenant_ids=attribution_info.tenant_ids,
                 query_id=query_id,
+                dataset_name=dataset_name,
                 result_or_error=QueryResultOrError(query_result=result, error=error),
             )
         if result:

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -440,6 +440,7 @@ def test_get_allocation_policy_configs(admin_api: FlaskClient) -> None:
             self,
             tenant_ids: dict[str, str | int],
             query_id: str,
+            dataset_name: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             pass

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -20,6 +20,7 @@ MAX_THREAD_NUMBER = 400
 # This policy does not use the query_id for any of its operation,
 # but we need to pass it for the interface
 QUERY_ID = "deadbeef"
+DATASET_NAME = "some_dataset"
 
 
 @pytest.fixture(scope="function")
@@ -54,6 +55,7 @@ def test_consume_quota(policy: BytesScannedWindowAllocationPolicy) -> None:
     policy.update_quota_balance(
         tenant_ids,
         QUERY_ID,
+        DATASET_NAME,
         QueryResultOrError(
             query_result=QueryResult(
                 result={"profile": {"bytes": ORG_SCAN_LIMIT}},
@@ -84,6 +86,7 @@ def test_org_isolation(policy: AllocationPolicy) -> None:
     policy.update_quota_balance(
         tenant_ids,
         QUERY_ID,
+        DATASET_NAME,
         QueryResultOrError(
             query_result=QueryResult(
                 result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}},
@@ -111,6 +114,7 @@ def test_killswitch(policy: AllocationPolicy) -> None:
     policy.update_quota_balance(
         tenant_ids,
         QUERY_ID,
+        DATASET_NAME,
         QueryResultOrError(
             query_result=QueryResult(
                 result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}},
@@ -134,6 +138,7 @@ def test_enforcement_switch(policy: AllocationPolicy) -> None:
     policy.update_quota_balance(
         tenant_ids,
         QUERY_ID,
+        DATASET_NAME,
         QueryResultOrError(
             query_result=QueryResult(
                 result={"profile": {"bytes": 20 * ORG_SCAN_LIMIT}},
@@ -164,6 +169,7 @@ def test_reject_queries_without_tenant_ids(policy: AllocationPolicy) -> None:
         policy.update_quota_balance(
             tenant_ids,
             QUERY_ID,
+            DATASET_NAME,
             QueryResultOrError(
                 query_result=QueryResult(
                     result={"profile": {"bytes": ORG_SCAN_LIMIT}},
@@ -207,6 +213,7 @@ def test_passthrough_subscriptions(policy: AllocationPolicy) -> None:
     policy.update_quota_balance(
         tenant_ids,
         QUERY_ID,
+        DATASET_NAME,
         QueryResultOrError(
             query_result=QueryResult(
                 result={"profile": {"bytes": ORG_SCAN_LIMIT * 1000}},
@@ -232,6 +239,7 @@ def test_single_thread_referrers(policy: AllocationPolicy) -> None:
     policy.update_quota_balance(
         tenant_ids,
         QUERY_ID,
+        DATASET_NAME,
         QueryResultOrError(
             query_result=QueryResult(
                 result={"profile": {"bytes": ORG_SCAN_LIMIT * 1000}},

--- a/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
+++ b/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from snuba.datasets.storage import StorageKey
+from snuba.datasets.storages.storage_key import StorageKey
 from snuba.query.allocation_policies import (
     AllocationPolicyViolation,
     AllocationPolicyViolations,
@@ -98,6 +98,7 @@ def test_rate_limit_concurrent_complete_query(
     policy.update_quota_balance(
         tenant_ids={"organization_id": 123},
         query_id="abc0",
+        dataset_name="dataset",
         result_or_error=_RESULT_SUCCESS,
     )
 
@@ -128,6 +129,7 @@ def test_update_quota_balance(policy: ConcurrentRateLimitAllocationPolicy) -> No
         policy.update_quota_balance(
             tenant_ids={"organization_id": 123},
             query_id=f"abc{i}",
+            dataset_name="some_dataset",
             result_or_error=_RESULT_FAIL,
         )
 
@@ -279,6 +281,7 @@ def test_override_isolation(
     policy.update_quota_balance(
         tenant_ids={"project_id": project_id, "referrer": overridden_referrer},
         query_id="uniq_string_1",
+        dataset_name="dataset",
         result_or_error=_RESULT_SUCCESS,
     )
     try:
@@ -295,6 +298,7 @@ def test_override_isolation(
     policy.update_quota_balance(
         tenant_ids={"project_id": project_id, "referrer": "a_different_referrer"},
         query_id="1",
+        dataset_name="dataset",
         result_or_error=_RESULT_SUCCESS,
     )
 

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -44,6 +44,7 @@ class RejectAllocationPolicy123(AllocationPolicy):
         self,
         tenant_ids: dict[str, str | int],
         query_id: str,
+        dataset_name: str,
         result_or_error: QueryResultOrError,
     ) -> None:
         return

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -328,6 +328,7 @@ def test_db_query_with_rejecting_allocation_policy() -> None:
             self,
             tenant_ids: dict[str, str | int],
             query_id: str,
+            dataset_name: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             return
@@ -396,6 +397,7 @@ def test_allocation_policy_threads_applied_to_query() -> None:
             self,
             tenant_ids: dict[str, str | int],
             query_id: str,
+            dataset_name: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             return
@@ -468,6 +470,7 @@ def test_allocation_policy_updates_quota() -> None:
             self,
             tenant_ids: dict[str, str | int],
             query_id: str,
+            dataset_name: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             nonlocal queries_run
@@ -497,6 +500,7 @@ def test_allocation_policy_updates_quota() -> None:
             self,
             tenant_ids: dict[str, str | int],
             query_id: str,
+            dataset_name: str,
             result_or_error: QueryResultOrError,
         ) -> None:
             nonlocal queries_run_duplicate


### PR DESCRIPTION
This PR is responsible for adding missing dataset tag to the new bytes scanned metric.