### PR TITLE
chore(self-hosted): Publish snuba image to dockerhub again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,3 +412,47 @@ jobs:
       - name: Upload to codecov
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
+  publish-to-dockerhub:
+    name: Publish Snuba to DockerHub
+    runs-on: ubuntu-20.04
+    if: ${{ (github.ref_name == 'master') }}
+    steps:
+      - uses: actions/checkout@v3 # v3.1.0
+      - name: Pull the test image
+        id: image_pull
+        env:
+          IMAGE_URL: us.gcr.io/sentryio/snuba:${{ github.sha }}
+        shell: bash
+        run: |
+          echo "We poll for the Docker image that the GCB/GHA build produces until it succeeds or this job times out."
+          echo "Polling for $IMAGE_URL"
+          timeout 20m bash -c 'until docker pull "$IMAGE_URL" 2>/dev/null; do sleep 10; done'
+      - name: Get short SHA for docker tag
+        id: short_sha
+        shell: bash
+        run: |
+          SHORT_SHA=$(git rev-parse --short "$GITHUB_SHA")
+          if [[ -z "$SHORT_SHA" ]]; then
+            echo "Short SHA empty? Re-running rev-parse."
+            git rev-parse --short "$GITHUB_SHA"
+          else
+            echo "sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          fi
+      - name: Push built docker image
+        shell: bash
+        env:
+          SHORT_SHA: ${{ steps.short_sha.outputs.sha }}
+          IMAGE_URL: us.gcr.io/sentryio/snuba:${{ github.sha }}
+        run: |
+          # only login if the password is set
+          if [[ "${{ secrets.DOCKER_HUB_RW_TOKEN }}" ]]; then echo "${{ secrets.DOCKER_HUB_RW_TOKEN }}" | docker login --username=sentrybuilder --password-stdin; fi
+          # We push 3 tags to Dockerhub:
+          # first, the full sha of the commit
+          docker tag ${IMAGE_URL} getsentry/snuba:${GITHUB_SHA}
+          docker push getsentry/snuba:${GITHUB_SHA}
+          # second, the short sha of the commit
+          docker tag ${IMAGE_URL} getsentry/snuba:${SHORT_SHA}
+          docker push getsentry/snuba:${SHORT_SHA}
+          # finally, nightly
+          docker tag ${IMAGE_URL} getsentry/snuba:nightly
+          docker push getsentry/snuba:nightly


### PR DESCRIPTION
Due to [removal of e2e tests](https://github.com/getsentry/snuba/pull/4660), we were no longer pushing to dockerhub. This resumes that process.