### PR TITLE
ref(admin) Sort capacity management keys

### DIFF
--- a/snuba/admin/static/capacity_management/allocation_policy.tsx
+++ b/snuba/admin/static/capacity_management/allocation_policy.tsx
@@ -18,6 +18,7 @@ function AllocationPolicyConfigs(props: {
   const [configs, setConfigs] = useState<AllocationPolicyConfig[]>([]);
 
   useEffect(() => {
+    policy.configs.sort();
     setConfigs(policy.configs);
   }, [policy]);
 


### PR DESCRIPTION
Sort the keys in the UI so that when you are switching between storages, the
keys will be in the same place every time.

Before: Notice that when you change storages the sort order changes, which 
makes it harder to edit multiple storages one after the other.
![table-changing-order](https://github.com/getsentry/snuba/assets/2727124/ed33434a-a729-405c-a376-35cdafbca45a)

After: The order stays persistent.
![table-changing-order-fix](https://github.com/getsentry/snuba/assets/2727124/c10ea591-060a-4aff-bcff-88a76ba5135e)