### PR TITLE
fix(ci): sort lists before compare

### DIFF
--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -169,10 +169,12 @@ class TestOptimize:
         partitions = optimize.get_partitions_to_optimize(
             clickhouse, storage, database, table
         )
-        assert [(p.date, p.retention_days) for p in partitions] == [
-            (base_monday, 90),
-            (a_month_earlier_monday, 90),
-        ]
+        assert sorted([(p.date, p.retention_days) for p in partitions]) == sorted(
+            [
+                (base_monday, 90),
+                (a_month_earlier_monday, 90),
+            ]
+        )
 
         # respects before (base is properly excluded)
         assert [


### PR DESCRIPTION
This test is flaky and fails if clickhouse returns partitions in a different order. Sort lists before doing to the compare to be more consistent.
