### PR TITLE
experiment(on-call): Profile bytes scanned potentially incorrect

### DIFF
--- a/snuba/clickhouse/native.py
+++ b/snuba/clickhouse/native.py
@@ -45,6 +45,7 @@ metrics = MetricsWrapper(environment.metrics, "clickhouse.native")
 
 class ClickhouseProfile(TypedDict):
     bytes: int
+    progress_bytes: int
     blocks: int
     rows: int
     elapsed: float
@@ -200,6 +201,7 @@ class ClickhousePool(object):
 
                     profile_data = ClickhouseProfile(
                         bytes=conn.last_query.profile_info.bytes or 0,
+                        progress_bytes=conn.last_query.progress.bytes or 0,
                         blocks=conn.last_query.profile_info.blocks or 0,
                         rows=conn.last_query.profile_info.rows or 0,
                         elapsed=conn.last_query.elapsed or 0.0,

--- a/tests/web/test_db_query.py
+++ b/tests/web/test_db_query.py
@@ -209,6 +209,7 @@ def test_db_query_success() -> None:
     assert set(result.result["profile"].keys()) == {  # type: ignore
         "elapsed",
         "bytes",
+        "progress_bytes",
         "blocks",
         "rows",
     }
@@ -216,7 +217,7 @@ def test_db_query_success() -> None:
 
 @pytest.mark.clickhouse_db
 @pytest.mark.redis_db
-def test_bypass_cache_refferer() -> None:
+def test_bypass_cache_referrer() -> None:
     query, storage, _ = _build_test_query("count(distinct(project_id))")
 
     query_metadata_list: list[ClickhouseQueryMetadata] = []
@@ -273,6 +274,7 @@ def test_bypass_cache_refferer() -> None:
             assert set(result.result["profile"].keys()) == {  # type: ignore
                 "elapsed",
                 "bytes",
+                "progress_bytes",
                 "blocks",
                 "rows",
             }


### PR DESCRIPTION
### Overview
- It seems `conn.last_query.profile.bytes` may be an incorrect value for bytes scanned for a query
- This change adds 2 metrics reporting `profile.bytes` and `progress.bytes`, it seems [progress](https://clickhouse.com/docs/en/native-protocol/server#progress) may be the correct bytes scanned value