### PR TITLE
Use snuba-admin spec for ST and SaaS

### DIFF
--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -17,7 +17,7 @@ local migrate_stage(stage_name, region) = [
           environment_variables: {
             // ST deployments use 'snuba' for container and label selectors
             // in migrations, whereas the US region deployment uses snuba-admin.
-            SNUBA_SERVICE_NAME: if getsentry.is_st(region) then 'snuba' else 'snuba-admin',
+            SNUBA_SERVICE_NAME: 'snuba-admin',
           },
           tasks: [
             if getsentry.is_st(region) then

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -15,8 +15,7 @@ local migrate_stage(stage_name, region) = [
           timeout: 1200,
           elastic_profile_id: 'snuba',
           environment_variables: {
-            // ST deployments use 'snuba' for container and label selectors
-            // in migrations, whereas the US region deployment uses snuba-admin.
+            // Use snuba-admin pod spec for running migrations
             SNUBA_SERVICE_NAME: 'snuba-admin',
           },
           tasks: [


### PR DESCRIPTION
Use the snuba-admin spec for deploys since snuba-admin is enable in ST. This avoid randomly selecting a pod spec. By consistently using the admin spec, we can make debugging a lot easier.
