### PR TITLE
improvement(visibility): make the replacer log project_ids for slow replacements

### DIFF
--- a/snuba/replacer.py
+++ b/snuba/replacer.py
@@ -589,5 +589,10 @@ class ReplacerWorker:
         projects_exceeding_limit = (
             self.__processing_time_counter.get_projects_exceeding_limit()
         )
+        logger.info(
+            "projects_exceeding_limit = {}".format(
+                ",".join(str(project_id) for project_id in projects_exceeding_limit)
+            )
+        )
         for project_id in projects_exceeding_limit:
             self.metrics.increment("project_processing_time_exceeded_time_limit")


### PR DESCRIPTION
We're seeing slow replacements in SaaS. Since we can't scale up we want to identify the suspect project_ids with confidence