### PR TITLE
test: No need to run Sentry CI in a matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,11 +276,11 @@ jobs:
 
     strategy:
       matrix:
-        instance: [0, 1]
+        instance: [0]
 
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 2
+      MATRIX_INSTANCE_TOTAL: 1
       MIGRATIONS_TEST_MIGRATE: 1
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,15 +272,9 @@ jobs:
   sentry:
     needs: [snuba-image]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
-
-    strategy:
-      matrix:
-        instance: [0]
+    timeout-minutes: 20
 
     env:
-      # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 1
       MIGRATIONS_TEST_MIGRATE: 1
 
     steps:


### PR DESCRIPTION
Sentry CI now only runs the subset of tests marked @pytest.mark.snuba_ci since https://github.com/getsentry/sentry/pull/56174

No need to split this across 2 jobs anymore as it should be a lot faster

