### PR TITLE
fix(on-call): Negative org ID in Tenant IDs crashes Querylog consumer

### DIFF
--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -133,6 +133,10 @@ class QuerylogProcessor(DatasetMessageProcessor):
                 continue
             valid_project_ids.append(pid)
         processed["projects"] = valid_project_ids
+        org_id = processed["organization"]
+        if not org_id or org_id <= 0:
+            logger.warning(f"Invalid Org ID in Querylog message: {org_id}")
+            processed["organization"] = 0
 
     def process_message(
         self, message: Querylog, metadata: KafkaMessageMetadata

--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -135,7 +135,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
         processed["projects"] = valid_project_ids
         org_id = processed["organization"]
         if not org_id or org_id <= 0:
-            logger.warning(f"Invalid Org ID in Querylog message: {org_id}")
+            logger.warning(f"Invalid Org ID in Querylog message: {org_id}", processed)
             processed["organization"] = 0
 
     def process_message(

--- a/snuba/datasets/processors/querylog_processor.py
+++ b/snuba/datasets/processors/querylog_processor.py
@@ -134,7 +134,7 @@ class QuerylogProcessor(DatasetMessageProcessor):
             valid_project_ids.append(pid)
         processed["projects"] = valid_project_ids
         org_id = processed["organization"]
-        if not org_id or org_id <= 0:
+        if org_id is not None and org_id <= 0:
             logger.warning(f"Invalid Org ID in Querylog message: {org_id}", processed)
             processed["organization"] = 0
 

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -258,7 +258,7 @@ class SnubaQueryMetadata:
         org_id = self.request.attribution_info.tenant_ids.get("organization_id")
         if org_id is not None and isinstance(org_id, int):
             if org_id <= 0:
-                logger.warning(f"Invalid Org ID in tenant_ids: {org_id}")
+                logger.warning(f"Invalid Org ID in tenant_ids: {org_id}", request_dict)
                 org_id = 0
             request_dict["organization"] = org_id
         return request_dict

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -257,9 +257,6 @@ class SnubaQueryMetadata:
         # TODO: Remove check once Org IDs are required
         org_id = self.request.attribution_info.tenant_ids.get("organization_id")
         if org_id is not None and isinstance(org_id, int):
-            if org_id <= 0:
-                logger.warning(f"Invalid Org ID in tenant_ids: {org_id}", request_dict)
-                org_id = 0
             request_dict["organization"] = org_id
         return request_dict
 

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -254,7 +254,7 @@ class SnubaQueryMetadata:
         # TODO: Remove check once Org IDs are required
         if org_id := self.request.attribution_info.tenant_ids.get("organization_id"):
             if isinstance(org_id, int):
-                request_dict["organization"] = org_id
+                request_dict["organization"] = max(org_id, 0)
         return request_dict
 
     @property

--- a/snuba/querylog/query_metadata.py
+++ b/snuba/querylog/query_metadata.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -15,8 +14,6 @@ from snuba.request import Request
 from snuba.state.cache.abstract import ExecutionTimeoutError
 from snuba.state.rate_limit import TABLE_RATE_LIMIT_NAME, RateLimitExceeded
 from snuba.utils.metrics.timer import Timer
-
-logger = logging.getLogger(__name__)
 
 
 class QueryStatus(Enum):


### PR DESCRIPTION
Querylog consumer is crashlooping due to negative org ID's in `tenant_ids`, (Clickhouse insert rejects)