### PR TITLE
fix(CI): Unblock deploys as they hard check for sentry matrix'd tests

### DIFF
--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -7,5 +7,4 @@
   "Tests and code coverage (test_distributed)" \
   "Tests and code coverage (test_distributed_migrations)" \
   "Dataset Config Validation" \
-  "sentry (0)" \
-  "sentry (1)"
+  "sentry"


### PR DESCRIPTION
#4720 
- This PR changed Sentry tests to no longer run as matrix, our deploy pipeline still expects matrix checks