### PR TITLE
test: Run different Sentry tests depending on files changed

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,0 +1,4 @@
+# Based off https://github.com/getsentry/sentry/blob/master/.github/file-filters.yml
+
+datasets:
+  - "snuba/datasets/**/*.yaml"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,4 +1,4 @@
 # Based off https://github.com/getsentry/sentry/blob/master/.github/file-filters.yml
 
 datasets:
-  - "snuba/datasets/**/*.yaml"
+  - "snuba/datasets/configuration/**/*.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,14 +376,11 @@ jobs:
         run: |
           make test-snuba
 
-  sentry-full:
-    if: needs.files-changed.outputs.datasets == 'true'
-    needs: [sentry]
-    steps:
-      - name: Run tests
+      - name: Run full tests
+        if: needs.files-changed.outputs.datasets == 'true'
         working-directory: sentry
         run: |
-          make test-snuba-full
+          make test-full
 
   clickhouse-21:
     needs: [linting, snuba-image]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
     # Map a step output to a job output
     outputs:
       datasets: ${{ steps.changes.outputs.datasets }}
-      backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
-      backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
-      migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
-      plugins: ${{ steps.changes.outputs.plugins }}
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,15 @@ jobs:
         run: |
           make test-snuba
 
+  sentry-full:
+    if: needs.files-changed.outputs.datasets == 'true'
+    needs: [sentry]
+    steps:
+      - name: Run tests
+        working-directory: sentry
+        run: |
+          make test-snuba-full
+
   clickhouse-21:
     needs: [linting, snuba-image]
     name: Tests on Clickhouse 21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,27 @@ on:
   pull_request:
 
 jobs:
+  files-changed:
+    name: detect what files changed
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # Map a step output to a job output
+    outputs:
+      datasets: ${{ steps.changes.outputs.datasets }}
+      backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
+      backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
+      migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}
+      plugins: ${{ steps.changes.outputs.plugins }}
+    steps:
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+
+      - name: Check for backend file changes
+        uses: getsentry/paths-filter@66f7f1844185eb7fb6738ea4ea59d74bb99199e5 # v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   linting:
     name: "pre-commit hooks" # (includes Python formatting + linting)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,7 @@ jobs:
           make test-snuba
 
       - name: Run full tests
+        # TODO: Adjust which changed files we care about
         if: needs.files-changed.outputs.datasets == 'true'
         working-directory: sentry
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,9 +290,13 @@ jobs:
     needs: [snuba-image, files-changed]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-
+    strategy:
+      matrix:
+        instance: [0, 1, 2]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
+      # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
+      MATRIX_INSTANCE_TOTAL: 3
 
     steps:
       # Checkout codebase
@@ -372,6 +376,7 @@ jobs:
           docker exec sentry_snuba snuba migrations migrate --force
 
       - name: Run snuba tests
+        if: needs.files-changed.outputs.datasets == 'false'
         working-directory: sentry
         run: |
           make test-snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
           curl -Os https://uploader.codecov.io/latest/linux/codecov && chmod +x codecov && ./codecov -t ${CODECOV_TOKEN}
 
   sentry:
-    needs: [snuba-image]
+    needs: [snuba-image, files-changed]
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -380,7 +380,7 @@ jobs:
         if: needs.files-changed.outputs.datasets == 'true'
         working-directory: sentry
         run: |
-          make test-full
+          make test-snuba-full
 
   clickhouse-21:
     needs: [linting, snuba-image]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,14 +289,14 @@ jobs:
   sentry:
     needs: [snuba-image, files-changed]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     strategy:
       matrix:
-        instance: [0, 1, 2]
+        instance: [0, 1]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
-      MATRIX_INSTANCE_TOTAL: 3
+      MATRIX_INSTANCE_TOTAL: 2
 
     steps:
       # Checkout codebase

--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -39,7 +39,8 @@ pipelines:
                                     "Tests and code coverage (test_distributed)" \
                                     "Tests and code coverage (test_distributed_migrations)" \
                                     "Dataset Config Validation" \
-                                    "sentry"
+                                    "sentry (0)" \
+                                    "sentry (1)"
                               - script: |
                                     /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
                                     ${GO_REVISION_SNUBA_REPO} \

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -7,4 +7,5 @@
   "Tests and code coverage (test_distributed)" \
   "Tests and code coverage (test_distributed_migrations)" \
   "Dataset Config Validation" \
-  "sentry"
+  "sentry (0)" \
+  "sentry (1)"

--- a/snuba/datasets/configuration/replays/entities/replays.yaml
+++ b/snuba/datasets/configuration/replays/entities/replays.yaml
@@ -129,6 +129,9 @@ query_processors:
         time: timestamp
       time_parse_columns:
         - timestamp
+  - processor: ProjectRateLimiterProcessor
+    args:
+      project_column: project_id
 validators:
   - validator: EntityRequiredColumnValidator
     args:

--- a/snuba/datasets/configuration/replays/entities/replays.yaml
+++ b/snuba/datasets/configuration/replays/entities/replays.yaml
@@ -129,9 +129,6 @@ query_processors:
         time: timestamp
       time_parse_columns:
         - timestamp
-  - processor: ProjectRateLimiterProcessor
-    args:
-      project_column: project_id
 validators:
   - validator: EntityRequiredColumnValidator
     args:


### PR DESCRIPTION
Runs different set of Sentry tests when specific paths are changed. The "full" coverage is designed for API related changes which we might want to test against all of the product features in Sentry.

Right now only changes to the yaml files trigger the full set of Sentry/Snuba tests, these should be reviewed later though.

Depends on https://github.com/getsentry/sentry/pull/56352