### PR TITLE
feat(capman): Cross-organization allocation policy

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
@@ -83,6 +83,7 @@ allocation_policies:
         - referrer
       default_config_overrides:
         is_enforced: 0
+        is_active: 0
       cross_org_referrer_limits:
         dynamic_sampling.counters.get_org_transaction_volumes:
           max_threads: 4

--- a/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
@@ -77,7 +77,16 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
-
+  - name: CrossOrgQueryAllocationPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+      cross_org_referrer_limits:
+        dynamic_sampling.counters.get_org_transaction_volumes:
+          max_threads: 4
+          concurrent_limit: 10
 query_processors:
   - processor: TableRateLimit
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters.yaml
@@ -87,6 +87,16 @@ allocation_policies:
         dynamic_sampling.counters.get_org_transaction_volumes:
           max_threads: 4
           concurrent_limit: 10
+        dynamic_sampling.counters.fetch_projects_with_count_per_transaction_volumes:
+            max_threads: 4
+            concurrent_limit: 10
+        dynamic_sampling.counters.fetch_projects_with_transaction_totals:
+            max_threads: 4
+            concurrent_limit: 10
+        dynamic_sampling.counters.get_active_orgs:
+            max_threads: 4
+            concurrent_limit: 10
+
 query_processors:
   - processor: TableRateLimit
   - processor: TupleUnaliaser

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -112,6 +112,7 @@ allocation_policies:
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
 
+
 query_processors:
   - processor: MappingOptimizer
     args:

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -48,7 +48,7 @@ class BaseConcurrentRateLimitAllocationPolicy(AllocationPolicy):
         ]
 
     @property
-    def rate_limit_name(self):
+    def rate_limit_name(self) -> str:
         raise NotImplementedError
 
     def _is_within_rate_limit(

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -118,16 +118,6 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
                 default=DEFAULT_CONCURRENT_QUERIES_LIMIT,
             ),
             AllocationPolicyConfig(
-                name="rate_limit_shard_factor",
-                description="""number of shards that each redis set is supposed to have.
-                 increasing this value multiplies the number of redis keys by that
-                 factor, and (on average) reduces the size of each redis set. You probably don't need to change this
-                 unless you're scaling out redis for some reason
-                 """,
-                value_type=int,
-                default=1,
-            ),
-            AllocationPolicyConfig(
                 name="referrer_project_override",
                 description="override concurrent limit for a specific project, referrer combo",
                 value_type=int,

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -31,18 +31,10 @@ _PASS_THROUGH_REFERRERS = set(
     ]
 )
 
-_RATE_LIMIT_NAME = "concurrent_limit_policy"
 
-
-class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
+class BaseConcurrentRateLimitAllocationPolicy(AllocationPolicy):
     def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
         return [
-            AllocationPolicyConfig(
-                name="concurrent_limit",
-                description="maximum amount of concurrent queries per tenant",
-                value_type=int,
-                default=DEFAULT_CONCURRENT_QUERIES_LIMIT,
-            ),
             AllocationPolicyConfig(
                 name="rate_limit_shard_factor",
                 description="""number of shards that each redis set is supposed to have.
@@ -53,35 +45,11 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
                 value_type=int,
                 default=1,
             ),
-            AllocationPolicyConfig(
-                name="referrer_project_override",
-                description="override concurrent limit for a specific project, referrer combo",
-                value_type=int,
-                default=-1,
-                param_types={"referrer": str, "project_id": int},
-            ),
-            AllocationPolicyConfig(
-                name="referrer_organization_override",
-                description="override concurrent limit for a specific organization_id, referrer combo",
-                value_type=int,
-                default=-1,
-                param_types={"referrer": str, "organization_id": int},
-            ),
-            AllocationPolicyConfig(
-                name="project_override",
-                description="override concurrent limit for a specific project_id",
-                value_type=int,
-                default=-1,
-                param_types={"project_id": int},
-            ),
-            AllocationPolicyConfig(
-                name="organization_override",
-                description="override concurrent limit for a specific organization_id",
-                value_type=int,
-                default=-1,
-                param_types={"organization_id": int},
-            ),
         ]
+
+    @property
+    def rate_limit_name(self):
+        raise NotImplementedError
 
     def _is_within_rate_limit(
         self, query_id: str, rate_limit_params: RateLimitParameters
@@ -139,6 +107,56 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
             rate_limit_prefix,
         )
 
+
+class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
+    def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
+        return super()._additional_config_definitions() + [
+            AllocationPolicyConfig(
+                name="concurrent_limit",
+                description="maximum amount of concurrent queries per tenant",
+                value_type=int,
+                default=DEFAULT_CONCURRENT_QUERIES_LIMIT,
+            ),
+            AllocationPolicyConfig(
+                name="rate_limit_shard_factor",
+                description="""number of shards that each redis set is supposed to have.
+                 increasing this value multiplies the number of redis keys by that
+                 factor, and (on average) reduces the size of each redis set. You probably don't need to change this
+                 unless you're scaling out redis for some reason
+                 """,
+                value_type=int,
+                default=1,
+            ),
+            AllocationPolicyConfig(
+                name="referrer_project_override",
+                description="override concurrent limit for a specific project, referrer combo",
+                value_type=int,
+                default=-1,
+                param_types={"referrer": str, "project_id": int},
+            ),
+            AllocationPolicyConfig(
+                name="referrer_organization_override",
+                description="override concurrent limit for a specific organization_id, referrer combo",
+                value_type=int,
+                default=-1,
+                param_types={"referrer": str, "organization_id": int},
+            ),
+            AllocationPolicyConfig(
+                name="project_override",
+                description="override concurrent limit for a specific project_id",
+                value_type=int,
+                default=-1,
+                param_types={"project_id": int},
+            ),
+            AllocationPolicyConfig(
+                name="organization_override",
+                description="override concurrent limit for a specific organization_id",
+                value_type=int,
+                default=-1,
+                param_types={"organization_id": int},
+            ),
+        ]
+
     def _get_overrides(self, tenant_ids: dict[str, str | int]) -> dict[str, int]:
         overrides = {}
         available_tenant_ids = set(tenant_ids.keys())
@@ -173,6 +191,10 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
             "Queries must have a project id or organization id"
         )
 
+    @property
+    def rate_limit_name(self) -> str:
+        return "concurrent_rate_limit_policy"
+
     def _get_rate_limit_params(
         self, tenant_ids: dict[str, str | int]
     ) -> tuple[RateLimitParameters, dict[str, int]]:
@@ -185,7 +207,7 @@ class ConcurrentRateLimitAllocationPolicy(AllocationPolicy):
 
         return (
             RateLimitParameters(
-                _RATE_LIMIT_NAME,
+                self.rate_limit_name,
                 bucket=str(tenant_value),
                 per_second_limit=None,
                 concurrent_limit=concurrent_limit,

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.query.allocation_policies import (
+    AllocationPolicyConfig,
+    QueryResultOrError,
+    QuotaAllowance,
+)
+from snuba.query.allocation_policies.concurrent_rate_limit import (
+    BaseConcurrentRateLimitAllocationPolicy,
+)
+from snuba.redis import RedisClientKey, get_redis_client
+from snuba.state.rate_limit import RateLimitParameters
+
+DEFAULT_CONCURRENT_QUERIES_LIMIT = 22
+DEFAULT_PER_SECOND_QUERIES_LIMIT = 50
+
+rds = get_redis_client(RedisClientKey.RATE_LIMITER)
+
+logger = logging.getLogger("snuba.query.allocation_policy_cross_org")
+
+_PASS_THROUGH_REFERRERS = set(
+    [
+        "subscriptions_executor",
+    ]
+)
+
+_RATE_LIMIT_NAME = "concurrent_limit_policy"
+
+
+class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
+    @property
+    def rate_limit_name(self) -> str:
+        return "cross_org_query_policy"
+
+    def _additional_config_definitions(self) -> list[AllocationPolicyConfig]:
+        return super()._additional_config_definitions() + [
+            AllocationPolicyConfig(
+                name="referrer_concurrent_override",
+                description="""override the concurrent limit for a referrer""",
+                value_type=int,
+                param_types={"referrer": str},
+                default=-1,
+            ),
+            AllocationPolicyConfig(
+                name="referrer_max_threads_override",
+                description="""override the max_threads for a referrer, applies to every query made by that referrer""",
+                param_types={"referrer": str},
+                value_type=int,
+                default=-1,
+            ),
+        ]
+
+    def _validate_cross_org_referrer_limits(
+        self, cross_org_referrer_limits: dict[str, dict[str, int]]
+    ) -> None:
+        for referrer, limits in cross_org_referrer_limits.items():
+            concurrent_limit = limits.get("concurrent_limit", None)
+            max_threads = limits.get("max_threads", None)
+            if not isinstance(max_threads, int):
+                raise ValueError(
+                    f"max_threads is required for {referrer} and must be an int"
+                )
+            if not isinstance(concurrent_limit, int):
+                raise ValueError(
+                    f"concurrent_limit is required for {referrer} and must be an int"
+                )
+
+    def __init__(
+        self,
+        storage_key: StorageKey,
+        required_tenant_types: list[str],
+        default_config_overrides: dict[str, Any],
+        **kwargs: str,
+    ) -> None:
+        super().__init__(
+            storage_key, required_tenant_types, default_config_overrides, **kwargs
+        )
+        self._registered_cross_org_referrers = cast(
+            "dict[str, dict[str, int]]", kwargs.get("cross_org_referrer_limits", {})
+        )
+        self._validate_cross_org_referrer_limits(self._registered_cross_org_referrers)
+
+    def _get_quota_allowance(
+        self, tenant_ids: dict[str, str | int], query_id: str
+    ) -> QuotaAllowance:
+        if tenant_ids.get("referrer", None) not in self._registered_cross_org_referrers:
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=self.max_threads,
+                explanation={"reason": "pass_through"},
+            )
+        referrer = str(tenant_ids.get("referrer", "no_referrer"))
+
+        thread_override = self.get_config_value(
+            "referrer_max_threads_override", {"referrer": referrer}
+        )
+
+        max_threads = (
+            thread_override
+            if thread_override != -1
+            else int(self._registered_cross_org_referrers[referrer]["max_threads"])
+        )
+
+        concurrent_override = self.get_config_value(
+            "referrer_concurrent_override", {"referrer": referrer}
+        )
+        concurrent_limit = (
+            concurrent_override
+            if concurrent_override != -1
+            else int(self._registered_cross_org_referrers[referrer]["concurrent_limit"])
+        )
+        can_run, explanation = self._is_within_rate_limit(
+            query_id,
+            RateLimitParameters(self.rate_limit_name, referrer, None, concurrent_limit),
+        )
+        return QuotaAllowance(
+            can_run=can_run,
+            max_threads=max_threads,
+            explanation={"reason": explanation},
+        )
+
+    def _update_quota_balance(
+        self,
+        tenant_ids: dict[str, str | int],
+        query_id: str,
+        result_or_error: QueryResultOrError,
+    ) -> None:
+        referrer = str(tenant_ids.get("referrer", "no_referrer"))
+        rate_limit_params = RateLimitParameters(
+            # limit number does not matter for ending a query so I just picked 22
+            self.rate_limit_name,
+            referrer,
+            None,
+            22,
+        )
+        self._end_query(query_id, rate_limit_params, result_or_error)

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -32,6 +32,27 @@ _RATE_LIMIT_NAME = "concurrent_limit_policy"
 
 
 class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
+    """A case-by-case allocation policy for cross-org queries. All referrers affected by this policy have to be registered
+    in this class's configuration through the `cross_org_referrer_limits` parameter. Example:
+
+    ```yaml
+        - name: CrossOrgQueryAllocationPolicy
+          args:
+            required_tenant_types:
+              - referrer
+            default_config_overrides:
+              is_enforced: 0
+              is_active: 0
+            cross_org_referrer_limits:
+              dynamic_sampling.counters.get_org_transaction_volumes:
+                max_threads: 4
+                concurrent_limit: 10
+    ```
+
+    Each referrer gets a concurrent limit (applied per referrer) and a max_threads limit (applied to every query made by that referrer).
+    Both limits are static but changeable at runtime
+    """
+
     @property
     def rate_limit_name(self) -> str:
         return "cross_org_query_policy"

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -106,8 +106,10 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
     def _get_max_threads(self, referrer: str) -> int:
         if not self._referrer_is_registered(referrer):
             return _UNREGISTERED_REFERRER_MAX_THREADS
-        thread_override = self.get_config_value(
-            "referrer_max_threads_override", {"referrer": referrer}
+        thread_override = int(
+            self.get_config_value(
+                "referrer_max_threads_override", {"referrer": referrer}
+            )
         )
         return (
             thread_override
@@ -118,8 +120,10 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
     def _get_concurrent_limit(self, referrer: str) -> int:
         if not self._referrer_is_registered(referrer):
             return _UNREGISTERED_REFERRER_CONCURRENT_QUERIES
-        concurrent_override = self.get_config_value(
-            "referrer_concurrent_override", {"referrer": referrer}
+        concurrent_override = int(
+            self.get_config_value(
+                "referrer_concurrent_override", {"referrer": referrer}
+            )
         )
         return (
             concurrent_override

--- a/tests/query/allocation_policies/test_cross_org_policy.py
+++ b/tests/query/allocation_policies/test_cross_org_policy.py
@@ -1,10 +1,23 @@
 import pytest
 
-from snuba.query.allocation_policies import AllocationPolicyViolation
+from snuba.query.allocation_policies import (
+    AllocationPolicyViolation,
+    QueryResultOrError,
+)
 from snuba.query.allocation_policies.cross_org import CrossOrgQueryAllocationPolicy
+from snuba.web import QueryResult
+
+_RESULT_SUCCESS = QueryResultOrError(
+    QueryResult(
+        result={"profile": {"bytes": 42069}},
+        extra={"stats": {}, "sql": "", "experiments": {}},
+    ),
+    error=None,
+)
 
 
 class TestCrossOrgQueryAllocationPolicy:
+    @pytest.mark.redis_db
     def test_policy_pass_basic(self):
         policy = CrossOrgQueryAllocationPolicy.from_kwargs(
             **{
@@ -12,41 +25,36 @@ class TestCrossOrgQueryAllocationPolicy:
                 "required_tenant_types": ["referrer"],
                 "cross_org_referrer_limits": {
                     "statistical_detectors": {
-                        "concurrent_limit": 2,
+                        "concurrent_limit": 1,
                         "max_threads": 1,
                     },
                 },
             }
         )
-        assert (
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "some_referrer"}, query_id="1"
-            ).can_run
-            is True
+        unimportant_allowance = policy.get_quota_allowance(
+            tenant_ids={"referrer": "some_referrer"}, query_id="1"
         )
-        assert (
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "some_referrer"}, query_id="2"
-            ).max_threads
-            == policy.max_threads
+        assert unimportant_allowance.can_run is True
+        assert unimportant_allowance.max_threads == 10
+        assert unimportant_allowance.explanation == {"reason": "pass_through"}
+        cross_org_allowance = policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
         )
-        assert (
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
-            ).can_run
-            is True
-        )
-        assert (
-            policy.get_quota_allowance(
-                tenant_ids={"referrer": "statistical_detectors"}, query_id="4"
-            ).max_threads
-            == 1
-        )
+        assert cross_org_allowance.can_run is True
+        assert cross_org_allowance.max_threads == 1
 
         with pytest.raises(AllocationPolicyViolation):
             policy.get_quota_allowance(
-                tenant_ids={"referrer": "statistical_detectors"}, query_id="5"
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
             )
+        policy.update_quota_balance(
+            tenant_ids={"referrer": "statistical_detectors"},
+            query_id="2",
+            result_or_error=_RESULT_SUCCESS,
+        )
+        assert policy.get_quota_allowance(
+            tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
+        ).can_run
 
     @pytest.mark.parametrize(
         "config",
@@ -81,3 +89,43 @@ class TestCrossOrgQueryAllocationPolicy:
     def test_bad_config(self, config) -> None:
         with pytest.raises(ValueError):
             CrossOrgQueryAllocationPolicy.from_kwargs(**config)
+
+    @pytest.mark.redis_db
+    def test_override(self):
+        policy = CrossOrgQueryAllocationPolicy.from_kwargs(
+            **{
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+                "cross_org_referrer_limits": {
+                    "statistical_detectors": {
+                        "concurrent_limit": 1,
+                        "max_threads": 1,
+                    },
+                },
+            }
+        )
+        policy.set_config_value(
+            "referrer_max_threads_override",
+            2,
+            {"referrer": "statistical_detectors"},
+        )
+        assert (
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="1"
+            ).max_threads
+            == 2
+        )
+        policy.update_quota_balance(
+            tenant_ids={"referrer": "statistical_detectors"},
+            query_id="1",
+            result_or_error=_RESULT_SUCCESS,
+        )
+        policy.set_config_value(
+            "referrer_concurrent_override",
+            0,
+            {"referrer": "statistical_detectors"},
+        )
+        with pytest.raises(AllocationPolicyViolation):
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
+            )

--- a/tests/query/allocation_policies/test_cross_org_policy.py
+++ b/tests/query/allocation_policies/test_cross_org_policy.py
@@ -1,0 +1,83 @@
+import pytest
+
+from snuba.query.allocation_policies import AllocationPolicyViolation
+from snuba.query.allocation_policies.cross_org import CrossOrgQueryAllocationPolicy
+
+
+class TestCrossOrgQueryAllocationPolicy:
+    def test_policy_pass_basic(self):
+        policy = CrossOrgQueryAllocationPolicy.from_kwargs(
+            **{
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+                "cross_org_referrer_limits": {
+                    "statistical_detectors": {
+                        "concurrent_limit": 2,
+                        "max_threads": 1,
+                    },
+                },
+            }
+        )
+        assert (
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "some_referrer"}, query_id="1"
+            ).can_run
+            is True
+        )
+        assert (
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "some_referrer"}, query_id="2"
+            ).max_threads
+            == policy.max_threads
+        )
+        assert (
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="3"
+            ).can_run
+            is True
+        )
+        assert (
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="4"
+            ).max_threads
+            == 1
+        )
+
+        with pytest.raises(AllocationPolicyViolation):
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "statistical_detectors"}, query_id="5"
+            )
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+                "cross_org_referrer_limits": {
+                    "statistical_detectors": {
+                        "max_threads": 1,
+                    },
+                },
+            },
+            {
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+                "cross_org_referrer_limits": {
+                    "statistical_detectors": {
+                        "concurrent_limit": 2,
+                    },
+                },
+            },
+            {
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+                "cross_org_referrer_limits": {
+                    "statistical_detectors": {"max_threads": {}, "concurrent_limit": 2},
+                },
+            },
+        ],
+    )
+    def test_bad_config(self, config) -> None:
+        with pytest.raises(ValueError):
+            CrossOrgQueryAllocationPolicy.from_kwargs(**config)

--- a/tests/query/allocation_policies/test_cross_org_policy.py
+++ b/tests/query/allocation_policies/test_cross_org_policy.py
@@ -129,3 +129,23 @@ class TestCrossOrgQueryAllocationPolicy:
             policy.get_quota_allowance(
                 tenant_ids={"referrer": "statistical_detectors"}, query_id="2"
             )
+
+    @pytest.mark.redis_db
+    def test_reject_cross_org_query_with_unregistered_referrer(self):
+        policy = CrossOrgQueryAllocationPolicy.from_kwargs(
+            **{
+                "storage_key": "generic_metrics_distributions",
+                "required_tenant_types": ["referrer"],
+                "cross_org_referrer_limits": {
+                    "statistical_detectors": {
+                        "concurrent_limit": 1,
+                        "max_threads": 1,
+                    },
+                },
+            }
+        )
+        with pytest.raises(AllocationPolicyViolation):
+            policy.get_quota_allowance(
+                tenant_ids={"referrer": "unregistered", "cross_org_query": 1},
+                query_id="1",
+            )


### PR DESCRIPTION
# Introduction

Before this PR all allocation policies have used a customer id (either `project_id` or `organization_id`) as the tenants for allocation policies. This has worked because most queries that have come in to snuba have been made on behalf of a specific customer. Recently however, new features are being developed where one query can issue scan data across organizations and are done outside of the customer’s control (e.g. escalating issues), as such, capacity to these queries will need to be managed differently.

# Blast Radius of this PR
This PR will roll out to production **inactive**. This means none of its code will run until it is turned on by a human being. The only storage this PR currently affects is `generic_metrics_counters`

# Goals

- Cross-org queries should not be able to monopolize the entire capacity of the cluster
- It should be easy to adjust the capacity allocation for a cross org referrer
- Simplicity of the policy
    - These kinds of queries are pretty new, we don’t have a good way of thinking about them yet, we just want some basic safeguards in place
    
    
 # Design

The `CrossOrgQueryPolicy` is implemented as a separate policy because its concerns are orthogonal to that of the customer based policies. Unlike the customer based policies, the amount of possible tenants is very small but each one has its own specific consideration. Therefore **the limits will be tuned on a case-by-case basis for the first iteration.**

## Interface

Every cross-org query referrer will have to be added manually to the configuration of that specific allocation policy. The config looks like:

```yaml
allocation_policies:
  - CrossOrgQueryPolicy
  cross_org_referrer_limits:
    statistical_detectors.get_top_transactions:
      max_threads: 4
      concurrent_limit: 2
    escalating_issues.scan_issues:
      max_threads: 10
      concurrent_limit: 1
```

The client will add the following field to the `tenant_ids` of the snuba request:

```yaml
cross_org_query: 1
```

This is done so that the other allocation policies which are for meant for customers will not try to enforce themselves on this query.

## Knobs and Levers

Both concurrent limit and max threads for each referrer can be overridden at runtime without deploy. Any referrers not defined in the config in source code will not be affected by the policy. 

Any query with `cross_org_query=1` in the `tenant_ids` dictionary will be rejected by the `CrossOrgQueryPolicy` . Since `cross_org_query=1` bypasses the customer specific rate limiters, it’s important to make sure they do not bypass this one