### PR TITLE
feat(deploy-gates): Add SaaS -> ST deploy gates

### DIFF
--- a/gocd/templates/bash/saas-ddog-health-check.sh
+++ b/gocd/templates/bash/saas-ddog-health-check.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/datadog/monitor_status.py --dry-run=true \
+  113296727 \
+  42722121
+
+
+# Above monitor IDs map to following monitors respectively:
+# Snuba - SLO - High API error rate
+# Snuba - Too many restarts on Snuba pods

--- a/gocd/templates/bash/saas-sentry-error-check.sh
+++ b/gocd/templates/bash/saas-sentry-error-check.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/sentry/release_error_events.py \
+  --project-id=300688 \
+  --project-slug=snuba \
+  --release="${GO_REVISION_SNUBA_REPO}" \
+  --duration=5 \
+  --error-events-limit=500 \
+  --skip-check=${SKIP_CANARY_CHECKS}

--- a/gocd/templates/bash/saas-sentry-health-check.sh
+++ b/gocd/templates/bash/saas-sentry-health-check.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/devinfra/scripts/checks/sentry/release_new_issues.py \
+  --project-id=300688 \
+  --project-slug=snuba \
+  --release="${GO_REVISION_SNUBA_REPO}" \
+  --new-issues-limit=0 \
+  --skip-check=${SKIP_CANARY_CHECKS}

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -67,6 +67,34 @@ local s4s_health_check(region) =
   else
     [];
 
+// Snuba deploy to ST is blocked till SaaS deploy is healthy
+local saas_health_check(region) =
+  if region == 'us' then
+    [
+      {
+        health_check: {
+          jobs: {
+            health_check: {
+              environment_variables: {
+                SENTRY_AUTH_TOKEN: '{{SECRET:[devinfra-sentryio][token]}}',
+                DATADOG_API_KEY: '{{SECRET:[devinfra][sentry_datadog_api_key]}}',
+                DATADOG_APP_KEY: '{{SECRET:[devinfra][sentry_datadog_app_key]}}',
+                LABEL_SELECTOR: 'service=snuba',
+              },
+              elastic_profile_id: 'snuba',
+              tasks: [
+                gocdtasks.script(importstr '../bash/saas-sentry-health-check.sh'),
+                gocdtasks.script(importstr '../bash/saas-sentry-error-check.sh'),
+                gocdtasks.script(importstr '../bash/saas-ddog-health-check.sh'),
+              ],
+            },
+          },
+        },
+      },
+    ]
+  else
+    [];
+
 // Snuba relies on checks to prevent folks from writing migrations and code
 // at the same time, this means there is a requirement that folks MUST deploy
 // the migration before merge code changes relying on that migration.

--- a/gocd/templates/pipelines/snuba.libsonnet
+++ b/gocd/templates/pipelines/snuba.libsonnet
@@ -214,5 +214,5 @@ function(region) {
       },
     },
 
-  ] + migrate_stage('migrate', region) + s4s_health_check(region),
+  ] + migrate_stage('migrate', region) + s4s_health_check(region) + saas_health_check(region),
 }


### PR DESCRIPTION
### Overview
- Adds 2 Sentry checks
    - One checks latest Release for any new issues
    - One checks latest Release for total error events > 500
- Adds a Datadog Monitor check
    - Simple check of two existing monitors
    - Currently this is set to dry-run, which means it won't block since I don't believe these monitors are appropriate for this check
    - We need to add some "current" status checks, all existing monitors check for ~5 minutes of data which could block a deploy fixing said monitor to begin with