### PR TITLE
Update gocd-jsonnet to v2.2.2

### DIFF
--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "libs"
         }
       },
-      "version": "v1.5.1"
+      "version": "v2.2.2"
     }
   ],
   "legacyImports": true

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "libs"
         }
       },
-      "version": "22b351221458e2d9add1014d6230e76f1bdd40c1",
-      "sum": "gF65Dh1Po+61V0CV5F05UFDEki0Z4ov4739GZXShqcM="
+      "version": "54bb0adceffb690bf4aa744b23acdb7888c51fd5",
+      "sum": "stYmA7r5/MARC5qkFFR+94R1W5juwjmRNVQFOTxmwVA="
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
This update makes a subtle change to rollbacks.

The current snuba rollbacks (i.e. before v2.2.2), would re-run the `deploy-primary` stage to perform a rollback. However, because each pipeline had a `pipeline-complete` stage at the end of each region, the pipelines would be paused AND locked. This caused some confusion when folks tried to fix re-enable their deployments.

In v2.2.2, the `pipeline-complete` stage is removed (this was a noop stage just used for chaining) and instead the pipelines are chained using the last stage. Rollbacks will the re-run the `deploy-primary` stage and once its finished all pipelines will be paused, but will not be locked.

Rolling this out needs a little attention because of a quirk with GoCD, which will trigger a deploy of all regions since the change causes GoCD to think a new deploy is needed for material `<pipeline name>@deploy-primary` instead of the old `<pipeline name>@pipeline-complete` material. The net effect of this is that all regions deploy in parallel for the last deploy that went out. This isn't too bad since the deploys should be a NOOP, but I'd prefer to let this roll out with one deploy at a time, just to be safe. I'm happy to manage this for snuba by pausing the pipelines and unpausing each one, letting it redeploy the last deploy.