### PR TITLE
feat(rust): Add processor metrics for Rust consumer

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
+++ b/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
@@ -60,6 +60,7 @@ impl Default for MetricsBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     #[test]
     fn metrics_buffer() {
         #[derive(Debug)]

--- a/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
+++ b/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
@@ -1,0 +1,87 @@
+use crate::utils::metrics::{get_metrics, Metrics};
+use core::fmt::Debug;
+use std::collections::BTreeMap;
+use std::mem;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+#[derive(Debug)]
+pub struct MetricsBuffer {
+    metrics: Arc<Mutex<Box<dyn Metrics>>>,
+    timers: BTreeMap<String, Duration>,
+    last_flush: Instant,
+}
+
+impl MetricsBuffer {
+    // A pretty shitty metrics buffer that only handles timing metrics
+    // and flushes them every second. Needs to be flush()-ed on shutdown
+    // Doesn't support tags
+    // Basically the same as https://github.com/getsentry/arroyo/blob/83f5f54e59892ad0b62946ef35d2daec3b561b10/arroyo/processing/processor.py#L80-L112
+    // We may want to replace this with the statsdproxy aggregation step.
+    pub fn new() -> Self {
+        Self {
+            metrics: get_metrics(),
+            timers: BTreeMap::new(),
+            last_flush: Instant::now(),
+        }
+    }
+
+    pub fn incr_timing(&mut self, metric: &str, duration: Duration) {
+        if let Some(value) = self.timers.get_mut(metric) {
+            *value += duration;
+        } else {
+            self.timers.insert(metric.to_string(), duration);
+        }
+        self.throttled_record();
+    }
+
+    pub fn flush(&mut self) {
+        let timers = mem::take(&mut self.timers);
+        for (metric, duration) in timers {
+            self.metrics
+                .timing(&metric, duration.as_millis() as u64, None);
+        }
+        self.last_flush = Instant::now();
+    }
+
+    fn throttled_record(&mut self) {
+        if self.last_flush.elapsed() > Duration::from_secs(1) {
+            self.flush();
+        }
+    }
+}
+
+impl Default for MetricsBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn metrics_buffer() {
+        #[derive(Debug)]
+        struct Test {
+            data: Vec<String>,
+        }
+
+        impl Metrics for Test {
+            fn increment(
+                &mut self,
+                _key: &str,
+                _value: Option<i64>,
+                _tags: Option<HashMap<&str, &str>>,
+            ) {
+            }
+
+            fn gauge(&mut self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+
+            fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+                // self.data.append((key.into(), value.into(), tags.into()))
+                self.data.push("asdf".to_string());
+            }
+        }
+    }
+}

--- a/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
+++ b/rust_snuba/rust_arroyo/src/processing/metrics_buffer.rs
@@ -56,33 +56,3 @@ impl Default for MetricsBuffer {
         Self::new()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashMap;
-    #[test]
-    fn metrics_buffer() {
-        #[derive(Debug)]
-        struct Test {
-            data: Vec<String>,
-        }
-
-        impl Metrics for Test {
-            fn increment(
-                &mut self,
-                _key: &str,
-                _value: Option<i64>,
-                _tags: Option<HashMap<&str, &str>>,
-            ) {
-            }
-
-            fn gauge(&mut self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
-
-            fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
-                // self.data.append((key.into(), value.into(), tags.into()))
-                self.data.push("asdf".to_string());
-            }
-        }
-    }
-}

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -78,6 +78,8 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
             start.elapsed().as_millis() as u64,
             None,
         );
+
+        // TODO: Figure out how to flush the metrics buffer from the recovation callback.
     }
 }
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -1,3 +1,4 @@
+mod metrics_buffer;
 pub mod strategies;
 
 use crate::backends::{AssignmentCallbacks, Consumer};
@@ -57,7 +58,7 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
         stg.strategy = Some(stg.processing_factory.create());
     }
     fn on_revoke(&mut self, _: Vec<Partition>) {
-        let metrics = get_metrics();
+        let mut metrics = get_metrics();
         let start = Instant::now();
 
         let mut stg = self.strategies.lock().unwrap();
@@ -96,6 +97,7 @@ pub struct StreamProcessor<'a, TPayload: Clone> {
     message: Option<Message<TPayload>>,
     processor_handle: ProcessorHandle,
     paused_timestamp: Option<Instant>,
+    metrics_buffer: metrics_buffer::MetricsBuffer,
 }
 
 impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
@@ -116,6 +118,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
                 shutdown_requested: Arc::new(AtomicBool::new(false)),
             },
             paused_timestamp: None,
+            metrics_buffer: metrics_buffer::MetricsBuffer::new(),
         }
     }
 
@@ -132,6 +135,7 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
             // If a message was carried over from the previous run, the consumer
             // should be paused and not returning any messages on ``poll``.
             let res = self.consumer.poll(Some(Duration::ZERO)).unwrap();
+
             match res {
                 None => {}
                 Some(_) => return Err(RunError::InvalidState),
@@ -139,16 +143,15 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
         } else {
             // Otherwise, we need to try fetch a new message from the consumer,
             // even if there is no active assignment and/or processing strategy.
-            let msg = self.consumer.poll(Some(Duration::from_secs(1)));
+            let poll_start = Instant::now();
             //TODO: Support errors properly
-            match msg {
-                Ok(None) => {
-                    self.message = None;
-                }
-                Ok(Some(inner)) => {
-                    self.message = Some(Message {
+            match self.consumer.poll(Some(Duration::from_secs(1))) {
+                Ok(msg) => {
+                    self.message = msg.map(|inner| Message {
                         inner_message: InnerMessage::BrokerMessage(inner),
                     });
+                    self.metrics_buffer
+                        .incr_timing("arroyo.consumer.poll.time", poll_start.elapsed());
                 }
                 Err(e) => {
                     log::error!("poll error: {}", e);
@@ -175,7 +178,12 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
 
                 let msg = self.message.take();
                 if let Some(msg_s) = msg {
+                    let processing_start = Instant::now();
                     let ret = strategy.submit(msg_s);
+                    self.metrics_buffer.incr_timing(
+                        "arroyo.consumer.processing.time",
+                        processing_start.elapsed(),
+                    );
                     match ret {
                         Ok(()) => {}
                         Err(_) => {
@@ -197,6 +205,10 @@ impl<'a, TPayload: 'static + Clone> StreamProcessor<'a, TPayload> {
                                 let res = self.consumer.resume(partitions);
                                 match res {
                                     Ok(()) => {
+                                        self.metrics_buffer.incr_timing(
+                                            "arroyo.consumer.paused.time",
+                                            self.paused_timestamp.unwrap().elapsed(),
+                                        );
                                         self.paused_timestamp = None;
                                     }
                                     Err(_) => return Err(RunError::PauseError),

--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -5,21 +5,21 @@ use std::sync::{Arc, Mutex, OnceLock};
 pub static METRICS: OnceLock<Arc<Mutex<Box<dyn Metrics>>>> = OnceLock::new();
 
 pub trait Metrics: Debug + Send + Sync {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>);
+    fn increment(&mut self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>);
 
-    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 
-    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 }
 
 impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+    fn increment(&mut self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().increment(key, value, tags)
     }
-    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().gauge(key, value, tags)
     }
-    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().timing(key, value, tags)
     }
 }
@@ -28,11 +28,11 @@ impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
 struct Noop {}
 
 impl Metrics for Noop {
-    fn increment(&self, _key: &str, _value: Option<i64>, _tags: Option<HashMap<&str, &str>>) {}
+    fn increment(&mut self, _key: &str, _value: Option<i64>, _tags: Option<HashMap<&str, &str>>) {}
 
-    fn gauge(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+    fn gauge(&mut self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 
-    fn timing(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+    fn timing(&mut self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 }
 
 pub fn configure_metrics(metrics: Box<dyn Metrics>) {

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -71,7 +71,8 @@ mod tests {
 
     #[test]
     fn statsd_metric_backend() {
-        let backend = StatsDBackend::new("0.0.0.0", 8125, "test", HashMap::from([("env", "prod")]));
+        let mut backend =
+            StatsDBackend::new("0.0.0.0", 8125, "test", HashMap::from([("env", "prod")]));
 
         backend.increment("a", 1, Some(HashMap::from([("tag1", "value1")])));
         backend.gauge("b", 20, Some(HashMap::from([("tag2", "value2")])));

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -45,7 +45,7 @@ impl StatsDBackend {
 }
 
 impl ArroyoMetrics for StatsDBackend {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+    fn increment(&mut self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) =
             self.send_with_tags(self.client.count_with_tags(key, value.unwrap_or(1)), tags)
         {
@@ -53,13 +53,13 @@ impl ArroyoMetrics for StatsDBackend {
         }
     }
 
-    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) = self.send_with_tags(self.client.gauge_with_tags(key, value), tags) {
             log::debug!("Error sending metric: {}", e);
         }
     }
 
-    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) = self.send_with_tags(self.client.time_with_tags(key, value), tags) {
             log::debug!("Error sending metric: {}", e);
         }

--- a/rust_snuba/src/metrics/testing.rs
+++ b/rust_snuba/src/metrics/testing.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn testing_metrics_backend() {
-        let backend = TestingMetricsBackend::new("snuba.rust-consumer");
+        let mut backend = TestingMetricsBackend::new("snuba.rust-consumer");
 
         backend.increment("a", 1, Some(HashMap::from([("tag1", "value1")])));
         backend.gauge("b", 20, Some(HashMap::from([("tag2", "value2")])));

--- a/rust_snuba/src/metrics/testing.rs
+++ b/rust_snuba/src/metrics/testing.rs
@@ -44,7 +44,7 @@ impl TestingMetricsBackend {
 }
 
 impl ArroyoMetrics for TestingMetricsBackend {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+    fn increment(&mut self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
         let builder = self.client.count_with_tags(key, value.unwrap_or(1));
 
         let res = self
@@ -56,7 +56,7 @@ impl ArroyoMetrics for TestingMetricsBackend {
         self.metric_calls.lock().unwrap().push(res);
     }
 
-    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         let builder = self.client.gauge_with_tags(key, value);
 
         let res = self
@@ -68,7 +68,7 @@ impl ArroyoMetrics for TestingMetricsBackend {
         self.metric_calls.lock().unwrap().push(res);
     }
 
-    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         let builder = self.client.time_with_tags(key, value);
 
         let res = self


### PR DESCRIPTION
Adds metrics for `arroyo.consumer.poll.time`, `arroyo.consumer.paused.time` and `arroyo.consumer.processing.time`.
