### PR TITLE
feat(rust): metrics.increment() no longer supports optional value

### DIFF
--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 pub static METRICS: OnceLock<Arc<Mutex<Box<dyn Metrics>>>> = OnceLock::new();
 
 pub trait Metrics: Debug + Send + Sync {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>);
+    fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>);
 
     fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 
@@ -13,7 +13,7 @@ pub trait Metrics: Debug + Send + Sync {
 }
 
 impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
+    fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().increment(key, value, tags)
     }
     fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
@@ -28,7 +28,7 @@ impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
 struct Noop {}
 
 impl Metrics for Noop {
-    fn increment(&self, _key: &str, _value: Option<i64>, _tags: Option<HashMap<&str, &str>>) {}
+    fn increment(&self, _key: &str, _value: i64, _tags: Option<HashMap<&str, &str>>) {}
 
     fn gauge(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -45,10 +45,8 @@ impl StatsDBackend {
 }
 
 impl ArroyoMetrics for StatsDBackend {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
-        if let Err(e) =
-            self.send_with_tags(self.client.count_with_tags(key, value.unwrap_or(1)), tags)
-        {
+    fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>) {
+        if let Err(e) = self.send_with_tags(self.client.count_with_tags(key, value), tags) {
             log::debug!("Error sending metric: {}", e);
         }
     }
@@ -75,7 +73,7 @@ mod tests {
     fn statsd_metric_backend() {
         let backend = StatsDBackend::new("0.0.0.0", 8125, "test", HashMap::from([("env", "prod")]));
 
-        backend.increment("a", Some(1), Some(HashMap::from([("tag1", "value1")])));
+        backend.increment("a", 1, Some(HashMap::from([("tag1", "value1")])));
         backend.gauge("b", 20, Some(HashMap::from([("tag2", "value2")])));
         backend.timing("c", 30, Some(HashMap::from([("tag3", "value3")])));
     }

--- a/rust_snuba/src/metrics/testing.rs
+++ b/rust_snuba/src/metrics/testing.rs
@@ -44,8 +44,8 @@ impl TestingMetricsBackend {
 }
 
 impl ArroyoMetrics for TestingMetricsBackend {
-    fn increment(&self, key: &str, value: Option<i64>, tags: Option<HashMap<&str, &str>>) {
-        let builder = self.client.count_with_tags(key, value.unwrap_or(1));
+    fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>) {
+        let builder = self.client.count_with_tags(key, value);
 
         let res = self
             .send_with_tags(builder, tags)
@@ -90,7 +90,7 @@ mod tests {
     fn testing_metrics_backend() {
         let backend = TestingMetricsBackend::new("snuba.rust-consumer");
 
-        backend.increment("a", Some(1), Some(HashMap::from([("tag1", "value1")])));
+        backend.increment("a", 1, Some(HashMap::from([("tag1", "value1")])));
         backend.gauge("b", 20, Some(HashMap::from([("tag2", "value2")])));
         backend.timing("c", 30, Some(HashMap::from([("tag3", "value3")])));
 


### PR DESCRIPTION
Seems kind of silly (and unintuitive) to allow value to be an option, and quietly apply a default of 1. Let's just make it required.