### PR TITLE
feat(consumer): allow group instance id to enable static membership

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -155,6 +155,12 @@ logger = logging.getLogger(__name__)
     type=str,
     help="Arroyo will touch this file at intervals to indicate health. If not provided, no health check is performed.",
 )
+@click.option(
+    "--group-instance-id",
+    type=str,
+    default=None,
+    help="Kafka group instance id. passing a value here will run kafka with static membership.",
+)
 def consumer(
     *,
     storage_name: str,
@@ -183,6 +189,7 @@ def consumer(
     profile_path: Optional[str] = None,
     max_poll_interval_ms: Optional[int] = None,
     health_check_file: Optional[str] = None,
+    group_instance_id: Optional[str] = None,
 ) -> None:
 
     setup_logging(log_level)
@@ -220,6 +227,7 @@ def consumer(
         slice_id=slice_id,
         max_batch_size=max_batch_size,
         max_batch_time_ms=max_batch_time_ms,
+        group_instance_id=group_instance_id,
     )
 
     consumer_builder = ConsumerBuilder(
@@ -247,6 +255,7 @@ def consumer(
         max_poll_interval_ms=max_poll_interval_ms,
         health_check_file=health_check_file,
         enforce_schema=enforce_schema,
+        group_instance_id=group_instance_id,
     )
 
     consumer = consumer_builder.build_base_consumer()

--- a/snuba/cli/rust_consumer.py
+++ b/snuba/cli/rust_consumer.py
@@ -79,7 +79,7 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
 @click.option(
     "--log-level",
     "log_level",
-    type=click.Choice(["error", "warn", "info", "debug", "trace"]),
+    type=click.Choice(["error", "warn", "info", "debug", "trace"], False),
     help="Logging level to use.",
     default="info",
 )
@@ -105,6 +105,12 @@ from snuba.datasets.storages.factory import get_writable_storage_keys
     help="Use the Rust instead of Python message processor (if available)",
     default=False,
 )
+@click.option(
+    "--group-instance-id",
+    type=str,
+    default=None,
+    help="Kafka group instance id. passing a value here will run kafka with static membership.",
+)
 def rust_consumer(
     *,
     storage_names: Sequence[str],
@@ -124,6 +130,7 @@ def rust_consumer(
     concurrency: Optional[int],
     processes: Optional[int],
     use_rust_processor: bool,
+    group_instance_id: Optional[str],
 ) -> None:
     """
     Experimental alternative to `snuba consumer`
@@ -140,6 +147,7 @@ def rust_consumer(
         max_batch_size=max_batch_size,
         max_batch_time_ms=max_batch_time_ms,
         slice_id=slice_id,
+        group_instance_id=group_instance_id,
     )
 
     consumer_config_raw = json.dumps(asdict(consumer_config))
@@ -148,7 +156,7 @@ def rust_consumer(
 
     import rust_snuba
 
-    os.environ["RUST_LOG"] = log_level
+    os.environ["RUST_LOG"] = log_level.lower()
 
     # XXX: Temporary way to quickly test different values for concurrency
     # Should be removed before this is put into  prod

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -77,6 +77,7 @@ class ConsumerBuilder:
         profile_path: Optional[str] = None,
         max_poll_interval_ms: Optional[int] = None,
         health_check_file: Optional[str] = None,
+        group_instance_id: Optional[str] = None,
     ) -> None:
         assert len(consumer_config.storages) == 1, "Only one storage supported"
         storage_key = StorageKey(consumer_config.storages[0].name)
@@ -148,6 +149,7 @@ class ConsumerBuilder:
         self.__profile_path = profile_path
         self.max_poll_interval_ms = max_poll_interval_ms
         self.health_check_file = health_check_file
+        self.group_instance_id = group_instance_id
 
         self.dlq_producer: Optional[KafkaProducer] = None
 
@@ -169,6 +171,8 @@ class ConsumerBuilder:
 
         if self.max_poll_interval_ms is not None:
             configuration["max.poll.interval.ms"] = self.max_poll_interval_ms
+        if self.group_instance_id is not None:
+            configuration["group.instance.id"] = self.group_instance_id
 
         def log_general_error(e: KafkaError) -> None:
             with configure_scope() as scope:

--- a/tests/cli/test_consumer.py
+++ b/tests/cli/test_consumer.py
@@ -26,6 +26,8 @@ def test_consumer_cli(*_mocks: Sequence[Mock]) -> None:
             "latest",
             "--health-check-file",
             "/tmp/test",
+            "--group-instance-id",
+            "test_group_instance_id",
         ],
     )
     assert result.exit_code == 0, result.output


### PR DESCRIPTION
We would like to experiment with running Kafka with static membership. This mode is enabled when consumer passing in the `group.instance.id` parameter.  This PR adds passing in the group instance id as a CLI parameter.