### PR TITLE
feat(CoGS): Monitor missing `use_case_id`

### DIFF
--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -196,7 +196,7 @@ def _run_query_pipeline(
             concurrent_queries_gauge=concurrent_queries_gauge,
         )
 
-    record_missing_tenant_ids(request)
+    record_missing_use_case_id(request, dataset)
 
     return (
         dataset.get_query_pipeline_builder()
@@ -205,20 +205,20 @@ def _run_query_pipeline(
     )
 
 
-def record_missing_tenant_ids(request: Request) -> None:
+def record_missing_use_case_id(request: Request, dataset: Dataset) -> None:
     """
-    Used to track how often the new `tenant_ids` field is not included in
-    a Snuba Request. Ideally, all requests contain this information and this
-    metric will be removed once all API calls from Sentry do include this info.
+    Used to track how often the new `use_case_id` Tenant ID is not included in
+    a Generic Metrics request.
     """
-    if (
-        not (tenant_ids := request.attribution_info.tenant_ids)
-        or tenant_ids.get("referrer") is None
-        or tenant_ids.get("organization_id") is None
-    ):
-        metrics.increment(
-            "request_without_tenant_ids", tags={"referrer": request.referrer}
-        )
+    if get_dataset_name(dataset) == "generic_metrics":
+        if (
+            not (tenant_ids := request.attribution_info.tenant_ids)
+            or tenant_ids.get("use_case_id") is None
+        ):
+            metrics.increment(
+                "gen_metrics_request_without_use_case_id",
+                tags={"referrer": request.referrer},
+            )
 
 
 def _dry_run_query_runner(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -213,11 +213,19 @@ def record_missing_use_case_id(request: Request, dataset: Dataset) -> None:
     if get_dataset_name(dataset) == "generic_metrics":
         if (
             not (tenant_ids := request.attribution_info.tenant_ids)
-            or tenant_ids.get("use_case_id") is None
+            or (use_case_id := tenant_ids.get("use_case_id")) is None
         ):
             metrics.increment(
                 "gen_metrics_request_without_use_case_id",
                 tags={"referrer": request.referrer},
+            )
+        else:
+            metrics.increment(
+                "gen_metrics_request_with_use_case_id",
+                tags={
+                    "referrer": request.referrer,
+                    "use_case_id": str(use_case_id),
+                },
             )
 
 


### PR DESCRIPTION
### Overview
- As part of analyzing cogs for the Generic Metrics dataset in Snuba, we need to see a split of the shared resource by use case (`use_case_id`)
- Currently, queries do not contain `use_case_id` so I'm starting to add a new Tenant ID for generic metrics queries for this
- This will eventually be a required Tenant ID for generic metrics queries
- Relevant Sentry PR adding some `use_case_id`:
    - https://github.com/getsentry/sentry/pull/56694

### Note
- Removing the existing monitoring for missing `tenant_ids` in Snuba requests
- This metric was used to power this [notebook](https://app.datadoghq.com/notebook/4890769/tenant-ids-notebook) during the introduction of `tenant_ids` in general but is no longer needed as we have Tenant IDs where needed and we auto reject queries without them

