### PR TITLE
feat(generic-metrics): Add support for 10s granularity

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -17,9 +17,6 @@ class OutputType(Enum):
 class AggregationOption(Enum):
     HIST = "hist"
     TEN_SECOND = "ten_second"
-    ONE_MINUTE = "one_minute"
-    ONE_HOUR = "one_hour"
-    ONE_DAY = "one_day"
 
 
 ILLEGAL_VALUE_IN_SET = "Illegal value in set."

--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -16,6 +16,7 @@ class OutputType(Enum):
 
 class AggregationOption(Enum):
     HIST = "hist"
+    TEN_SECOND = "ten_second"
 
 
 ILLEGAL_VALUE_IN_SET = "Illegal value in set."
@@ -25,6 +26,7 @@ ILLEGAL_VALUE_IN_COUNTER = "Illegal value in counter."
 INT_FLOAT_EXPECTED = "Int or Float expected"
 
 # These are the hardcoded values from the materialized view
+GRANULARITY_TEN_SECONDS = 0
 GRANULARITY_ONE_MINUTE = 1
 GRANULARITY_ONE_HOUR = 2
 GRANULARITY_ONE_DAY = 3
@@ -91,11 +93,6 @@ def aggregation_options_for_distribution_message(
     aggregation_options = {
         "min_retention_days": retention_days,
         "materialization_version": 2,
-        "granularities": [
-            GRANULARITY_ONE_MINUTE,
-            GRANULARITY_ONE_HOUR,
-            GRANULARITY_ONE_DAY,
-        ],
     }
 
     if aggregation_setting := message.get("aggregation_option"):
@@ -103,7 +100,22 @@ def aggregation_options_for_distribution_message(
         if parsed_aggregation_setting is AggregationOption.HIST:
             return {
                 **aggregation_options,
+                "granularities": [
+                    GRANULARITY_ONE_MINUTE,
+                    GRANULARITY_ONE_HOUR,
+                    GRANULARITY_ONE_DAY,
+                ],
                 "enable_histogram": 1,
+            }
+        if parsed_aggregation_setting is AggregationOption.TEN_SECOND:
+            return {
+                **aggregation_options,
+                "granularities": [
+                    GRANULARITY_ONE_MINUTE,
+                    GRANULARITY_ONE_HOUR,
+                    GRANULARITY_ONE_DAY,
+                    GRANULARITY_TEN_SECONDS,
+                ],
             }
 
     return aggregation_options

--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -17,6 +17,9 @@ class OutputType(Enum):
 class AggregationOption(Enum):
     HIST = "hist"
     TEN_SECOND = "ten_second"
+    ONE_MINUTE = "one_minute"
+    ONE_HOUR = "one_hour"
+    ONE_DAY = "one_day"
 
 
 ILLEGAL_VALUE_IN_SET = "Illegal value in set."

--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -90,6 +90,13 @@ def aggregation_options_for_set_message(
 def aggregation_options_for_distribution_message(
     message: Mapping[str, Any], retention_days: int
 ) -> Mapping[str, Any]:
+    granularity_dict = {
+        "granularities": [
+            GRANULARITY_ONE_MINUTE,
+            GRANULARITY_ONE_HOUR,
+            GRANULARITY_ONE_DAY,
+        ],
+    }
     aggregation_options = {
         "min_retention_days": retention_days,
         "materialization_version": 2,
@@ -100,25 +107,14 @@ def aggregation_options_for_distribution_message(
         if parsed_aggregation_setting is AggregationOption.HIST:
             return {
                 **aggregation_options,
-                "granularities": [
-                    GRANULARITY_ONE_MINUTE,
-                    GRANULARITY_ONE_HOUR,
-                    GRANULARITY_ONE_DAY,
-                ],
+                **granularity_dict,
                 "enable_histogram": 1,
             }
         if parsed_aggregation_setting is AggregationOption.TEN_SECOND:
-            return {
-                **aggregation_options,
-                "granularities": [
-                    GRANULARITY_ONE_MINUTE,
-                    GRANULARITY_ONE_HOUR,
-                    GRANULARITY_ONE_DAY,
-                    GRANULARITY_TEN_SECONDS,
-                ],
-            }
+            granularity_dict["granularities"].append(GRANULARITY_TEN_SECONDS)
+            return {**aggregation_options, **granularity_dict}
 
-    return aggregation_options
+    return {**aggregation_options, **granularity_dict}
 
 
 def aggregation_options_for_counter_message(

--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -77,14 +77,21 @@ def value_for_counter_message(message: Mapping[str, Any]) -> Mapping[str, Any]:
 def aggregation_options_for_set_message(
     message: Mapping[str, Any], retention_days: int
 ) -> Mapping[str, Any]:
-    return {
-        "materialization_version": 1,
+    granularity_dict = {
         "granularities": [
             GRANULARITY_ONE_MINUTE,
             GRANULARITY_ONE_HOUR,
             GRANULARITY_ONE_DAY,
         ],
     }
+
+    if aggregation_setting := message.get("aggregation_option"):
+        parsed_aggregation_setting = AggregationOption(aggregation_setting)
+        if parsed_aggregation_setting is AggregationOption.TEN_SECOND:
+            granularity_dict["granularities"].append(GRANULARITY_TEN_SECONDS)
+            return {"materialization_version": 1, **granularity_dict}
+
+    return {"materialization_version": 1, **granularity_dict}
 
 
 def aggregation_options_for_distribution_message(
@@ -120,11 +127,18 @@ def aggregation_options_for_distribution_message(
 def aggregation_options_for_counter_message(
     message: Mapping[str, Any], retention_days: int
 ) -> Mapping[str, Any]:
-    return {
-        "materialization_version": 1,
+    granularity_dict = {
         "granularities": [
             GRANULARITY_ONE_MINUTE,
             GRANULARITY_ONE_HOUR,
             GRANULARITY_ONE_DAY,
         ],
     }
+
+    if aggregation_setting := message.get("aggregation_option"):
+        parsed_aggregation_setting = AggregationOption(aggregation_setting)
+        if parsed_aggregation_setting is AggregationOption.TEN_SECOND:
+            granularity_dict["granularities"].append(GRANULARITY_TEN_SECONDS)
+            return {"materialization_version": 1, **granularity_dict}
+
+    return {"materialization_version": 1, **granularity_dict}

--- a/tests/datasets/processors/test_generic_metrics_processor.py
+++ b/tests/datasets/processors/test_generic_metrics_processor.py
@@ -2,17 +2,16 @@ import pytest
 
 from snuba.datasets.processors.generic_metrics_processor import (
     GenericCountersMetricsProcessor,
+    GenericDistributionsMetricsProcessor,
 )
 
 
 @pytest.mark.parametrize(
     "message, expected_output",
     [
+        pytest.param({"type": "c", "metric_id": 1, "value": 10}, True, id="counter"),
         pytest.param(
-            {"type": "c", "name": "my_counter", "value": 10}, True, id="counter"
-        ),
-        pytest.param(
-            {"type": "d", "name": "my_distribution", "value": 20},
+            {"type": "d", "metric_id": 2, "value": 20},
             False,
             id="distribution",
         ),
@@ -21,6 +20,30 @@ from snuba.datasets.processors.generic_metrics_processor import (
 def test__should_process(message, expected_output):
     processor = GenericCountersMetricsProcessor()
     assert processor._should_process(message) == expected_output
+
+
+@pytest.mark.parametrize(
+    "message, expected_output",
+    [
+        pytest.param(
+            {
+                "type": "d",
+                "metric_id": 3,
+                "value": [5, 7, 10],
+                "aggregation_option": "ten_second",
+            },
+            {
+                "min_retention_days": 90,
+                "materialization_version": 2,
+                "granularities": [0, 1, 2, 3],
+            },
+            id="ten_second",
+        ),
+    ],
+)
+def test__aggregation_options(message, expected_output):
+    processor = GenericDistributionsMetricsProcessor()
+    assert processor._aggregation_options(message, expected_output)
 
 
 @pytest.mark.parametrize(

--- a/tests/datasets/processors/test_generic_metrics_processor.py
+++ b/tests/datasets/processors/test_generic_metrics_processor.py
@@ -44,7 +44,7 @@ def test__should_process(message, expected_output):
                 "type": "d",
                 "metric_id": 4,
                 "value": [5, 7, 10],
-                "aggregation_option": "ten_second",
+                "aggregation_option": "hist",
             },
             {
                 "min_retention_days": 90,

--- a/tests/datasets/processors/test_generic_metrics_processor.py
+++ b/tests/datasets/processors/test_generic_metrics_processor.py
@@ -39,6 +39,20 @@ def test__should_process(message, expected_output):
             },
             id="ten_second",
         ),
+        pytest.param(
+            {
+                "type": "d",
+                "metric_id": 4,
+                "value": [5, 7, 10],
+                "aggregation_option": "ten_second",
+            },
+            {
+                "min_retention_days": 90,
+                "materialization_version": 2,
+                "granularities": [1, 2, 3],
+            },
+            id="hist",
+        ),
     ],
 )
 def test__aggregation_options(message, expected_output):


### PR DESCRIPTION
`CUSTOM` use case needs 10 second granularity support. Need to double check if this is the only metric type they need it for.

This would go in after the corresponding Sentry changes: https://github.com/getsentry/sentry/pull/56707

UPDATE: confirmed that `CUSTOM` use case wants it for all metric types