### PR TITLE
feat(oncall): Use profile_bytes in bytes scanned allocation policy

### DIFF
--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -302,3 +302,27 @@ def test_use_progress_bytes(policy: AllocationPolicy) -> None:
         policy.get_quota_allowance(tenant_ids=tenant_ids, query_id=QUERY_ID).max_threads
         == 1
     )
+
+
+@pytest.mark.redis_db
+def test_no_bytes_scanned(policy: AllocationPolicy) -> None:
+    _configure_policy(policy)
+    tenant_ids: dict[str, str | int] = {
+        "referrer": "do_something",
+        "organization_id": 1,
+    }
+    no_bytes_scanned_info_result = QueryResultOrError(
+        query_result=QueryResult(
+            result={
+                "profile": {
+                    # bytes scanned info is missing
+                }
+            },
+            extra={"stats": {}, "sql": "", "experiments": {}},
+        ),
+        error=None,
+    )
+    policy.set_config_value("use_progress_bytes_scanned", 0)
+    policy.update_quota_balance(tenant_ids, QUERY_ID, no_bytes_scanned_info_result)
+    policy.set_config_value("use_progress_bytes_scanned", 1)
+    policy.update_quota_balance(tenant_ids, QUERY_ID, no_bytes_scanned_info_result)


### PR DESCRIPTION
It looks like the bytes scanned metric we are using is not actually telling us how many bytes were scanned by the query. This PR:

* Gives a way to switch to using the other bytes_scanned metric for the allocation policy
* emits metrics for both bytes scanned metrics
* the `bytes_scanned` metric changes metric is actually being enforced
* Tests the new behavior

### Rollout

The rollout of this should be storage-by-storage as the numbers are wildly different