### PR TITLE
feat(rust): Rebuild Produce strategy based on RunTaskInThreads

### DIFF
--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -59,10 +59,8 @@ async fn main() {
         fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
             let producer = KafkaProducer::new(self.config.clone());
             let topic = TopicOrPartition::Topic(self.topic.clone());
-            let reverse_string_and_produce_strategy = Transform::new(
-                reverse_string,
-                Produce::new(producer, Box::new(Noop {}), topic),
-            );
+            let reverse_string_and_produce_strategy =
+                Transform::new(reverse_string, Produce::new(Noop {}, producer, 5, topic));
             Box::new(reverse_string_and_produce_strategy)
         }
     }

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -22,11 +22,6 @@ impl KafkaProducer {
 }
 
 impl KafkaProducer {
-    pub fn poll(&self) {
-        let producer = self.producer.as_ref().unwrap();
-        producer.poll(Duration::ZERO);
-    }
-
     pub fn flush(&self) {
         let producer = self.producer.as_ref().unwrap();
         producer.flush(Duration::from_millis(5000));
@@ -34,6 +29,11 @@ impl KafkaProducer {
 }
 
 impl ArroyoProducer<KafkaPayload> for KafkaProducer {
+    fn poll(&self) {
+        let producer = self.producer.as_ref().unwrap();
+        producer.poll(Duration::ZERO);
+    }
+
     fn produce(&self, destination: &TopicOrPartition, payload: &KafkaPayload) {
         let topic = match destination {
             TopicOrPartition::Topic(topic) => topic.name.as_ref(),

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -153,6 +153,8 @@ pub trait Consumer<'a, TPayload: Clone> {
 }
 
 pub trait Producer<TPayload>: Send + Sync {
+    fn poll(&self);
+
     /// Produce to a topic or partition.
     fn produce(&self, destination: &TopicOrPartition, payload: &TPayload);
 

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -153,8 +153,6 @@ pub trait Consumer<'a, TPayload: Clone> {
 }
 
 pub trait Producer<TPayload>: Send + Sync {
-    fn poll(&self);
-
     /// Produce to a topic or partition.
     fn produce(&self, destination: &TopicOrPartition, payload: &TPayload);
 

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -152,7 +152,7 @@ pub trait Consumer<'a, TPayload: Clone> {
     fn closed(&self) -> bool;
 }
 
-pub trait Producer<TPayload> {
+pub trait Producer<TPayload>: Send + Sync {
     /// Produce to a topic or partition.
     fn produce(&self, destination: &TopicOrPartition, payload: &TPayload);
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -1,144 +1,85 @@
-use crate::backends::kafka::producer::KafkaProducer;
 use crate::backends::kafka::types::KafkaPayload;
 use crate::backends::Producer;
-use crate::processing::strategies::{
-    merge_commit_request, CommitRequest, MessageRejected, ProcessingStrategy,
+use crate::processing::strategies::run_task_in_threads::{
+    RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
+use crate::processing::strategies::{CommitRequest, MessageRejected, ProcessingStrategy};
 use crate::types::{Message, TopicOrPartition};
-use futures::Future;
-use log::warn;
-use std::collections::VecDeque;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
-use std::time::{Duration, Instant};
-use tokio::task::JoinHandle;
+use std::time::Duration;
 
-pub struct ProduceFuture {
-    pub producer: Arc<KafkaProducer>,
-    destination: Arc<TopicOrPartition>,
-    payload: KafkaPayload,
-    pub completed: bool,
-}
-
-impl Future for ProduceFuture {
-    type Output = ();
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> std::task::Poll<()> {
-        self.producer.produce(&self.destination, &self.payload);
-        std::task::Poll::Ready(())
-    }
-}
-pub struct Produce<TPayload: Clone + Send + Sync> {
-    pub producer: Arc<KafkaProducer>,
-    pub next_step: Box<dyn ProcessingStrategy<TPayload>>,
-    queue: VecDeque<(Message<TPayload>, JoinHandle<()>)>,
+struct ProduceMessage {
+    producer: Arc<dyn Producer<KafkaPayload>>,
     topic: Arc<TopicOrPartition>,
-    closed: bool,
-    max_queue_size: usize,
 }
 
-impl Produce<KafkaPayload> {
-    pub fn new(
-        producer: KafkaProducer,
-        next_step: Box<dyn ProcessingStrategy<KafkaPayload>>,
-        topic: TopicOrPartition,
-    ) -> Self {
-        Produce {
+impl ProduceMessage {
+    pub fn new(producer: impl Producer<KafkaPayload> + 'static, topic: TopicOrPartition) -> Self {
+        ProduceMessage {
             producer: Arc::new(producer),
-            next_step,
-            queue: VecDeque::new(),
             topic: Arc::new(topic),
-            closed: false,
-            max_queue_size: 1000,
         }
     }
 }
 
-impl ProcessingStrategy<KafkaPayload> for Produce<KafkaPayload> {
+impl TaskRunner<KafkaPayload, KafkaPayload> for ProduceMessage {
+    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<KafkaPayload> {
+        let producer = self.producer.clone();
+        let topic = self.topic.clone();
+
+        Box::pin(async move {
+            producer.produce(&topic, &message.payload());
+            Ok(message)
+        })
+    }
+}
+
+pub struct Produce {
+    inner: Box<dyn ProcessingStrategy<KafkaPayload>>,
+}
+
+impl Produce {
+    pub fn new<N>(
+        next_step: N,
+        producer: impl Producer<KafkaPayload> + 'static,
+        concurrency: usize,
+        topic: TopicOrPartition,
+    ) -> Self
+    where
+        N: ProcessingStrategy<KafkaPayload> + 'static,
+    {
+        let inner = Box::new(RunTaskInThreads::new(
+            next_step,
+            Box::new(ProduceMessage::new(producer, topic)),
+            concurrency,
+        ));
+
+        Produce { inner }
+    }
+}
+
+impl ProcessingStrategy<KafkaPayload> for Produce {
     fn poll(&mut self) -> Option<CommitRequest> {
-        let mut commit_request = None;
-
-        while !self.queue.is_empty() {
-            let (message, handle) = self.queue.pop_front().unwrap();
-
-            if handle.is_finished() {
-                let new_message = message.clone();
-                // block_on(async{
-                //     handle.await.unwrap();
-                // });
-                let next_commit = self.next_step.poll();
-                commit_request = merge_commit_request(commit_request, next_commit);
-
-                self.next_step.submit(new_message).unwrap()
-            } else {
-                break;
-            }
-        }
-        commit_request
+        self.inner.poll()
     }
 
     fn submit(
         &mut self,
         message: Message<KafkaPayload>,
     ) -> Result<(), MessageRejected<KafkaPayload>> {
-        if self.closed {
-            panic!("Attempted to submit a message to a closed Produce strategy")
-        }
-        if self.queue.len() >= self.max_queue_size {
-            return Err(MessageRejected { message });
-        }
-
-        let produce_fut = ProduceFuture {
-            producer: Arc::clone(&self.producer),
-            destination: Arc::clone(&self.topic),
-            payload: message.payload(),
-            completed: false,
-        };
-        // spawn the future
-        let handle = tokio::spawn(produce_fut);
-
-        self.queue.push_back((message, handle));
-        Ok(())
+        self.inner.submit(message)
     }
 
     fn close(&mut self) {
-        self.closed = true;
+        self.inner.close();
     }
 
     fn terminate(&mut self) {
-        self.closed = true;
-        self.next_step.terminate()
+        self.inner.terminate();
     }
 
     fn join(&mut self, timeout: Option<Duration>) -> Option<CommitRequest> {
-        let start = Instant::now();
-        let mut remaining: Option<Duration> = timeout;
-        let mut commit_request = None;
-
-        while !self.queue.is_empty() {
-            if let Some(t) = remaining {
-                remaining = Some(t - start.elapsed());
-                if remaining.unwrap() <= Duration::from_secs(0) {
-                    warn!("Timeout reached while waiting for the queue to be empty");
-                    break;
-                }
-            }
-            let (message, handle) = self.queue.pop_front().unwrap();
-            if handle.is_finished() {
-                let new_message = message.clone();
-                let next_commit = self.next_step.poll();
-                commit_request = merge_commit_request(commit_request, next_commit);
-
-                // TODO: Handle message rejected
-                self.next_step.submit(new_message).unwrap()
-            } else {
-                break;
-            }
-        }
-
-        self.next_step.close();
-        let next_commit = self.next_step.join(remaining);
-        merge_commit_request(commit_request, next_commit)
+        self.inner.join(timeout)
     }
 }
 
@@ -152,12 +93,10 @@ mod tests {
     use crate::types::{BrokerMessage, InnerMessage};
     use crate::types::{Message, Partition, Topic, TopicOrPartition};
     use chrono::Utc;
-    use std::collections::VecDeque;
-    use std::sync::Arc;
     use std::time::Duration;
 
-    #[tokio::test]
-    async fn test_produce() {
+    #[test]
+    fn test_produce() {
         let config = KafkaConfig::new_consumer_config(
             vec![std::env::var("DEFAULT_BROKERS").unwrap_or("127.0.0.1:9092".to_string())],
             "my_group".to_string(),
@@ -192,15 +131,12 @@ mod tests {
         }
 
         let producer: KafkaProducer = KafkaProducer::new(config);
-
-        let mut strategy: Produce<KafkaPayload> = Produce {
-            next_step: Box::new(Noop {}),
-            producer: Arc::new(producer),
-            queue: VecDeque::new(),
-            topic: Arc::new(TopicOrPartition::Topic(partition.topic.clone())),
-            closed: false,
-            max_queue_size: 1000,
-        };
+        let mut strategy = Produce::new(
+            Noop {},
+            producer,
+            10,
+            TopicOrPartition::Topic(partition.topic.clone()),
+        );
 
         let payload_str = "hello world".to_string().as_bytes().to_vec();
         let message = Message {
@@ -217,5 +153,7 @@ mod tests {
         };
 
         strategy.submit(message).unwrap();
+        strategy.close();
+        let _ = strategy.join(None);
     }
 }


### PR DESCRIPTION
Produce is simply a special case of RunTaskInThreads. Let's reuse the underlying strategy to avoid reimplementing the part where we keep track of the handles in multiple places.

Also switch to threaded producer. Producer was not being polled previously.