### PR TITLE
feat(cardinality): Add predefined queries

### DIFF
--- a/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
+++ b/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
@@ -8,7 +8,9 @@ from snuba.utils.registered_class import RegisteredClass
 # Start index is 9223372036854775808
 METRICS_START_INDEX = 1 << 63
 
-
+# TODO: These enum definitions do not work right now. Most likely because
+# f-string formatting does not work as intended when defining the sql. We hardcode
+# the values in the queries for now.
 class IndexedIDs(Enum):
     # Tags
     SPAN_DESCRIPTION_TAG = METRICS_START_INDEX + 249
@@ -29,19 +31,19 @@ class CardinalityQuery(PreDefinedQuery, metaclass=RegisteredClass):
 class SpanGroupingCardinality(CardinalityQuery):
     """Get the span groups with the highest cardinality across all projects and orgs."""
 
-    sql = f"""
-SELECT org_id, project_id,
-    tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG})] AS `span.category`,
-    uniq(tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_GROUP_TAG})] AS `span group`) AS groups
-FROM generic_metric_distributions_aggregated_dist
-WHERE (granularity = 3)
-AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
-AND (metric_id IN [{IndexedIDs.SPAN_DURATION_METRIC}, {IndexedIDs.SPAN_EXCLUSIVE_TIME_METRIC}])
-AND `span.category` = {{span_category}}
-GROUP BY org_id, project_id, `span.category`
-ORDER BY groups DESC
-LIMIT 100
-"""
+    sql = """
+    SELECT org_id, project_id,
+    tags.raw_value [indexOf(tags.key, 9223372036854776062)] AS `span.category`,
+    uniq(tags.raw_value [indexOf(tags.key, 9223372036854776060)]) AS count_groups
+    FROM generic_metric_distributions_aggregated_dist
+    WHERE (granularity = 3)
+    AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+    AND (metric_id IN [9223372036854776212, 9223372036854776213])
+    AND `span.category` = '{{span_category}}'
+    GROUP BY org_id, project_id, `span.category`
+    ORDER BY count_groups DESC
+    LIMIT 100
+    """
 
 
 class SpanGroupingCardinalitySamples(CardinalityQuery):
@@ -49,17 +51,17 @@ class SpanGroupingCardinalitySamples(CardinalityQuery):
     Get a sample list of the span groups for a given org and project.
     """
 
-    sql = f"""
-SELECT DISTINCT
-    tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG})] AS `span.category`,
-    tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_GROUP_TAG})] AS `span.group`,
-    tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_DESCRIPTION_TAG})] AS `span.description`
-FROM generic_metric_distributions_aggregated_dist
-WHERE (granularity = 3)
-AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
-AND (org_id = {{org_id}})
-AND (project_id = {{project_id}})
-AND (metric_id = {IndexedIDs.SPAN_EXCLUSIVE_TIME_LIGHT_METRIC})
-ORDER BY span.description
-LIMIT 1000
-"""
+    sql = """
+    SELECT DISTINCT
+    tags.raw_value[indexOf(tags.key, 9223372036854776062)] AS `span.category`,
+    tags.raw_value[indexOf(tags.key, 9223372036854776060)] AS `span.group`,
+    tags.raw_value[indexOf(tags.key, 9223372036854776057)] AS `span.description`
+    FROM generic_metric_distributions_aggregated_dist
+    WHERE (granularity = 3)
+    AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+    AND (org_id = {{org_id}})
+    AND (project_id = {{project_id}})
+    AND (metric_id = 9223372036854776214)
+    ORDER BY span.description
+    LIMIT 1000
+    """

--- a/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
+++ b/snuba/admin/clickhouse/predefined_cardinality_analyzer_queries.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from snuba.admin.clickhouse.common import PreDefinedQuery
+from snuba.utils.registered_class import RegisteredClass
+
+# Start index is 9223372036854775808
+METRICS_START_INDEX = 1 << 63
+
+
+class IndexedIDs(Enum):
+    # Tags
+    SPAN_DESCRIPTION_TAG = METRICS_START_INDEX + 249
+    SPAN_CATEGORY_TAG = METRICS_START_INDEX + 254
+    SPAN_GROUP_TAG = METRICS_START_INDEX + 252
+    # Metric names
+    SPAN_DURATION_METRIC = METRICS_START_INDEX + 404
+    SPAN_EXCLUSIVE_TIME_METRIC = METRICS_START_INDEX + 405
+    SPAN_EXCLUSIVE_TIME_LIGHT_METRIC = METRICS_START_INDEX + 406
+
+
+class CardinalityQuery(PreDefinedQuery, metaclass=RegisteredClass):
+    @classmethod
+    def config_key(cls) -> str:
+        return cls.__name__
+
+
+class SpanGroupingCardinality(CardinalityQuery):
+    """Get the span groups with the highest cardinality across all projects and orgs."""
+
+    sql = f"""
+SELECT org_id, project_id,
+    tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG})] AS `span.category`,
+    uniq(tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_GROUP_TAG})] AS `span group`) AS groups
+FROM generic_metric_distributions_aggregated_dist
+WHERE (granularity = 3)
+AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+AND (metric_id IN [{IndexedIDs.SPAN_DURATION_METRIC}, {IndexedIDs.SPAN_EXCLUSIVE_TIME_METRIC}])
+AND `span.category` = {{span_category}}
+GROUP BY org_id, project_id, `span.category`
+ORDER BY groups DESC
+LIMIT 100
+"""
+
+
+class SpanGroupingCardinalitySamples(CardinalityQuery):
+    """
+    Get a sample list of the span groups for a given org and project.
+    """
+
+    sql = f"""
+SELECT DISTINCT
+    tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG})] AS `span.category`,
+    tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_GROUP_TAG})] AS `span.group`,
+    tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_DESCRIPTION_TAG})] AS `span.description`
+FROM generic_metric_distributions_aggregated_dist
+WHERE (granularity = 3)
+AND (timestamp >= now() - INTERVAL {{hour_window}} HOUR)
+AND (org_id = {{org_id}})
+AND (project_id = {{project_id}})
+AND (metric_id = {IndexedIDs.SPAN_EXCLUSIVE_TIME_LIGHT_METRIC})
+ORDER BY span.description
+LIMIT 1000
+"""

--- a/snuba/admin/static/api_client.tsx
+++ b/snuba/admin/static/api_client.tsx
@@ -62,6 +62,7 @@ interface Client {
   getPredefinedQuerylogOptions: () => Promise<[PredefinedQuery]>;
   getQuerylogSchema: () => Promise<QuerylogResult>;
   executeQuerylogQuery: (req: QuerylogRequest) => Promise<QuerylogResult>;
+  getPredefinedCardinalityQueryOptions: () => Promise<[PredefinedQuery]>;
   executeCardinalityQuery: (
     req: CardinalityQueryRequest
   ) => Promise<CardinalityQueryResult>;
@@ -298,6 +299,10 @@ function Client() {
           return resp.json().then(Promise.reject.bind(Promise));
         }
       });
+    },
+    getPredefinedCardinalityQueryOptions: () => {
+      const url = baseUrl + "cardinality_queries";
+      return fetch(url).then((resp) => resp.json());
     },
     executeCardinalityQuery: (query: CardinalityQueryRequest) => {
       const url = baseUrl + "cardinality_query";

--- a/snuba/admin/static/cardinality_analyzer/index.tsx
+++ b/snuba/admin/static/cardinality_analyzer/index.tsx
@@ -9,6 +9,14 @@ function CardinalityQueries(props: { api: Client }) {
     PredefinedQuery[]
   >([]);
 
+  useEffect(() => {
+    props.api.getPredefinedCardinalityQueryOptions().then((res) => {
+      res.forEach(
+          (queryOption) => (queryOption.sql = formatSQL(queryOption.sql))
+      );
+      setPredefinedQueryOptions(res);
+    });
+  }, []);
 
   function tablePopulator(queryResult: CardinalityQueryResult) {
     return (
@@ -20,7 +28,6 @@ function CardinalityQueries(props: { api: Client }) {
       </div>
     );
   }
-
   function formatSQL(sql: string) {
     const formatted = sql
       .split("\n")
@@ -34,7 +41,7 @@ function CardinalityQueries(props: { api: Client }) {
       {QueryDisplay({
         api: props.api,
         resultDataPopulator: tablePopulator,
-        predefinedQueryOptions: [],
+        predefinedQueryOptions: predefinedQueryOptions,
       })}
     </div>
   );

--- a/snuba/admin/views.py
+++ b/snuba/admin/views.py
@@ -23,6 +23,9 @@ from snuba.admin.clickhouse.capacity_management import (
 from snuba.admin.clickhouse.common import InvalidCustomQuery
 from snuba.admin.clickhouse.migration_checks import run_migration_checks_and_policies
 from snuba.admin.clickhouse.nodes import get_storage_info
+from snuba.admin.clickhouse.predefined_cardinality_analyzer_queries import (
+    CardinalityQuery,
+)
 from snuba.admin.clickhouse.predefined_querylog_queries import QuerylogQuery
 from snuba.admin.clickhouse.predefined_system_queries import SystemQuery
 from snuba.admin.clickhouse.querylog import describe_querylog_schema, run_querylog_query
@@ -308,6 +311,13 @@ def clickhouse_queries() -> Response:
 @check_tool_perms(tools=[AdminTools.QUERYLOG])
 def querylog_queries() -> Response:
     res = [q.to_json() for q in QuerylogQuery.all_classes()]
+    return make_response(jsonify(res), 200)
+
+
+@application.route("/cardinality_queries")
+@check_tool_perms(tools=[AdminTools.CARDINALITY_ANALYZER])
+def cardinality_queries() -> Response:
+    res = [q.to_json() for q in CardinalityQuery.all_classes()]
     return make_response(jsonify(res), 200)
 
 


### PR DESCRIPTION
This PR adds support for 2 predefined cardinality queries used with starfish 
1. Find the list of projects which have a high cardinality
2. For the list of projects which have a high cardinality find sample values to determine how grouping can be improved.