### PR TITLE
Revert "ref(rust): Rewrite check_for_results to use better way of joining process pool (#4703)"

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1205,8 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "procspawn"
-version = "1.0.0"
-source = "git+https://github.com/getsentry/procspawn?branch=fix/join-timeout-pool#d3c91e199ed60a07dda1c19739f649e77dd96419"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5a680d772408c77498b0339175746b5dae18724b26877b919e6ecabb680e83"
 dependencies = [
  "backtrace",
  "ctor",
@@ -1215,7 +1216,6 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -37,12 +37,11 @@ ctrlc = "3.2.5"
 sentry = "0.31.0"
 reqwest = "0.11.11"
 uuid = "1.4.1"
-# running on procspawn fork because it's unclear https://github.com/mitsuhiko/procspawn/pull/48 is safe
-procspawn = { version = "1.0.0", features = ["json"], git = "https://github.com/getsentry/procspawn", branch = "fix/join-timeout-pool" }
+procspawn = { version = "0.10.2", features = ["json"] }
 
 [features]
 ffi = ["pyo3/extension-module"]
 
 [dev-dependencies]
 pyo3 = { version = "*", features = ["auto-initialize"] }
-procspawn = { version = "1.0.0", features = ["test-support", "json"], git = "https://github.com/getsentry/procspawn", branch = "fix/join-timeout-pool" }
+procspawn = { version = "0.10.2", features = ["test-support", "json"] }

--- a/rust_snuba/src/runtime_config.rs
+++ b/rust_snuba/src/runtime_config.rs
@@ -20,13 +20,7 @@ mod tests {
 
     #[test]
     fn test_runtime_config() {
-        // on macos, this test is polluting something in the global process state causing
-        // other tests to hang, therefore isolate it in another subprocess of its own.
-        let handle = procspawn::spawn((), |()| {
-            let config = get_str_config("test");
-            assert_eq!(config.unwrap(), None);
-        });
-
-        handle.join().unwrap();
+        let config = get_str_config("test");
+        assert_eq!(config.unwrap(), None);
     }
 }

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -75,26 +75,29 @@ impl PythonTransformStep {
     }
 
     fn check_for_results(&mut self) {
-        while let Some(handle) = self.handles.pop_front() {
-            let (original_message_meta, message_result) = match handle {
+        // procspawn has no join() timeout that does not consume the handle on timeout.
+        //
+        // Additionally we have observed, at least on MacOS, that procspawn's active_count() only
+        // decreases when the handle is consumed. Therefore our count of actually saturated
+        // processes is `self.processing_pool.active_count() - self.handles.len()`.
+        //
+        // If no process is saturated (i.e. above equation is <= 0), we can conclude that all tasks
+        // are done and all handles can be joined and consumed without waiting.
+        while {
+            let active_count = self
+                .processing_pool
+                .as_ref()
+                .map_or(0, |pool| pool.active_count());
+            let may_have_finished_handles = active_count <= self.handles.len();
+            may_have_finished_handles && !self.handles.is_empty()
+        } {
+            let (original_message_meta, message_result) = match self.handles.pop_front().unwrap() {
                 TaskHandle::Procspawn {
                     original_message_meta,
                     join_handle,
                 } => {
-                    let mut handle = join_handle.into_inner().unwrap();
-                    let result = match handle.join_timeout(Duration::ZERO) {
-                        Ok(result) => result,
-                        Err(e) if e.is_timeout() => {
-                            self.handles.push_front(TaskHandle::Procspawn {
-                                original_message_meta,
-                                join_handle: Mutex::new(handle),
-                            });
-                            return;
-                        }
-                        Err(e) => {
-                            panic!("procspawn failed: {}", e);
-                        }
-                    };
+                    let handle = join_handle.into_inner().unwrap();
+                    let result = handle.join().expect("procspawn failed");
                     (original_message_meta, result)
                 }
                 TaskHandle::Immediate {
@@ -102,7 +105,6 @@ impl PythonTransformStep {
                     result,
                 } => (original_message_meta, result),
             };
-
             match message_result {
                 Ok(data) => {
                     if let Err(MessageRejected {


### PR DESCRIPTION
This reverts commit 9cf07cdcf3ee69841aa660f97b537cee70e170f6.

(revert #4703)

The commit in question is speculated to cause deadlocks (no clear evidence), and while in theory it is faster, in practice we can't use it right now. next time use QE to validate perf improvements.