### PR TITLE
CI: add clickhouse 21 checks to gocd 

### DIFF
--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -8,4 +8,5 @@
   "Tests and code coverage (test_distributed_migrations)" \
   "Dataset Config Validation" \
   "sentry (0)" \
-  "sentry (1)"
+  "sentry (1)" \
+  "Tests on Clickhouse 21"

--- a/scripts/fetch_service_refs.py
+++ b/scripts/fetch_service_refs.py
@@ -27,7 +27,7 @@ def pipeline_passed(pipeline: Dict[str, Any]) -> bool:
 
 
 # print the most recent passing sha for a repo
-def main(pipeline_name: str = "deploy-snuba", repo: str = "snuba") -> int:
+def main(pipeline_name: str = "deploy-snuba-us", repo: str = "snuba") -> int:
     GOCD_ACCESS_TOKEN = os.environ.get("GOCD_ACCESS_TOKEN")
     if not GOCD_ACCESS_TOKEN:
         raise SystemExit(


### PR DESCRIPTION
* Adds the clickhouse 21 test to be checked in gocd
* Fixes a bug were we were checking shas against the old pipeline 
