### PR TITLE
feat(rust): KafkaProducer improvements

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -77,7 +77,8 @@ mod tests {
             headers: None,
             payload: Some("asdf".as_bytes().to_vec()),
         };
-        producer.produce(&destination, &payload);
-        producer.close();
+        producer
+            .produce(&destination, payload)
+            .expect("Message produced")
     }
 }

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -32,6 +32,13 @@ pub enum ConsumerError {
     BrokerError(#[from] Box<dyn std::error::Error>),
 }
 
+#[non_exhaustive]
+#[derive(Error, Debug)]
+pub enum ProducerError {
+    #[error("The producer errored")]
+    ProducerErrorred,
+}
+
 /// This is basically an observer pattern to receive the callbacks from
 /// the consumer when partitions are assigned/revoked.
 pub trait AssignmentCallbacks: Send + Sync {
@@ -154,7 +161,9 @@ pub trait Consumer<'a, TPayload: Clone> {
 
 pub trait Producer<TPayload>: Send + Sync {
     /// Produce to a topic or partition.
-    fn produce(&self, destination: &TopicOrPartition, payload: &TPayload);
-
-    fn close(&mut self);
+    fn produce(
+        &self,
+        destination: &TopicOrPartition,
+        payload: TPayload,
+    ) -> Result<(), ProducerError>;
 }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -28,7 +28,9 @@ impl TaskRunner<KafkaPayload, KafkaPayload> for ProduceMessage {
         let topic = self.topic.clone();
 
         Box::pin(async move {
-            producer.produce(&topic, &message.payload());
+            producer
+                .produce(&topic, message.payload())
+                .expect("Message was produced");
             Ok(message)
         })
     }


### PR DESCRIPTION
- Producer.produce() can return an error rather than panicking
- Remove producer.close(). Not needed since Drop takes care of this
- Removes an unnecessary clone()