### PR TITLE
feat: Support passing custom metric name to RunTaskInThreads

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -54,6 +54,7 @@ impl Produce {
             next_step,
             Box::new(ProduceMessage::new(producer, topic)),
             concurrency,
+            Some("produce"),
         ));
 
         Produce { inner }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -198,7 +198,7 @@ mod tests {
             }
         }
 
-        let mut strategy = RunTaskInThreads::new(Noop {}, Box::new(IdentityTaskRunner {}), 1);
+        let mut strategy = RunTaskInThreads::new(Noop {}, Box::new(IdentityTaskRunner {}), 1, None);
 
         let message = Message::new_any_message("hello_world".to_string(), BTreeMap::new());
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -20,13 +20,13 @@ use rust_arroyo::utils::metrics::configure_metrics;
 
 use pyo3::prelude::*;
 
+use crate::config;
+use crate::logging::{setup_logging, setup_sentry};
 use crate::metrics::statsd::StatsDBackend;
 use crate::processors;
 use crate::strategies::clickhouse::ClickhouseWriterStep;
 use crate::strategies::python::PythonTransformStep;
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
-use crate::config;
-use crate::logging::{setup_sentry, setup_logging};
 
 #[pyfunction]
 pub fn consumer(
@@ -144,6 +144,7 @@ pub fn consumer_impl(
                         next_step,
                         Box::new(task_runner),
                         self.concurrency,
+                        Some("process_message"),
                     ))
                 }
                 _ => Box::new(

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -73,6 +73,7 @@ impl ClickhouseWriterStep {
                 skip_write,
             )),
             concurrency,
+            Some("clickhouse"),
         ));
 
         ClickhouseWriterStep { inner }


### PR DESCRIPTION
We use this strategy all over the place (and under the hood of other strategies as well). Support passing a custom metric name to disambiguate.
