### PR TITLE
feat(COGS): `create_subscription` requests now support Tenant IDs

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -39,7 +39,6 @@ from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
-from snuba.state import get_config
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -221,9 +220,6 @@ class SubscriptionData:
             "resolution": self.resolution_sec,
             "query": self.query,
         }
-
-        if get_config("save_subscription_with_tenant_ids", 0):
-            subscription_data_dict["tenant_ids"] = self.tenant_ids
 
         subscription_processors = self.entity.get_subscription_processors()
         if subscription_processors:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -40,6 +40,7 @@ from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
+from snuba.state import get_config
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -219,8 +220,11 @@ class SubscriptionData:
             "time_window": self.time_window_sec,
             "resolution": self.resolution_sec,
             "query": self.query,
-            "tenant_ids": self.tenant_ids,
         }
+
+        if get_config("save_subscription_with_tenant_ids", 0):
+            subscription_data_dict["tenant_ids"] = self.tenant_ids
+
         subscription_processors = self.entity.get_subscription_processors()
         if subscription_processors:
             for processor in subscription_processors:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -46,7 +46,13 @@ from snuba.utils.metrics.timer import Timer
 SUBSCRIPTION_REFERRER = "subscription"
 
 # These are subscription payload keys which need to be set as attributes in SubscriptionData.
-SUBSCRIPTION_DATA_PAYLOAD_KEYS = {"project_id", "time_window", "resolution", "query"}
+SUBSCRIPTION_DATA_PAYLOAD_KEYS = {
+    "project_id",
+    "time_window",
+    "resolution",
+    "query",
+    "tenant_ids",
+}
 
 logger = logging.getLogger("snuba.subscriptions")
 
@@ -79,6 +85,7 @@ class SubscriptionData:
     time_window_sec: int
     entity: Entity
     query: str
+    tenant_ids: Mapping[str, Any]
     metadata: Mapping[str, Any]
 
     def add_conditions(
@@ -199,6 +206,7 @@ class SubscriptionData:
             resolution_sec=int(data["resolution"]),
             query=data["query"],
             entity=entity,
+            tenant_ids=data.get("tenant_ids", {}),
             metadata=metadata,
         )
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import partial
 from typing import (
@@ -87,8 +87,8 @@ class SubscriptionData:
     time_window_sec: int
     entity: Entity
     query: str
-    tenant_ids: MutableMapping[str, Any]
     metadata: Mapping[str, Any]
+    tenant_ids: MutableMapping[str, Any] = field(default_factory=lambda: dict())
 
     def add_conditions(
         self,
@@ -210,8 +210,8 @@ class SubscriptionData:
             resolution_sec=int(data["resolution"]),
             query=data["query"],
             entity=entity,
-            tenant_ids=data.get("tenant_ids", dict()),
             metadata=metadata,
+            tenant_ids=data.get("tenant_ids", dict()),
         )
 
     def to_dict(self) -> Mapping[str, Any]:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Iterator,
     Mapping,
-    MutableMapping,
     NamedTuple,
     NewType,
     Optional,
@@ -88,7 +87,7 @@ class SubscriptionData:
     entity: Entity
     query: str
     metadata: Mapping[str, Any]
-    tenant_ids: MutableMapping[str, Any] = field(default_factory=lambda: dict())
+    tenant_ids: Mapping[str, Any] = field(default_factory=lambda: dict())
 
     def add_conditions(
         self,
@@ -172,15 +171,16 @@ class SubscriptionData:
                 custom_processing.append(validator.validate)
         custom_processing.append(partial(self.add_conditions, timestamp, offset))
 
-        self.tenant_ids["referrer"] = referrer
-        if "organization_id" not in self.tenant_ids:
+        tenant_ids = {**self.tenant_ids}
+        tenant_ids["referrer"] = referrer
+        if "organization_id" not in tenant_ids:
             # TODO: Subscriptions queries should have an org ID
-            self.tenant_ids["organization_id"] = 1
+            tenant_ids["organization_id"] = 1
 
         request = build_request(
             {
                 "query": self.query,
-                "tenant_ids": self.tenant_ids,
+                "tenant_ids": tenant_ids,
             },
             parse_snql_query,
             SubscriptionQuerySettings,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -236,13 +236,16 @@ def record_subscription_created_missing_tenant_ids(request: Request) -> None:
     Used to track how often new subscriptions are created without Tenant IDs.
     """
     if request.referrer == SUBSCRIPTION_REFERRER:
-        if (
-            not (tenant_ids := request.attribution_info.tenant_ids)
-            or "organization_id" not in tenant_ids
-        ):
+        if not (tenant_ids := request.attribution_info.tenant_ids):
             metrics.increment("subscription_created_without_tenant_ids")
         else:
-            metrics.increment("subscription_created_with_tenant_ids")
+            metrics.increment(
+                "subscription_created_with_tenant_ids",
+                tags={
+                    "use_case_id": str(tenant_ids.get("use_case_id")),
+                    "has_org_id": str(tenant_ids.get("organization_id") is not None),
+                },
+            )
 
 
 def _dry_run_query_runner(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -34,6 +34,7 @@ from snuba.querylog import record_query
 from snuba.querylog.query_metadata import SnubaQueryMetadata
 from snuba.reader import Reader
 from snuba.request import Request
+from snuba.subscriptions.data import SUBSCRIPTION_REFERRER
 from snuba.utils.metrics.gauge import Gauge
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.util import with_span
@@ -197,6 +198,7 @@ def _run_query_pipeline(
         )
 
     record_missing_use_case_id(request, dataset)
+    record_subscription_created_missing_tenant_ids(request)
 
     return (
         dataset.get_query_pipeline_builder()
@@ -227,6 +229,20 @@ def record_missing_use_case_id(request: Request, dataset: Dataset) -> None:
                     "use_case_id": str(use_case_id),
                 },
             )
+
+
+def record_subscription_created_missing_tenant_ids(request: Request) -> None:
+    """
+    Used to track how often new subscriptions are created without Tenant IDs.
+    """
+    if request.referrer == SUBSCRIPTION_REFERRER:
+        if (
+            not (tenant_ids := request.attribution_info.tenant_ids)
+            or "organization_id" not in tenant_ids
+        ):
+            metrics.increment("subscription_created_without_tenant_ids")
+        else:
+            metrics.increment("subscription_created_with_tenant_ids")
 
 
 def _dry_run_query_runner(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2243,6 +2243,49 @@ class TestCreateSubscriptionApi(BaseApiTest):
             "subscription_id": f"0/{expected_uuid.hex}",
         }
 
+    def test_tenant_ids(self) -> None:
+        expected_uuid = uuid.uuid1()
+
+        tenant_ids = {
+            "organization_id": 1,
+            "referrer": "my-referrer",
+            "use_case_id": "transactions",
+        }
+
+        with patch("snuba.subscriptions.subscription.uuid1") as uuid4:
+            uuid4.return_value = expected_uuid
+            resp = self.app.post(
+                f"{self.dataset_name}/{self.entity_key}/subscriptions",
+                data=json.dumps(
+                    {
+                        "project_id": 1,
+                        "query": "MATCH (events) SELECT count() AS count WHERE platform IN tuple('a')",
+                        "time_window": int(timedelta(minutes=10).total_seconds()),
+                        "resolution": int(timedelta(minutes=1).total_seconds()),
+                        "tenant_ids": tenant_ids,
+                    }
+                ).encode("utf-8"),
+            )
+
+        assert resp.status_code == 202
+        data = json.loads(resp.data)
+        assert data == {
+            "subscription_id": f"0/{expected_uuid.hex}",
+        }
+
+        subscription_id = data["subscription_id"]
+        partition = subscription_id.split("/", 1)[0]
+
+        _, data = list(
+            RedisSubscriptionDataStore(
+                get_redis_client(RedisClientKey.SUBSCRIPTION_STORE),
+                EntityKey.EVENTS,
+                partition,
+            ).all()
+        )[0]
+        assert data.tenant_ids == dict()  # not saved to the redis store
+        assert "tenant_ids" not in data.to_dict()  # doesn't show up in dictified data
+
     def test_selected_entity_is_used(self) -> None:
         """
         Test that ensures that the passed entity is the selected one, not the dataset's default


### PR DESCRIPTION
### Overview
- As part of figuring out what % of generic metrics subscriptions queries originate from which use case IDs, we need to add extra data to the create subscription request
- This has a side effect of also enabling us to categorize subscriptions by Organization ID once Sentry starts sending `tenant_ids` as part of the request
- Sentry change [here](https://github.com/getsentry/sentry/pull/57101)

### Changes
- `POST /<dataset>/<entity>/subscriptions` route (`create_subscription`) now supports `tenant_ids` in the request
- These Tenant IDs are stored in `SubscriptionData` but *not* serialized into Redis when the subscription is saved
    - For now, this PR will increment a simple metric checking how many subscription are vs aren't being created with `tenant_ids`
