### PR TITLE
feat(COGS): Enable Subscriptions to save and execute with `tenant_ids`

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -45,6 +45,7 @@ from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
 
 SUBSCRIPTION_REFERRER = "subscription"
+ENABLE_TENANT_IDS_RUNTIME_CONFIG = "save_subscription_with_tenant_ids"
 
 # These are subscription payload keys which need to be set as attributes in SubscriptionData.
 SUBSCRIPTION_DATA_PAYLOAD_KEYS = {
@@ -222,7 +223,7 @@ class SubscriptionData:
             "query": self.query,
         }
 
-        if get_config("save_subscription_with_tenant_ids", 0):
+        if get_config(ENABLE_TENANT_IDS_RUNTIME_CONFIG, 0):
             subscription_data_dict["tenant_ids"] = self.tenant_ids
 
         subscription_processors = self.entity.get_subscription_processors()

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -39,7 +39,6 @@ from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
-from snuba.state import get_config
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -221,9 +220,6 @@ class SubscriptionData:
             "resolution": self.resolution_sec,
             "query": self.query,
         }
-
-        if get_config("save_subscription_with_tenant_ids", 0):
-            subscription_data_dict["tenant_ids"] = self.tenant_ids
 
         subscription_processors = self.entity.get_subscription_processors()
         if subscription_processors:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -40,6 +40,7 @@ from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
+from snuba.state import get_config
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -219,8 +220,11 @@ class SubscriptionData:
             "time_window": self.time_window_sec,
             "resolution": self.resolution_sec,
             "query": self.query,
-            "tenant_ids": self.tenant_ids,
         }
+
+        if get_config("save_subscription_with_tenant_ids", 0):
+            subscription_data_dict["tenant_ids"] = self.tenant_ids
+
         subscription_processors = self.entity.get_subscription_processors()
         if subscription_processors:
             for processor in subscription_processors:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -46,7 +46,13 @@ from snuba.utils.metrics.timer import Timer
 SUBSCRIPTION_REFERRER = "subscription"
 
 # These are subscription payload keys which need to be set as attributes in SubscriptionData.
-SUBSCRIPTION_DATA_PAYLOAD_KEYS = {"project_id", "time_window", "resolution", "query"}
+SUBSCRIPTION_DATA_PAYLOAD_KEYS = {
+    "project_id",
+    "time_window",
+    "resolution",
+    "query",
+    "tenant_ids",
+}
 
 logger = logging.getLogger("snuba.subscriptions")
 
@@ -79,6 +85,7 @@ class SubscriptionData:
     time_window_sec: int
     entity: Entity
     query: str
+    tenant_ids: Mapping[str, Any]
     metadata: Mapping[str, Any]
 
     def add_conditions(
@@ -199,6 +206,7 @@ class SubscriptionData:
             resolution_sec=int(data["resolution"]),
             query=data["query"],
             entity=entity,
+            tenant_ids=data.get("tenant_ids", {}),
             metadata=metadata,
         )
 

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -39,6 +39,7 @@ from snuba.reader import Result
 from snuba.request import Request
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
+from snuba.state import get_config
 from snuba.subscriptions.utils import Tick
 from snuba.utils.metrics import MetricsBackend
 from snuba.utils.metrics.timer import Timer
@@ -220,6 +221,9 @@ class SubscriptionData:
             "resolution": self.resolution_sec,
             "query": self.query,
         }
+
+        if get_config("save_subscription_with_tenant_ids", 0):
+            subscription_data_dict["tenant_ids"] = self.tenant_ids
 
         subscription_processors = self.entity.get_subscription_processors()
         if subscription_processors:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import partial
 from typing import (
@@ -87,8 +87,8 @@ class SubscriptionData:
     time_window_sec: int
     entity: Entity
     query: str
-    tenant_ids: MutableMapping[str, Any]
     metadata: Mapping[str, Any]
+    tenant_ids: MutableMapping[str, Any] = field(default_factory=lambda: dict())
 
     def add_conditions(
         self,
@@ -210,8 +210,8 @@ class SubscriptionData:
             resolution_sec=int(data["resolution"]),
             query=data["query"],
             entity=entity,
-            tenant_ids=data.get("tenant_ids", dict()),
             metadata=metadata,
+            tenant_ids=data.get("tenant_ids", dict()),
         )
 
     def to_dict(self) -> Mapping[str, Any]:

--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Iterator,
     Mapping,
-    MutableMapping,
     NamedTuple,
     NewType,
     Optional,
@@ -88,7 +87,7 @@ class SubscriptionData:
     entity: Entity
     query: str
     metadata: Mapping[str, Any]
-    tenant_ids: MutableMapping[str, Any] = field(default_factory=lambda: dict())
+    tenant_ids: Mapping[str, Any] = field(default_factory=lambda: dict())
 
     def add_conditions(
         self,
@@ -172,15 +171,16 @@ class SubscriptionData:
                 custom_processing.append(validator.validate)
         custom_processing.append(partial(self.add_conditions, timestamp, offset))
 
-        self.tenant_ids["referrer"] = referrer
-        if "organization_id" not in self.tenant_ids:
+        tenant_ids = {**self.tenant_ids}
+        tenant_ids["referrer"] = referrer
+        if "organization_id" not in tenant_ids:
             # TODO: Subscriptions queries should have an org ID
-            self.tenant_ids["organization_id"] = 1
+            tenant_ids["organization_id"] = 1
 
         request = build_request(
             {
                 "query": self.query,
-                "tenant_ids": self.tenant_ids,
+                "tenant_ids": tenant_ids,
             },
             parse_snql_query,
             SubscriptionQuerySettings,

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -236,13 +236,16 @@ def record_subscription_created_missing_tenant_ids(request: Request) -> None:
     Used to track how often new subscriptions are created without Tenant IDs.
     """
     if request.referrer == SUBSCRIPTION_REFERRER:
-        if (
-            not (tenant_ids := request.attribution_info.tenant_ids)
-            or "organization_id" not in tenant_ids
-        ):
+        if not (tenant_ids := request.attribution_info.tenant_ids):
             metrics.increment("subscription_created_without_tenant_ids")
         else:
-            metrics.increment("subscription_created_with_tenant_ids")
+            metrics.increment(
+                "subscription_created_with_tenant_ids",
+                tags={
+                    "use_case_id": str(tenant_ids.get("use_case_id")),
+                    "has_org_id": str(tenant_ids.get("organization_id") is not None),
+                },
+            )
 
 
 def _dry_run_query_runner(

--- a/snuba/web/query.py
+++ b/snuba/web/query.py
@@ -34,6 +34,7 @@ from snuba.querylog import record_query
 from snuba.querylog.query_metadata import SnubaQueryMetadata
 from snuba.reader import Reader
 from snuba.request import Request
+from snuba.subscriptions.data import SUBSCRIPTION_REFERRER
 from snuba.utils.metrics.gauge import Gauge
 from snuba.utils.metrics.timer import Timer
 from snuba.utils.metrics.util import with_span
@@ -197,6 +198,7 @@ def _run_query_pipeline(
         )
 
     record_missing_use_case_id(request, dataset)
+    record_subscription_created_missing_tenant_ids(request)
 
     return (
         dataset.get_query_pipeline_builder()
@@ -227,6 +229,20 @@ def record_missing_use_case_id(request: Request, dataset: Dataset) -> None:
                     "use_case_id": str(use_case_id),
                 },
             )
+
+
+def record_subscription_created_missing_tenant_ids(request: Request) -> None:
+    """
+    Used to track how often new subscriptions are created without Tenant IDs.
+    """
+    if request.referrer == SUBSCRIPTION_REFERRER:
+        if (
+            not (tenant_ids := request.attribution_info.tenant_ids)
+            or "organization_id" not in tenant_ids
+        ):
+            metrics.increment("subscription_created_without_tenant_ids")
+        else:
+            metrics.increment("subscription_created_with_tenant_ids")
 
 
 def _dry_run_query_runner(


### PR DESCRIPTION
### Overview
- Builds upon #4775
- Introduces the ability to actually save Tenant IDs into Redis and use them when executing the subscription queries

### How does it work?
- Enabling the `save_subscription_with_tenant_ids` will make the `SubscriptionData.to_dict()` method to start returning `tenant_ids` in the dict representation of the subscription data, if my understanding is correct this will:
    - Update the message posted to scheduled-subscriptions to also include a `tenant_ids` field
    - Update the data stored in Redis to include the same
    - Update the request made by `subscriptions_executor` to start including a `tenant_ids` field
    - Update the original request in messages produced to the subscription result topic to include `tenant_ids`
- All in all, it _should_ just work, ie it should just add Tenant IDs and have them accessible at query process time for us to analyze subscriptions queries by organization in querylog

### Gotchas
- Enabling this new form of subscription will require some sort of backfill of existing subscriptions to now include the new Tenant IDs so the stored subscriptions do not differ pre/post change, and this will likely need to be done every time a new Tenant ID (eg `use_case_id`) is introduced and is required for subscriptions query analysis