### PR TITLE
fix(generic-metrics): fix(generic-metrics): Update default `decasecond_retention_days` and `min_retention_days` columns for sets

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -304,6 +304,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0015_sets_add_options",
             "0016_counters_add_options",
             "0017_distributions_mv2",
+            "0018_sets_update_opt_default",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0018_sets_update_opt_default.py
+++ b/snuba/snuba_migrations/generic_metrics/0018_sets_update_opt_default.py
@@ -1,0 +1,68 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers
+from snuba.migrations.operations import OperationTarget, SqlOperation
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+
+    storage_set_key = StorageSetKey.GENERIC_METRICS_DISTRIBUTIONS
+
+    local_table_name = "generic_metric_sets_raw_local"
+    dist_table_name = "generic_metric_sets_raw_dist"
+
+    before = [
+        Column(
+            "decasecond_retention_days",
+            UInt(8, MigrationModifiers(default=str("retention_days"))),
+        ),
+        Column(
+            "min_retention_days",
+            UInt(8, MigrationModifiers(default=str("retention_days"))),
+        ),
+    ]
+
+    after = [
+        Column(
+            "decasecond_retention_days",
+            UInt(8, MigrationModifiers(default=str("7"))),
+        ),
+        Column(
+            "min_retention_days",
+            UInt(8, MigrationModifiers(default=str("30"))),
+        ),
+    ]
+
+    def forwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in self.after
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]
+
+    def backwards_ops(self) -> Sequence[SqlOperation]:
+        return [
+            operations.ModifyColumn(
+                storage_set=self.storage_set_key,
+                table_name=table_name,
+                column=column,
+                target=target,
+            )
+            for column in self.before
+            for table_name, target in [
+                (self.local_table_name, OperationTarget.LOCAL),
+                (self.dist_table_name, OperationTarget.DISTRIBUTED),
+            ]
+        ]


### PR DESCRIPTION
### Stack PR Chain

| PR                                                   | Changes                                                  | Status        | Branch From                                          |
| ---------------------------------------------------- | -------------------------------------------------------- | ------------- | ---------------------------------------------------- |
| [#1](https://github.com/getsentry/snuba/pull/4780) | ~~Update default `decasecond_retention_days` and `min_retention_days` columns for distributions~~ | closed          | master  |
| [#2](https://github.com/getsentry/snuba/pull/4782) | ➤ Update default `decasecond_retention_days` and `min_retention_days` columns for sets | In review | master |
| [#3](https://github.com/getsentry/snuba/pull/4781) | Update default `decasecond_retention_days` and `min_retention_days` columns for counters | In review | [#2](https://github.com/getsentry/snuba/pull/4782) |


### Overview

Right now, only the default values for `decasecond_retention_days` and `min_retention_days` in the distribution table is correct. This is because the distribution table is the only table that is using mat view V2 (which uses those 2 columns). As we start applying mat view V2 to the other 2 tables (counter/sets), we need to make sure the default values are correct in those tables.

Updates the default values for `decasecond_retention_days` and `min_retention_days` columns to 7 and 30 so that it is the same as the distribution table. Before, those values are set to `retention_days`.