### PR TITLE
feat: Port the commit log encoder/decoder to Rust

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
  "tokio",
  "uuid 1.4.1",
 ]

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -38,6 +38,7 @@ reqwest = "0.11.11"
 uuid = "1.4.1"
 procspawn = { version = "0.10.2", features = ["json"] }
 pretty_env_logger = "0.5.0"
+thiserror = "1.0"
 
 [features]
 ffi = ["pyo3/extension-module"]

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -70,7 +70,7 @@ mod tests {
         let configuration =
             KafkaConfig::new_producer_config(vec!["127.0.0.1:9092".to_string()], None);
 
-        let mut producer = KafkaProducer::new(configuration);
+        let producer = KafkaProducer::new(configuration);
 
         let payload = KafkaPayload {
             key: None,

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_log.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_log.rs
@@ -1,4 +1,4 @@
-use rust_arroyo::backends::kafka::types::KafkaPayload;
+use crate::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
 use std::str;
 use thiserror::Error;

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -86,7 +86,7 @@ mod tests {
             key: Some(b"topic:0:group1".to_vec()),
             headers: None,
             payload: Some(
-                b"{'offset': 5, 'orig_message_ts': '2023-09-26T21:58:14.191325Z'}".to_vec(),
+                b"{\"offset\": 5, \"orig_message_ts\": \"2023-09-26T21:58:14.191325Z\"}".to_vec(),
             ),
         };
 

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -85,9 +85,7 @@ mod tests {
         let payload = KafkaPayload {
             key: Some(b"topic:0:group1".to_vec()),
             headers: None,
-            payload: Some(
-                b"{\"offset\": 5, \"orig_message_ts\": \"2023-09-26T21:58:14.191325Z\"}".to_vec(),
-            ),
+            payload: Some(b"{\"offset\": 5, \"orig_message_ts\": 1696381946.0}".to_vec()),
         };
 
         let payload_clone = payload.clone();

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -1,0 +1,85 @@
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use serde::{Deserialize, Serialize};
+use std::str;
+
+#[derive(Debug, Serialize)]
+struct Commit {
+    topic: String,
+    partition: u16,
+    consumer_group: String,
+    orig_message_ts: f64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Payload {
+    offset: u64,
+    orig_message_ts: f64,
+}
+
+impl From<KafkaPayload> for Commit {
+    fn from(payload: KafkaPayload) -> Self {
+        let key = payload.key.unwrap();
+
+        let data: Vec<&str> = str::from_utf8(&key).unwrap().split(':').collect();
+        assert!(data.len() == 3);
+
+        let topic = data[0].to_string();
+        let partition = data[1].parse::<u16>().unwrap();
+        let consumer_group = data[2].to_string();
+
+        let d: Payload = serde_json::from_slice(&payload.payload.unwrap()).unwrap();
+
+        Commit {
+            topic,
+            partition,
+            consumer_group,
+            orig_message_ts: d.orig_message_ts,
+        }
+    }
+}
+
+impl From<Commit> for KafkaPayload {
+    fn from(commit: Commit) -> Self {
+        let key = Some(
+            format!(
+                "{}:{}:{}",
+                commit.topic, commit.partition, commit.consumer_group
+            )
+            .into_bytes(),
+        );
+
+        let payload = Some(serde_json::to_vec(&commit).unwrap());
+
+        KafkaPayload {
+            key,
+            headers: None,
+            payload,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Produce;
+    use crate::backends::kafka::config::KafkaConfig;
+    use crate::backends::kafka::producer::KafkaProducer;
+    use crate::processing::strategies::{CommitRequest, MessageRejected, ProcessingStrategy};
+    use crate::types::{BrokerMessage, InnerMessage};
+    use crate::types::{Message, Partition, Topic, TopicOrPartition};
+    use chrono::Utc;
+    use rust_arroyo::backends::kafka::types::KafkaPayload;
+    use std::time::Duration;
+
+    #[test]
+    fn commit() {
+        let payload = KafkaPayload {
+            key: Some(b"topic:0:group1"),
+            headers: None,
+            payload: Some(b"{'offset': 5, 'orig_message_ts': '2023-09-26T21:58:14.191325Z'}"),
+        };
+
+        let commit: Commit = payload.into();
+        assert_eq!(commit.partition.index, 0);
+        assert_eq!(commit.into(), payload);
+    }
+}

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -16,30 +16,37 @@ struct Payload {
     orig_message_ts: f64,
 }
 
-impl From<KafkaPayload> for Commit {
-    fn from(payload: KafkaPayload) -> Self {
+impl TryFrom<KafkaPayload> for Commit {
+    type Error = anyhow::Error;
+
+    fn try_from(payload: KafkaPayload) -> Result<Self, anyhow::Error> {
         let key = payload.key.unwrap();
 
         let data: Vec<&str> = str::from_utf8(&key).unwrap().split(':').collect();
-        assert!(data.len() == 3);
+        if data.len() != 3 {
+            return Err(anyhow::anyhow!("Invalid payload"));
+        }
 
         let topic = data[0].to_string();
         let partition = data[1].parse::<u16>().unwrap();
         let consumer_group = data[2].to_string();
 
-        let d: Payload = serde_json::from_slice(&payload.payload.unwrap()).unwrap();
+        let d: Payload =
+            serde_json::from_slice(&payload.payload.ok_or(anyhow::anyhow!("Invalid payload"))?)?;
 
-        Commit {
+        Ok(Commit {
             topic,
             partition,
             consumer_group,
             orig_message_ts: d.orig_message_ts,
-        }
+        })
     }
 }
 
-impl From<Commit> for KafkaPayload {
-    fn from(commit: Commit) -> Self {
+impl TryFrom<Commit> for KafkaPayload {
+    type Error = anyhow::Error;
+
+    fn try_from(commit: Commit) -> Result<Self, anyhow::Error> {
         let key = Some(
             format!(
                 "{}:{}:{}",
@@ -48,38 +55,36 @@ impl From<Commit> for KafkaPayload {
             .into_bytes(),
         );
 
-        let payload = Some(serde_json::to_vec(&commit).unwrap());
+        let payload = Some(serde_json::to_vec(&commit)?);
 
-        KafkaPayload {
+        Ok(KafkaPayload {
             key,
             headers: None,
             payload,
-        }
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Produce;
-    use crate::backends::kafka::config::KafkaConfig;
-    use crate::backends::kafka::producer::KafkaProducer;
-    use crate::processing::strategies::{CommitRequest, MessageRejected, ProcessingStrategy};
-    use crate::types::{BrokerMessage, InnerMessage};
-    use crate::types::{Message, Partition, Topic, TopicOrPartition};
-    use chrono::Utc;
-    use rust_arroyo::backends::kafka::types::KafkaPayload;
-    use std::time::Duration;
+    use super::*;
 
     #[test]
     fn commit() {
         let payload = KafkaPayload {
-            key: Some(b"topic:0:group1"),
+            key: Some(b"topic:0:group1".to_vec()),
             headers: None,
-            payload: Some(b"{'offset': 5, 'orig_message_ts': '2023-09-26T21:58:14.191325Z'}"),
+            payload: Some(
+                b"{'offset': 5, 'orig_message_ts': '2023-09-26T21:58:14.191325Z'}".to_vec(),
+            ),
         };
 
-        let commit: Commit = payload.into();
-        assert_eq!(commit.partition.index, 0);
-        assert_eq!(commit.into(), payload);
+        let payload_clone = payload.clone();
+
+        let commit: Commit = payload.try_into().unwrap();
+        assert_eq!(commit.partition, 0);
+        let transformed: KafkaPayload = commit.try_into().unwrap();
+        assert_eq!(transformed.key, payload_clone.key);
+        assert_eq!(transformed.payload, payload_clone.payload);
     }
 }

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -90,7 +90,7 @@ mod tests {
         let payload = KafkaPayload {
             key: Some(b"topic:0:group1".to_vec()),
             headers: None,
-            payload: Some(b"{\"offset\": 5, \"orig_message_ts\": 1696381946.0}".to_vec()),
+            payload: Some(b"{\"offset\": 5,\"orig_message_ts\": 1696381946.0}".to_vec()),
         };
 
         let payload_clone = payload.clone();

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -3,12 +3,13 @@ use serde::{Deserialize, Serialize};
 use std::str;
 use thiserror::Error;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 struct Commit {
     topic: String,
     partition: u16,
     consumer_group: String,
     orig_message_ts: f64,
+    offset: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -50,6 +51,7 @@ impl TryFrom<KafkaPayload> for Commit {
             partition,
             consumer_group,
             orig_message_ts: d.orig_message_ts,
+            offset: d.offset,
         })
     }
 }
@@ -66,7 +68,10 @@ impl TryFrom<Commit> for KafkaPayload {
             .into_bytes(),
         );
 
-        let payload = Some(serde_json::to_vec(&commit)?);
+        let payload = Some(serde_json::to_vec(&Payload {
+            offset: commit.offset,
+            orig_message_ts: commit.orig_message_ts,
+        })?);
 
         Ok(KafkaPayload {
             key,

--- a/rust_snuba/src/strategies/mod.rs
+++ b/rust_snuba/src/strategies/mod.rs
@@ -1,2 +1,3 @@
 pub mod clickhouse;
+pub mod commit_log;
 pub mod python;


### PR DESCRIPTION
Ports https://github.com/getsentry/arroyo/blob/f43a9d69ab0e504869f88fcc39ede98bc0cc6807/arroyo/backends/kafka/commit.py to Rust. The codec is not used yet.