### PR TITLE
fix(metrics): Update metrics processor to write use_case_id

### DIFF
--- a/snuba/datasets/processors/metrics_aggregate_processor.py
+++ b/snuba/datasets/processors/metrics_aggregate_processor.py
@@ -83,6 +83,7 @@ class MetricsAggregateProcessor(DatasetMessageProcessor, ABC):
                 "org_id": _literal(message["org_id"]),
                 "project_id": _literal(message["project_id"]),
                 "metric_id": _literal(message["metric_id"]),
+                "use_case_id": _literal(message.get("use_case_id", "sessions")),
                 "timestamp": _call(
                     "toDateTime",
                     (

--- a/snuba/datasets/processors/metrics_bucket_processor.py
+++ b/snuba/datasets/processors/metrics_bucket_processor.py
@@ -103,6 +103,7 @@ class MetricsBucketProcessor(DatasetMessageProcessor, ABC):
             "org_id": message["org_id"],
             "project_id": message["project_id"],
             "metric_id": message["metric_id"],
+            "use_case_id": message.get("use_case_id", "sessions"),
             "timestamp": timestamp,
             "tags.key": keys,
             "tags.value": values,

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -60,7 +60,7 @@ MAPPING_META_TAG_VALUES_STRINGS = {
 }
 
 SET_MESSAGE_SHARED = {
-    "use_case_id": "release-health",
+    "use_case_id": "sessions",
     "org_id": 1,
     "project_id": 2,
     "metric_id": 1232341,
@@ -76,7 +76,7 @@ SET_MESSAGE_SHARED = {
 
 SET_MESSAGE_TAG_VALUES_STRINGS = {
     "version": 2,
-    "use_case_id": "release-health",
+    "use_case_id": "sessions",
     "org_id": 1,
     "project_id": 2,
     "metric_id": 1232341,
@@ -91,7 +91,7 @@ SET_MESSAGE_TAG_VALUES_STRINGS = {
 }
 
 COUNTER_MESSAGE_SHARED = {
-    "use_case_id": "release-health",
+    "use_case_id": "sessions",
     "org_id": 1,
     "project_id": 2,
     "metric_id": 1232341,
@@ -107,7 +107,7 @@ COUNTER_MESSAGE_SHARED = {
 
 DIST_VALUES = [324.12, 345.23, 4564.56, 567567]
 DIST_MESSAGE_SHARED = {
-    "use_case_id": "release-health",
+    "use_case_id": "sessions",
     "org_id": 1,
     "project_id": 2,
     "metric_id": 1232341,
@@ -129,6 +129,7 @@ TEST_CASES_BUCKETS = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
+                "use_case_id": "sessions",
                 "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
@@ -152,6 +153,7 @@ TEST_CASES_BUCKETS = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
+                "use_case_id": "sessions",
                 "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
@@ -175,6 +177,7 @@ TEST_CASES_BUCKETS = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
+                "use_case_id": "sessions",
                 "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -245,6 +245,7 @@ TEST_CASES_AGGREGATES = [
                 "org_id": _literal(1),
                 "project_id": _literal(2),
                 "metric_id": _literal(1232341),
+                "use_case_id": _literal("sessions"),
                 "timestamp": _call(
                     "toDateTime", (_literal(MOCK_TIME_BUCKET.isoformat()),)
                 ),
@@ -274,6 +275,7 @@ TEST_CASES_AGGREGATES = [
                 "org_id": _literal(1),
                 "project_id": _literal(2),
                 "metric_id": _literal(1232341),
+                "use_case_id": _literal("sessions"),
                 "timestamp": _call(
                     "toDateTime", (_literal(MOCK_TIME_BUCKET.isoformat()),)
                 ),
@@ -299,6 +301,7 @@ TEST_CASES_AGGREGATES = [
                 "org_id": _literal(1),
                 "project_id": _literal(2),
                 "metric_id": _literal(1232341),
+                "use_case_id": _literal("sessions"),
                 "timestamp": _call(
                     "toDateTime", (_literal(MOCK_TIME_BUCKET.isoformat()),)
                 ),

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -441,6 +441,7 @@ TEST_CASES_POLYMORPHIC = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
+                "use_case_id": "sessions",
                 "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
@@ -461,6 +462,7 @@ TEST_CASES_POLYMORPHIC = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
+                "use_case_id": "sessions",
                 "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
@@ -481,6 +483,7 @@ TEST_CASES_POLYMORPHIC = [
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
+                "use_case_id": "sessions",
                 "timestamp": expected_timestamp,
                 "tags.key": [10, 20, 30],
                 "tags.value": [11, 22, 33],
@@ -532,7 +535,7 @@ TEST_CASES_GENERIC = [
         SET_MESSAGE_SHARED,
         [
             {
-                "use_case_id": "release-health",
+                "use_case_id": "sessions",
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,
@@ -554,7 +557,7 @@ TEST_CASES_GENERIC = [
         SET_MESSAGE_TAG_VALUES_STRINGS,
         [
             {
-                "use_case_id": "release-health",
+                "use_case_id": "sessions",
                 "org_id": 1,
                 "project_id": 2,
                 "metric_id": 1232341,


### PR DESCRIPTION
This PR is responsible for updating the metrics bucket processor to write use_case_id in ClickHouse. Currently in the metrics dataset (release-health), we are writing empty strings (`""`) as part of the `use_case_id`. As a result, this has caused some [confusion around querying for use_case_id](https://github.com/getsentry/sentry/pull/57005) in release-health. Since `use_case_id` is required in [kafka schema](https://github.com/getsentry/sentry-kafka-schemas/blob/8a28e031579e2d40e49a3086c74fdfbb93ac6fc7/schemas/snuba-metrics.v1.schema.json#L74), this field should be already be sent as part of the kafka message. Note: the metrics dataset only contains the `sessions` use_case_id anyways. A data migration might be necessary to follow this PR to update all the existing rows.