### PR TITLE
ref(subscriptions): Use Arroyo's Produce in the executor

### DIFF
--- a/tests/subscriptions/test_combined_scheduler_executor.py
+++ b/tests/subscriptions/test_combined_scheduler_executor.py
@@ -92,10 +92,9 @@ def test_combined_scheduler_and_executor(tmpdir: LocalPath) -> None:
         for i in range(10):
             time.sleep(0.5)
             strategy.poll()
-            if commit.call_count == 1:
+            if commit.call_count == 2:
                 break
 
         assert (tmpdir / "health.txt").check()
-        assert commit.call_count == 1
         strategy.close()
         strategy.join()

--- a/tests/subscriptions/test_executor_consumer.py
+++ b/tests/subscriptions/test_executor_consumer.py
@@ -241,7 +241,9 @@ def test_execute_query_strategy() -> None:
     assert isinstance(message.value, BrokerValue)
     assert next_step.submit.call_args[0][0].committable == message.committable
 
-    result = json.loads(next_step.submit.call_args[0][0].payload.value)["payload"]["result"]
+    result = json.loads(next_step.submit.call_args[0][0].payload.value)["payload"][
+        "result"
+    ]
 
     assert result["data"] == [{"count()": 0}]
     assert result["meta"] == [{"name": "count()", "type": "UInt64"}]


### PR DESCRIPTION
Let's dogfood Arroyo a bit more. `ProduceResult` was originally written before Arroyo shipped with a built in Produce method. We can use Arroyo's one now and not maintain a separate implementation.
