### PR TITLE
ci: Run Snuba tests against multiple ClickHouse versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,6 +394,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         version:
           [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,11 +388,20 @@ jobs:
         run: |
           make test-snuba-full
 
-  clickhouse-21:
+  clickhouse-versions:
     needs: [linting, snuba-image]
-    name: Tests on Clickhouse 21
+    name: Tests on multiple clickhouse versions
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        version:
+          [
+            "21.8.13.1.altinitystable",
+            "22.3.15.34.altinitystable",
+            "22.8.15.25.altinitystable",
+          ]
+
     steps:
       - uses: actions/checkout@v2
         name: Checkout code
@@ -427,9 +436,9 @@ jobs:
         run: |
           docker network create --attachable cloudbuild
 
-      - name: Docker Snuba Test Clickhouse 21
+      - name: Docker Snuba Test other ClickHouse versions
         run: |
-          export CLICKHOUSE_IMAGE=altinity/clickhouse-server:21.8.13.1.altinitystable
+          export CLICKHOUSE_IMAGE=altinity/clickhouse-server:${{matrix.version}}
           SNUBA_IMAGE=snuba-test SNUBA_SETTINGS=test docker-compose -f docker-compose.gcb.yml run --rm snuba-test
 
       - name: Upload to codecov

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -37,6 +37,7 @@ services:
     command:
       - "-m"
       - "pytest"
+      - "-x"
       - "-vv"
       - "${TEST_LOCATION:-tests}"
       - "--cov"

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -37,7 +37,6 @@ services:
     command:
       - "-m"
       - "pytest"
-      - "-x"
       - "-vv"
       - "${TEST_LOCATION:-tests}"
       - "--cov"
@@ -66,7 +65,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
       KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
   clickhouse:
-    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
+    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
     volumes:
       - ./config/clickhouse/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
@@ -80,7 +79,7 @@ services:
   clickhouse-query:
     depends_on:
       - zookeeper
-    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
+    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
@@ -92,7 +91,7 @@ services:
   clickhouse-01:
     depends_on:
       - zookeeper
-    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
+    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-01.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -105,7 +104,7 @@ services:
   clickhouse-02:
     depends_on:
       - zookeeper
-    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
+    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-02.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -118,7 +117,7 @@ services:
   clickhouse-03:
     depends_on:
       - zookeeper
-    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
+    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-03.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -131,7 +130,7 @@ services:
   clickhouse-04:
     depends_on:
       - zookeeper
-    image: '${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}'
+    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-04.xml:/etc/clickhouse-server/config.d/macros.xml

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -9,4 +9,4 @@
   "Dataset Config Validation" \
   "sentry (0)" \
   "sentry (1)" \
-  "Tests on Clickhouse 21"
+  "Tests on multiple clickhouse versions (21.8.13.1.altinitystable)"


### PR DESCRIPTION
Not all of these are passing right now or blocking for merge/deploy. This change aims to provide more visibility into which features do not work on future ClickHouse versions so we can prioritize fixing these. It also prevents us merging future changes that do not work well in certain versions of ClickHouse that we should support.
