### PR TITLE
ref: Get rid of pytz

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,7 +7,6 @@ freezegun==1.2.2
 mypy==1.1.1
 types-python-dateutil==2.8.19
 types-python-jose==3.3.0
-types-pytz==2022.2.1.0
 types-pyyaml==6.0.11
 types-requests==2.28.10
 types-setuptools==65.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ pytest-cov==3.0.0
 pytest-watch==4.2.0
 python-dateutil==2.8.2
 python-rapidjson==1.8
-pytz==2022.2.1
 redis==4.3.4
 sentry-arroyo==2.14.8
 sentry-kafka-schemas==0.1.29

--- a/tests/datasets/cdc/test_groupassignee.py
+++ b/tests/datasets/cdc/test_groupassignee.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
-import pytz
 
 from snuba.clusters.cluster import ClickhouseClientSettings
 from snuba.consumers.types import KafkaMessageMetadata
@@ -137,7 +136,7 @@ class TestGroupassignee:
         "record_deleted": 0,
         "user_id": 1,
         "team_id": None,
-        "date_added": datetime(2019, 9, 19, 0, 17, 55, tzinfo=pytz.UTC),
+        "date_added": datetime(2019, 9, 19, 0, 17, 55, tzinfo=timezone.utc),
     }
 
     PROCESSED_UPDATE = {
@@ -147,7 +146,7 @@ class TestGroupassignee:
         "record_deleted": 0,
         "user_id": 1,
         "team_id": None,
-        "date_added": datetime(2019, 9, 19, 0, 17, 55, tzinfo=pytz.UTC),
+        "date_added": datetime(2019, 9, 19, 0, 17, 55, tzinfo=timezone.utc),
     }
 
     DELETED = {
@@ -169,7 +168,8 @@ class TestGroupassignee:
 
         ret = processor.process_message(self.INSERT_MSG, metadata)
         assert ret == InsertBatch(
-            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 55, 32443, tzinfo=pytz.UTC)
+            [self.PROCESSED],
+            datetime(2019, 9, 19, 0, 17, 55, 32443, tzinfo=timezone.utc),
         )
         write_processed_messages(self.storage, [ret])
         results = (
@@ -190,7 +190,8 @@ class TestGroupassignee:
 
         ret = processor.process_message(self.UPDATE_MSG_NO_KEY_CHANGE, metadata)
         assert ret == InsertBatch(
-            [self.PROCESSED], datetime(2019, 9, 19, 0, 6, 56, 376853, tzinfo=pytz.UTC)
+            [self.PROCESSED],
+            datetime(2019, 9, 19, 0, 6, 56, 376853, tzinfo=timezone.utc),
         )
 
         # Tests an update with key change which becomes a two inserts:
@@ -198,12 +199,13 @@ class TestGroupassignee:
         ret = processor.process_message(self.UPDATE_MSG_WITH_KEY_CHANGE, metadata)
         assert ret == InsertBatch(
             [self.DELETED, self.PROCESSED_UPDATE],
-            datetime(2019, 9, 19, 0, 6, 56, 376853, tzinfo=pytz.UTC),
+            datetime(2019, 9, 19, 0, 6, 56, 376853, tzinfo=timezone.utc),
         )
 
         ret = processor.process_message(self.DELETE_MSG, metadata)
         assert ret == InsertBatch(
-            [self.DELETED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+            [self.DELETED],
+            datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=timezone.utc),
         )
 
     def test_bulk_load(self) -> None:

--- a/tests/datasets/cdc/test_groupedmessage.py
+++ b/tests/datasets/cdc/test_groupedmessage.py
@@ -1,7 +1,6 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
-import pytz
 
 from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
@@ -207,9 +206,9 @@ class TestGroupedMessage:
         "id": 74,
         "record_deleted": 0,
         "status": 0,
-        "last_seen": datetime(2019, 6, 19, 6, 46, 28, tzinfo=pytz.UTC),
-        "first_seen": datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
-        "active_at": datetime(2019, 6, 19, 6, 45, 32, tzinfo=pytz.UTC),
+        "last_seen": datetime(2019, 6, 19, 6, 46, 28, tzinfo=timezone.utc),
+        "first_seen": datetime(2019, 6, 19, 6, 45, 32, tzinfo=timezone.utc),
+        "active_at": datetime(2019, 6, 19, 6, 45, 32, tzinfo=timezone.utc),
         "first_release_id": None,
     }
 
@@ -234,7 +233,8 @@ class TestGroupedMessage:
 
         ret = processor.process_message(self.INSERT_MSG, metadata)
         assert ret == InsertBatch(
-            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+            [self.PROCESSED],
+            datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=timezone.utc),
         )
         write_processed_messages(self.storage, [ret])
         results = (
@@ -257,12 +257,14 @@ class TestGroupedMessage:
 
         ret = processor.process_message(self.UPDATE_MSG, metadata)
         assert ret == InsertBatch(
-            [self.PROCESSED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+            [self.PROCESSED],
+            datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=timezone.utc),
         )
 
         ret = processor.process_message(self.DELETE_MSG, metadata)
         assert ret == InsertBatch(
-            [self.DELETED], datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=pytz.UTC)
+            [self.DELETED],
+            datetime(2019, 9, 19, 0, 17, 21, 447870, tzinfo=timezone.utc),
         )
 
     def test_bulk_load(self) -> None:

--- a/tests/datasets/entities/test_pluggable_entity.py
+++ b/tests/datasets/entities/test_pluggable_entity.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Mapping
 
 import pytest
-import pytz
 
 from snuba.attribution import get_app_id
 from snuba.attribution.attribution_info import AttributionInfo
@@ -45,7 +44,7 @@ from snuba.utils.schemas import DateTime, Nested, UInt
 @pytest.fixture
 def start_time() -> datetime:
     return (datetime.utcnow() - timedelta(days=1)).replace(
-        hour=12, minute=15, second=0, microsecond=0, tzinfo=pytz.utc
+        hour=12, minute=15, second=0, microsecond=0, tzinfo=timezone.utc
     )
 
 

--- a/tests/datasets/test_cdc_events.py
+++ b/tests/datasets/test_cdc_events.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 
 import pytest
-import pytz
 import simplejson as json
 
 from snuba.datasets.entities.entity_key import EntityKey
@@ -62,7 +61,7 @@ class TestCdcEvents(BaseApiTest):
         self.event = get_raw_event()
         self.project_id = self.event["project_id"]
         self.base_time = datetime.utcnow().replace(
-            second=0, microsecond=0, tzinfo=pytz.utc
+            second=0, microsecond=0, tzinfo=timezone.utc
         ) - timedelta(minutes=90)
         self.next_time = self.base_time + timedelta(minutes=95)
 

--- a/tests/datasets/test_errors_processor.py
+++ b/tests/datasets/test_errors_processor.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, Sequence
 from unittest.mock import ANY
 from uuid import UUID
 
 import pytest
-import pytz
 
 from snuba.consumers.types import KafkaMessageMetadata
 from snuba.datasets.processors.errors_processor import ErrorsProcessor
@@ -345,7 +344,7 @@ class ErrorEvent:
                 str(UUID("04233d08ac90cf6fc015b1be5932e7e3")),
                 str(UUID("04233d08ac90cf6fc015b1be5932e7e4")),
             ],
-            "received": self.received_timestamp.astimezone(pytz.utc).replace(
+            "received": self.received_timestamp.astimezone(timezone.utc).replace(
                 tzinfo=None, microsecond=0
             ),
             "message": "",

--- a/tests/datasets/test_group_attributes_join.py
+++ b/tests/datasets/test_group_attributes_join.py
@@ -1,10 +1,9 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import partial
 from typing import Any, Mapping
 
 import pytest
-import pytz
 import simplejson as json
 
 from snuba.datasets.entities.entity_key import EntityKey
@@ -36,7 +35,7 @@ def write_group_attribute_row(row: Mapping[str, Any]) -> None:
 def _convert_clickhouse_datetime_str(str: str) -> str:
     return (
         datetime.strptime(str, "%Y-%m-%d %H:%M:%S")
-        .replace(microsecond=0, tzinfo=pytz.utc)
+        .replace(microsecond=0, tzinfo=timezone.utc)
         .isoformat()
     )
 
@@ -52,7 +51,7 @@ class TestEventsGroupAttributes(BaseApiTest):
         self.event = get_raw_event()
         self.project_id = self.event["project_id"]
         self.base_time = datetime.utcnow().replace(
-            second=0, microsecond=0, tzinfo=pytz.utc
+            second=0, microsecond=0, tzinfo=timezone.utc
         ) - timedelta(minutes=90)
         self.next_time = self.base_time + timedelta(minutes=95)
 
@@ -216,7 +215,7 @@ class TestSearchIssuesGroupAttributes(BaseApiTest):
         self.app.post = partial(self.app.post, headers={"referer": "test"})
 
         self.base_time = datetime.utcnow().replace(
-            second=0, microsecond=0, tzinfo=pytz.utc
+            second=0, microsecond=0, tzinfo=timezone.utc
         ) - timedelta(minutes=90)
         self.next_time = self.base_time + timedelta(minutes=95)
         self.occurrence = self.get_search_issue_occurrence(self.base_time)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import calendar
 import time
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Generator, List, Sequence, Tuple, Union
 from unittest.mock import MagicMock, patch
 
 import pytest
-import pytz
 import simplejson as json
 from dateutil.parser import parse as parse_datetime
 from sentry_sdk import Client, Hub
@@ -266,7 +265,7 @@ class TestApi(SimpleAPITest):
                         "selected_columns": ["time"],
                         "groupby": "time",
                         "from_date": (self.base_time + skew)
-                        .replace(tzinfo=pytz.utc)
+                        .replace(tzinfo=timezone.utc)
                         .isoformat(),
                         "to_date": (
                             self.base_time + skew + timedelta(minutes=self.minutes)

--- a/tests/test_discover_api.py
+++ b/tests/test_discover_api.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Tuple, Union
 
 import pytest
-import pytz
 import simplejson as json
 
 from snuba.datasets.entities.entity_key import EntityKey
@@ -42,7 +41,7 @@ class TestDiscoverApi(BaseApiTest):
         self.project_id = self.event["project_id"]
         self.skew = timedelta(minutes=180)
         self.base_time = datetime.utcnow().replace(
-            second=0, microsecond=0, tzinfo=pytz.utc
+            second=0, microsecond=0, tzinfo=timezone.utc
         ) - timedelta(minutes=90)
 
         events_storage = get_entity(EntityKey.EVENTS).get_writable_storage()

--- a/tests/test_generic_metrics_api.py
+++ b/tests/test_generic_metrics_api.py
@@ -1,10 +1,9 @@
 import itertools
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterable, Mapping, Tuple, Union
 
 import pytest
-import pytz
 from pytest import approx
 from snuba_sdk import AliasedExpression, Function, Request
 from snuba_sdk.column import Column
@@ -27,7 +26,7 @@ SNQL_ROUTE = "/generic_metrics/snql"
 
 def utc_yesterday_12_15() -> datetime:
     return (datetime.utcnow() - timedelta(days=1)).replace(
-        hour=12, minute=15, second=0, microsecond=0, tzinfo=pytz.utc
+        hour=12, minute=15, second=0, microsecond=0, tzinfo=timezone.utc
     )
 
 

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Generator, Optional, Tuple, Union, cast
 
 import pytest
-import pytz
 import simplejson as json
 from pytest import approx
 
@@ -41,7 +40,7 @@ def teardown_common() -> None:
 
 def utc_yesterday_12_15() -> datetime:
     return (datetime.utcnow() - timedelta(days=1)).replace(
-        hour=12, minute=15, second=0, microsecond=0, tzinfo=pytz.utc
+        hour=12, minute=15, second=0, microsecond=0, tzinfo=timezone.utc
     )
 
 
@@ -227,10 +226,10 @@ class TestOrgMetricsApiCounters(BaseApiTest):
         self.skew = timedelta(seconds=self.seconds)
 
         self.base_time = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         self.sentry_received_timestamp = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
         self.storage = cast(
             WritableTableStorage,

--- a/tests/test_org_sessions_api.py
+++ b/tests/test_org_sessions_api.py
@@ -1,10 +1,9 @@
 import itertools
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import uuid4
 
 import pytest
-import pytz
 import simplejson as json
 from snuba_sdk import Request
 from snuba_sdk.column import Column
@@ -32,7 +31,7 @@ class TestOrgSessionsApi(BaseApiTest):
     def setup_teardown(self, clickhouse_db: None) -> None:
         # values for test data
         self.started = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
 
         self.storage = get_writable_storage(StorageKey.SESSIONS_RAW)

--- a/tests/test_outcomes_api.py
+++ b/tests/test_outcomes_api.py
@@ -1,10 +1,9 @@
 import itertools
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional, Tuple, Union
 
 import pytest
-import pytz
 import simplejson as json
 from sentry_relay import DataCategory
 
@@ -89,7 +88,7 @@ class TestLegacyOutcomesApi(BaseApiTest):
         write_processed_messages(self.storage, outcomes)
 
     def format_time(self, time: datetime) -> str:
-        return time.replace(tzinfo=pytz.utc).isoformat()
+        return time.replace(tzinfo=timezone.utc).isoformat()
 
     def test_happy_path_querying(self, get_project_id: Callable[[], int]) -> None:
         project_id = get_project_id()
@@ -358,7 +357,7 @@ class TestOutcomesAPI(BaseApiTest):
         write_processed_messages(self.storage, outcomes)
 
     def format_time(self, time: datetime) -> str:
-        return time.replace(tzinfo=pytz.utc).isoformat()
+        return time.replace(tzinfo=timezone.utc).isoformat()
 
     @pytest.fixture(autouse=True)
     def setup_teardown(self, clickhouse_db: None) -> None:

--- a/tests/test_replacer.py
+++ b/tests/test_replacer.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import importlib
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Mapping, MutableMapping, Sequence
 from unittest import mock
 
 import pytest
-import pytz
 import simplejson as json
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import BrokerValue, Message, Partition, Topic
@@ -98,7 +97,7 @@ class TestReplacer:
 
         assert self._issue_count(self.project_id) == [{"count": 1, "group_id": 1}]
 
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now(tz=timezone.utc)
 
         project_id = self.project_id
 
@@ -171,7 +170,7 @@ class TestReplacer:
         assert _issue_count() == [{"count": 1, "group_id": 1}]
         assert _issue_count(total=True) == [{"count": 1, "group_id": 1}]
 
-        timestamp = datetime.now(tz=pytz.utc)
+        timestamp = datetime.now(tz=timezone.utc)
 
         message: Message[KafkaPayload] = Message(
             BrokerValue(

--- a/tests/test_sessions_api.py
+++ b/tests/test_sessions_api.py
@@ -1,9 +1,8 @@
 import itertools
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Mapping, Sequence, Tuple, Union
 
 import pytest
-import pytz
 import simplejson as json
 
 from snuba import settings
@@ -18,7 +17,7 @@ from tests.helpers import write_processed_messages
 
 class BaseSessionsMockTest:
     started = datetime.utcnow().replace(
-        minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+        minute=0, second=0, microsecond=0, tzinfo=timezone.utc
     )
     storage = get_writable_storage(StorageKey.SESSIONS_RAW)
 
@@ -95,7 +94,7 @@ class TestLegacySessionsApi(BaseSessionsMockTest, BaseApiTest):
         self.minutes = 180
         self.skew = timedelta(minutes=self.minutes)
         self.started = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         )
 
         self.storage = get_writable_storage(StorageKey.SESSIONS_RAW)

--- a/tests/test_spans_api.py
+++ b/tests/test_spans_api.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Generator, Tuple, Union
 
 import pytest
-import pytz
 import simplejson as json
 
 from snuba import settings, state
@@ -46,7 +45,7 @@ class TestSpansApi(BaseApiTest):
         self.trace_id = "7400045b25c443b885914600aa83ad04"
 
         self.base_time = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         ) - timedelta(minutes=self.minutes)
         self.storage = get_writable_storage(StorageKey.SPANS)
         state.set_config("log_bad_span_message_percentage", 1)

--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -1,11 +1,10 @@
 import calendar
 import uuid
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Generator, Tuple, Union
 
 import pytest
-import pytz
 import simplejson as json
 
 from snuba import settings, state
@@ -49,7 +48,7 @@ class TestTransactionsApi(BaseApiTest):
         self.skew = timedelta(minutes=self.minutes)
 
         self.base_time = datetime.utcnow().replace(
-            minute=0, second=0, microsecond=0, tzinfo=pytz.utc
+            minute=0, second=0, microsecond=0, tzinfo=timezone.utc
         ) - timedelta(minutes=self.minutes)
         self.storage = get_writable_storage(StorageKey.TRANSACTIONS)
         self.generate_fizzbuzz_events()


### PR DESCRIPTION
It was only used in tests, and we don't need a separate library for this