### PR TITLE
feat(admin): Link to available Snuba Admin regions

### DIFF
--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -11,13 +11,10 @@ import DeadLetterQueue from "./dead_letter_queue";
 import CardinalityAnalyzer from "./cardinality_analyzer";
 import ProductionQueries from "./production_queries";
 import SnubaExplain from "./snuba_explain";
-
-function Placeholder(props: any) {
-  return null;
-}
+import Welcome from "./welcome";
 
 const NAV_ITEMS = [
-  { id: "overview", display: "🤿 Snuba Admin", component: Placeholder },
+  { id: "overview", display: "🤿 Snuba Admin", component: Welcome },
   { id: "config", display: "⚙️ Runtime Config", component: RuntimeConfig },
   {
     id: "capacity-management",

--- a/snuba/admin/static/welcome/index.tsx
+++ b/snuba/admin/static/welcome/index.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+function Welcome() {
+  const PROD_URL_START = "https://snuba-admin";
+
+  const AVAILABLE_REGIONS =
+    "https://www.notion.so/sentry/Snuba-Admin-8344d5d508014d4a867cdb1b8e8d22cf";
+
+  const URL = window.location.origin;
+
+  function urls() {
+    let current_region = "localhost";
+    if (URL.startsWith(PROD_URL_START)) {
+      current_region = currentRegion();
+    }
+    return (
+      <div>
+        <p>
+          Current region: <strong>{current_region}</strong>
+        </p>
+        <p>
+          Available{" "}
+          <a href={AVAILABLE_REGIONS} target="_blank">
+            regions
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  function currentRegion() {
+    if (URL.startsWith(PROD_URL_START + ".getsentry.net")) {
+      return "SaaS";
+    }
+
+    let regex = /https:\/\/snuba-admin\.(.*?)\.getsentry\.net/;
+    let match = URL.match(regex);
+
+    if (match && match[1]) {
+      return match[1];
+    }
+    return "<unknown current region>";
+  }
+
+  return <div>{urls()}</div>;
+}
+
+export default Welcome;


### PR DESCRIPTION
### Overview
- Earlier today I was on s4s admin console and was confused for a split second as to why there were no runtime configs

### Changes
- Display current region
- Link to notion doc with all available snuba admin deployments

### Notes
- These could just be linked directly but I didn't want to put those regions in our codebase
- Alternative is to set a runtime config of all regions and have an API call to get them and display 
    -  I could do this if we really care but I think linking to the doc is sufficient

### Screenshot
<img width="659" alt="Screenshot 2023-09-29 at 4 11 23 PM" src="https://github.com/getsentry/snuba/assets/23463457/8cd7b1f8-f107-4825-b83e-450d23375d86">
