### PR TITLE
feat(capman): Allow concurrent rate limit policies to set max_query_duration_s

### DIFF
--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -26,13 +26,6 @@ def admin_api() -> FlaskClient:
     return application.test_client()
 
 
-@mock.patch("snuba.admin.auth.redis_client")
-def test_migration_groups(mock_redis, admin_api: FlaskClient) -> None:
-    mock_redis.get.side_effect = Exception("failed connection")
-    response = admin_api.get("/migrations/events/list")
-    assert response.status_code == 200
-
-
 @pytest.mark.redis_db
 def test_get_configs(admin_api: FlaskClient) -> None:
     response = admin_api.get("/configs")

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -26,6 +26,13 @@ def admin_api() -> FlaskClient:
     return application.test_client()
 
 
+@mock.patch("snuba.admin.auth.redis_client")
+def test_migration_groups(mock_redis, admin_api: FlaskClient) -> None:
+    mock_redis.get.side_effect = Exception("failed connection")
+    response = admin_api.get("/migrations/events/list")
+    assert response.status_code == 200
+
+
 @pytest.mark.redis_db
 def test_get_configs(admin_api: FlaskClient) -> None:
     response = admin_api.get("/configs")


### PR DESCRIPTION
Currently, `state.max_query_duration_s` is used by the concurrent rate limiter to know how long a TTL to set in Redis. That value is currently set to `60 seconds` while the max request time we allow is 30 seconds. This means that we are potentially storing double the amount of data in redis as we need.

This PR allows us to change that value at runtime so we can experiment with changing the value and saving redis memory. 