### PR TITLE
fix(UI): Add missing space between emoji and 'Cardinality Analyzer'

### DIFF
--- a/snuba/admin/static/data.tsx
+++ b/snuba/admin/static/data.tsx
@@ -68,7 +68,7 @@ const NAV_ITEMS = [
   },
   {
     id: "cardinality-analyzer",
-    display: "🔢Cardinality Analyzer!!!",
+    display: "🔢 Cardinality Analyzer!!!",
     component: CardinalityAnalyzer,
   },
   {


### PR DESCRIPTION
### Overview

It has been bothering me for a while now... There appears to be a missing space between the emoji and "Cardinality Analyzer!!!" in the snuba admin UI

<img width="203" alt="image" src="https://github.com/getsentry/snuba/assets/14865283/3b50d799-1ecb-4c6e-ab14-94596678d24c">
