### PR TITLE
feat(capman): update policies to skip cross org queries

### DIFF
--- a/snuba/query/allocation_policies/__init__.py
+++ b/snuba/query/allocation_policies/__init__.py
@@ -437,6 +437,9 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
             and self._required_tenant_types == other._required_tenant_types
         )
 
+    def is_cross_org_query(self, tenant_ids: dict[str, str | int]) -> bool:
+        return bool(tenant_ids.get("cross_org_query", False))
+
     @classmethod
     def from_kwargs(cls, **kwargs: str) -> "AllocationPolicy":
         required_tenant_types = kwargs.pop("required_tenant_types", None)
@@ -635,7 +638,7 @@ class AllocationPolicy(ABC, metaclass=RegisteredClass):
 
         class_name = self.__class__.__name__
 
-        # config doesn't exist
+        # config doesn't existhttps://riseup.net/en
         if config_key not in definitions:
             raise InvalidPolicyConfig(
                 f"'{config_key}' is not a valid config for {class_name}!"

--- a/snuba/query/allocation_policies/bytes_scanned_window_policy.py
+++ b/snuba/query/allocation_policies/bytes_scanned_window_policy.py
@@ -121,6 +121,8 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
     def _are_tenant_ids_valid(
         self, tenant_ids: dict[str, str | int]
     ) -> tuple[bool, str]:
+        if self.is_cross_org_query(tenant_ids):
+            return True, "cross org query"
         if tenant_ids.get("referrer") is None:
             return False, "no referrer"
         if (
@@ -141,6 +143,12 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
                 return QuotaAllowance(
                     can_run=False, max_threads=0, explanation={"reason": why}
                 )
+        if self.is_cross_org_query(tenant_ids):
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=self.max_threads,
+                explanation={"reason": "cross_org_query"},
+            )
         referrer = tenant_ids.get("referrer", "no_referrer")
         org_id = tenant_ids.get("organization_id", None)
         if referrer in _PASS_THROUGH_REFERRERS:
@@ -218,11 +226,13 @@ class BytesScannedWindowAllocationPolicy(AllocationPolicy):
         query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
-        if result_or_error.error:
-            return
         ids_are_valid, why = self._are_tenant_ids_valid(tenant_ids)
         if not ids_are_valid:
             # we already logged the reason before the query
+            return
+        if self.is_cross_org_query(tenant_ids):
+            return
+        if result_or_error.error:
             return
         bytes_scanned = self._get_bytes_scanned_in_query(tenant_ids, result_or_error)
         query_result = result_or_error.query_result

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -214,6 +214,13 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
                 max_threads=self.max_threads,
                 explanation={"reason": "pass_through"},
             )
+        if self.is_cross_org_query(tenant_ids):
+            return QuotaAllowance(
+                can_run=True,
+                max_threads=self.max_threads,
+                explanation={"reason": "pass_through"},
+            )
+
         rate_limit_params, overrides = self._get_rate_limit_params(tenant_ids)
         within_rate_limit, why = self._is_within_rate_limit(query_id, rate_limit_params)
         return QuotaAllowance(
@@ -226,5 +233,7 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
         query_id: str,
         result_or_error: QueryResultOrError,
     ) -> None:
+        if self.is_cross_org_query(tenant_ids):
+            return
         rate_limit_params, _ = self._get_rate_limit_params(tenant_ids)
         self._end_query(query_id, rate_limit_params, result_or_error)

--- a/snuba/query/allocation_policies/concurrent_rate_limit.py
+++ b/snuba/query/allocation_policies/concurrent_rate_limit.py
@@ -218,7 +218,7 @@ class ConcurrentRateLimitAllocationPolicy(BaseConcurrentRateLimitAllocationPolic
             return QuotaAllowance(
                 can_run=True,
                 max_threads=self.max_threads,
-                explanation={"reason": "pass_through"},
+                explanation={"reason": "cross_org"},
             )
 
         rate_limit_params, overrides = self._get_rate_limit_params(tenant_ids)

--- a/snuba/query/allocation_policies/cross_org.py
+++ b/snuba/query/allocation_policies/cross_org.py
@@ -139,8 +139,8 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
     ) -> QuotaAllowance:
         referrer = str(tenant_ids.get("referrer", "no_referrer"))
 
-        if not self._referrer_is_registered(referrer) and not tenant_ids.get(
-            "cross_org_query", False
+        if not self._referrer_is_registered(referrer) and not self.is_cross_org_query(
+            tenant_ids
         ):
             # This is not a cross org query and the referrer is not registered. This is outside the responsibility of this policy
             return QuotaAllowance(
@@ -167,6 +167,10 @@ class CrossOrgQueryAllocationPolicy(BaseConcurrentRateLimitAllocationPolicy):
         result_or_error: QueryResultOrError,
     ) -> None:
         referrer = str(tenant_ids.get("referrer", "no_referrer"))
+        if not self._referrer_is_registered(referrer) and not self.is_cross_org_query(
+            tenant_ids
+        ):
+            return
         rate_limit_params = RateLimitParameters(
             self.rate_limit_name,
             referrer,

--- a/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
+++ b/tests/query/allocation_policies/test_bytes_scanned_window_allocation_policy.py
@@ -326,3 +326,20 @@ def test_no_bytes_scanned(policy: AllocationPolicy) -> None:
     policy.update_quota_balance(tenant_ids, QUERY_ID, no_bytes_scanned_info_result)
     policy.set_config_value("use_progress_bytes_scanned", 1)
     policy.update_quota_balance(tenant_ids, QUERY_ID, no_bytes_scanned_info_result)
+
+
+@pytest.mark.redis_db
+def test_cross_org(policy: AllocationPolicy) -> None:
+    _configure_policy(policy)
+    tenant_ids: dict[str, str | int] = {
+        "referrer": "do_something",
+        "cross_org_query": 1,
+    }
+    assert policy.get_quota_allowance(tenant_ids=tenant_ids, query_id=QUERY_ID).can_run
+    assert (
+        policy.get_quota_allowance(tenant_ids=tenant_ids, query_id=QUERY_ID).max_threads
+        == policy.max_threads
+    )
+    # make sure that this can be called with cross org queries
+    # and nothing raises
+    policy.update_quota_balance(tenant_ids, QUERY_ID, None)  # type: ignore

--- a/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
+++ b/tests/query/allocation_policies/test_concurrent_rate_limit_policy.py
@@ -316,3 +316,19 @@ def test_pass_through(policy: ConcurrentRateLimitAllocationPolicy) -> None:
             )
     except AllocationPolicyViolation:
         pytest.fail("should not have been blocked")
+
+
+@pytest.mark.redis_db
+def test_cross_org(policy: ConcurrentRateLimitAllocationPolicy) -> None:
+    tenant_ids: dict[str, str | int] = {
+        "referrer": "do_something",
+        "cross_org_query": 1,
+    }
+    assert policy.get_quota_allowance(tenant_ids=tenant_ids, query_id="a").can_run
+    assert (
+        policy.get_quota_allowance(tenant_ids=tenant_ids, query_id="b").max_threads
+        == policy.max_threads
+    )
+    # make sure that this can be called with cross org queries
+    # and nothing raises
+    policy.update_quota_balance(tenant_ids, "c", None)  # type: ignore


### PR DESCRIPTION
in order to allow the cross org policy to take effect, we have to keep the non-cross org policies from rejecting the query. Add and test that functionality