### PR TITLE
feat(capman): add cross org policy to generic metrics distributions

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions.yaml
@@ -111,6 +111,18 @@ allocation_policies:
         is_enforced: 1
         throttled_thread_number: 1
         org_limit_bytes_scanned: 100000
+  - name: CrossOrgQueryAllocationPolicy
+    args:
+      required_tenant_types:
+        - referrer
+      default_config_overrides:
+        is_enforced: 0
+        is_active: 0
+      cross_org_referrer_limits:
+        statistical_detectors.distributions.fetch_top_transaction_names:
+          max_threads: 4
+          concurrent_limit: 10
+
 
 
 query_processors:


### PR DESCRIPTION
Adds statistical detectors job to cross org query policy. Register the statistical detectors query as well

