### PR TITLE
fix(dlq): Add sane defaults to the dlq policy

### DIFF
--- a/snuba/cli/multistorage_consumer.py
+++ b/snuba/cli/multistorage_consumer.py
@@ -254,7 +254,10 @@ def multistorage_consumer(
             KafkaDlqProducer(
                 dlq_producer, Topic(consumer_config.dlq_topic.physical_topic_name)
             ),
-            DlqLimit(),
+            DlqLimit(
+                max_invalid_ratio=0.01,
+                max_consecutive_count=1000,
+            ),
             None,
         )
     else:

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -379,7 +379,10 @@ class ConsumerBuilder:
                     self.dlq_producer,
                     Topic(self.__consumer_config.dlq_topic.physical_topic_name),
                 ),
-                DlqLimit(),
+                DlqLimit(
+                    max_invalid_ratio=0.01,
+                    max_consecutive_count=1000,
+                ),
                 None,
             )
         else:


### PR DESCRIPTION
The current dlq policy allows for 100% of problematic messages to be swallowed by the dlq. That would not be ideal since in effect we could be sending 100% of the messages to the dlq. Instead, we configure a max invalid ratio of 0.01 and max consecutive count of 1000 per partition. We set them both because the counts are not persisted across consumer restarts. So when a consumer crashes when the dlq policy limit is hit, the counters are reset.