### PR TITLE
feat(generic-metrics): Write `retention_days` to `min_retention_days` columns for sets and counters

### DIFF
--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -552,6 +552,7 @@ TEST_CASES_GENERIC = [
                 "timeseries_id": ANY,
                 "retention_days": 30,
                 "granularities": [1, 2, 3],
+                "min_retention_days": 30,
             }
         ],
         id="all tag values ints",
@@ -574,6 +575,7 @@ TEST_CASES_GENERIC = [
                 "timeseries_id": ANY,
                 "retention_days": 30,
                 "granularities": [1, 2, 3],
+                "min_retention_days": 30,
             }
         ],
         id="all tag values strings",


### PR DESCRIPTION
### Overview

After the migration from https://github.com/getsentry/snuba/pull/4782, `min_retention_days` columns for sets and counters (which controls the retention days for minute granularity for metrics) now have default values of 30 days. This pr updates the processors to write `retention_days` to those columns so its behaviour is the same as distribution. This after this pr is merged, we will apply mv2 to these tables which actually reads from `min_retention_days`.