### PR TITLE
feat(generic-metrics): Bump `materialization_version` for generic sets metrics to 2

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Any, Iterable, Mapping, MutableMapping
 
+from snuba.state import get_config
+
 
 class InputType(Enum):
     SET = "s"
@@ -93,7 +95,7 @@ def aggregation_options_for_set_message(
             GRANULARITY_ONE_DAY,
         ],
         "min_retention_days": retention_days,
-        "materialization_version": 1,
+        "materialization_version": get_config("gen_metric_sets_mv_ver", 1),
     }
 
     if aggregation_setting := message.get("aggregation_option"):


### PR DESCRIPTION
### Overview

Bump the materialization version for generic sets metrics to 2 to use the new mat view introduced in https://github.com/getsentry/snuba/pull/4803


### Local testing

Ran `send_metrics.py` and emitted metrics to sentry → snuba

Confirmed `materialization_version` is 2 in raw table

```sql
SELECT
    use_case_id,
    org_id,
    project_id,
    metric_id,
    timestamp,
    materialization_version
FROM generic_metric_sets_raw_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*AS934XZV'), tags.raw_value)

Query id: 6fc6d8e4-dff2-400a-80d6-9ff192479c25

┌─use_case_id───────┬─org_id─┬─project_id─┬─metric_id─┬───────────timestamp─┬─materialization_version─┐
│ custom            │      1 │          3 │     65556 │ 2023-10-07 04:07:32 │                       2 │
│ escalating_issues │      1 │          3 │     65545 │ 2023-10-07 04:07:32 │                       2 │
│ spans             │      1 │          3 │     65536 │ 2023-10-07 04:07:32 │                       2 │
│ transactions      │      1 │          3 │     65551 │ 2023-10-07 04:07:32 │                       2 │
└───────────────────┴────────┴────────────┴───────────┴─────────────────────┴─────────────────────────┘
```

Confirmed spans, escalating_issues, and transactions are rolled up by 3 granularities, and custom is rolled up by 4 granularities.

```sql
SELECT
    use_case_id,
    org_id,
    project_id,
    metric_id,
    timestamp,
    granularity
FROM generic_metric_sets_local
WHERE arrayExists(v -> match(v, 'metric_e2e_.*AS934XZV'), tags.raw_value)

Query id: eac7285c-ce43-4882-9f00-dfbbddbb8a71

┌─use_case_id───────┬─org_id─┬─project_id─┬─metric_id─┬───────────timestamp─┬─granularity─┐
│ spans             │      1 │          3 │     65536 │ 2023-10-07 04:07:00 │           1 │
│ spans             │      1 │          3 │     65536 │ 2023-10-07 04:00:00 │           2 │
│ spans             │      1 │          3 │     65536 │ 2023-10-07 00:00:00 │           3 │
│ escalating_issues │      1 │          3 │     65545 │ 2023-10-07 04:07:00 │           1 │
│ escalating_issues │      1 │          3 │     65545 │ 2023-10-07 04:00:00 │           2 │
│ escalating_issues │      1 │          3 │     65545 │ 2023-10-07 00:00:00 │           3 │
│ transactions      │      1 │          3 │     65551 │ 2023-10-07 04:07:00 │           1 │
│ transactions      │      1 │          3 │     65551 │ 2023-10-07 04:00:00 │           2 │
│ transactions      │      1 │          3 │     65551 │ 2023-10-07 00:00:00 │           3 │
│ custom            │      1 │          3 │     65556 │ 2023-10-07 04:07:00 │           1 │
│ custom            │      1 │          3 │     65556 │ 2023-10-07 04:00:00 │           2 │
│ custom            │      1 │          3 │     65556 │ 2023-10-07 00:00:00 │           3 │
└───────────────────┴────────┴────────────┴───────────┴─────────────────────┴─────────────┘
┌─use_case_id─┬─org_id─┬─project_id─┬─metric_id─┬───────────timestamp─┬─granularity─┐
│ custom      │      1 │          3 │     65556 │ 2023-10-07 04:07:30 │           0 │
└─────────────┴────────┴────────────┴───────────┴─────────────────────┴─────────────┘

```