### PR TITLE
feat(processor): Add 10s to generic metrics granularity processors

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/counters.yaml
@@ -24,7 +24,7 @@ schema:
     {
       name: value,
       type: AggregateFunction,
-      args: { func: sum, arg_types: [ { type: Float, args: { size: 64 } } ] },
+      args: { func: sum, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
   ]
 
@@ -93,6 +93,7 @@ query_processors:
   - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
+        10: 0
         60: 1
         3600: 2
         86400: 3
@@ -123,14 +124,12 @@ validators:
 required_time_column: timestamp
 partition_key_column_name: org_id
 subscription_processors:
-  -
-    processor: AddColumnCondition
+  - processor: AddColumnCondition
     args:
       extra_condition_data_key: organization
       extra_condition_column: org_id
 subscription_validators:
-  -
-    validator: AggregationValidator
+  - validator: AggregationValidator
     args:
       max_allowed_aggregations: 3
       disallowed_aggregations: [having, orderby]

--- a/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/distributions.yaml
@@ -285,6 +285,7 @@ query_processors:
   - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
+        10: 0
         60: 1
         3600: 2
         86400: 3
@@ -315,14 +316,12 @@ validators:
 required_time_column: timestamp
 partition_key_column_name: org_id
 subscription_processors:
-  -
-    processor: AddColumnCondition
+  - processor: AddColumnCondition
     args:
       extra_condition_data_key: organization
       extra_condition_column: org_id
 subscription_validators:
-  -
-    validator: AggregationValidator
+  - validator: AggregationValidator
     args:
       max_allowed_aggregations: 3
       disallowed_aggregations: [having, orderby]

--- a/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/sets.yaml
@@ -97,6 +97,7 @@ query_processors:
   - processor: MappedGranularityProcessor
     args:
       accepted_granularities:
+        10: 0
         60: 1
         3600: 2
         86400: 3
@@ -127,14 +128,12 @@ validators:
 required_time_column: timestamp
 partition_key_column_name: org_id
 subscription_processors:
-  -
-    processor: AddColumnCondition
+  - processor: AddColumnCondition
     args:
       extra_condition_data_key: organization
       extra_condition_column: org_id
 subscription_validators:
-  -
-    validator: AggregationValidator
+  - validator: AggregationValidator
     args:
       max_allowed_aggregations: 3
       disallowed_aggregations: [having, orderby]


### PR DESCRIPTION
Since we are now able to store metrics at the 10s granularity, we also want to make that data queryable. Adding 10s to the allowed granularities for the query processors.