### PR TITLE
fix: Fix committing in the no-skip-write python consumer

### DIFF
--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -125,27 +125,26 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             message.payload.join()
             return message
 
-        commit_strategy: ProcessingStrategy[Union[FilteredPayload, ProcessedMessage]]
+        flush_and_commit: ProcessingStrategy[ProcessedMessageBatchWriter]
 
-        commit_strategy = CommitOffsets(commit)
-
-        collect: ProcessingStrategy[Union[FilteredPayload, ProcessedMessage]]
         if self.__skip_write:
-            collect = commit_strategy
+            flush_and_commit = CommitOffsets(commit)
         else:
-            collect = Reduce[ProcessedMessage, ProcessedMessageBatchWriter](
-                self.__max_insert_batch_size,
-                self.__max_insert_batch_time,
-                accumulator,
-                self.__collector,
-                RunTaskInThreads(
-                    flush_batch,
-                    # We process up to 2 insert batches in parallel
-                    2,
-                    3,
-                    commit_strategy,
-                ),
+            flush_and_commit = RunTaskInThreads(
+                flush_batch,
+                # We process up to 2 insert batches in parallel
+                2,
+                3,
+                CommitOffsets(commit),
             )
+
+        collect = Reduce[ProcessedMessage, ProcessedMessageBatchWriter](
+            self.__max_insert_batch_size,
+            self.__max_insert_batch_time,
+            accumulator,
+            self.__collector,
+            flush_and_commit,
+        )
 
         transform_function = self.__process_message
 


### PR DESCRIPTION
The consumer now always performs the Reduce step even if it's skipping writes. This is important since the commit strategy is IMMEDIATE and we would attempting to commit every offset otherwise.

