### PR TITLE
remove `--force` from ST migrations

### DIFF
--- a/gocd/templates/bash/migrate-st.sh
+++ b/gocd/templates/bash/migrate-st.sh
@@ -23,4 +23,4 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   "snuba-migrate" \
   "us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
   -- \
-  snuba migrations migrate --check-dangerous --force
+  snuba migrations migrate --check-dangerous


### PR DESCRIPTION
No sure why this was there in the first place. Removing to prevent running unsafe migrations in ST