### PR TITLE
fix: fix 0001_functions and 0001_querylog for clickhouse 23

### DIFF
--- a/snuba/migrations/migration.py
+++ b/snuba/migrations/migration.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence
 from snuba.clusters.cluster import get_cluster
 from snuba.migrations.check_dangerous import check_dangerous_operation
 from snuba.migrations.context import Context
-from snuba.migrations.operations import OperationTarget, RunPython, SqlOperation
+from snuba.migrations.operations import GenericOperation, OperationTarget, SqlOperation
 from snuba.migrations.status import Status
 from snuba.utils.types import ColumnStatesMapType
 
@@ -55,11 +55,11 @@ class CodeMigration(Migration, ABC):
     """
 
     @abstractmethod
-    def forwards_global(self) -> Sequence[RunPython]:
+    def forwards_global(self) -> Sequence[GenericOperation]:
         raise NotImplementedError
 
     @abstractmethod
-    def backwards_global(self) -> Sequence[RunPython]:
+    def backwards_global(self) -> Sequence[GenericOperation]:
         raise NotImplementedError
 
     def forwards(self, context: Context, dry_run: bool) -> None:

--- a/snuba/migrations/migration_utilities.py
+++ b/snuba/migrations/migration_utilities.py
@@ -1,0 +1,36 @@
+from typing import Tuple
+
+from snuba.clusters.cluster import ClickhouseClientSettings, get_cluster
+from snuba.clusters.storage_sets import StorageSetKey
+
+ClickhouseVersion = Tuple[int, int]
+
+
+def get_clickhouse_version_for_storage_set(
+    storage_set: StorageSetKey,
+) -> ClickhouseVersion:
+    cluster = get_cluster(storage_set)
+    versions = set()
+    for node in cluster.get_local_nodes():
+        connection = cluster.get_node_connection(ClickhouseClientSettings.MIGRATE, node)
+        ver = connection.execute("SELECT version()").results[0][0]
+
+        versions.add(tuple(map(int, ver.split(".")[:2])))
+
+    if len(versions) != 1:
+        raise RuntimeError(
+            f"found multiple clickhouse versions in local nodes of storage set {storage_set}: {versions}"
+        )
+
+    (ver,) = versions
+    return ver
+
+
+_CLICKHOUSE_SETTINGS_SUPPORTED = {
+    # https://github.com/ClickHouse/ClickHouse/pull/12433#issuecomment-685987783
+    "allow_nullable_key": (20, 7),
+}
+
+
+def supports_setting(clickhouse_version: ClickhouseVersion, setting: str) -> bool:
+    return _CLICKHOUSE_SETTINGS_SUPPORTED[setting] <= clickhouse_version

--- a/snuba/migrations/migration_utilities.py
+++ b/snuba/migrations/migration_utilities.py
@@ -9,6 +9,11 @@ ClickhouseVersion = Tuple[int, int]
 def get_clickhouse_version_for_storage_set(
     storage_set: StorageSetKey,
 ) -> ClickhouseVersion:
+    """
+    Determine the clickhouse version for a storage set. Assumes (and verifies)
+    that all local nodes have the same version for simplicity.
+    """
+
     cluster = get_cluster(storage_set)
     versions = set()
     for node in cluster.get_local_nodes():
@@ -33,4 +38,8 @@ _CLICKHOUSE_SETTINGS_SUPPORTED = {
 
 
 def supports_setting(clickhouse_version: ClickhouseVersion, setting: str) -> bool:
+    """
+    For a given setting, determine whether the given clickhouse version
+    supports it.
+    """
     return _CLICKHOUSE_SETTINGS_SUPPORTED[setting] <= clickhouse_version

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -560,7 +560,7 @@ class RunSqlAsCode(GenericOperation):
         self.__operation_function = operation_function
 
     @cached_property
-    def _operation(self):
+    def _operation(self) -> SqlOperation:
         if callable(self.__operation_function):
             return self.__operation_function()
         else:

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -495,7 +495,7 @@ class InsertIntoSelect(SqlOperation):
         )
 
 
-class GenericMigration(ABC):
+class GenericOperation(ABC):
     @abstractmethod
     def execute(self, logger: logging.Logger) -> None:
         raise NotImplementedError
@@ -514,7 +514,7 @@ class GenericMigration(ABC):
         raise NotImplementedError
 
 
-class RunPython(GenericMigration):
+class RunPython(GenericOperation):
     """
     `new_node_func` should only be provided in the (probably rare)
     scenario where there is a Python script that must be rerun anytime
@@ -547,7 +547,13 @@ class RunPython(GenericMigration):
         return self.__description
 
 
-class RunSqlAsCode(GenericMigration):
+class RunSqlAsCode(GenericOperation):
+    """
+    A wrapper around SqlOperation that can be used to run additional code
+    directly before execution, to determine which kind of operation should be
+    returned.
+    """
+
     def __init__(
         self, operation_function: Union[SqlOperation, Callable[[], SqlOperation]]
     ) -> None:

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -8,12 +8,11 @@ import structlog
 
 from snuba.clickhouse.columns import Column
 from snuba.clickhouse.native import ClickhousePool
-from snuba.clusters.cluster import (
-    ClickhouseClientSettings,
-    ClickhouseNode,
-    ClickhouseNodeType,
-    get_cluster,
-)
+
+# this import needs to be exactly like this in order to facilitate use of
+# importlib.reload in tests
+from snuba.clusters import cluster
+from snuba.clusters.cluster import ClickhouseClientSettings, ClickhouseNode, get_cluster
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations.columns import MigrationModifiers
 from snuba.migrations.table_engines import TableEngine
@@ -504,7 +503,7 @@ class GenericOperation(ABC):
     def execute_new_node(
         self,
         storage_sets: Sequence[StorageSetKey],
-        node_type: ClickhouseNodeType,
+        node_type: cluster.ClickhouseNodeType,
         clickhouse: ClickhousePool,
     ) -> None:
         raise NotImplementedError
@@ -537,7 +536,7 @@ class RunPython(GenericOperation):
     def execute_new_node(
         self,
         storage_sets: Sequence[StorageSetKey],
-        node_type: ClickhouseNodeType,
+        node_type: cluster.ClickhouseNodeType,
         clickhouse: ClickhousePool,
     ) -> None:
         if self.__new_node_func is not None:
@@ -572,10 +571,10 @@ class RunSqlAsCode(GenericOperation):
     def execute_new_node(
         self,
         storage_sets: Sequence[StorageSetKey],
-        node_type: ClickhouseNodeType,
+        node_type: cluster.ClickhouseNodeType,
         clickhouse: ClickhousePool,
     ) -> None:
-        if node_type == ClickhouseNodeType.LOCAL:
+        if node_type == cluster.ClickhouseNodeType.LOCAL:
             if self._operation.target != OperationTarget.LOCAL:
                 return
         else:

--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Union
 
 from snuba import settings
 from snuba.clickhouse.escaping import escape_string
@@ -41,7 +41,7 @@ class MergeTree(TableEngine):
         partition_by: Optional[str] = None,
         sample_by: Optional[str] = None,
         ttl: Optional[str] = None,
-        settings: Optional[Mapping[str, str]] = None,
+        settings: Optional[Mapping[str, Union[str, int]]] = None,
         unsharded: bool = False,
     ) -> None:
         self._storage_set_value = storage_set.value

--- a/snuba/snuba_migrations/functions/0001_functions.py
+++ b/snuba/snuba_migrations/functions/0001_functions.py
@@ -1,4 +1,4 @@
-from typing import List, MutableMapping, Sequence, Union
+from typing import List, MutableMapping, Optional, Sequence, Union
 
 from snuba.clickhouse.columns import (
     UUID,
@@ -10,6 +10,7 @@ from snuba.clickhouse.columns import (
     String,
     UInt,
 )
+from snuba.clickhouse.native import ClickhousePool
 from snuba.clusters.storage_sets import StorageSetKey
 from snuba.migrations import migration, migration_utilities, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
@@ -69,13 +70,15 @@ class Migration(migration.CodeMigration):
 
     local_view_table = "functions_local"
 
-    def _create_functions_mv_table(self) -> operations.SqlOperation:
+    def _create_functions_mv_table(
+        self, clickhouse: Optional[ClickhousePool]
+    ) -> operations.SqlOperation:
         table_settings: MutableMapping[str, Union[int, str]] = {
             "index_granularity": self.index_granularity,
         }
 
         clickhouse_version = migration_utilities.get_clickhouse_version_for_storage_set(
-            self.storage_set
+            self.storage_set, clickhouse
         )
         if migration_utilities.supports_setting(
             clickhouse_version, "allow_nullable_key"

--- a/snuba/snuba_migrations/functions/0001_functions.py
+++ b/snuba/snuba_migrations/functions/0001_functions.py
@@ -97,13 +97,13 @@ class Migration(migration.CodeMigration):
             target=operations.OperationTarget.LOCAL,
         )
 
-    def forwards_global(self) -> Sequence[operations.GenericMigration]:
+    def forwards_global(self) -> Sequence[operations.GenericOperation]:
         return [*self._forwards_local(), *self._forwards_dist()]
 
-    def backwards_global(self) -> Sequence[operations.GenericMigration]:
+    def backwards_global(self) -> Sequence[operations.GenericOperation]:
         return [*self._backwards_local(), *self._backwards_dist()]
 
-    def _forwards_local(self) -> Sequence[operations.GenericMigration]:
+    def _forwards_local(self) -> Sequence[operations.GenericOperation]:
         return [
             operations.RunSqlAsCode(
                 operations.CreateTable(
@@ -132,7 +132,7 @@ class Migration(migration.CodeMigration):
             ),
         ]
 
-    def _backwards_local(self) -> Sequence[operations.GenericMigration]:
+    def _backwards_local(self) -> Sequence[operations.GenericOperation]:
         return [
             operations.RunSqlAsCode(
                 operations.DropTable(
@@ -157,7 +157,7 @@ class Migration(migration.CodeMigration):
             ),
         ]
 
-    def _forwards_dist(self) -> Sequence[operations.GenericMigration]:
+    def _forwards_dist(self) -> Sequence[operations.GenericOperation]:
         return [
             operations.RunSqlAsCode(
                 operations.CreateTable(
@@ -185,7 +185,7 @@ class Migration(migration.CodeMigration):
             ),
         ]
 
-    def _backwards_dist(self) -> Sequence[operations.GenericMigration]:
+    def _backwards_dist(self) -> Sequence[operations.GenericOperation]:
         return [
             operations.RunSqlAsCode(
                 operations.DropTable(

--- a/snuba/snuba_migrations/functions/0001_functions.py
+++ b/snuba/snuba_migrations/functions/0001_functions.py
@@ -91,7 +91,10 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
                     order_by="(project_id, transaction_name, timestamp, depth, parent_fingerprint, fingerprint, name, package, path, is_application, platform, environment, release, os_name, os_version, retention_days)",
                     primary_key="(project_id, transaction_name, timestamp, depth, parent_fingerprint, fingerprint)",
                     partition_by="(retention_days, toMonday(timestamp))",
-                    settings={"index_granularity": self.index_granularity},
+                    settings={
+                        "allow_nullable_key": 1,
+                        "index_granularity": self.index_granularity,
+                    },
                     ttl="timestamp + toIntervalDay(retention_days)",
                 ),
             ),

--- a/snuba/snuba_migrations/functions/0001_functions.py
+++ b/snuba/snuba_migrations/functions/0001_functions.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence
+from typing import List, MutableMapping, Sequence, Union
 
 from snuba.clickhouse.columns import (
     UUID,
@@ -11,7 +11,7 @@ from snuba.clickhouse.columns import (
     UInt,
 )
 from snuba.clusters.storage_sets import StorageSetKey
-from snuba.migrations import migration, operations, table_engines
+from snuba.migrations import migration, migration_utilities, operations, table_engines
 from snuba.migrations.columns import MigrationModifiers as Modifiers
 
 common_columns: List[Column[Modifiers]] = [
@@ -69,13 +69,41 @@ class Migration(migration.CodeMigration):
 
     local_view_table = "functions_local"
 
+    def _create_functions_mv_table(self) -> operations.SqlOperation:
+        table_settings: MutableMapping[str, Union[int, str]] = {
+            "index_granularity": self.index_granularity,
+        }
+
+        clickhouse_version = migration_utilities.get_clickhouse_version_for_storage_set(
+            self.storage_set
+        )
+        if migration_utilities.supports_setting(
+            clickhouse_version, "allow_nullable_key"
+        ):
+            table_settings["allow_nullable_key"] = 1
+
+        return operations.CreateTable(
+            storage_set=self.storage_set,
+            table_name=self.local_materialized_table,
+            columns=agg_columns,
+            engine=table_engines.AggregatingMergeTree(
+                storage_set=self.storage_set,
+                order_by="(project_id, transaction_name, timestamp, depth, parent_fingerprint, fingerprint, name, package, path, is_application, platform, environment, release, os_name, os_version, retention_days)",
+                primary_key="(project_id, transaction_name, timestamp, depth, parent_fingerprint, fingerprint)",
+                partition_by="(retention_days, toMonday(timestamp))",
+                settings=table_settings,
+                ttl="timestamp + toIntervalDay(retention_days)",
+            ),
+            target=operations.OperationTarget.LOCAL,
+        )
+
     def forwards_global(self) -> Sequence[operations.GenericMigration]:
-        return [*self.forwards_local(), *self.forwards_dist()]
+        return [*self._forwards_local(), *self._forwards_dist()]
 
     def backwards_global(self) -> Sequence[operations.GenericMigration]:
-        return [*self.backwards_local(), *self.backwards_dist()]
+        return [*self._backwards_local(), *self._backwards_dist()]
 
-    def forwards_local(self) -> Sequence[operations.GenericMigration]:
+    def _forwards_local(self) -> Sequence[operations.GenericMigration]:
         return [
             operations.RunSqlAsCode(
                 operations.CreateTable(
@@ -91,25 +119,7 @@ class Migration(migration.CodeMigration):
                     target=operations.OperationTarget.LOCAL,
                 )
             ),
-            operations.RunSqlAsCode(
-                operations.CreateTable(
-                    storage_set=self.storage_set,
-                    table_name=self.local_materialized_table,
-                    columns=agg_columns,
-                    engine=table_engines.AggregatingMergeTree(
-                        storage_set=self.storage_set,
-                        order_by="(project_id, transaction_name, timestamp, depth, parent_fingerprint, fingerprint, name, package, path, is_application, platform, environment, release, os_name, os_version, retention_days)",
-                        primary_key="(project_id, transaction_name, timestamp, depth, parent_fingerprint, fingerprint)",
-                        partition_by="(retention_days, toMonday(timestamp))",
-                        settings={
-                            "allow_nullable_key": 1,
-                            "index_granularity": self.index_granularity,
-                        },
-                        ttl="timestamp + toIntervalDay(retention_days)",
-                    ),
-                    target=operations.OperationTarget.LOCAL,
-                )
-            ),
+            operations.RunSqlAsCode(self._create_functions_mv_table),
             operations.RunSqlAsCode(
                 operations.CreateMaterializedView(
                     storage_set=self.storage_set,
@@ -122,7 +132,7 @@ class Migration(migration.CodeMigration):
             ),
         ]
 
-    def backwards_local(self) -> Sequence[operations.GenericMigration]:
+    def _backwards_local(self) -> Sequence[operations.GenericMigration]:
         return [
             operations.RunSqlAsCode(
                 operations.DropTable(
@@ -147,7 +157,7 @@ class Migration(migration.CodeMigration):
             ),
         ]
 
-    def forwards_dist(self) -> Sequence[operations.GenericMigration]:
+    def _forwards_dist(self) -> Sequence[operations.GenericMigration]:
         return [
             operations.RunSqlAsCode(
                 operations.CreateTable(
@@ -175,7 +185,7 @@ class Migration(migration.CodeMigration):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.GenericMigration]:
+    def _backwards_dist(self) -> Sequence[operations.GenericMigration]:
         return [
             operations.RunSqlAsCode(
                 operations.DropTable(

--- a/snuba/snuba_migrations/functions/0001_functions.py
+++ b/snuba/snuba_migrations/functions/0001_functions.py
@@ -101,7 +101,7 @@ class Migration(migration.CodeMigration):
         return [*self._forwards_local(), *self._forwards_dist()]
 
     def backwards_global(self) -> Sequence[operations.GenericOperation]:
-        return [*self._backwards_local(), *self._backwards_dist()]
+        return [*self._backwards_dist(), *self._backwards_local()]
 
     def _forwards_local(self) -> Sequence[operations.GenericOperation]:
         return [

--- a/snuba/snuba_migrations/querylog/0001_querylog.py
+++ b/snuba/snuba_migrations/querylog/0001_querylog.py
@@ -64,7 +64,6 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
                     storage_set=StorageSetKey.QUERYLOG,
                     order_by="(toStartOfDay(timestamp), request_id)",
                     partition_by="(toMonday(timestamp))",
-                    sample_by="request_id",
                 ),
             )
         ]


### PR DESCRIPTION
In order to upgrade to ClickHouse 23, we need to ensure all migrations run.

## functions

0001_functions uses a nullable column in the primary key. version 23 judges us for this, and one has to use allow_nullable_key to explicitly opt into permitting this `CREATE TABLE` statement.

To make matters worse, version 20.3 (a version we support) does not support the `allow_nullable_key` setting and will throw an error if it is set. So there is no table schema that works on both versions of ClickHouse.

However, the upside is that upgrading from ClickHouse version 21.6 to 23 appears to permit this schema regardless for old tables, but refuses to create new tables with the same schema. I tested this by recreating the container with the new image like so:

0. Be on `ghcr.io/getsentry/image-mirror-altinity-clickhouse-server:21.6.1.6734-testing-arm` due to MacOS M1
1. `docker container rm sentry_clickhouse`
2. patch sentry to use a different image `altinity/clickhouse-server:23.3.8.22.altinitystable`
3. `sentry devservices up`

`SHOW CREATE TABLE functions_mv_local` in version 23 will now return a piece of SQL that is not valid under the same version (as the `allow_nullable_key` setting is missing), but queries work.

Action plan:

1. make migrations on empty cluster pass by fixing the initial migration to conditionally set `allow_nullable_key` depending on the clickhouse version (this PR)
2. in production, upgrade to version 23 (TBD)
3. at this point, clusters may have inconsistent schemas (the setting is there or it is not, depending on when the table was created, NOT depending on the clickhouse version) -- but doesn't matter, the same set of queries work.
4. at a later point, when we are able to raise the minimum supported version to 23, check in a migration that adds the setting to existing tables (just for cleanliness and to make the output of `SHOW CREATE TABLE` valid again)

Note: **I don't think this is how ClickHouse intended us to upgrade versions at all.** It seems that they expected that applications only ever support two consecutive major versions at a time, so that we can instead:

1. upgrade everything from 20 to 21 without code changes
2. drop support for 20 and start setting `allow_nullable_key` unconditionally
3. upgrade everything from 21 to 22
4. drop support for 21
5. and so on until we reach version 23

## querylog

Very similar to functions, except a lot simpler.

0001_querylog has a `SAMPLE BY` clause that is invalid under ClickHouse version 23, as it is invalid to sample by a UUID. We don't use `SAMPLE BY` on querylog in practice, and it turns out that any use of `SAMPLE BY` already does not work today on version 20, as UUIDs were never intended to be supported.

So, removing the `SAMPLE BY` key in querylog has no downsides. In-place upgrades work, in that tables created on version 21 will just work in version 23, even though `SHOW CREATE TABLE` will return a schema that is invalid for new tables under version 23.

## risks

Diverging schemas between clickhouse versions is tricky. The fact that `SHOW CREATE TABLE` returns invalid SQL for newer versions of clickhouse might impact our ability to recreate a table in prod, should we choose to do so without a migration.

There is a gap in test coverage for our migrations. Ideally there would be a CI job that runs half of the migrations on version 20 or 21, performs an in-place upgrade in CI, then runs the other half.