### PR TITLE
feat: Reduce logging in Rust consumers

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -112,7 +112,6 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
         }
 
         if self.handles.len() > self.concurrency {
-            log::warn!("Reached max concurrency, rejecting message");
             return Err(MessageRejected { message });
         }
 


### PR DESCRIPTION
Logging is expensive, let's stop writing the most useless logs. we already have a metric for this anyway.
