### PR TITLE
ref: Simplify collector / processed message batch writer

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -145,7 +145,7 @@ class InsertBatchWriter:
         self.__messages: MutableSequence[Message[BytesInsertBatch]] = []
         self.__closed = False
 
-    def add(self, message: Message[BytesInsertBatch]) -> None:
+    def submit(self, message: Message[BytesInsertBatch]) -> None:
         assert not self.__closed
 
         self.__messages.append(message)
@@ -228,7 +228,7 @@ class ReplacementBatchWriter:
         self.__messages: MutableSequence[Message[ReplacementBatch]] = []
         self.__closed = False
 
-    def add(self, message: Message[ReplacementBatch]) -> None:
+    def submit(self, message: Message[ReplacementBatch]) -> None:
         assert not self.__closed
 
         self.__messages.append(message)
@@ -285,12 +285,12 @@ class ProcessedMessageBatchWriter:
             return
 
         if isinstance(message.payload, BytesInsertBatch):
-            self.__insert_batch_writer.add(cast(Message[BytesInsertBatch], message))
+            self.__insert_batch_writer.submit(cast(Message[BytesInsertBatch], message))
         elif isinstance(message.payload, ReplacementBatch):
             if self.__replacement_batch_writer is None:
                 raise TypeError("writer not configured to support replacements")
 
-            self.__replacement_batch_writer.add(
+            self.__replacement_batch_writer.submit(
                 cast(Message[ReplacementBatch], message)
             )
         else:

--- a/snuba/consumers/strategy_factory.py
+++ b/snuba/consumers/strategy_factory.py
@@ -122,7 +122,6 @@ class KafkaConsumerStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
             message: Message[ProcessedMessageBatchWriter],
         ) -> Message[ProcessedMessageBatchWriter]:
             message.payload.close()
-            message.payload.join()
             return message
 
         flush_and_commit: ProcessingStrategy[ProcessedMessageBatchWriter]


### PR DESCRIPTION
It's super unintuitive (and pointless) that this was copying the Arroyo strategy interface. There is no need for the separate close() and join() methods.

