### PR TITLE
enable deploy to experimental static membership consumers

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -52,6 +52,8 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --container-name="rust-spans-reference-consumer" \
   --container-name="rust-profiles-consumer" \
   --container-name="rust-profiling-functions-consumer" \
+  --container-name="spans-exp-static-off" \
+  --container-name="spans-exp-static-on" \
   --container-name="dlq-consumer" \
   --container-name="group-attributes-consumer" \
 && /devinfra/scripts/k8s/k8s-deploy.py \


### PR DESCRIPTION
This will enable deploying images to the experimental consumers with static membership enables. By observing this for a while we can track improvements it makes to rebalancing.