### PR TITLE
fix(clickhouse-v23.3): Fix function tuple can't have lambda expression as arguments bug

### DIFF
--- a/snuba/clickhouse/formatter/expression.py
+++ b/snuba/clickhouse/formatter/expression.py
@@ -172,7 +172,7 @@ class ExpressionFormatterBase(ExpressionVisitor[str], ABC):
 
     def visit_lambda(self, exp: Lambda) -> str:
         parameters = [self.__escape_identifier_enforce(v) for v in exp.parameters]
-        ret = f"({', '.join(parameters)} -> {exp.transformation.accept(self)})"
+        ret = f"{', '.join(parameters)} -> {exp.transformation.accept(self)}"
         return self._alias(ret, exp.alias)
 
 

--- a/snuba/query/expressions.py
+++ b/snuba/query/expressions.py
@@ -253,7 +253,7 @@ class StringifyVisitor(ExpressionVisitor[str]):
         self.__level += 1
         transformation_str = exp.transformation.accept(self)
         self.__level -= 1
-        return f"{self._get_line_prefix()}({params_str} ->\n{transformation_str}\n{self._get_line_prefix()}){self._get_alias_str(exp)}"
+        return f"{self._get_line_prefix()}({params_str}) ->\n{transformation_str}\n{self._get_line_prefix()}{self._get_alias_str(exp)}"
 
 
 OptionalScalarType = Union[None, bool, str, float, int, date, datetime]

--- a/tests/query/processors/test_arrayjoin_optimizer.py
+++ b/tests/query/processors/test_arrayjoin_optimizer.py
@@ -478,7 +478,7 @@ def test_formatting() -> None:
         ),
         Literal(None, 1),
     ).accept(ClickhouseExpressionFormatter()) == (
-        "(tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), "
+        "(tupleElement((arrayJoin(arrayMap(x, y -> (x, y), "
         "tags.key, tags.value)) AS snuba_all_tags), 1) AS tags_key)"
     )
 
@@ -496,9 +496,9 @@ def test_formatting() -> None:
         ),
         Literal(None, 1),
     ).accept(ClickhouseExpressionFormatter()) == (
-        "(tupleElement((arrayJoin(arrayFilter((pair -> in("
-        "tupleElement(pair, 1), ('t1', 't2'))), "
-        "arrayMap((x, y -> (x, y)), tags.key, tags.value))) AS snuba_all_tags), 1) AS tags_key)"
+        "(tupleElement((arrayJoin(arrayFilter(pair -> in("
+        "tupleElement(pair, 1), ('t1', 't2')), "
+        "arrayMap(x, y -> (x, y), tags.key, tags.value))) AS snuba_all_tags), 1) AS tags_key)"
     )
 
 
@@ -526,7 +526,7 @@ def test_aliasing() -> None:
     )
 
     assert sql == (
-        "SELECT (tupleElement((arrayJoin(arrayMap((x, y -> (x, y)), "
+        "SELECT (tupleElement((arrayJoin(arrayMap(x, y -> (x, y), "
         "tags.key, tags.value)) AS snuba_all_tags), 2) AS _snuba_tags_value) "
         f"FROM {transactions_table_name} "
         "WHERE in((tupleElement(snuba_all_tags, 1) AS _snuba_tags_key), ('t1', 't2')) "

--- a/tests/query/processors/test_handled_functions.py
+++ b/tests/query/processors/test_handled_functions.py
@@ -76,7 +76,7 @@ def test_handled_processor() -> None:
         ClickhouseExpressionFormatter()
     )
     assert ret == (
-        "(arrayAll((x -> (isNull(x) OR notEquals(assumeNotNull(x), 0))), exception_stacks.mechanism_handled) AS result)"
+        "(arrayAll(x -> (isNull(x) OR notEquals(assumeNotNull(x), 0)), exception_stacks.mechanism_handled) AS result)"
     )
 
 
@@ -160,7 +160,7 @@ def test_not_handled_processor() -> None:
         ClickhouseExpressionFormatter()
     )
     assert ret == (
-        "(arrayExists((x -> isNotNull(x) AND equals(assumeNotNull(x), 0)), exception_stacks.mechanism_handled) AS result)"
+        "(arrayExists(x -> isNotNull(x) AND equals(assumeNotNull(x), 0), exception_stacks.mechanism_handled) AS result)"
     )
 
 

--- a/tests/query/processors/test_slice_of_map_optimizer.py
+++ b/tests/query/processors/test_slice_of_map_optimizer.py
@@ -76,8 +76,8 @@ tests = [
                 ),
             ),
         ),
-        "arrayMap((x -> replaceAll(toString(x), '-', '')), arraySlice(column1, 0, 2))",
-        id="arrayMap((x -> replaceAll(toString(x), '-', '')), arraySlice(column1, 0, 2))",
+        "arrayMap(x -> replaceAll(toString(x), '-', ''), arraySlice(column1, 0, 2))",
+        id="arrayMap(x -> replaceAll(toString(x), '-', ''), arraySlice(column1, 0, 2))",
     )
 ]
 

--- a/tests/query/processors/test_uuid_array_column_processor.py
+++ b/tests/query/processors/test_uuid_array_column_processor.py
@@ -89,8 +89,8 @@ tests = [
                 Literal(None, 2),
             ),
         ),
-        "arraySlice(arrayMap((x -> replaceAll(toString(x), '-', '')), column1), 0, 2)",
-        id="arraySlice(arrayMap((x -> replaceAll(toString(x), '-', '')), column1), 0, 2)",
+        "arraySlice(arrayMap(x -> replaceAll(toString(x), '-', ''), column1), 0, 2)",
+        id="arraySlice(arrayMap(x -> replaceAll(toString(x), '-', ''), column1), 0, 2)",
     ),
 ]
 

--- a/tests/query/test_expressions.py
+++ b/tests/query/test_expressions.py
@@ -279,13 +279,13 @@ TEST_CASES = [
                 (Argument(None, "a"), Argument(None, "b"), Argument(None, "c")),
             ),
         ),
-        """(a,b,c ->
+        """(a,b,c) ->
   some_func(
     a,
     b,
     c
   )
-)""",
+""",
     ),
 ]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1989,7 +1989,7 @@ class TestApi(SimpleAPITest):
         result = json.loads(response.data)
 
         val = (
-            "SELECT (arrayMap((x -> replaceAll(toString(x), '-', '')), "
+            "SELECT (arrayMap(x -> replaceAll(toString(x), '-', ''), "
             "arraySlice(hierarchical_hashes, 0, 2)) AS `_snuba_arraySlice(hierarchical_hashes, 0, 2)`)"
         )
         assert result["sql"].startswith(val)
@@ -2039,7 +2039,7 @@ class TestApi(SimpleAPITest):
         result = json.loads(response.data)
 
         val = (
-            "SELECT (arrayJoin((arrayMap((x -> replaceAll(toString(x), '-', '')), "
+            "SELECT (arrayJoin((arrayMap(x -> replaceAll(toString(x), '-', ''), "
             "hierarchical_hashes) AS _snuba_hierarchical_hashes)) AS `_snuba_arrayJoin(hierarchical_hashes)`)"
         )
         assert result["sql"].startswith(val)


### PR DESCRIPTION
### Overview
This PR is responsible for fixing a SQL parsing bug when upgrading to ClickHouse v23.3. The new version of ClickHouse fails numerous tag queries in our test suite with the following error:
```
DB::Exception: Function tuple can't have lambda-expressions as arguments
```

When Snuba parses lambda functions, it currently wraps it with a set of extra parentheses to visually group the statement together. However, in ClickHouse > v22.8, that extra set of parentheses now resolves as a `tuple()` which causes the error above.

### Example
Offending query which use to be valid:
```
SELECT tupleElement(
	arrayJoin(
		arrayMap((x, y -> (x, y)), [1, 2, 3], [4,5,6])
	), 
1)
```
Change query into this instead:
```
SELECT tupleElement(
	arrayJoin(
		arrayMap((x, y) -> tuple(x, y), [1, 2, 3], [4,5,6])
	), 
1)
```