### PR TITLE
ref(23.3) Fix test so it runs on 23.3

### DIFF
--- a/tests/test_transactions_api.py
+++ b/tests/test_transactions_api.py
@@ -539,7 +539,7 @@ class TestTransactionsApi(BaseApiTest):
                     "tenant_ids": {"referrer": "r", "organization_id": 1234},
                     "project": 1,
                     "selected_columns": ["event_id"],
-                    "conditions": [["transaction", "LIKE", "stuff \\\" ' \\' stuff\\"]],
+                    "conditions": [["transaction", "LIKE", "stuff \\\" ' \\' stuff"]],
                     "limit": 4,
                     "orderby": ["event_id"],
                     "from_date": (self.base_time - self.skew).isoformat(),


### PR DESCRIPTION
23.3 has an issue with having trailing escape charaters in LIKE conditions.
Changing the test allows it to work on 23.3.

In the future it will probably be worth having validation on this specific case
but in the interest of unblocking the upgrade, that work will be tracked
separately.