### PR TITLE
feat(slack): Allow sending files in slack client

### DIFF
--- a/tests/admin/notifications/slack/test_client.py
+++ b/tests/admin/notifications/slack/test_client.py
@@ -1,0 +1,54 @@
+import tempfile
+from unittest.mock import ANY, MagicMock, patch
+
+import pytest
+
+from snuba.admin.notifications.slack.client import SlackClient
+
+
+@pytest.fixture
+def slack_client() -> SlackClient:
+    return SlackClient(channel_id="test_channel", token="test_token")
+
+
+def test_post_message(slack_client: SlackClient) -> None:
+    message = {"text": "test message"}
+    with patch("requests.post", MagicMock()) as mock_post:
+        slack_client.post_message(message)
+
+        mock_post.assert_called_once_with(
+            "https://slack.com/api/chat.postMessage",
+            headers={
+                "Authorization": "Bearer test_token",
+                "Content-Type": "application/json",
+            },
+            json={"channel": "test_channel", **message},
+        )
+
+
+def test_post_file(slack_client: SlackClient) -> None:
+    with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+        # Write some test data to the file
+        f.write(b"test,data")
+        # Get the file path
+        file_path = f.name
+        print(file_path)
+
+        file_name = "test_file"
+        file_type = "text/plain"
+        initial_comment = "test comment"
+
+        with patch("requests.post", MagicMock()) as mock_post:
+            slack_client.post_file(file_name, file_path, file_type, initial_comment)
+
+            mock_post.assert_called_once_with(
+                "https://slack.com/api/files.upload",
+                headers={"Authorization": "Bearer test_token"},
+                data={
+                    "channels": "test_channel",
+                    "initial_comment": initial_comment,
+                },
+                files={
+                    "file": (file_name, ANY, file_type),
+                },
+            )


### PR DESCRIPTION
In order to report cardinality, we need the ability to send files to slack channels. This PR adds a new api `post_file` which uses the slack API endpoint for sending a file to a channel.

Tested the change by writing a program which uses the `post_file` API and verifying that the message got sent to the correct channel
<img width="1401" alt="Screenshot 2023-10-16 at 10 55 25 AM" src="https://github.com/getsentry/snuba/assets/84807402/4eb1a6cd-6104-4db4-ae80-72f6d365ac47">
