### PR TITLE
lint(generic-metrics): Remove feature flag for gen-metrics sets mat view version

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import Any, Iterable, Mapping, MutableMapping
 
-from snuba.state import get_config
-
 
 class InputType(Enum):
     SET = "s"
@@ -95,7 +93,7 @@ def aggregation_options_for_set_message(
             GRANULARITY_ONE_DAY,
         ],
         "min_retention_days": retention_days,
-        "materialization_version": get_config("gen_metric_sets_mv_ver", 1),
+        "materialization_version": 2,
     }
 
     if aggregation_setting := message.get("aggregation_option"):

--- a/tests/datasets/processors/test_generic_metrics_processor.py
+++ b/tests/datasets/processors/test_generic_metrics_processor.py
@@ -39,7 +39,7 @@ def test__should_process(
             },
             {
                 "min_retention_days": 90,
-                "materialization_version": 1,
+                "materialization_version": 2,
                 "granularities": [1, 2, 3, 0],
             },
             90,

--- a/tests/datasets/test_metrics_processor.py
+++ b/tests/datasets/test_metrics_processor.py
@@ -585,7 +585,54 @@ TEST_CASES_GENERIC = [
 
 @pytest.mark.parametrize(
     "message, expected_output",
-    TEST_CASES_GENERIC,
+    [
+        pytest.param(
+            SET_MESSAGE_SHARED,
+            [
+                {
+                    "use_case_id": "sessions",
+                    "org_id": 1,
+                    "project_id": 2,
+                    "metric_id": 1232341,
+                    "timestamp": expected_timestamp,
+                    "tags.key": [10, 20, 30],
+                    "tags.indexed_value": [11, 22, 33],
+                    "tags.raw_value": ["value-1", "value-2", "value-3"],
+                    "metric_type": "set",
+                    "set_values": [324234, 345345, 456456, 567567],
+                    "materialization_version": 2,
+                    "timeseries_id": ANY,
+                    "retention_days": 30,
+                    "granularities": [1, 2, 3],
+                    "min_retention_days": 30,
+                }
+            ],
+            id="all tag values ints",
+        ),
+        pytest.param(
+            SET_MESSAGE_TAG_VALUES_STRINGS,
+            [
+                {
+                    "use_case_id": "sessions",
+                    "org_id": 1,
+                    "project_id": 2,
+                    "metric_id": 1232341,
+                    "timestamp": expected_timestamp,
+                    "tags.key": [10, 20, 30],
+                    "tags.indexed_value": [0, 0, 0],
+                    "tags.raw_value": ["value-1", "value-2", "value-3"],
+                    "metric_type": "set",
+                    "set_values": [324234, 345345, 456456, 567567],
+                    "materialization_version": 2,
+                    "timeseries_id": ANY,
+                    "retention_days": 30,
+                    "granularities": [1, 2, 3],
+                    "min_retention_days": 30,
+                }
+            ],
+            id="all tag values strings",
+        ),
+    ],
 )
 def test_generic_metrics_sets_processor(
     message: Mapping[str, Any], expected_output: Optional[Sequence[Mapping[str, Any]]]


### PR DESCRIPTION
Remove the flag that controls the materialization version