### PR TITLE
feat(generic-metrics): Bump `materialization_version` for generic sets metrics to 2

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from typing import Any, Iterable, Mapping, MutableMapping
 
+from snuba.state import get_config
+
 
 class InputType(Enum):
     SET = "s"
@@ -133,7 +135,7 @@ def aggregation_options_for_counter_message(
             GRANULARITY_ONE_DAY,
         ],
         "min_retention_days": retention_days,
-        "materialization_version": 1,
+        "materialization_version": get_config("gen_metric_counters_mv_ver", 1),
     }
 
     if aggregation_setting := message.get("aggregation_option"):


### PR DESCRIPTION
### Overview

Bump the materialization version for generic sets metrics to 2 to use the new mat view introduced in https://github.com/getsentry/snuba/pull/4803
