### PR TITLE
feat: Write received_p99 to commit log

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -274,9 +274,9 @@ class ProcessedMessageBatchWriter:
         self.__replacement_batch_writer = replacement_batch_writer
         self.__commit_log_config = commit_log_config
         self.__offsets_to_produce: MutableMapping[Partition, Tuple[int, datetime]] = {}
-        self.__received_timestamps: MutableMapping[Partition, List[int]] = defaultdict(
-            list
-        )
+        self.__received_timestamps: MutableMapping[
+            Partition, List[float]
+        ] = defaultdict(list)
 
         self.__closed = False
 

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -268,11 +268,15 @@ class ProcessedMessageBatchWriter:
         # If commit log config is passed, we will produce to the commit log topic
         # upon closing each batch.
         commit_log_config: Optional[CommitLogConfig] = None,
+        metrics: Optional[MetricsBackend] = None,
     ) -> None:
         self.__insert_batch_writer = insert_batch_writer
         self.__replacement_batch_writer = replacement_batch_writer
         self.__commit_log_config = commit_log_config
         self.__offsets_to_produce: MutableMapping[Partition, Tuple[int, datetime]] = {}
+        self.__received_timestamps: MutableMapping[
+            Partition, List[datetime]
+        ] = defaultdict(list)
 
         self.__closed = False
 
@@ -284,19 +288,25 @@ class ProcessedMessageBatchWriter:
         if message.payload is None:
             return
 
+        assert isinstance(message.value, BrokerValue)
+
         if isinstance(message.payload, BytesInsertBatch):
-            self.__insert_batch_writer.submit(cast(Message[BytesInsertBatch], message))
+            insert_message = cast(Message[BytesInsertBatch], message)
+            self.__insert_batch_writer.submit(insert_message)
+            origin_timestamp = insert_message.payload.origin_timestamp
+            if origin_timestamp is not None:
+                self.__received_timestamps[message.value.partition].append(
+                    origin_timestamp
+                )
         elif isinstance(message.payload, ReplacementBatch):
             if self.__replacement_batch_writer is None:
                 raise TypeError("writer not configured to support replacements")
-
             self.__replacement_batch_writer.submit(
                 cast(Message[ReplacementBatch], message)
             )
         else:
             raise TypeError("unexpected payload type")
 
-        assert isinstance(message.value, BrokerValue)
         self.__offsets_to_produce[message.value.partition] = (
             message.value.next_offset,
             message.value.timestamp,
@@ -317,10 +327,24 @@ class ProcessedMessageBatchWriter:
             self.__replacement_batch_writer.close()
 
         if self.__commit_log_config is not None:
-            for partition, (offset, timestamp) in self.__offsets_to_produce.items():
+            for partition, (
+                offset,
+                timestamp,
+            ) in self.__offsets_to_produce.items():
+                received_timestamps = self.__received_timestamps.pop(partition, [])
+                received_timestamps.sort()
+                if len(received_timestamps):
+                    received_p99 = received_timestamps[
+                        int(len(received_timestamps) * 0.99)
+                    ]
+
                 payload = commit_codec.encode(
                     CommitLogCommit(
-                        self.__commit_log_config.group_id, partition, offset, timestamp
+                        self.__commit_log_config.group_id,
+                        partition,
+                        offset,
+                        timestamp,
+                        received_p99,
                     )
                 )
                 self.__commit_log_config.producer.produce(
@@ -370,9 +394,7 @@ def build_batch_writer(
     )
 
     def build_writer() -> ProcessedMessageBatchWriter:
-        insert_batch_writer = InsertBatchWriter(
-            writer, MetricsWrapper(metrics, "insertions")
-        )
+        insert_metrics = MetricsWrapper(metrics, "insertions")
 
         replacement_batch_writer: Optional[ReplacementBatchWriter]
         if supports_replacements:
@@ -385,7 +407,10 @@ def build_batch_writer(
             replacement_batch_writer = None
 
         return ProcessedMessageBatchWriter(
-            insert_batch_writer, replacement_batch_writer, commit_log_config
+            InsertBatchWriter(writer, insert_metrics),
+            replacement_batch_writer,
+            commit_log_config,
+            metrics=insert_metrics,
         )
 
     return build_writer
@@ -672,6 +697,12 @@ def build_multistorage_batch_writer(
     else:
         replacement_batch_writer = None
 
+    insertion_metrics = MetricsWrapper(
+        metrics,
+        "insertions",
+        {"storage": storage.get_storage_key().value},
+    )
+
     return ProcessedMessageBatchWriter(
         InsertBatchWriter(
             storage.get_table_writer().get_batch_writer(
@@ -679,13 +710,10 @@ def build_multistorage_batch_writer(
                 {"load_balancing": "in_order", "insert_distributed_sync": 1},
                 slice_id=slice_id,
             ),
-            MetricsWrapper(
-                metrics,
-                "insertions",
-                {"storage": storage.get_storage_key().value},
-            ),
+            insertion_metrics,
         ),
         replacement_batch_writer,
+        metrics=insertion_metrics,
     )
 
 

--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -296,7 +296,7 @@ class ProcessedMessageBatchWriter:
             origin_timestamp = insert_message.payload.origin_timestamp
             if origin_timestamp is not None:
                 self.__received_timestamps[message.value.partition].append(
-                    origin_timestamp
+                    datetime.timestamp(origin_timestamp)
                 )
         elif isinstance(message.payload, ReplacementBatch):
             if self.__replacement_batch_writer is None:

--- a/snuba/processor.py
+++ b/snuba/processor.py
@@ -34,7 +34,10 @@ NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
 class InsertBatch(NamedTuple):
     rows: Sequence[WriterTableRow]
+    # origin_timestamp is the timestamp of the event when was received by Relay
     origin_timestamp: Optional[datetime]
+    # sentry_received_timestamp is the timestamp of the event when received by the ingest
+    # consumer in Sentry
     sentry_received_timestamp: Optional[datetime] = None
 
 


### PR DESCRIPTION
This supports the subscriptions to opt into using received_p99 for scheduling instead of the current orig_message_ts

Needs https://github.com/getsentry/arroyo/pull/295