### PR TITLE
feat(subscriptions): Add mechanism for storage to define timestamp used for scheduling

### DIFF
--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -368,5 +368,6 @@ stream_loader:
   replacement_topic: event-replacements
   commit_log_topic: snuba-commit-log
   subscription_scheduler_mode: partition
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-events
   subscription_result_topic: events-subscription-results

--- a/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
@@ -57,6 +57,7 @@ stream_loader:
       header_value: c
   commit_log_topic: snuba-generic-metrics-counters-commit-log
   subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-counters
   subscription_result_topic: generic-metrics-subscription-results
   # We noticed that the Snuba generic metrics consumers are unable to

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -57,6 +57,7 @@ stream_loader:
       header_value: d
   commit_log_topic: snuba-generic-metrics-distributions-commit-log
   subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-distributions
   subscription_result_topic: generic-metrics-subscription-results
   # We noticed that the Snuba generic metrics consumers are unable to

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -57,6 +57,7 @@ stream_loader:
       header_value: s
   commit_log_topic: snuba-generic-metrics-sets-commit-log
   subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-sets
   subscription_result_topic: generic-metrics-subscription-results
   # We noticed that the Snuba generic metrics consumers are unable to

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -36,13 +36,20 @@ STREAM_LOADER_SCHEMA = {
             "type": ["string", "null"],
             "description": "Name of the subscription scheduled Kafka topic",
         },
+        "subscription_result_topic": {
+            "type": ["string", "null"],
+            "description": "Name of the subscription result Kafka topic",
+        },
         "subscription_scheduler_mode": {
             "type": ["string", "null"],
             "description": "The subscription scheduler mode used (e.g. partition or global). This must be specified if subscriptions are supported for this storage",
         },
-        "subscription_result_topic": {
-            "type": ["string", "null"],
-            "description": "Name of the subscription result Kafka topic",
+        "subscription_synchronization_timestamp": {
+            "anyOf": [
+                {"type": "string", "enum": ["orig_message_ts", "received_p99"]},
+                {"type": "null"},
+            ],
+            "description": "Field to be used for timestamp synchronization by the scheduler",
         },
         "replacement_topic": {
             "type": ["string", "null"],

--- a/snuba/datasets/configuration/metrics/storages/raw.yaml
+++ b/snuba/datasets/configuration/metrics/storages/raw.yaml
@@ -48,6 +48,7 @@ stream_loader:
   default_topic: snuba-metrics
   commit_log_topic: snuba-metrics-commit-log
   subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-metrics
   subscription_result_topic: metrics-subscription-results
   dlq_topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/sessions/storages/raw.yaml
+++ b/snuba/datasets/configuration/sessions/storages/raw.yaml
@@ -39,4 +39,5 @@ stream_loader:
   commit_log_topic: snuba-sessions-commit-log
   subscription_result_topic: sessions-subscription-results
   subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-sessions

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -181,6 +181,20 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
     )
     subscription_result_topic = __get_topic(loader_config, "subscription_result_topic")
 
+    subscription_synchronization_timestamp = loader_config.get(
+        "subscription_synchronization_timestamp"
+    )
+
+    subscription_values = [
+        bool(subscription_scheduled_topic),
+        bool(subscription_scheduler_mode),
+        bool(subscription_result_topic),
+        bool(subscription_synchronization_timestamp),
+    ]
+    assert all(subscription_values) or not any(
+        subscription_values
+    ), "provide all subscription config or none"
+
     dlq_topic = __get_topic(loader_config, "dlq_topic")
 
     return build_kafka_stream_loader_from_settings(
@@ -192,6 +206,7 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
         subscription_scheduler_mode,
         subscription_scheduled_topic,
         subscription_result_topic,
+        subscription_synchronization_timestamp,
         dlq_topic,
     )
 

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -259,5 +259,6 @@ stream_loader:
   default_topic: transactions
   commit_log_topic: snuba-transactions-commit-log
   subscription_scheduler_mode: global
+  subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-transactions
   subscription_result_topic: transactions-subscription-results

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -87,6 +87,7 @@ class KafkaStreamLoader:
         replacement_topic_spec: Optional[KafkaTopicSpec] = None,
         commit_log_topic_spec: Optional[KafkaTopicSpec] = None,
         subscription_scheduler_mode: Optional[SchedulingWatermarkMode] = None,
+        subscription_synchronization_timestamp: Optional[str] = None,
         subscription_scheduled_topic_spec: Optional[KafkaTopicSpec] = None,
         subscription_result_topic_spec: Optional[KafkaTopicSpec] = None,
         dlq_topic_spec: Optional[KafkaTopicSpec] = None,
@@ -148,6 +149,7 @@ def build_kafka_stream_loader_from_settings(
     subscription_scheduler_mode: Optional[SchedulingWatermarkMode] = None,
     subscription_scheduled_topic: Optional[Topic] = None,
     subscription_result_topic: Optional[Topic] = None,
+    subscription_synchronization_timestamp: Optional[str] = None,
     dlq_topic: Optional[Topic] = None,
 ) -> KafkaStreamLoader:
     default_topic_spec = KafkaTopicSpec(default_topic)
@@ -189,6 +191,7 @@ def build_kafka_stream_loader_from_settings(
         replacement_topic_spec,
         commit_log_topic_spec,
         subscription_scheduler_mode=subscription_scheduler_mode,
+        subscription_synchronization_timestamp=subscription_synchronization_timestamp,
         subscription_scheduled_topic_spec=subscription_scheduled_topic_spec,
         subscription_result_topic_spec=subscription_result_topic_spec,
         dlq_topic_spec=dlq_topic_spec,

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -24,6 +24,7 @@ def test_build_stream_loader() -> None:
             },
             "commit_log_topic": "snuba-generic-metrics-sets-commit-log",
             "subscription_scheduler_mode": "global",
+            "subscription_synchronization_timestamp": "orig_message_ts",
             "subscription_scheduled_topic": "scheduled-subscriptions-generic-metrics-sets",
             "subscription_result_topic": "generic-metrics-subscription-results",
             "dlq_topic": "snuba-dead-letter-generic-metrics",


### PR DESCRIPTION
Eventually each storage can define which timestamp will be used for scheduling. This is a non functional change that adds the `subscription_synchronization_timestamp` key to the storage configuration, but does not use it yet.
