### PR TITLE
deps: bump to debian 12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,18 @@ updates:
       # sentry-kafka-schemas has its own lints to ensure it is reasonably
       # up-to-date -- we should rely on them
       - dependency-name: "sentry-kafka-schemas"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 0 # security updates only
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+      day: "sunday"
+    open-pull-requests-limit: 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.8.18
 
-FROM python:${PYTHON_VERSION}-slim-bullseye as build_base
+FROM python:${PYTHON_VERSION}-slim-bookworm as build_base
 WORKDIR /usr/src/snuba
 
 ENV PIP_NO_CACHE_DIR=off \


### PR DESCRIPTION
- Bumps the base Docker image from Debian 11 to Debian 12.
- Configures Dependabot to open PRs for Docker image and GitHub Action updates.

Partially addresses #4871 