### PR TITLE
fix: Log step name in run_task_in_threads

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -107,12 +107,12 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
 
     fn submit(&mut self, message: Message<TPayload>) -> Result<(), MessageRejected<TPayload>> {
         if self.message_carried_over.is_some() {
-            log::warn!("carried over message, rejecting subsequent messages");
+            log::warn!("[{}] carried over message, rejecting subsequent messages", self.metric_name);
             return Err(MessageRejected { message });
         }
 
         if self.handles.len() > self.concurrency {
-            log::warn!("Reached max concurrency, rejecting message");
+            log::warn!("[{}] Reached max concurrency, rejecting message", self.metric_name);
             return Err(MessageRejected { message });
         }
 
@@ -144,7 +144,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
             if let Some(t) = remaining {
                 remaining = Some(t - start.elapsed());
                 if remaining.unwrap() <= Duration::from_secs(0) {
-                    log::warn!("Timeout reached while waiting for tasks to finish");
+                    log::warn!("[{}] Timeout reached while waiting for tasks to finish", self.metric_name);
                     break;
                 }
             }


### PR DESCRIPTION
we have multiple instantiations of run_task_in_threads that we need to
distinguish by, and we already fixed that for metrics. Need to do it for
logs as well
