### PR TITLE
configure dependabot and dependency review

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 10
+    groups:
+      maintine-dependencies:
+        patterns:
+          - "@mantine/*"
+      tiptap-dependencies:
+        patterns:
+          - "@tiptap/*"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: "Dependency Review"
+on:
+  pull_request:
+    branches: ["master"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Dependency Review
+        uses: actions/dependency-review-action@6c5ccdad469c9f8a2996bfecaec55a631a347034 # v3.1.0
+        with:
+          # Possible values: "critical", "high", "moderate", "low"
+          fail-on-severity: high


### PR DESCRIPTION
- Use Dependabot's new grouping feature to update modules together. This will reduce the number of PRs and weird states where versions get mismatched.
- Configure Dependency Review in CI to prevent new dependencies being added that have known high or critical severity vulnerabilities.