### PR TITLE
feat(generic-metrics): Add gauges storage set locally

### DIFF
--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -105,6 +105,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "generic_metrics_counters",
             "spans",
             "group_attributes",
+            "generic_metrics_gauges",
         },
         "single_node": True,
     },

--- a/snuba/settings/settings_distributed.py
+++ b/snuba/settings/settings_distributed.py
@@ -28,6 +28,7 @@ CLUSTERS = [
             "generic_metrics_counters",
             "spans",
             "group_attributes",
+            "generic_metrics_gauges",
         },
         "single_node": False,
         "cluster_name": "cluster_one_sh",

--- a/snuba/settings/settings_test_distributed_migrations.py
+++ b/snuba/settings/settings_test_distributed_migrations.py
@@ -56,6 +56,7 @@ CLUSTERS: Sequence[Mapping[str, Any]] = [
             "generic_metrics_counters",
             "spans",
             "group_attributes",
+            "generic_metrics_gauges",
         },
         "single_node": False,
         "cluster_name": "storage_cluster",


### PR DESCRIPTION
Because the generic metrics migration group is marked with the `COMPLETE` Readiness State, we need to make sure that storage set keys are defined/pointing to the right clusters in _all_ environments before any migrations (https://github.com/getsentry/snuba/pull/4847) can be run. 

This can be merged prior to any clusters being provisioned since this is for local env.