### PR TITLE
lint(generic-metrics): Remove feature flag for gen-metrics counters mat view version

### DIFF
--- a/snuba/datasets/metrics_messages.py
+++ b/snuba/datasets/metrics_messages.py
@@ -1,8 +1,6 @@
 from enum import Enum
 from typing import Any, Iterable, Mapping, MutableMapping
 
-from snuba.state import get_config
-
 
 class InputType(Enum):
     SET = "s"
@@ -135,7 +133,7 @@ def aggregation_options_for_counter_message(
             GRANULARITY_ONE_DAY,
         ],
         "min_retention_days": retention_days,
-        "materialization_version": get_config("gen_metric_counters_mv_ver", 1),
+        "materialization_version": 2,
     }
 
     if aggregation_setting := message.get("aggregation_option"):

--- a/tests/datasets/processors/test_generic_metrics_processor.py
+++ b/tests/datasets/processors/test_generic_metrics_processor.py
@@ -109,7 +109,7 @@ def test__dists_aggregation_options(
             },
             {
                 "min_retention_days": 90,
-                "materialization_version": 1,
+                "materialization_version": 2,
                 "granularities": [1, 2, 3, 0],
             },
             90,


### PR DESCRIPTION
### Overview

Remove the feature flag that determines the materialization version since it is now confirmed to be working