### PR TITLE
feat(cardinality): Cardinalily analysis reporting

### DIFF
--- a/snuba/cli/spans_cardinality_analyzer.py
+++ b/snuba/cli/spans_cardinality_analyzer.py
@@ -1,0 +1,74 @@
+import csv
+from typing import Optional, Sequence
+
+import click
+import structlog
+
+from snuba import settings
+from snuba.admin.notifications.slack.client import SlackClient
+from snuba.clickhouse.span_cardinality_analyzer import (
+    SpanGroupingCardinalityResult,
+    span_grouping_cardinality_query,
+    span_grouping_distinct_modules_query,
+)
+from snuba.clusters.cluster import ClickhouseClientSettings
+from snuba.datasets.storages.factory import get_storage
+from snuba.datasets.storages.storage_key import StorageKey
+from snuba.environment import setup_logging, setup_sentry
+
+logger = structlog.get_logger().bind(module=__name__)
+
+
+def write_cardnaltiy_to_csv(
+    results: Sequence[SpanGroupingCardinalityResult], filename: str
+) -> None:
+    with open(filename, mode="w") as file:
+        writer = csv.writer(file)
+        writer.writerow(["org_id", "project_id", "category", "cardinality"])
+        for row in results:
+            writer.writerow(row)
+
+
+@click.command()
+@click.option("--log-level", help="Logging level to use.")
+def spans_cardinality_analyzer(
+    *,
+    log_level: Optional[str] = None,
+) -> None:
+    """
+    Analyze the cardinality of metrics extracted from spans. Intended to be run as a cron job.
+    """
+    setup_logging(log_level)
+    setup_sentry()
+
+    slack_client = SlackClient(
+        settings.STARFISH_SLACK_CHANNEL_ID, settings.SLACK_API_TOKEN
+    )
+
+    storage_key = StorageKey("generic_metrics_distributions")
+    storage = get_storage(storage_key)
+
+    connection = storage.get_cluster().get_query_connection(
+        ClickhouseClientSettings.CARDINALITY_ANALYZER
+    )
+
+    # Get the distinct span modules we are ingesting.
+    result = connection.execute(
+        span_grouping_distinct_modules_query(time_window_hrs=1),
+    )
+    distinct_span_groups = [row[0] for row in result.results]
+
+    # Get the cardinality of each module and write to CSV file and send to Slack
+    for span_group in distinct_span_groups:
+        logger.info(f"Getting cardinality for span group: {span_group}")
+        result = connection.execute(
+            span_grouping_cardinality_query(span_group, time_window_hrs=24, limit=1000)
+        )
+
+        write_cardnaltiy_to_csv(result.results, f"/tmp/{span_group}.csv")
+        slack_client.post_file(
+            file_name=f"{span_group}.csv",
+            file_path=f"/tmp/{span_group}.csv",
+            file_type="csv",
+            initial_comment=f"Span Grouping Cardinality Report: {span_group}",
+        )

--- a/snuba/clickhouse/span_cardinality_analyzer.py
+++ b/snuba/clickhouse/span_cardinality_analyzer.py
@@ -1,0 +1,100 @@
+from enum import Enum
+from typing import NamedTuple, NewType
+
+# Start index is 9223372036854775808
+METRICS_START_INDEX = 1 << 63
+
+SQL = NewType("SQL", str)
+
+
+class IndexedIDs(Enum):
+    # Tags
+    SPAN_DESCRIPTION_TAG = METRICS_START_INDEX + 249
+    SPAN_CATEGORY_TAG = METRICS_START_INDEX + 254
+    SPAN_GROUP_TAG = METRICS_START_INDEX + 252
+    # Metric names
+    SPAN_DURATION_METRIC = METRICS_START_INDEX + 404
+    SPAN_EXCLUSIVE_TIME_METRIC = METRICS_START_INDEX + 405
+    SPAN_EXCLUSIVE_TIME_LIGHT_METRIC = METRICS_START_INDEX + 406
+
+
+class SpanGroupingCardinalityResult(NamedTuple):
+    org_id: int
+    project_id: int
+    category: str
+    groups: int
+
+
+def span_grouping_distinct_modules_query(time_window_hrs: int) -> SQL:
+    """
+    Form the clickhouse query to get the distinct span modules we are ingesting.
+    The result of this query can be used to get the cardinality of individual modules.
+    """
+    if time_window_hrs > 2:
+        raise ValueError("Time window cannot be greater than 2 hours")
+
+    query = f"""
+SELECT DISTINCT
+tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG.value})] AS `span.category`
+FROM generic_metric_distributions_aggregated_dist
+WHERE granularity = 2
+AND timestamp >= now() - INTERVAL {time_window_hrs} HOUR
+AND metric_id IN [{IndexedIDs.SPAN_DURATION_METRIC.value}, {IndexedIDs.SPAN_EXCLUSIVE_TIME_METRIC.value}]
+"""
+    return SQL(query)
+
+
+def span_grouping_cardinality_query(
+    span_category: str, time_window_hrs: int, limit: int
+) -> SQL:
+    """
+    Form the clickhouse query to analyze the cardinality of metrics extracted from spans.
+    The result of this query informs how high the cardinality of a given span module is.
+    """
+    if time_window_hrs > 24:
+        raise ValueError("Time window cannot be greater than 24 hours")
+
+    if limit > 1000:
+        raise ValueError("Limit cannot be greater than 1000")
+
+    query = f"""
+SELECT org_id, project_id,
+tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG.value})] AS `span.category`,
+uniq(tags.raw_value [indexOf(tags.key, {IndexedIDs.SPAN_GROUP_TAG.value})]) AS count_groups
+FROM generic_metric_distributions_aggregated_dist
+WHERE (granularity = 2)
+AND (timestamp >= now() - INTERVAL {time_window_hrs} HOUR)
+AND (metric_id IN [{IndexedIDs.SPAN_DURATION_METRIC.value},
+{IndexedIDs.SPAN_EXCLUSIVE_TIME_METRIC.value}])
+AND `span.category` = '{span_category}'
+GROUP BY org_id, project_id, `span.category`
+ORDER BY count_groups DESC
+LIMIT {limit}
+"""
+    return SQL(query)
+
+
+def span_samples_for_group_query(
+    span_group: SpanGroupingCardinalityResult, time_window_hrs: int, limit: int
+) -> SQL:
+    """
+    Form the query to get the sample of spans for a given span group.
+    """
+    if limit > 2000:
+        raise ValueError("Limit cannot be greater than 2000")
+
+    query = f"""
+SELECT DISTINCT
+tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_CATEGORY_TAG.value})] AS `span.op`,
+tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_GROUP_TAG.value})] AS `span.group`,
+tags.raw_value[indexOf(tags.key, {IndexedIDs.SPAN_DESCRIPTION_TAG.value})] AS `span.description`
+FROM generic_metric_distributions_aggregated_dist
+WHERE (granularity = 2)
+AND (timestamp >= now() - INTERVAL {time_window_hrs} HOUR)
+AND (org_id = {span_group.org_id})
+AND (project_id = {span_group.project_id})
+AND (metric_id = {IndexedIDs.SPAN_EXCLUSIVE_TIME_LIGHT_METRIC.value})
+ORDER BY `span.description`
+LIMIT {limit}
+"""
+    return SQL(query)

--- a/snuba/clusters/cluster.py
+++ b/snuba/clusters/cluster.py
@@ -86,6 +86,8 @@ class ClickhouseClientSettings(Enum):
             # Allow more threads for faster processing since cardinality queries
             # need more resources.
             "max_threads": 10,
+            # Don't use up production cache for cardinality analyzer queries.
+            "use_uncompressed_cache": 0,
         },
         None,
     )

--- a/snuba/settings/__init__.py
+++ b/snuba/settings/__init__.py
@@ -190,6 +190,7 @@ SENTRY_TRACE_SAMPLE_RATE = 0
 # Snuba Admin Options
 SLACK_API_TOKEN = os.environ.get("SLACK_API_TOKEN")
 SNUBA_SLACK_CHANNEL_ID = os.environ.get("SNUBA_SLACK_CHANNEL_ID")
+STARFISH_SLACK_CHANNEL_ID = os.environ.get("STARFISH_SLACK_CHANNEL_ID")
 
 # Snuba Options
 


### PR DESCRIPTION
As we introduce more modules for metrics extraction from spans there is a bigger need to keep track of how cardinality evolves for different modules. This PR adds the queries which are used to perform cardinality analysis as a snuba cli command. The intention is for the snuba cli command to run as a cron job. The cron job would run the desired queries, dump the results in a CSV file locally and then send the file to a slack channel.

### Testing
Tested locally with some fake data and verified that the files get sent to slack

<img width="1397" alt="Screenshot 2023-10-18 at 3 40 53 PM" src="https://github.com/getsentry/snuba/assets/84807402/ef121281-bd75-4816-ac98-170a6a59f5d9">
