### PR TITLE
feat(rust): Invalid message has partition and offset properties

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -14,7 +14,10 @@ pub struct MessageRejected<T> {
 }
 
 #[derive(Debug, Clone)]
-pub struct InvalidMessage;
+pub struct InvalidMessage {
+    pub partition: Partition,
+    pub offset: u64,
+}
 
 /// Signals that we need to commit offsets
 #[derive(Debug, Clone, PartialEq)]

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -26,7 +26,7 @@ use crate::metrics::statsd::StatsDBackend;
 use crate::processors;
 use crate::strategies::clickhouse::ClickhouseWriterStep;
 use crate::strategies::python::PythonTransformStep;
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
 
 #[pyfunction]
 pub fn consumer(
@@ -101,8 +101,7 @@ pub fn consumer_impl(
                         func: fn(
                             KafkaPayload,
                             KafkaMessageMetadata,
-                        )
-                            -> Result<BytesInsertBatch, InvalidMessage>,
+                        ) -> Result<BytesInsertBatch, BadMessage>,
                     }
 
                     impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
@@ -133,7 +132,10 @@ pub fn consumer_impl(
                                             timestamp: broker_message.timestamp,
                                         }),
                                     }),
-                                    Err(e) => Err(e),
+                                    Err(_e) => Err(InvalidMessage {
+                                        partition: broker_message.partition,
+                                        offset: broker_message.offset,
+                                    }),
                                 }
                             })
                         }

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -3,12 +3,11 @@ mod profiles;
 mod querylog;
 mod spans;
 
-use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
-use rust_arroyo::processing::strategies::InvalidMessage;
 
 type ProcessingFunction =
-    fn(KafkaPayload, KafkaMessageMetadata) -> Result<BytesInsertBatch, InvalidMessage>;
+    fn(KafkaPayload, KafkaMessageMetadata) -> Result<BytesInsertBatch, BadMessage>;
 
 pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -7,6 +7,9 @@ pub struct BytesInsertBatch {
 }
 
 #[derive(Clone, Debug)]
+pub struct BadMessage;
+
+#[derive(Clone, Debug)]
 pub struct KafkaMessageMetadata {
     pub partition: u16,
     pub offset: u64,


### PR DESCRIPTION
This is needed so we can DLQ these messages later - this matches how InvalidMessage works in Python Arroyo
