### PR TITLE
fix(migrations): Fix handling distributed clusters with - in their names

### DIFF
--- a/snuba/migrations/table_engines.py
+++ b/snuba/migrations/table_engines.py
@@ -164,7 +164,7 @@ class Distributed(TableEngine):
             f", {self.__sharding_key}" if self.__sharding_key else ""
         )
 
-        return f"Distributed({cluster_name}, {database_name}, {self.__local_table_name}{optional_sharding_key})"
+        return f"Distributed(`{cluster_name}`, {database_name}, {self.__local_table_name}{optional_sharding_key})"
 
 
 class Merge(TableEngine):

--- a/tests/migrations/test_table_engines.py
+++ b/tests/migrations/test_table_engines.py
@@ -97,7 +97,7 @@ dist_test_cases = [
         table_engines.Distributed(
             local_table_name="test_table_local", sharding_key="event_id"
         ),
-        "Distributed(cluster_1, default, test_table_local, event_id)",
+        "Distributed(`cluster_1`, default, test_table_local, event_id)",
         id="Disributed",
     )
 ]


### PR DESCRIPTION
Clusters with `-` & numbers in their names fail as Clickhouse thinks it's an arithmetic operation.  Surrounding the cluster name in back ticks should fix this.