### PR TITLE
feat(oncall): add error handling for corrupted payloads

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -418,6 +418,47 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
         assert False, "unexpected fallthrough"
 
 
+def _sanitize_payload(payload: Dict[str, Any], res: Dict[str, Any]) -> None:
+    def hex_encode_if_bytes(value: Any) -> Any:
+        if isinstance(value, bytes):
+            try:
+                return value.decode("utf-8")
+            except UnicodeDecodeError:
+                # encode the byte string in a hex string
+                return "RAW_BYTE_STRING__" + value.hex()
+
+        return value
+
+    for k, v in payload.items():
+        if isinstance(v, dict):
+            res[hex_encode_if_bytes(k)] = {}
+            _sanitize_payload(v, res[hex_encode_if_bytes(k)])
+        elif isinstance(v, list):
+            res[hex_encode_if_bytes(k)] = []
+            for item in v:
+                if isinstance(item, dict):
+                    res[hex_encode_if_bytes(k)].append({})
+                    _sanitize_payload(item, res[hex_encode_if_bytes(k)][-1])
+                else:
+                    res[hex_encode_if_bytes(k)].append(hex_encode_if_bytes(item))
+        else:
+            res[hex_encode_if_bytes(k)] = hex_encode_if_bytes(v)
+
+
+def dump_payload(payload: Dict[str, Any]) -> str:
+    try:
+        return json.dumps(payload, default=str)
+    except UnicodeDecodeError:
+        # If there were any string that could not be decoded, we
+        # encode the problematic bytes in a hex string.
+        # this is to prevent other clients downstream of us from having
+        # to deal with potentially malicious strings and to prevent one
+        # bad string from breaking the entire payload.
+        sanitized_payload = {}
+        _sanitize_payload(payload, sanitized_payload)
+        return json.dumps(sanitized_payload, default=str)
+
+
 @with_span()
 def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Response:
     assert http_request.method == "POST"
@@ -503,9 +544,7 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
     if settings.STATS_IN_RESPONSE or request.query_settings.get_debug():
         payload.update(result.extra)
 
-    return Response(
-        json.dumps(payload, default=str), 200, {"Content-Type": "application/json"}
-    )
+    return Response(dump_payload(payload), 200, {"Content-Type": "application/json"})
 
 
 @application.errorhandler(InvalidSubscriptionError)

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -425,7 +425,7 @@ def _sanitize_payload(payload: Dict[str, Any], res: Dict[str, Any]) -> None:
                 return value.decode("utf-8")
             except UnicodeDecodeError:
                 # encode the byte string in a hex string
-                return "RAW_BYTE_STRING__" + value.hex()
+                return "RAW_BYTESTRING__" + value.hex()
 
         return value
 

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -418,7 +418,9 @@ def snql_dataset_query_view(*, dataset: Dataset, timer: Timer) -> Union[Response
         assert False, "unexpected fallthrough"
 
 
-def _sanitize_payload(payload: Dict[str, Any], res: Dict[str, Any]) -> None:
+def _sanitize_payload(
+    payload: MutableMapping[str, Any], res: MutableMapping[str, Any]
+) -> None:
     def hex_encode_if_bytes(value: Any) -> Any:
         if isinstance(value, bytes):
             try:
@@ -445,7 +447,7 @@ def _sanitize_payload(payload: Dict[str, Any], res: Dict[str, Any]) -> None:
             res[hex_encode_if_bytes(k)] = hex_encode_if_bytes(v)
 
 
-def dump_payload(payload: Dict[str, Any]) -> str:
+def dump_payload(payload: MutableMapping[str, Any]) -> str:
     try:
         return json.dumps(payload, default=str)
     except UnicodeDecodeError:
@@ -454,7 +456,7 @@ def dump_payload(payload: Dict[str, Any]) -> str:
         # this is to prevent other clients downstream of us from having
         # to deal with potentially malicious strings and to prevent one
         # bad string from breaking the entire payload.
-        sanitized_payload = {}
+        sanitized_payload: MutableMapping[str, Any] = {}
         _sanitize_payload(payload, sanitized_payload)
         return json.dumps(sanitized_payload, default=str)
 

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -59,7 +59,7 @@ def test_response_dumping() -> None:
     dumped_payload = dump_payload(data)
 
     clean_data = copy.deepcopy(data)
-    clean_data["data"][3]["release"] = "RAW_BYTESTRING__" + b"x;\x83\xc0\x05".hex()
+    clean_data["data"][3]["release"] = "RAW_BYTESTRING__" + b"x;\x83\xc0\x05".hex()  # type: ignore
     assert json.loads(dumped_payload) == clean_data
 
 

--- a/tests/web/test_views.py
+++ b/tests/web/test_views.py
@@ -59,7 +59,7 @@ def test_response_dumping() -> None:
     dumped_payload = dump_payload(data)
 
     clean_data = copy.deepcopy(data)
-    clean_data["data"][3]["release"] = b"x;\x83\xc0\x05".hex()
+    clean_data["data"][3]["release"] = "RAW_BYTESTRING__" + b"x;\x83\xc0\x05".hex()
     assert json.loads(dumped_payload) == clean_data
 
 


### PR DESCRIPTION
A single tenant customer has some garbage data in their releases that causes the response to crash

if this happens we go through the payload and hex-encode the non-string byte values