### PR TITLE
CI unblock: revert sharding, don't run full sentry test suite

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,7 +1,3 @@
 # Based off https://github.com/getsentry/sentry/blob/master/.github/file-filters.yml
 
-api_changes:
-  - "snuba/datasets/configuration/**/*.yaml"
-  - "snuba/web/*.py"
-  - "snuba/query/**/*.py"
-  - "snuba/snuba_migrations/**/*"
+api_changes: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,11 +292,12 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        instance: [0, 1, 3, 4, 5, 6, 7]
+        instance: [0, 1]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.
-      MATRIX_INSTANCE_TOTAL: 8
+      MATRIX_INSTANCE_TOTAL: 2
+
     steps:
       # Checkout codebase
       - name: Checkout snuba

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        instance: [0, 1, 2, 3, 4, 5, 6, 7]
+        instance: [0, 1, 3, 4, 5, 6, 7]
     env:
       MIGRATIONS_TEST_MIGRATE: 1
       # XXX: `MATRIX_INSTANCE_TOTAL` must be hardcoded to the length of `strategy.matrix.instance`.

--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -40,13 +40,7 @@ pipelines:
                                     "Tests and code coverage (test_distributed_migrations)" \
                                     "Dataset Config Validation" \
                                     "sentry (0)" \
-                                    "sentry (1)" \
-                                    "sentry (2)" \
-                                    "sentry (3)" \
-                                    "sentry (4)" \
-                                    "sentry (5)" \
-                                    "sentry (6)" \
-                                    "sentry (7)"
+                                    "sentry (1)"
                               - script: |
                                     /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
                                     ${GO_REVISION_SNUBA_REPO} \


### PR DESCRIPTION
Currently the sentry test suite is taking too long and blocking deployments. This PR unblocks the CI pipeline for the weekend in case of emergency. This should not be a permanent state