### PR TITLE
feat: Max poll interval ms default to 30 seconds

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -149,6 +149,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--max-poll-interval-ms",
     type=int,
+    default=30000,
 )
 @click.option(
     "--health-check-file",
@@ -194,7 +195,7 @@ def consumer(
     enforce_schema: bool = False,
     log_level: Optional[str] = None,
     profile_path: Optional[str] = None,
-    max_poll_interval_ms: Optional[int] = None,
+    max_poll_interval_ms: int = 30000,
     health_check_file: Optional[str] = None,
     group_instance_id: Optional[str] = None,
     skip_write: bool

--- a/snuba/consumers/consumer_builder.py
+++ b/snuba/consumers/consumer_builder.py
@@ -173,6 +173,11 @@ class ConsumerBuilder:
 
         if self.max_poll_interval_ms is not None:
             configuration["max.poll.interval.ms"] = self.max_poll_interval_ms
+            # HACK: If the max poll interval is less than 45 seconds, set the session timeout
+            # to the same. (it's default is 45 seconds and it must be <= to max.poll.interval.ms)
+            if self.max_poll_interval_ms < 45000:
+                configuration["session.timeout.ms"] = self.max_poll_interval_ms
+
         if self.group_instance_id is not None:
             configuration["group.instance.id"] = self.group_instance_id
 


### PR DESCRIPTION
This is the same default we apply to all consumers in Sentry
