### PR TITLE
feat(scheduler): Scheduler can switch between different timestamps

### DIFF
--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -103,6 +103,9 @@ class KafkaStreamLoader:
         self.__replacement_topic_spec = replacement_topic_spec
         self.__commit_log_topic_spec = commit_log_topic_spec
         self.__subscription_scheduler_mode = subscription_scheduler_mode
+        self.__subscription_synchronization_timestamp = (
+            subscription_synchronization_timestamp
+        )
         self.__subscription_scheduled_topic_spec = subscription_scheduled_topic_spec
         self.__subscription_result_topic_spec = subscription_result_topic_spec
         self.__pre_filter = pre_filter
@@ -129,6 +132,9 @@ class KafkaStreamLoader:
 
     def get_subscription_scheduler_mode(self) -> Optional[SchedulingWatermarkMode]:
         return self.__subscription_scheduler_mode
+
+    def get_subscription_sychronization_timestamp(self) -> Optional[str]:
+        return self.__subscription_synchronization_timestamp
 
     def get_subscription_scheduled_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__subscription_scheduled_topic_spec

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -41,7 +41,7 @@ class MessageDetails(NamedTuple):
     orig_message_ts: float
     # The timestamp the message was first received by Sentry (Relay)
     # It is optional since it is not currently present on all topics
-    received_ts: Optional[float]
+    received_p99: Optional[float]
 
 
 class CommitLogTickConsumer(Consumer[Tick]):
@@ -98,12 +98,15 @@ class CommitLogTickConsumer(Consumer[Tick]):
         consumer: Consumer[KafkaPayload],
         followed_consumer_group: str,
         metrics: MetricsBackend,
+        synchronization_timestamp: str,
         time_shift: Optional[timedelta] = None,
     ) -> None:
         self.__consumer = consumer
         self.__followed_consumer_group = followed_consumer_group
         self.__previous_messages: MutableMapping[Partition, MessageDetails] = {}
         self.__metrics = metrics
+        assert synchronization_timestamp in ("orig_message_ts", "received_p99")
+        self.__synchronization_timestamp = synchronization_timestamp
         self.__time_shift = time_shift.total_seconds() if time_shift is not None else 0
 
     def subscribe(
@@ -132,7 +135,6 @@ class CommitLogTickConsumer(Consumer[Tick]):
 
         try:
             commit = commit_codec.decode(value.payload)
-            assert commit.orig_message_ts is not None
         except Exception:
             logger.error(
                 f"Error decoding commit log message for followed group: {self.__followed_consumer_group}.",
@@ -150,7 +152,8 @@ class CommitLogTickConsumer(Consumer[Tick]):
         if previous_message is not None:
             try:
                 time_interval = Interval(
-                    previous_message.orig_message_ts, commit.orig_message_ts
+                    getattr(previous_message, self.__synchronization_timestamp),
+                    getattr(commit.orig_message_ts, self.__synchronization_timestamp),
                 )
                 offset_interval = Interval(previous_message.offset, commit.offset)
             except InvalidRangeError:
@@ -172,7 +175,7 @@ class CommitLogTickConsumer(Consumer[Tick]):
             result = None
 
         self.__previous_messages[commit.partition] = MessageDetails(
-            commit.offset, commit.orig_message_ts, None
+            commit.offset, commit.orig_message_ts, commit.received_p99
         )
 
         return result
@@ -245,8 +248,13 @@ class SchedulerBuilder:
 
         mode = stream_loader.get_subscription_scheduler_mode()
         assert mode is not None
-
         self.__mode = mode
+
+        synchronization_timestamp = (
+            stream_loader.get_subscription_sychronization_timestamp()
+        )
+        assert synchronization_timestamp is not None
+        self.__synchronization_timestamp = synchronization_timestamp
 
         self.__partitions = stream_loader.get_default_topic_spec().partitions_number
 
@@ -301,6 +309,7 @@ class SchedulerBuilder:
             KafkaConsumer(consumer_configuration),
             followed_consumer_group=self.__followed_consumer_group,
             metrics=self.__metrics,
+            synchronization_timestamp=self.__synchronization_timestamp,
             time_shift=(
                 timedelta(seconds=self.__delay_seconds * -1)
                 if self.__delay_seconds is not None

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -153,7 +153,7 @@ class CommitLogTickConsumer(Consumer[Tick]):
             try:
                 time_interval = Interval(
                     getattr(previous_message, self.__synchronization_timestamp),
-                    getattr(commit.orig_message_ts, self.__synchronization_timestamp),
+                    getattr(commit, self.__synchronization_timestamp),
                 )
                 offset_interval = Interval(previous_message.offset, commit.offset)
             except InvalidRangeError:

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -192,6 +192,7 @@ def test_tick_consumer(time_shift: Optional[timedelta]) -> None:
         inner_consumer,
         followed_consumer_group,
         TestingMetricsBackend(),
+        "orig_message_ts",
         time_shift=time_shift,
     )
 
@@ -311,7 +312,10 @@ def test_tick_consumer_non_monotonic() -> None:
     inner_consumer = broker.get_consumer("group")
 
     consumer = CommitLogTickConsumer(
-        inner_consumer, followed_consumer_group, TestingMetricsBackend()
+        inner_consumer,
+        followed_consumer_group,
+        TestingMetricsBackend(),
+        "orig_message_ts",
     )
 
     def _assignment_callback(offsets: Mapping[Partition, int]) -> None:
@@ -404,7 +408,10 @@ def test_invalid_commit_log_message(caplog: Any) -> None:
     inner_consumer = broker.get_consumer("group")
 
     consumer = CommitLogTickConsumer(
-        inner_consumer, followed_consumer_group, TestingMetricsBackend()
+        inner_consumer,
+        followed_consumer_group,
+        TestingMetricsBackend(),
+        "orig_message_ts",
     )
 
     now = datetime.now()


### PR DESCRIPTION
Scheduler can switch between using orig_message_ts and received_p99 for scheduling. Note this does not change anything functionally yet, as everything is still configured to orig_message_ts.