### PR TITLE
ref(subscriptions): Move --delay-seconds from CLI arg to yaml definition

### DIFF
--- a/snuba/cli/subscriptions_scheduler.py
+++ b/snuba/cli/subscriptions_scheduler.py
@@ -157,10 +157,8 @@ def subscriptions_scheduler(
         storage is not None
     ), f"Entity {entity_name} does not have a writable storage by default."
 
-    if stale_threshold_seconds is not None and delay_seconds is not None:
-        assert (
-            stale_threshold_seconds > delay_seconds
-        ), "stale_threshold_seconds must be greater than delay_seconds"
+    if stale_threshold_seconds is not None:
+        assert stale_threshold_seconds > 120, "stale_threshold_seconds must be 120"
 
     stream_loader = storage.get_table_writer().get_stream_loader()
 
@@ -185,7 +183,6 @@ def subscriptions_scheduler(
         auto_offset_reset,
         not no_strict_offset_reset,
         schedule_ttl,
-        delay_seconds,
         stale_threshold_seconds,
         metrics,
         slice_id,

--- a/snuba/cli/subscriptions_scheduler_executor.py
+++ b/snuba/cli/subscriptions_scheduler_executor.py
@@ -65,7 +65,9 @@ from snuba.utils.streams.metrics_adapter import StreamMetricsAdapter
     help="Forces the kafka consumer auto offset reset.",
 )
 @click.option("--schedule-ttl", type=int, default=60 * 5)
-@click.option("--delay-seconds", type=int)
+@click.option(
+    "--delay-seconds", type=int, help="Deprecated. Will be removed in a follow up"
+)
 @click.option(
     "--stale-threshold-seconds",
     type=int,
@@ -139,7 +141,6 @@ def subscriptions_scheduler_executor(
         auto_offset_reset,
         not no_strict_offset_reset,
         schedule_ttl,
-        delay_seconds,
         stale_threshold_seconds,
         total_concurrent_queries,
         metrics,

--- a/snuba/datasets/configuration/events/storages/errors.yaml
+++ b/snuba/datasets/configuration/events/storages/errors.yaml
@@ -371,3 +371,4 @@ stream_loader:
   subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-events
   subscription_result_topic: events-subscription-results
+  subscription_delay_seconds: 60

--- a/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/counters_bucket.yaml
@@ -60,6 +60,7 @@ stream_loader:
   subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-counters
   subscription_result_topic: generic-metrics-subscription-results
+  subscription_delay_seconds: 60
   # We noticed that the Snuba generic metrics consumers are unable to
   # shut down successfully with a DLQ policy, when we remove the policy
   # the issue is fixed. We also reproduced it on the errors consumer

--- a/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/distributions_bucket.yaml
@@ -60,6 +60,7 @@ stream_loader:
   subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-distributions
   subscription_result_topic: generic-metrics-subscription-results
+  subscription_delay_seconds: 60
   # We noticed that the Snuba generic metrics consumers are unable to
   # shut down successfully with a DLQ policy, when we remove the policy
   # the issue is fixed. We also reproduced it on the errors consumer

--- a/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/sets_bucket.yaml
@@ -60,6 +60,8 @@ stream_loader:
   subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-generic-metrics-sets
   subscription_result_topic: generic-metrics-subscription-results
+  subscription_delay_seconds: 60
+
   # We noticed that the Snuba generic metrics consumers are unable to
   # shut down successfully with a DLQ policy, when we remove the policy
   # the issue is fixed. We also reproduced it on the errors consumer

--- a/snuba/datasets/configuration/json_schema.py
+++ b/snuba/datasets/configuration/json_schema.py
@@ -51,6 +51,12 @@ STREAM_LOADER_SCHEMA = {
             ],
             "description": "Field to be used for timestamp synchronization by the scheduler",
         },
+        "subscription_delay_seconds": {
+            "type": ["integer", "null"],
+            "minimum": 0,
+            "maximum": 120,
+            "description": "Additional delay in seconds to be added before scheduling. Amount added depends on the synchronization timestamp used. For orig_message_ts, we typically add 60 seconds to account for ingest time as it is not included.",
+        },
         "replacement_topic": {
             "type": ["string", "null"],
             "description": "Name of the replacements Kafka topic",

--- a/snuba/datasets/configuration/metrics/storages/raw.yaml
+++ b/snuba/datasets/configuration/metrics/storages/raw.yaml
@@ -49,6 +49,7 @@ stream_loader:
   commit_log_topic: snuba-metrics-commit-log
   subscription_scheduler_mode: global
   subscription_synchronization_timestamp: orig_message_ts
+  subscription_delay_seconds: 60
   subscription_scheduled_topic: scheduled-subscriptions-metrics
   subscription_result_topic: metrics-subscription-results
   dlq_topic: snuba-dead-letter-metrics

--- a/snuba/datasets/configuration/sessions/storages/raw.yaml
+++ b/snuba/datasets/configuration/sessions/storages/raw.yaml
@@ -41,3 +41,4 @@ stream_loader:
   subscription_scheduler_mode: global
   subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-sessions
+  subscription_delay_seconds: 60

--- a/snuba/datasets/configuration/storage_builder.py
+++ b/snuba/datasets/configuration/storage_builder.py
@@ -185,15 +185,7 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
         "subscription_synchronization_timestamp"
     )
 
-    subscription_values = [
-        bool(subscription_scheduled_topic),
-        bool(subscription_scheduler_mode),
-        bool(subscription_result_topic),
-        bool(subscription_synchronization_timestamp),
-    ]
-    assert all(subscription_values) or not any(
-        subscription_values
-    ), "provide all subscription config or none"
+    subscription_delay_seconds = loader_config.get("subscription_delay_seconds")
 
     dlq_topic = __get_topic(loader_config, "dlq_topic")
 
@@ -207,6 +199,7 @@ def build_stream_loader(loader_config: dict[str, Any]) -> KafkaStreamLoader:
         subscription_scheduled_topic,
         subscription_result_topic,
         subscription_synchronization_timestamp,
+        subscription_delay_seconds,
         dlq_topic,
     )
 

--- a/snuba/datasets/configuration/transactions/storages/transactions.yaml
+++ b/snuba/datasets/configuration/transactions/storages/transactions.yaml
@@ -262,3 +262,4 @@ stream_loader:
   subscription_synchronization_timestamp: orig_message_ts
   subscription_scheduled_topic: scheduled-subscriptions-transactions
   subscription_result_topic: transactions-subscription-results
+  subscription_delay_seconds: 60

--- a/snuba/datasets/table_storage.py
+++ b/snuba/datasets/table_storage.py
@@ -90,13 +90,19 @@ class KafkaStreamLoader:
         subscription_synchronization_timestamp: Optional[str] = None,
         subscription_scheduled_topic_spec: Optional[KafkaTopicSpec] = None,
         subscription_result_topic_spec: Optional[KafkaTopicSpec] = None,
+        subscription_delay_seconds: Optional[int] = None,
         dlq_topic_spec: Optional[KafkaTopicSpec] = None,
     ) -> None:
-        assert (
-            (subscription_scheduler_mode is None)
-            == (subscription_scheduled_topic_spec is None)
-            == (subscription_result_topic_spec is None)
-        )
+        subscription_values = [
+            bool(subscription_scheduled_topic_spec),
+            bool(subscription_scheduler_mode),
+            bool(subscription_result_topic_spec),
+            bool(subscription_synchronization_timestamp),
+            bool(subscription_delay_seconds),
+        ]
+        assert all(subscription_values) or not any(
+            subscription_values
+        ), "provide all subscription config or none"
 
         self.__processor = processor
         self.__default_topic_spec = default_topic_spec
@@ -105,6 +111,7 @@ class KafkaStreamLoader:
         self.__subscription_scheduler_mode = subscription_scheduler_mode
         self.__subscription_scheduled_topic_spec = subscription_scheduled_topic_spec
         self.__subscription_result_topic_spec = subscription_result_topic_spec
+        self.__subscription_delay_seconds = subscription_delay_seconds
         self.__pre_filter = pre_filter
         self.__dlq_topic_spec = dlq_topic_spec
 
@@ -136,6 +143,9 @@ class KafkaStreamLoader:
     def get_subscription_result_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__subscription_result_topic_spec
 
+    def get_subscription_delay_seconds(self) -> Optional[int]:
+        return self.__subscription_delay_seconds
+
     def get_dlq_topic_spec(self) -> Optional[KafkaTopicSpec]:
         return self.__dlq_topic_spec
 
@@ -150,6 +160,7 @@ def build_kafka_stream_loader_from_settings(
     subscription_scheduled_topic: Optional[Topic] = None,
     subscription_result_topic: Optional[Topic] = None,
     subscription_synchronization_timestamp: Optional[str] = None,
+    subscription_delay_seconds: Optional[int] = None,
     dlq_topic: Optional[Topic] = None,
 ) -> KafkaStreamLoader:
     default_topic_spec = KafkaTopicSpec(default_topic)
@@ -194,6 +205,7 @@ def build_kafka_stream_loader_from_settings(
         subscription_synchronization_timestamp=subscription_synchronization_timestamp,
         subscription_scheduled_topic_spec=subscription_scheduled_topic_spec,
         subscription_result_topic_spec=subscription_result_topic_spec,
+        subscription_delay_seconds=subscription_delay_seconds,
         dlq_topic_spec=dlq_topic_spec,
     )
 

--- a/snuba/subscriptions/combined_scheduler_executor.py
+++ b/snuba/subscriptions/combined_scheduler_executor.py
@@ -73,7 +73,9 @@ def build_scheduler_executor_consumer(
         delay_seconds = stream_loader.get_subscription_delay_seconds()
         assert delay_seconds is not None
 
-        return TopicConfig(partition_count, commit_log_topic_spec, result_topic_spec, delay_seconds)
+        return TopicConfig(
+            partition_count, commit_log_topic_spec, result_topic_spec, delay_seconds
+        )
 
     entity_topic_configurations = [
         get_topic_configuration_for_entity(entity_name) for entity_name in entity_names
@@ -82,7 +84,12 @@ def build_scheduler_executor_consumer(
     for c in entity_topic_configurations[1:]:
         assert c == entity_topic_configuration
 
-    partitions, commit_log_topic, result_topic, delay_seconds = entity_topic_configuration
+    (
+        partitions,
+        commit_log_topic,
+        result_topic,
+        delay_seconds,
+    ) = entity_topic_configuration
 
     tick_consumer = CommitLogTickConsumer(
         KafkaConsumer(

--- a/snuba/subscriptions/scheduler_consumer.py
+++ b/snuba/subscriptions/scheduler_consumer.py
@@ -219,7 +219,6 @@ class SchedulerBuilder:
         auto_offset_reset: str,
         strict_offset_reset: Optional[bool],
         schedule_ttl: int,
-        delay_seconds: Optional[int],
         stale_threshold_seconds: Optional[int],
         metrics: MetricsBackend,
         slice_id: Optional[int] = None,
@@ -257,6 +256,9 @@ class SchedulerBuilder:
         self.__auto_offset_reset = auto_offset_reset
         self.__strict_offset_reset = strict_offset_reset
         self.__schedule_ttl = schedule_ttl
+
+        delay_seconds = stream_loader.get_subscription_delay_seconds()
+        assert delay_seconds is not None
         self.__delay_seconds = delay_seconds
         self.__stale_threshold_seconds = stale_threshold_seconds
         self.__metrics = metrics

--- a/tests/datasets/configuration/test_utils.py
+++ b/tests/datasets/configuration/test_utils.py
@@ -25,6 +25,7 @@ def test_build_stream_loader() -> None:
             "commit_log_topic": "snuba-generic-metrics-sets-commit-log",
             "subscription_scheduler_mode": "global",
             "subscription_synchronization_timestamp": "orig_message_ts",
+            "subscription_delay_seconds": 60,
             "subscription_scheduled_topic": "scheduled-subscriptions-generic-metrics-sets",
             "subscription_result_topic": "generic-metrics-subscription-results",
             "dlq_topic": "snuba-dead-letter-generic-metrics",

--- a/tests/subscriptions/test_scheduler_consumer.py
+++ b/tests/subscriptions/test_scheduler_consumer.py
@@ -91,7 +91,6 @@ def test_scheduler_consumer(tmpdir: LocalPath) -> None:
         False,
         60 * 5,
         None,
-        None,
         metrics_backend,
         health_check_file=(tmpdir / "health.txt").strpath,
     )


### PR DESCRIPTION
The main motivations for this are:
1. The amount of delay depends on the synchronization timestamp used, and this is defined at the storage level in code. For example if "orig_message_ts" is used, a longer delay will be applied than if "received_p99" is used, since received will be set earlier in the pipeline.
2. The same CLI args get applied in all Sentry deployments, and this makes it easier to keep them in sync
3. Rolling out different values per storage via CLI will probably break some of our templates and require too much rework.

There are no functional changes here since we have 60 configured everywhere right now.