### PR TITLE
ref(migrations): raise error if no node found

### DIFF
--- a/snuba/migrations/errors.py
+++ b/snuba/migrations/errors.py
@@ -23,3 +23,7 @@ class InvalidClickhouseVersion(SerializableException):
 
 class InactiveClickhouseReplica(SerializableException):
     pass
+
+
+class NodesNotFound(SerializableException):
+    pass

--- a/snuba/migrations/operations.py
+++ b/snuba/migrations/operations.py
@@ -60,7 +60,6 @@ class SqlOperation(ABC):
 
         if self.target == OperationTarget.LOCAL:
             if not local_nodes:
-                print("MEEPS", local_nodes)
                 raise NodesNotFound(f"No nodes found for {cluster_name}")
             nodes = local_nodes
         elif self.target == OperationTarget.DISTRIBUTED:


### PR DESCRIPTION
Ran into this earlier today where the cluster was misnamed so while there were no errors, the migrations did not actually run on the nodes we wanted, and in fact, updated the migrations table as if we had.

Assuming you've made it to the `execute` step of a migration, I think it's safe to say that if there are no nodes to run the migration on, something is wrong. 

cc @rgibert 