### PR TITLE
clickhouse upgrades: 22.8 fixes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,8 +153,6 @@ def _build_migrations_cache() -> None:
         cluster = storage.get_cluster()
         database = cluster.get_database()
         nodes = [*cluster.get_local_nodes(), *cluster.get_distributed_nodes()]
-        mv_tables = []
-        non_mv_tables = []
         for node in nodes:
             if (cluster, node) not in MIGRATIONS_CACHE:
                 connection = cluster.get_node_connection(
@@ -163,6 +161,8 @@ def _build_migrations_cache() -> None:
                 rows = connection.execute(
                     f"SELECT name, create_table_query FROM system.tables WHERE database='{database}'"
                 )
+                mv_tables = []
+                non_mv_tables = []
                 for table_name, create_table_query in rows.results:
                     if "MATERIALIZED VIEW" in create_table_query:
                         mv_tables.append((table_name, create_table_query))

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1070,11 +1070,8 @@ class TestSnQLApi(BaseApiTest):
     #         ),
     #     )
 
-    #     print("response.sata", response.data)
-
     #     assert b"DB::Exception: Type mismatch" in response.data
     #     assert response.status_code == 400
-    #     assert False
 
     def test_clickhouse_illegal_type_error(self) -> None:
         response = self.post(

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1049,29 +1049,28 @@ class TestSnQLApi(BaseApiTest):
 
         assert response.status_code == 200
 
-    # def test_clickhouse_type_mismatch_error(self) -> None:
-    #     """Test that snql queries that cause Clickhosue type errors have a 400 status code."""
-    #     response = self.post(
-    #         "/discover/snql",
-    #         data=json.dumps(
-    #             {
-    #                 "query": f"""MATCH (discover_events)
-    #                 SELECT count()
-    #                 WHERE type != 'transaction' AND project_id = {self.project_id}
-    #                 AND timestamp >= toDateTime('{self.base_time.isoformat()}')
-    #                 AND timestamp < toDateTime('{self.next_time.isoformat()}')
-    #                 AND type IN array(1, 2, 3)
-    #                 LIMIT 1000""",
-    #                 "turbo": False,
-    #                 "consistent": True,
-    #                 "debug": True,
-    #                 "tenant_ids": {"referrer": "r", "organization_id": 123},
-    #             }
-    #         ),
-    #     )
+    def test_clickhouse_type_mismatch_error(self) -> None:
+        """Test that snql queries that cause Clickhosue type errors have a 400 status code."""
+        response = self.post(
+            "/discover/snql",
+            data=json.dumps(
+                {
+                    "query": f"""MATCH (discover_events)
+                    SELECT count()
+                    WHERE type != 'transaction' AND project_id = {self.project_id}
+                    AND timestamp >= toDateTime('{self.base_time.isoformat()}')
+                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
+                    AND project_id IN array('one', 'two')
+                    LIMIT 1000""",
+                    "turbo": False,
+                    "consistent": True,
+                    "debug": True,
+                    "tenant_ids": {"referrer": "r", "organization_id": 123},
+                }
+            ),
+        )
 
-    #     assert b"DB::Exception: Type mismatch" in response.data
-    #     assert response.status_code == 400
+        assert response.status_code == 400
 
     def test_clickhouse_illegal_type_error(self) -> None:
         response = self.post(

--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1049,29 +1049,32 @@ class TestSnQLApi(BaseApiTest):
 
         assert response.status_code == 200
 
-    def test_clickhouse_type_mismatch_error(self) -> None:
-        """Test that snql queries that cause Clickhosue type errors have a 400 status code."""
-        response = self.post(
-            "/discover/snql",
-            data=json.dumps(
-                {
-                    "query": f"""MATCH (discover_events)
-                    SELECT count()
-                    WHERE type != 'transaction' AND project_id = {self.project_id}
-                    AND timestamp >= toDateTime('{self.base_time.isoformat()}')
-                    AND timestamp < toDateTime('{self.next_time.isoformat()}')
-                    AND type IN array(1, 2, 3)
-                    LIMIT 1000""",
-                    "turbo": False,
-                    "consistent": True,
-                    "debug": True,
-                    "tenant_ids": {"referrer": "r", "organization_id": 123},
-                }
-            ),
-        )
+    # def test_clickhouse_type_mismatch_error(self) -> None:
+    #     """Test that snql queries that cause Clickhosue type errors have a 400 status code."""
+    #     response = self.post(
+    #         "/discover/snql",
+    #         data=json.dumps(
+    #             {
+    #                 "query": f"""MATCH (discover_events)
+    #                 SELECT count()
+    #                 WHERE type != 'transaction' AND project_id = {self.project_id}
+    #                 AND timestamp >= toDateTime('{self.base_time.isoformat()}')
+    #                 AND timestamp < toDateTime('{self.next_time.isoformat()}')
+    #                 AND type IN array(1, 2, 3)
+    #                 LIMIT 1000""",
+    #                 "turbo": False,
+    #                 "consistent": True,
+    #                 "debug": True,
+    #                 "tenant_ids": {"referrer": "r", "organization_id": 123},
+    #             }
+    #         ),
+    #     )
 
-        assert b"DB::Exception: Type mismatch" in response.data
-        assert response.status_code == 400
+    #     print("response.sata", response.data)
+
+    #     assert b"DB::Exception: Type mismatch" in response.data
+    #     assert response.status_code == 400
+    #     assert False
 
     def test_clickhouse_illegal_type_error(self) -> None:
         response = self.post(


### PR DESCRIPTION
Ran test locally against 22.8 and I _think_ these two tests were the only troublesome ones?

* `test_clickhouse_type_mismatch_error`
* `test_error_handling` 

But wanted to put up a PR to verify that's the case

For the `test_error_handling` one, the format of the error has seemingly changed from something like:
```
Code: 60, e.displayText() = DB::Exception: Table default.not_existing doesn't exist. (version 19.11.4.24 (official build))
```
to
```
Code: 41. DB::ParsingException: Cannot parse datetime: (while reading the value of key timestamp): While executing ParallelParsingBlockInputFormat: (at row 2). (CANNOT_PARSE_DATETIME) (version 22.8.15.25.altinitystable (altinity build))
```


As for the `test_clickhouse_type_mismatch_error` one... when I put in the following snql from the test we can update the test to still be relevant https://github.com/getsentry/snuba/pull/4926

But the reason it was passing with the previous way it was written was due to

`
ClickHouse allows types to differ in the left and the right parts of IN subquery. In this case it converts the left side value to the type of the right side, as if the [accurateCastOrNull](https://clickhouse.com/docs/en/sql-reference/functions/type-conversion-functions#type_conversion_function-accurate-cast_or_null) function is applied. That means, that the data type becomes [Nullable](https://clickhouse.com/docs/en/sql-reference/data-types/nullable), and if the conversion cannot be performed, it returns [NULL](https://clickhouse.com/docs/en/sql-reference/syntax#null-literal).
`
which is documented in https://clickhouse.com/docs/en/sql-reference/operators/in#select-in-operators
