### PR TITLE
fix: Test failed in specific versions of Clickhouse

### DIFF
--- a/tests/test_snql_api.py
+++ b/tests/test_snql_api.py
@@ -1060,7 +1060,7 @@ class TestSnQLApi(BaseApiTest):
                     WHERE type != 'transaction' AND project_id = {self.project_id}
                     AND timestamp >= toDateTime('{self.base_time.isoformat()}')
                     AND timestamp < toDateTime('{self.next_time.isoformat()}')
-                    AND type IN array(1, 2, 3)
+                    AND project_id IN array('one', 'two')
                     LIMIT 1000""",
                     "turbo": False,
                     "consistent": True,
@@ -1070,7 +1070,6 @@ class TestSnQLApi(BaseApiTest):
             ),
         )
 
-        assert b"DB::Exception: Type mismatch" in response.data
         assert response.status_code == 400
 
     def test_clickhouse_illegal_type_error(self) -> None:


### PR DESCRIPTION
This test was failing in certain versions of Clickhouse because some versions
automatically cast the `type` condition to match types, meaning the test didn't
fail. Use a different column instead and don't try to match the exact error
message (since that changes between versions too).