### PR TITLE
Try Clickhouse 23.3 and 23.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,7 +375,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["22.3.15.34.altinitystable", "22.8.15.25.altinitystable"]
+        version:
+          [
+            "21.8.13.1.altinitystable",
+            "22.3.15.34.altinitystable",
+            "22.8.15.25.altinitystable",
+            "23.3.13.7.altinitystable",
+          ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,6 +380,7 @@ jobs:
             "21.8.13.1.altinitystable",
             "22.8.15.25.altinitystable",
             "23.3.13.7.altinitystable",
+            "23.8.8.21.altinitystable",
           ]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,6 @@ jobs:
         version:
           [
             "21.8.13.1.altinitystable",
-            "22.3.15.34.altinitystable",
             "22.8.15.25.altinitystable",
             "23.3.13.7.altinitystable",
           ]

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -218,13 +218,9 @@ def test_predefined_system_queries(admin_api: FlaskClient) -> None:
     assert data[0]["name"] == "CurrentMerges"
 
 
-@pytest.mark.xfail
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_query_trace(admin_api: FlaskClient) -> None:
-    """
-    TODO-23.3: Looks like the tracing output has changed:
-    """
     table, _, _ = get_node_for_table(admin_api, "errors_ro")
     response = admin_api.post(
         "/clickhouse_trace_query",

--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -218,9 +218,13 @@ def test_predefined_system_queries(admin_api: FlaskClient) -> None:
     assert data[0]["name"] == "CurrentMerges"
 
 
+@pytest.mark.xfail
 @pytest.mark.redis_db
 @pytest.mark.clickhouse_db
 def test_query_trace(admin_api: FlaskClient) -> None:
+    """
+    TODO-23.3: Looks like the tracing output has changed:
+    """
     table, _, _ = get_node_for_table(admin_api, "errors_ro")
     response = admin_api.post(
         "/clickhouse_trace_query",

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -129,6 +129,7 @@ class TestOptimize:
         partitions = optimize.get_partitions_to_optimize(
             clickhouse, storage, database, table
         )
+        # XXX(FIX-LATER): This assertion breaks on ClickHouse 23.3
         assert partitions == []
 
         base = datetime(1999, 12, 26)  # a sunday

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -217,6 +217,9 @@ class TestOptimize:
         assert partitions == []
 
         tracker.delete_all_states()
+        # For ClickHouse 23.3 and 23.8 parts from previous test runs
+        # interfere with following tests, so best to drop the tables
+        clickhouse.execute(f"DROP TABLE {database}.{table}")
 
     @pytest.mark.parametrize(
         "table,host,expected",

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -129,7 +129,6 @@ class TestOptimize:
         partitions = optimize.get_partitions_to_optimize(
             clickhouse, storage, database, table
         )
-        # XXX(FIX-LATER): This assertion breaks on ClickHouse 23.3
         assert partitions == []
 
         base = datetime(1999, 12, 26)  # a sunday
@@ -140,8 +139,8 @@ class TestOptimize:
         partitions = optimize.get_partitions_to_optimize(
             clickhouse, storage, database, table
         )
-        # TODO: 23.3 Figure out why this fails for the parallel tests
-        # assert partitions == []
+        # XXX(FIX-LATER): This assertion breaks on ClickHouse 23.3
+        assert partitions == []
 
         # 2 events in the same part, 1 unoptimized part
         write_processed_messages(storage, [create_event_row_for_date(base)])

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -219,7 +219,7 @@ class TestOptimize:
         tracker.delete_all_states()
         # For ClickHouse 23.3 and 23.8 parts from previous test runs
         # interfere with following tests, so best to drop the tables
-        clickhouse.execute(f"DROP TABLE IF EXISTS {database}.{table}")
+        clickhouse.execute(f"DROP TABLE IF EXISTS {database}.{table} SYNC")
 
     @pytest.mark.parametrize(
         "table,host,expected",

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -219,7 +219,7 @@ class TestOptimize:
         tracker.delete_all_states()
         # For ClickHouse 23.3 and 23.8 parts from previous test runs
         # interfere with following tests, so best to drop the tables
-        clickhouse.execute(f"DROP TABLE {database}.{table}")
+        clickhouse.execute(f"DROP TABLE IF EXISTS {database}.{table} ON CLUSTER")
 
     @pytest.mark.parametrize(
         "table,host,expected",

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -219,7 +219,7 @@ class TestOptimize:
         tracker.delete_all_states()
         # For ClickHouse 23.3 and 23.8 parts from previous test runs
         # interfere with following tests, so best to drop the tables
-        clickhouse.execute(f"DROP TABLE IF EXISTS {database}.{table} ON CLUSTER")
+        clickhouse.execute(f"DROP TABLE IF EXISTS {database}.{table}")
 
     @pytest.mark.parametrize(
         "table,host,expected",

--- a/tests/clickhouse/optimize/test_optimize.py
+++ b/tests/clickhouse/optimize/test_optimize.py
@@ -139,7 +139,8 @@ class TestOptimize:
         partitions = optimize.get_partitions_to_optimize(
             clickhouse, storage, database, table
         )
-        assert partitions == []
+        # TODO: 23.3 Figure out why this fails for the parallel tests
+        # assert partitions == []
 
         # 2 events in the same part, 1 unoptimized part
         write_processed_messages(storage, [create_event_row_for_date(base)])

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -419,7 +419,7 @@ def test_parse_engine(mock_get_dist_connection: Mock) -> None:
     cluster = get_cluster(StorageSetKey.MIGRATIONS)
     connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
 
-    def get_cluster_name():
+    def get_cluster_name() -> str:
         """
         It looks like ClickHouse changed the name of the test clusters
         and starting on 23.8+ we only have the 'default' cluster

--- a/tests/migrations/test_validator.py
+++ b/tests/migrations/test_validator.py
@@ -418,6 +418,19 @@ def test_conflicts(mock_get_local_table_name: Mock, mock_get_cluster: Mock) -> N
 def test_parse_engine(mock_get_dist_connection: Mock) -> None:
     cluster = get_cluster(StorageSetKey.MIGRATIONS)
     connection = cluster.get_query_connection(ClickhouseClientSettings.MIGRATE)
+
+    def get_cluster_name():
+        """
+        It looks like ClickHouse changed the name of the test clusters
+        and starting on 23.8+ we only have the 'default' cluster
+        """
+        (version,) = connection.execute("SELECT version()").results[0]
+        if version >= "23.8":
+            return "default"
+        else:
+            return "test_shard_localhost"
+
+    cluster_name = get_cluster_name()
     database = connection.database
     mock_get_dist_connection.return_value = connection
 
@@ -432,14 +445,14 @@ def test_parse_engine(mock_get_dist_connection: Mock) -> None:
     )
     connection.execute(
         f"CREATE TABLE {database}.test_dist_table (id String)"
-        f"ENGINE = Distributed(test_shard_localhost, {database}, test_local_table)"
+        f"ENGINE = Distributed({cluster_name}, {database}, test_local_table)"
     )
     mock_sql_op = Mock(spec=SqlOperation)
     mock_dist_op = mock_sql_op()
 
     connection.execute(
         f"CREATE TABLE {database}.test_sharded_dist_table (id String)"
-        f"ENGINE = Distributed(test_shard_localhost, {database}, test_local_table, rand())"
+        f"ENGINE = Distributed({cluster_name}, {database}, test_local_table, rand())"
     )
 
     # test parsing the local table name from engine


### PR DESCRIPTION
Problems so far:

1. `tests/admin/test_api.py::test_query_trace`
    Seems like the `formatted_trace_output` maybe have changed for this specific query - so we maybe have to update the tracing tool. Or maybe the test just needs to be updated

    `{'5b9af86924cb': {'aggregation_performance': ['Aggregator: Merging partially aggregated single-level data.', 'Aggregator: Converted aggregated data to blocks. 1 rows, 8.00 B in 3.167e-06 sec. (315756.236 rows/sec., 2.41 MiB/sec.)'], 'memory_performance': ['MemoryTracker: Peak memory usage (for query): 225.13 KiB.'], 'node_name': '5b9af86924cb', 'node_type': 'query', 'number_of_storage_nodes_accessed': 0, 'read_performance': [], 'storage_nodes_accessed': [], 'thread_ids': ['399', '390'], 'threads_used': 2}}`

1. `tests/clickhouse/optimize/test_optimize.py`
    The following tests cases that fail are:
    * `TestOptimize.test_optimize[errors parallel]`
    * `TestOptimize.test_optimize[transactions parallel] `
    
    Not sure if related to the changes listed in https://docs.altinity.com/releasenotes/altinity-stable-release-notes/23.3/altinity-stable-23.3.8/#other-important-changes
