### PR TITLE
fix(migrations): Discover's migrations don't reflect our Prod setup.

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -135,6 +135,7 @@ class DiscoverLoader(DirectoryLoader):
             "0005_discover_fix_transaction_name",
             "0006_discover_add_trace_id",
             "0007_discover_add_span_id",
+            "0008_discover_fix_dist_merge_table",
         ]
 
 

--- a/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
@@ -79,6 +79,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 storage_set=StorageSetKey.DISCOVER,
                 table_name="discover_dist",
                 columns=columns,
+                target=OperationTarget.DISTRIBUTED,
                 engine=table_engines.Distributed(
                     local_table_name="discover_local", sharding_key=None,
                 ),

--- a/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
@@ -2,6 +2,7 @@ from typing import List, Sequence
 
 from snuba.clickhouse.columns import (
     UUID,
+    Array,
     Column,
     DateTime,
     IPv4,
@@ -39,7 +40,7 @@ columns: List[Column[Modifiers]] = [
     Column("http_method", String(Modifiers(low_cardinality=True, nullable=True))),
     Column("http_referer", String(Modifiers(nullable=True))),
     Column("tags", Nested([("key", String()), ("value", String())])),
-    Column("_tags_hash_map", UInt(64)),
+    Column("_tags_hash_map", Array(UInt(64))),
     Column("contexts", Nested([("key", String()), ("value", String())])),
     Column("trace_id", UUID(Modifiers(nullable=True))),
     Column("span_id", UInt(64, Modifiers(nullable=True))),
@@ -81,8 +82,7 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 target=OperationTarget.DISTRIBUTED,
                 engine=table_engines.Distributed(
-                    local_table_name="discover_local",
-                    sharding_key=None,
+                    local_table_name="discover_local", sharding_key=None,
                 ),
             ),
         ]

--- a/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
@@ -82,7 +82,8 @@ class Migration(migration.ClickhouseNodeMigration):
                 columns=columns,
                 target=OperationTarget.DISTRIBUTED,
                 engine=table_engines.Distributed(
-                    local_table_name="discover_local", sharding_key=None,
+                    local_table_name="discover_local",
+                    sharding_key=None,
                 ),
             ),
         ]

--- a/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
+++ b/snuba/snuba_migrations/discover/0008_discover_fix_dist_merge_table.py
@@ -47,16 +47,10 @@ columns: List[Column[Modifiers]] = [
 ]
 
 
-class Migration(migration.ClickhouseNodeMigrationLegacy):
+class Migration(migration.ClickhouseNodeMigration):
     blocking = True
 
-    def forwards_local(self) -> Sequence[operations.SqlOperation]:
-        return []
-
-    def backwards_local(self) -> Sequence[operations.SqlOperation]:
-        return []
-
-    def forwards_dist(self) -> Sequence[operations.SqlOperation]:
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.DISCOVER,
@@ -74,7 +68,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
             ),
         ]
 
-    def backwards_dist(self) -> Sequence[operations.SqlOperation]:
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
         return [
             operations.DropTable(
                 storage_set=StorageSetKey.DISCOVER,
@@ -86,8 +80,7 @@ class Migration(migration.ClickhouseNodeMigrationLegacy):
                 table_name="discover_dist",
                 columns=columns,
                 engine=table_engines.Distributed(
-                    local_table_name="discover_local",
-                    sharding_key=None,
+                    local_table_name="discover_local", sharding_key=None,
                 ),
             ),
         ]


### PR DESCRIPTION
Our current `discover` migrations don't leave Discover in a working state for our Production setup.  Discover is a `Merge` table of our `errors` and `transactions` clusters, the current migrations make `discover_dist` a `Distributed` table for `discover_local` which in turn is trying to be a `Merge` table of `errors_local` and `transactions_local`.  Since we don't have `errors_local` and `transactions_local` in the same cluster as `discover_local`, this leaves a new setup in a state where Discover is pointing to non-existent tables.

This latest (blocking) migration should get new setups to match our existing Production setup, it drops the existing `discover_dist` as a `Distributed` table and replaces it with a `Merge` table pointing to the `errors_dist` and `transactions_dist` tables which are then `Distributed` tables to their respective clusters.
