### PR TITLE
fix: Commit offsets from strategy join

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -21,7 +21,7 @@ fn main() {
         false,
         None,
     );
-    let mut consumer = KafkaConsumer::new(config);
+    let mut consumer = KafkaConsumer::new(config).unwrap();
     let topic = Topic {
         name: "test_static".to_string(),
     };

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -24,7 +24,7 @@ fn main() {
         false,
         None,
     );
-    let consumer = Box::new(KafkaConsumer::new(config));
+    let consumer = KafkaConsumer::new(config).unwrap();
     let topic = Topic {
         name: "test_static".to_string(),
     };

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -73,7 +73,7 @@ async fn main() {
         None,
     );
 
-    let consumer = Box::new(KafkaConsumer::new(config.clone()));
+    let consumer = KafkaConsumer::new(config.clone()).unwrap();
     let mut processor = StreamProcessor::new(
         consumer,
         Box::new(ReverseStringAndProduceStrategyFactory {

--- a/rust_snuba/rust_arroyo/src/backends/local/broker.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/broker.rs
@@ -32,7 +32,7 @@ impl From<TopicDoesNotExist> for BrokerError {
     }
 }
 
-impl<TPayload: Clone> LocalBroker<TPayload> {
+impl<TPayload: Clone + Send> LocalBroker<TPayload> {
     pub fn new(storage: Box<dyn MessageStorage<TPayload>>, clock: Box<dyn Clock>) -> Self {
         Self {
             storage,

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -24,10 +24,10 @@ struct SubscriptionState {
     last_eof_at: HashMap<Partition, u64>,
 }
 
-pub struct LocalConsumer<'a, TPayload: Clone> {
+pub struct LocalConsumer<TPayload: Clone> {
     id: Uuid,
     group: String,
-    broker: &'a mut LocalBroker<TPayload>,
+    broker: LocalBroker<TPayload>,
     pending_callback: VecDeque<Callback>,
     paused: HashSet<Partition>,
     // The offset that a the last ``EndOfPartition`` exception that was
@@ -40,10 +40,10 @@ pub struct LocalConsumer<'a, TPayload: Clone> {
     closed: bool,
 }
 
-impl<'a, TPayload: Clone> LocalConsumer<'a, TPayload> {
+impl<TPayload: Clone> LocalConsumer<TPayload> {
     pub fn new(
         id: Uuid,
-        broker: &'a mut LocalBroker<TPayload>,
+        broker: LocalBroker<TPayload>,
         group: String,
         enable_end_of_partition: bool,
     ) -> Self {
@@ -68,7 +68,7 @@ impl<'a, TPayload: Clone> LocalConsumer<'a, TPayload> {
     }
 }
 
-impl<'a, TPayload: Clone> Consumer<'a, TPayload> for LocalConsumer<'a, TPayload> {
+impl<TPayload: Clone + Send> Consumer<TPayload> for LocalConsumer<TPayload> {
     fn subscribe(
         &mut self,
         topics: &[Topic],
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_consumer_subscription() {
-        let mut broker = build_broker();
+        let broker = build_broker();
 
         let topic1 = Topic {
             name: "test1".to_string(),
@@ -338,7 +338,7 @@ mod tests {
 
         let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(EmptyCallbacks {});
         let mut consumer =
-            LocalConsumer::new(Uuid::nil(), &mut broker, "test_group".to_string(), true);
+            LocalConsumer::new(Uuid::nil(), broker, "test_group".to_string(), true);
         assert!(consumer.subscription_state.topics.is_empty());
 
         let res = consumer.subscribe(&[topic1.clone(), topic2.clone()], my_callbacks);
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_subscription_callback() {
-        let mut broker = build_broker();
+        let broker = build_broker();
 
         let topic1 = Topic {
             name: "test1".to_string(),
@@ -456,7 +456,7 @@ mod tests {
         let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(TheseCallbacks {});
 
         let mut consumer =
-            LocalConsumer::new(Uuid::nil(), &mut broker, "test_group".to_string(), true);
+            LocalConsumer::new(Uuid::nil(), broker, "test_group".to_string(), true);
 
         let _ = consumer.subscribe(&[topic1, topic2], my_callbacks);
         let _ = consumer.poll(Some(Duration::from_millis(100)));
@@ -501,7 +501,7 @@ mod tests {
 
         let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(TheseCallbacks {});
         let mut consumer =
-            LocalConsumer::new(Uuid::nil(), &mut broker, "test_group".to_string(), true);
+            LocalConsumer::new(Uuid::nil(), broker, "test_group".to_string(), true);
 
         let _ = consumer.subscribe(&[topic2], my_callbacks);
 
@@ -523,7 +523,7 @@ mod tests {
 
     #[test]
     fn test_paused() {
-        let mut broker = build_broker();
+        let broker = build_broker();
         let topic2 = Topic {
             name: "test2".to_string(),
         };
@@ -533,7 +533,7 @@ mod tests {
         };
         let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(EmptyCallbacks {});
         let mut consumer =
-            LocalConsumer::new(Uuid::nil(), &mut broker, "test_group".to_string(), false);
+            LocalConsumer::new(Uuid::nil(), broker, "test_group".to_string(), false);
         let _ = consumer.subscribe(&[topic2], my_callbacks);
 
         assert_eq!(consumer.poll(None).unwrap(), None);
@@ -549,10 +549,10 @@ mod tests {
 
     #[test]
     fn test_commit() {
-        let mut broker = build_broker();
+        let broker = build_broker();
         let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(EmptyCallbacks {});
         let mut consumer =
-            LocalConsumer::new(Uuid::nil(), &mut broker, "test_group".to_string(), false);
+            LocalConsumer::new(Uuid::nil(), broker, "test_group".to_string(), false);
         let topic2 = Topic {
             name: "test2".to_string(),
         };

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -41,7 +41,7 @@ pub enum ProducerError {
 
 /// This is basically an observer pattern to receive the callbacks from
 /// the consumer when partitions are assigned/revoked.
-pub trait AssignmentCallbacks: Send + Sync {
+pub trait AssignmentCallbacks: Send {
     fn on_assign(&mut self, partitions: HashMap<Partition, u64>);
     fn on_revoke(&mut self, partitions: Vec<Partition>);
 }
@@ -80,7 +80,7 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// occurs even if the consumer retains ownership of the partition across
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
-pub trait Consumer<'a, TPayload: Clone> {
+pub trait Consumer<TPayload: Clone>: Send {
     fn subscribe(
         &mut self,
         topic: &[Topic],

--- a/rust_snuba/rust_arroyo/src/backends/storages/memory.rs
+++ b/rust_snuba/rust_arroyo/src/backends/storages/memory.rs
@@ -68,7 +68,7 @@ impl<TPayload: Clone> Default for MemoryMessageStorage<TPayload> {
     }
 }
 
-impl<TPayload: Clone> MessageStorage<TPayload> for MemoryMessageStorage<TPayload> {
+impl<TPayload: Clone + Send> MessageStorage<TPayload> for MemoryMessageStorage<TPayload> {
     fn create_topic(&mut self, topic: Topic, partitions: u16) -> Result<(), TopicExists> {
         if self.topics.contains_key(&topic) {
             return Err(TopicExists);

--- a/rust_snuba/rust_arroyo/src/backends/storages/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/storages/mod.rs
@@ -21,7 +21,7 @@ pub enum ConsumeError {
     OffsetOutOfRange,
 }
 
-pub trait MessageStorage<TPayload: Clone> {
+pub trait MessageStorage<TPayload: Clone + Send>: Send {
     // Create a topic with the given number of partitions.
     //
     // If the topic already exists, a ``TopicExists`` exception will be

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -74,8 +74,6 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
             None => {}
             Some(s) => {
                 s.close();
-                // TODO: We need to actually call consumer.commit() with the commit request.
-                // Right now we are never committing during consumer shutdown.
                 if let Some(commit_request) = s.join(None) {
                     let mut consumer = self.consumer.lock().unwrap();
                     consumer.stage_offsets(commit_request.positions).unwrap();

--- a/rust_snuba/rust_arroyo/src/utils/clock.rs
+++ b/rust_snuba/rust_arroyo/src/utils/clock.rs
@@ -1,7 +1,7 @@
 use std::thread::sleep;
 use std::time::{Duration, SystemTime};
 
-pub trait Clock {
+pub trait Clock: Send {
     fn time(&self) -> SystemTime;
 
     fn sleep(self, duration: Duration);

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -236,7 +236,7 @@ pub fn consumer_impl(
     let clickhouse_cluster_config = first_storage.clickhouse_cluster.clone();
     let clickhouse_table_name = first_storage.clickhouse_table_name.clone();
 
-    let consumer = Box::new(KafkaConsumer::new(config));
+    let consumer = KafkaConsumer::new(config).unwrap();
     let mut processor = StreamProcessor::new(
         consumer,
         Box::new(ConsumerStrategyFactory {


### PR DESCRIPTION
The return value of Strategy.join() is currently ignored, because we
have no access to the consumer from within the assignment callbacks.

Shuffle a few things around so that consumer callbacks contain Arc to
the consumer internally.

SNS-2473