### PR TITLE
fix(23.3): Fix test for different versions of Clickhouse

### DIFF
--- a/tests/admin/test_api.py
+++ b/tests/admin/test_api.py
@@ -233,7 +233,7 @@ def test_query_trace(admin_api: FlaskClient) -> None:
     data = json.loads(response.data)
     assert "<Debug> executeQuery" in data["trace_output"]
     key = next(iter(data["formatted_trace_output"]))
-    assert "executeQuery" in data["formatted_trace_output"][key]["read_performance"][0]
+    assert "read_performance" in data["formatted_trace_output"][key]
 
 
 @pytest.mark.redis_db


### PR DESCRIPTION
Different versions of Clickhouse return slightly different trace outputs.
Instead of verifying the actual string, verify the structure instead.
