### PR TITLE
perf: Support ignoring consistent queries with sample rate

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
@@ -180,15 +181,6 @@ def execute_query(
     """
     # Apply clickhouse query setting overrides
     clickhouse_query_settings.update(query_settings.get_clickhouse_settings())
-
-    # Force query to use the first shard replica, which
-    # should have synchronously received any cluster writes
-    # before this query is run.
-    consistent = query_settings.get_consistent()
-    stats["consistent"] = consistent
-    if consistent:
-        clickhouse_query_settings["load_balancing"] = "in_order"
-        clickhouse_query_settings["max_threads"] = 1
 
     result = reader.execute(
         formatted_query,
@@ -529,6 +521,26 @@ def _raw_query(
     timer.mark("get_configs")
 
     sql = formatted_query.get_sql()
+
+    # Force query to use the first shard replica, which
+    # should have synchronously received any cluster writes
+    # before this query is run.
+    consistent = query_settings.get_consistent()
+    stats["consistent"] = consistent
+    if consistent:
+        sample_rate = state.get_config(
+            f"{dataset_name}_ignore_consistent_queries_sample_rate", 0
+        )
+        assert sample_rate is not None
+        ignore_consistent = random.random() < float(sample_rate)
+        if not ignore_consistent:
+            clickhouse_query_settings["load_balancing"] = "in_order"
+            clickhouse_query_settings["max_threads"] = 1
+        else:
+            metrics.increment(
+                "ignored_consistent_queries",
+                tags={"dataset": dataset_name, "referrer": attribution_info.referrer},
+            )
 
     update_with_status = partial(
         update_query_metadata_and_stats,

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -525,14 +525,15 @@ def _raw_query(
     # Force query to use the first shard replica, which
     # should have synchronously received any cluster writes
     # before this query is run.
-    if query_settings.get_consistent():
+    consistent = query_settings.get_consistent()
+    stats["consistent"] = consistent
+    if consistent:
         sample_rate = state.get_config(
             f"{dataset_name}_ignore_consistent_queries_sample_rate", 0
         )
         assert sample_rate is not None
         ignore_consistent = random.random() < float(sample_rate)
         if not ignore_consistent:
-            stats["consistent"] = True
             clickhouse_query_settings["load_balancing"] = "in_order"
             clickhouse_query_settings["max_threads"] = 1
         else:

--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -525,18 +525,18 @@ def _raw_query(
     # Force query to use the first shard replica, which
     # should have synchronously received any cluster writes
     # before this query is run.
-    consistent = query_settings.get_consistent()
-    stats["consistent"] = consistent
-    if consistent:
+    if query_settings.get_consistent():
         sample_rate = state.get_config(
             f"{dataset_name}_ignore_consistent_queries_sample_rate", 0
         )
         assert sample_rate is not None
         ignore_consistent = random.random() < float(sample_rate)
         if not ignore_consistent:
+            stats["consistent"] = True
             clickhouse_query_settings["load_balancing"] = "in_order"
             clickhouse_query_settings["max_threads"] = 1
         else:
+            stats["consistent"] = False
             metrics.increment(
                 "ignored_consistent_queries",
                 tags={"dataset": dataset_name, "referrer": attribution_info.referrer},


### PR DESCRIPTION
This PR is responsible for adding a way to ignore incoming concurrent queries depending on the dataset's configured sample rate runtime config. In order to better manage the health of our systems, we need a way to load balance queries  among our ClickHouse nodes to avoid problems like table rate limits and requiring to scale our cluster despite still having capacity in the cluster (`nodes =! 1-1`). Search_issues dataset is a example of a dataset with high volumes of `consistent` queries, but very low replication lag. It is possible most of those queries do not actually need to be executed on the same write node. 

This can be configured by configuration keys e.g. `search_issues_ignore_consistent_queries_sample_rate`. This flag should be set to a value between 0 and 1 where 0 means we never ignore any incoming consistent queries and 1 means ignoring all consistent queries.