### PR TITLE
feat: Add the Snuba commit log compaction settings

### DIFF
--- a/snuba/utils/streams/topics.py
+++ b/snuba/utils/streams/topics.py
@@ -80,5 +80,38 @@ def get_topic_creation_config(topic: Topic) -> Mapping[str, str]:
         Topic.GENERIC_EVENTS: {"message.timestamp.type": "LogAppendTime"},
         Topic.QUERYLOG: {"max.message.bytes": "2000000"},
         Topic.GROUP_ATTRIBUTES: {"message.timestamp.type": "LogAppendTime"},
+        Topic.COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.TRANSACTIONS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.SESSIONS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.METRICS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.GENERIC_METRICS_SETS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.GENERIC_METRICS_DISTRIBUTIONS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.GENERIC_METRICS_COUNTERS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
+        Topic.GENERIC_EVENTS_COMMIT_LOG: {
+            "cleanup.policy": "compact,delete",
+            "min.compaction.lag.ms": "3600000",
+        },
     }
+
     return config.get(topic, {})


### PR DESCRIPTION
Add the compaction settings to match what we do in production.

Note: We currently have "compact" instead of "compact,delete" defined in prod, but this should be fixed.
