### PR TITLE
fix: Properly clear state between batches

### DIFF
--- a/snuba/consumers/consumer.py
+++ b/snuba/consumers/consumer.py
@@ -358,6 +358,7 @@ class ProcessedMessageBatchWriter:
                 )
                 self.__commit_log_config.producer.poll(0.0)
         self.__offsets_to_produce.clear()
+        self.__received_timestamps.clear()
 
 
 json_row_encoder = JSONRowEncoder()


### PR DESCRIPTION
This is a fix for SNUBA-3XE, which caused subscription scheduler to crashloop in INC-548.

