### PR TITLE
ref(rust): Split factory into separate module

### DIFF
--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConsumerConfig {
-    pub storages: Vec<StoragesConfig>,
+    pub storages: Vec<StorageConfig>,
     pub raw_topic: TopicConfig,
     pub commit_log_topic: Option<TopicConfig>,
     pub replacements_topic: Option<TopicConfig>,
@@ -31,9 +31,9 @@ impl ConsumerConfig {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct StoragesConfig {
+pub struct StorageConfig {
     pub name: String,
     pub clickhouse_table_name: String,
     pub clickhouse_cluster: ClickhouseConfig,

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -7,26 +6,19 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::kafka::KafkaConsumer;
-use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
-use rust_arroyo::processing::strategies::reduce::Reduce;
-use rust_arroyo::processing::strategies::run_task_in_threads::{
-    RunTaskFunc, RunTaskInThreads, TaskRunner,
-};
-use rust_arroyo::processing::strategies::InvalidMessage;
-use rust_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
+
 use rust_arroyo::processing::StreamProcessor;
-use rust_arroyo::types::{BrokerMessage, InnerMessage, Message, Topic};
+use rust_arroyo::types::Topic;
 use rust_arroyo::utils::metrics::configure_metrics;
 
 use pyo3::prelude::*;
 
 use crate::config;
+use crate::factory::ConsumerStrategyFactory;
 use crate::logging::{setup_logging, setup_sentry};
 use crate::metrics::statsd::StatsDBackend;
 use crate::processors;
-use crate::strategies::clickhouse::ClickhouseWriterStep;
-use crate::strategies::python::PythonTransformStep;
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::KafkaMessageMetadata;
 
 #[pyfunction]
 pub fn consumer(
@@ -58,109 +50,6 @@ pub fn consumer_impl(
     concurrency: usize,
     use_rust_processor: bool,
 ) {
-    struct ConsumerStrategyFactory {
-        processor_config: config::MessageProcessorConfig,
-        max_batch_size: usize,
-        max_batch_time: Duration,
-        clickhouse_cluster_config: config::ClickhouseConfig,
-        clickhouse_table_name: String,
-        skip_write: bool,
-        concurrency: usize,
-        use_rust_processor: bool,
-    }
-
-    impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
-        fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
-            let accumulator = Arc::new(|mut acc: BytesInsertBatch, value: BytesInsertBatch| {
-                for row in value.rows {
-                    acc.rows.push(row);
-                }
-                acc
-            });
-
-            let next_step = Reduce::new(
-                Box::new(ClickhouseWriterStep::new(
-                    CommitOffsets::new(Duration::from_secs(1)),
-                    self.clickhouse_cluster_config.clone(),
-                    self.clickhouse_table_name.clone(),
-                    self.skip_write,
-                    2,
-                )),
-                accumulator,
-                BytesInsertBatch { rows: vec![] },
-                self.max_batch_size,
-                self.max_batch_time,
-            );
-
-            match (
-                self.use_rust_processor,
-                processors::get_processing_function(&self.processor_config.python_class_name),
-            ) {
-                (true, Some(func)) => {
-                    struct MessageProcessor {
-                        func: fn(
-                            KafkaPayload,
-                            KafkaMessageMetadata,
-                        ) -> Result<BytesInsertBatch, BadMessage>,
-                    }
-
-                    impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
-                        fn get_task(
-                            &self,
-                            message: Message<KafkaPayload>,
-                        ) -> RunTaskFunc<BytesInsertBatch> {
-                            let func = self.func;
-
-                            Box::pin(async move {
-                                let broker_message = match message.inner_message {
-                                    InnerMessage::BrokerMessage(msg) => msg,
-                                    _ => panic!("Unexpected message type"),
-                                };
-
-                                let metadata = KafkaMessageMetadata {
-                                    partition: broker_message.partition.index,
-                                    offset: broker_message.offset,
-                                    timestamp: broker_message.timestamp,
-                                };
-
-                                match func(broker_message.payload, metadata) {
-                                    Ok(transformed) => Ok(Message {
-                                        inner_message: InnerMessage::BrokerMessage(BrokerMessage {
-                                            payload: transformed,
-                                            partition: broker_message.partition,
-                                            offset: broker_message.offset,
-                                            timestamp: broker_message.timestamp,
-                                        }),
-                                    }),
-                                    Err(_e) => Err(InvalidMessage {
-                                        partition: broker_message.partition,
-                                        offset: broker_message.offset,
-                                    }),
-                                }
-                            })
-                        }
-                    }
-
-                    let task_runner = MessageProcessor { func };
-                    Box::new(RunTaskInThreads::new(
-                        next_step,
-                        Box::new(task_runner),
-                        self.concurrency,
-                        Some("process_message"),
-                    ))
-                }
-                _ => Box::new(
-                    PythonTransformStep::new(
-                        self.processor_config.clone(),
-                        self.concurrency,
-                        next_step,
-                    )
-                    .unwrap(),
-                ),
-            }
-        }
-    }
-
     setup_logging();
 
     let consumer_config = config::ConsumerConfig::load_from_str(consumer_config_raw).unwrap();
@@ -207,7 +96,7 @@ pub fn consumer_impl(
         procspawn::init();
     }
 
-    let first_storage = &consumer_config.storages[0];
+    let first_storage = consumer_config.storages[0].clone();
 
     log::info!("Starting consumer for {:?}", first_storage.name,);
 
@@ -232,23 +121,17 @@ pub fn consumer_impl(
         Some(broker_config),
     );
 
-    let processor_config = first_storage.message_processor.clone();
-    let clickhouse_cluster_config = first_storage.clickhouse_cluster.clone();
-    let clickhouse_table_name = first_storage.clickhouse_table_name.clone();
-
     let consumer = Box::new(KafkaConsumer::new(config));
     let mut processor = StreamProcessor::new(
         consumer,
-        Box::new(ConsumerStrategyFactory {
-            processor_config,
+        Box::new(ConsumerStrategyFactory::new(
+            first_storage,
             max_batch_size,
             max_batch_time,
-            clickhouse_cluster_config,
-            clickhouse_table_name,
             skip_write,
             concurrency,
             use_rust_processor,
-        }),
+        )),
     );
 
     processor.subscribe(Topic {

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -1,0 +1,139 @@
+use crate::config;
+use crate::processors;
+use crate::strategies::clickhouse::ClickhouseWriterStep;
+use crate::strategies::python::PythonTransformStep;
+use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use rust_arroyo::backends::kafka::types::KafkaPayload;
+use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
+use rust_arroyo::processing::strategies::reduce::Reduce;
+use rust_arroyo::processing::strategies::run_task_in_threads::{
+    RunTaskFunc, RunTaskInThreads, TaskRunner,
+};
+use rust_arroyo::processing::strategies::InvalidMessage;
+use rust_arroyo::processing::strategies::{ProcessingStrategy, ProcessingStrategyFactory};
+use rust_arroyo::types::{BrokerMessage, InnerMessage, Message};
+use std::sync::Arc;
+use std::time::Duration;
+
+pub struct ConsumerStrategyFactory {
+    storage_config: config::StorageConfig,
+    max_batch_size: usize,
+    max_batch_time: Duration,
+    skip_write: bool,
+    concurrency: usize,
+    use_rust_processor: bool,
+}
+
+impl ConsumerStrategyFactory {
+    pub fn new(
+        storage_config: config::StorageConfig,
+        max_batch_size: usize,
+        max_batch_time: Duration,
+        skip_write: bool,
+        concurrency: usize,
+        use_rust_processor: bool,
+    ) -> Self {
+        Self {
+            storage_config,
+            max_batch_size,
+            max_batch_time,
+            skip_write,
+            concurrency,
+            use_rust_processor,
+        }
+    }
+}
+
+impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
+    fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+        let accumulator = Arc::new(|mut acc: BytesInsertBatch, value: BytesInsertBatch| {
+            for row in value.rows {
+                acc.rows.push(row);
+            }
+            acc
+        });
+
+        let next_step = Reduce::new(
+            Box::new(ClickhouseWriterStep::new(
+                CommitOffsets::new(Duration::from_secs(1)),
+                self.storage_config.clickhouse_cluster.clone(),
+                self.storage_config.clickhouse_table_name.clone(),
+                self.skip_write,
+                2,
+            )),
+            accumulator,
+            BytesInsertBatch { rows: vec![] },
+            self.max_batch_size,
+            self.max_batch_time,
+        );
+
+        match (
+            self.use_rust_processor,
+            processors::get_processing_function(
+                &self.storage_config.message_processor.python_class_name,
+            ),
+        ) {
+            (true, Some(func)) => {
+                struct MessageProcessor {
+                    func: fn(
+                        KafkaPayload,
+                        KafkaMessageMetadata,
+                    ) -> Result<BytesInsertBatch, BadMessage>,
+                }
+
+                impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
+                    fn get_task(
+                        &self,
+                        message: Message<KafkaPayload>,
+                    ) -> RunTaskFunc<BytesInsertBatch> {
+                        let func = self.func;
+
+                        Box::pin(async move {
+                            let broker_message = match message.inner_message {
+                                InnerMessage::BrokerMessage(msg) => msg,
+                                _ => panic!("Unexpected message type"),
+                            };
+
+                            let metadata = KafkaMessageMetadata {
+                                partition: broker_message.partition.index,
+                                offset: broker_message.offset,
+                                timestamp: broker_message.timestamp,
+                            };
+
+                            match func(broker_message.payload, metadata) {
+                                Ok(transformed) => Ok(Message {
+                                    inner_message: InnerMessage::BrokerMessage(BrokerMessage {
+                                        payload: transformed,
+                                        partition: broker_message.partition,
+                                        offset: broker_message.offset,
+                                        timestamp: broker_message.timestamp,
+                                    }),
+                                }),
+                                Err(_e) => Err(InvalidMessage {
+                                    partition: broker_message.partition,
+                                    offset: broker_message.offset,
+                                }),
+                            }
+                        })
+                    }
+                }
+
+                let task_runner = MessageProcessor { func };
+                Box::new(RunTaskInThreads::new(
+                    next_step,
+                    Box::new(task_runner),
+                    self.concurrency,
+                    Some("process_message"),
+                ))
+            }
+            _ => Box::new(
+                PythonTransformStep::new(
+                    self.storage_config.message_processor.clone(),
+                    self.concurrency,
+                    next_step,
+                )
+                .unwrap(),
+            ),
+        }
+    }
+}

--- a/rust_snuba/src/lib.rs
+++ b/rust_snuba/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod consumer;
+mod factory;
 mod logging;
 mod metrics;
 mod processors;


### PR DESCRIPTION
consumer.rs is getting unwieldy, split the factory into a separate file. Also passes the whole StorageConfig object to the factory - we will need more data from this object later to produce to the commit log.

Most of this diff is just copy and paste, without functional changes

