### PR TITLE
ci: Switch default ClickHouse version in CI to 21.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,12 +397,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          [
-            "21.8.13.1.altinitystable",
-            "22.3.15.34.altinitystable",
-            "22.8.15.25.altinitystable",
-          ]
+        version: ["22.3.15.34.altinitystable", "22.8.15.25.altinitystable"]
 
     steps:
       - uses: actions/checkout@v2

--- a/docker-compose.gcb.yml
+++ b/docker-compose.gcb.yml
@@ -66,7 +66,7 @@ services:
       KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
       KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
   clickhouse:
-    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
+    image: "${CLICKHOUSE_IMAGE:-altinity/clickhouse-server:21.8.13.1.altinitystable}"
     volumes:
       - ./config/clickhouse/macros.xml:/etc/clickhouse-server/config.d/macros.xml
       - ./config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
@@ -80,7 +80,7 @@ services:
   clickhouse-query:
     depends_on:
       - zookeeper
-    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
+    image: "${CLICKHOUSE_IMAGE:-altinity/clickhouse-server:21.8.13.1.altinitystable}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
@@ -92,7 +92,7 @@ services:
   clickhouse-01:
     depends_on:
       - zookeeper
-    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
+    image: "${CLICKHOUSE_IMAGE:-altinity/clickhouse-server:21.8.13.1.altinitystable}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-01.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -105,7 +105,7 @@ services:
   clickhouse-02:
     depends_on:
       - zookeeper
-    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
+    image: "${CLICKHOUSE_IMAGE:-altinity/clickhouse-server:21.8.13.1.altinitystable}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-02.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -118,7 +118,7 @@ services:
   clickhouse-03:
     depends_on:
       - zookeeper
-    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
+    image: "${CLICKHOUSE_IMAGE:-altinity/clickhouse-server:21.8.13.1.altinitystable}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-03.xml:/etc/clickhouse-server/config.d/macros.xml
@@ -131,7 +131,7 @@ services:
   clickhouse-04:
     depends_on:
       - zookeeper
-    image: "${CLICKHOUSE_IMAGE:-yandex/clickhouse-server:20.3.9.70}"
+    image: "${CLICKHOUSE_IMAGE:-altinity/clickhouse-server:21.8.13.1.altinitystable}"
     profiles: ["multi_node"]
     volumes:
       - ./test_distributed_migrations/config/clickhouse/macros-04.xml:/etc/clickhouse-server/config.d/macros.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       # Uncomment this to run sentry's snuba testsuite
       #SNUBA_SETTINGS: test
   clickhouse:
-    image: yandex/clickhouse-server:20.3.9.70
+    image: altinity/clickhouse-server:21.8.13.1.altinitystable
     ports:
       - "9000:9000"
       - "9009:9009"

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -14,5 +14,4 @@
   "sentry (4)" \
   "sentry (5)" \
   "sentry (6)" \
-  "sentry (7)" \
-  "Tests on multiple clickhouse versions (21.8.13.1.altinitystable)"
+  "sentry (7)"


### PR DESCRIPTION
We are about to drop support for 20.3. Let's run 21.8 as default in CI
