### PR TITLE
feat(generic-metrics): Bump gauges storage readiness state to partial

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_gauges
 storage:
   key: generic_metrics_gauges
   set_key: generic_metrics_gauges
-readiness_state: limited
+readiness_state: partial
 schema:
   columns:
     [

--- a/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
+++ b/snuba/datasets/configuration/generic_metrics/storages/gauges_bucket.yaml
@@ -4,7 +4,7 @@ name: generic_metrics_gauges_raw
 storage:
   key: generic_metrics_gauges_raw
   set_key: generic_metrics_gauges
-readiness_state: limited
+readiness_state: partial
 schema:
   columns:
     [


### PR DESCRIPTION
The current readiness state is limited, which means the storage is only available for querying/health checks only in local env. Bumping it to partial to activate it for s4s and saas.