### PR TITLE
experiment(ratelimit): add runtime config to rate limit with redis transaction

### DIFF
--- a/snuba/state/rate_limit.py
+++ b/snuba/state/rate_limit.py
@@ -226,8 +226,11 @@ def rate_limit_start_request(
     query_bucket = _get_bucket_key(
         rate_limit_prefix, rate_limit_params.bucket, bucket_shard
     )
+    use_transaction_pipe = bool(
+        state.get_config("rate_limit_use_transaction_pipe", False)
+    )
 
-    pipe = rds.pipeline(transaction=False)
+    pipe = rds.pipeline(transaction=use_transaction_pipe)
 
     # cleanup old query timestamps past our retention window
     #

--- a/tests/state/test_rate_limit.py
+++ b/tests/state/test_rate_limit.py
@@ -30,9 +30,16 @@ def rate_limit_shards(request: Any) -> None:
     state.set_config("rate_limit_shard_factor", request.param)
 
 
+@pytest.fixture(params=[0, 1])
+def use_transaction_pipe(request: Any) -> None:
+    state.set_config("rate_limit_use_transaction_pipe", request.param)
+
+
 class TestRateLimit:
     @pytest.mark.redis_db
-    def test_ratelimit_aggregator(self, rate_limit_shards: Any) -> None:
+    def test_ratelimit_aggregator(
+        self, rate_limit_shards: Any, use_transaction_pipe: Any
+    ) -> None:
         # No concurrent limit should not raise
         rate_limit_params1 = RateLimitParameters("foo", "bar", None, 1)
         rate_limit_params2 = RateLimitParameters("foo", "bar", None, 0)
@@ -46,7 +53,9 @@ class TestRateLimit:
                 pass
 
     @pytest.mark.redis_db
-    def test_concurrent_limit(self, rate_limit_shards: Any) -> None:
+    def test_concurrent_limit(
+        self, rate_limit_shards: Any, use_transaction_pipe: Any
+    ) -> None:
         # No concurrent limit should not raise
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)
         with rate_limit(rate_limit_params) as stats:
@@ -85,7 +94,9 @@ class TestRateLimit:
                 pass
 
     @pytest.mark.redis_db
-    def test_fails_open(self, rate_limit_shards: Any) -> None:
+    def test_fails_open(
+        self, rate_limit_shards: Any, use_transaction_pipe: Any
+    ) -> None:
         with patch("snuba.state.rate_limit.rds.pipeline") as pipeline:
             pipeline.execute.side_effect = Exception("Boom!")
             rate_limit_params = RateLimitParameters("foo", "bar", 4, 20)
@@ -93,7 +104,9 @@ class TestRateLimit:
                 pass
 
     @pytest.mark.redis_db
-    def test_per_second_limit(self, rate_limit_shards: Any) -> None:
+    def test_per_second_limit(
+        self, rate_limit_shards: Any, use_transaction_pipe: Any
+    ) -> None:
         bucket = uuid.uuid4()
         rate_limit_params = RateLimitParameters("foo", str(bucket), 1, None)
         # Create 30 queries at time 0, should all be allowed
@@ -126,7 +139,9 @@ class TestRateLimit:
                 assert stats is not None
 
     @pytest.mark.redis_db
-    def test_aggregator(self, rate_limit_shards: Any) -> None:
+    def test_aggregator(
+        self, rate_limit_shards: Any, use_transaction_pipe: Any
+    ) -> None:
         # do not raise with multiple valid rate limits
         rate_limit_params_outer = RateLimitParameters("foo", "bar", None, 5)
         rate_limit_params_inner = RateLimitParameters("foo", "bar", None, 5)
@@ -155,7 +170,7 @@ class TestRateLimit:
                 pass
 
     @pytest.mark.redis_db
-    def test_rate_limit_container(self) -> None:
+    def test_rate_limit_container(self, use_transaction_pipe: Any) -> None:
         rate_limit_container = RateLimitStatsContainer()
         rate_limit_stats = RateLimitStats(rate=0.5, concurrent=2)
 
@@ -170,7 +185,7 @@ class TestRateLimit:
         }
 
     @pytest.mark.redis_db
-    def test_bypass_rate_limit(self) -> None:
+    def test_bypass_rate_limit(self, use_transaction_pipe: Any) -> None:
         rate_limit_params = RateLimitParameters("foo", "bar", None, None)
         state.set_config("bypass_rate_limit", 1)
 
@@ -178,7 +193,7 @@ class TestRateLimit:
             assert stats is None
 
     @pytest.mark.redis_db
-    def test_rate_limit_exceptions(self) -> None:
+    def test_rate_limit_exceptions(self, use_transaction_pipe: Any) -> None:
         params = RateLimitParameters("foo", "bar", None, 5)
         bucket = "{}{}".format(state.ratelimit_prefix, params.bucket)
 
@@ -204,7 +219,7 @@ class TestRateLimit:
         assert count() == 2
 
     @pytest.mark.redis_db
-    def test_rate_limit_ttl(self) -> None:
+    def test_rate_limit_ttl(self, use_transaction_pipe: Any) -> None:
         params = RateLimitParameters("foo", "bar", None, 5)
         bucket = "{}{}".format(state.ratelimit_prefix, params.bucket)
 
@@ -228,7 +243,7 @@ tests = [
 )
 @pytest.mark.redis_db
 def test_rate_limit_failures(
-    vals: Tuple[int, int, int], rate_limit_shards: Any
+    vals: Tuple[int, int, int], rate_limit_shards: Any, use_transaction_pipe: Any
 ) -> None:
     params = []
     for i, v in enumerate(vals):


### PR DESCRIPTION
### Context

As part of debugging the rate limiter memory leak, it showed up that the rate limiter was creating non-expirable keys 

https://www.notion.so/sentry/Experiment-7-Turn-on-concurrent-rate-limit-policy-monitor-non-expirable-keys-cc0b7a18cd8d4eed943ace6c3f9beedf

With https://getsentry.atlassian.net/browse/OPS-4087 , it was confirmed that the non-expiring keys were from this rate limit function. Both from the allocation policy and the legacy rate limiter (but many more on the allocation policy).

```
snuba-ratelimit:5889476
errors_ro.ConcurrentRateLimitAllocationPolicy.rate_limit4504594023645190
```

There are two tickets on stackoverflow that hint that this may be a race condition (also when using redis for ratelimiting).
https://stackoverflow.com/questions/42350277/redis-keys-getting-stuck-with-ttl-at-1?noredirect=1&lq=1
https://stackoverflow.com/questions/69661031/redis-key-ttl-becoming-1-even-when-expiry-is-being-set-in-a-multi-transaction

Our case is not the same but I think it's worth trying to do the `zadd` and `expire` in a transaction and see how that affects the creation of non-expirable keys

### This PR

* introduces using a transaction pipeline as a runtime config option
* runs the rate limit tests with both transactional and non-transactional pipelines 
