### PR TITLE
feat(rust): Log config when consumer starts up

### DIFF
--- a/rust_snuba/src/config.rs
+++ b/rust_snuba/src/config.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ConsumerConfig {
     pub storages: Vec<StorageConfig>,
@@ -15,7 +15,7 @@ pub struct ConsumerConfig {
     pub env: EnvConfig,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct TopicConfig {
     pub physical_topic_name: String,
     pub logical_topic_name: String,
@@ -31,7 +31,7 @@ impl ConsumerConfig {
     }
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct StorageConfig {
     pub name: String,
@@ -40,7 +40,7 @@ pub struct StorageConfig {
     pub message_processor: MessageProcessorConfig,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ClickhouseConfig {
     pub host: String,
@@ -51,14 +51,14 @@ pub struct ClickhouseConfig {
     pub database: String,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct MessageProcessorConfig {
     pub python_class_name: String,
     pub python_module: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct EnvConfig {
     pub sentry_dsn: Option<String>,

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -56,6 +56,8 @@ pub fn consumer_impl(
     let max_batch_size = consumer_config.max_batch_size;
     let max_batch_time = Duration::from_millis(consumer_config.max_batch_time_ms);
 
+    log::info!("Starting Rust consumer with config: {:?}", consumer_config);
+
     // TODO: Support multiple storages
     assert_eq!(consumer_config.storages.len(), 1);
     assert!(consumer_config.replacements_topic.is_none());


### PR DESCRIPTION
Some config data passed from Python (specifically, logical topic name) does not appear to be as expected in production. Let's log the whole config object when the consumer starts to help with debugging.
