### PR TITLE
ci(cardinality): Deploy the new container image

### DIFF
--- a/gocd/pipelines/snuba-stable.yaml
+++ b/gocd/pipelines/snuba-stable.yaml
@@ -112,7 +112,8 @@ pipelines:
                                     --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                                     --type="cronjob" \
                                     --container-name="cleanup" \
-                                    --container-name="optimize"
+                                    --container-name="optimize" \
+                                    --container-name="cardinality-report"
             - deploy:
                   fetch_materials: true
                   jobs:
@@ -169,4 +170,5 @@ pipelines:
                                     --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \
                                     --type="cronjob" \
                                     --container-name="cleanup" \
-                                    --container-name="optimize"
+                                    --container-name="optimize" \
+                                    --container-name="cardinality-report"

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -61,6 +61,7 @@ eval $(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}"
   --type="cronjob" \
   --container-name="cleanup" \
   --container-name="optimize" \
+  --container-name="cardinality-report" \
 && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="${LABEL_SELECTOR}" \
   --image="us.gcr.io/sentryio/snuba:${GO_REVISION_SNUBA_REPO}" \


### PR DESCRIPTION
Seeing error in when the cron job is run that the cardinality file does not exist. Guessing that its because it is using an older container image which does not have the required change. Deploying newer images might help.