### PR TITLE
observability(oncall): log full request on unknown referrers

### DIFF
--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -489,12 +489,6 @@ def dataset_query(dataset: Dataset, body: Dict[str, Any], timer: Timer) -> Respo
 
     with sentry_sdk.start_span(description="build_schema", op="validate"):
         schema = RequestSchema.build(HTTPQuerySettings)
-    logger.info(
-        "received request with referrer: ",
-        referrer,
-        body.get("referrer", "no referrer"),
-        body.get("tenant_ids"),
-    )
     request = build_request(
         body, parse_snql_query, HTTPQuerySettings, schema, dataset, timer, referrer
     )

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -463,12 +463,14 @@ def dump_payload(payload: MutableMapping[str, Any]) -> str:
         return json.dumps(sanitized_payload, default=str)
 
 
-def _get_and_log_referrer(request: SnubaRequest) -> None:
+def _get_and_log_referrer(request: SnubaRequest, body: Dict[str, Any]) -> None:
     metrics.increment(
         "just_referrer_count", tags={"referrer": request.attribution_info.referrer}
     )
     if random.random() < get_float_config("log-referrer-sample-rate", 0.001):  # type: ignore
         logger.info(f"Received referrer: {request.attribution_info.referrer}")
+        if request.attribution_info.referrer == "<unknown>":
+            logger.info(f"Received unknown referrer from request: {request}, {body}")
 
 
 @with_span()

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -67,6 +67,7 @@ from snuba.request import Request as SnubaRequest
 from snuba.request.exceptions import InvalidJsonRequestException, JsonDecodeException
 from snuba.request.schema import RequestSchema
 from snuba.request.validation import build_request, parse_snql_query
+from snuba.state import get_float_config
 from snuba.state.rate_limit import RateLimitExceeded
 from snuba.subscriptions.codecs import SubscriptionDataCodec
 from snuba.subscriptions.data import PartitionId
@@ -466,8 +467,8 @@ def _get_and_log_referrer(request: SnubaRequest) -> None:
     metrics.increment(
         "just_referrer_count", tags={"referrer": request.attribution_info.referrer}
     )
-    if random.random() < 0.05:
-        logger.info(f"Referrer: {request.attribution_info.referrer}")
+    if random.random() < get_float_config("log-referrer-sample-rate", 0.001):  # type: ignore
+        logger.info(f"Received referrer: {request.attribution_info.referrer}")
 
 
 @with_span()


### PR DESCRIPTION
It looks like on single tenant we are actually not parsing a referrer out the the request. Double check whether this is actually a snuba issue or not by logging the full request body

![image](https://github.com/getsentry/snuba/assets/3169433/b66fda7e-d1ad-416a-8be1-cbdcbf013559)
