### PR TITLE
feat(rust): Port the buffered messages class to Rust

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -47,8 +47,6 @@ impl<TPayload> BufferedMessages<TPayload> {
                     }
                 };
             }
-
-            return None;
         }
 
         None

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -1,0 +1,95 @@
+#![allow(dead_code)]
+use crate::types::{BrokerMessage, Partition};
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, VecDeque};
+
+/// Stores messages that are pending commit. This is used to retreive raw messages
+// in case they need to be placed in the DLQ.
+pub struct BufferedMessages<TPayload> {
+    buffered_messages: BTreeMap<Partition, VecDeque<BrokerMessage<TPayload>>>,
+}
+
+impl<TPayload> BufferedMessages<TPayload> {
+    pub fn new() -> Self {
+        BufferedMessages {
+            buffered_messages: BTreeMap::new(),
+        }
+    }
+
+    // Add message to the buffer.
+    pub fn append(&mut self, message: BrokerMessage<TPayload>) {
+        match self.buffered_messages.get_mut(&message.partition) {
+            Some(messages) => {
+                messages.push_back(message);
+            }
+            None => {
+                self.buffered_messages
+                    .insert(message.partition.clone(), VecDeque::from([message]));
+            }
+        };
+    }
+
+    // Return the message at the given offset or None if it is not found in the buffer.
+    // Messages up to the offset for the given partition are removed.
+    pub fn pop(&mut self, partition: &Partition, offset: u64) -> Option<BrokerMessage<TPayload>> {
+        if let Some(messages) = self.buffered_messages.get_mut(partition) {
+            #[allow(clippy::never_loop)]
+            while let Some(message) = messages.front_mut() {
+                match message.offset.cmp(&offset) {
+                    Ordering::Equal => {
+                        return messages.pop_front();
+                    }
+                    Ordering::Greater => {
+                        break;
+                    }
+                    Ordering::Less => {
+                        messages.pop_front();
+                    }
+                };
+            }
+
+            return None;
+        }
+
+        None
+    }
+
+    // Clear the buffer. Should be called on rebalance.
+    pub fn reset(&mut self) {
+        self.buffered_messages.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::Topic;
+    use chrono::Utc;
+
+    use super::*;
+
+    #[test]
+    fn test_buffered_messages() {
+        let mut buffer = BufferedMessages::new();
+        let partition = Partition {
+            topic: Topic {
+                name: "test".to_string(),
+            },
+            index: 1,
+        };
+
+        for i in 0..10 {
+            buffer.append(BrokerMessage {
+                partition: partition.clone(),
+                offset: i,
+                payload: i,
+                timestamp: Utc::now(),
+            });
+        }
+
+        assert_eq!(buffer.pop(&partition, 0).unwrap().offset, 0);
+        assert_eq!(buffer.pop(&partition, 8).unwrap().offset, 8);
+        assert_eq!(buffer.pop(&partition, 1), None); // Removed when we popped offset 8
+        assert_eq!(buffer.pop(&partition, 9).unwrap().offset, 9);
+        assert_eq!(buffer.pop(&partition, 10), None); // Doesn't exist
+    }
+}

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -24,7 +24,7 @@ impl<TPayload> BufferedMessages<TPayload> {
             }
             None => {
                 self.buffered_messages
-                    .insert(message.partition.clone(), VecDeque::from([message]));
+                    .insert(message.partition, VecDeque::from([message]));
             }
         };
     }
@@ -69,9 +69,7 @@ mod tests {
     fn test_buffered_messages() {
         let mut buffer = BufferedMessages::new();
         let partition = Partition {
-            topic: Topic {
-                name: "test".to_string(),
-            },
+            topic: Topic::new("test"),
             index: 1,
         };
 

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -1,3 +1,4 @@
+mod dlq;
 mod metrics_buffer;
 pub mod strategies;
 


### PR DESCRIPTION
This is the start of the DLQ implementation. It adds the struct that keeps track of seen messages from the broker so they can be produced to the DLQ if needed later.
It is basically a 1:1 port of current Arroyo code here ( https://github.com/getsentry/arroyo/blob/112667abdc2ef5c9137e361c0b2bbf69703bc524/arroyo/dlq.py#L215-L269) that we run in the Python consumer. Actual DLQing of messages will be implemented as a follow up.

