### PR TITLE
fix(generic-metrics): Fix function names in gauges entity

### DIFF
--- a/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
@@ -44,7 +44,11 @@ schema:
     {
       name: last,
       type: AggregateFunction,
-      args: { func: argMax, arg_types: [{ type: Float, args: { size: 64 } }] },
+      args:
+        {
+          func: argMax,
+          arg_types: [{ type: Float, args: { size: 64 } }, { type: DateTime }],
+        },
     },
   ]
 

--- a/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
+++ b/snuba/datasets/configuration/generic_metrics/entities/gauges.yaml
@@ -39,12 +39,12 @@ schema:
     {
       name: count,
       type: AggregateFunction,
-      args: { func: count, arg_types: [{ type: UInt, args: { size: 64 } }] },
+      args: { func: sum, arg_types: [{ type: UInt, args: { size: 64 } }] },
     },
     {
       name: last,
       type: AggregateFunction,
-      args: { func: count, arg_types: [{ type: Float, args: { size: 64 } }] },
+      args: { func: argMax, arg_types: [{ type: Float, args: { size: 64 } }] },
     },
   ]
 


### PR DESCRIPTION
There were some typos where the `func` field in the entity definition were incorrect and need to point to the correct Clickhouse AggregateFunction we are using. From my understanding this should not be a functional change since `func` is just representing the name of the function