### PR TITLE
feat(settings): Allow runtime configurable referrer overrides

### DIFF
--- a/snuba/web/db_query.py
+++ b/snuba/web/db_query.py
@@ -465,7 +465,7 @@ def _get_query_settings_from_config(
 ) -> MutableMapping[str, Any]:
     """
     Helper function to get the query settings from the config. Order of precedence
-    for overlapping config wihtin this method is:
+    for overlapping config within this method is:
     1. referrer/<referrer>/query_settings/<setting>
     2. <override_prefix>/query_settings/<setting>
     3. query_settings/<setting>


### PR DESCRIPTION
In certain cases we would like to allow a referrer to override certain clickhouse settings. For example, in single tenant environments where the cluster is completely owned by a tenant we might want to allow them to use all replicas in parallel using setting like max_parallel_replicas. Making it referrer based allows the setting to only kick in for certain high volume bursty referrers rather than applying the settings at all times on the whole dataset.