### PR TITLE
Add support for join queries to the subscription system

### DIFF
--- a/snuba/subscriptions/data.py
+++ b/snuba/subscriptions/data.py
@@ -31,6 +31,7 @@ from snuba.query.conditions import (
     binary_condition,
     combine_and_conditions,
 )
+from snuba.query.data_source.join import JoinClause
 from snuba.query.data_source.simple import Entity as EntityDS
 from snuba.query.expressions import Column, Expression, Literal
 from snuba.query.logical import Query
@@ -55,7 +56,6 @@ SUBSCRIPTION_DATA_PAYLOAD_KEYS = {
 }
 
 logger = logging.getLogger("snuba.subscriptions")
-
 
 PartitionId = NewType("PartitionId", int)
 
@@ -94,48 +94,67 @@ class SubscriptionData:
         offset: Optional[int],
         query: Union[CompositeQuery[EntityDS], Query],
     ) -> None:
-        # TODO: Support composite queries with multiple entities.
+        added_timestamp_column = False
         from_clause = query.get_from_clause()
-        if not isinstance(from_clause, EntityDS):
-            raise InvalidSubscriptionError("Only simple queries are supported")
-        entity = get_entity(from_clause.key)
-        required_timestamp_column = entity.required_time_column
-        if required_timestamp_column is None:
+        entities = []
+        if isinstance(from_clause, JoinClause):
+            for alias, node in from_clause.get_alias_node_map().items():
+                assert isinstance(node.data_source, EntityDS), node.data_source
+                entities.append((alias, get_entity(node.data_source.key)))
+        elif isinstance(from_clause, EntityDS):
+            entities = [(None, get_entity(from_clause.key))]
+        else:
             raise InvalidSubscriptionError(
-                "Entity must have a timestamp column for subscriptions"
+                "Only simple queries and join queries are supported"
             )
+        for alias, entity in entities:
+            conditions_to_add: Sequence[Expression] = [
+                binary_condition(
+                    ConditionFunctions.EQ,
+                    Column(None, alias, "project_id"),
+                    Literal(None, self.project_id),
+                ),
+            ]
 
-        conditions_to_add: Sequence[Expression] = [
-            binary_condition(
-                ConditionFunctions.EQ,
-                Column(None, None, "project_id"),
-                Literal(None, self.project_id),
-            ),
-            binary_condition(
-                ConditionFunctions.GTE,
-                Column(None, None, required_timestamp_column),
-                Literal(None, (timestamp - timedelta(seconds=self.time_window_sec))),
-            ),
-            binary_condition(
-                ConditionFunctions.LT,
-                Column(None, None, required_timestamp_column),
-                Literal(None, timestamp),
-            ),
-        ]
+            required_timestamp_column = entity.required_time_column
+            if required_timestamp_column is not None:
+                added_timestamp_column = True
+                conditions_to_add.extend(
+                    [
+                        binary_condition(
+                            ConditionFunctions.GTE,
+                            Column(None, alias, required_timestamp_column),
+                            Literal(
+                                None,
+                                (timestamp - timedelta(seconds=self.time_window_sec)),
+                            ),
+                        ),
+                        binary_condition(
+                            ConditionFunctions.LT,
+                            Column(None, alias, required_timestamp_column),
+                            Literal(None, timestamp),
+                        ),
+                    ]
+                )
 
-        new_condition = combine_and_conditions(conditions_to_add)
-        condition = query.get_condition()
-        if condition:
-            new_condition = binary_condition(
-                BooleanFunctions.AND, condition, new_condition
+            new_condition = combine_and_conditions(conditions_to_add)
+            condition = query.get_condition()
+            if condition:
+                new_condition = binary_condition(
+                    BooleanFunctions.AND, condition, new_condition
+                )
+
+            query.set_ast_condition(new_condition)
+
+            subscription_processors = self.entity.get_subscription_processors()
+            if subscription_processors:
+                for processor in subscription_processors:
+                    processor.process(query, self.metadata, offset)
+
+        if not added_timestamp_column:
+            raise InvalidSubscriptionError(
+                "At least one Entity must have a timestamp column for subscriptions"
             )
-
-        query.set_ast_condition(new_condition)
-
-        subscription_processors = self.entity.get_subscription_processors()
-        if subscription_processors:
-            for processor in subscription_processors:
-                processor.process(query, self.metadata, offset)
 
     def validate(self) -> None:
         if self.time_window_sec < 60:

--- a/tests/query/snql/test_invalid_queries.py
+++ b/tests/query/snql/test_invalid_queries.py
@@ -1,5 +1,6 @@
 import re
 from typing import Optional
+from unittest import mock
 
 import pytest
 
@@ -114,7 +115,8 @@ def test_failures(query_body: str, message: str) -> None:
 
     events = get_dataset("events")
     events_entity = get_entity(EntityKey.EVENTS)
-    setattr(events_entity, "get_join_relationship", events_mock)
 
-    with pytest.raises(ParsingException, match=re.escape(message)):
+    with pytest.raises(ParsingException, match=re.escape(message)), mock.patch.object(
+        events_entity, "get_join_relationship", events_mock
+    ):
         parse_snql_query(query_body, events)

--- a/tests/query/snql/test_query.py
+++ b/tests/query/snql/test_query.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest import mock
 
 import pytest
 
@@ -1975,9 +1976,9 @@ def test_format_expressions(query_body: str, expected_query: LogicalQuery) -> No
         )
 
     events_entity = get_entity(EntityKey.EVENTS)
-    setattr(events_entity, "get_join_relationship", events_mock)
 
-    query, _ = parse_snql_query(query_body, events)
+    with mock.patch.object(events_entity, "get_join_relationship", events_mock):
+        query, _ = parse_snql_query(query_body, events)
 
     eq, reason = query.equals(expected_query)
     assert eq, reason

--- a/tests/query/snql/test_snql_anonymizer.py
+++ b/tests/query/snql/test_snql_anonymizer.py
@@ -157,6 +157,7 @@ def test_format_expressions(query_body: str, expected_snql_anonymized: str) -> N
         "contains": (EntityKey.TRANSACTIONS, "event_id"),
         "assigned": (EntityKey.GROUPASSIGNEE, "group_id"),
         "bookmark": (EntityKey.GROUPEDMESSAGE, "first_release_id"),
+        "attributes": (EntityKey.GROUP_ATTRIBUTES, "group_id"),
     }
 
     def events_mock(relationship: str) -> JoinRelationship:

--- a/tests/query/snql/test_snql_anonymizer.py
+++ b/tests/query/snql/test_snql_anonymizer.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 from snuba.datasets.entities.entity_key import EntityKey
@@ -157,7 +159,6 @@ def test_format_expressions(query_body: str, expected_snql_anonymized: str) -> N
         "contains": (EntityKey.TRANSACTIONS, "event_id"),
         "assigned": (EntityKey.GROUPASSIGNEE, "group_id"),
         "bookmark": (EntityKey.GROUPEDMESSAGE, "first_release_id"),
-        "attributes": (EntityKey.GROUP_ATTRIBUTES, "group_id"),
     }
 
     def events_mock(relationship: str) -> JoinRelationship:
@@ -170,8 +171,7 @@ def test_format_expressions(query_body: str, expected_snql_anonymized: str) -> N
         )
 
     events_entity = get_entity(EntityKey.EVENTS)
-    setattr(events_entity, "get_join_relationship", events_mock)
-
-    _, snql_anonymized = parse_snql_query(query_body, events)
+    with mock.patch.object(events_entity, "get_join_relationship", events_mock):
+        _, snql_anonymized = parse_snql_query(query_body, events)
 
     assert snql_anonymized == expected_snql_anonymized

--- a/tests/subscriptions/__init__.py
+++ b/tests/subscriptions/__init__.py
@@ -12,7 +12,7 @@ from snuba.datasets.factory import get_dataset
 from snuba.datasets.storages.factory import get_writable_storage
 from snuba.datasets.storages.storage_key import StorageKey
 from snuba.processor import InsertEvent
-from tests.helpers import write_unprocessed_events
+from tests.helpers import write_raw_unprocessed_events, write_unprocessed_events
 
 
 class BaseSubscriptionTest:
@@ -54,6 +54,34 @@ class BaseSubscriptionTest:
                         "retention_days": settings.DEFAULT_RETENTION_DAYS,
                     }
                 )
+                for tick in range(self.minutes)
+            ],
+        )
+        ga_storage = get_writable_storage(StorageKey.GROUP_ATTRIBUTES)
+        write_raw_unprocessed_events(
+            ga_storage,
+            [
+                {
+                    "group_deleted": False,
+                    "project_id": self.project_id,
+                    "group_id": tick,
+                    "status": 0,
+                    "substatus": 7,
+                    "first_seen": (self.base_time + timedelta(minutes=tick)).strftime(
+                        settings.PAYLOAD_DATETIME_FORMAT
+                    ),
+                    "num_comments": 0,
+                    "assignee_user_id": None,
+                    "assignee_team_id": None,
+                    "owner_suspect_commit_user_id": None,
+                    "owner_ownership_rule_user_id": None,
+                    "owner_ownership_rule_team_id": None,
+                    "owner_codeowners_user_id": None,
+                    "owner_codeowners_team_id": None,
+                    "timestamp": (self.base_time + timedelta(minutes=tick)).strftime(
+                        settings.PAYLOAD_DATETIME_FORMAT
+                    ),
+                }
                 for tick in range(self.minutes)
             ],
         )

--- a/tests/subscriptions/test_data.py
+++ b/tests/subscriptions/test_data.py
@@ -34,6 +34,22 @@ TESTS = [
         SubscriptionData(
             project_id=1,
             query=(
+                "MATCH (events: events) -[attributes]-> (ga: group_attributes) "
+                "SELECT count() AS count "
+                "WHERE events.platform IN tuple('a') AND ga.group_status IN array(0)"
+            ),
+            time_window_sec=500 * 60,
+            resolution_sec=60,
+            entity=get_entity(EntityKey.EVENTS),
+            metadata={},
+        ),
+        None,
+        id="SnQL subscription",
+    ),
+    pytest.param(
+        SubscriptionData(
+            project_id=1,
+            query=(
                 "MATCH (events) "
                 "SELECT count() AS count, avg(timestamp) AS average_t "
                 "WHERE "


### PR DESCRIPTION
Issues team wants to create error metric alerts that filter out archived issues. To do this we need to join to the group attributes table. This pr adds the ability to support joins to the subscription system.


