### PR TITLE
Give `Topic` and `Partition` a `new` fn

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
@@ -2085,7 +2085,7 @@ version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -2358,7 +2358,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]

--- a/rust_snuba/rust_arroyo/Cargo.toml
+++ b/rust_snuba/rust_arroyo/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.26"
-uuid = "0.8"
-rdkafka = { version = "0.36", features = ["cmake-build"] }
-thiserror = "1.0"
 clap = "2.18.0"
-tokio = { version = "1.19.2", features = ["full"] }
-futures = "0.3.21"
 env_logger = "0.9.0"
+futures = "0.3.21"
 log = "0.4.17"
+rdkafka = { version = "0.36", features = ["cmake-build"] }
+serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-serde = {version = "1.0.137", features = ["derive"] }
+thiserror = "1.0"
+tokio = { version = "1.19.2", features = ["full"] }
+uuid = "0.8"

--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -22,9 +22,7 @@ fn main() {
         None,
     );
     let mut consumer = KafkaConsumer::new(config);
-    let topic = Topic {
-        name: "test_static".to_string(),
-    };
+    let topic = Topic::new("test_static");
     let res = consumer.subscribe(&[topic], Box::new(EmptyCallbacks {}));
     assert!(res.is_ok());
     println!("Subscribed");

--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -26,9 +26,7 @@ fn main() {
         None,
     );
     let consumer = Arc::new(Mutex::new(KafkaConsumer::new(config)));
-    let topic = Topic {
-        name: "test_static".to_string(),
-    };
+    let topic = Topic::new("test_static");
 
     let mut processor = StreamProcessor::new(consumer, Box::new(TestFactory {}));
     processor.subscribe(topic);

--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -79,14 +79,10 @@ async fn main() {
         consumer,
         Box::new(ReverseStringAndProduceStrategyFactory {
             config: config.clone(),
-            topic: Topic {
-                name: "test_out".to_string(),
-            },
+            topic: Topic::new("test_out"),
         }),
     );
-    processor.subscribe(Topic {
-        name: "test_in".to_string(),
-    });
+    processor.subscribe(Topic::new("test_in"));
     println!("running processor. transforming from test_in to test_out");
     processor.run().unwrap();
 }

--- a/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
+++ b/rust_snuba/rust_arroyo/src/backends/kafka/producer.rs
@@ -28,8 +28,8 @@ impl ArroyoProducer<KafkaPayload> for KafkaProducer {
         payload: KafkaPayload,
     ) -> Result<(), ProducerError> {
         let topic = match destination {
-            TopicOrPartition::Topic(topic) => topic.name.as_ref(),
-            TopicOrPartition::Partition(partition) => partition.topic.name.as_ref(),
+            TopicOrPartition::Topic(topic) => topic.as_str(),
+            TopicOrPartition::Partition(partition) => partition.topic.as_str(),
         };
 
         let msg_key = payload.key.unwrap_or_default();
@@ -63,9 +63,7 @@ mod tests {
     use crate::types::{Topic, TopicOrPartition};
     #[test]
     fn test_producer() {
-        let topic = Topic {
-            name: "test".to_string(),
-        };
+        let topic = Topic::new("test");
         let destination = TopicOrPartition::Topic(topic);
         let configuration =
             KafkaConfig::new_producer_config(vec!["127.0.0.1:9092".to_string()], None);

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -400,9 +400,7 @@ mod tests {
         let clock = SystemClock {};
         let mut broker = LocalBroker::new(Box::new(storage), Box::new(clock));
 
-        let topic1 = Topic {
-            name: "test1".to_string(),
-        };
+        let topic1 = Topic::new("test1");
 
         let _ = broker.create_topic(topic1, 1);
         broker
@@ -419,9 +417,7 @@ mod tests {
         )));
 
         let mut processor = StreamProcessor::new(consumer, Box::new(TestFactory {}));
-        processor.subscribe(Topic {
-            name: "test1".to_string(),
-        });
+        processor.subscribe(Topic::new("test1"));
         let res = processor.run_once();
         assert!(res.is_ok())
     }
@@ -429,13 +425,8 @@ mod tests {
     #[test]
     fn test_consume() {
         let mut broker = build_broker();
-        let topic1 = Topic {
-            name: "test1".to_string(),
-        };
-        let partition = Partition {
-            topic: topic1,
-            index: 0,
-        };
+        let topic1 = Topic::new("test1");
+        let partition = Partition::new(topic1, 0);
         let _ = broker.produce(&partition, "message1".to_string());
         let _ = broker.produce(&partition, "message2".to_string());
 
@@ -447,9 +438,7 @@ mod tests {
         )));
 
         let mut processor = StreamProcessor::new(consumer, Box::new(TestFactory {}));
-        processor.subscribe(Topic {
-            name: "test1".to_string(),
-        });
+        processor.subscribe(Topic::new("test1"));
         let res = processor.run_once();
         assert!(res.is_ok());
         let res = processor.run_once();

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -78,18 +78,8 @@ mod tests {
     #[test]
     fn test_commit_offsets() {
         env_logger::init();
-        let partition1 = Partition {
-            topic: Topic {
-                name: "noop-commit".to_string(),
-            },
-            index: 0,
-        };
-        let partition2 = Partition {
-            topic: Topic {
-                name: "noop-commit".to_string(),
-            },
-            index: 1,
-        };
+        let partition1 = Partition::new(Topic::new("noop-commit"), 0);
+        let partition2 = Partition::new(Topic::new("noop-commit"), 1);
         let timestamp = DateTime::from(SystemTime::now());
 
         let m1 = Message {

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -134,18 +134,8 @@ mod tests {
 
     #[test]
     fn merge() {
-        let partition = Partition {
-            topic: Topic {
-                name: "topic".to_string(),
-            },
-            index: 0,
-        };
-        let partition_2 = Partition {
-            topic: Topic {
-                name: "topic".to_string(),
-            },
-            index: 1,
-        };
+        let partition = Partition::new(Topic::new("topic"), 0);
+        let partition_2 = Partition::new(Topic::new("topic"), 1);
 
         let a = Some(CommitRequest {
             positions: HashMap::from([(partition.clone(), 1)]),

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -104,12 +104,7 @@ mod tests {
             None,
         );
 
-        let partition = Partition {
-            topic: Topic {
-                name: "test".to_string(),
-            },
-            index: 0,
-        };
+        let partition = Partition::new(Topic::new("test"), 0);
 
         struct Noop {}
         impl ProcessingStrategy<KafkaPayload> for Noop {

--- a/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
@@ -232,12 +232,7 @@ mod tests {
             }
         }
 
-        let partition1 = Partition {
-            topic: Topic {
-                name: "test".to_string(),
-            },
-            index: 0,
-        };
+        let partition1 = Partition::new(Topic::new("test"), 0);
 
         let max_batch_size = 2;
         let max_batch_time = Duration::from_secs(1);

--- a/rust_snuba/rust_arroyo/src/processing/strategies/transform.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/transform.rs
@@ -136,12 +136,7 @@ mod tests {
 
         let mut strategy = Transform::new(identity, Noop {});
 
-        let partition = Partition {
-            topic: Topic {
-                name: "test".to_string(),
-            },
-            index: 0,
-        };
+        let partition = Partition::new(Topic::new("test"), 0);
 
         strategy
             .submit(Message {

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -139,9 +139,7 @@ pub fn consumer_impl(
         )),
     );
 
-    processor.subscribe(Topic {
-        name: consumer_config.raw_topic.physical_topic_name.to_owned(),
-    });
+    processor.subscribe(Topic::new(&consumer_config.raw_topic.physical_topic_name));
 
     let mut handle = processor.get_handle();
 

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -267,12 +267,7 @@ mod tests {
                 headers: None,
                 payload: Some(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec()),
             },
-            Partition {
-                topic: Topic {
-                    name: "test".to_owned(),
-                },
-                index: 1,
-            },
+            Partition::new(Topic::new("test"), 1),
             1,
             Utc::now(),
         ))

--- a/rust_snuba/src/strategies/validate_schema.rs
+++ b/rust_snuba/src/strategies/validate_schema.rs
@@ -128,12 +128,7 @@ mod tests {
 
     #[test]
     fn validate_schema() {
-        let partition = Partition {
-            topic: Topic {
-                name: "test".to_string(),
-            },
-            index: 0,
-        };
+        let partition = Partition::new(Topic::new("test"), 0);
 
         struct Noop {}
         impl ProcessingStrategy<KafkaPayload> for Noop {


### PR DESCRIPTION
This also turns `Topic` into an `Arc<str>` which is cheaper to clone. Making `Topic` completely opaque like this also makes it possible to maybe intern it and make it eventually `Copy` as well.