### PR TITLE
ref: Remove most Clone bounds

### DIFF
--- a/rust_snuba/rust_arroyo/src/backends/local/broker.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/broker.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use uuid::Uuid;
 
-pub struct LocalBroker<TPayload: Clone> {
+pub struct LocalBroker<TPayload> {
     storage: Box<dyn MessageStorage<TPayload>>,
     clock: Box<dyn Clock>,
     offsets: HashMap<String, HashMap<Partition, u64>>,
@@ -32,7 +32,7 @@ impl From<TopicDoesNotExist> for BrokerError {
     }
 }
 
-impl<TPayload: Clone + Send> LocalBroker<TPayload> {
+impl<TPayload: Send> LocalBroker<TPayload> {
     pub fn new(storage: Box<dyn MessageStorage<TPayload>>, clock: Box<dyn Clock>) -> Self {
         Self {
             storage,

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -24,7 +24,7 @@ struct SubscriptionState {
     last_eof_at: HashMap<Partition, u64>,
 }
 
-pub struct LocalConsumer<TPayload: Clone> {
+pub struct LocalConsumer<TPayload> {
     id: Uuid,
     group: String,
     broker: LocalBroker<TPayload>,
@@ -40,7 +40,7 @@ pub struct LocalConsumer<TPayload: Clone> {
     closed: bool,
 }
 
-impl<TPayload: Clone> LocalConsumer<TPayload> {
+impl<TPayload> LocalConsumer<TPayload> {
     pub fn new(
         id: Uuid,
         broker: LocalBroker<TPayload>,
@@ -68,7 +68,7 @@ impl<TPayload: Clone> LocalConsumer<TPayload> {
     }
 }
 
-impl<TPayload: Clone + Send> Consumer<TPayload> for LocalConsumer<TPayload> {
+impl<TPayload: Send> Consumer<TPayload> for LocalConsumer<TPayload> {
     fn subscribe(
         &mut self,
         topics: &[Topic],

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -80,7 +80,7 @@ pub trait AssignmentCallbacks: Send {
 /// occurs even if the consumer retains ownership of the partition across
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
-pub trait Consumer<TPayload: Clone>: Send {
+pub trait Consumer<TPayload>: Send {
     fn subscribe(
         &mut self,
         topic: &[Topic],

--- a/rust_snuba/rust_arroyo/src/backends/storages/memory.rs
+++ b/rust_snuba/rust_arroyo/src/backends/storages/memory.rs
@@ -49,11 +49,11 @@ impl<TPayload> TopicMessages<TPayload> {
     }
 }
 
-pub struct MemoryMessageStorage<TPayload: Clone> {
+pub struct MemoryMessageStorage<TPayload> {
     topics: HashMap<Topic, TopicMessages<TPayload>>,
 }
 
-impl<TPayload: Clone> Default for MemoryMessageStorage<TPayload> {
+impl<TPayload> Default for MemoryMessageStorage<TPayload> {
     fn default() -> Self {
         MemoryMessageStorage {
             topics: HashMap::new(),

--- a/rust_snuba/rust_arroyo/src/backends/storages/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/storages/mod.rs
@@ -21,7 +21,7 @@ pub enum ConsumeError {
     OffsetOutOfRange,
 }
 
-pub trait MessageStorage<TPayload: Clone + Send>: Send {
+pub trait MessageStorage<TPayload: Send>: Send {
     // Create a topic with the given number of partitions.
     //
     // If the topic already exists, a ``TopicExists`` exception will be

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -113,7 +113,7 @@ pub struct StreamProcessor<TPayload> {
     metrics_buffer: metrics_buffer::MetricsBuffer,
 }
 
-impl<TPayload: 'static + Clone> StreamProcessor<TPayload> {
+impl<TPayload: 'static> StreamProcessor<TPayload> {
     pub fn new(
         consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
         processing_factory: Box<dyn ProcessingStrategyFactory<TPayload>>,

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -27,12 +27,12 @@ pub enum RunError {
     PauseError,
 }
 
-struct Strategies<TPayload: Clone> {
+struct Strategies<TPayload> {
     processing_factory: Box<dyn ProcessingStrategyFactory<TPayload>>,
     strategy: Option<Box<dyn ProcessingStrategy<TPayload>>>,
 }
 
-struct Callbacks<TPayload: Clone> {
+struct Callbacks<TPayload> {
     strategies: Arc<Mutex<Strategies<TPayload>>>,
     consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
 }
@@ -48,7 +48,7 @@ impl ProcessorHandle {
     }
 }
 
-impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
+impl<TPayload: 'static> AssignmentCallbacks for Callbacks<TPayload> {
     // TODO: Having the initialization of the strategy here
     // means that ProcessingStrategy and ProcessingStrategyFactory
     // have to be Send and Sync, which is really limiting and unnecessary.
@@ -87,7 +87,7 @@ impl<TPayload: 'static + Clone> AssignmentCallbacks for Callbacks<TPayload> {
     }
 }
 
-impl<TPayload: Clone> Callbacks<TPayload> {
+impl<TPayload> Callbacks<TPayload> {
     pub fn new(
         strategies: Arc<Mutex<Strategies<TPayload>>>,
         consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
@@ -103,7 +103,7 @@ impl<TPayload: Clone> Callbacks<TPayload> {
 /// instance and a ``ProcessingStrategy``, ensuring that processing
 /// strategies are instantiated on partition assignment and closed on
 /// partition revocation.
-pub struct StreamProcessor<TPayload: Clone> {
+pub struct StreamProcessor<TPayload> {
     consumer: Arc<Mutex<dyn Consumer<TPayload>>>,
     strategies: Arc<Mutex<Strategies<TPayload>>>,
     message: Option<Message<TPayload>>,

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -10,7 +10,7 @@ pub struct CommitOffsets {
     last_commit_time: SystemTime,
     commit_frequency: Duration,
 }
-impl<T: Clone> ProcessingStrategy<T> for CommitOffsets {
+impl<T> ProcessingStrategy<T> for CommitOffsets {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         Ok(self.commit(false))
     }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -67,7 +67,7 @@ pub fn merge_commit_request(
 ///
 /// This interface is intentionally not prescriptive, and affords a
 /// significant degree of flexibility for the various implementations.
-pub trait ProcessingStrategy<TPayload: Clone>: Send + Sync {
+pub trait ProcessingStrategy<TPayload>: Send + Sync {
     /// Poll the processor to check on the status of asynchronous tasks or
     /// perform other scheduled work.
     ///
@@ -119,7 +119,7 @@ pub trait ProcessingStrategy<TPayload: Clone>: Send + Sync {
     fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage>;
 }
 
-pub trait ProcessingStrategyFactory<TPayload: Clone>: Send + Sync {
+pub trait ProcessingStrategyFactory<TPayload>: Send + Sync {
     /// Instantiate and return a ``ProcessingStrategy`` instance.
     ///
     /// :param commit: A function that accepts a mapping of ``Partition``

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -31,7 +31,7 @@ impl TaskRunner<KafkaPayload, KafkaPayload> for ProduceMessage {
 
         Box::pin(async move {
             producer
-                .produce(&topic, message.payload())
+                .produce(&topic, message.payload().clone())
                 .expect("Message was produced");
             Ok(message)
         })

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -13,11 +13,11 @@ use tokio::task::JoinHandle;
 pub type RunTaskFunc<TTransformed> =
     Pin<Box<dyn Future<Output = Result<Message<TTransformed>, InvalidMessage>> + Send>>;
 
-pub trait TaskRunner<TPayload: Clone, TTransformed: Clone + Send + Sync>: Send + Sync {
+pub trait TaskRunner<TPayload, TTransformed: Send + Sync>: Send + Sync {
     fn get_task(&self, message: Message<TPayload>) -> RunTaskFunc<TTransformed>;
 }
 
-pub struct RunTaskInThreads<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> {
+pub struct RunTaskInThreads<TPayload: Send + Sync, TTransformed: Send + Sync> {
     next_step: Box<dyn ProcessingStrategy<TTransformed>>,
     task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
     concurrency: usize,
@@ -29,9 +29,7 @@ pub struct RunTaskInThreads<TPayload: Clone + Send + Sync, TTransformed: Clone +
     metric_name: String,
 }
 
-impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
-    RunTaskInThreads<TPayload, TTransformed>
-{
+impl<TPayload: Send + Sync, TTransformed: Send + Sync> RunTaskInThreads<TPayload, TTransformed> {
     pub fn new<N>(
         next_step: N,
         task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
@@ -62,8 +60,8 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
     }
 }
 
-impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
-    ProcessingStrategy<TPayload> for RunTaskInThreads<TPayload, TTransformed>
+impl<TPayload: Send + Sync, TTransformed: Send + Sync + 'static> ProcessingStrategy<TPayload>
+    for RunTaskInThreads<TPayload, TTransformed>
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         let commit_request = self.next_step.poll()?;
@@ -211,7 +209,7 @@ mod tests {
 
         struct IdentityTaskRunner {}
 
-        impl<T: Clone + Send + Sync + 'static> TaskRunner<T, T> for IdentityTaskRunner {
+        impl<T: Send + Sync + 'static> TaskRunner<T, T> for IdentityTaskRunner {
             fn get_task(&self, message: Message<T>) -> RunTaskFunc<T> {
                 Box::pin(async move { Ok(message) })
             }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/transform.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/transform.rs
@@ -5,16 +5,14 @@ use crate::processing::strategies::{
 use crate::types::Message;
 use std::time::Duration;
 
-pub struct Transform<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> {
+pub struct Transform<TPayload: Send + Sync, TTransformed: Send + Sync> {
     pub function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
     pub next_step: Box<dyn ProcessingStrategy<TTransformed>>,
     pub message_carried_over: Option<Message<TTransformed>>,
     pub commit_request_carried_over: Option<CommitRequest>,
 }
 
-impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
-    Transform<TPayload, TTransformed>
-{
+impl<TPayload: Send + Sync, TTransformed: Send + Sync> Transform<TPayload, TTransformed> {
     pub fn new<N>(
         function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
         next_step: N,
@@ -31,7 +29,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
     }
 }
 
-impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> ProcessingStrategy<TPayload>
+impl<TPayload: Send + Sync, TTransformed: Send + Sync> ProcessingStrategy<TPayload>
     for Transform<TPayload, TTransformed>
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
@@ -65,25 +63,21 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> Processin
             return Err(SubmitError::MessageRejected(MessageRejected { message }));
         }
 
-        match (self.function)(message.payload()) {
-            Err(invalid_message) => {
+        let next_message = message
+            .try_map(self.function)
+            .map_err(SubmitError::InvalidMessage)?;
+
+        match self.next_step.submit(next_message) {
+            Err(SubmitError::MessageRejected(MessageRejected {
+                message: transformed_message,
+            })) => {
+                self.message_carried_over = Some(transformed_message);
+            }
+            Err(SubmitError::InvalidMessage(invalid_message)) => {
                 return Err(SubmitError::InvalidMessage(invalid_message));
             }
-            Ok(transformed) => {
-                let next_message = message.replace(transformed);
-                match self.next_step.submit(next_message) {
-                    Err(SubmitError::MessageRejected(MessageRejected {
-                        message: transformed_message,
-                    })) => {
-                        self.message_carried_over = Some(transformed_message);
-                    }
-                    Err(SubmitError::InvalidMessage(invalid_message)) => {
-                        return Err(SubmitError::InvalidMessage(invalid_message));
-                    }
-                    Ok(_) => {}
-                }
-            }
-        };
+            Ok(_) => {}
+        }
         Ok(())
     }
 

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -25,7 +25,7 @@ impl<T> TestStrategy<T> {
     }
 }
 
-impl<T: Send + Clone> ProcessingStrategy<T> for TestStrategy<T> {
+impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         Ok(None)
     }

--- a/rust_snuba/rust_arroyo/src/types/mod.rs
+++ b/rust_snuba/rust_arroyo/src/types/mod.rs
@@ -75,7 +75,7 @@ pub struct BrokerMessage<T> {
     pub timestamp: DateTime<Utc>,
 }
 
-impl<T: Clone> BrokerMessage<T> {
+impl<T> BrokerMessage<T> {
     pub fn new(payload: T, partition: Partition, offset: u64, timestamp: DateTime<Utc>) -> Self {
         Self {
             payload,
@@ -85,7 +85,7 @@ impl<T: Clone> BrokerMessage<T> {
         }
     }
 
-    pub fn replace<TReplaced: Clone>(self, replacement: TReplaced) -> BrokerMessage<TReplaced> {
+    pub fn replace<TReplaced>(self, replacement: TReplaced) -> BrokerMessage<TReplaced> {
         BrokerMessage {
             payload: replacement,
             partition: self.partition,
@@ -93,9 +93,31 @@ impl<T: Clone> BrokerMessage<T> {
             timestamp: self.timestamp,
         }
     }
+
+    /// Map a fallible function over this messages's payload.
+    pub fn try_map<TReplaced, E, F: FnOnce(T) -> Result<TReplaced, E>>(
+        self,
+        f: F,
+    ) -> Result<BrokerMessage<TReplaced>, E> {
+        let Self {
+            payload,
+            partition,
+            offset,
+            timestamp,
+        } = self;
+
+        let payload = f(payload)?;
+
+        Ok(BrokerMessage {
+            payload,
+            partition,
+            offset,
+            timestamp,
+        })
+    }
 }
 
-impl<T: Clone> fmt::Display for BrokerMessage<T> {
+impl<T> fmt::Display for BrokerMessage<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -111,7 +133,7 @@ pub struct AnyMessage<T> {
     pub committable: BTreeMap<Partition, u64>,
 }
 
-impl<T: Clone> AnyMessage<T> {
+impl<T> AnyMessage<T> {
     pub fn new(payload: T, committable: BTreeMap<Partition, u64>) -> Self {
         Self {
             payload,
@@ -119,15 +141,33 @@ impl<T: Clone> AnyMessage<T> {
         }
     }
 
-    pub fn replace<TReplaced: Clone>(self, replacement: TReplaced) -> AnyMessage<TReplaced> {
+    pub fn replace<TReplaced>(self, replacement: TReplaced) -> AnyMessage<TReplaced> {
         AnyMessage {
             payload: replacement,
             committable: self.committable,
         }
     }
+
+    /// Map a fallible function over this messages's payload.
+    pub fn try_map<TReplaced, E, F: FnOnce(T) -> Result<TReplaced, E>>(
+        self,
+        f: F,
+    ) -> Result<AnyMessage<TReplaced>, E> {
+        let Self {
+            payload,
+            committable,
+        } = self;
+
+        let payload = f(payload)?;
+
+        Ok(AnyMessage {
+            payload,
+            committable,
+        })
+    }
 }
 
-impl<T: Clone> fmt::Display for AnyMessage<T> {
+impl<T> fmt::Display for AnyMessage<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "AnyMessage(committable={:?})", self.committable)
     }
@@ -144,7 +184,7 @@ pub struct Message<T> {
     pub inner_message: InnerMessage<T>,
 }
 
-impl<T: Clone> Message<T> {
+impl<T> Message<T> {
     pub fn new_broker_message(
         payload: T,
         partition: Partition,
@@ -170,28 +210,37 @@ impl<T: Clone> Message<T> {
         }
     }
 
-    pub fn payload(&self) -> T {
+    pub fn payload(&self) -> &T {
         match &self.inner_message {
-            InnerMessage::BrokerMessage(BrokerMessage { payload, .. }) => payload.clone(),
-            InnerMessage::AnyMessage(AnyMessage { payload, .. }) => payload.clone(),
+            InnerMessage::BrokerMessage(BrokerMessage { payload, .. }) => payload,
+            InnerMessage::AnyMessage(AnyMessage { payload, .. }) => payload,
         }
     }
 
-    pub fn committable(&self) -> BTreeMap<Partition, u64> {
+    /// Consumes the method and returns its payload.
+    pub fn into_payload(self) -> T {
+        match self.inner_message {
+            InnerMessage::BrokerMessage(BrokerMessage { payload, .. }) => payload,
+            InnerMessage::AnyMessage(AnyMessage { payload, .. }) => payload,
+        }
+    }
+
+    /// Returns an iterator over this message's committable offsets.
+    pub fn committable(&self) -> Committable {
         match &self.inner_message {
             InnerMessage::BrokerMessage(BrokerMessage {
                 partition, offset, ..
-            }) => {
-                let mut map = BTreeMap::new();
-                // TODO: Get rid of the clone
-                map.insert(*partition, offset + 1);
-                map
+            }) => Committable(CommittableInner::Broker(std::iter::once((
+                *partition,
+                offset + 1,
+            )))),
+            InnerMessage::AnyMessage(AnyMessage { committable, .. }) => {
+                Committable(CommittableInner::Any(committable.iter()))
             }
-            InnerMessage::AnyMessage(AnyMessage { committable, .. }) => committable.clone(),
         }
     }
 
-    pub fn replace<TReplaced: Clone>(self, replacement: TReplaced) -> Message<TReplaced> {
+    pub fn replace<TReplaced>(self, replacement: TReplaced) -> Message<TReplaced> {
         match self.inner_message {
             InnerMessage::BrokerMessage(inner) => Message {
                 inner_message: InnerMessage::BrokerMessage(inner.replace(replacement)),
@@ -201,9 +250,26 @@ impl<T: Clone> Message<T> {
             },
         }
     }
+
+    /// Map a fallible function over this messages's payload.
+    pub fn try_map<TReplaced, E, F: FnOnce(T) -> Result<TReplaced, E>>(
+        self,
+        f: F,
+    ) -> Result<Message<TReplaced>, E> {
+        match self.inner_message {
+            InnerMessage::BrokerMessage(inner) => {
+                let inner = inner.try_map(f)?;
+                Ok(inner.into())
+            }
+            InnerMessage::AnyMessage(inner) => {
+                let inner = inner.try_map(f)?;
+                Ok(inner.into())
+            }
+        }
+    }
 }
 
-impl<T: Clone> fmt::Display for Message<T> {
+impl<T> fmt::Display for Message<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.inner_message {
             InnerMessage::BrokerMessage(BrokerMessage {
@@ -229,6 +295,43 @@ impl<T: Clone> fmt::Display for Message<T> {
                         .join(",")
                 )
             }
+        }
+    }
+}
+
+impl<T> From<BrokerMessage<T>> for Message<T> {
+    fn from(value: BrokerMessage<T>) -> Self {
+        Self {
+            inner_message: InnerMessage::BrokerMessage(value),
+        }
+    }
+}
+
+impl<T> From<AnyMessage<T>> for Message<T> {
+    fn from(value: AnyMessage<T>) -> Self {
+        Self {
+            inner_message: InnerMessage::AnyMessage(value),
+        }
+    }
+}
+
+enum CommittableInner<'a> {
+    Any(std::collections::btree_map::Iter<'a, Partition, u64>),
+    Broker(std::iter::Once<(Partition, u64)>),
+}
+
+/// An iterator over a `Message`'s committable offsets.
+///
+/// This is produced by [`Message::committable`].
+pub struct Committable<'a>(CommittableInner<'a>);
+
+impl<'a> Iterator for Committable<'a> {
+    type Item = (Partition, u64);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.0 {
+            CommittableInner::Any(ref mut inner) => inner.next().map(|(k, v)| (*k, *v)),
+            CommittableInner::Broker(ref mut inner) => inner.next(),
         }
     }
 }

--- a/rust_snuba/src/strategies/clickhouse.rs
+++ b/rust_snuba/src/strategies/clickhouse.rs
@@ -29,7 +29,7 @@ impl TaskRunner<BytesInsertBatch, BytesInsertBatch> for ClickhouseWriter {
         Box::pin(async move {
             let len = message.payload().rows.len();
             let mut data = vec![];
-            for row in message.payload().rows {
+            for row in &message.payload().rows {
                 data.extend(row);
                 data.extend(b"\n");
             }

--- a/rust_snuba/src/strategies/validate_schema.rs
+++ b/rust_snuba/src/strategies/validate_schema.rs
@@ -41,9 +41,9 @@ impl TaskRunner<KafkaPayload, KafkaPayload> for SchemaValidator {
         let mut errored = false;
 
         if let Some(schema) = &self.schema {
-            let payload = message.payload().payload.unwrap();
+            let payload = message.payload().payload.as_ref().unwrap();
 
-            let res = schema.validate_json(&payload);
+            let res = schema.validate_json(payload);
 
             if let Err(err) = res {
                 log::error!("Validation error {}", err);


### PR DESCRIPTION
This removes almost all `Clone` bounds from types and functions.

Many of these bounds were spurious, i.e., removing them had no effect whatever, but in some cases I removed an avoidable clone. To this end, I introduced some methods on `Message` and changed others:
* `try_map` maps a fallible function over the message to avoid cloning the payload, mapping it, and then replacing the mapped payload;
* `into_payload` consumes the message and returns the payload (avoids the clone in `payload`);
* `payload` now returns a reference to the inner payload;
* `committable` now returns an iterator over the message's committable offsets to avoid cloning the inner map (or creating it from scratch for `BrokerMessage`)

There are some clones/`Clone` bounds I couldn't figure out how to get rid of:
* There is a clone in `ProduceMessage::get_task` (previously implicit in the `payload` call). This stems from the fact that we want to `produce` the message (which consumes it) but also return it. I don't know if this is necessary or what to do about it.
* `InMemoryMessageStorage` still has its `Clone` bound on its `MessageStore` impl because the `consume` function on `MessageStorage` requires it to return an owned `Message`. I see two possibilities here to remove this: Either we change the trait to return a reference to the message or we remove the message from the `InMemoryMessageStorage` when we return it. Neither of these might be possible, in which case I guess we have to eat the clone.
* `Reduce still has the `Clone` bound on `TResult` because its `initial_value` is is used over and over to create new `BatchState`s. I don't see a way around this.