### PR TITLE
ref(rust): Rename Transform to RunTask

### DIFF
--- a/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
+++ b/rust_snuba/rust_arroyo/examples/transform_and_produce.rs
@@ -10,7 +10,7 @@ use rust_arroyo::backends::kafka::producer::KafkaProducer;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::kafka::KafkaConsumer;
 use rust_arroyo::processing::strategies::produce::Produce;
-use rust_arroyo::processing::strategies::transform::Transform;
+use rust_arroyo::processing::strategies::run_task::Transform;
 use rust_arroyo::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, ProcessingStrategyFactory, SubmitError,
 };

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -6,7 +6,7 @@ pub mod commit_offsets;
 pub mod produce;
 pub mod reduce;
 pub mod run_task_in_threads;
-pub mod transform;
+pub mod run_task;
 
 #[derive(Debug, Clone)]
 pub enum SubmitError<T> {

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task.rs
@@ -5,7 +5,7 @@ use crate::processing::strategies::{
 use crate::types::Message;
 use std::time::Duration;
 
-pub struct Transform<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> {
+pub struct RunTask<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> {
     pub function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
     pub next_step: Box<dyn ProcessingStrategy<TTransformed>>,
     pub message_carried_over: Option<Message<TTransformed>>,
@@ -13,7 +13,7 @@ pub struct Transform<TPayload: Clone + Send + Sync, TTransformed: Clone + Send +
 }
 
 impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
-    Transform<TPayload, TTransformed>
+    RunTask<TPayload, TTransformed>
 {
     pub fn new<N>(
         function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
@@ -32,7 +32,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync>
 }
 
 impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync> ProcessingStrategy<TPayload>
-    for Transform<TPayload, TTransformed>
+    for RunTask<TPayload, TTransformed>
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         match self.next_step.poll() {
@@ -111,7 +111,7 @@ mod tests {
     use chrono::Utc;
 
     #[test]
-    fn test_transform() {
+    fn test_run_task() {
         fn identity(value: String) -> Result<String, InvalidMessage> {
             Ok(value)
         }
@@ -134,7 +134,7 @@ mod tests {
             }
         }
 
-        let mut strategy = Transform::new(identity, Noop {});
+        let mut strategy = RunTask::new(identity, Noop {});
 
         let partition = Partition::new(Topic::new("test"), 0);
 


### PR DESCRIPTION
We no longer use the name transform in the python version either. Since the function is allowed to have side effects, we call it RunTask. Let's keep the same naming convention here.
