### PR TITLE
fix(rust): Fix duration underflow

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
@@ -84,24 +84,35 @@ impl<T: Clone + Send + Sync, TResult: Clone + Send + Sync> ProcessingStrategy<T>
 
     fn join(&mut self, timeout: Option<Duration>) -> Result<Option<CommitRequest>, InvalidMessage> {
         let start = Instant::now();
-        let mut remaining: Option<Duration> = timeout;
         if self.message_carried_over.is_some() {
             while self.message_carried_over.is_some() {
                 let next_commit = self.next_step.poll()?;
                 self.commit_request_carried_over =
                     merge_commit_request(self.commit_request_carried_over.take(), next_commit);
                 self.flush(true)?;
-                if let Some(t) = remaining {
-                    if t <= Duration::from_secs(0) {
+                if let Some(t) = timeout {
+                    if start.elapsed() > t {
                         log::warn!("Timeout reached while waiting for tasks to finish");
                         break;
                     }
-                    remaining = Some(t - start.elapsed());
                 }
             }
         } else {
             self.flush(true)?;
         }
+
+        let remaining = match timeout {
+            Some(t) => {
+                let elapsed = start.elapsed();
+                if elapsed > t {
+                    Some(Duration::ZERO)
+                } else {
+                    Some(t - elapsed)
+                }
+            }
+            None => None,
+        };
+
         let next_commit = self.next_step.join(remaining)?;
 
         Ok(merge_commit_request(

--- a/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
@@ -101,17 +101,7 @@ impl<T: Clone + Send + Sync, TResult: Clone + Send + Sync> ProcessingStrategy<T>
             self.flush(true)?;
         }
 
-        let remaining = match timeout {
-            Some(t) => {
-                let elapsed = start.elapsed();
-                if elapsed > t {
-                    Some(Duration::ZERO)
-                } else {
-                    Some(t - elapsed)
-                }
-            }
-            None => None,
-        };
+        let remaining: Option<Duration> = timeout.map(|t| t.checked_sub(start.elapsed()).unwrap_or(Duration::ZERO));
 
         let next_commit = self.next_step.join(remaining)?;
 

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -173,17 +173,7 @@ impl<TPayload: Clone + Send + Sync, TTransformed: Clone + Send + Sync + 'static>
         self.handles.clear();
         self.metrics_buffer.flush();
 
-        let remaining = match timeout {
-            Some(t) => {
-                let elapsed = start.elapsed();
-                if elapsed > t {
-                    Some(Duration::ZERO)
-                } else {
-                    Some(t - elapsed)
-                }
-            }
-            None => None,
-        };
+        let remaining = timeout.map(|t| t.checked_sub(start.elapsed()).unwrap_or(Duration::ZERO));
 
         let next_commit = self.next_step.join(remaining)?;
 


### PR DESCRIPTION
Duration can't be negative so it is not safe to subtract elapsed from timeout like the prior approach did
