### PR TITLE
Use more early-returns

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -75,7 +75,7 @@ mod tests {
 
         for i in 0..10 {
             buffer.append(BrokerMessage {
-                partition: partition.clone(),
+                partition,
                 offset: i,
                 payload: i,
                 timestamp: Utc::now(),

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -41,13 +41,7 @@ impl CommitOffsets {
     }
 
     fn commit(&mut self, force: bool) -> Option<CommitRequest> {
-        if SystemTime::now()
-            > self
-                .last_commit_time
-                .checked_add(self.commit_frequency)
-                .unwrap()
-            || force
-        {
+        if self.last_commit_time.elapsed().unwrap_or_default() > self.commit_frequency || force {
             if !self.partitions.is_empty() {
                 let ret = Some(CommitRequest {
                     positions: self.partitions.clone(),

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -35,10 +35,8 @@ impl CommitRequest {
     pub fn merge(mut self, other: CommitRequest) -> Self {
         // Merge commit requests, keeping the highest offset for each partition
         for (partition, offset) in other.positions {
-            if self.positions.contains_key(&partition) {
-                if self.positions[&partition] < offset {
-                    self.positions.insert(partition, offset);
-                }
+            if let Some(pos_offset) = self.positions.get_mut(&partition) {
+                *pos_offset = (*pos_offset).max(offset);
             } else {
                 self.positions.insert(partition, offset);
             }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/produce.rs
@@ -12,14 +12,14 @@ use std::time::Duration;
 
 struct ProduceMessage {
     producer: Arc<dyn Producer<KafkaPayload>>,
-    topic: Arc<TopicOrPartition>,
+    topic: TopicOrPartition,
 }
 
 impl ProduceMessage {
     pub fn new(producer: impl Producer<KafkaPayload> + 'static, topic: TopicOrPartition) -> Self {
         ProduceMessage {
             producer: Arc::new(producer),
-            topic: Arc::new(topic),
+            topic,
         }
     }
 }
@@ -27,7 +27,7 @@ impl ProduceMessage {
 impl TaskRunner<KafkaPayload, KafkaPayload> for ProduceMessage {
     fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<KafkaPayload> {
         let producer = self.producer.clone();
-        let topic = self.topic.clone();
+        let topic = self.topic;
 
         Box::pin(async move {
             producer

--- a/rust_snuba/rust_arroyo/src/types/mod.rs
+++ b/rust_snuba/rust_arroyo/src/types/mod.rs
@@ -61,7 +61,7 @@ impl fmt::Display for Partition {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TopicOrPartition {
     Topic(Topic),
     Partition(Partition),

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -9,64 +9,59 @@ pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
 ) -> Result<BytesInsertBatch, BadMessage> {
-    if let Some(payload_bytes) = payload.payload {
-        let msg: FromFunctionsMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-            log::error!("Failed to deserialize message: {}", err);
+    let payload_bytes = payload.payload.ok_or(BadMessage)?;
+    let msg: FromFunctionsMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
+        log::error!("Failed to deserialize message: {}", err);
+        BadMessage
+    })?;
+
+    let profile_id = Uuid::parse_str(msg.profile_id.as_str()).map_err(|_err| BadMessage)?;
+    let timestamp = match msg.timestamp {
+        Some(timestamp) => timestamp,
+        _ => SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_err| BadMessage)?
+            .as_secs(),
+    };
+    let device_classification = msg.device_class.unwrap_or_default();
+
+    let mut rows = Vec::with_capacity(msg.functions.len());
+    for from in msg.functions {
+        let function = Function {
+            // Profile metadata
+            browser_name: msg.browser_name.clone(),
+            device_classification,
+            dist: msg.dist.clone(),
+            environment: msg.environment.clone(),
+            http_method: msg.http_method.clone(),
+            platform: msg.platform.clone(),
+            profile_id: profile_id.to_string(),
+            project_id: msg.project_id,
+            release: msg.release.clone(),
+            retention_days: msg.retention_days,
+            timestamp,
+            transaction_name: msg.transaction_name.clone(),
+            transaction_op: msg.transaction_op.clone(),
+            transaction_status: msg.transaction_status as u8,
+
+            // Function metadata
+            fingerprint: from.fingerprint,
+            durations: from.self_times_ns,
+            function: from.function.clone(),
+            package: from.package.clone(),
+            name: from.function,
+            is_application: from.in_app as u8,
+
+            ..Default::default()
+        };
+        let serialized = serde_json::to_vec(&function).map_err(|err| {
+            log::error!("Failed to serialize message: {}", err);
             BadMessage
         })?;
-
-        let profile_id = Uuid::parse_str(msg.profile_id.as_str()).map_err(|_err| BadMessage)?;
-        let timestamp = match msg.timestamp {
-            Some(timestamp) => timestamp,
-            _ => SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map_err(|_err| BadMessage)?
-                .as_secs(),
-        };
-        let device_classification = match msg.device_class {
-            Some(device_classification) => device_classification,
-            _ => 0,
-        };
-        let mut rows = Vec::with_capacity(msg.functions.len());
-
-        for from in &msg.functions {
-            let function = Function {
-                // Profile metadata
-                browser_name: msg.browser_name.clone(),
-                device_classification,
-                dist: msg.dist.clone(),
-                environment: msg.environment.clone(),
-                http_method: msg.http_method.clone(),
-                platform: msg.platform.clone(),
-                profile_id: profile_id.to_string(),
-                project_id: msg.project_id,
-                release: msg.release.clone(),
-                retention_days: msg.retention_days,
-                timestamp,
-                transaction_name: msg.transaction_name.clone(),
-                transaction_op: msg.transaction_op.clone(),
-                transaction_status: msg.transaction_status as u8,
-
-                // Function metadata
-                fingerprint: from.fingerprint,
-                durations: from.self_times_ns.clone(),
-                function: from.function.clone(),
-                package: from.package.clone(),
-                name: from.function.clone(),
-                is_application: from.in_app as u8,
-
-                ..Default::default()
-            };
-            let serialized = serde_json::to_vec(&function).map_err(|err| {
-                log::error!("Failed to serialize message: {}", err);
-                BadMessage
-            })?;
-            rows.push(serialized);
-        }
-
-        return Ok(BytesInsertBatch { rows });
+        rows.push(serialized);
     }
-    Err(BadMessage)
+
+    Ok(BytesInsertBatch { rows })
 }
 
 #[derive(Debug, Deserialize)]

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -10,24 +10,21 @@ pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
 ) -> Result<BytesInsertBatch, BadMessage> {
-    if let Some(payload_bytes) = payload.payload {
-        let msg: FromQuerylogMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-            log::error!("Failed to deserialize message: {}", err);
-            BadMessage
-        })?;
-        let querylog_msg: QuerylogMessage = msg.try_into()?;
+    let payload_bytes = payload.payload.ok_or(BadMessage)?;
+    let msg: FromQuerylogMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
+        log::error!("Failed to deserialize message: {}", err);
+        BadMessage
+    })?;
+    let querylog_msg: QuerylogMessage = msg.try_into()?;
 
-        let serialized = serde_json::to_vec(&querylog_msg).map_err(|err| {
-            log::error!("Failed to serialize message: {}", err);
-            BadMessage
-        })?;
+    let serialized = serde_json::to_vec(&querylog_msg).map_err(|err| {
+        log::error!("Failed to serialize message: {}", err);
+        BadMessage
+    })?;
 
-        return Ok(BytesInsertBatch {
-            rows: vec![serialized],
-        });
-    }
-
-    Err(BadMessage)
+    Ok(BytesInsertBatch {
+        rows: vec![serialized],
+    })
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -6,28 +6,26 @@ use uuid::Uuid;
 
 pub fn process_message(
     payload: KafkaPayload,
-    _metadata: KafkaMessageMetadata,
+    metadata: KafkaMessageMetadata,
 ) -> Result<BytesInsertBatch, BadMessage> {
-    if let Some(payload_bytes) = payload.payload {
-        let msg: FromSpanMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-            log::error!("Failed to deserialize message: {}", err);
-            BadMessage
-        })?;
-        let mut span: Span = msg.try_into()?;
+    let payload_bytes = payload.payload.ok_or(BadMessage)?;
+    let msg: FromSpanMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
+        log::error!("Failed to deserialize message: {}", err);
+        BadMessage
+    })?;
+    let mut span: Span = msg.try_into()?;
 
-        span.offset = _metadata.offset;
-        span.partition = _metadata.partition;
+    span.offset = metadata.offset;
+    span.partition = metadata.partition;
 
-        let serialized = serde_json::to_vec(&span).map_err(|err| {
-            log::error!("Failed to serialize processed message: {}", err);
-            BadMessage
-        })?;
+    let serialized = serde_json::to_vec(&span).map_err(|err| {
+        log::error!("Failed to serialize processed message: {}", err);
+        BadMessage
+    })?;
 
-        return Ok(BytesInsertBatch {
-            rows: vec![serialized],
-        });
-    }
-    Err(BadMessage)
+    Ok(BytesInsertBatch {
+        rows: vec![serialized],
+    })
 }
 
 const DEFAULT_RETENTION_DAYS: u16 = 90;


### PR DESCRIPTION
This is just a bunch of refactorings introducing `let-else` and other patterns to avoid rightward drift in a ton of places.

Best reviewed with the "ignore whitespace" setting.