### PR TITLE
Avoid Mutex on `AssignmentCallbacks`

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_consumer.rs
+++ b/rust_snuba/rust_arroyo/examples/base_consumer.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 
 struct EmptyCallbacks {}
 impl AssignmentCallbacks for EmptyCallbacks {
-    fn on_assign(&mut self, _: HashMap<Partition, u64>) {}
-    fn on_revoke(&mut self, _: Vec<Partition>) {}
+    fn on_assign(&self, _: HashMap<Partition, u64>) {}
+    fn on_revoke(&self, _: Vec<Partition>) {}
 }
 
 fn main() {

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -290,8 +290,8 @@ mod tests {
 
     struct EmptyCallbacks {}
     impl AssignmentCallbacks for EmptyCallbacks {
-        fn on_assign(&mut self, _: HashMap<Partition, u64>) {}
-        fn on_revoke(&mut self, _: Vec<Partition>) {}
+        fn on_assign(&self, _: HashMap<Partition, u64>) {}
+        fn on_revoke(&self, _: Vec<Partition>) {}
     }
 
     fn build_broker() -> LocalBroker<String> {
@@ -347,7 +347,7 @@ mod tests {
 
         struct TheseCallbacks {}
         impl AssignmentCallbacks for TheseCallbacks {
-            fn on_assign(&mut self, partitions: HashMap<Partition, u64>) {
+            fn on_assign(&self, partitions: HashMap<Partition, u64>) {
                 let topic1 = Topic::new("test1");
                 let topic2 = Topic::new("test2");
                 assert_eq!(
@@ -377,7 +377,7 @@ mod tests {
                     ])
                 )
             }
-            fn on_revoke(&mut self, partitions: Vec<Partition>) {
+            fn on_revoke(&self, partitions: Vec<Partition>) {
                 let topic1 = Topic::new("test1");
                 let topic2 = Topic::new("test2");
                 assert_eq!(
@@ -422,7 +422,7 @@ mod tests {
 
         struct TheseCallbacks {}
         impl AssignmentCallbacks for TheseCallbacks {
-            fn on_assign(&mut self, partitions: HashMap<Partition, u64>) {
+            fn on_assign(&self, partitions: HashMap<Partition, u64>) {
                 let topic2 = Topic::new("test2");
                 assert_eq!(
                     partitions,
@@ -435,7 +435,7 @@ mod tests {
                     ),])
                 );
             }
-            fn on_revoke(&mut self, _: Vec<Partition>) {}
+            fn on_revoke(&self, _: Vec<Partition>) {}
         }
 
         let my_callbacks: Box<dyn AssignmentCallbacks> = Box::new(TheseCallbacks {});

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -41,9 +41,9 @@ pub enum ProducerError {
 
 /// This is basically an observer pattern to receive the callbacks from
 /// the consumer when partitions are assigned/revoked.
-pub trait AssignmentCallbacks: Send {
-    fn on_assign(&mut self, partitions: HashMap<Partition, u64>);
-    fn on_revoke(&mut self, partitions: Vec<Partition>);
+pub trait AssignmentCallbacks: Send + Sync {
+    fn on_assign(&self, partitions: HashMap<Partition, u64>);
+    fn on_revoke(&self, partitions: Vec<Partition>);
 }
 
 /// This abstract class provides an interface for consuming messages from a

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -56,11 +56,11 @@ impl<TPayload: 'static> AssignmentCallbacks for Callbacks<TPayload> {
     // Revisit this so that it is not the callback that perform the
     // initialization.  But we just provide a signal back to the
     // processor to do that.
-    fn on_assign(&mut self, _: HashMap<Partition, u64>) {
+    fn on_assign(&self, _: HashMap<Partition, u64>) {
         let mut stg = self.strategies.lock().unwrap();
         stg.strategy = Some(stg.processing_factory.create());
     }
-    fn on_revoke(&mut self, _: Vec<Partition>) {
+    fn on_revoke(&self, _: Vec<Partition>) {
         let mut metrics = get_metrics();
         let start = Instant::now();
 


### PR DESCRIPTION
The `AssignmentCallbacks` don’t need to take `&mut self`, which can remove one `Mutex`.

The reason for this is that the only non-test usage has internal `Mutex` usage anyway.