### PR TITLE
ref(rust): Fix inconsistency in metrics trait

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -61,7 +61,7 @@ impl<TPayload: 'static> AssignmentCallbacks for Callbacks<TPayload> {
         stg.strategy = Some(stg.processing_factory.create());
     }
     fn on_revoke(&self, _: Vec<Partition>) {
-        let mut metrics = get_metrics();
+        let metrics = get_metrics();
         let start = Instant::now();
 
         let mut stg = self.strategies.lock().unwrap();

--- a/rust_snuba/rust_arroyo/src/utils/metrics.rs
+++ b/rust_snuba/rust_arroyo/src/utils/metrics.rs
@@ -7,19 +7,19 @@ pub static METRICS: OnceLock<Arc<Mutex<Box<dyn Metrics>>>> = OnceLock::new();
 pub trait Metrics: Debug + Send + Sync {
     fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>);
 
-    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 
-    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>);
 }
 
 impl Metrics for Arc<Mutex<Box<dyn Metrics>>> {
     fn increment(&self, key: &str, value: i64, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().increment(key, value, tags)
     }
-    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().gauge(key, value, tags)
     }
-    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         self.as_ref().lock().unwrap().timing(key, value, tags)
     }
 }
@@ -30,9 +30,9 @@ struct Noop {}
 impl Metrics for Noop {
     fn increment(&self, _key: &str, _value: i64, _tags: Option<HashMap<&str, &str>>) {}
 
-    fn gauge(&mut self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+    fn gauge(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 
-    fn timing(&mut self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
+    fn timing(&self, _key: &str, _value: u64, _tags: Option<HashMap<&str, &str>>) {}
 }
 
 pub fn configure_metrics(metrics: Box<dyn Metrics>) {

--- a/rust_snuba/src/metrics/statsd.rs
+++ b/rust_snuba/src/metrics/statsd.rs
@@ -49,13 +49,13 @@ impl ArroyoMetrics for StatsDBackend {
         }
     }
 
-    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) = self.send_with_tags(self.client.gauge_with_tags(key, value), tags) {
             log::debug!("Error sending metric: {}", e);
         }
     }
 
-    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         if let Err(e) = self.send_with_tags(self.client.time_with_tags(key, value), tags) {
             log::debug!("Error sending metric: {}", e);
         }

--- a/rust_snuba/src/metrics/testing.rs
+++ b/rust_snuba/src/metrics/testing.rs
@@ -56,7 +56,7 @@ impl ArroyoMetrics for TestingMetricsBackend {
         self.metric_calls.lock().unwrap().push(res);
     }
 
-    fn gauge(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn gauge(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         let builder = self.client.gauge_with_tags(key, value);
 
         let res = self
@@ -68,7 +68,7 @@ impl ArroyoMetrics for TestingMetricsBackend {
         self.metric_calls.lock().unwrap().push(res);
     }
 
-    fn timing(&mut self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
+    fn timing(&self, key: &str, value: u64, tags: Option<HashMap<&str, &str>>) {
         let builder = self.client.time_with_tags(key, value);
 
         let res = self


### PR DESCRIPTION
No need for gauge() and timing() to take &mut self when increment() only takes &self.

