### PR TITLE
Remove `BadMessage` in favor of `anyhow::Error`

### DIFF
--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -390,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
- "uuid 1.5.0",
+ "uuid",
 ]
 
 [[package]]
@@ -906,7 +906,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "tempfile",
- "uuid 1.5.0",
+ "uuid",
  "winapi 0.3.9",
 ]
 
@@ -978,7 +978,7 @@ dependencies = [
  "serde_json",
  "time",
  "url",
- "uuid 1.5.0",
+ "uuid",
 ]
 
 [[package]]
@@ -1750,7 +1750,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "uuid 0.8.2",
+ "uuid",
 ]
 
 [[package]]
@@ -1776,7 +1776,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "uuid 1.5.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2027,7 +2027,7 @@ dependencies = [
  "thiserror",
  "time",
  "url",
- "uuid 1.5.0",
+ "uuid",
 ]
 
 [[package]]
@@ -2542,12 +2542,6 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"

--- a/rust_snuba/Cargo.lock
+++ b/rust_snuba/Cargo.lock
@@ -116,6 +116,9 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "atty"
@@ -1887,6 +1890,7 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest",
+ "sentry-anyhow",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -1896,6 +1900,17 @@ dependencies = [
  "sentry-tracing",
  "tokio",
  "ureq",
+]
+
+[[package]]
+name = "sentry-anyhow"
+version = "0.31.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4fd76cd5c14676228996a31aa214adb049920b103bbc5b5a4114d05323995c5"
+dependencies = [
+ "anyhow",
+ "sentry-backtrace",
+ "sentry-core",
 ]
 
 [[package]]

--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [workspace]
-members = [
-    "rust_arroyo",
-]
+members = ["rust_arroyo"]
+
+[features]
+ffi = ["pyo3/extension-module"]
 
 [lib]
 # The name of the native library. This is the name which will be used in Python to import the
@@ -20,30 +21,27 @@ name = "rust_snuba"
 crate-type = ["cdylib"]
 
 [dependencies]
-anyhow = "1.0.69"
+anyhow = { version = "1.0.69", features = ["backtrace"] }
 cadence = "0.29.1"
 chrono = { version = "0.4.26", features = ["serde"] }
-futures = "0.3.21"
-rust_arroyo = { path = "./rust_arroyo" }
-serde_yaml = "0.9.19"
-tokio = { version = "1.19.2", features = ["full"] }
-log = "0.4"
-serde = { version = "1.0", features = ["derive"]}
-serde_json = { version = "1.0" }
-glob = "0.3.1"
-pyo3 = { version = "0.18.1", features = ["chrono"] }
 ctrlc = "3.2.5"
-sentry = { version = "0.31.0", features = ["log"] }
-reqwest = "0.11.11"
-uuid = "1.4.1"
-procspawn = { version = "0.10.2", features = ["json"] }
+futures = "0.3.21"
+glob = "0.3.1"
+log = "0.4"
 pretty_env_logger = "0.5.0"
-thiserror = "1.0"
+procspawn = { version = "0.10.2", features = ["json"] }
+pyo3 = { version = "0.18.1", features = ["chrono"] }
+reqwest = "0.11.11"
+rust_arroyo = { path = "./rust_arroyo" }
+sentry = { version = "0.31.0", features = ["anyhow", "log"] }
 sentry-kafka-schemas = "0.1.32"
-
-[features]
-ffi = ["pyo3/extension-module"]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+serde_yaml = "0.9.19"
+thiserror = "1.0"
+tokio = { version = "1.19.2", features = ["full"] }
+uuid = "1.4.1"
 
 [dev-dependencies]
-pyo3 = { version = "*", features = ["auto-initialize"] }
 procspawn = { version = "0.10.2", features = ["test-support", "json"] }
+pyo3 = { version = "*", features = ["auto-initialize"] }

--- a/rust_snuba/rust_arroyo/Cargo.toml
+++ b/rust_snuba/rust_arroyo/Cargo.toml
@@ -17,4 +17,4 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
-uuid = "0.8"
+uuid = "1.5.0"

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -69,6 +69,8 @@ pub fn consumer_impl(
     // setup sentry
     if let Some(dsn) = consumer_config.env.sentry_dsn {
         log::debug!("Using sentry dsn {:?}", dsn);
+        // this forces anyhow to record stack traces when capturing an error:
+        std::env::set_var("RUST_BACKTRACE", "1");
         _sentry_guard = Some(setup_sentry(dsn));
     }
 

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -3,7 +3,7 @@ use crate::processors;
 use crate::strategies::clickhouse::ClickhouseWriterStep;
 use crate::strategies::python::PythonTransformStep;
 use crate::strategies::validate_schema::ValidateSchema;
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::processing::strategies::commit_offsets::CommitOffsets;
 use rust_arroyo::processing::strategies::reduce::Reduce;
@@ -49,12 +49,70 @@ impl ConsumerStrategyFactory {
     }
 }
 
+struct MessageProcessor {
+    func: fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>,
+}
+
+impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
+    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<BytesInsertBatch> {
+        let func = self.func;
+
+        Box::pin(async move {
+            let broker_message = match message.inner_message {
+                InnerMessage::BrokerMessage(msg) => msg,
+                _ => panic!("Unexpected message type"),
+            };
+
+            let metadata = KafkaMessageMetadata {
+                partition: broker_message.partition.index,
+                offset: broker_message.offset,
+                timestamp: broker_message.timestamp,
+            };
+
+            match func(broker_message.payload, metadata) {
+                Ok(transformed) => Ok(Message {
+                    inner_message: InnerMessage::BrokerMessage(BrokerMessage {
+                        payload: transformed,
+                        partition: broker_message.partition,
+                        offset: broker_message.offset,
+                        timestamp: broker_message.timestamp,
+                    }),
+                }),
+                Err(err) => {
+                    // TODO: after moving to `tracing`, we can properly attach `err` to the log.
+                    // however, as Sentry captures `error` logs as errors by default,
+                    // we would double-log this error here:
+                    log::error!("Failed processing message: {err}");
+                    sentry::with_scope(
+                        |_scope| {
+                            // FIXME(swatinem): we already moved `broker_message.payload`
+                            // let payload = broker_message
+                            //     .payload
+                            //     .payload
+                            //     .as_deref()
+                            //     .map(String::from_utf8_lossy)
+                            //     .into();
+                            // scope.set_extra("payload", payload)
+                        },
+                        || {
+                            sentry::integrations::anyhow::capture_anyhow(&err);
+                        },
+                    );
+
+                    Err(RunTaskError::InvalidMessage(InvalidMessage {
+                        partition: broker_message.partition,
+                        offset: broker_message.offset,
+                    }))
+                }
+            }
+        })
+    }
+}
+
 impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
     fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
         let accumulator = Arc::new(|mut acc: BytesInsertBatch, value: BytesInsertBatch| {
-            for row in value.rows {
-                acc.rows.push(row);
-            }
+            acc.rows.extend(value.rows);
             acc
         });
 
@@ -79,50 +137,6 @@ impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
             ),
         ) {
             (true, Some(func)) => {
-                struct MessageProcessor {
-                    func: fn(
-                        KafkaPayload,
-                        KafkaMessageMetadata,
-                    ) -> Result<BytesInsertBatch, BadMessage>,
-                }
-
-                impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
-                    fn get_task(
-                        &self,
-                        message: Message<KafkaPayload>,
-                    ) -> RunTaskFunc<BytesInsertBatch> {
-                        let func = self.func;
-
-                        Box::pin(async move {
-                            let broker_message = match message.inner_message {
-                                InnerMessage::BrokerMessage(msg) => msg,
-                                _ => panic!("Unexpected message type"),
-                            };
-
-                            let metadata = KafkaMessageMetadata {
-                                partition: broker_message.partition.index,
-                                offset: broker_message.offset,
-                                timestamp: broker_message.timestamp,
-                            };
-
-                            match func(broker_message.payload, metadata) {
-                                Ok(transformed) => Ok(Message {
-                                    inner_message: InnerMessage::BrokerMessage(BrokerMessage {
-                                        payload: transformed,
-                                        partition: broker_message.partition,
-                                        offset: broker_message.offset,
-                                        timestamp: broker_message.timestamp,
-                                    }),
-                                }),
-                                Err(_e) => Err(RunTaskError::InvalidMessage(InvalidMessage {
-                                    partition: broker_message.partition,
-                                    offset: broker_message.offset,
-                                })),
-                            }
-                        })
-                    }
-                }
-
                 let task_runner = MessageProcessor { func };
                 Box::new(ValidateSchema::new(
                     RunTaskInThreads::new(

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -1,33 +1,31 @@
-use crate::processors::spans::SpanStatus;
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
-use std::time::{SystemTime, UNIX_EPOCH};
 use uuid::Uuid;
+
+use crate::processors::spans::SpanStatus;
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
-) -> Result<BytesInsertBatch, BadMessage> {
-    let payload_bytes = payload.payload.ok_or(BadMessage)?;
-    let msg: FromFunctionsMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-        log::error!("Failed to deserialize message: {}", err);
-        BadMessage
-    })?;
+) -> anyhow::Result<BytesInsertBatch> {
+    let payload_bytes = payload.payload.context("Expected payload")?;
+    let msg: FromFunctionsMessage = serde_json::from_slice(&payload_bytes)?;
 
-    let profile_id = Uuid::parse_str(msg.profile_id.as_str()).map_err(|_err| BadMessage)?;
     let timestamp = match msg.timestamp {
         Some(timestamp) => timestamp,
-        _ => SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_err| BadMessage)?
-            .as_secs(),
+        _ => SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs(),
     };
     let device_classification = msg.device_class.unwrap_or_default();
 
     let mut rows = Vec::with_capacity(msg.functions.len());
     for from in msg.functions {
         let function = Function {
+            profile_id: msg.profile_id,
+            project_id: msg.project_id,
             // Profile metadata
             browser_name: msg.browser_name.clone(),
             device_classification,
@@ -35,8 +33,6 @@ pub fn process_message(
             environment: msg.environment.clone(),
             http_method: msg.http_method.clone(),
             platform: msg.platform.clone(),
-            profile_id: profile_id.to_string(),
-            project_id: msg.project_id,
             release: msg.release.clone(),
             retention_days: msg.retention_days,
             timestamp,
@@ -54,10 +50,7 @@ pub fn process_message(
 
             ..Default::default()
         };
-        let serialized = serde_json::to_vec(&function).map_err(|err| {
-            log::error!("Failed to serialize message: {}", err);
-            BadMessage
-        })?;
+        let serialized = serde_json::to_vec(&function)?;
         rows.push(serialized);
     }
 
@@ -75,6 +68,8 @@ struct FromFunction {
 
 #[derive(Debug, Deserialize)]
 struct FromFunctionsMessage {
+    profile_id: Uuid,
+    project_id: u64,
     #[serde(default)]
     browser_name: Option<String>,
     #[serde(default)]
@@ -87,8 +82,6 @@ struct FromFunctionsMessage {
     #[serde(default)]
     http_method: Option<String>,
     platform: String,
-    profile_id: String,
-    project_id: u64,
     #[serde(default)]
     release: Option<String>,
     retention_days: u32,
@@ -101,6 +94,8 @@ struct FromFunctionsMessage {
 
 #[derive(Default, Debug, Serialize)]
 struct Function {
+    profile_id: Uuid,
+    project_id: u64,
     browser_name: Option<String>,
     device_classification: u32,
     dist: Option<String>,
@@ -115,8 +110,6 @@ struct Function {
     name: String,
     package: String,
     platform: String,
-    profile_id: String,
-    project_id: u64,
     release: Option<String>,
     retention_days: u32,
     timestamp: u64,

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -1,14 +1,14 @@
-mod utils;
 mod functions;
 mod profiles;
 mod querylog;
 mod spans;
+mod utils;
 
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 
 type ProcessingFunction =
-    fn(KafkaPayload, KafkaMessageMetadata) -> Result<BytesInsertBatch, BadMessage>;
+    fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>;
 
 pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -1,35 +1,31 @@
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use uuid::Uuid;
+
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-) -> Result<BytesInsertBatch, BadMessage> {
-    let payload_bytes = payload.payload.ok_or(BadMessage)?;
-    let msg: FromProfileMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-        log::error!("Failed to deserialize message: {}", err);
-        BadMessage
-    })?;
-    let mut profile_msg: ProfileMessage = msg.try_into()?;
+) -> anyhow::Result<BytesInsertBatch> {
+    let payload_bytes = payload.payload.context("Expected payload")?;
+    let mut msg: ProfileMessage = serde_json::from_slice(&payload_bytes)?;
 
-    profile_msg.offset = metadata.offset;
-    profile_msg.partition = metadata.partition;
+    // we always want an empty string at least
+    msg.device_classification = Some(msg.device_classification.unwrap_or_default());
+    msg.offset = metadata.offset;
+    msg.partition = metadata.partition;
 
-    let serialized = serde_json::to_vec(&profile_msg).map_err(|err| {
-        log::error!("Failed to serialize message: {}", err);
-        BadMessage
-    })?;
+    let serialized = serde_json::to_vec(&msg)?;
 
     Ok(BytesInsertBatch {
         rows: vec![serialized],
     })
 }
 
-#[derive(Debug, Deserialize)]
-struct FromProfileMessage {
+#[derive(Debug, Deserialize, Serialize)]
+struct ProfileMessage {
     #[serde(default)]
     android_api_level: Option<u32>,
     #[serde(default)]
@@ -48,78 +44,20 @@ struct FromProfileMessage {
     environment: Option<String>,
     organization_id: u64,
     platform: String,
-    profile_id: String,
+    profile_id: Uuid,
     project_id: u64,
     received: i64,
     retention_days: u32,
-    trace_id: String,
-    transaction_id: String,
+    trace_id: Uuid,
+    transaction_id: Uuid,
     transaction_name: String,
     version_code: String,
     version_name: String,
-}
 
-#[derive(Default, Debug, Serialize)]
-struct ProfileMessage {
-    android_api_level: Option<u32>,
-    architecture: Option<String>,
-    device_classification: String,
-    device_locale: String,
-    device_manufacturer: String,
-    device_model: String,
-    device_os_build_number: Option<String>,
-    device_os_name: String,
-    device_os_version: String,
-    duration_ns: u64,
-    environment: Option<String>,
+    #[serde(default)]
     offset: u64,
-    organization_id: u64,
+    #[serde(default)]
     partition: u16,
-    platform: String,
-    profile_id: String,
-    project_id: u64,
-    received: i64,
-    retention_days: u32,
-    trace_id: String,
-    transaction_id: String,
-    transaction_name: String,
-    version_code: String,
-    version_name: String,
-}
-
-impl TryFrom<FromProfileMessage> for ProfileMessage {
-    type Error = BadMessage;
-    fn try_from(from: FromProfileMessage) -> Result<ProfileMessage, BadMessage> {
-        let profile_id = Uuid::parse_str(from.profile_id.as_str()).map_err(|_err| BadMessage)?;
-        let trace_id = Uuid::parse_str(from.trace_id.as_str()).map_err(|_err| BadMessage)?;
-        let transaction_id =
-            Uuid::parse_str(from.transaction_id.as_str()).map_err(|_err| BadMessage)?;
-        Ok(Self {
-            android_api_level: from.android_api_level,
-            architecture: from.architecture,
-            device_classification: from.device_classification.unwrap_or_default(),
-            device_locale: from.device_locale,
-            device_manufacturer: from.device_manufacturer,
-            device_model: from.device_model,
-            device_os_build_number: from.device_os_build_number,
-            device_os_name: from.device_os_name,
-            device_os_version: from.device_os_version,
-            duration_ns: from.duration_ns,
-            environment: from.environment,
-            organization_id: from.organization_id,
-            platform: from.platform,
-            profile_id: profile_id.to_string(),
-            project_id: from.project_id,
-            received: from.received,
-            retention_days: from.retention_days,
-            trace_id: trace_id.to_string(),
-            transaction_id: transaction_id.to_string(),
-            transaction_name: from.transaction_name,
-            version_code: from.version_code,
-            version_name: from.version_name,
-            ..Default::default()
-        })
-    }
 }
 
 #[cfg(test)]

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -1,26 +1,24 @@
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+
+use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{ser::Error, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use uuid::Uuid;
+
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     _metadata: KafkaMessageMetadata,
-) -> Result<BytesInsertBatch, BadMessage> {
-    let payload_bytes = payload.payload.ok_or(BadMessage)?;
-    let msg: FromQuerylogMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-        log::error!("Failed to deserialize message: {}", err);
-        BadMessage
-    })?;
+) -> anyhow::Result<BytesInsertBatch> {
+    let payload_bytes = payload.payload.context("Expected payload")?;
+    let msg: FromQuerylogMessage = serde_json::from_slice(&payload_bytes)?;
+
     let querylog_msg: QuerylogMessage = msg.try_into()?;
 
-    let serialized = serde_json::to_vec(&querylog_msg).map_err(|err| {
-        log::error!("Failed to serialize message: {}", err);
-        BadMessage
-    })?;
+    let serialized = serde_json::to_vec(&querylog_msg)?;
 
     Ok(BytesInsertBatch {
         rows: vec![serialized],
@@ -89,36 +87,6 @@ struct Stats {
     extra: BTreeMap<String, Value>,
 }
 
-#[derive(Debug, Serialize)]
-struct SortedStats {
-    #[serde(flatten)]
-    stats: BTreeMap<String, Value>,
-}
-
-impl From<Stats> for SortedStats {
-    fn from(from: Stats) -> SortedStats {
-        // consistent, cache hit, max_threads and is_duplicated may not be present
-        let mut stats = from.extra;
-        if from.consistent.is_some() {
-            stats.insert("consistent".to_string(), from.consistent.into());
-        }
-        stats.insert("final".to_string(), from.r#final.into());
-        if from.cache_hit.is_some() {
-            stats.insert("cache_hit".to_string(), from.cache_hit.into());
-        }
-        stats.insert("sample".to_string(), from.sample.into());
-        if from.max_threads.is_some() {
-            stats.insert("max_threads".to_string(), from.max_threads.into());
-        }
-        stats.insert("clickhouse_table".to_string(), from.clickhouse_table.into());
-        stats.insert("query_id".to_string(), from.query_id.into());
-        if from.is_duplicate.is_some() {
-            stats.insert("is_duplicate".to_string(), from.is_duplicate.into());
-        }
-        Self { stats }
-    }
-}
-
 #[derive(Debug, Deserialize)]
 struct Profile {
     time_range: Option<u32>,
@@ -156,7 +124,7 @@ struct WhereProfile {
 struct FromQuery {
     sql: String,
     status: String,
-    trace_id: String,
+    trace_id: Uuid,
     stats: Stats,
     profile: Profile,
     #[serde(default, deserialize_with = "nullable_result_profile")]
@@ -170,7 +138,7 @@ struct QueryList {
     #[serde(rename(serialize = "clickhouse_queries.status"))]
     status: Vec<String>,
     #[serde(rename(serialize = "clickhouse_queries.trace_id"))]
-    trace_id: Vec<String>,
+    trace_id: Vec<Uuid>,
     #[serde(rename(serialize = "clickhouse_queries.stats"))]
     stats: Vec<String>,
     #[serde(rename(serialize = "clickhouse_queries.final"))]
@@ -210,8 +178,8 @@ struct QueryList {
 }
 
 impl TryFrom<Vec<FromQuery>> for QueryList {
-    type Error = BadMessage;
-    fn try_from(from: Vec<FromQuery>) -> Result<QueryList, BadMessage> {
+    type Error = anyhow::Error;
+    fn try_from(from: Vec<FromQuery>) -> anyhow::Result<QueryList> {
         let mut sql = vec![];
         let mut status = vec![];
         let mut trace_id = vec![];
@@ -237,25 +205,20 @@ impl TryFrom<Vec<FromQuery>> for QueryList {
         for q in from {
             sql.push(q.sql);
             status.push(q.status);
-            trace_id.push(
-                Uuid::parse_str(&q.trace_id)
-                    .map_err(|_| BadMessage)?
-                    .to_string(),
-            );
-            stats.push(
-                serde_json::to_string(&SortedStats::from(q.stats.clone()))
-                    .map_err(|_| BadMessage)?,
-            );
+            trace_id.push(q.trace_id);
             r#final.push(q.stats.r#final as u8);
             cache_hit.push(q.stats.cache_hit.unwrap_or(0));
-            sample.push(match q.stats.sample {
-                Some(Value::Number(n)) => n.as_f64().unwrap_or(0.0) as f32,
-                _ => 0.0,
-            });
+            let sample_value = q
+                .stats
+                .sample
+                .as_ref()
+                .and_then(Value::as_f64)
+                .unwrap_or_default() as f32;
+            sample.push(sample_value);
             max_threads.push(q.stats.max_threads.unwrap_or(0));
             num_days.push(q.profile.time_range.unwrap_or(0));
-            clickhouse_table.push(q.stats.clickhouse_table);
-            query_id.push(q.stats.query_id);
+            clickhouse_table.push(q.stats.clickhouse_table.clone());
+            query_id.push(q.stats.query_id.clone());
             is_duplicate.push(q.stats.is_duplicate.unwrap_or(0));
             consistent.push(q.stats.consistent.unwrap_or(false) as u8);
             all_columns.push(q.profile.all_columns);
@@ -266,6 +229,30 @@ impl TryFrom<Vec<FromQuery>> for QueryList {
             array_join_columns.push(q.profile.array_join_cols);
             bytes_scanned.push(q.result_profile.bytes);
             duration_ms.push((q.result_profile.elapsed * 1000.0) as u64);
+
+            // consistent, cache hit, max_threads and is_duplicated may not be present
+            let mut sorted_stats = q.stats.extra;
+            if let Some(consistent) = q.stats.consistent {
+                sorted_stats.insert("consistent".to_string(), consistent.into());
+            }
+            sorted_stats.insert("final".to_string(), q.stats.r#final.into());
+            if let Some(cache_hit) = q.stats.cache_hit {
+                sorted_stats.insert("cache_hit".to_string(), cache_hit.into());
+            }
+            sorted_stats.insert("sample".to_string(), q.stats.sample.into());
+            if let Some(max_threads) = q.stats.max_threads {
+                sorted_stats.insert("max_threads".to_string(), max_threads.into());
+            }
+            sorted_stats.insert(
+                "clickhouse_table".to_string(),
+                q.stats.clickhouse_table.into(),
+            );
+            sorted_stats.insert("query_id".to_string(), q.stats.query_id.into());
+            if let Some(is_duplicate) = q.stats.is_duplicate {
+                sorted_stats.insert("is_duplicate".to_string(), is_duplicate.into());
+            }
+
+            stats.push(serde_json::to_string(&sorted_stats)?);
         }
 
         Ok(Self {
@@ -320,8 +307,8 @@ struct QuerylogMessage {
 }
 
 impl TryFrom<FromQuerylogMessage> for QuerylogMessage {
-    type Error = BadMessage;
-    fn try_from(from: FromQuerylogMessage) -> Result<QuerylogMessage, BadMessage> {
+    type Error = anyhow::Error;
+    fn try_from(from: FromQuerylogMessage) -> anyhow::Result<QuerylogMessage> {
         Ok(Self {
             request: from.request,
             dataset: from.dataset,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -1,28 +1,26 @@
-use crate::types::{BadMessage, BytesInsertBatch, KafkaMessageMetadata};
+use std::collections::BTreeMap;
+
+use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use uuid::Uuid;
-use crate::processors::utils::{default_retention_days, DEFAULT_RETENTION_DAYS, hex_to_u64};
+
+use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETENTION_DAYS};
+use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
     payload: KafkaPayload,
     metadata: KafkaMessageMetadata,
-) -> Result<BytesInsertBatch, BadMessage> {
-    let payload_bytes = payload.payload.ok_or(BadMessage)?;
-    let msg: FromSpanMessage = serde_json::from_slice(&payload_bytes).map_err(|err| {
-        log::error!("Failed to deserialize message: {}", err);
-        BadMessage
-    })?;
+) -> anyhow::Result<BytesInsertBatch> {
+    let payload_bytes = payload.payload.context("Expected payload")?;
+    let msg: FromSpanMessage = serde_json::from_slice(&payload_bytes)?;
+
     let mut span: Span = msg.try_into()?;
 
     span.offset = metadata.offset;
     span.partition = metadata.partition;
 
-    let serialized = serde_json::to_vec(&span).map_err(|err| {
-        log::error!("Failed to serialize processed message: {}", err);
-        BadMessage
-    })?;
+    let serialized = serde_json::to_vec(&span)?;
 
     Ok(BytesInsertBatch {
         rows: vec![serialized],
@@ -132,10 +130,7 @@ impl FromSentryTags {
             tags.insert(key.into(), value.into());
         }
 
-        (
-            tags.keys().cloned().collect(),
-            tags.values().cloned().collect(),
-        )
+        tags.into_iter().unzip()
     }
 }
 
@@ -191,12 +186,12 @@ struct Span {
 }
 
 impl TryFrom<FromSpanMessage> for Span {
-    type Error = BadMessage;
+    type Error = anyhow::Error;
 
-    fn try_from(from: FromSpanMessage) -> Result<Span, BadMessage> {
+    fn try_from(from: FromSpanMessage) -> anyhow::Result<Span> {
         let end_timestamp_ms = from.start_timestamp_ms + from.duration_ms as u64;
         let group = if let Some(group) = &from.sentry_tags.group {
-            u64::from_str_radix(group, 16).map_err(|_| BadMessage)?
+            u64::from_str_radix(group, 16)?
         } else {
             0
         };
@@ -205,8 +200,7 @@ impl TryFrom<FromSpanMessage> for Span {
         let transaction_op = from.sentry_tags.transaction_op.unwrap_or_default();
 
         let tags = from.tags.unwrap_or_default();
-        let mut tag_keys: Vec<String> = tags.clone().into_keys().collect();
-        let mut tag_values: Vec<String> = tags.into_values().collect();
+        let (mut tag_keys, mut tag_values): (Vec<_>, Vec<_>) = tags.into_iter().unzip();
 
         if let Some(http_method) = from.sentry_tags.http_method.clone() {
             tag_keys.push("http.method".into());

--- a/rust_snuba/src/types.rs
+++ b/rust_snuba/src/types.rs
@@ -7,9 +7,6 @@ pub struct BytesInsertBatch {
 }
 
 #[derive(Clone, Debug)]
-pub struct BadMessage;
-
-#[derive(Clone, Debug)]
 pub struct KafkaMessageMetadata {
     pub partition: u16,
     pub offset: u64,


### PR DESCRIPTION
This removes the `BadMessage` error type and related manual logging and error conversion. It also centralizes logging of those errors, configuring anyhow in such a way that it captures stack traces in those cases, and sends those errors to Sentry, however without the failing payloads for now.

Apart from this, it also streamlines some of the processors, in particular removing manual `Uuid` parsing, and avoiding a bunch of `Clone`s.

fixes SNS-2523
however, SNS-2529 is not quite fixed by this