### PR TITLE
ref(rust): Add source information to `RunError`

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -31,6 +31,6 @@ fn main() {
     let mut processor = StreamProcessor::new(consumer, Box::new(TestFactory {}));
     processor.subscribe(topic);
     for _ in 0..20 {
-        let _ = processor.run_once();
+        processor.run_once().unwrap();
     }
 }

--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -2,14 +2,17 @@ mod dlq;
 mod metrics_buffer;
 pub mod strategies;
 
-use crate::backends::{AssignmentCallbacks, Consumer};
-use crate::processing::strategies::{MessageRejected, SubmitError};
-use crate::types::{InnerMessage, Message, Partition, Topic};
-use crate::utils::metrics::{get_metrics, Metrics};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use thiserror::Error;
+
+use crate::backends::{AssignmentCallbacks, Consumer};
+use crate::processing::strategies::{MessageRejected, SubmitError};
+use crate::types::{InnerMessage, Message, Partition, Topic};
+use crate::utils::metrics::{get_metrics, Metrics};
 use strategies::{ProcessingStrategy, ProcessingStrategyFactory};
 
 #[derive(Debug, Clone)]
@@ -21,11 +24,20 @@ pub struct PollError;
 #[derive(Debug, Clone)]
 pub struct PauseError;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Error)]
 pub enum RunError {
+    #[error("invalid state")]
     InvalidState,
-    PollError,
-    PauseError,
+    #[error("poll error")]
+    PollError {
+        #[source]
+        source: Option<Box<dyn std::error::Error + 'static>>,
+    },
+    #[error("pause error")]
+    PauseError {
+        #[source]
+        source: Option<Box<dyn std::error::Error + 'static>>,
+    },
 }
 
 struct Strategies<TPayload> {
@@ -182,9 +194,11 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
                     self.metrics_buffer
                         .incr_timing("arroyo.consumer.poll.time", poll_start.elapsed());
                 }
-                Err(e) => {
-                    log::error!("poll error: {}", e);
-                    return Err(RunError::PollError);
+                Err(error) => {
+                    log::error!("poll error: {}", error);
+                    return Err(RunError::PollError {
+                        source: Some(Box::new(error)),
+                    });
                 }
             }
         }
@@ -240,7 +254,12 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
                         Ok(()) => {
                             self.is_paused = false;
                         }
-                        Err(_) => return Err(RunError::PauseError),
+                        Err(error) => {
+                            log::error!("pause error: {}", error);
+                            return Err(RunError::PauseError {
+                                source: Some(Box::new(error)),
+                            });
+                        }
                     }
                 }
 
@@ -288,7 +307,12 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
                         Ok(()) => {
                             self.is_paused = true;
                         }
-                        Err(_) => return Err(RunError::PauseError),
+                        Err(error) => {
+                            log::error!("pause error: {}", error);
+                            return Err(RunError::PauseError {
+                                source: Some(Box::new(error)),
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This adds source information to `RunError::PauseError` and `RunError::PollError`. It also unwraps in the `base_processor` example to make it obvious when an error happens.