### PR TITLE
fix(rust): Rename metrics namespace, and implement one metric from python

### DIFF
--- a/rust_snuba/rust_arroyo/src/processing/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/mod.rs
@@ -150,6 +150,9 @@ impl<TPayload: 'static> StreamProcessor<TPayload> {
     }
 
     pub fn run_once(&mut self) -> Result<(), RunError> {
+        let metrics = get_metrics();
+        metrics.increment("arroyo.consumer.run_once", 1, None);
+
         if self.is_paused {
             // If the consumer waas paused, it should not be returning any messages
             // on ``poll``.

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -92,7 +92,7 @@ pub fn consumer_impl(
         configure_metrics(Box::new(StatsDBackend::new(
             &host,
             port,
-            "snuba.rust_consumer",
+            "snuba.consumer",
             tags,
         )));
     }


### PR DESCRIPTION
In order to make the Rust consumer emit the same metrics as Python
consumer, we need to use the same namespace. This is probably risky as
it could break alerts that do not apply the correct tag filters. We'll
just find out, I'm oncall anyway.

Also add a metric that already exists in Python, to see if it will show
up correctly.
