### PR TITLE
Spawn only one Tokio Runtime

### DIFF
--- a/rust_snuba/Cargo.toml
+++ b/rust_snuba/Cargo.toml
@@ -40,7 +40,7 @@ thiserror = "1.0"
 tokio = { version = "1.19.2", features = ["full"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-uuid = "1.4.1"
+uuid = "1.5.0"
 
 [dev-dependencies]
 procspawn = { version = "0.10.2", features = ["test-support", "json"] }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -1,14 +1,17 @@
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+
+use tokio::runtime::{Handle, Runtime};
+use tokio::task::JoinHandle;
+
 use crate::processing::metrics_buffer::MetricsBuffer;
 use crate::processing::strategies::{
     merge_commit_request, CommitRequest, InvalidMessage, MessageRejected, ProcessingStrategy,
     SubmitError,
 };
 use crate::types::Message;
-use std::collections::VecDeque;
-use std::future::Future;
-use std::pin::Pin;
-use std::time::{Duration, Instant};
-use tokio::task::JoinHandle;
 
 pub enum RunTaskError {
     RetryableError,
@@ -22,11 +25,61 @@ pub trait TaskRunner<TPayload, TTransformed>: Send + Sync {
     fn get_task(&self, message: Message<TPayload>) -> RunTaskFunc<TTransformed>;
 }
 
+/// This is configuration for the [`RunTaskInThreads`] strategy.
+///
+/// It defines the runtime on which tasks are being spawned, and the number of
+/// concurrently running tasks.
+pub struct ConcurrencyConfig {
+    /// The configured number of concurrently running tasks.
+    pub concurrency: usize,
+    runtime: RuntimeOrHandle,
+}
+
+impl ConcurrencyConfig {
+    /// Creates a new [`ConcurrencyConfig`], spawning a new [`Runtime`].
+    ///
+    /// The runtime will use the number of worker threads given by the `concurrency`,
+    /// and also limit the number of concurrently running tasks as well.
+    pub fn new(concurrency: usize) -> Self {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(concurrency)
+            .enable_all()
+            .build()
+            .unwrap();
+        Self {
+            concurrency,
+            runtime: RuntimeOrHandle::Runtime(runtime),
+        }
+    }
+
+    /// Creates a new [`ConcurrencyConfig`], reusing an existing [`Runtime`] via
+    /// its [`Handle`].
+    pub fn with_runtime(concurrency: usize, runtime: Handle) -> Self {
+        Self {
+            concurrency,
+            runtime: RuntimeOrHandle::Handle(runtime),
+        }
+    }
+
+    /// Returns a [`Handle`] to the underlying runtime.
+    pub fn handle(&self) -> Handle {
+        match &self.runtime {
+            RuntimeOrHandle::Handle(handle) => handle.clone(),
+            RuntimeOrHandle::Runtime(runtime) => runtime.handle().to_owned(),
+        }
+    }
+}
+
+enum RuntimeOrHandle {
+    Handle(Handle),
+    Runtime(Runtime),
+}
+
 pub struct RunTaskInThreads<TPayload, TTransformed> {
     next_step: Box<dyn ProcessingStrategy<TTransformed>>,
     task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
     concurrency: usize,
-    runtime: tokio::runtime::Runtime,
+    runtime: Handle,
     handles: VecDeque<JoinHandle<Result<Message<TTransformed>, RunTaskError>>>,
     message_carried_over: Option<Message<TTransformed>>,
     commit_request_carried_over: Option<CommitRequest>,
@@ -38,7 +91,7 @@ impl<TPayload, TTransformed> RunTaskInThreads<TPayload, TTransformed> {
     pub fn new<N>(
         next_step: N,
         task_runner: Box<dyn TaskRunner<TPayload, TTransformed>>,
-        concurrency: usize,
+        concurrency: &ConcurrencyConfig,
         // If provided, this name is used for metrics
         custom_strategy_name: Option<&'static str>,
     ) -> Self
@@ -50,12 +103,8 @@ impl<TPayload, TTransformed> RunTaskInThreads<TPayload, TTransformed> {
         RunTaskInThreads {
             next_step: Box::new(next_step),
             task_runner,
-            concurrency,
-            runtime: tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(concurrency)
-                .enable_all()
-                .build()
-                .unwrap(),
+            concurrency: concurrency.concurrency,
+            runtime: concurrency.handle(),
             handles: VecDeque::new(),
             message_carried_over: None,
             commit_request_carried_over: None,
@@ -134,7 +183,8 @@ impl<TPayload, TTransformed: Send + Sync + 'static> ProcessingStrategy<TPayload>
             return Err(SubmitError::MessageRejected(MessageRejected { message }));
         }
 
-        let handle = self.runtime.spawn(self.task_runner.get_task(message));
+        let task = self.task_runner.get_task(message);
+        let handle = self.runtime.spawn(task);
         self.handles.push_back(handle);
 
         Ok(())
@@ -223,7 +273,9 @@ mod tests {
             }
         }
 
-        let mut strategy = RunTaskInThreads::new(Noop {}, Box::new(IdentityTaskRunner {}), 1, None);
+        let concurrency = ConcurrencyConfig::new(1);
+        let mut strategy =
+            RunTaskInThreads::new(Noop {}, Box::new(IdentityTaskRunner {}), &concurrency, None);
 
         let message = Message::new_any_message("hello_world".to_string(), BTreeMap::new());
 

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -8,6 +8,7 @@ use rust_arroyo::backends::kafka::config::KafkaConfig;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::kafka::KafkaConsumer;
 
+use rust_arroyo::processing::strategies::run_task_in_threads::ConcurrencyConfig;
 use rust_arroyo::processing::StreamProcessor;
 use rust_arroyo::types::Topic;
 use rust_arroyo::utils::metrics::configure_metrics;
@@ -144,7 +145,7 @@ pub fn consumer_impl(
             max_batch_size,
             max_batch_time,
             skip_write,
-            concurrency,
+            ConcurrencyConfig::new(concurrency),
             python_max_queue_depth,
             use_rust_processor,
         )),

--- a/rust_snuba/src/strategies/commit_log.rs
+++ b/rust_snuba/src/strategies/commit_log.rs
@@ -1,7 +1,7 @@
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use rust_arroyo::backends::Producer;
 use rust_arroyo::processing::strategies::run_task_in_threads::{
-    RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
+    ConcurrencyConfig, RunTaskError, RunTaskFunc, RunTaskInThreads, TaskRunner,
 };
 use rust_arroyo::processing::strategies::{
     CommitRequest, InvalidMessage, ProcessingStrategy, SubmitError,
@@ -143,7 +143,7 @@ impl ProduceCommitLog {
     pub fn new<N>(
         next_step: N,
         producer: impl Producer<KafkaPayload> + 'static,
-        concurrency: usize,
+        concurrency: &ConcurrencyConfig,
         topic: TopicOrPartition,
         skip_produce: bool,
     ) -> Self
@@ -278,10 +278,11 @@ mod tests {
 
         let next_step = Noop { payloads: vec![] };
 
+        let concurrency = ConcurrencyConfig::new(1);
         let mut strategy = ProduceCommitLog::new(
             next_step,
             producer,
-            1,
+            &concurrency,
             TopicOrPartition::Topic(Topic::new("test")),
             false,
         );


### PR DESCRIPTION
Instead of having each `RunTaskInThreads` strategy spawn (and kill) its own runtime every time it is (re-)started, usage of runtimes is now controlled using a `ConcurrencyConfig`.

This way, all the strategies that internally run in a thread pool will share that same thread pool.
That also means that the total number of (worker) threads that are spawned is truely limited to `concurrency`, and not `concurrency * number-of-RunTaskInThreads`.