### PR TITLE
fix: Introduce --concurrency as alias for --processes

### DIFF
--- a/snuba/cli/consumer.py
+++ b/snuba/cli/consumer.py
@@ -125,6 +125,7 @@ logger = logging.getLogger(__name__)
 @click.option("--log-level", help="Logging level to use.")
 @click.option(
     "--processes",
+    "--concurrency",
     type=int,
 )
 @click.option(


### PR DESCRIPTION
--processes is not available in Rust consumers because it's a bad name
if you're really using threads.

Make it so that there is overlap between Python and Rust again.
