### PR TITLE
fix(referrer): Only use referrer passed in tenant_ids

### DIFF
--- a/snuba/request/validation.py
+++ b/snuba/request/validation.py
@@ -67,8 +67,8 @@ def _consistent_override(original_setting: bool, referrer: str) -> bool:
 
 
 def update_attribution_info(
-    request_parts: RequestParts, referrer: str, query_project_id: int
-) -> dict[str, str]:
+    request_parts: RequestParts, referrer: str, query_project_id: Optional[int]
+) -> dict[str, Any]:
     attribution_info = dict(request_parts.attribution_info)
 
     attribution_info["app_id"] = get_app_id(request_parts.attribution_info["app_id"])

--- a/snuba/web/views.py
+++ b/snuba/web/views.py
@@ -154,7 +154,7 @@ def check_clickhouse(metric_tags: dict[str, Any] | None = None) -> bool:
             for storage in storages
         }
 
-        for (cluster_key, cluster) in unique_clusters.items():
+        for cluster_key, cluster in unique_clusters.items():
             clickhouse = cluster.get_query_connection(ClickhouseClientSettings.QUERY)
             clickhouse_tables = clickhouse.execute("show tables").results
             known_table_names = connection_grouped_table_names[cluster_key]

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 
 import pytest
 
+from snuba import state
 from snuba.datasets.entities.entity_key import EntityKey
 from snuba.datasets.entities.factory import get_entity
 from snuba.datasets.factory import get_dataset
@@ -118,6 +119,8 @@ TENANT_ID_TESTS = [
             "tenant_ids": {"organization_id": 1, "referrer": "test"},
         },
         {"organization_id": 1, "referrer": "test", "project_id": 1},
+        "my_request",
+        0,
         id="one project id in query",
     ),
     pytest.param(
@@ -135,18 +138,47 @@ TENANT_ID_TESTS = [
             "tenant_ids": {"organization_id": 1, "referrer": "test"},
         },
         {"organization_id": 1, "referrer": "test"},
+        "my_request",
+        0,
+        id="multiple projects, no project tenant",
+    ),
+    pytest.param(
+        {
+            "query": (
+                "MATCH (events) "
+                "SELECT count() AS count BY time "
+                "WHERE "
+                "project_id IN tuple(1, 2, 3, 4) AND"
+                "timestamp >= toDateTime('2011-07-01t19:54:15') AND"
+                "timestamp < toDateTime('2018-07-06t19:54:15') "
+                "LIMIT 1000 "
+                "GRANULARITY 60"
+            ),
+            "tenant_ids": {"organization_id": 1, "referrer": "test"},
+        },
+        {"organization_id": 1, "referrer": "test"},
+        "test",
+        1,
         id="multiple projects, no project tenant",
     ),
 ]
 
 
-@pytest.mark.parametrize("request_payload, expected_tenant_ids", TENANT_ID_TESTS)
+@pytest.mark.redis_db
+@pytest.mark.parametrize(
+    "request_payload, expected_tenant_ids, expected_referrer, only_use_tenant_id_referrer",
+    TENANT_ID_TESTS,
+)
 def test_tenant_ids(
-    request_payload: dict[str, Any], expected_tenant_ids: dict[str, Any]
+    request_payload: dict[str, Any],
+    expected_tenant_ids: dict[str, Any],
+    expected_referrer: str,
+    only_use_tenant_id_referrer: bool,
 ) -> None:
     dataset = get_dataset("events")
     schema = RequestSchema.build(HTTPQuerySettings)
 
+    state.set_config("only_use_tenant_id_referrer", only_use_tenant_id_referrer)
     request = build_request(
         request_payload,
         parse_snql_query,
@@ -156,4 +188,5 @@ def test_tenant_ids(
         Timer("test"),
         "my_request",
     )
+    assert request.referrer == expected_referrer
     assert request.attribution_info.tenant_ids == expected_tenant_ids

--- a/tests/request/test_build_request.py
+++ b/tests/request/test_build_request.py
@@ -159,7 +159,7 @@ TENANT_ID_TESTS = [
         {"organization_id": 1, "referrer": "test"},
         "test",
         1,
-        id="multiple projects, no project tenant",
+        id="only use tenant_id referrer in request",
     ),
 ]
 


### PR DESCRIPTION
Currently, ST datadog is not displaying metrics with the proper tagged referrers. This is because in ST, the referrer (as part of the HTTP request) is not being sent. However, the referrer within the tenant_id (part of the body) is being sent. We enforce this in our allocation policies. This PR is responsible for only using the referrer being passed in the tenant_id. A runtime config `only_use_tenant_id_referrer` is used in case of unexpected behaviours.