### PR TITLE
meta: Make processing team codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,9 @@
 # Use owners-snuba by default
 * @getsentry/owners-snuba
 
+# rust_snuba
+* @getsentry/owners-snuba @getsentry/owners-processing
+
 # Legal
 /LICENSE  @getsentry/owners-legal
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 * @getsentry/owners-snuba
 
 # rust_snuba
-* @getsentry/owners-snuba @getsentry/owners-processing
+/rust_snuba @getsentry/owners-snuba @getsentry/owners-processing
 
 # Legal
 /LICENSE  @getsentry/owners-legal


### PR DESCRIPTION
This is likely temporary for the duration of the rust consumer project
