### PR TITLE
feat(rust): Start buffering messages for DLQ

### DIFF
--- a/rust_snuba/rust_arroyo/examples/base_processor.rs
+++ b/rust_snuba/rust_arroyo/examples/base_processor.rs
@@ -11,8 +11,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 struct TestFactory {}
-impl ProcessingStrategyFactory<KafkaPayload> for TestFactory {
-    fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+impl ProcessingStrategyFactory<Arc<KafkaPayload>> for TestFactory {
+    fn create(&self) -> Box<dyn ProcessingStrategy<Arc<KafkaPayload>>> {
         Box::new(CommitOffsets::new(Duration::from_secs(1)))
     }
 }

--- a/rust_snuba/rust_arroyo/src/backends/local/broker.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/broker.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use thiserror::Error;
 use uuid::Uuid;
 
-pub struct LocalBroker<TPayload> {
+pub struct LocalBroker<TPayload: Clone> {
     storage: Box<dyn MessageStorage<TPayload>>,
     clock: Box<dyn Clock>,
     offsets: HashMap<String, HashMap<Partition, u64>>,
@@ -32,7 +32,7 @@ impl From<TopicDoesNotExist> for BrokerError {
     }
 }
 
-impl<TPayload> LocalBroker<TPayload> {
+impl<TPayload: Clone> LocalBroker<TPayload> {
     pub fn new(storage: Box<dyn MessageStorage<TPayload>>, clock: Box<dyn Clock>) -> Self {
         Self {
             storage,

--- a/rust_snuba/rust_arroyo/src/backends/local/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/local/mod.rs
@@ -24,7 +24,7 @@ struct SubscriptionState {
     last_eof_at: HashMap<Partition, u64>,
 }
 
-pub struct LocalConsumer<TPayload> {
+pub struct LocalConsumer<TPayload: Clone> {
     id: Uuid,
     group: String,
     broker: LocalBroker<TPayload>,
@@ -40,7 +40,7 @@ pub struct LocalConsumer<TPayload> {
     closed: bool,
 }
 
-impl<TPayload> LocalConsumer<TPayload> {
+impl<TPayload: Clone> LocalConsumer<TPayload> {
     pub fn new(
         id: Uuid,
         broker: LocalBroker<TPayload>,
@@ -73,7 +73,7 @@ impl<TPayload> LocalConsumer<TPayload> {
     }
 }
 
-impl<TPayload> Consumer<TPayload> for LocalConsumer<TPayload> {
+impl<TPayload: Clone> Consumer<TPayload> for LocalConsumer<TPayload> {
     fn subscribe(
         &mut self,
         topics: &[Topic],

--- a/rust_snuba/rust_arroyo/src/backends/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/mod.rs
@@ -80,7 +80,7 @@ pub trait AssignmentCallbacks: Send + Sync {
 /// occurs even if the consumer retains ownership of the partition across
 /// assignments.) For this reason, it is generally good practice to ensure
 /// offsets are committed as part of the revocation callback.
-pub trait Consumer<TPayload>: Send {
+pub trait Consumer<TPayload: Clone>: Send {
     fn subscribe(
         &mut self,
         topic: &[Topic],

--- a/rust_snuba/rust_arroyo/src/backends/storages/memory.rs
+++ b/rust_snuba/rust_arroyo/src/backends/storages/memory.rs
@@ -8,11 +8,11 @@ use std::convert::TryFrom;
 /// Stores a list of messages for each partition of a topic.
 ///
 /// `self.messages[i][j]` is the `j`-th message of the `i`-th partition.
-struct TopicMessages<TPayload> {
+struct TopicMessages<TPayload: Clone> {
     messages: Vec<Vec<BrokerMessage<TPayload>>>,
 }
 
-impl<TPayload> TopicMessages<TPayload> {
+impl<TPayload: Clone> TopicMessages<TPayload> {
     /// Creates empty messsage queues for the given number of partitions.
     fn new(partitions: u16) -> Self {
         Self {
@@ -49,11 +49,11 @@ impl<TPayload> TopicMessages<TPayload> {
     }
 }
 
-pub struct MemoryMessageStorage<TPayload> {
+pub struct MemoryMessageStorage<TPayload: Clone> {
     topics: HashMap<Topic, TopicMessages<TPayload>>,
 }
 
-impl<TPayload> Default for MemoryMessageStorage<TPayload> {
+impl<TPayload: Clone> Default for MemoryMessageStorage<TPayload> {
     fn default() -> Self {
         MemoryMessageStorage {
             topics: HashMap::new(),

--- a/rust_snuba/rust_arroyo/src/backends/storages/mod.rs
+++ b/rust_snuba/rust_arroyo/src/backends/storages/mod.rs
@@ -21,7 +21,7 @@ pub enum ConsumeError {
     OffsetOutOfRange,
 }
 
-pub trait MessageStorage<TPayload>: Send {
+pub trait MessageStorage<TPayload: Clone>: Send {
     // Create a topic with the given number of partitions.
     //
     // If the topic already exists, a ``TopicExists`` exception will be

--- a/rust_snuba/rust_arroyo/src/processing/dlq.rs
+++ b/rust_snuba/rust_arroyo/src/processing/dlq.rs
@@ -5,11 +5,11 @@ use std::collections::{BTreeMap, VecDeque};
 
 /// Stores messages that are pending commit. This is used to retreive raw messages
 // in case they need to be placed in the DLQ.
-pub struct BufferedMessages<TPayload> {
+pub struct BufferedMessages<TPayload: Clone> {
     buffered_messages: BTreeMap<Partition, VecDeque<BrokerMessage<TPayload>>>,
 }
 
-impl<TPayload> BufferedMessages<TPayload> {
+impl<TPayload: Clone> BufferedMessages<TPayload> {
     pub fn new() -> Self {
         BufferedMessages {
             buffered_messages: BTreeMap::new(),

--- a/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/commit_offsets.rs
@@ -10,7 +10,7 @@ pub struct CommitOffsets {
     last_commit_time: SystemTime,
     commit_frequency: Duration,
 }
-impl<T> ProcessingStrategy<T> for CommitOffsets {
+impl<T: Clone> ProcessingStrategy<T> for CommitOffsets {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         Ok(self.commit(false))
     }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/mod.rs
@@ -5,17 +5,17 @@ use std::time::Duration;
 pub mod commit_offsets;
 pub mod produce;
 pub mod reduce;
-pub mod run_task_in_threads;
 pub mod run_task;
+pub mod run_task_in_threads;
 
 #[derive(Debug, Clone)]
-pub enum SubmitError<T> {
+pub enum SubmitError<T: Clone> {
     MessageRejected(MessageRejected<T>),
     InvalidMessage(InvalidMessage),
 }
 
 #[derive(Debug, Clone)]
-pub struct MessageRejected<T> {
+pub struct MessageRejected<T: Clone> {
     pub message: Message<T>,
 }
 
@@ -65,7 +65,7 @@ pub fn merge_commit_request(
 ///
 /// This interface is intentionally not prescriptive, and affords a
 /// significant degree of flexibility for the various implementations.
-pub trait ProcessingStrategy<TPayload>: Send + Sync {
+pub trait ProcessingStrategy<TPayload: Clone>: Send + Sync {
     /// Poll the processor to check on the status of asynchronous tasks or
     /// perform other scheduled work.
     ///

--- a/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/reduce.rs
@@ -209,7 +209,7 @@ mod tests {
             pub submitted: Arc<Mutex<Vec<T>>>,
         }
 
-        impl<T: Send + Sync> ProcessingStrategy<T> for NextStep<T> {
+        impl<T: Clone + Send + Sync> ProcessingStrategy<T> for NextStep<T> {
             fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
                 Ok(None)
             }

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task.rs
@@ -5,14 +5,14 @@ use crate::processing::strategies::{
 use crate::types::Message;
 use std::time::Duration;
 
-pub struct RunTask<TPayload, TTransformed> {
+pub struct RunTask<TPayload, TTransformed: Clone> {
     pub function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
     pub next_step: Box<dyn ProcessingStrategy<TTransformed>>,
     pub message_carried_over: Option<Message<TTransformed>>,
     pub commit_request_carried_over: Option<CommitRequest>,
 }
 
-impl<TPayload, TTransformed> RunTask<TPayload, TTransformed> {
+impl<TPayload, TTransformed: Clone> RunTask<TPayload, TTransformed> {
     pub fn new<N>(
         function: fn(TPayload) -> Result<TTransformed, InvalidMessage>,
         next_step: N,
@@ -29,7 +29,7 @@ impl<TPayload, TTransformed> RunTask<TPayload, TTransformed> {
     }
 }
 
-impl<TPayload, TTransformed: Send + Sync> ProcessingStrategy<TPayload>
+impl<TPayload: Clone, TTransformed: Clone + Send + Sync> ProcessingStrategy<TPayload>
     for RunTask<TPayload, TTransformed>
 {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {

--- a/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
+++ b/rust_snuba/rust_arroyo/src/processing/strategies/run_task_in_threads.rs
@@ -217,7 +217,7 @@ mod tests {
 
         struct IdentityTaskRunner {}
 
-        impl<T: Send + Sync + 'static> TaskRunner<T, T> for IdentityTaskRunner {
+        impl<T: Clone + Send + Sync + 'static> TaskRunner<T, T> for IdentityTaskRunner {
             fn get_task(&self, message: Message<T>) -> RunTaskFunc<T> {
                 Box::pin(async move { Ok(message) })
             }

--- a/rust_snuba/rust_arroyo/src/testutils.rs
+++ b/rust_snuba/rust_arroyo/src/testutils.rs
@@ -7,11 +7,11 @@ use crate::processing::strategies::{
 use crate::types::Message;
 
 #[derive(Clone)]
-pub struct TestStrategy<T> {
+pub struct TestStrategy<T: Clone> {
     pub messages: Arc<Mutex<Vec<Message<T>>>>,
 }
 
-impl<T> Default for TestStrategy<T> {
+impl<T: Clone> Default for TestStrategy<T> {
     fn default() -> Self {
         TestStrategy {
             messages: Arc::new(Mutex::new(Vec::new())),
@@ -19,13 +19,13 @@ impl<T> Default for TestStrategy<T> {
     }
 }
 
-impl<T> TestStrategy<T> {
+impl<T: Clone> TestStrategy<T> {
     pub fn new() -> Self {
         TestStrategy::default()
     }
 }
 
-impl<T: Send> ProcessingStrategy<T> for TestStrategy<T> {
+impl<T: Clone + Send> ProcessingStrategy<T> for TestStrategy<T> {
     fn poll(&mut self) -> Result<Option<CommitRequest>, InvalidMessage> {
         Ok(None)
     }

--- a/rust_snuba/rust_arroyo/src/types/mod.rs
+++ b/rust_snuba/rust_arroyo/src/types/mod.rs
@@ -68,14 +68,14 @@ pub enum TopicOrPartition {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct BrokerMessage<T> {
+pub struct BrokerMessage<T: Clone> {
     pub payload: T,
     pub partition: Partition,
     pub offset: u64,
     pub timestamp: DateTime<Utc>,
 }
 
-impl<T> BrokerMessage<T> {
+impl<T: Clone> BrokerMessage<T> {
     pub fn new(payload: T, partition: Partition, offset: u64, timestamp: DateTime<Utc>) -> Self {
         Self {
             payload,
@@ -85,7 +85,7 @@ impl<T> BrokerMessage<T> {
         }
     }
 
-    pub fn replace<TReplaced>(self, replacement: TReplaced) -> BrokerMessage<TReplaced> {
+    pub fn replace<TReplaced: Clone>(self, replacement: TReplaced) -> BrokerMessage<TReplaced> {
         BrokerMessage {
             payload: replacement,
             partition: self.partition,
@@ -95,7 +95,7 @@ impl<T> BrokerMessage<T> {
     }
 
     /// Map a fallible function over this messages's payload.
-    pub fn try_map<TReplaced, E, F: FnOnce(T) -> Result<TReplaced, E>>(
+    pub fn try_map<TReplaced: Clone, E, F: FnOnce(T) -> Result<TReplaced, E>>(
         self,
         f: F,
     ) -> Result<BrokerMessage<TReplaced>, E> {
@@ -117,7 +117,7 @@ impl<T> BrokerMessage<T> {
     }
 }
 
-impl<T> fmt::Display for BrokerMessage<T> {
+impl<T: Clone> fmt::Display for BrokerMessage<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -174,17 +174,17 @@ impl<T> fmt::Display for AnyMessage<T> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum InnerMessage<T> {
+pub enum InnerMessage<T: Clone> {
     BrokerMessage(BrokerMessage<T>),
     AnyMessage(AnyMessage<T>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Message<T> {
+pub struct Message<T: Clone> {
     pub inner_message: InnerMessage<T>,
 }
 
-impl<T> Message<T> {
+impl<T: Clone> Message<T> {
     pub fn new_broker_message(
         payload: T,
         partition: Partition,
@@ -240,7 +240,7 @@ impl<T> Message<T> {
         }
     }
 
-    pub fn replace<TReplaced>(self, replacement: TReplaced) -> Message<TReplaced> {
+    pub fn replace<TReplaced: Clone>(self, replacement: TReplaced) -> Message<TReplaced> {
         match self.inner_message {
             InnerMessage::BrokerMessage(inner) => Message {
                 inner_message: InnerMessage::BrokerMessage(inner.replace(replacement)),
@@ -252,7 +252,7 @@ impl<T> Message<T> {
     }
 
     /// Map a fallible function over this messages's payload.
-    pub fn try_map<TReplaced, E, F: FnOnce(T) -> Result<TReplaced, E>>(
+    pub fn try_map<TReplaced: Clone, E, F: FnOnce(T) -> Result<TReplaced, E>>(
         self,
         f: F,
     ) -> Result<Message<TReplaced>, E> {
@@ -269,7 +269,7 @@ impl<T> Message<T> {
     }
 }
 
-impl<T> fmt::Display for Message<T> {
+impl<T: Clone> fmt::Display for Message<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.inner_message {
             InnerMessage::BrokerMessage(BrokerMessage {
@@ -299,7 +299,7 @@ impl<T> fmt::Display for Message<T> {
     }
 }
 
-impl<T> From<BrokerMessage<T>> for Message<T> {
+impl<T: Clone> From<BrokerMessage<T>> for Message<T> {
     fn from(value: BrokerMessage<T>) -> Self {
         Self {
             inner_message: InnerMessage::BrokerMessage(value),
@@ -307,7 +307,7 @@ impl<T> From<BrokerMessage<T>> for Message<T> {
     }
 }
 
-impl<T> From<AnyMessage<T>> for Message<T> {
+impl<T: Clone> From<AnyMessage<T>> for Message<T> {
     fn from(value: AnyMessage<T>) -> Self {
         Self {
             inner_message: InnerMessage::AnyMessage(value),

--- a/rust_snuba/src/consumer.rs
+++ b/rust_snuba/src/consumer.rs
@@ -166,11 +166,11 @@ pub fn process_message(
     match processors::get_processing_function(name) {
         None => None,
         Some(func) => {
-            let payload = KafkaPayload {
+            let payload = Arc::new(KafkaPayload {
                 key: None,
                 headers: None,
                 payload: Some(value),
-            };
+            });
 
             let meta = KafkaMessageMetadata {
                 partition,

--- a/rust_snuba/src/factory.rs
+++ b/rust_snuba/src/factory.rs
@@ -50,11 +50,11 @@ impl ConsumerStrategyFactory {
 }
 
 struct MessageProcessor {
-    func: fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>,
+    func: fn(Arc<KafkaPayload>, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>,
 }
 
-impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
-    fn get_task(&self, message: Message<KafkaPayload>) -> RunTaskFunc<BytesInsertBatch> {
+impl TaskRunner<Arc<KafkaPayload>, BytesInsertBatch> for MessageProcessor {
+    fn get_task(&self, message: Message<Arc<KafkaPayload>>) -> RunTaskFunc<BytesInsertBatch> {
         let func = self.func;
 
         Box::pin(async move {
@@ -109,8 +109,8 @@ impl TaskRunner<KafkaPayload, BytesInsertBatch> for MessageProcessor {
     }
 }
 
-impl ProcessingStrategyFactory<KafkaPayload> for ConsumerStrategyFactory {
-    fn create(&self) -> Box<dyn ProcessingStrategy<KafkaPayload>> {
+impl ProcessingStrategyFactory<Arc<KafkaPayload>> for ConsumerStrategyFactory {
+    fn create(&self) -> Box<dyn ProcessingStrategy<Arc<KafkaPayload>>> {
         let accumulator = Arc::new(|mut acc: BytesInsertBatch, value: BytesInsertBatch| {
             acc.rows.extend(value.rows);
             acc

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -167,11 +167,11 @@ mod tests {
             "device_class": 2,
             "retention_days": 30
         }"#;
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/functions.rs
+++ b/rust_snuba/src/processors/functions.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
@@ -9,11 +10,11 @@ use crate::processors::spans::SpanStatus;
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
-    payload: KafkaPayload,
+    payload: Arc<KafkaPayload>,
     _metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let msg: FromFunctionsMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload.as_ref().context("Expected payload")?;
+    let msg: FromFunctionsMessage = serde_json::from_slice(payload_bytes)?;
 
     let timestamp = match msg.timestamp {
         Some(timestamp) => timestamp,

--- a/rust_snuba/src/processors/mod.rs
+++ b/rust_snuba/src/processors/mod.rs
@@ -6,9 +6,10 @@ mod utils;
 
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 use rust_arroyo::backends::kafka::types::KafkaPayload;
+use std::sync::Arc;
 
 type ProcessingFunction =
-    fn(KafkaPayload, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>;
+    fn(Arc<KafkaPayload>, KafkaMessageMetadata) -> anyhow::Result<BytesInsertBatch>;
 
 pub fn get_processing_function(name: &str) -> Option<ProcessingFunction> {
     match name {

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -1,16 +1,17 @@
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
-    payload: KafkaPayload,
+    payload: Arc<KafkaPayload>,
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let mut msg: ProfileMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload.as_ref().context("Expected payload")?;
+    let mut msg: ProfileMessage = serde_json::from_slice(payload_bytes)?;
 
     // we always want an empty string at least
     msg.device_classification = Some(msg.device_classification.unwrap_or_default());

--- a/rust_snuba/src/processors/profiles.rs
+++ b/rust_snuba/src/processors/profiles.rs
@@ -94,11 +94,11 @@ mod tests {
             "version_code": "1337",
             "version_name": "v42.0.0"
         }"#;
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -426,11 +426,11 @@ mod tests {
             "snql_anonymized": "MATCH Entity(events) SELECT tags_key, tags_value, (count() AS count), (min(timestamp) AS first_seen), (max(timestamp) AS last_seen) GROUP BY tags_key, tags_value WHERE greaterOrEquals(timestamp, toDateTime('$S')) AND less(timestamp, toDateTime('$S')) AND in(project_id, tuple(-1337)) AND in(project_id, tuple(-1337)) AND in(group_id, tuple(-1337)) ORDER BY count DESC LIMIT 4 BY tags_key LIMIT 1000 OFFSET 0"
           }"#;
 
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/querylog.rs
+++ b/rust_snuba/src/processors/querylog.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -10,11 +11,11 @@ use uuid::Uuid;
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
-    payload: KafkaPayload,
+    payload: Arc<KafkaPayload>,
     _metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let msg: FromQuerylogMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload.as_ref().context("Expected payload")?;
+    let msg: FromQuerylogMessage = serde_json::from_slice(payload_bytes)?;
 
     let querylog_msg: QuerylogMessage = msg.try_into()?;
 

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -450,11 +450,11 @@ mod tests {
         let span = valid_span();
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.unwrap().as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -469,11 +469,11 @@ mod tests {
         span.sentry_tags.status = Option::None;
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.unwrap().as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -488,11 +488,11 @@ mod tests {
         span.sentry_tags.status = Some("".into());
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.unwrap().as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -507,11 +507,11 @@ mod tests {
         span.retention_days = default_retention_days();
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.unwrap().as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,
@@ -526,11 +526,11 @@ mod tests {
         span.tags = Option::None;
         let data = serde_json::to_string(&span);
         assert!(data.is_ok());
-        let payload = KafkaPayload {
+        let payload = Arc::new(KafkaPayload {
             key: None,
             headers: None,
             payload: Some(data.unwrap().as_bytes().to_vec()),
-        };
+        });
         let meta = KafkaMessageMetadata {
             partition: 0,
             offset: 1,

--- a/rust_snuba/src/processors/spans.rs
+++ b/rust_snuba/src/processors/spans.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use anyhow::Context;
 use rust_arroyo::backends::kafka::types::KafkaPayload;
@@ -9,11 +10,11 @@ use crate::processors::utils::{default_retention_days, hex_to_u64, DEFAULT_RETEN
 use crate::types::{BytesInsertBatch, KafkaMessageMetadata};
 
 pub fn process_message(
-    payload: KafkaPayload,
+    payload: Arc<KafkaPayload>,
     metadata: KafkaMessageMetadata,
 ) -> anyhow::Result<BytesInsertBatch> {
-    let payload_bytes = payload.payload.context("Expected payload")?;
-    let msg: FromSpanMessage = serde_json::from_slice(&payload_bytes)?;
+    let payload_bytes = payload.payload.as_ref().context("Expected payload")?;
+    let msg: FromSpanMessage = serde_json::from_slice(payload_bytes)?;
 
     let mut span: Span = msg.try_into()?;
 

--- a/rust_snuba/src/strategies/python.rs
+++ b/rust_snuba/src/strategies/python.rs
@@ -261,11 +261,11 @@ mod tests {
 
         let _ = step.poll();
         step.submit(Message::new_broker_message(
-            KafkaPayload {
+            Arc::new(KafkaPayload {
                 key: None,
                 headers: None,
                 payload: Some(br#"{ "timestamp": "2023-03-28T18:50:44.000000Z", "org_id": 1, "project_id": 1, "key_id": 1, "outcome": 1, "reason": "discarded-hash", "event_id": "4ff942d62f3f4d5db9f53b5a015b5fd9", "category": 1, "quantity": 1 }"#.to_vec()),
-            },
+            }),
             Partition::new(Topic::new("test"), 1),
             1,
             Utc::now(),


### PR DESCRIPTION
This implements buffering of messages that are pending commit. Later, it can be used by the DLQ to retrieve untransformed messages which are deemed invalid and produced to the DLQ, (and logged to Sentry).

I'm adding this functionality now (even though rest of DLQ is not really done) because:
1. I think it might have some implications for how we've defined TPayload in a bunch of places (it probably needs to be Clone), and
2. It is likely to have performance implications that we should start understanding better now.
3. The first strategy must now take `Arc<TPayload>` instead of `TPayload`

Might need to bump requested memory a bit when we roll this out.

