### PR TITLE
Move sentry makefile target into snuba

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,14 +380,27 @@ jobs:
         if: needs.files-changed.outputs.api_changes == 'false'
         working-directory: sentry
         run: |
-          make test-snuba
+          pytest -k 'not __In' tests \
+            -m snuba_ci \
+            -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 
       - name: Run full tests
         # TODO: Adjust which changed files we care about
         if: needs.files-changed.outputs.api_changes == 'true'
         working-directory: sentry
         run: |
-          make test-snuba-full
+          pytest -k 'not __In' tests/snuba \
+              tests/sentry/eventstream/kafka \
+              tests/sentry/post_process_forwarder \
+              tests/sentry/snuba \
+              tests/sentry/search/events \
+              tests/sentry/event_manager \
+              -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
+
+      - name: Run CI module tests
+        if: needs.files-changed.outputs.api_changes == 'true'
+        working-directory: sentry
+        run: pytest -k 'not __In' tests -vv -m snuba_ci
 
   clickhouse-versions:
     needs: [linting, snuba-image]

--- a/snuba/query/processors/physical/prewhere.py
+++ b/snuba/query/processors/physical/prewhere.py
@@ -29,6 +29,7 @@ ALLOWED_OPERATORS = [
 metrics = MetricsWrapper(environment.metrics, "prewhere")
 
 
+# Changing this so all of CI runs
 class PrewhereProcessor(ClickhouseQueryProcessor):
     """
     Moves top level conditions into the pre-where clause according to


### PR DESCRIPTION
Coming from https://github.com/getsentry/sentry/pull/60050/files

Sentry does not use this target anymore, we just use it for CI. So we just put it in our CI workflow