### PR TITLE
fix(generic-metrics): Add raw tags hash to gauges dist table

### DIFF
--- a/snuba/migrations/group_loader.py
+++ b/snuba/migrations/group_loader.py
@@ -312,6 +312,7 @@ class GenericMetricsLoader(DirectoryLoader):
             "0023_gauges_raw_table",
             "0024_gauges_mv",
             "0025_counters_add_raw_tags_hash_column",
+            "0026_gauges_add_raw_tags_hash_column",
         ]
 
 

--- a/snuba/snuba_migrations/generic_metrics/0026_gauges_add_raw_tags_hash_column.py
+++ b/snuba/snuba_migrations/generic_metrics/0026_gauges_add_raw_tags_hash_column.py
@@ -1,0 +1,68 @@
+from typing import Sequence
+
+from snuba.clickhouse.columns import Array, Column, UInt
+from snuba.clusters.storage_sets import StorageSetKey
+from snuba.datasets.storages.tags_hash_map import (
+    hash_map_int_column_definition,
+    hash_map_int_key_str_value_column_definition,
+)
+from snuba.migrations import migration, operations
+from snuba.migrations.columns import MigrationModifiers as Modifiers
+
+
+class Migration(migration.ClickhouseNodeMigration):
+    blocking = False
+    dist_table_name = "generic_metric_gauges_aggregated_dist"
+    storage_set_key = StorageSetKey.GENERIC_METRICS_GAUGES
+
+    def forwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                column=Column(
+                    "_indexed_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_column_definition(
+                                "tags.key", "tags.indexed_value"
+                            )
+                        ),
+                    ),
+                ),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.AddColumn(
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                column=Column(
+                    "_raw_tags_hash",
+                    Array(
+                        UInt(64),
+                        Modifiers(
+                            materialized=hash_map_int_key_str_value_column_definition(
+                                "tags.key", "tags.raw_value"
+                            )
+                        ),
+                    ),
+                ),
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]
+
+    def backwards_ops(self) -> Sequence[operations.SqlOperation]:
+        return [
+            operations.DropColumn(
+                column_name="_raw_tags_hash",
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+            operations.DropColumn(
+                column_name="_indexed_tags_hash",
+                storage_set=self.storage_set_key,
+                table_name=self.dist_table_name,
+                target=operations.OperationTarget.DISTRIBUTED,
+            ),
+        ]


### PR DESCRIPTION
This column already exists on the local tables, adding to the gauges dist tables.

Requires: https://github.com/getsentry/snuba/pull/4998